### PR TITLE
Reduce PR NVHPC CI coverage

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -112,7 +112,8 @@ workflows:
     - {jobs: ['test'], project: 'nvbench_helper', ctk: '13.0', cxx: ['gcc15', 'clang20'], gpu: 'rtx2080'}
     - {jobs: ['test'], project: 'nvbench_helper', ctk: '13.X', cxx: ['gcc',   'clang'],   gpu: 'rtx2080'}
     # NVHPC build
-    - {jobs: ['build'], cxx: 'nvhpc', ctk: 'nvhpc', std: 'all', project: ['libcudacxx', 'cub', 'thrust', 'cudax', 'stdpar'], cpu: ['amd64', 'arm64']}
+    - {jobs: ['build'], cxx: 'nvhpc', ctk: 'nvhpc', std: 'max', project: ['libcudacxx', 'thrust', 'stdpar'], cpu: 'amd64'}
+    - {jobs: ['build_nolid'], cxx: 'nvhpc', ctk: 'nvhpc', std: 'max', project: 'cub', cpu: 'amd64'}
     # clang-cuda
     - {jobs: ['build'], cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda',  std: 'all', sm: '75;80;90;100;120'}
     - {jobs: ['build'], project: 'libcudacxx', cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda',  std: 23, sm: '75;80;90;100;120'}


### PR DESCRIPTION
## Summary

Reduce PR NVHPC coverage from 32 build jobs to 4:
- libcu++
- CUB BuildNoLaunch
- Thrust
- NVHPC stdpar

All four now use the latest C++ dialect on linux-amd64.

## Why

Recent PR CI history shows NVHPC costs ~9.4 aggregate CI hours per successful PR run. This keeps one current NVHPC signal per key project while dropping duplicated C++17, arm64, cudax, and extra CUB launch-mode coverage from per-PR CI.