### PR TITLE
Disable Tile compilation mode

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -151,11 +151,7 @@
 #  define _CCCL_DEVICE_COMPILATION() 0
 #endif // ^^^ not compiling device code ^^^
 
-#if defined(__CUDACC_TILE__) && _CCCL_CUDA_COMPILER(NVCC, >, 13, 3)
-#  define _CCCL_TILE_COMPILATION() 1
-#else // ^^^ compiling .cu file in tile mode ^^^ / vvv not compiling in tile mode vvv
-#  define _CCCL_TILE_COMPILATION() 0
-#endif // ^^^ not compiling .cu file ^^^
+#define _CCCL_TILE_COMPILATION() 0
 
 #define _CCCL_CUDACC_MAKE_VERSION(_MAJOR, _MINOR) ((_MAJOR) * 1000 + (_MINOR) * 10)
 


### PR DESCRIPTION
## Description

Temporarily disables CCCL Tile compilation support for the 3.4.x patch release by forcing `_CCCL_TILE_COMPILATION()` to always evaluate to `0`.

## Validation

- `nvcc --enable-tile -Ilibcudacxx/include -x cu -c /tmp/cccl_tile_macro_check.cu -o /tmp/cccl_tile_macro_check.o`
- `pre-commit run --files libcudacxx/include/cuda/std/__cccl/compiler.h`
