### PR TITLE
[libcu++] Avoid use of `__CUDA_ARCH__` in fpemu

### DIFF
--- a/libcudacxx/include/cuda/__fp/fpemu_impl.h
+++ b/libcudacxx/include/cuda/__fp/fpemu_impl.h
@@ -50,6 +50,8 @@
 #include <cuda/std/__bit/bit_cast.h>
 #include <cuda/std/__bit/countl.h>
 
+#include <nv/target>
+
 #include <cuda/std/__cccl/prologue.h>
 
 namespace cuda::experimental
@@ -528,7 +530,7 @@ _CCCL_API constexpr __fpemu_uint128& __fpemu_uint128::operator>>=(int __shift) n
 #endif // native vs emulated 128-bit
 
 #undef _CCCL_FPEMU_MAX
-#if defined(__CUDA_ARCH__) && !defined(__CUDA_LIBDEVICE__)
+#if _CCCL_DEVICE_COMPILATION() && !defined(__CUDA_LIBDEVICE__)
 // Global-scope qualifier: inside namespace cuda::experimental an
 // unqualified `max` now resolves to the fpmp2 max() template, which
 // shadows the CUDA device `::max(int, int)` builtin we want here.
@@ -586,31 +588,32 @@ _CCCL_TRIVIAL_API uint32_t __invert_msb(uint32_t __sign) noexcept
 template <fpemu_accuracy _Acc = fpemu_accuracy::high>
 _CCCL_TRIVIAL_API uint32_t __mul_32(__uint32x2 __a, __uint32x2 __b) noexcept
 {
-  uint32_t __res;
-#if defined __CUDA_ARCH__
-  __uint32x2 __a64 = ::cuda::std::bit_cast<__uint32x2>(__a);
-  __uint32x2 __b64 = ::cuda::std::bit_cast<__uint32x2>(__b);
-  uint32_t __res32;
-  asm("{\n\t"
-      ".reg .u32 r0, ahi, bhi;\n\t"
-      "mov.b32         ahi, %1;   \n\t"
-      "mov.b32         bhi, %2;   \n\t"
-      "mad.hi.u32      r0, ahi, bhi,  0;\n\t"
-      "mov.b32         %0, r0;     \n\t"
-      "}"
-      : "=r"(__res32)
-      : "r"(__a64.x[1]), "r"(__b64.x[1]));
-  __res = __res32;
-#else
-  // Split inputs into 32-bit parts
-  uint32_t __ahi = __a.x[1];
-  uint32_t __bhi = __b.x[1];
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE,
+    ({
+      __uint32x2 __a64 = ::cuda::std::bit_cast<__uint32x2>(__a);
+      __uint32x2 __b64 = ::cuda::std::bit_cast<__uint32x2>(__b);
+      uint32_t __res32;
+      asm("{\n\t"
+          ".reg .u32 r0, ahi, bhi;\n\t"
+          "mov.b32         ahi, %1;   \n\t"
+          "mov.b32         bhi, %2;   \n\t"
+          "mad.hi.u32      r0, ahi, bhi,  0;\n\t"
+          "mov.b32         %0, r0;     \n\t"
+          "}"
+          : "=r"(__res32)
+          : "r"(__a64.x[1]), "r"(__b64.x[1]));
+      return __res32;
+    }),
+    ({
+      // Split inputs into 32-bit parts
+      uint32_t __ahi = __a.x[1];
+      uint32_t __bhi = __b.x[1];
 
-  // Compute high 32 bits directly
-  uint64_t __hi_hi = uint64_t(__ahi) * __bhi; // (a.hi * b.hi)
-  __res            = uint32_t(__hi_hi >> 32);
-#endif
-  return __res;
+      // Compute high 32 bits directly
+      uint64_t __hi_hi = uint64_t(__ahi) * __bhi; // (a.hi * b.hi)
+      return static_cast<uint32_t>(__hi_hi >> 32);
+    }))
 } //__mul_32
 
 //! @brief Multiply two 64-bit integers and return the high 64 bits of the result
@@ -629,53 +632,55 @@ _CCCL_TRIVIAL_API uint32_t __mul_32(__uint32x2 __a, __uint32x2 __b) noexcept
 template <fpemu_accuracy _Acc = fpemu_accuracy::high>
 _CCCL_TRIVIAL_API __uint32x2 __mul_64(__uint32x2 __a, __uint32x2 __b) noexcept
 {
-  __uint32x2 __res;
-#if defined __CUDA_ARCH__
-  uint64_t __a64 = ::cuda::std::bit_cast<uint64_t>(__a);
-  uint64_t __b64 = ::cuda::std::bit_cast<uint64_t>(__b);
-  uint64_t __res64;
-  asm("{\n\t"
-      ".reg .u32 r0, r1, r2, r3, alo, ahi, blo, bhi;\n\t"
-      "mov.b64         {alo,ahi}, %1;   \n\t"
-      "mov.b64         {blo,bhi}, %2;   \n\t"
-      "mad.lo.cc.u32   r1, alo, bhi, 0;\n\t"
-      "madc.hi.u32     r2, alo, bhi,  0;\n\t"
-      "mad.lo.cc.u32   r1, ahi, blo, r1;\n\t"
-      "madc.hi.cc.u32  r2, ahi, blo, r2;\n\t"
-      "madc.hi.u32     r3, ahi, bhi,  0;\n\t"
-      "mad.lo.cc.u32   r2, ahi, bhi, r2;\n\t"
-      "addc.u32        r3, r3,  0;      \n\t"
-      "mov.b64         %0, {r2,r3};     \n\t"
-      "}"
-      : "=l"(__res64)
-      : "l"(__a64), "l"(__b64));
-  __res = ::cuda::std::bit_cast<__uint32x2>(__res64);
-#else
-  // Split inputs into 32-bit parts
-  uint32_t __alo = __a.x[0];
-  uint32_t __ahi = __a.x[1];
-  uint32_t __blo = __b.x[0];
-  uint32_t __bhi = __b.x[1];
+  NV_IF_TARGET(NV_IS_DEVICE,
+               ({
+                 uint64_t __a64 = ::cuda::std::bit_cast<uint64_t>(__a);
+                 uint64_t __b64 = ::cuda::std::bit_cast<uint64_t>(__b);
+                 uint64_t __res64;
+                 asm("{\n\t"
+                     ".reg .u32 r0, r1, r2, r3, alo, ahi, blo, bhi;\n\t"
+                     "mov.b64         {alo,ahi}, %1;   \n\t"
+                     "mov.b64         {blo,bhi}, %2;   \n\t"
+                     "mad.lo.cc.u32   r1, alo, bhi, 0;\n\t"
+                     "madc.hi.u32     r2, alo, bhi,  0;\n\t"
+                     "mad.lo.cc.u32   r1, ahi, blo, r1;\n\t"
+                     "madc.hi.cc.u32  r2, ahi, blo, r2;\n\t"
+                     "madc.hi.u32     r3, ahi, bhi,  0;\n\t"
+                     "mad.lo.cc.u32   r2, ahi, bhi, r2;\n\t"
+                     "addc.u32        r3, r3,  0;      \n\t"
+                     "mov.b64         %0, {r2,r3};     \n\t"
+                     "}"
+                     : "=l"(__res64)
+                     : "l"(__a64), "l"(__b64));
+                 return ::cuda::std::bit_cast<__uint32x2>(__res64);
+               }),
+               ({
+                 // Split inputs into 32-bit parts
+                 uint32_t __alo = __a.x[0];
+                 uint32_t __ahi = __a.x[1];
+                 uint32_t __blo = __b.x[0];
+                 uint32_t __bhi = __b.x[1];
 
-  // Compute partial products that contribute to high 64 bits
-  uint64_t __lo_hi = uint64_t(__alo) * __bhi; // (a.lo * b.hi)
-  uint64_t __hi_lo = uint64_t(__ahi) * __blo; // (a.hi * b.lo)
-  uint64_t __hi_hi = uint64_t(__ahi) * __bhi; // (a.hi * b.hi)
+                 // Compute partial products that contribute to high 64 bits
+                 uint64_t __lo_hi = uint64_t(__alo) * __bhi; // (a.lo * b.hi)
+                 uint64_t __hi_lo = uint64_t(__ahi) * __blo; // (a.hi * b.lo)
+                 uint64_t __hi_hi = uint64_t(__ahi) * __bhi; // (a.hi * b.hi)
 
-  // Extract high parts and combine
-  uint32_t __lo_hi_hi = uint32_t(__lo_hi >> 32);
-  uint32_t __hi_lo_hi = uint32_t(__hi_lo >> 32);
-  uint32_t __hi_hi_lo = uint32_t(__hi_hi);
-  uint32_t __hi_hi_hi = uint32_t(__hi_hi >> 32);
+                 // Extract high parts and combine
+                 uint32_t __lo_hi_hi = uint32_t(__lo_hi >> 32);
+                 uint32_t __hi_lo_hi = uint32_t(__hi_lo >> 32);
+                 uint32_t __hi_hi_lo = uint32_t(__hi_hi);
+                 uint32_t __hi_hi_hi = uint32_t(__hi_hi >> 32);
 
-  // Combine high parts with carries
-  uint64_t __hi = uint64_t(__lo_hi_hi) + __hi_lo_hi + __hi_hi_lo;
+                 // Combine high parts with carries
+                 uint64_t __hi = uint64_t(__lo_hi_hi) + __hi_lo_hi + __hi_hi_lo;
 
-  // Store high result
-  __res.x[0] = uint32_t(__hi);
-  __res.x[1] = uint32_t(__hi >> 32) + __hi_hi_hi;
-#endif
-  return __res;
+                 // Store high result
+                 __uint32x2 __res;
+                 __res.x[0] = uint32_t(__hi);
+                 __res.x[1] = uint32_t(__hi >> 32) + __hi_hi_hi;
+                 return __res;
+               }))
 } //__mul_64
 
 //! @brief Multiply two 64-bit integers and return the full 128-bit result
@@ -727,26 +732,29 @@ _CCCL_TRIVIAL_API __uint32x4 __mul_128(__uint32x2 __a, __uint32x2 __b) noexcept
   __res.lo.x[0] = __lo_lo_lo;
   __res.lo.x[1] = __mid_lo;
 
-#if defined __CUDA_ARCH__
-  uint64_t __a64   = ::cuda::std::bit_cast<uint64_t>(__a);
-  uint64_t __b64   = ::cuda::std::bit_cast<uint64_t>(__b);
-  uint64_t __res64 = __umul64hi(__a64, __b64);
-  __res.hi         = ::cuda::std::bit_cast<__uint32x2>(__res64);
-#else
-  uint64_t __hi_hi    = uint64_t(__ahi) * __bhi; // (a.hi * b.hi)
-  uint32_t __lo_hi_hi = uint32_t(__lo_hi >> 32);
-  uint32_t __hi_lo_hi = uint32_t(__hi_lo >> 32);
-  uint32_t __hi_hi_lo = uint32_t(__hi_hi);
-  uint32_t __mid_hi   = uint32_t(__mid >> 32);
-  uint64_t __hi       = uint64_t(__mid_hi) + __lo_hi_hi + __hi_lo_hi + __hi_hi_lo;
-  uint32_t __hi_hi_hi = uint32_t(__hi_hi >> 32);
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE,
+    ({
+      uint64_t __a64   = ::cuda::std::bit_cast<uint64_t>(__a);
+      uint64_t __b64   = ::cuda::std::bit_cast<uint64_t>(__b);
+      uint64_t __res64 = __umul64hi(__a64, __b64);
+      __res.hi         = ::cuda::std::bit_cast<__uint32x2>(__res64);
+    }),
+    ({
+      uint64_t __hi_hi    = uint64_t(__ahi) * __bhi; // (a.hi * b.hi)
+      uint32_t __lo_hi_hi = uint32_t(__lo_hi >> 32);
+      uint32_t __hi_lo_hi = uint32_t(__hi_lo >> 32);
+      uint32_t __hi_hi_lo = uint32_t(__hi_hi);
+      uint32_t __mid_hi   = uint32_t(__mid >> 32);
+      uint64_t __hi       = uint64_t(__mid_hi) + __lo_hi_hi + __hi_lo_hi + __hi_hi_lo;
+      uint32_t __hi_hi_hi = uint32_t(__hi_hi >> 32);
 
-  // Store high result
-  __res.hi.x[0] = uint32_t(__hi);
-  __res.hi.x[1] = uint32_t(__hi >> 32) + __hi_hi_hi;
-#endif
+      // Store high result
+      __res.hi.x[0] = uint32_t(__hi);
+      __res.hi.x[1] = uint32_t(__hi >> 32) + __hi_hi_hi;
+    }))
   return __res;
-} //__mul_128
+}
 
 //! @brief Shift a 64-bit value left by a specified amount
 //!
@@ -774,9 +782,7 @@ _CCCL_TRIVIAL_API __uint32x2 __shl_64(__uint32x2 __man, int __shift) noexcept
 _CCCL_TRIVIAL_API __uint32x2 __shr_64(__uint32x2 __man, int __shift) noexcept
 {
   uint64_t __man64 = ::cuda::std::bit_cast<uint64_t>(__man);
-#ifndef __CUDA_ARCH__
-  __shift = (__shift > 0) ? (__shift > 64) ? 64 : __shift : 0;
-#endif
+  NV_IF_TARGET(NV_IS_HOST, ({ __shift = (__shift > 0) ? (__shift > 64) ? 64 : __shift : 0; }))
   __man64 = __man64 >> __shift;
   return ::cuda::std::bit_cast<__uint32x2>(__man64);
 } //__shr_64
@@ -797,28 +803,27 @@ _CCCL_TRIVIAL_API __uint32x2 __shr_64(__uint32x2 __man, int __shift) noexcept
 template <__fpemu_rounding _Rm = __fpemu_rounding::rn>
 _CCCL_TRIVIAL_API float __fmul_dir(float __x, float __y) noexcept
 {
-#if defined(__CUDA_ARCH__)
-  if constexpr (_Rm == __fpemu_rounding::rn)
-  {
-    return __fmul_rn(__x, __y);
-  }
-  else if constexpr (_Rm == __fpemu_rounding::rz)
-  {
-    return __fmul_rz(__x, __y);
-  }
-  else if constexpr (_Rm == __fpemu_rounding::ru)
-  {
-    return __fmul_ru(__x, __y);
-  }
-  else
-  {
-    return __fmul_rd(__x, __y);
-  }
-#else
-  (void) _Rm;
-  return __x * __y;
-#endif
-} //__fmul_dir
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE,
+                    ({
+                      if constexpr (_Rm == __fpemu_rounding::rn)
+                      {
+                        return __fmul_rn(__x, __y);
+                      }
+                      else if constexpr (_Rm == __fpemu_rounding::rz)
+                      {
+                        return __fmul_rz(__x, __y);
+                      }
+                      else if constexpr (_Rm == __fpemu_rounding::ru)
+                      {
+                        return __fmul_ru(__x, __y);
+                      }
+                      else
+                      {
+                        return __fmul_rd(__x, __y);
+                      }
+                    }),
+                    ({ return __x * __y; }))
+}
 
 //! @brief Single-precision add with directed rounding (fast add paths)
 //!
@@ -826,36 +831,34 @@ _CCCL_TRIVIAL_API float __fmul_dir(float __x, float __y) noexcept
 template <__fpemu_rounding _Rm = __fpemu_rounding::rn>
 _CCCL_TRIVIAL_API float __fadd_dir(float __x, float __y) noexcept
 {
-#if defined(__CUDA_ARCH__)
-  if constexpr (_Rm == __fpemu_rounding::rn)
-  {
-    return __fadd_rn(__x, __y);
-  }
-  else if constexpr (_Rm == __fpemu_rounding::rz)
-  {
-    return __fadd_rz(__x, __y);
-  }
-  else if constexpr (_Rm == __fpemu_rounding::ru)
-  {
-    return __fadd_ru(__x, __y);
-  }
-  else
-  {
-    return __fadd_rd(__x, __y);
-  }
-#else
-  (void) _Rm;
-  return __x + __y;
-#endif
-} //__fadd_dir
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE,
+                    ({
+                      if constexpr (_Rm == __fpemu_rounding::rn)
+                      {
+                        return __fadd_rn(__x, __y);
+                      }
+                      else if constexpr (_Rm == __fpemu_rounding::rz)
+                      {
+                        return __fadd_rz(__x, __y);
+                      }
+                      else if constexpr (_Rm == __fpemu_rounding::ru)
+                      {
+                        return __fadd_ru(__x, __y);
+                      }
+                      else
+                      {
+                        return __fadd_rd(__x, __y);
+                      }
+                    }),
+                    ({ return __x + __y; }))
+}
 
 template <__fpemu_rounding _Rm = __fpemu_rounding::rn>
 _CCCL_TRIVIAL_API __uint32x2 __shr_64_rnd(__uint32x2 __man, int __shift, bool __sign = false) noexcept
 {
   uint64_t __man64 = ::cuda::std::bit_cast<uint64_t>(__man);
-#ifndef __CUDA_ARCH__
-  __shift = (__shift > 0) ? (__shift > 64) ? 64 : __shift : 0;
-#endif
+  NV_IF_TARGET(NV_IS_HOST, ({ __shift = (__shift > 0) ? (__shift > 64) ? 64 : __shift : 0; }))
+
   if (__shift <= 0)
   {
     return __man;
@@ -886,9 +889,8 @@ _CCCL_TRIVIAL_API __uint32x2 __shr_64_rnd(__uint32x2 __man, int __shift, bool __
 template <__fpemu_rounding _Rm = __fpemu_rounding::rn>
 _CCCL_TRIVIAL_API __fpemu_uint128 __shr_128_rnd(__fpemu_uint128 __man, int __shift, bool __sign = false) noexcept
 {
-#ifndef __CUDA_ARCH__
-  __shift = (__shift > 0) ? ((__shift > 127) ? 127 : __shift) : 0;
-#endif
+  NV_IF_TARGET(NV_IS_HOST, ({ __shift = (__shift > 0) ? ((__shift > 127) ? 127 : __shift) : 0; }))
+
   if (__shift <= 0)
   {
     return __man;
@@ -942,9 +944,8 @@ _CCCL_TRIVIAL_API __fpemu_uint128 __shr_128_jam(__fpemu_uint128 __man, int __shi
 template <fpemu_accuracy _Acc = fpemu_accuracy::high>
 _CCCL_TRIVIAL_API __uint32x2 __sar_64(__uint32x2 __man, int __shift) noexcept
 {
-#ifndef __CUDA_ARCH__
-  __shift = (__shift > 0) ? (__shift > 63) ? 63 : __shift : 0;
-#endif
+  NV_IF_TARGET(NV_IS_HOST, ({ __shift = (__shift > 0) ? (__shift > 63) ? 63 : __shift : 0; }))
+
   int64_t __man64  = ::cuda::std::bit_cast<int64_t>(__man);
   __man64          = __man64 >> __shift;
   __uint32x2 __res = ::cuda::std::bit_cast<__uint32x2>(__man64);
@@ -966,9 +967,8 @@ _CCCL_TRIVIAL_API __uint32x2 __sar_64(__uint32x2 __man, int __shift) noexcept
 template <fpemu_accuracy _Acc = fpemu_accuracy::high, __fpemu_rounding _Rm = __fpemu_rounding::rn>
 _CCCL_TRIVIAL_API __uint32x2 __sar_64_rnd(__uint32x2 __man, int __shift, bool __sign = false) noexcept
 {
-#ifndef __CUDA_ARCH__
-  __shift = (__shift > 0) ? (__shift > 63) ? 63 : __shift : 0;
-#endif
+  NV_IF_TARGET(NV_IS_HOST, ({ __shift = (__shift > 0) ? (__shift > 63) ? 63 : __shift : 0; }))
+
   int64_t __man64     = ::cuda::std::bit_cast<int64_t>(__man);
   int64_t __man64_res = __man64 >> __shift;
   __uint32x2 __res    = ::cuda::std::bit_cast<__uint32x2>(__man64_res);

--- a/libcudacxx/include/cuda/__fp/fpemu_impl_div.h
+++ b/libcudacxx/include/cuda/__fp/fpemu_impl_div.h
@@ -40,6 +40,8 @@
 #include <cuda/__fp/fpemu_impl_unpack.h>
 #include <cuda/std/__bit/countl.h>
 
+#include <nv/target>
+
 #include <cuda/std/__cccl/prologue.h>
 
 namespace cuda::experimental
@@ -64,12 +66,11 @@ _CCCL_TRIVIAL_API uint32_t __internal_fp64emu_div_recip32(uint32_t __b32) noexce
   // Fast fp32 reciprocal seed. The Newton step below refines it and the
   // final trim guarantees a strict underestimate, so the low accuracy of
   // the SFU approximation (rcp.approx) is acceptable here.
-#if defined(__CUDA_ARCH__)
-  float __rf;
-  asm("rcp.approx.ftz.f32 %0, %1;" : "=f"(__rf) : "f"(__bf));
-#else
-  float __rf = 1.0f / __bf; // host fallback
-#endif
+  float __rf{};
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, ({ asm("rcp.approx.ftz.f32 %0, %1;"
+                         : "=f"(__rf)
+                         : "f"(__bf)); }), ({ __rf = 1.0f / __bf; }))
   uint64_t __r = (uint64_t) (__rf * 4294967296.0f); // rf * 2^32
 
   if (__r < 0x80000000ULL)

--- a/libcudacxx/include/cuda/__fp/fpemu_impl_fma.h
+++ b/libcudacxx/include/cuda/__fp/fpemu_impl_fma.h
@@ -37,11 +37,13 @@
 #include <cuda/__fp/fpemu_impl_unpack.h>
 #include <cuda/std/__bit/countl.h>
 
+#include <nv/target>
+
 #include <cuda/std/__cccl/prologue.h>
 
 namespace cuda::experimental
 {
-#if !(defined(__CUDA_ARCH__))
+#if _CCCL_HOST_COMPILATION()
 // Host seed: the libm symbol. The exception spec must match the platform's
 // <math.h> prototype exactly, otherwise this extern-"C" redeclaration conflicts
 // with ::fma when <cmath> is also in the TU (in C++17+ the exception spec is
@@ -50,12 +52,12 @@ namespace cuda::experimental
 //   - MSVC's CRT/CUDA prototype carries no exception specification, so a
 //     noexcept redeclaration is a mismatched extern-"C" overload (C2382/C2733
 //     under C++20); declare it without noexcept to match.
-#  if defined(_MSC_VER)
+#  if _CCCL_COMPILER(MSVC)
 extern "C" double fma(double __x, double __y, double __z);
-#  else
+#  else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
 extern "C" double fma(double __x, double __y, double __z) noexcept;
-#  endif
-#endif
+#  endif // ^^^ !_CCCL_COMPILER(MSVC) ^^^
+#endif // _CCCL_HOST_COMPILATION()
 
 //! @brief Pure FMA core operating on the unpacked representation.
 //!
@@ -135,10 +137,11 @@ __internal_fp64emu_fma_unpacked(__fpbits64_unpacked __a, __fpbits64_unpacked __b
   int32_t __delta_a = __exponent_r - __exponent_ab_new;
   int32_t __delta_b = __exponent_r - __exponent_c;
 
-#ifndef __CUDA_ARCH__
-  __delta_a = (__delta_a > 127) ? 127 : __delta_a;
-  __delta_b = (__delta_b > 127) ? 127 : __delta_b;
-#endif
+  NV_IF_TARGET(NV_IS_HOST, ({
+                 __delta_a = (__delta_a > 127) ? 127 : __delta_a;
+                 __delta_b = (__delta_b > 127) ? 127 : __delta_b;
+               }))
+
   // Shift mantissas with jam only (SoftFloat shiftRightJam*); round at pack
   __mantissa_ab = __shr_128_jam(__mantissa_ab, __delta_a);
   __mantissa_c  = __shr_128_jam(__mantissa_c << 64, __delta_b);

--- a/libcudacxx/include/cuda/__fp/fpemu_impl_sqrt.h
+++ b/libcudacxx/include/cuda/__fp/fpemu_impl_sqrt.h
@@ -40,25 +40,27 @@
 #include <cuda/__fp/fpemu_impl_unpack.h>
 #include <cuda/std/__bit/countl.h>
 
+#include <nv/target>
+
 #include <cuda/std/__cccl/prologue.h>
 
 namespace cuda::experimental
 {
-#if !(defined(__CUDA_ARCH__))
+#if _CCCL_HOST_COMPILATION()
 // Host seeds: the libm symbols. On glibc these are declared noexcept to match
 // the standard <math.h> prototypes (marked __THROW); otherwise the extern-"C"
 // redeclarations conflict with ::sqrt/::sqrtf when <cmath> is also in the TU
 // (-Werror). On MSVC the CRT/CUDA prototypes carry no exception specification,
 // so a noexcept redeclaration is a mismatched extern-"C" overload (C2382/C2733
 // under C++20); declare them without noexcept to match.
-#  if defined(_MSC_VER)
+#  if _CCCL_COMPILER(MSVC)
 extern "C" double sqrt(double __x);
 extern "C" float sqrtf(float __x); // host seed for the reciprocal-sqrt builtin
-#  else
+#  else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
 extern "C" double sqrt(double __x) noexcept;
 extern "C" float sqrtf(float __x) noexcept; // host seed for the reciprocal-sqrt builtin
-#  endif
-#endif
+#  endif // ^^^ !_CCCL_COMPILER(MSVC) ^^^
+#endif // _CCCL_HOST_COMPILATION()
 
 // ========================================================================
 // Native fp64 square root.
@@ -81,12 +83,11 @@ _CCCL_TRIVIAL_API uint32_t __internal_fp64emu_sqrt_recip_sqrt32(uint32_t __odd_e
   // Seed: r ~ 2^47 * rsqrt(a / 2^odd_exp). Halving the radicand for the
   // odd-exponent case folds the sqrt(2) factor into the same 2^47 scale.
   float __af = __odd_exp ? (float) __a * 0.5f : (float) __a;
-#if defined(__CUDA_ARCH__)
-  float __rf;
-  asm("rsqrt.approx.ftz.f32 %0, %1;" : "=f"(__rf) : "f"(__af));
-#else
-  float __rf = 1.0f / sqrtf(__af); // host fallback
-#endif
+  float __rf{};
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, ({ asm("rsqrt.approx.ftz.f32 %0, %1;"
+                         : "=f"(__rf)
+                         : "f"(__af)); }), ({ __rf = 1.0f / sqrtf(__af); }))
   uint64_t __r = (uint64_t) (__rf * 140737488355328.0f); // * 2^47
 
   if (__r < 0x80000000ULL)

--- a/libcudacxx/include/cuda/__fp/fpemu_impl_unpack.h
+++ b/libcudacxx/include/cuda/__fp/fpemu_impl_unpack.h
@@ -51,6 +51,8 @@
 #include <cuda/__fp/fpemu_impl.h>
 #include <cuda/std/__bit/countl.h>
 
+#include <nv/target>
+
 #include <cuda/std/__cccl/prologue.h>
 
 namespace cuda::experimental
@@ -135,9 +137,8 @@ _CCCL_TRIVIAL_API __fpbits64 __internal_fp64emu_pack(__fpbits64_unpacked __x) no
   int32_t __exponent  = __e > 0 ? __e : 0;
 
   int __shift = __e > 0 ? 0 : -__e;
-#ifndef __CUDA_ARCH__
-  __shift = (__shift > 0) ? (__shift > 63) ? 63 : __shift : 0;
-#endif
+  NV_IF_TARGET(NV_IS_HOST, ({ __shift = (__shift > 0) ? (__shift > 63) ? 63 : __shift : 0; }))
+
   if (__shift > 0)
   {
     const uint64_t __mask                 = (__shift >= 64) ? ~0ULL : ((1ULL << __shift) - 1);


### PR DESCRIPTION
We have our own macros that should be instead - either nv-target macros or our compilation control macros.