### PR TITLE
Fix RAPIDS conda environment permissions

### DIFF
--- a/ci/rapids/rapids-entrypoint.sh
+++ b/ci/rapids/rapids-entrypoint.sh
@@ -9,6 +9,9 @@ if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
 fi
 
 ci/rapids/post-create-command.sh;
+mkdir -p "${HOME}/.conda/pkgs" "${HOME}/.conda/envs";
+sudo mkdir -p /opt/conda/pkgs /opt/conda/envs;
+sudo chown -R "$(id -u):$(id -g)" /opt/conda/pkgs /opt/conda/envs;
 rapids-post-start-command -f;
 
 if [[ -n "${GITHUB_ACTIONS:-}" ]]; then


### PR DESCRIPTION
## Summary

Fix RAPIDS devcontainer conda environment creation when the CCCL entrypoint switches from root to the runtime `coder` user.

The RAPIDS `26.06-cpp-mambaforge` image keeps `/opt/conda` root-owned, with `/opt/conda/pkgs` missing and `/opt/conda/envs` root-owned. `rapids-post-start-command -f` creates the `rapids` conda environment as `coder`, so libmamba fails to create `/opt/conda/pkgs` and `/opt/conda/envs/rapids/conda-meta`.

This prepares the conda directories immediately before RAPIDS environment creation:

- create `${HOME}/.conda/pkgs` and `${HOME}/.conda/envs` for RAPIDS env bookkeeping
- create `/opt/conda/pkgs` and `/opt/conda/envs`
- chown only those `/opt/conda` cache/env directories to the runtime user

The commit includes `[skip-matrix][skip-vdc][skip-docs][skip-matx][skip-pytorch]` so PR CI should skip the non-RAPIDS jobs while keeping RAPIDS third-party jobs enabled.

## Validation

- `bash -n ci/rapids/rapids-entrypoint.sh`
- `git diff --cached --check`
- `RAPIDS_LIBS=rmm CONDA_ENV_CREATE_QUIET=true .devcontainer/launch.sh -d -c 13.0 -H rapids-conda -- ./ci/rapids/rapids-entrypoint.sh /bin/bash -lc 'conda env list'`

The minimal RAPIDS launch created `rapids` at `/opt/conda/envs/rapids`; `/opt/conda/pkgs`, `/opt/conda/envs`, and `/opt/conda/envs/rapids` were owned by `coder`, with no conda permission errors.
