### PR TITLE
[libcu++] Try and work around gcc11.2 bug with tuple

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -85,13 +85,13 @@ public:
   }
 
   // Going through an inline variable forces instantiation of the default constructors of all _Tp fr old GCC
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+  template <class _Constraints = __tuple_constraints<_Tp...>,
+            enable_if_t<__can_construct_implicitly<_Constraints::__select_default_constructible>, int> = 0>
   _CCCL_API constexpr tuple() noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
   {}
 
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+  template <class _Constraints = __tuple_constraints<_Tp...>,
+            enable_if_t<__can_construct_explicitly<_Constraints::__select_default_constructible>, int> = 0>
   _CCCL_API explicit constexpr tuple() noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
   {}
 
@@ -99,16 +99,16 @@ public:
   _CCCL_HIDE_FROM_ABI tuple(tuple&&)      = default;
 
   template <class _Alloc,
-            __select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+            class _Constraints = __tuple_constraints<_Tp...>,
+            enable_if_t<__can_construct_implicitly<_Constraints::__select_default_constructible>, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t,
                             _Alloc const& __a) noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
       : __base_(allocator_arg_t(), __a)
   {}
 
   template <class _Alloc,
-            __select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+            class _Constraints = __tuple_constraints<_Tp...>,
+            enable_if_t<__can_construct_explicitly<_Constraints::__select_default_constructible>, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t,
                                      _Alloc const& __a) noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
       : __base_(allocator_arg_t(), __a)
@@ -525,44 +525,37 @@ public:
     __t.swap(__u);
   }
 
-  template <class... _UTypes>
-  using _ComparisonConstraints =
-    decltype(::cuda::std::__tuple_is_comparable(__tuple_types<_Tp...>{}, __tuple_types<_UTypes...>{}));
-
   _CCCL_EXEC_CHECK_DISABLE
-  template <class... _UTypes, size_t... _Indices, class _Constraints = _ComparisonConstraints<_UTypes...>>
+  template <class... _UTypes, size_t... _Indices, class _Constraints = __tuple_constraints<_Tp...>>
   [[nodiscard]] _CCCL_API constexpr bool __equal(const tuple<_UTypes...>& __other, __tuple_indices<_Indices...>) const
-    noexcept(_Constraints::__nothrow_equality_comparable)
+    noexcept(_Constraints::template __is_nothrow_equality_comparable_v<_UTypes...>)
   {
     using ::cuda::std::get;
     return ((get<_Indices>(*this) == get<_Indices>(__other)) && ...);
   }
 
   // Not a friend function because MSVC has issues with nested namespaces and thrust::tuple
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__equality_comparable)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
+  _CCCL_REQUIRES(_Constraints::template __is_equality_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator==(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_equality_comparable)
+    noexcept(_Constraints::template __is_nothrow_equality_comparable_v<_UTypes...>)
   {
     return __equal(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__equality_comparable)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
+  _CCCL_REQUIRES(_Constraints::template __is_equality_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator!=(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_equality_comparable)
+    noexcept(_Constraints::template __is_nothrow_equality_comparable_v<_UTypes...>)
   {
     return !__equal(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <class... _UTypes,
-            size_t _CurrentIndex,
-            size_t... _Indices,
-            class _Constraints = _ComparisonConstraints<_UTypes...>>
+  template <class... _UTypes, size_t _CurrentIndex, size_t... _Indices, class _Constraints = __tuple_constraints<_Tp...>>
   [[nodiscard]] _CCCL_API constexpr bool
   __tuple_less_than(const tuple<_UTypes...>& __other, __tuple_indices<_CurrentIndex, _Indices...>) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
   {
     using ::cuda::std::get;
     if constexpr (sizeof...(_Indices) == 0)
@@ -583,34 +576,34 @@ public:
     }
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__less_than_comparable)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
+  _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator<(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return __tuple_less_than(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__less_than_comparable)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
+  _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator>(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return __rhs.__tuple_less_than(*this, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__less_than_comparable)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
+  _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator>=(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return !__tuple_less_than(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__less_than_comparable)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
+  _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator<=(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return !__rhs.__tuple_less_than(*this, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -91,22 +91,49 @@ inline constexpr bool __tuple_like_with_size<_Tuple, _ExpectedSize, true> =
   _ExpectedSize == tuple_size<remove_cvref_t<_Tuple>>::value;
 
 template <class... _Types>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_default_constructible(__tuple_types<_Types...>) noexcept
+struct __tuple_constraints;
+
+template <class... _Types>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __tuple_get_constraints(__tuple_types<_Types...>) noexcept
 {
-  if constexpr (!(is_default_constructible_v<_Types> && ...))
-  {
-    return __select_constructor::__invalid;
-  }
-  else if constexpr ((__is_implicitly_default_constructible<_Types>::value && ...))
-  {
-    return __select_constructor::__implicit;
-  }
-  else
-  {
-    return __select_constructor::__explicit;
-  }
+  return __tuple_constraints<_Types...>{};
 }
+
+template <class... _Types>
+struct __tuple_constraints
+{
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor __select_default_constructible_() noexcept
+  {
+    if constexpr (!(is_default_constructible_v<_Types> && ...))
+    {
+      return __select_constructor::__invalid;
+    }
+    else if constexpr ((__is_implicitly_default_constructible<_Types>::value && ...))
+    {
+      return __select_constructor::__implicit;
+    }
+    else
+    {
+      return __select_constructor::__explicit;
+    }
+  }
+
+  static constexpr __select_constructor __select_default_constructible = __select_default_constructible_();
+
+  template <class... _UTypes>
+  static constexpr bool __is_equality_comparable_v = (__is_cpp17_equality_comparable_v<_Types, _UTypes> && ...);
+
+  template <class... _UTypes>
+  static constexpr bool __is_nothrow_equality_comparable_v =
+    (__is_cpp17_nothrow_equality_comparable_v<_Types, _UTypes> && ...);
+
+  template <class... _UTypes>
+  static constexpr bool __is_less_than_comparable_v = (__is_cpp17_less_than_comparable_v<_Types, _UTypes> && ...);
+
+  template <class... _UTypes>
+  static constexpr bool __is_nothrow_less_than_comparable_v =
+    (__is_cpp17_nothrow_less_than_comparable_v<_Types, _UTypes> && ...);
+};
 
 template <class... _Types>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
@@ -281,9 +308,9 @@ __tuple_select_variadic_constructible_less_rank(__tuple_types<_Types...>, __tupl
   else
   { // MSVC has issues with constexpr variables here, so no `__can_construct<_Trait>` or constexpr variable
     using __arg_list = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_UTypes)>;
-    if constexpr (::cuda::std::__tuple_select_variadic_constructible(__arg_list{}, __tuple_types<_UTypes...>{})
+    if constexpr (::cuda::std::__tuple_select_variadic_constructible_v<__arg_list, __tuple_types<_UTypes...>>
                     == __select_constructor::__invalid
-                  || ::cuda::std::__tuple_select_variadic_constructible(__arg_list{}, __tuple_types<_UTypes...>{})
+                  || ::cuda::std::__tuple_select_variadic_constructible_v<__arg_list, __tuple_types<_UTypes...>>
                        == __select_constructor::__deleted)
     {
       return __select_constructor::__invalid;
@@ -291,10 +318,9 @@ __tuple_select_variadic_constructible_less_rank(__tuple_types<_Types...>, __tupl
     else
     {
       using __defaulted_list = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_Types), sizeof...(_UTypes)>;
-      if constexpr (::cuda::std::__tuple_select_default_constructible(__defaulted_list{})
-                      == __select_constructor::__invalid
-                    || ::cuda::std::__tuple_select_default_constructible(__defaulted_list{})
-                         == __select_constructor::__deleted)
+      using __defaulted_constraints = decltype(::cuda::std::__tuple_get_constraints(__defaulted_list{}));
+      if constexpr (__defaulted_constraints::__select_default_constructible == __select_constructor::__invalid
+                    || __defaulted_constraints::__select_default_constructible == __select_constructor::__deleted)
       {
         return __select_constructor::__invalid;
       }
@@ -434,69 +460,14 @@ template <class _UTuple, class _TupleTypes, class _TupleIndices>
 inline constexpr __select_constructor __tuple_select_tuple_like_constructible_v =
   ::cuda::std::__tuple_select_tuple_like_constructible<_UTuple>(_TupleTypes{}, _TupleIndices{});
 
-_CCCL_EXEC_CHECK_DISABLE
-template <class _UTuple, class _Type, class... _Types, size_t _Index, size_t... _Indices>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL bool
-__tuple_nothrow_tuple_like_constructible(__tuple_types<_Type, _Types...>, __tuple_indices<_Index, _Indices...>) noexcept
-{
-  using ::cuda::std::get;
-  if constexpr (!is_nothrow_constructible_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
-  {
-    return false;
-  }
-  else if constexpr (sizeof...(_Types) != 0)
-  {
-    return ::cuda::std::__tuple_nothrow_tuple_like_constructible<_UTuple>(
-      __tuple_types<_Types...>{}, __tuple_indices<_Indices...>{});
-  }
-  else
-  {
-    return true;
-  }
-}
+template <class, class, class>
+inline constexpr bool __tuple_nothrow_tuple_like_constructible_v = false;
 
-template <class _UTuple>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL bool
-__tuple_nothrow_tuple_like_constructible(__tuple_types<>, __tuple_indices<>) noexcept
-{
-  return true;
-}
-
-template <class _UTuple, class _TupleTypes, class _TupleIndices>
-inline constexpr bool __tuple_nothrow_tuple_like_constructible_v =
-  ::cuda::std::__tuple_nothrow_tuple_like_constructible<_UTuple>(_TupleTypes{}, _TupleIndices{});
-
-struct _InvalidTupleComparison
-{
-  static constexpr bool __equality_comparable         = false;
-  static constexpr bool __nothrow_equality_comparable = false;
-
-  static constexpr bool __less_than_comparable         = false;
-  static constexpr bool __nothrow_less_than_comparable = false;
-};
-
-template <class, class>
-struct _TupleComparableTraits;
-
-template <class... _Types, class... _UTypes>
-struct _TupleComparableTraits<__tuple_types<_Types...>, __tuple_types<_UTypes...>>
-{
-  static constexpr bool __equality_comparable = (__is_cpp17_equality_comparable_v<_Types, _UTypes> && ...);
-  static constexpr bool __nothrow_equality_comparable =
-    (__is_cpp17_nothrow_equality_comparable_v<_Types, _UTypes> && ...);
-
-  static constexpr bool __less_than_comparable = (__is_cpp17_less_than_comparable_v<_Types, _UTypes> && ...);
-  static constexpr bool __nothrow_less_than_comparable =
-    (__is_cpp17_nothrow_less_than_comparable_v<_Types, _UTypes> && ...);
-};
-
-template <class... _Types, class... _UTypes, enable_if_t<(sizeof...(_Types) == sizeof...(_UTypes)), int> = 0>
-[[nodiscard]]
-_CCCL_API _CCCL_CONSTEVAL auto __tuple_is_comparable(__tuple_types<_Types...>, __tuple_types<_UTypes...>) noexcept
-  -> _TupleComparableTraits<__tuple_types<_Types...>, __tuple_types<_UTypes...>>;
-template <class>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __tuple_is_comparable(...) noexcept -> _InvalidTupleComparison;
-
+template <class _UTuple, class... _Types, size_t... _Indices>
+inline constexpr bool
+  __tuple_nothrow_tuple_like_constructible_v<_UTuple, __tuple_types<_Types...>, __tuple_indices<_Indices...>> =
+    (is_nothrow_constructible_v<_Types, decltype(::cuda::std::__adl_get<_Indices>(::cuda::std::declval<_UTuple>()))>
+     && ...);
 template <class... _Types>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_assignment
 __tuple_select_const_copy_assignable(__tuple_types<_Types...>) noexcept

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -193,8 +193,8 @@ struct __pair_base
   _T2 second;
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+  template <class _Constraints = __tuple_constraints<_T1, _T2>,
+            enable_if_t<__can_construct_implicitly<_Constraints::__select_default_constructible>, int> = 0>
   _CCCL_API constexpr __pair_base() noexcept(is_nothrow_default_constructible_v<_T1>
                                              && is_nothrow_default_constructible_v<_T2>)
       : first()
@@ -202,8 +202,8 @@ struct __pair_base
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+  template <class _Constraints = __tuple_constraints<_T1, _T2>,
+            enable_if_t<__can_construct_explicitly<_Constraints::__select_default_constructible>, int> = 0>
   _CCCL_API explicit constexpr __pair_base() noexcept(
     is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : first()
@@ -235,8 +235,8 @@ struct __pair_base<_T1, _T2, true>
   _T2 second;
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+  template <class _Constraints = __tuple_constraints<_T1, _T2>,
+            enable_if_t<__can_construct_implicitly<_Constraints::__select_default_constructible>, int> = 0>
   _CCCL_API constexpr __pair_base() noexcept(is_nothrow_default_constructible_v<_T1>
                                              && is_nothrow_default_constructible_v<_T2>)
       : first()
@@ -244,8 +244,8 @@ struct __pair_base<_T1, _T2, true>
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+  template <class _Constraints = __tuple_constraints<_T1, _T2>,
+            enable_if_t<__can_construct_explicitly<_Constraints::__select_default_constructible>, int> = 0>
   _CCCL_API explicit constexpr __pair_base() noexcept(
     is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : first()
@@ -305,14 +305,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   using first_type  = _T1;
   using second_type = _T2;
 
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+  template <class _Constraints = __tuple_constraints<_T1, _T2>,
+            enable_if_t<__can_construct_implicitly<_Constraints::__select_default_constructible>, int> = 0>
   _CCCL_API constexpr pair() noexcept(is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : __base()
   {}
 
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+  template <class _Constraints = __tuple_constraints<_T1, _T2>,
+            enable_if_t<__can_construct_explicitly<_Constraints::__select_default_constructible>, int> = 0>
   _CCCL_API explicit constexpr pair() noexcept(is_nothrow_default_constructible_v<_T1>
                                                && is_nothrow_default_constructible_v<_T2>)
       : __base()


### PR DESCRIPTION
It looks like there is a bug in gcc 11.2 where it does not recognize the emoty struct __tuple_types as a literal type.

We can work around this by moving the uses of that in SFINAE constraints into inline variables