### PR TITLE
CUB: Add a custom test wrapper with memory classification

### DIFF
--- a/cub/test/catch2_test_block_adjacent_difference.cu
+++ b/cub/test/catch2_test_block_adjacent_difference.cu
@@ -3,7 +3,7 @@
 
 #include <cub/block/block_adjacent_difference.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <int ThreadsInBlock, int ItemsPerThread, class T, class ActionT>
 __global__ void block_adj_diff_kernel(T* data, ActionT action, bool in_place)
@@ -217,8 +217,9 @@ struct params_t
   static constexpr bool read_left       = c2h::get<3, TestType>::value;
 };
 
-C2H_TEST("Block adjacent difference works with full tiles",
+CUB_TEST("Block adjacent difference works with full tiles",
          "[adjacent difference][block]",
+         CUB_SMALL,
          key_types,
          items_per_thread,
          threads_in_block,
@@ -240,8 +241,9 @@ C2H_TEST("Block adjacent difference works with full tiles",
   REQUIRE(h_data == d_data);
 }
 
-C2H_TEST("Block adjacent difference works with last tiles",
+CUB_TEST("Block adjacent difference works with last tiles",
          "[adjacent difference][block]",
+         CUB_SMALL,
          key_types,
          items_per_thread,
          threads_in_block,
@@ -265,8 +267,9 @@ C2H_TEST("Block adjacent difference works with last tiles",
   REQUIRE(h_data == d_data);
 }
 
-C2H_TEST("Block adjacent difference works with single tiles",
+CUB_TEST("Block adjacent difference works with single tiles",
          "[adjacent difference][block]",
+         CUB_SMALL,
          key_types,
          items_per_thread,
          threads_in_block,
@@ -293,8 +296,9 @@ C2H_TEST("Block adjacent difference works with single tiles",
   REQUIRE(h_data == d_data);
 }
 
-C2H_TEST("Block adjacent difference works with middle tiles",
+CUB_TEST("Block adjacent difference works with middle tiles",
          "[adjacent difference][block]",
+         CUB_SMALL,
          key_types,
          items_per_thread,
          threads_in_block,
@@ -319,7 +323,7 @@ C2H_TEST("Block adjacent difference works with middle tiles",
   REQUIRE(h_data == d_data);
 }
 
-C2H_TEST("Block adjacent difference supports custom types", "[adjacent difference][block]", threads_in_block)
+CUB_TEST("Block adjacent difference supports custom types", "[adjacent difference][block]", CUB_SMALL, threads_in_block)
 {
   using key_t = c2h::custom_type_t<c2h::equal_comparable_t, c2h::subtractable_t>;
 

--- a/cub/test/catch2_test_block_histogram.cu
+++ b/cub/test/catch2_test_block_histogram.cu
@@ -13,7 +13,7 @@
 #include <limits>
 #include <string>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <int BINS,
           int BLOCK_THREADS,
@@ -67,8 +67,9 @@ struct params_t
   static constexpr cub::BlockHistogramAlgorithm algorithm = c2h::get<4, TestType>::value;
 };
 
-C2H_TEST("Block histogram can be computed with uniform input",
+CUB_TEST("Block histogram can be computed with uniform input",
          "[histogram][block]",
+         CUB_SMALL,
          types,
          items_per_thread,
          threads_in_block,
@@ -107,8 +108,9 @@ c2h::host_vector<int> compute_host_reference(int bins, const c2h::host_vector<Sa
   return h_reference;
 }
 
-C2H_TEST("Block histogram can be computed with modulo input",
+CUB_TEST("Block histogram can be computed with modulo input",
          "[histogram][block]",
+         CUB_SMALL,
          types,
          items_per_thread,
          threads_in_block,
@@ -134,8 +136,9 @@ C2H_TEST("Block histogram can be computed with modulo input",
   REQUIRE(h_reference == d_histogram);
 }
 
-C2H_TEST("Block histogram can be computed with random input",
+CUB_TEST("Block histogram can be computed with random input",
          "[histogram][block]",
+         CUB_SMALL,
          types,
          items_per_thread,
          threads_in_block,

--- a/cub/test/catch2_test_block_load.cu
+++ b/cub/test/catch2_test_block_load.cu
@@ -6,7 +6,7 @@
 #include <cub/util_allocator.cuh>
 #include <cub/util_arch.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <int ItemsPerThread, int ThreadsInBlock, cub::BlockLoadAlgorithm LoadAlgorithm>
 static __device__ int get_output_idx(int item)
@@ -122,8 +122,9 @@ struct params_t
   static constexpr cub::BlockLoadAlgorithm load_algorithm = c2h::get<3, TestType>::value;
 };
 
-C2H_TEST("Block load works with even block sizes",
+CUB_TEST("Block load works with even block sizes",
          "[load][block]",
+         CUB_SMALL,
          types,
          items_per_thread,
          even_threads_in_block,
@@ -139,8 +140,9 @@ C2H_TEST("Block load works with even block sizes",
     d_input, thrust::raw_pointer_cast(d_input.data()));
 }
 
-C2H_TEST("Block load works with even odd sizes",
+CUB_TEST("Block load works with even odd sizes",
          "[load][block]",
+         CUB_SMALL,
          types,
          items_per_thread,
          odd_threads_in_block,
@@ -157,8 +159,13 @@ C2H_TEST("Block load works with even odd sizes",
 
 // WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
 #if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
-C2H_TEST(
-  "Block load works with even vector types", "[load][block]", vec_types, items_per_thread, a_block_size, load_algorithm)
+CUB_TEST("Block load works with even vector types",
+         "[load][block]",
+         CUB_SMALL,
+         vec_types,
+         items_per_thread,
+         a_block_size,
+         load_algorithm)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -170,7 +177,7 @@ C2H_TEST(
 }
 #endif // !(NVCC 12.0 and GCC 11.4 and C++20)
 
-C2H_TEST("Block load works with custom types", "[load][block]", items_per_thread, load_algorithm)
+CUB_TEST("Block load works with custom types", "[load][block]", CUB_SMALL, items_per_thread, load_algorithm)
 {
   using type                                              = c2h::custom_type_t<c2h::equal_comparable_t>;
   constexpr int items_per_thread                          = c2h::get<0, TestType>::value;
@@ -183,7 +190,7 @@ C2H_TEST("Block load works with custom types", "[load][block]", items_per_thread
   test_block_load<items_per_thread, threads_in_block, load_algorithm>(d_input, thrust::raw_pointer_cast(d_input.data()));
 }
 
-C2H_TEST("Block load works with caching iterators", "[load][block]", items_per_thread, load_algorithm)
+CUB_TEST("Block load works with caching iterators", "[load][block]", CUB_SMALL, items_per_thread, load_algorithm)
 {
   using type                                              = int;
   constexpr int items_per_thread                          = c2h::get<0, TestType>::value;
@@ -199,8 +206,9 @@ C2H_TEST("Block load works with caching iterators", "[load][block]", items_per_t
 }
 
 #if IPT == 1
-C2H_TEST("Vectorized block load with const and non-const datatype and different alignment cases",
+CUB_TEST("Vectorized block load with const and non-const datatype and different alignment cases",
          "[load][block]",
+         CUB_SMALL,
          c2h::type_list<const int*, int*>)
 {
   using type           = int;

--- a/cub/test/catch2_test_block_load_to_shared.cu
+++ b/cub/test/catch2_test_block_load_to_shared.cu
@@ -10,7 +10,7 @@
 #include <cuda/cmath>
 #include <cuda/std/type_traits>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 enum struct test_mode
 {
@@ -201,7 +201,7 @@ struct params_t
   static constexpr int tile_size        = items_per_thread * threads_in_block;
 };
 
-C2H_TEST("Block load to shared works", "[load][block]", types, items_per_thread, threads_in_block, modes)
+CUB_TEST("Block load to shared works", "[load][block]", CUB_SMALL, types, items_per_thread, threads_in_block, modes)
 {
   using params             = params_t<TestType>;
   using type               = typename params::type;
@@ -214,7 +214,12 @@ C2H_TEST("Block load to shared works", "[load][block]", types, items_per_thread,
     d_input, thrust::raw_pointer_cast(d_input.data()));
 }
 
-C2H_TEST("Block load to shared works with even vector types", "[load][block]", vec_types, items_per_thread, a_block_size)
+CUB_TEST("Block load to shared works with even vector types",
+         "[load][block]",
+         CUB_SMALL,
+         vec_types,
+         items_per_thread,
+         a_block_size)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -224,7 +229,7 @@ C2H_TEST("Block load to shared works with even vector types", "[load][block]", v
   test_block_load<params::items_per_thread, params::threads_in_block>(d_input, thrust::raw_pointer_cast(d_input.data()));
 }
 
-C2H_TEST("Block load to shared works with custom types", "[load][block]", items_per_thread)
+CUB_TEST("Block load to shared works with custom types", "[load][block]", CUB_SMALL, items_per_thread)
 {
   using type                     = c2h::custom_type_t<c2h::equal_comparable_t>;
   constexpr int items_per_thread = c2h::get<0, TestType>::value;
@@ -236,7 +241,8 @@ C2H_TEST("Block load to shared works with custom types", "[load][block]", items_
   test_block_load<items_per_thread, threads_in_block>(d_input, thrust::raw_pointer_cast(d_input.data()));
 }
 
-C2H_TEST("Block load to shared works with dyn smem and internal TempStorage", "[load][block]", items_per_thread)
+CUB_TEST(
+  "Block load to shared works with dyn smem and internal TempStorage", "[load][block]", CUB_SMALL, items_per_thread)
 {
   using type                     = int;
   constexpr int items_per_thread = c2h::get<0, TestType>::value;
@@ -249,8 +255,9 @@ C2H_TEST("Block load to shared works with dyn smem and internal TempStorage", "[
 }
 
 #if IPT == 1
-C2H_TEST("Block load to shared works with const and non-const datatype and different alignment cases",
+CUB_TEST("Block load to shared works with const and non-const datatype and different alignment cases",
          "[load][block]",
+         CUB_SMALL,
          c2h::type_list<const int*, int*>)
 {
   using type           = int;

--- a/cub/test/catch2_test_block_merge_sort.cu
+++ b/cub/test/catch2_test_block_merge_sort.cu
@@ -14,7 +14,7 @@
 
 #include <algorithm>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 struct CustomLess
 {
@@ -181,8 +181,9 @@ struct params_t
   static constexpr int tile_size        = items_per_thread * threads_in_block;
 };
 
-C2H_TEST("Block merge sort can sort keys in partial tiles",
+CUB_TEST("Block merge sort can sort keys in partial tiles",
          "[merge sort][block]",
+         CUB_SMALL,
          key_types,
          items_per_thread,
          threads_in_block)
@@ -204,8 +205,12 @@ C2H_TEST("Block merge sort can sort keys in partial tiles",
   REQUIRE(h_reference == d_keys);
 }
 
-C2H_TEST(
-  "Block merge sort can sort keys in full tiles", "[merge sort][block]", key_types, items_per_thread, threads_in_block)
+CUB_TEST("Block merge sort can sort keys in full tiles",
+         "[merge sort][block]",
+         CUB_SMALL,
+         key_types,
+         items_per_thread,
+         threads_in_block)
 {
   using params = params_t<TestType>;
   using key_t  = typename params::key_t;
@@ -224,8 +229,9 @@ C2H_TEST(
   REQUIRE(h_reference == d_keys);
 }
 
-C2H_TEST("Block merge sort can sort pairs in partial tiles",
+CUB_TEST("Block merge sort can sort pairs in partial tiles",
          "[merge sort][block]",
+         CUB_SMALL,
          key_types,
          items_per_thread,
          threads_in_block)
@@ -270,8 +276,12 @@ C2H_TEST("Block merge sort can sort pairs in partial tiles",
   REQUIRE(h_vals == d_vals);
 }
 
-C2H_TEST(
-  "Block merge sort can sort pairs in full tiles", "[merge sort][block]", key_types, items_per_thread, threads_in_block)
+CUB_TEST("Block merge sort can sort pairs in full tiles",
+         "[merge sort][block]",
+         CUB_SMALL,
+         key_types,
+         items_per_thread,
+         threads_in_block)
 {
   using params  = params_t<TestType>;
   using key_t   = typename params::key_t;
@@ -312,7 +322,7 @@ C2H_TEST(
   REQUIRE(h_vals == d_vals);
 }
 
-C2H_TEST("Block merge sort can sort pairs with mixed types", "[merge sort][block]", threads_in_block)
+CUB_TEST("Block merge sort can sort pairs with mixed types", "[merge sort][block]", CUB_SMALL, threads_in_block)
 {
   using key_t   = std::int32_t;
   using value_t = std::int64_t;
@@ -356,7 +366,7 @@ C2H_TEST("Block merge sort can sort pairs with mixed types", "[merge sort][block
   REQUIRE(h_vals == d_vals);
 }
 
-C2H_TEST("Block merge sort can sort large tiles", "[merge sort][block]", threads_in_block)
+CUB_TEST("Block merge sort can sort large tiles", "[merge sort][block]", CUB_SMALL, threads_in_block)
 {
   using key_t = std::uint16_t;
 
@@ -381,7 +391,7 @@ C2H_TEST("Block merge sort can sort large tiles", "[merge sort][block]", threads
   REQUIRE(h_reference == d_keys);
 }
 
-C2H_TEST("Block merge sort is stable", "[merge sort][block]", threads_in_block)
+CUB_TEST("Block merge sort is stable", "[merge sort][block]", CUB_SMALL, threads_in_block)
 {
   using key_t = c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>;
 

--- a/cub/test/catch2_test_block_prefetch.cu
+++ b/cub/test/catch2_test_block_prefetch.cu
@@ -12,7 +12,7 @@
 #include <cuda/std/memory>
 #include <cuda/stream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // BlockPrefetch emits global-memory prefetch *hints*: they carry no functional result and cannot be observed from
 // the device program. A runtime test can therefore only assert that issuing the hints compiles and never faults for
@@ -22,7 +22,9 @@
 // verified out-of-band (cuobjdump), not here.
 
 // Compile-time coverage of the trait that gates every hint.
-C2H_TEST("can_prefetch_from accepts contiguous iterators and rejects explicit cache paths", "[prefetch][block]")
+CUB_TEST("can_prefetch_from accepts contiguous iterators and rejects explicit cache paths",
+         "[prefetch][block]",
+         CUB_SMALL)
 {
   STATIC_REQUIRE(cub::detail::can_prefetch_from<int*>);
   STATIC_REQUIRE(cub::detail::can_prefetch_from<const double*>);
@@ -77,8 +79,9 @@ struct params_t
   static constexpr cub::detail::LoadPrefetch level = c2h::get<2, TestType>::value;
 };
 
-C2H_TEST("BlockPrefetch runs for every level and tile shape",
+CUB_TEST("BlockPrefetch runs for every level and tile shape",
          "[prefetch][block]",
+         CUB_SMALL,
          types,
          threads_in_block,
          load_prefetch_levels)
@@ -97,7 +100,7 @@ C2H_TEST("BlockPrefetch runs for every level and tile shape",
   test_block_prefetch<type, params::threads_in_block, params::level>(d_input, thrust::raw_pointer_cast(d_input.data()));
 }
 
-C2H_TEST("BlockPrefetch is a no-op for CacheModifiedInputIterator", "[prefetch][block]", load_prefetch_levels)
+CUB_TEST("BlockPrefetch is a no-op for CacheModifiedInputIterator", "[prefetch][block]", CUB_SMALL, load_prefetch_levels)
 {
   using type                                = int;
   constexpr int threads_in_block            = 128;
@@ -115,7 +118,7 @@ C2H_TEST("BlockPrefetch is a no-op for CacheModifiedInputIterator", "[prefetch][
   test_block_prefetch<type, threads_in_block, level>(d_input, in);
 }
 
-C2H_TEST("BlockPrefetch works with thrust vector iterators", "[prefetch][block]", load_prefetch_levels)
+CUB_TEST("BlockPrefetch works with thrust vector iterators", "[prefetch][block]", CUB_SMALL, load_prefetch_levels)
 {
   using type                                = int;
   constexpr int threads_in_block            = 128;
@@ -137,7 +140,7 @@ C2H_TEST("BlockPrefetch works with thrust vector iterators", "[prefetch][block]"
   test_block_prefetch<type, threads_in_block, level>(d_input, universal_input.cbegin());
 }
 
-C2H_TEST("BlockPrefetch works with cuda::buffer iterators", "[prefetch][block]", load_prefetch_levels)
+CUB_TEST("BlockPrefetch works with cuda::buffer iterators", "[prefetch][block]", CUB_SMALL, load_prefetch_levels)
 {
   using type                                = int;
   constexpr int threads_in_block            = 128;
@@ -165,7 +168,7 @@ C2H_TEST("BlockPrefetch works with cuda::buffer iterators", "[prefetch][block]",
   test_block_prefetch<type, threads_in_block, level>(d_input, buf.begin());
 }
 
-C2H_TEST("BlockPrefetch handles unaligned tile bases", "[prefetch][block]", c2h::type_list<uint8_t, int32_t>)
+CUB_TEST("BlockPrefetch handles unaligned tile bases", "[prefetch][block]", CUB_SMALL, c2h::type_list<uint8_t, int32_t>)
 {
   using type                     = c2h::get<0, TestType>;
   constexpr int threads_in_block = 128;
@@ -186,7 +189,7 @@ C2H_TEST("BlockPrefetch handles unaligned tile bases", "[prefetch][block]", c2h:
   test_block_prefetch<type, threads_in_block, cub::detail::LoadPrefetch::bulk_l2>(d_input, start);
 }
 
-C2H_TEST("BlockPrefetch honors a non-default stride", "[prefetch][block]")
+CUB_TEST("BlockPrefetch honors a non-default stride", "[prefetch][block]", CUB_SMALL)
 {
   using type                     = int;
   constexpr int threads_in_block = 64;

--- a/cub/test/catch2_test_block_radix_sort_custom.cu
+++ b/cub/test/catch2_test_block_radix_sort_custom.cu
@@ -7,6 +7,7 @@
 
 #include "catch2_test_block_radix_sort.cuh"
 #include "cub/block/radix_rank_sort_operations.cuh"
+#include "cub_test_macros.h"
 
 // example-begin custom-type
 struct custom_t
@@ -938,7 +939,7 @@ __global__ void sort_pairs_descending_blocked_to_striped_bits()
   REQUIRE_DEVICE(thread_values[threadIdx.x][1] == expected_values[threadIdx.x][1]);
 }
 
-TEST_CASE("Block radix sort works in some corner cases", "[radix][sort][block]")
+CUB_TEST_CASE("Block radix sort works in some corner cases", "[radix][sort][block]", CUB_SMALL)
 {
   sort_keys<<<1, 2>>>();
   REQUIRE(cudaSuccess == cudaGetLastError());

--- a/cub/test/catch2_test_block_radix_sort_keys.cu
+++ b/cub/test/catch2_test_block_radix_sort_keys.cu
@@ -8,7 +8,7 @@
 #include <utility>
 
 #include "catch2_test_block_radix_sort.cuh"
-#include <c2h/catch2_test_helper.h> // _CCCL_HAS_NVFP8()
+#include "cub_test_macros.h" // _CCCL_HAS_NVFP8()
 
 // %PARAM% TEST_MEMOIZE mem 0:1
 // %PARAM% TEST_ALGORITHM alg 0:1
@@ -75,8 +75,9 @@ bool binary_equal(
   return thrust::equal(c2h::device_policy, d_output_ptr, d_output_ptr + d_output.size(), d_reference_ptr);
 }
 
-C2H_TEST("Block radix sort can sort keys",
+CUB_TEST("Block radix sort can sort keys",
          "[radix][sort][block]",
+         CUB_SMALL,
          types,
          no_value_types,
          items_per_thread,
@@ -119,8 +120,9 @@ C2H_TEST("Block radix sort can sort keys",
   REQUIRE(binary_equal(d_output, h_reference, d_input));
 }
 
-C2H_TEST("Block radix sort can sort keys in descending order",
+CUB_TEST("Block radix sort can sort keys in descending order",
          "[radix][sort][block]",
+         CUB_SMALL,
          types,
          no_value_types,
          items_per_thread,

--- a/cub/test/catch2_test_block_radix_sort_pairs.cu
+++ b/cub/test/catch2_test_block_radix_sort_pairs.cu
@@ -8,7 +8,7 @@
 #include <utility>
 
 #include "catch2_test_block_radix_sort.cuh"
-#include <c2h/catch2_test_helper.h> // _CCCL_HAS_NVFP8()
+#include "cub_test_macros.h" // _CCCL_HAS_NVFP8()
 
 // %PARAM% TEST_MEMOIZE mem 0:1
 // %PARAM% TEST_ALGORITHM alg 0:1
@@ -78,8 +78,9 @@ bool binary_equal(
   return thrust::equal(c2h::device_policy, d_output_ptr, d_output_ptr + d_output.size(), d_reference_ptr);
 }
 
-C2H_TEST("Block radix sort can sort pairs",
+CUB_TEST("Block radix sort can sort pairs",
          "[radix][sort][block]",
+         CUB_SMALL,
          key_types,
          no_value_types,
          items_per_thread,
@@ -130,8 +131,9 @@ C2H_TEST("Block radix sort can sort pairs",
   REQUIRE(binary_equal(d_output_values, h_reference.second, d_input_values));
 }
 
-C2H_TEST("Block radix sort can sort pairs in descending order",
+CUB_TEST("Block radix sort can sort pairs in descending order",
          "[radix][sort][block]",
+         CUB_SMALL,
          key_types,
          no_value_types,
          items_per_thread,
@@ -182,8 +184,9 @@ C2H_TEST("Block radix sort can sort pairs in descending order",
   REQUIRE(binary_equal(d_output_values, h_reference.second, d_input_values));
 }
 
-C2H_TEST("Block radix sort can sort mixed pairs",
+CUB_TEST("Block radix sort can sort mixed pairs",
          "[radix][sort][block]",
+         CUB_SMALL,
          key_types,
          value_types,
          items_per_thread,
@@ -234,8 +237,9 @@ C2H_TEST("Block radix sort can sort mixed pairs",
   REQUIRE(d_output_values == h_reference.second);
 }
 
-C2H_TEST("Block radix sort can sort mixed pairs in descending order",
+CUB_TEST("Block radix sort can sort mixed pairs in descending order",
          "[radix][sort][block]",
+         CUB_SMALL,
          key_types,
          value_types,
          items_per_thread,

--- a/cub/test/catch2_test_block_reduce.cu
+++ b/cub/test/catch2_test_block_reduce.cu
@@ -6,7 +6,7 @@
 #include <limits>
 #include <numeric>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <cub::BlockReduceAlgorithm Algorithm,
           int ItemsPerThread,
@@ -136,8 +136,14 @@ struct params_t
   static constexpr cub::BlockReduceAlgorithm algorithm = c2h::get<4, TestType>::value;
 };
 
-C2H_TEST(
-  "Block reduce works with sum", "[reduce][block]", types, items_per_thread, block_dim_xs, block_dim_yzs, algorithm)
+CUB_TEST("Block reduce works with sum",
+         "[reduce][block]",
+         CUB_SMALL,
+         types,
+         items_per_thread,
+         block_dim_xs,
+         block_dim_yzs,
+         algorithm)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -162,8 +168,9 @@ C2H_TEST(
   REQUIRE_APPROX_EQ(h_reference, d_out);
 }
 
-C2H_TEST("Block reduce works with sum in partial tiles",
+CUB_TEST("Block reduce works with sum in partial tiles",
          "[reduce][block]",
+         CUB_SMALL,
          types,
          single_item_per_thread,
          block_dim_xs,
@@ -193,8 +200,9 @@ C2H_TEST("Block reduce works with sum in partial tiles",
   REQUIRE_APPROX_EQ(h_reference, d_out);
 }
 
-C2H_TEST("Block reduce works with custom op",
+CUB_TEST("Block reduce works with custom op",
          "[reduce][block]",
+         CUB_SMALL,
          types,
          items_per_thread,
          block_dim_xs,
@@ -224,8 +232,9 @@ C2H_TEST("Block reduce works with custom op",
   REQUIRE_APPROX_EQ(h_reference, d_out);
 }
 
-C2H_TEST("Block reduce works with custom op in partial tiles",
+CUB_TEST("Block reduce works with custom op in partial tiles",
          "[reduce][block]",
+         CUB_SMALL,
          types,
          single_item_per_thread,
          block_dim_xs,
@@ -255,7 +264,7 @@ C2H_TEST("Block reduce works with custom op in partial tiles",
   REQUIRE_APPROX_EQ(h_reference, d_out);
 }
 
-C2H_TEST("Block reduce works with custom types", "[reduce][block]", block_dim_xs, block_dim_yzs, algorithm)
+CUB_TEST("Block reduce works with custom types", "[reduce][block]", CUB_SMALL, block_dim_xs, block_dim_yzs, algorithm)
 {
   using type = c2h::custom_type_t<c2h::accumulateable_t, c2h::equal_comparable_t>;
 
@@ -283,7 +292,8 @@ C2H_TEST("Block reduce works with custom types", "[reduce][block]", block_dim_xs
   REQUIRE(h_reference == d_out);
 }
 
-C2H_TEST("Block reduce works with vec types", "[reduce][block]", vec_types, block_dim_xs, block_dim_yzs, algorithm)
+CUB_TEST(
+  "Block reduce works with vec types", "[reduce][block]", CUB_SMALL, vec_types, block_dim_xs, block_dim_yzs, algorithm)
 {
   using type = c2h::get<0, TestType>;
 

--- a/cub/test/catch2_test_block_run_length_decode.cu
+++ b/cub/test/catch2_test_block_run_length_decode.cu
@@ -13,7 +13,7 @@
 #include <cuda/iterator>
 #include <cuda/std/type_traits>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 /******************************************************************************
  * HELPER CLASS FOR RUN-LENGTH DECODING TESTS
@@ -470,9 +470,10 @@ struct params_t
   static constexpr int block_dim_z              = BlockDimZ;
 };
 
-C2H_TEST_LIST(
+CUB_TEST_LIST(
   "Block Run Length Decode works with run lengths and offsets relative to each run",
   "[rld][block]",
+  CUB_SMALL,
   params_t<1, 1, 64>,
   params_t<1, 3, 32, 2, 3>,
   params_t<1, 1, 128>,
@@ -494,10 +495,11 @@ C2H_TEST_LIST(
                               DO_TEST_RELATIVE_OFFSETS>();
 }
 
-C2H_TEST_LIST(
+CUB_TEST_LIST(
   "Block Run Length Decode works with run lengths and performs normal run-length "
   "decoding",
   "[rld][block]",
+  CUB_SMALL,
   params_t<1, 1, 64>,
   params_t<1, 3, 32, 2, 3>,
   params_t<1, 1, 128>,
@@ -519,10 +521,11 @@ C2H_TEST_LIST(
                               DO_NOT_TEST_RELATIVE_OFFSETS>();
 }
 
-C2H_TEST_LIST(
+CUB_TEST_LIST(
   "Block Run Length Decode works with run offsets and generates offsets relative to "
   "each run",
   "[rld][block]",
+  CUB_SMALL,
   params_t<1, 1, 64>,
   params_t<1, 3, 32, 2, 3>,
   params_t<1, 1, 128>,
@@ -544,10 +547,11 @@ C2H_TEST_LIST(
                               DO_TEST_RELATIVE_OFFSETS>();
 }
 
-C2H_TEST_LIST(
+CUB_TEST_LIST(
   "Block Run Length Decode works with run offsets and performs normal run-length "
   "decoding",
   "[rld][block]",
+  CUB_SMALL,
   params_t<1, 1, 64>,
   params_t<1, 3, 32, 2, 3>,
   params_t<1, 1, 128>,

--- a/cub/test/catch2_test_block_scan.cu
+++ b/cub/test/catch2_test_block_scan.cu
@@ -5,7 +5,7 @@
 
 #include <climits>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <cub::BlockScanAlgorithm Algorithm,
           int ItemsPerThread,
@@ -394,8 +394,15 @@ struct params_t
   static constexpr scan_mode mode                    = c2h::get<5, TestType>::value;
 };
 
-C2H_TEST(
-  "Block scan works with sum", "[scan][block]", types, block_dim_x, block_dim_yz, items_per_thread, algorithm, modes)
+CUB_TEST("Block scan works with sum",
+         "[scan][block]",
+         CUB_SMALL,
+         types,
+         block_dim_x,
+         block_dim_yz,
+         items_per_thread,
+         algorithm,
+         modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -413,8 +420,9 @@ C2H_TEST(
   REQUIRE_APPROX_EQ(h_out, d_out);
 }
 
-C2H_TEST("Block scan works with sum single",
+CUB_TEST("Block scan works with sum single",
          "[scan][block]",
+         CUB_SMALL,
          types,
          block_dim_x,
          block_dim_yz,
@@ -438,7 +446,7 @@ C2H_TEST("Block scan works with sum single",
   REQUIRE_APPROX_EQ(h_out, d_out);
 }
 
-C2H_TEST("Block scan works with vec types", "[scan][block]", vec_types, algorithm, modes)
+CUB_TEST("Block scan works with vec types", "[scan][block]", CUB_SMALL, vec_types, algorithm, modes)
 {
   constexpr int items_per_thread              = 3;
   constexpr int block_dim_x                   = 256;
@@ -462,7 +470,7 @@ C2H_TEST("Block scan works with vec types", "[scan][block]", vec_types, algorith
   REQUIRE(h_out == d_out);
 }
 
-C2H_TEST("Block scan works with custom types", "[scan][block]", algorithm, modes)
+CUB_TEST("Block scan works with custom types", "[scan][block]", CUB_SMALL, algorithm, modes)
 {
   constexpr int items_per_thread              = 3;
   constexpr int block_dim_x                   = 256;
@@ -486,7 +494,7 @@ C2H_TEST("Block scan works with custom types", "[scan][block]", algorithm, modes
   REQUIRE(h_out == d_out);
 }
 
-C2H_TEST("Block scan returns valid block aggregate", "[scan][block]", algorithm, modes, block_dim_yz)
+CUB_TEST("Block scan returns valid block aggregate", "[scan][block]", CUB_SMALL, algorithm, modes, block_dim_yz)
 {
   constexpr int items_per_thread              = 3;
   constexpr int block_dim_x                   = 64;
@@ -516,7 +524,7 @@ C2H_TEST("Block scan returns valid block aggregate", "[scan][block]", algorithm,
   REQUIRE(block_aggregate == d_block_aggregate[0]);
 }
 
-C2H_TEST("Block scan supports prefix op", "[scan][block]", algorithm, modes, block_dim_yz)
+CUB_TEST("Block scan supports prefix op", "[scan][block]", CUB_SMALL, algorithm, modes, block_dim_yz)
 {
   constexpr int items_per_thread              = 3;
   constexpr int block_dim_x                   = 64;
@@ -544,7 +552,7 @@ C2H_TEST("Block scan supports prefix op", "[scan][block]", algorithm, modes, blo
   REQUIRE(h_out == d_out);
 }
 
-C2H_TEST("Block scan supports custom scan op", "[scan][block]", algorithm, modes, block_dim_yz)
+CUB_TEST("Block scan supports custom scan op", "[scan][block]", CUB_SMALL, algorithm, modes, block_dim_yz)
 {
   constexpr int items_per_thread              = 3;
   constexpr int block_dim_x                   = 64;
@@ -582,7 +590,7 @@ C2H_TEST("Block scan supports custom scan op", "[scan][block]", algorithm, modes
   REQUIRE(h_out == d_out);
 }
 
-C2H_TEST("Block custom op scan works with initial value", "[scan][block]", algorithm, modes, block_dim_yz)
+CUB_TEST("Block custom op scan works with initial value", "[scan][block]", CUB_SMALL, algorithm, modes, block_dim_yz)
 {
   constexpr int items_per_thread              = 3;
   constexpr int block_dim_x                   = 64;
@@ -616,8 +624,9 @@ C2H_TEST("Block custom op scan works with initial value", "[scan][block]", algor
   REQUIRE(h_out == d_out);
 }
 
-C2H_TEST("Block custom op scan with initial value returns valid block aggregate",
+CUB_TEST("Block custom op scan with initial value returns valid block aggregate",
          "[scan][block]",
+         CUB_SMALL,
          algorithm,
          modes,
          block_dim_yz)
@@ -662,7 +671,7 @@ C2H_TEST("Block custom op scan with initial value returns valid block aggregate"
   REQUIRE(h_block_aggregate == d_block_aggregate[0]);
 }
 
-C2H_TEST("Block scan supports prefix op and custom scan op", "[scan][block]", algorithm, modes, block_dim_yz)
+CUB_TEST("Block scan supports prefix op and custom scan op", "[scan][block]", CUB_SMALL, algorithm, modes, block_dim_yz)
 {
   constexpr int items_per_thread              = 3;
   constexpr int block_dim_x                   = 64;

--- a/cub/test/catch2_test_block_scan_api.cu
+++ b/cub/test/catch2_test_block_scan_api.cu
@@ -9,7 +9,7 @@
 
 #include <cuda/std/numeric>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 constexpr int num_items_per_thread = 2;
 constexpr int block_num_threads    = 64;
@@ -41,7 +41,7 @@ __global__ void InclusiveBlockScanKernel(int* output)
   output[threadIdx.x * 2 + 1] = thread_data[1];
 }
 
-C2H_TEST("Block array-based inclusive scan works with initial value", "[scan][block]")
+CUB_TEST("Block array-based inclusive scan works with initial value", "[scan][block]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(block_num_threads * num_items_per_thread);
 
@@ -95,7 +95,7 @@ __global__ void InclusiveBlockScanKernelAggregate(int* output, int* d_block_aggr
   output[threadIdx.x * 2 + 1] = thread_data[1];
 }
 
-C2H_TEST("Block array-based inclusive scan with block aggregate works with initial value", "[scan][block]")
+CUB_TEST("Block array-based inclusive scan with block aggregate works with initial value", "[scan][block]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(block_num_threads * num_items_per_thread);
 

--- a/cub/test/catch2_test_block_shuffle.cu
+++ b/cub/test/catch2_test_block_shuffle.cu
@@ -14,7 +14,7 @@
 
 #include <algorithm>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <int BlockDimX, int BlockDimY, int BlockDimZ, int ItemsPerThread, class T, class ActionT>
 __global__ void block_shuffle_kernel(T* data, ActionT action)
@@ -183,7 +183,8 @@ struct params_t
   static constexpr int tile_size        = items_per_thread * threads_in_block;
 };
 
-C2H_TEST("Block shuffle offset works", "[shuffle][block]", types, single_item_per_thread, block_dim_x, block_dim_yz)
+CUB_TEST(
+  "Block shuffle offset works", "[shuffle][block]", CUB_SMALL, types, single_item_per_thread, block_dim_x, block_dim_yz)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -208,7 +209,8 @@ C2H_TEST("Block shuffle offset works", "[shuffle][block]", types, single_item_pe
   REQUIRE(h_ref == d_data);
 }
 
-C2H_TEST("Block shuffle rotate works", "[shuffle][block]", types, single_item_per_thread, block_dim_x, block_dim_yz)
+CUB_TEST(
+  "Block shuffle rotate works", "[shuffle][block]", CUB_SMALL, types, single_item_per_thread, block_dim_x, block_dim_yz)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -229,7 +231,7 @@ C2H_TEST("Block shuffle rotate works", "[shuffle][block]", types, single_item_pe
   REQUIRE(h_ref == d_data);
 }
 
-C2H_TEST("Block shuffle up works", "[shuffle][block]", types, items_per_thread, block_dim_x, block_dim_yz)
+CUB_TEST("Block shuffle up works", "[shuffle][block]", CUB_SMALL, types, items_per_thread, block_dim_x, block_dim_yz)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -247,8 +249,9 @@ C2H_TEST("Block shuffle up works", "[shuffle][block]", types, items_per_thread, 
   REQUIRE(d_ref == d_data);
 }
 
-C2H_TEST("Block shuffle up works when suffix is required",
+CUB_TEST("Block shuffle up works when suffix is required",
          "[shuffle][block]",
+         CUB_SMALL,
          types,
          items_per_thread,
          block_dim_x,
@@ -277,7 +280,7 @@ C2H_TEST("Block shuffle up works when suffix is required",
   REQUIRE(d_suffix_ref == d_suffix);
 }
 
-C2H_TEST("Block shuffle down works", "[shuffle][block]", types, items_per_thread, block_dim_x, block_dim_yz)
+CUB_TEST("Block shuffle down works", "[shuffle][block]", CUB_SMALL, types, items_per_thread, block_dim_x, block_dim_yz)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -295,8 +298,9 @@ C2H_TEST("Block shuffle down works", "[shuffle][block]", types, items_per_thread
   REQUIRE(d_ref == d_data);
 }
 
-C2H_TEST("Block shuffle down works when prefix is required",
+CUB_TEST("Block shuffle down works when prefix is required",
          "[shuffle][block]",
+         CUB_SMALL,
          types,
          items_per_thread,
          block_dim_x,

--- a/cub/test/catch2_test_block_store.cu
+++ b/cub/test/catch2_test_block_store.cu
@@ -6,7 +6,7 @@
 #include <cub/util_allocator.cuh>
 #include <cub/util_arch.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <int ItemsPerThread, int ThreadsInBlock, cub::BlockStoreAlgorithm /* StoreAlgorithm */>
 struct output_idx
@@ -136,8 +136,9 @@ struct params_t
   static constexpr cub::BlockStoreAlgorithm store_algorithm = c2h::get<3, TestType>::value;
 };
 
-C2H_TEST("Block store works with even block sizes",
+CUB_TEST("Block store works with even block sizes",
          "[store][block]",
+         CUB_SMALL,
          types,
          items_per_thread,
          even_threads_in_block,
@@ -159,8 +160,9 @@ C2H_TEST("Block store works with even block sizes",
   REQUIRE(d_input == d_output);
 }
 
-C2H_TEST("Block store works with even odd sizes",
+CUB_TEST("Block store works with even odd sizes",
          "[store][block]",
+         CUB_SMALL,
          types,
          items_per_thread,
          odd_threads_in_block,
@@ -184,8 +186,9 @@ C2H_TEST("Block store works with even odd sizes",
 
 // WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
 #if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
-C2H_TEST("Block store works with even vector types",
+CUB_TEST("Block store works with even vector types",
          "[store][block]",
+         CUB_SMALL,
          vec_types,
          items_per_thread,
          a_block_size,
@@ -208,7 +211,7 @@ C2H_TEST("Block store works with even vector types",
 }
 #endif // !(NVCC 12.0 and GCC 11.4 and C++20)
 
-C2H_TEST("Block store works with custom types", "[store][block]", items_per_thread, store_algorithm)
+CUB_TEST("Block store works with custom types", "[store][block]", CUB_SMALL, items_per_thread, store_algorithm)
 {
   using type                                                = c2h::custom_type_t<c2h::equal_comparable_t>;
   constexpr int items_per_thread                            = c2h::get<0, TestType>::value;
@@ -229,7 +232,7 @@ C2H_TEST("Block store works with custom types", "[store][block]", items_per_thre
   REQUIRE(d_input == d_output);
 }
 
-C2H_TEST("Block store works with caching iterators", "[store][block]", items_per_thread, store_algorithm)
+CUB_TEST("Block store works with caching iterators", "[store][block]", CUB_SMALL, items_per_thread, store_algorithm)
 {
   using type                                                = int;
   constexpr int items_per_thread                            = c2h::get<0, TestType>::value;
@@ -251,7 +254,10 @@ C2H_TEST("Block store works with caching iterators", "[store][block]", items_per
 }
 
 #if IPT == 1
-C2H_TEST("Vectorized block store with different alignment cases", "[store][block]", c2h::enum_type_list<int, 1, 4, 7>)
+CUB_TEST("Vectorized block store with different alignment cases",
+         "[store][block]",
+         CUB_SMALL,
+         c2h::enum_type_list<int, 1, 4, 7>)
 {
   using type                     = int;
   constexpr int items_per_thread = c2h::get<0, TestType>::value;

--- a/cub/test/catch2_test_block_topk.cu
+++ b/cub/test/catch2_test_block_topk.cu
@@ -16,7 +16,7 @@
 #include <cmath>
 
 #include "catch2_test_block_topk_common.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace
 {
@@ -103,7 +103,8 @@ struct block_shape
 using block_shapes_full_tile =
   c2h::type_list<block_shape<64, 8>, block_shape<256, 2>, block_shape<32, 16>, block_shape<128, 4>>;
 
-C2H_TEST("block_topk preserves keys across FP edge cases", "[block][topk]", fp_key_types, select_direction_max)
+CUB_TEST(
+  "block_topk preserves keys across FP edge cases", "[block][topk]", CUB_SMALL, fp_key_types, select_direction_max)
 {
   using key_t                            = c2h::get<0, TestType>;
   static constexpr bool select_max       = c2h::get<1, TestType>::value;
@@ -147,8 +148,9 @@ C2H_TEST("block_topk preserves keys across FP edge cases", "[block][topk]", fp_k
   }
 }
 
-C2H_TEST("block_topk::select_* selects the right top-k on a full tile",
+CUB_TEST("block_topk::select_* selects the right top-k on a full tile",
          "[block][topk]",
+         CUB_SMALL,
          fp_key_types,
          block_shapes_full_tile,
          select_direction_max)
@@ -190,7 +192,7 @@ C2H_TEST("block_topk::select_* selects the right top-k on a full tile",
   }
 }
 
-C2H_TEST("block_topk::{Min,Max}Keys preserve -0.0 in output", "[block][topk][float]", select_direction_max)
+CUB_TEST("block_topk::{Min,Max}Keys preserve -0.0 in output", "[block][topk][float]", CUB_SMALL, select_direction_max)
 {
   static constexpr bool select_max       = c2h::get<0, TestType>::value;
   static constexpr int threads_per_block = 128;

--- a/cub/test/catch2_test_c2h_checked_cuda_allocator.cu
+++ b/cub/test/catch2_test_c2h_checked_cuda_allocator.cu
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <new> // std::bad_alloc
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 std::size_t get_alloc_bytes()
 {
@@ -24,8 +24,9 @@ std::size_t get_alloc_bytes()
   return alloc_bytes;
 }
 
-C2H_TEST("c2h::device_vector throws when requested allocations exceed free device memory",
-         "[c2h][checked_cuda_allocator][device_vector]")
+CUB_TEST("c2h::device_vector throws when requested allocations exceed free device memory",
+         "[c2h][checked_cuda_allocator][device_vector]",
+         CUB_SMALL)
 {
   c2h::device_vector<char> vec;
 
@@ -33,8 +34,9 @@ C2H_TEST("c2h::device_vector throws when requested allocations exceed free devic
   REQUIRE_THROWS_AS(vec.resize(alloc_bytes), std::bad_alloc);
 }
 
-C2H_TEST("c2h::device_policy throws when requested allocations exceed free device memory",
-         "[c2h][checked_cuda_allocator][device_policy]")
+CUB_TEST("c2h::device_policy throws when requested allocations exceed free device memory",
+         "[c2h][checked_cuda_allocator][device_policy]",
+         CUB_SMALL)
 {
   cuda::std::pair<char*, std::ptrdiff_t> buffer{nullptr, 0};
   auto policy = thrust::detail::derived_cast(thrust::detail::strip_const(c2h::device_policy));

--- a/cub/test/catch2_test_cc_dispatch.cu
+++ b/cub/test/catch2_test_cc_dispatch.cu
@@ -5,7 +5,7 @@
 
 #include <cuda/std/__algorithm/find_if.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using cuda::compute_capability;
 
@@ -60,7 +60,9 @@ struct closure_all
   }
 };
 
-C2H_TEST("dispatch_compute_cap prunes based on __CUDA_ARCH_LIST__/NV_TARGET_SM_INTEGER_LIST", "[util][dispatch]")
+CUB_TEST("dispatch_compute_cap prunes based on __CUDA_ARCH_LIST__/NV_TARGET_SM_INTEGER_LIST",
+         "[util][dispatch]",
+         CUB_SMALL)
 {
   for (const auto cc : cuda::__target_compute_capabilities())
   {
@@ -115,7 +117,7 @@ struct policy_selector_minimal
   }
 };
 
-C2H_TEST("dispatch_compute_cap invokes correct policy", "[util][dispatch]")
+CUB_TEST("dispatch_compute_cap invokes correct policy", "[util][dispatch]", CUB_SMALL)
 {
   for (const auto cc : cuda::__target_compute_capabilities())
   {
@@ -140,7 +142,7 @@ struct policy_selector_not_regular
   }
 };
 
-C2H_TEST("policy_selector concept", "[util][dispatch]")
+CUB_TEST("policy_selector concept", "[util][dispatch]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cub::detail::policy_selector<policy_selector_all, a_policy>);
   STATIC_REQUIRE(::cub::detail::policy_selector<policy_selector_some, a_policy>);

--- a/cub/test/catch2_test_debug.cu
+++ b/cub/test/catch2_test_debug.cu
@@ -1,15 +1,15 @@
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-TEST_CASE("CubDebug returns input error", "[debug][utils]")
+CUB_TEST_CASE("CubDebug returns input error", "[debug][utils]", CUB_SMALL)
 {
   REQUIRE(CubDebug(cudaSuccess) == cudaSuccess);
   REQUIRE(CubDebug(cudaErrorInvalidConfiguration) == cudaErrorInvalidConfiguration);
 }
 
-TEST_CASE("CubDebug returns new errors", "[debug][utils]")
+CUB_TEST_CASE("CubDebug returns new errors", "[debug][utils]", CUB_SMALL)
 {
   cub::detail::EmptyKernel<int><<<0, 0>>>();
   cudaError error = cudaPeekAtLastError();
@@ -18,7 +18,7 @@ TEST_CASE("CubDebug returns new errors", "[debug][utils]")
   REQUIRE(CubDebug(cudaSuccess) != cudaSuccess);
 }
 
-TEST_CASE("CubDebug prefers input errors", "[debug][utils]")
+CUB_TEST_CASE("CubDebug prefers input errors", "[debug][utils]", CUB_SMALL)
 {
   cub::detail::EmptyKernel<int><<<0, 0>>>();
   cudaError error = cudaPeekAtLastError();
@@ -27,7 +27,7 @@ TEST_CASE("CubDebug prefers input errors", "[debug][utils]")
   REQUIRE(CubDebug(cudaErrorMemoryAllocation) != cudaSuccess);
 }
 
-TEST_CASE("CubDebug resets last error", "[debug][utils]")
+CUB_TEST_CASE("CubDebug resets last error", "[debug][utils]", CUB_SMALL)
 {
   cub::detail::EmptyKernel<int><<<0, 0>>>();
   cudaError error = cudaPeekAtLastError();

--- a/cub/test/catch2_test_device_adjacent_difference_api.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_api.cu
@@ -5,14 +5,16 @@
 
 #include <cub/device/device_adjacent_difference.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // Guard: the legacy memory-size query call with all defaults (no explicit difference_op,
 // no explicit stream) must resolve unambiguously to the legacy temp-storage overload
 // when the env passthrough overload is also visible. If the env overload's SFINAE
 // is too loose, this becomes "ambiguous overload" or silently dispatches to env.
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy legacy size-query is unambiguous", "[adjacent_difference][device]")
+CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy legacy size-query is unambiguous",
+         "[adjacent_difference][device]",
+         CUB_SMALL)
 {
   int* d_in    = nullptr;
   int* d_out   = nullptr;
@@ -22,7 +24,9 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy legacy size-query is unambi
   REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractLeftCopy(nullptr, bytes, d_in, d_out, n));
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeft legacy size-query is unambiguous", "[adjacent_difference][device]")
+CUB_TEST("DeviceAdjacentDifference::SubtractLeft legacy size-query is unambiguous",
+         "[adjacent_difference][device]",
+         CUB_SMALL)
 {
   int* d_in    = nullptr;
   size_t bytes = 0;
@@ -31,8 +35,9 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft legacy size-query is unambiguou
   REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractLeft(nullptr, bytes, d_in, n));
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy legacy size-query is unambiguous",
-         "[adjacent_difference][device]")
+CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy legacy size-query is unambiguous",
+         "[adjacent_difference][device]",
+         CUB_SMALL)
 {
   int* d_in    = nullptr;
   int* d_out   = nullptr;
@@ -42,7 +47,9 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy legacy size-query is unamb
   REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractRightCopy(nullptr, bytes, d_in, d_out, n));
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRight legacy size-query is unambiguous", "[adjacent_difference][device]")
+CUB_TEST("DeviceAdjacentDifference::SubtractRight legacy size-query is unambiguous",
+         "[adjacent_difference][device]",
+         CUB_SMALL)
 {
   int* d_in    = nullptr;
   size_t bytes = 0;

--- a/cub/test/catch2_test_device_adjacent_difference_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_custom_policy_hub.cu
@@ -15,7 +15,7 @@
 #include <cuda/std/functional>
 #include <cuda/std/numeric>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -36,7 +36,7 @@ struct my_policy_hub
   };
 };
 
-C2H_TEST("DispatchAdjacentDifference::Dispatch: custom policy hub", "[device][adjacent_difference]")
+CUB_TEST("DispatchAdjacentDifference::Dispatch: custom policy hub", "[device][adjacent_difference]", CUB_SMALL)
 {
   using value_t            = int;
   using offset_t           = unsigned;

--- a/cub/test/catch2_test_device_adjacent_difference_env.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env.cu
@@ -25,14 +25,15 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceAdjacentDifference::SubtractRight, device_adja
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("Device adjacent difference subtract left copy works with default environment",
-          "[adjacent_difference][device]")
+CUB_TEST_CASE("Device adjacent difference subtract left copy works with default environment",
+              "[adjacent_difference][device]",
+              CUB_SMALL)
 {
   auto input  = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
   auto output = c2h::device_vector<int>(8);
@@ -45,7 +46,9 @@ TEST_CASE("Device adjacent difference subtract left copy works with default envi
   REQUIRE(output == expected);
 }
 
-TEST_CASE("Device adjacent difference subtract left works with default environment", "[adjacent_difference][device]")
+CUB_TEST_CASE("Device adjacent difference subtract left works with default environment",
+              "[adjacent_difference][device]",
+              CUB_SMALL)
 {
   auto data = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
 
@@ -55,8 +58,9 @@ TEST_CASE("Device adjacent difference subtract left works with default environme
   REQUIRE(data == expected);
 }
 
-TEST_CASE("Device adjacent difference subtract right copy works with default environment",
-          "[adjacent_difference][device]")
+CUB_TEST_CASE("Device adjacent difference subtract right copy works with default environment",
+              "[adjacent_difference][device]",
+              CUB_SMALL)
 {
   auto input  = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
   auto output = c2h::device_vector<int>(8);
@@ -69,7 +73,9 @@ TEST_CASE("Device adjacent difference subtract right copy works with default env
   REQUIRE(output == expected);
 }
 
-TEST_CASE("Device adjacent difference subtract right works with default environment", "[adjacent_difference][device]")
+CUB_TEST_CASE("Device adjacent difference subtract right works with default environment",
+              "[adjacent_difference][device]",
+              CUB_SMALL)
 {
   auto data = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
 
@@ -81,7 +87,7 @@ TEST_CASE("Device adjacent difference subtract right works with default environm
 
 #endif
 
-C2H_TEST("Device adjacent difference subtract left copy uses environment", "[adjacent_difference][device]")
+CUB_TEST("Device adjacent difference subtract left copy uses environment", "[adjacent_difference][device]", CUB_SMALL)
 {
   auto input  = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
   auto output = c2h::device_vector<int>(8);
@@ -99,7 +105,7 @@ C2H_TEST("Device adjacent difference subtract left copy uses environment", "[adj
   REQUIRE(output == expected);
 }
 
-C2H_TEST("Device adjacent difference subtract left uses environment", "[adjacent_difference][device]")
+CUB_TEST("Device adjacent difference subtract left uses environment", "[adjacent_difference][device]", CUB_SMALL)
 {
   auto data = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
 
@@ -116,7 +122,7 @@ C2H_TEST("Device adjacent difference subtract left uses environment", "[adjacent
   REQUIRE(data == expected);
 }
 
-C2H_TEST("Device adjacent difference subtract right copy uses environment", "[adjacent_difference][device]")
+CUB_TEST("Device adjacent difference subtract right copy uses environment", "[adjacent_difference][device]", CUB_SMALL)
 {
   auto input  = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
   auto output = c2h::device_vector<int>(8);
@@ -134,7 +140,7 @@ C2H_TEST("Device adjacent difference subtract right copy uses environment", "[ad
   REQUIRE(output == expected);
 }
 
-C2H_TEST("Device adjacent difference subtract right uses environment", "[adjacent_difference][device]")
+CUB_TEST("Device adjacent difference subtract right uses environment", "[adjacent_difference][device]", CUB_SMALL)
 {
   auto data = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
 
@@ -179,7 +185,8 @@ struct adj_diff_tuning
 using block_sizes =
   c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy can be tuned", "[adjacent_difference][device]", block_sizes)
+CUB_TEST(
+  "DeviceAdjacentDifference::SubtractLeftCopy can be tuned", "[adjacent_difference][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto input                               = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
@@ -195,7 +202,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy can be tuned", "[adjacent_d
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeft can be tuned", "[adjacent_difference][device]", block_sizes)
+CUB_TEST("DeviceAdjacentDifference::SubtractLeft can be tuned", "[adjacent_difference][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto data                                = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
@@ -210,7 +217,8 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft can be tuned", "[adjacent_diffe
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy can be tuned", "[adjacent_difference][device]", block_sizes)
+CUB_TEST(
+  "DeviceAdjacentDifference::SubtractRightCopy can be tuned", "[adjacent_difference][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto input                               = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
@@ -226,7 +234,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy can be tuned", "[adjacent_
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRight can be tuned", "[adjacent_difference][device]", block_sizes)
+CUB_TEST("DeviceAdjacentDifference::SubtractRight can be tuned", "[adjacent_difference][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto data                                = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
@@ -244,7 +252,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight can be tuned", "[adjacent_diff
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test AdjacentDifferencePolicy properties", "[adjacent_difference][device]")
+CUB_TEST("Test AdjacentDifferencePolicy properties", "[adjacent_difference][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::AdjacentDifferencePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::AdjacentDifferencePolicy>);

--- a/cub/test/catch2_test_device_adjacent_difference_env_api.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env_api.cu
@@ -13,9 +13,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceAdjacentDifference::SubtractLeftCopy accepts stream", "[adjacent_difference][env]")
+CUB_TEST("cub::DeviceAdjacentDifference::SubtractLeftCopy accepts stream", "[adjacent_difference][env]", CUB_SMALL)
 {
   // example-begin subtract-left-copy-env-stream
   auto input  = thrust::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
@@ -38,7 +38,7 @@ C2H_TEST("cub::DeviceAdjacentDifference::SubtractLeftCopy accepts stream", "[adj
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceAdjacentDifference::SubtractLeft accepts stream", "[adjacent_difference][env]")
+CUB_TEST("cub::DeviceAdjacentDifference::SubtractLeft accepts stream", "[adjacent_difference][env]", CUB_SMALL)
 {
   // example-begin subtract-left-env-stream
   auto data = thrust::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
@@ -60,7 +60,7 @@ C2H_TEST("cub::DeviceAdjacentDifference::SubtractLeft accepts stream", "[adjacen
   REQUIRE(data == expected);
 }
 
-C2H_TEST("cub::DeviceAdjacentDifference::SubtractRightCopy accepts stream", "[adjacent_difference][env]")
+CUB_TEST("cub::DeviceAdjacentDifference::SubtractRightCopy accepts stream", "[adjacent_difference][env]", CUB_SMALL)
 {
   // example-begin subtract-right-copy-env-stream
   auto input  = thrust::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
@@ -84,7 +84,7 @@ C2H_TEST("cub::DeviceAdjacentDifference::SubtractRightCopy accepts stream", "[ad
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceAdjacentDifference::SubtractRight accepts stream", "[adjacent_difference][env]")
+CUB_TEST("cub::DeviceAdjacentDifference::SubtractRight accepts stream", "[adjacent_difference][env]", CUB_SMALL)
 {
   // example-begin subtract-right-env-stream
   auto data = thrust::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
@@ -122,8 +122,9 @@ struct AdjacentDifferencePolicySelector
 };
 // example-end subtract-left-copy-policy-selector
 
-C2H_TEST("cub::DeviceAdjacentDifference::SubtractLeftCopy accepts a custom policy selector",
-         "[adjacent_difference][env]")
+CUB_TEST("cub::DeviceAdjacentDifference::SubtractLeftCopy accepts a custom policy selector",
+         "[adjacent_difference][env]",
+         CUB_SMALL)
 {
   // example-begin subtract-left-copy-tuning
   auto input  = thrust::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};

--- a/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
@@ -14,7 +14,7 @@
 #include <numeric>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceAdjacentDifference::SubtractLeft, adjacent_difference_subtract_left);
@@ -32,7 +32,8 @@ using all_types =
 
 using types = c2h::type_list<std::uint8_t, std::int32_t>;
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeft can run with empty input", "[device][adjacent_difference]", types)
+CUB_TEST(
+  "DeviceAdjacentDifference::SubtractLeft can run with empty input", "[device][adjacent_difference]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -42,7 +43,10 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft can run with empty input", "[de
   adjacent_difference_subtract_left(in.begin(), num_items, cuda::std::minus<>{});
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy can run with empty input", "[device][adjacent_difference]", types)
+CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy can run with empty input",
+         "[device][adjacent_difference]",
+         CUB_SMALL,
+         types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -53,7 +57,10 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy can run with empty input", 
   adjacent_difference_subtract_left_copy(in.begin(), out.begin(), num_items, cuda::std::minus<>{});
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy does not change the input", "[device][adjacent_difference]", types)
+CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy does not change the input",
+         "[device][adjacent_difference]",
+         CUB_SMALL,
+         types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -68,8 +75,9 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy does not change the input",
 }
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with user provided memory and environment",
+CUB_TEST("DeviceAdjacentDifference::SubtractLeft works with user provided memory and environment",
          "[device][adjacent_difference]",
+         CUB_SMALL,
          types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -155,7 +163,8 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with user provided memory
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with iterators", "[device][adjacent_difference]", types)
+CUB_TEST(
+  "DeviceAdjacentDifference::SubtractLeft works with iterators", "[device][adjacent_difference]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -173,8 +182,9 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with iterators", "[device
 }
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with user provided memory and environment",
+CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with user provided memory and environment",
          "[device][adjacent_difference]",
+         CUB_SMALL,
          types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -260,8 +270,9 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with user provided me
   }
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy accepts cuda::device_buffer input",
-         "[adjacent_difference][device]")
+CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy accepts cuda::device_buffer input",
+         "[adjacent_difference][device]",
+         CUB_SMALL)
 {
   using type = std::int32_t;
 
@@ -278,7 +289,8 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy accepts cuda::device_buffer
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with iterators", "[device][adjacent_difference]", types)
+CUB_TEST(
+  "DeviceAdjacentDifference::SubtractLeftCopy works with iterators", "[device][adjacent_difference]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -296,7 +308,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with iterators", "[de
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with pointers", "[device][adjacent_difference]", types)
+CUB_TEST("DeviceAdjacentDifference::SubtractLeft works with pointers", "[device][adjacent_difference]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -313,7 +325,8 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with pointers", "[device]
   REQUIRE(reference == in);
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with pointers", "[device][adjacent_difference]", types)
+CUB_TEST(
+  "DeviceAdjacentDifference::SubtractLeftCopy works with pointers", "[device][adjacent_difference]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -347,8 +360,9 @@ struct cust_diff
   }
 };
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with custom difference",
+CUB_TEST("DeviceAdjacentDifference::SubtractLeft works with custom difference",
          "[device][adjacent_difference]",
+         CUB_SMALL,
          all_types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -366,8 +380,9 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with custom difference",
   REQUIRE(reference == in);
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with custom difference",
+CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with custom difference",
          "[device][adjacent_difference]",
+         CUB_SMALL,
          all_types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -406,8 +421,9 @@ struct convertible_from_T
   }
 };
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with a different output type",
+CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with a different output type",
          "[device][adjacent_difference]",
+         CUB_SMALL,
          types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -442,8 +458,9 @@ struct check_difference
   }
 };
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with large indexes",
-         "[device][adjacent_difference][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]")
+CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with large indexes",
+         "[device][adjacent_difference][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]",
+         CUB_SMALL)
 {
   constexpr cuda::std::size_t num_items = 1ll << 33;
   c2h::device_vector<int> error(1);
@@ -472,7 +489,9 @@ private:
   unsigned long long* counts_;
 };
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy uses right number of invocations", "[device][adjacent_difference]")
+CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy uses right number of invocations",
+         "[device][adjacent_difference]",
+         CUB_SMALL)
 {
   const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
   c2h::device_vector<unsigned long long> counts(1, 0);

--- a/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
@@ -13,7 +13,7 @@
 #include <numeric>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceAdjacentDifference::SubtractRight, adjacent_difference_subtract_right);
@@ -31,7 +31,8 @@ using all_types =
 
 using types = c2h::type_list<std::uint8_t, std::int32_t>;
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRight can run with empty input", "[device][adjacent_difference]", types)
+CUB_TEST(
+  "DeviceAdjacentDifference::SubtractRight can run with empty input", "[device][adjacent_difference]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -41,7 +42,10 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight can run with empty input", "[d
   adjacent_difference_subtract_right(in.begin(), num_items, cuda::std::minus<>{});
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy can run with empty input", "[device][adjacent_difference]", types)
+CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy can run with empty input",
+         "[device][adjacent_difference]",
+         CUB_SMALL,
+         types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -52,7 +56,10 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy can run with empty input",
   adjacent_difference_subtract_right_copy(in.begin(), out.begin(), num_items, cuda::std::minus<>{});
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy does not change the input", "[device][adjacent_difference]", types)
+CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy does not change the input",
+         "[device][adjacent_difference]",
+         CUB_SMALL,
+         types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -94,8 +101,9 @@ struct ref_diff
 _CCCL_SUPPRESS_DEPRECATED_POP
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DeviceAdjacentDifference::SubtractRight works with user provided memory and environment",
+CUB_TEST("DeviceAdjacentDifference::SubtractRight works with user provided memory and environment",
          "[device][adjacent_difference]",
+         CUB_SMALL,
          types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -184,7 +192,8 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight works with user provided memor
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRight works with iterators", "[device][adjacent_difference]", types)
+CUB_TEST(
+  "DeviceAdjacentDifference::SubtractRight works with iterators", "[device][adjacent_difference]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -205,8 +214,9 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight works with iterators", "[devic
 }
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with user provided memory and environment",
+CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy works with user provided memory and environment",
          "[device][adjacent_difference]",
+         CUB_SMALL,
          types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -295,7 +305,8 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with user provided m
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with iterators", "[device][adjacent_difference]", types)
+CUB_TEST(
+  "DeviceAdjacentDifference::SubtractRightCopy works with iterators", "[device][adjacent_difference]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -315,7 +326,8 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with iterators", "[d
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRight works with pointers", "[device][adjacent_difference]", types)
+CUB_TEST(
+  "DeviceAdjacentDifference::SubtractRight works with pointers", "[device][adjacent_difference]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -334,7 +346,8 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight works with pointers", "[device
   REQUIRE(reference == in);
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with pointers", "[device][adjacent_difference]", types)
+CUB_TEST(
+  "DeviceAdjacentDifference::SubtractRightCopy works with pointers", "[device][adjacent_difference]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -382,8 +395,9 @@ struct cust_diff
 };
 _CCCL_SUPPRESS_DEPRECATED_POP
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRight works with custom difference",
+CUB_TEST("DeviceAdjacentDifference::SubtractRight works with custom difference",
          "[device][adjacent_difference]",
+         CUB_SMALL,
          all_types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -403,8 +417,9 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight works with custom difference",
   REQUIRE(reference == in);
 }
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with custom difference",
+CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy works with custom difference",
          "[device][adjacent_difference]",
+         CUB_SMALL,
          types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -445,8 +460,9 @@ struct convertible_from_T
   }
 };
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with a different output type",
+CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy works with a different output type",
          "[device][adjacent_difference]",
+         CUB_SMALL,
          types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -483,8 +499,9 @@ struct check_difference
   }
 };
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with large indexes",
-         "[device][adjacent_difference][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]")
+CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy works with large indexes",
+         "[device][adjacent_difference][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]",
+         CUB_SMALL)
 {
   constexpr cuda::std::size_t num_items = 1ll << 33;
   c2h::device_vector<int> error(1);
@@ -513,8 +530,9 @@ private:
   unsigned long long* counts_;
 };
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy uses right number of invocations",
-         "[device][adjacent_difference]")
+CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy uses right number of invocations",
+         "[device][adjacent_difference]",
+         CUB_SMALL)
 {
   const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
   c2h::device_vector<unsigned long long> counts(1, 0);

--- a/cub/test/catch2_test_device_batched_topk_api.cu
+++ b/cub/test/catch2_test_device_batched_topk_api.cu
@@ -18,9 +18,9 @@
 #include <cuda/std/__execution/env.h>
 #include <cuda/std/functional>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceBatchedTopK::MaxKeys temp-storage API example", "[batched_topk][device]")
+CUB_TEST("cub::DeviceBatchedTopK::MaxKeys temp-storage API example", "[batched_topk][device]", CUB_SMALL)
 {
   // example-begin batched-topk-max-keys
   constexpr int num_segments = 2;
@@ -76,7 +76,7 @@ C2H_TEST("cub::DeviceBatchedTopK::MaxKeys temp-storage API example", "[batched_t
   REQUIRE(keys_out == expected_result_set);
 }
 
-C2H_TEST("cub::DeviceBatchedTopK::MinKeys temp-storage API example", "[batched_topk][device]")
+CUB_TEST("cub::DeviceBatchedTopK::MinKeys temp-storage API example", "[batched_topk][device]", CUB_SMALL)
 {
   // example-begin batched-topk-min-keys
   constexpr int num_segments = 2;
@@ -124,7 +124,7 @@ C2H_TEST("cub::DeviceBatchedTopK::MinKeys temp-storage API example", "[batched_t
   REQUIRE(keys_out == expected_result_set);
 }
 
-C2H_TEST("cub::DeviceBatchedTopK::MaxPairs temp-storage API example", "[batched_topk][device]")
+CUB_TEST("cub::DeviceBatchedTopK::MaxPairs temp-storage API example", "[batched_topk][device]", CUB_SMALL)
 {
   // example-begin batched-topk-max-pairs
   constexpr int num_segments = 2;
@@ -197,7 +197,7 @@ C2H_TEST("cub::DeviceBatchedTopK::MaxPairs temp-storage API example", "[batched_
   REQUIRE(keys_out == expected_result_set);
 }
 
-C2H_TEST("cub::DeviceBatchedTopK::MinPairs temp-storage API example", "[batched_topk][device]")
+CUB_TEST("cub::DeviceBatchedTopK::MinPairs temp-storage API example", "[batched_topk][device]", CUB_SMALL)
 {
   // example-begin batched-topk-min-pairs
   constexpr int num_segments = 2;
@@ -271,7 +271,9 @@ C2H_TEST("cub::DeviceBatchedTopK::MinPairs temp-storage API example", "[batched_
 
 // The temporary storage size requirement must not assume a particular base-pointer alignment (the public contract
 // states that no special alignment is required). Over-allocate by one byte and offset the base pointer.
-C2H_TEST("cub::DeviceBatchedTopK::MaxKeys handles a misaligned temporary storage pointer", "[batched_topk][device]")
+CUB_TEST("cub::DeviceBatchedTopK::MaxKeys handles a misaligned temporary storage pointer",
+         "[batched_topk][device]",
+         CUB_SMALL)
 {
   constexpr int num_segments = 2;
   constexpr int segment_size = 8;

--- a/cub/test/catch2_test_device_batched_topk_env_api.cu
+++ b/cub/test/catch2_test_device_batched_topk_env_api.cu
@@ -20,9 +20,9 @@
 #include <cuda/std/functional>
 #include <cuda/stream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceBatchedTopK::MaxKeys env-alloc example", "[batched_topk][device][env]")
+CUB_TEST("cub::DeviceBatchedTopK::MaxKeys env-alloc example", "[batched_topk][device][env]", CUB_SMALL)
 {
   // example-begin batched-topk-max-keys-env
   constexpr int num_segments = 2;
@@ -65,7 +65,7 @@ C2H_TEST("cub::DeviceBatchedTopK::MaxKeys env-alloc example", "[batched_topk][de
   REQUIRE(keys_out == expected_result_set);
 }
 
-C2H_TEST("cub::DeviceBatchedTopK::MinKeys env-alloc example", "[batched_topk][device][env]")
+CUB_TEST("cub::DeviceBatchedTopK::MinKeys env-alloc example", "[batched_topk][device][env]", CUB_SMALL)
 {
   // example-begin batched-topk-min-keys-env
   constexpr int num_segments = 2;
@@ -107,7 +107,7 @@ C2H_TEST("cub::DeviceBatchedTopK::MinKeys env-alloc example", "[batched_topk][de
   REQUIRE(keys_out == expected_result_set);
 }
 
-C2H_TEST("cub::DeviceBatchedTopK::MaxPairs env-alloc example", "[batched_topk][device][env]")
+CUB_TEST("cub::DeviceBatchedTopK::MaxPairs env-alloc example", "[batched_topk][device][env]", CUB_SMALL)
 {
   // example-begin batched-topk-max-pairs-env
   constexpr int num_segments = 2;
@@ -173,7 +173,7 @@ C2H_TEST("cub::DeviceBatchedTopK::MaxPairs env-alloc example", "[batched_topk][d
   REQUIRE(keys_out == expected_result_set);
 }
 
-C2H_TEST("cub::DeviceBatchedTopK::MinPairs env-alloc example", "[batched_topk][device][env]")
+CUB_TEST("cub::DeviceBatchedTopK::MinPairs env-alloc example", "[batched_topk][device][env]", CUB_SMALL)
 {
   // example-begin batched-topk-min-pairs-env
   constexpr int num_segments = 2;

--- a/cub/test/catch2_test_device_bulk.cu
+++ b/cub/test/catch2_test_device_bulk.cu
@@ -11,7 +11,7 @@
 #include <cuda/std/type_traits>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -32,7 +32,7 @@ struct incrementer_t
   }
 };
 
-C2H_TEST("Device bulk works", "[bulk][device]", offset_type)
+CUB_TEST("Device bulk works", "[bulk][device]", CUB_SMALL, offset_type)
 {
   using offset_t = c2h::get<0, TestType>;
 

--- a/cub/test/catch2_test_device_copy_api.cu
+++ b/cub/test/catch2_test_device_copy_api.cu
@@ -7,14 +7,14 @@
 
 #include <cuda/std/cstdint>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // Guard: the legacy memory-size query call with all defaults (no explicit stream)
 // must resolve unambiguously to the legacy temp-storage overload when the env
 // passthrough overload is also visible. If the env overload's SFINAE is too loose,
 // this becomes "ambiguous overload" or silently dispatches to env.
 
-C2H_TEST("DeviceCopy::Batched legacy size-query is unambiguous", "[copy][device]")
+CUB_TEST("DeviceCopy::Batched legacy size-query is unambiguous", "[copy][device]", CUB_SMALL)
 {
   // DeviceCopy::Batched takes iterator-of-iterators for input/output ranges.
   int** in                        = nullptr;

--- a/cub/test/catch2_test_device_copy_batched.cu
+++ b/cub/test/catch2_test_device_copy_batched.cu
@@ -19,7 +19,7 @@
 #include "catch2_segmented_sort_helper.cuh"
 #include "catch2_test_device_memcpy_batched_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -94,7 +94,7 @@ struct object_with_non_trivial_ctor
   }
 };
 
-C2H_TEST("DeviceCopy::Batched works", "[copy]")
+CUB_TEST("DeviceCopy::Batched works", "[copy]", CUB_SMALL)
 try
 {
   // Type used for indexing into the array of ranges
@@ -257,8 +257,9 @@ catch (std::bad_alloc& e)
   std::cerr << "Caught bad_alloc: " << e.what() << '\n';
 }
 
-C2H_TEST("DeviceCopy::Batched works for a very large range",
-         "[copy][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
+CUB_TEST("DeviceCopy::Batched works for a very large range",
+         "[copy][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_LARGE)
 try
 {
   using data_t        = uint64_t;
@@ -290,7 +291,7 @@ catch (std::bad_alloc& e)
   std::cerr << "Caught bad_alloc: " << e.what() << '\n';
 }
 
-C2H_TEST("DeviceCopy::Batched works for non-trivial ctors", "[copy]")
+CUB_TEST("DeviceCopy::Batched works for non-trivial ctors", "[copy]", CUB_SMALL)
 {
   using iterator = c2h::device_vector<object_with_non_trivial_ctor>::iterator;
 
@@ -308,8 +309,9 @@ C2H_TEST("DeviceCopy::Batched works for non-trivial ctors", "[copy]")
   REQUIRE(in == out);
 }
 
-C2H_TEST("DeviceMemcpy::Batched works for a very large number of ranges",
-         "[copy][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
+CUB_TEST("DeviceMemcpy::Batched works for a very large number of ranges",
+         "[copy][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_LARGE)
 try
 {
   using item_t         = uint8_t;

--- a/cub/test/catch2_test_device_copy_env.cu
+++ b/cub/test/catch2_test_device_copy_env.cu
@@ -24,7 +24,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceCopy::Batched, device_copy_batched);
 
 #include <cuda/__execution/require.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
@@ -50,7 +50,7 @@ struct get_size
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("DeviceCopy::Batched works with default environment", "[copy][device]")
+CUB_TEST_CASE("DeviceCopy::Batched works with default environment", "[copy][device]", CUB_SMALL)
 {
   // 3 ranges: [10, 20], [30, 40, 50], [60]
   auto d_src     = c2h::device_vector<int>{10, 20, 30, 40, 50, 60};
@@ -73,7 +73,7 @@ TEST_CASE("DeviceCopy::Batched works with default environment", "[copy][device]"
 
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DeviceCopy::Batched uses environment", "[copy][device]")
+CUB_TEST("DeviceCopy::Batched uses environment", "[copy][device]", CUB_SMALL)
 {
   // 3 ranges: [10, 20], [30, 40, 50], [60]
   auto d_src     = c2h::device_vector<int>{10, 20, 30, 40, 50, 60};
@@ -100,7 +100,7 @@ C2H_TEST("DeviceCopy::Batched uses environment", "[copy][device]")
   REQUIRE(d_dst == d_src);
 }
 
-TEST_CASE("DeviceCopy::Batched uses custom stream", "[copy][device]")
+CUB_TEST_CASE("DeviceCopy::Batched uses custom stream", "[copy][device]", CUB_SMALL)
 {
   // 3 ranges: [10, 20], [30, 40, 50], [60]
   auto d_src     = c2h::device_vector<int>{10, 20, 30, 40, 50, 60};
@@ -153,7 +153,7 @@ using block_sizes =
 
 #if TEST_LAUNCH != 1
 
-C2H_TEST("DeviceCopy::Batched can be tuned", "[copy][device]", block_sizes)
+CUB_TEST("DeviceCopy::Batched can be tuned", "[copy][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 

--- a/cub/test/catch2_test_device_copy_env_api.cu
+++ b/cub/test/catch2_test_device_copy_env_api.cu
@@ -16,9 +16,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceCopy::Batched accepts env with stream", "[copy][env]")
+CUB_TEST("cub::DeviceCopy::Batched accepts env with stream", "[copy][env]", CUB_SMALL)
 {
   // example-begin copy-batched-env
   // 3 contiguous ranges copied via Batched API
@@ -90,7 +90,7 @@ struct BatchedCopyPolicySelector
 
 _CCCL_DIAG_POP
 
-C2H_TEST("cub::DeviceCopy::Batched accepts a custom policy selector", "[copy][env]")
+CUB_TEST("cub::DeviceCopy::Batched accepts a custom policy selector", "[copy][env]", CUB_SMALL)
 {
   // example-begin copy-batched-tuning
   // 3 contiguous ranges copied via Batched API with custom tuning
@@ -127,7 +127,7 @@ C2H_TEST("cub::DeviceCopy::Batched accepts a custom policy selector", "[copy][en
 
 #endif // _CCCL_STD_VER >= 2020
 
-C2H_TEST("cub::DeviceCopy::Copy mdspan accepts env with stream", "[copy][env]")
+CUB_TEST("cub::DeviceCopy::Copy mdspan accepts env with stream", "[copy][env]", CUB_SMALL)
 {
   // example-begin copy-mdspan-env
   // Copy a 2D array using mdspan

--- a/cub/test/catch2_test_device_copy_mdspan.cu
+++ b/cub/test/catch2_test_device_copy_mdspan.cu
@@ -15,7 +15,7 @@
 #include <cuda/std/execution>
 #include <cuda/std/mdspan>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <catch2_test_launch_helper.h>
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
@@ -26,14 +26,14 @@ using dims_1d_t = cuda::std::dims<1, int>;
 using dims_2d_t = cuda::std::dims<2, int>;
 using dims_4d_t = cuda::std::dims<4, int>;
 
-C2H_TEST("DeviceCopy::Copy: empty mdspan", "[copy][mdspan]")
+CUB_TEST("DeviceCopy::Copy: empty mdspan", "[copy][mdspan]", CUB_SMALL)
 {
   auto mdspan_in_empty  = cuda::std::mdspan<int, dims_1d_t>(nullptr, 0);
   auto mdspan_out_empty = cuda::std::mdspan<int, dims_1d_t>(nullptr, 0);
   device_copy_mdspan(mdspan_in_empty, mdspan_out_empty);
 }
 
-C2H_TEST("DeviceCopy::Copy: 1D, 2D, 4D mdspan with matching layouts", "[copy][mdspan]")
+CUB_TEST("DeviceCopy::Copy: 1D, 2D, 4D mdspan with matching layouts", "[copy][mdspan]", CUB_SMALL)
 {
   constexpr size_t num_items = 10000;
   c2h::device_vector<int> d_input(num_items, thrust::no_init);
@@ -61,7 +61,9 @@ C2H_TEST("DeviceCopy::Copy: 1D, 2D, 4D mdspan with matching layouts", "[copy][md
 }
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DeviceCopy::Copy: 1D, 2D, 4D mdspan with matching layouts and user provided memory", "[copy][mdspan]")
+CUB_TEST("DeviceCopy::Copy: 1D, 2D, 4D mdspan with matching layouts and user provided memory",
+         "[copy][mdspan]",
+         CUB_SMALL)
 {
   constexpr size_t num_items = 10000;
   c2h::device_vector<int> d_input(num_items, thrust::no_init);
@@ -147,7 +149,7 @@ C2H_TEST("DeviceCopy::Copy: 1D, 2D, 4D mdspan with matching layouts and user pro
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DeviceCopy::Copy: 2D, 4D mdspan with compatible layouts", "[copy][mdspan]")
+CUB_TEST("DeviceCopy::Copy: 2D, 4D mdspan with compatible layouts", "[copy][mdspan]", CUB_SMALL)
 {
   constexpr size_t num_items = 10000;
   c2h::device_vector<int> d_input(num_items, thrust::no_init);
@@ -175,7 +177,7 @@ struct is_42
   }
 };
 
-C2H_TEST("DeviceCopy::Copy: 2D strided mdspan", "[copy][mdspan]")
+CUB_TEST("DeviceCopy::Copy: 2D strided mdspan", "[copy][mdspan]", CUB_SMALL)
 {
   constexpr size_t num_items = (2 * 100 + 20) * 100;
   c2h::device_vector<int> d_input(num_items, thrust::no_init);
@@ -209,7 +211,7 @@ C2H_TEST("DeviceCopy::Copy: 2D strided mdspan", "[copy][mdspan]")
   REQUIRE(count == expected_untouched);
 }
 
-C2H_TEST("DeviceCopy::Copy: 2D strided mdspan + contiguous mdspan", "[copy][mdspan]")
+CUB_TEST("DeviceCopy::Copy: 2D strided mdspan + contiguous mdspan", "[copy][mdspan]", CUB_SMALL)
 {
   constexpr size_t num_items = (2 * 100 + 20) * 100;
   c2h::device_vector<int> d_input(num_items, thrust::no_init);

--- a/cub/test/catch2_test_device_copy_mdspan_api.cu
+++ b/cub/test/catch2_test_device_copy_mdspan_api.cu
@@ -8,14 +8,14 @@
 
 #include <cuda/std/mdspan>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 void check_status(cudaError_t status)
 {
   REQUIRE(status == cudaSuccess);
 }
 
-C2H_TEST("DeviceCopy::Copy Mdspan API example", "[copy][mdspan]")
+CUB_TEST("DeviceCopy::Copy Mdspan API example", "[copy][mdspan]", CUB_SMALL)
 {
   // clang-format off
 // example-begin copy-mdspan-example-op

--- a/cub/test/catch2_test_device_decoupled_look_back.cu
+++ b/cub/test/catch2_test_device_decoupled_look_back.cu
@@ -5,7 +5,7 @@
 
 #include <cub/device/device_scan.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <class ScanTileStateT>
 __global__ void init_kernel(ScanTileStateT tile_state, int blocks_in_grid)
@@ -93,7 +93,8 @@ c2h::host_vector<MessageT> compute_reference(const c2h::device_vector<MessageT>&
   return reference;
 }
 
-C2H_TEST("Decoupled look-back works with various message types", "[decoupled look-back][device]", message_types)
+CUB_TEST(
+  "Decoupled look-back works with various message types", "[decoupled look-back][device]", CUB_SMALL, message_types)
 {
   using message_t         = typename c2h::get<0, TestType>;
   using scan_tile_state_t = cub::ScanTileState<message_t>;

--- a/cub/test/catch2_test_device_exclusive_scan_noncommutative.cu
+++ b/cub/test/catch2_test_device_exclusive_scan_noncommutative.cu
@@ -5,7 +5,7 @@
 
 #include <thrust/tabulate.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <catch2_test_device_scan.cuh>
 
 /* Consider free monoid with two generators, ``q`` and ``p``, modulo defining relationship (``p * q == 1``).
@@ -126,7 +126,7 @@ struct populate_sparse_write_input
 // On sm_100+ the lookahead tile size is num_scan_stor_threads * items_per_thread, which is
 // ~4000–32000 elements depending on element size, so 50'000 guarantees multiple tiles for all types.
 
-C2H_TEST("Device exclusive scan works with non-commutative bicyclic monoid operator", "[scan][device]")
+CUB_TEST("Device exclusive scan works with non-commutative bicyclic monoid operator", "[scan][device]", CUB_SMALL)
 {
   using pair_t = cuda::std::pair<unsigned, unsigned>;
   using op_t   = impl::bicyclic_monoid_op<unsigned>;
@@ -169,7 +169,7 @@ C2H_TEST("Device exclusive scan works with non-commutative bicyclic monoid opera
   REQUIRE(h_expected == h_output);
 }
 
-C2H_TEST("Device exclusive scan works with PropagateLastWrite operator", "[scan][device]")
+CUB_TEST("Device exclusive scan works with PropagateLastWrite operator", "[scan][device]", CUB_SMALL)
 {
   // PropagateLastWrite<char> uses char values: contiguous, trivially copyable, arithmetic —
   // all conditions that enable the lookahead kernel on sm_100+.
@@ -226,7 +226,7 @@ C2H_TEST("Device exclusive scan works with PropagateLastWrite operator", "[scan]
   REQUIRE(h_expected == h_output);
 }
 
-C2H_TEST("Device exclusive scan PropagateLastWrite reproduces original bug-report input", "[scan][device]")
+CUB_TEST("Device exclusive scan PropagateLastWrite reproduces original bug-report input", "[scan][device]", CUB_SMALL)
 {
   // Regression test using the exact input pattern from the original bug report.
   // This input has a cluster of write symbols near the end that must be correctly

--- a/cub/test/catch2_test_device_find.cu
+++ b/cub/test/catch2_test_device_find.cu
@@ -13,7 +13,7 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -47,7 +47,7 @@ auto compute_find_if_reference(InputIt first, InputIt last, Predicate predicate)
   return static_cast<OffsetT>(std::distance(first, it));
 }
 
-C2H_TEST("Device find_if works", "[device][find_if]", value_types, offset_types)
+CUB_TEST("Device find_if works", "[device][find_if]", CUB_SMALL, value_types, offset_types)
 {
   using input_t  = c2h::get<0, TestType>;
   using offset_t = c2h::get<1, TestType>;
@@ -160,7 +160,7 @@ C2H_TEST("Device find_if works", "[device][find_if]", value_types, offset_types)
   }
 }
 
-C2H_TEST("Device find_if works with non primitive iterator", "[device][find_if]")
+CUB_TEST("Device find_if works with non primitive iterator", "[device][find_if]", CUB_SMALL)
 {
   using input_t  = int32_t;
   using offset_t = int32_t;
@@ -243,7 +243,7 @@ struct index_to_value
 static_assert(!cuda::std::is_default_constructible_v<NotDefaultConstructible>,
               "NotDefaultConstructible should not be default constructible");
 
-C2H_TEST("Device find_if works with non default constructible types", "[device][find_if]")
+CUB_TEST("Device find_if works with non default constructible types", "[device][find_if]", CUB_SMALL)
 {
   using input_t  = NotDefaultConstructible;
   using offset_t = int;
@@ -334,21 +334,22 @@ void test_vectorized(Variant variant, HostVariant host_variant, std::size_t num_
   CHECK(offsets_ref == offsets_h);
 }
 
-C2H_TEST("DeviceFind::LowerBound works", "[find][device][binary-search]", binary_search_types)
+CUB_TEST("DeviceFind::LowerBound works", "[find][device][binary-search]", CUB_SMALL, binary_search_types)
 {
   using value_type = c2h::get<0, TestType>;
   test_vectorized<value_type>(lower_bound, std_lower_bound);
 }
 
-C2H_TEST("DeviceFind::UpperBound works", "[find][device][binary-search]", binary_search_types)
+CUB_TEST("DeviceFind::UpperBound works", "[find][device][binary-search]", CUB_SMALL, binary_search_types)
 {
   using value_type = c2h::get<0, TestType>;
   test_vectorized<value_type>(upper_bound, std_upper_bound);
 }
 
 // this test exceeds 4GiB of memory and the range of 32-bit integers
-C2H_TEST("DeviceFind::LowerBound really large input",
-         "[find][device][binary-search][skip-cs-rangecheck][skip-cs-initcheck][skip-cs-synccheck]")
+CUB_TEST("DeviceFind::LowerBound really large input",
+         "[find][device][binary-search][skip-cs-rangecheck][skip-cs-initcheck][skip-cs-synccheck]",
+         CUB_LARGE)
 {
   try
   {
@@ -364,8 +365,9 @@ C2H_TEST("DeviceFind::LowerBound really large input",
 }
 
 // this test exceeds 4GiB of memory and the range of 32-bit integers
-C2H_TEST("DeviceFind::UpperBound really large input",
-         "[find][device][binary-search][skip-cs-rangecheck][skip-cs-initcheck][skip-cs-synccheck]")
+CUB_TEST("DeviceFind::UpperBound really large input",
+         "[find][device][binary-search][skip-cs-rangecheck][skip-cs-initcheck][skip-cs-synccheck]",
+         CUB_LARGE)
 {
   try
   {

--- a/cub/test/catch2_test_device_find_api.cu
+++ b/cub/test/catch2_test_device_find_api.cu
@@ -7,7 +7,7 @@
 
 #include <thrust/device_vector.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // example-begin find-if-predicate
 struct is_greater_than_t
@@ -20,7 +20,7 @@ struct is_greater_than_t
 };
 // example-end find-if-predicate
 
-C2H_TEST("cub::DeviceFind::FindIf works with int data elements", "[find][device]")
+CUB_TEST("cub::DeviceFind::FindIf works with int data elements", "[find][device]", CUB_SMALL)
 {
   // example-begin device-find-if
   constexpr int num_items         = 8;
@@ -47,7 +47,7 @@ C2H_TEST("cub::DeviceFind::FindIf works with int data elements", "[find][device]
   REQUIRE(d_out[0] == expected);
 }
 
-C2H_TEST("cub::DeviceFind::LowerBound works with int data elements", "[find][device]")
+CUB_TEST("cub::DeviceFind::LowerBound works with int data elements", "[find][device]", CUB_SMALL)
 {
   // example-begin device-lower-bound
   thrust::device_vector<int> d_range  = {0, 2, 4, 6, 8};
@@ -83,7 +83,7 @@ C2H_TEST("cub::DeviceFind::LowerBound works with int data elements", "[find][dev
   REQUIRE(d_output == expected);
 }
 
-C2H_TEST("cub::DeviceFind::UpperBound works with int data elements", "[find][device]")
+CUB_TEST("cub::DeviceFind::UpperBound works with int data elements", "[find][device]", CUB_SMALL)
 {
   // example-begin device-upper-bound
   thrust::device_vector<int> d_range  = {0, 2, 4, 6, 8};
@@ -124,7 +124,7 @@ C2H_TEST("cub::DeviceFind::UpperBound works with int data elements", "[find][dev
 // passthrough overload is also visible. If the env overload's SFINAE is too loose,
 // this becomes "ambiguous overload" or silently dispatches to env.
 
-C2H_TEST("DeviceFind::FindIf legacy size-query is unambiguous", "[find][device]")
+CUB_TEST("DeviceFind::FindIf legacy size-query is unambiguous", "[find][device]", CUB_SMALL)
 {
   int* d_in    = nullptr;
   int* d_out   = nullptr;
@@ -134,7 +134,7 @@ C2H_TEST("DeviceFind::FindIf legacy size-query is unambiguous", "[find][device]"
   REQUIRE(cudaSuccess == cub::DeviceFind::FindIf(nullptr, bytes, d_in, d_out, is_greater_than_t{0}, n));
 }
 
-C2H_TEST("DeviceFind::LowerBound legacy size-query is unambiguous", "[find][device]")
+CUB_TEST("DeviceFind::LowerBound legacy size-query is unambiguous", "[find][device]", CUB_SMALL)
 {
   int* d_range  = nullptr;
   int* d_values = nullptr;
@@ -148,7 +148,7 @@ C2H_TEST("DeviceFind::LowerBound legacy size-query is unambiguous", "[find][devi
     == cub::DeviceFind::LowerBound(nullptr, bytes, d_range, range_n, d_values, values_n, d_output, cuda::std::less{}));
 }
 
-C2H_TEST("DeviceFind::UpperBound legacy size-query is unambiguous", "[find][device]")
+CUB_TEST("DeviceFind::UpperBound legacy size-query is unambiguous", "[find][device]", CUB_SMALL)
 {
   int* d_range  = nullptr;
   int* d_values = nullptr;

--- a/cub/test/catch2_test_device_find_bound_sorted_values.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values.cu
@@ -11,7 +11,7 @@
 #include <algorithm>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -77,19 +77,21 @@ void test_sorted(Variant variant,
   CHECK(offsets_ref == offsets_h);
 }
 
-C2H_TEST("DeviceFind::LowerBoundSortedValues works", "[find][device][binary-search]", types)
+CUB_TEST("DeviceFind::LowerBoundSortedValues works", "[find][device][binary-search]", CUB_SMALL, types)
 {
   using value_type = c2h::get<0, TestType>;
   test_sorted<value_type>(lower_bound_sorted_values, std_lower_bound);
 }
 
-C2H_TEST("DeviceFind::UpperBoundSortedValues works", "[find][device][binary-search]", types)
+CUB_TEST("DeviceFind::UpperBoundSortedValues works", "[find][device][binary-search]", CUB_SMALL, types)
 {
   using value_type = c2h::get<0, TestType>;
   test_sorted<value_type>(upper_bound_sorted_values, std_upper_bound);
 }
 
-C2H_TEST("DeviceFind::LowerBoundSortedValues works with a transform output iterator", "[find][device][binary-search]")
+CUB_TEST("DeviceFind::LowerBoundSortedValues works with a transform output iterator",
+         "[find][device][binary-search]",
+         CUB_SMALL)
 {
   using value_type = int;
   using Result     = std::ptrdiff_t;
@@ -131,19 +133,21 @@ C2H_TEST("DeviceFind::LowerBoundSortedValues works with a transform output itera
   CHECK(offsets_ref == offsets_h);
 }
 
-C2H_TEST("DeviceFind::LowerBoundSortedValues works with descending order", "[find][device][binary-search]", types)
+CUB_TEST(
+  "DeviceFind::LowerBoundSortedValues works with descending order", "[find][device][binary-search]", CUB_SMALL, types)
 {
   using value_type = c2h::get<0, TestType>;
   test_sorted<value_type>(lower_bound_sorted_values, std_lower_bound, 7492, 749, cuda::std::greater<value_type>{});
 }
 
-C2H_TEST("DeviceFind::UpperBoundSortedValues works with descending order", "[find][device][binary-search]", types)
+CUB_TEST(
+  "DeviceFind::UpperBoundSortedValues works with descending order", "[find][device][binary-search]", CUB_SMALL, types)
 {
   using value_type = c2h::get<0, TestType>;
   test_sorted<value_type>(upper_bound_sorted_values, std_upper_bound, 7492, 749, cuda::std::greater<value_type>{});
 }
 
-C2H_TEST("DeviceFind::LowerBoundSortedValues input sizes", "[find][device][binary-search]")
+CUB_TEST("DeviceFind::LowerBoundSortedValues input sizes", "[find][device][binary-search]", CUB_SMALL)
 {
   using value_type                   = int;
   const std::size_t range_num_items  = GENERATE(0, 1, 23, 123, 3234);
@@ -152,7 +156,7 @@ C2H_TEST("DeviceFind::LowerBoundSortedValues input sizes", "[find][device][binar
   test_sorted<value_type>(lower_bound_sorted_values, std_lower_bound, range_num_items, values_num_items);
 }
 
-C2H_TEST("DeviceFind::UpperBoundSortedValues input sizes", "[find][device][binary-search]")
+CUB_TEST("DeviceFind::UpperBoundSortedValues input sizes", "[find][device][binary-search]", CUB_SMALL)
 {
   using value_type                   = int;
   const std::size_t range_num_items  = GENERATE(0, 1, 23, 123, 3234);
@@ -161,7 +165,7 @@ C2H_TEST("DeviceFind::UpperBoundSortedValues input sizes", "[find][device][binar
   test_sorted<value_type>(upper_bound_sorted_values, std_upper_bound, range_num_items, values_num_items);
 }
 
-C2H_TEST("DeviceFind::LowerBoundSortedValues almost tile-sized input sizes", "[find][device][binary-search]")
+CUB_TEST("DeviceFind::LowerBoundSortedValues almost tile-sized input sizes", "[find][device][binary-search]", CUB_SMALL)
 {
   using value_type = int;
   cuda::compute_capability cc{};
@@ -174,7 +178,7 @@ C2H_TEST("DeviceFind::LowerBoundSortedValues almost tile-sized input sizes", "[f
   test_sorted<value_type>(lower_bound_sorted_values, std_lower_bound, 1, tile_size);
 }
 
-C2H_TEST("DeviceFind::UpperBoundSortedValues almost tile-sized input sizes", "[find][device][binary-search]")
+CUB_TEST("DeviceFind::UpperBoundSortedValues almost tile-sized input sizes", "[find][device][binary-search]", CUB_SMALL)
 {
   using value_type = int;
   cuda::compute_capability cc{};
@@ -188,8 +192,9 @@ C2H_TEST("DeviceFind::UpperBoundSortedValues almost tile-sized input sizes", "[f
 }
 
 // this test exceeds 4GiB of memory and the range of 32-bit integers
-C2H_TEST("DeviceFind::LowerBoundSortedValues really large input",
-         "[find][device][binary-search][skip-cs-rangecheck][skip-cs-initcheck][skip-cs-synccheck]")
+CUB_TEST("DeviceFind::LowerBoundSortedValues really large input",
+         "[find][device][binary-search][skip-cs-rangecheck][skip-cs-initcheck][skip-cs-synccheck]",
+         CUB_LARGE)
 {
   try
   {
@@ -206,8 +211,9 @@ C2H_TEST("DeviceFind::LowerBoundSortedValues really large input",
 }
 
 // this test exceeds 4GiB of memory and the range of 32-bit integers
-C2H_TEST("DeviceFind::UpperBoundSortedValues really large input",
-         "[find][device][binary-search][skip-cs-rangecheck][skip-cs-initcheck][skip-cs-synccheck]")
+CUB_TEST("DeviceFind::UpperBoundSortedValues really large input",
+         "[find][device][binary-search][skip-cs-rangecheck][skip-cs-initcheck][skip-cs-synccheck]",
+         CUB_LARGE)
 {
   try
   {

--- a/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
@@ -20,13 +20,13 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceFind::UpperBoundSortedValues, device_upper_bou
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("Device LowerBoundSortedValues works with default environment", "[find][device][binary-search]")
+CUB_TEST_CASE("Device LowerBoundSortedValues works with default environment", "[find][device][binary-search]", CUB_SMALL)
 {
   auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
   auto d_values = c2h::device_vector<int>{0, 3, 4, 7};
@@ -45,7 +45,7 @@ TEST_CASE("Device LowerBoundSortedValues works with default environment", "[find
   REQUIRE(d_output == expected);
 }
 
-TEST_CASE("Device UpperBoundSortedValues works with default environment", "[find][device][binary-search]")
+CUB_TEST_CASE("Device UpperBoundSortedValues works with default environment", "[find][device][binary-search]", CUB_SMALL)
 {
   auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
   auto d_values = c2h::device_vector<int>{0, 3, 4, 7};
@@ -66,7 +66,7 @@ TEST_CASE("Device UpperBoundSortedValues works with default environment", "[find
 
 #endif
 
-C2H_TEST("Device LowerBoundSortedValues uses environment", "[find][device][binary-search]")
+CUB_TEST("Device LowerBoundSortedValues uses environment", "[find][device][binary-search]", CUB_SMALL)
 {
   auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
   auto d_values = c2h::device_vector<int>{0, 3, 4, 7};
@@ -100,7 +100,7 @@ C2H_TEST("Device LowerBoundSortedValues uses environment", "[find][device][binar
   REQUIRE(d_output == expected);
 }
 
-C2H_TEST("Device UpperBoundSortedValues uses environment", "[find][device][binary-search]")
+CUB_TEST("Device UpperBoundSortedValues uses environment", "[find][device][binary-search]", CUB_SMALL)
 {
   auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
   auto d_values = c2h::device_vector<int>{0, 3, 4, 7};
@@ -135,7 +135,7 @@ C2H_TEST("Device UpperBoundSortedValues uses environment", "[find][device][binar
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test FindBoundSortedValuesPolicy properties", "[find][device][binary-search]")
+CUB_TEST("Test FindBoundSortedValuesPolicy properties", "[find][device][binary-search]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::FindBoundSortedValuesPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::FindBoundSortedValuesPolicy>);

--- a/cub/test/catch2_test_device_find_bound_sorted_values_env_api.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values_env_api.cu
@@ -13,9 +13,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceFind::LowerBoundSortedValues accepts env with stream", "[find][env][binary-search]")
+CUB_TEST("cub::DeviceFind::LowerBoundSortedValues accepts env with stream", "[find][env][binary-search]", CUB_SMALL)
 {
   // example-begin lower-bound-sorted-values-env
   thrust::device_vector<int> d_range  = {0, 2, 4, 6, 8};
@@ -46,7 +46,7 @@ C2H_TEST("cub::DeviceFind::LowerBoundSortedValues accepts env with stream", "[fi
   REQUIRE(d_output == expected);
 }
 
-C2H_TEST("cub::DeviceFind::UpperBoundSortedValues accepts env with stream", "[find][env][binary-search]")
+CUB_TEST("cub::DeviceFind::UpperBoundSortedValues accepts env with stream", "[find][env][binary-search]", CUB_SMALL)
 {
   // example-begin upper-bound-sorted-values-env
   thrust::device_vector<int> d_range  = {0, 2, 4, 6, 8};
@@ -91,7 +91,9 @@ struct FindBoundSortedValuesPolicySelector
 };
 // example-end lower-bound-sorted-values-policy-selector
 
-C2H_TEST("cub::DeviceFind::LowerBoundSortedValues accepts a custom policy selector", "[find][env][binary-search]")
+CUB_TEST("cub::DeviceFind::LowerBoundSortedValues accepts a custom policy selector",
+         "[find][env][binary-search]",
+         CUB_SMALL)
 {
   // example-begin lower-bound-sorted-values-tuning
   thrust::device_vector<int> d_range  = {0, 2, 4, 6, 8};

--- a/cub/test/catch2_test_device_find_env.cu
+++ b/cub/test/catch2_test_device_find_env.cu
@@ -26,7 +26,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceFind::UpperBound, device_upper_bound);
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
@@ -56,7 +56,7 @@ using block_sizes =
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("Device FindIf works with default environment", "[find][device]")
+CUB_TEST_CASE("Device FindIf works with default environment", "[find][device]", CUB_SMALL)
 {
   constexpr int num_items = 8;
   auto d_in               = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6, 7};
@@ -92,7 +92,7 @@ TEST_CASE("Device FindIf works with default environment", "[find][device]")
   }
 }
 
-TEST_CASE("Device FindIf no match returns num_items with default environment", "[find][device]")
+CUB_TEST_CASE("Device FindIf no match returns num_items with default environment", "[find][device]", CUB_SMALL)
 {
   constexpr int num_items = 5;
   auto d_in               = c2h::device_vector<int>{0, 1, 2, 3, 4};
@@ -128,7 +128,7 @@ TEST_CASE("Device FindIf no match returns num_items with default environment", "
   }
 }
 
-TEST_CASE("Device LowerBound works with default environment", "[find][device]")
+CUB_TEST_CASE("Device LowerBound works with default environment", "[find][device]", CUB_SMALL)
 {
   auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
   auto d_values = c2h::device_vector<int>{1, 3, 5, 7};
@@ -147,7 +147,7 @@ TEST_CASE("Device LowerBound works with default environment", "[find][device]")
   REQUIRE(d_output == expected);
 }
 
-TEST_CASE("Device UpperBound works with default environment", "[find][device]")
+CUB_TEST_CASE("Device UpperBound works with default environment", "[find][device]", CUB_SMALL)
 {
   auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
   auto d_values = c2h::device_vector<int>{1, 3, 5, 7};
@@ -168,7 +168,7 @@ TEST_CASE("Device UpperBound works with default environment", "[find][device]")
 
 #endif
 
-C2H_TEST("Device FindIf uses environment", "[find][device]")
+CUB_TEST("Device FindIf uses environment", "[find][device]", CUB_SMALL)
 {
   constexpr int num_items = 8;
   auto d_in               = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6, 7};
@@ -185,7 +185,7 @@ C2H_TEST("Device FindIf uses environment", "[find][device]")
   REQUIRE(d_out[0] == 5);
 }
 
-C2H_TEST("Device FindIf works with user provided memory and environment", "[find][device]")
+CUB_TEST("Device FindIf works with user provided memory and environment", "[find][device]", CUB_SMALL)
 {
   constexpr int num_items = 8;
   auto d_in               = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6, 7};
@@ -257,7 +257,7 @@ C2H_TEST("Device FindIf works with user provided memory and environment", "[find
   }
 }
 
-C2H_TEST("Device LowerBound uses environment", "[find][device]")
+CUB_TEST("Device LowerBound uses environment", "[find][device]", CUB_SMALL)
 {
   auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
   auto d_values = c2h::device_vector<int>{1, 3, 5, 7};
@@ -291,7 +291,7 @@ C2H_TEST("Device LowerBound uses environment", "[find][device]")
   REQUIRE(d_output == expected);
 }
 
-C2H_TEST("Device LowerBound works with user provided memory and environment", "[find][device]")
+CUB_TEST("Device LowerBound works with user provided memory and environment", "[find][device]", CUB_SMALL)
 {
   auto d_range                     = c2h::device_vector<int>{0, 2, 4, 6, 8};
   auto d_values                    = c2h::device_vector<int>{1, 3, 5, 7};
@@ -388,7 +388,7 @@ C2H_TEST("Device LowerBound works with user provided memory and environment", "[
   }
 }
 
-C2H_TEST("Device UpperBound uses environment", "[find][device]")
+CUB_TEST("Device UpperBound uses environment", "[find][device]", CUB_SMALL)
 {
   auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
   auto d_values = c2h::device_vector<int>{1, 3, 5, 7};
@@ -422,7 +422,7 @@ C2H_TEST("Device UpperBound uses environment", "[find][device]")
   REQUIRE(d_output == expected);
 }
 
-C2H_TEST("Device UpperBound works with user provided memory and environment", "[find][device]")
+CUB_TEST("Device UpperBound works with user provided memory and environment", "[find][device]", CUB_SMALL)
 {
   auto d_range                     = c2h::device_vector<int>{0, 2, 4, 6, 8};
   auto d_values                    = c2h::device_vector<int>{1, 3, 5, 7};
@@ -520,7 +520,7 @@ C2H_TEST("Device UpperBound works with user provided memory and environment", "[
 }
 
 #if TEST_LAUNCH != 1
-C2H_TEST("Device FindIf can be tuned", "[find][device]", block_sizes)
+CUB_TEST("Device FindIf can be tuned", "[find][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -541,7 +541,7 @@ C2H_TEST("Device FindIf can be tuned", "[find][device]", block_sizes)
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test FindIfPolicy properties", "[find][device]")
+CUB_TEST("Test FindIfPolicy properties", "[find][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::FindIfPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::FindIfPolicy>);

--- a/cub/test/catch2_test_device_find_env_api.cu
+++ b/cub/test/catch2_test_device_find_env_api.cu
@@ -13,7 +13,7 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // example-begin find-if-predicate
 struct is_greater_than_t
@@ -26,7 +26,7 @@ struct is_greater_than_t
 };
 // example-end find-if-predicate
 
-C2H_TEST("cub::DeviceFind::FindIf accepts env with stream", "[find][env]")
+CUB_TEST("cub::DeviceFind::FindIf accepts env with stream", "[find][env]", CUB_SMALL)
 {
   // example-begin find-if-env
   constexpr int num_items         = 8;
@@ -51,7 +51,7 @@ C2H_TEST("cub::DeviceFind::FindIf accepts env with stream", "[find][env]")
   REQUIRE(d_out[0] == expected);
 }
 
-C2H_TEST("cub::DeviceFind::LowerBound accepts env with stream", "[find][env]")
+CUB_TEST("cub::DeviceFind::LowerBound accepts env with stream", "[find][env]", CUB_SMALL)
 {
   // example-begin lower-bound-env
   thrust::device_vector<int> d_range  = {0, 2, 4, 6, 8};
@@ -82,7 +82,7 @@ C2H_TEST("cub::DeviceFind::LowerBound accepts env with stream", "[find][env]")
   REQUIRE(d_output == expected);
 }
 
-C2H_TEST("cub::DeviceFind::UpperBound accepts env with stream", "[find][env]")
+CUB_TEST("cub::DeviceFind::UpperBound accepts env with stream", "[find][env]", CUB_SMALL)
 {
   // example-begin upper-bound-env
   thrust::device_vector<int> d_range  = {0, 2, 4, 6, 8};
@@ -128,7 +128,7 @@ struct FindPolicySelector
 };
 // example-end find-if-policy-selector
 
-C2H_TEST("cub::DeviceFind::FindIf accepts a custom policy selector", "[find][env]")
+CUB_TEST("cub::DeviceFind::FindIf accepts a custom policy selector", "[find][env]", CUB_SMALL)
 {
   // example-begin find-if-tuning
   auto d_in  = thrust::device_vector<int>{0, 1, 2, 3, 4, 5, 6, 7};

--- a/cub/test/catch2_test_device_for.cu
+++ b/cub/test/catch2_test_device_for.cu
@@ -13,7 +13,7 @@
 #include <cuda/iterator>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -63,7 +63,7 @@ struct referencing_operator_t
   }
 };
 
-C2H_TEST("Device for each works", "[for][device]")
+CUB_TEST("Device for each works", "[for][device]", CUB_SMALL)
 {
   constexpr int max_items = 5000000;
   constexpr int min_items = 1;
@@ -90,7 +90,7 @@ C2H_TEST("Device for each works", "[for][device]")
   REQUIRE(num_of_once_marked_items == num_items);
 }
 
-C2H_TEST("Device for each works with bad operators", "[for][device]")
+CUB_TEST("Device for each works with bad operators", "[for][device]", CUB_SMALL)
 {
   constexpr int max_items = 5000000;
   constexpr int min_items = 1;
@@ -111,7 +111,7 @@ C2H_TEST("Device for each works with bad operators", "[for][device]")
   REQUIRE(thrust::equal(c2h::device_policy, input.begin(), input.end(), cuda::counting_iterator(std::size_t{})));
 }
 
-C2H_TEST("Device for each works with unaligned vectors", "[for][device]")
+CUB_TEST("Device for each works with unaligned vectors", "[for][device]", CUB_SMALL)
 {
   constexpr int max_items = 5000000;
   constexpr int min_items = 1;
@@ -142,7 +142,7 @@ C2H_TEST("Device for each works with unaligned vectors", "[for][device]")
 
 using offset_type = c2h::type_list<std::int32_t, std::uint32_t, std::uint64_t, std::int64_t>;
 
-C2H_TEST("Device for each n works", "[for][device]", offset_type)
+CUB_TEST("Device for each n works", "[for][device]", CUB_SMALL, offset_type)
 {
   using offset_t = c2h::get<0, TestType>;
 
@@ -170,7 +170,7 @@ C2H_TEST("Device for each n works", "[for][device]", offset_type)
   REQUIRE(num_of_once_marked_items == num_items);
 }
 
-C2H_TEST("Device for each n works with bad operators", "[for][device]", offset_type)
+CUB_TEST("Device for each n works with bad operators", "[for][device]", CUB_SMALL, offset_type)
 {
   using offset_t = c2h::get<0, TestType>;
 
@@ -193,7 +193,7 @@ C2H_TEST("Device for each n works with bad operators", "[for][device]", offset_t
   REQUIRE(thrust::equal(c2h::device_policy, input.begin(), input.end(), cuda::counting_iterator(std::size_t{})));
 }
 
-C2H_TEST("Device for each n works with unaligned vectors", "[for][device]", offset_type)
+CUB_TEST("Device for each n works with unaligned vectors", "[for][device]", CUB_SMALL, offset_type)
 {
   using offset_t = c2h::get<0, TestType>;
 
@@ -224,7 +224,7 @@ C2H_TEST("Device for each n works with unaligned vectors", "[for][device]", offs
   REQUIRE(num_of_once_marked_items == num_items);
 }
 
-C2H_TEST("Device for each works with counting iterator", "[for][device]")
+CUB_TEST("Device for each works with counting iterator", "[for][device]", CUB_SMALL)
 {
   using offset_t               = int;
   constexpr offset_t max_items = 5000000;

--- a/cub/test/catch2_test_device_for_api.cu
+++ b/cub/test/catch2_test_device_for_api.cu
@@ -13,7 +13,7 @@
 #include <cuda/iterator>
 #include <cuda/std/tuple>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // example-begin bulk-square-t
 struct square_t
@@ -72,7 +72,7 @@ struct tabulate_output_op
   }
 };
 
-C2H_TEST("Device bulk works with temporary storage", "[bulk][device]")
+CUB_TEST("Device bulk works with temporary storage", "[bulk][device]", CUB_SMALL)
 {
   // example-begin bulk-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
@@ -100,7 +100,7 @@ C2H_TEST("Device bulk works with temporary storage", "[bulk][device]")
   REQUIRE(vec == expected);
 }
 
-C2H_TEST("Device bulk works without temporary storage", "[bulk][device]")
+CUB_TEST("Device bulk works without temporary storage", "[bulk][device]", CUB_SMALL)
 {
   // example-begin bulk-wo-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
@@ -118,7 +118,7 @@ C2H_TEST("Device bulk works without temporary storage", "[bulk][device]")
   REQUIRE(vec == expected);
 }
 
-C2H_TEST("Device for each n works with temporary storage", "[for_each][device]")
+CUB_TEST("Device for each n works with temporary storage", "[for_each][device]", CUB_SMALL)
 {
   // example-begin for-each-n-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
@@ -150,7 +150,7 @@ C2H_TEST("Device for each n works with temporary storage", "[for_each][device]")
   REQUIRE(vec == expected);
 }
 
-C2H_TEST("Device for each n works without temporary storage", "[for_each][device]")
+CUB_TEST("Device for each n works without temporary storage", "[for_each][device]", CUB_SMALL)
 {
   // example-begin for-each-n-wo-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
@@ -168,7 +168,9 @@ C2H_TEST("Device for each n works without temporary storage", "[for_each][device
   REQUIRE(vec == expected);
 }
 
-C2H_TEST("Device for each n works with a tabulate output iterator in a thrust zip iterator", "[for_each][device]")
+CUB_TEST("Device for each n works with a tabulate output iterator in a thrust zip iterator",
+         "[for_each][device]",
+         CUB_SMALL)
 {
   c2h::device_vector<int> input = {1, 2, 3, 4};
   c2h::device_vector<int> output(input.size());
@@ -185,7 +187,9 @@ C2H_TEST("Device for each n works with a tabulate output iterator in a thrust zi
   REQUIRE(output == input);
 }
 
-C2H_TEST("Device for each n works with a tabulate output iterator in a cuda zip iterator", "[for_each][device]")
+CUB_TEST("Device for each n works with a tabulate output iterator in a cuda zip iterator",
+         "[for_each][device]",
+         CUB_SMALL)
 {
   c2h::device_vector<int> input = {1, 2, 3, 4};
   c2h::device_vector<int> output(input.size());
@@ -202,7 +206,7 @@ C2H_TEST("Device for each n works with a tabulate output iterator in a cuda zip 
   REQUIRE(output == input);
 }
 
-C2H_TEST("Device for each works with temporary storage", "[for_each][device]")
+CUB_TEST("Device for each works with temporary storage", "[for_each][device]", CUB_SMALL)
 {
   // example-begin for-each-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
@@ -234,7 +238,7 @@ C2H_TEST("Device for each works with temporary storage", "[for_each][device]")
   REQUIRE(vec == expected);
 }
 
-C2H_TEST("Device for each works without temporary storage", "[for_each][device]")
+CUB_TEST("Device for each works without temporary storage", "[for_each][device]", CUB_SMALL)
 {
   // example-begin for-each-wo-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
@@ -252,7 +256,7 @@ C2H_TEST("Device for each works without temporary storage", "[for_each][device]"
   REQUIRE(vec == expected);
 }
 
-C2H_TEST("Device for each n copy works with temporary storage", "[for_each][device]")
+CUB_TEST("Device for each n copy works with temporary storage", "[for_each][device]", CUB_SMALL)
 {
   // example-begin for-each-copy-n-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
@@ -285,7 +289,7 @@ C2H_TEST("Device for each n copy works with temporary storage", "[for_each][devi
   REQUIRE(count == expected);
 }
 
-C2H_TEST("Device for each n copy works without temporary storage", "[for_each][device]")
+CUB_TEST("Device for each n copy works without temporary storage", "[for_each][device]", CUB_SMALL)
 {
   // example-begin for-each-copy-n-wo-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
@@ -304,7 +308,7 @@ C2H_TEST("Device for each n copy works without temporary storage", "[for_each][d
   REQUIRE(count == expected);
 }
 
-C2H_TEST("Device for each copy works with temporary storage", "[for_each][device]")
+CUB_TEST("Device for each copy works with temporary storage", "[for_each][device]", CUB_SMALL)
 {
   // example-begin for-each-copy-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
@@ -337,7 +341,7 @@ C2H_TEST("Device for each copy works with temporary storage", "[for_each][device
   REQUIRE(count == expected);
 }
 
-C2H_TEST("Device for each copy works without temporary storage", "[for_each][device]")
+CUB_TEST("Device for each copy works without temporary storage", "[for_each][device]", CUB_SMALL)
 {
   // example-begin for-each-copy-wo-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
@@ -372,7 +376,7 @@ struct noop_ref_t
   __device__ void operator()(int&) const {}
 };
 
-C2H_TEST("DeviceFor::Bulk legacy size-query is unambiguous", "[for][device]")
+CUB_TEST("DeviceFor::Bulk legacy size-query is unambiguous", "[for][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -381,7 +385,7 @@ C2H_TEST("DeviceFor::Bulk legacy size-query is unambiguous", "[for][device]")
   REQUIRE(cudaSuccess == cub::DeviceFor::Bulk(d_temp_storage, temp_storage_bytes, n, noop_t{}));
 }
 
-C2H_TEST("DeviceFor::ForEachN legacy size-query is unambiguous", "[for][device]")
+CUB_TEST("DeviceFor::ForEachN legacy size-query is unambiguous", "[for][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -391,7 +395,7 @@ C2H_TEST("DeviceFor::ForEachN legacy size-query is unambiguous", "[for][device]"
   REQUIRE(cudaSuccess == cub::DeviceFor::ForEachN(d_temp_storage, temp_storage_bytes, d_in, n, noop_ref_t{}));
 }
 
-C2H_TEST("DeviceFor::ForEach legacy size-query is unambiguous", "[for][device]")
+CUB_TEST("DeviceFor::ForEach legacy size-query is unambiguous", "[for][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -401,7 +405,7 @@ C2H_TEST("DeviceFor::ForEach legacy size-query is unambiguous", "[for][device]")
   REQUIRE(cudaSuccess == cub::DeviceFor::ForEach(d_temp_storage, temp_storage_bytes, d_first, d_last, noop_ref_t{}));
 }
 
-C2H_TEST("DeviceFor::ForEachCopyN legacy size-query is unambiguous", "[for][device]")
+CUB_TEST("DeviceFor::ForEachCopyN legacy size-query is unambiguous", "[for][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -411,7 +415,7 @@ C2H_TEST("DeviceFor::ForEachCopyN legacy size-query is unambiguous", "[for][devi
   REQUIRE(cudaSuccess == cub::DeviceFor::ForEachCopyN(d_temp_storage, temp_storage_bytes, d_in, n, noop_t{}));
 }
 
-C2H_TEST("DeviceFor::ForEachCopy legacy size-query is unambiguous", "[for][device]")
+CUB_TEST("DeviceFor::ForEachCopy legacy size-query is unambiguous", "[for][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;

--- a/cub/test/catch2_test_device_for_copy.cu
+++ b/cub/test/catch2_test_device_for_copy.cu
@@ -12,7 +12,7 @@
 #include <cuda/iterator>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -48,7 +48,7 @@ public:
   }
 };
 
-C2H_TEST("Device for each works", "[for_copy][device]")
+CUB_TEST("Device for each works", "[for_copy][device]", CUB_SMALL)
 {
   constexpr int max_items = 5000000;
   constexpr int min_items = 1;
@@ -76,7 +76,7 @@ C2H_TEST("Device for each works", "[for_copy][device]")
   REQUIRE(num_of_once_marked_items == num_items);
 }
 
-C2H_TEST("Device for each works with unaligned vectors", "[for_copy][device]")
+CUB_TEST("Device for each works with unaligned vectors", "[for_copy][device]", CUB_SMALL)
 {
   constexpr int max_items = 5000000;
   constexpr int min_items = 1;
@@ -105,7 +105,7 @@ C2H_TEST("Device for each works with unaligned vectors", "[for_copy][device]")
   REQUIRE(num_of_once_marked_items == num_items);
 }
 
-C2H_TEST("Device for each n works", "[for_copy][device]", offset_type)
+CUB_TEST("Device for each n works", "[for_copy][device]", CUB_SMALL, offset_type)
 {
   using offset_t = c2h::get<0, TestType>;
 
@@ -133,7 +133,7 @@ C2H_TEST("Device for each n works", "[for_copy][device]", offset_type)
   REQUIRE(num_of_once_marked_items == num_items);
 }
 
-C2H_TEST("Device for each n works with unaligned vectors", "[for_copy][device]", offset_type)
+CUB_TEST("Device for each n works with unaligned vectors", "[for_copy][device]", CUB_SMALL, offset_type)
 {
   using offset_t = c2h::get<0, TestType>;
 
@@ -164,7 +164,7 @@ C2H_TEST("Device for each n works with unaligned vectors", "[for_copy][device]",
   REQUIRE(num_of_once_marked_items == num_items);
 }
 
-C2H_TEST("Device for each works with counting iterator", "[for][device]")
+CUB_TEST("Device for each works with counting iterator", "[for][device]", CUB_SMALL)
 {
   using offset_t               = int;
   constexpr offset_t max_items = 5000000;

--- a/cub/test/catch2_test_device_for_each_in_extents.cu
+++ b/cub/test/catch2_test_device_for_each_in_extents.cu
@@ -13,7 +13,7 @@
 #include <cuda/std/mdspan>
 #include <cuda/std/span>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/utility.h>
 #include <catch2_test_launch_helper.h>
 
@@ -121,7 +121,7 @@ auto build_static_extents(IndexType, cuda::std::index_sequence<Dimensions...>)
   return {};
 }
 
-C2H_TEST("DeviceFor::ForEachInExtents static", "[ForEachInExtents][static][device]", index_types, dimensions)
+CUB_TEST("DeviceFor::ForEachInExtents static", "[ForEachInExtents][static][device]", CUB_SMALL, index_types, dimensions)
 {
   using index_type    = c2h::get<0, TestType>;
   using dims          = c2h::get<1, TestType>;
@@ -144,7 +144,7 @@ C2H_TEST("DeviceFor::ForEachInExtents static", "[ForEachInExtents][static][devic
 #endif // !_CCCL_COMPILER(MSVC)
 }
 
-C2H_TEST("DeviceFor::ForEachInExtents 3D dynamic", "[ForEachInExtents][dynamic][device]", index_types_dynamic)
+CUB_TEST("DeviceFor::ForEachInExtents 3D dynamic", "[ForEachInExtents][dynamic][device]", CUB_SMALL, index_types_dynamic)
 {
   [[maybe_unused]] constexpr int rank = 3;
   using index_type                    = c2h::get<0, TestType>;
@@ -181,7 +181,7 @@ struct incrementer_t
   }
 };
 
-C2H_TEST("DeviceFor::ForEachInExtents works", "[ForEachInExtents]")
+CUB_TEST("DeviceFor::ForEachInExtents works", "[ForEachInExtents]", CUB_SMALL)
 {
   constexpr int max_items  = 5000000;
   constexpr int min_items  = 1;

--- a/cub/test/catch2_test_device_for_each_in_extents_api.cu
+++ b/cub/test/catch2_test_device_for_each_in_extents_api.cu
@@ -24,7 +24,7 @@
 #  include <cstdlib>
 #  include <iostream>
 
-#  include <c2h/catch2_test_helper.h>
+#  include "catch2_test_macros.h"
 
 // example-begin for-each-in-extents-op
 struct linear_store_3D
@@ -41,7 +41,7 @@ struct linear_store_3D
 // example-end for-each-in-extents-op
 
 // clang-format off
-C2H_TEST("Device ForEachInExtents", "[ForEachInExtents][device]")
+CUB_TEST("Device ForEachInExtents", "[ForEachInExtents][device]", CUB_SMALL)
 {
   // example-begin for-each-in-extents-example
   using                            data_t = cuda::std::array<int, 3>;

--- a/cub/test/catch2_test_device_for_each_in_extents_api.cu
+++ b/cub/test/catch2_test_device_for_each_in_extents_api.cu
@@ -24,7 +24,7 @@
 #  include <cstdlib>
 #  include <iostream>
 
-#  include "catch2_test_macros.h"
+#  include "cub_test_macros.h"
 
 // example-begin for-each-in-extents-op
 struct linear_store_3D

--- a/cub/test/catch2_test_device_for_each_in_layout.cu
+++ b/cub/test/catch2_test_device_for_each_in_layout.cu
@@ -13,7 +13,7 @@
 #include <cuda/std/mdspan>
 #include <cuda/std/span>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/utility.h>
 #include <catch2_test_launch_helper.h>
 
@@ -136,7 +136,8 @@ auto build_static_extents(IndexType, cuda::std::index_sequence<Dimensions...>)
   return {};
 }
 
-C2H_TEST("DeviceFor::ForEachInLayout static", "[ForEachInLayout][static][device]", index_types, dimensions, layouts)
+CUB_TEST(
+  "DeviceFor::ForEachInLayout static", "[ForEachInLayout][static][device]", CUB_SMALL, index_types, dimensions, layouts)
 {
   using index_type    = c2h::get<0, TestType>;
   using dims          = c2h::get<1, TestType>;
@@ -163,7 +164,11 @@ C2H_TEST("DeviceFor::ForEachInLayout static", "[ForEachInLayout][static][device]
 #endif // !_CCCL_COMPILER(MSVC)
 }
 
-C2H_TEST("DeviceFor::ForEachInLayout 3D dynamic", "[ForEachInLayout][dynamic][device]", index_types_dynamic, layouts)
+CUB_TEST("DeviceFor::ForEachInLayout 3D dynamic",
+         "[ForEachInLayout][dynamic][device]",
+         CUB_SMALL,
+         index_types_dynamic,
+         layouts)
 {
   [[maybe_unused]] constexpr int rank = 3;
   using index_type                    = c2h::get<0, TestType>;
@@ -205,7 +210,7 @@ struct incrementer_t
   }
 };
 
-C2H_TEST("DeviceFor::ForEachInLayout no duplicates", "[ForEachInLayout][no_duplicates][device]", layouts)
+CUB_TEST("DeviceFor::ForEachInLayout no duplicates", "[ForEachInLayout][no_duplicates][device]", CUB_SMALL, layouts)
 {
   constexpr int min_items = 1;
   constexpr int max_items = 5000000;

--- a/cub/test/catch2_test_device_for_each_in_layout_api.cu
+++ b/cub/test/catch2_test_device_for_each_in_layout_api.cu
@@ -22,7 +22,7 @@
 #  include <cstdlib>
 #  include <iostream>
 
-#  include <c2h/catch2_test_helper.h>
+#  include "catch2_test_macros.h"
 
 // example-begin for-each-in-layout-op
 struct layout_store_3D
@@ -39,7 +39,7 @@ struct layout_store_3D
 // example-end for-each-in-layout-op
 
 // clang-format off
-C2H_TEST("Device ForEachInLayout", "[ForEachInLayout][device]")
+CUB_TEST("Device ForEachInLayout", "[ForEachInLayout][device]", CUB_SMALL)
 {
   // example-begin for-each-in-layout-example
   using data_t             = cuda::std::array<int, 3>;

--- a/cub/test/catch2_test_device_for_each_in_layout_api.cu
+++ b/cub/test/catch2_test_device_for_each_in_layout_api.cu
@@ -22,7 +22,7 @@
 #  include <cstdlib>
 #  include <iostream>
 
-#  include "catch2_test_macros.h"
+#  include "cub_test_macros.h"
 
 // example-begin for-each-in-layout-op
 struct layout_store_3D

--- a/cub/test/catch2_test_device_for_env.cu
+++ b/cub/test/catch2_test_device_for_env.cu
@@ -14,7 +14,7 @@
 
 #include <sstream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 struct square_ref_op
 {
@@ -51,7 +51,7 @@ struct odd_count_op
 // Bulk
 // -----------------------------------------------------------------------
 
-C2H_TEST("DeviceFor::Bulk env uses custom stream", "[for][env]")
+CUB_TEST("DeviceFor::Bulk env uses custom stream", "[for][env]", CUB_SMALL)
 {
   auto vec = c2h::device_vector<int>{1, 2, 3, 4};
   square_idx_op op{thrust::raw_pointer_cast(vec.data())};
@@ -71,7 +71,7 @@ C2H_TEST("DeviceFor::Bulk env uses custom stream", "[for][env]")
 // ForEachN
 // -----------------------------------------------------------------------
 
-C2H_TEST("DeviceFor::ForEachN env uses custom stream", "[for][env]")
+CUB_TEST("DeviceFor::ForEachN env uses custom stream", "[for][env]", CUB_SMALL)
 {
   auto vec = c2h::device_vector<int>{1, 2, 3, 4};
   square_ref_op op{};
@@ -91,7 +91,7 @@ C2H_TEST("DeviceFor::ForEachN env uses custom stream", "[for][env]")
 // ForEach
 // -----------------------------------------------------------------------
 
-C2H_TEST("DeviceFor::ForEach env uses custom stream", "[for][env]")
+CUB_TEST("DeviceFor::ForEach env uses custom stream", "[for][env]", CUB_SMALL)
 {
   auto vec = c2h::device_vector<int>{1, 2, 3, 4};
   square_ref_op op{};
@@ -111,7 +111,7 @@ C2H_TEST("DeviceFor::ForEach env uses custom stream", "[for][env]")
 // ForEachCopyN
 // -----------------------------------------------------------------------
 
-C2H_TEST("DeviceFor::ForEachCopyN env uses custom stream", "[for][env]")
+CUB_TEST("DeviceFor::ForEachCopyN env uses custom stream", "[for][env]", CUB_SMALL)
 {
   auto vec   = c2h::device_vector<int>{1, 2, 3, 4};
   auto count = c2h::device_vector<int>(1);
@@ -132,7 +132,7 @@ C2H_TEST("DeviceFor::ForEachCopyN env uses custom stream", "[for][env]")
 // ForEachCopy
 // -----------------------------------------------------------------------
 
-C2H_TEST("DeviceFor::ForEachCopy env uses custom stream", "[for][env]")
+CUB_TEST("DeviceFor::ForEachCopy env uses custom stream", "[for][env]", CUB_SMALL)
 {
   auto vec   = c2h::device_vector<int>{1, 2, 3, 4};
   auto count = c2h::device_vector<int>(1);
@@ -174,7 +174,7 @@ struct block_size_extracting_op
 using block_sizes =
   c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
 
-C2H_TEST("DeviceFor::Bulk can be tuned", "[for][device]", block_sizes)
+CUB_TEST("DeviceFor::Bulk can be tuned", "[for][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -185,7 +185,7 @@ C2H_TEST("DeviceFor::Bulk can be tuned", "[for][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceFor::ForEachN can be tuned", "[for][device]", block_sizes)
+CUB_TEST("DeviceFor::ForEachN can be tuned", "[for][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_data{1, 2, 3, 4};
@@ -197,7 +197,7 @@ C2H_TEST("DeviceFor::ForEachN can be tuned", "[for][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceFor::ForEach can be tuned", "[for][device]", block_sizes)
+CUB_TEST("DeviceFor::ForEach can be tuned", "[for][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_data{1, 2, 3, 4};
@@ -209,7 +209,7 @@ C2H_TEST("DeviceFor::ForEach can be tuned", "[for][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceFor::ForEachCopyN can be tuned", "[for][device]", block_sizes)
+CUB_TEST("DeviceFor::ForEachCopyN can be tuned", "[for][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_data{1, 2, 3, 4};
@@ -221,7 +221,7 @@ C2H_TEST("DeviceFor::ForEachCopyN can be tuned", "[for][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceFor::ForEachCopy can be tuned", "[for][device]", block_sizes)
+CUB_TEST("DeviceFor::ForEachCopy can be tuned", "[for][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_data{1, 2, 3, 4};
@@ -234,7 +234,7 @@ C2H_TEST("DeviceFor::ForEachCopy can be tuned", "[for][device]", block_sizes)
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test ForPolicy properties", "[for][device]")
+CUB_TEST("Test ForPolicy properties", "[for][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ForPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ForPolicy>);

--- a/cub/test/catch2_test_device_for_env_api.cu
+++ b/cub/test/catch2_test_device_for_env_api.cu
@@ -14,7 +14,7 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // example-begin bulk-square-env-t
 struct square_t
@@ -53,7 +53,7 @@ struct odd_count_t
 };
 // example-end odd-count-env-t
 
-C2H_TEST("cub::DeviceFor::Bulk env-based API", "[for][env]")
+CUB_TEST("cub::DeviceFor::Bulk env-based API", "[for][env]", CUB_SMALL)
 {
   // example-begin bulk-env
   auto vec = thrust::device_vector<int>{1, 2, 3, 4};
@@ -76,7 +76,7 @@ C2H_TEST("cub::DeviceFor::Bulk env-based API", "[for][env]")
   REQUIRE(vec == expected);
 }
 
-C2H_TEST("cub::DeviceFor::ForEachN env-based API", "[for][env]")
+CUB_TEST("cub::DeviceFor::ForEachN env-based API", "[for][env]", CUB_SMALL)
 {
   // example-begin for-each-n-env
   auto vec = thrust::device_vector<int>{1, 2, 3, 4};
@@ -99,7 +99,7 @@ C2H_TEST("cub::DeviceFor::ForEachN env-based API", "[for][env]")
   REQUIRE(vec == expected);
 }
 
-C2H_TEST("cub::DeviceFor::ForEach env-based API", "[for][env]")
+CUB_TEST("cub::DeviceFor::ForEach env-based API", "[for][env]", CUB_SMALL)
 {
   // example-begin for-each-env
   auto vec = thrust::device_vector<int>{1, 2, 3, 4};
@@ -122,7 +122,7 @@ C2H_TEST("cub::DeviceFor::ForEach env-based API", "[for][env]")
   REQUIRE(vec == expected);
 }
 
-C2H_TEST("cub::DeviceFor::ForEachCopyN env-based API", "[for][env]")
+CUB_TEST("cub::DeviceFor::ForEachCopyN env-based API", "[for][env]", CUB_SMALL)
 {
   // example-begin for-each-copy-n-env
   auto vec   = thrust::device_vector<int>{1, 2, 3, 4};
@@ -146,7 +146,7 @@ C2H_TEST("cub::DeviceFor::ForEachCopyN env-based API", "[for][env]")
   REQUIRE(count == expected_count);
 }
 
-C2H_TEST("cub::DeviceFor::ForEachCopy env-based API", "[for][env]")
+CUB_TEST("cub::DeviceFor::ForEachCopy env-based API", "[for][env]", CUB_SMALL)
 {
   // example-begin for-each-copy-env
   auto vec   = thrust::device_vector<int>{1, 2, 3, 4};
@@ -182,7 +182,7 @@ struct ForPolicySelector
 };
 // example-end bulk-policy-selector
 
-C2H_TEST("cub::DeviceFor::Bulk accepts a custom policy selector", "[for][env]")
+CUB_TEST("cub::DeviceFor::Bulk accepts a custom policy selector", "[for][env]", CUB_SMALL)
 {
   // example-begin bulk-tuning
   auto vec = thrust::device_vector<int>{1, 2, 3, 4};

--- a/cub/test/catch2_test_device_for_utils.cu
+++ b/cub/test/catch2_test_device_for_utils.cu
@@ -5,7 +5,7 @@
 
 #include <cub/device/device_for.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <class T>
 struct value_t
@@ -73,7 +73,7 @@ void test()
   STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, tpl_value_t>::value);
 }
 
-C2H_TEST("Device for utils correctly detect value overloads", "[for][device]")
+CUB_TEST("Device for utils correctly detect value overloads", "[for][device]", CUB_SMALL)
 {
   ::test<int>();
   ::test<double>();

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -26,7 +26,7 @@
 #include <tuple>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/extended_types.h>
 #include <c2h/vector.h>
 
@@ -513,7 +513,7 @@ using types =
                  float,
                  double>;
 
-C2H_TEST("DeviceHistogram::Histogram* basic use", "[histogram][device]", types)
+CUB_TEST("DeviceHistogram::Histogram* basic use", "[histogram][device]", CUB_SMALL, types)
 {
   using sample_t = c2h::get<0, TestType>;
   using level_t  = cs::conditional_t<cuda::is_floating_point_v<sample_t>, sample_t, int>;
@@ -525,7 +525,7 @@ C2H_TEST("DeviceHistogram::Histogram* basic use", "[histogram][device]", types)
 
 // TODO(bgruber): float produces INFs in the HistogramRange test setup AND the HistogramEven implementation
 // This test covers int32 and int64 arithmetic for bin computation
-C2H_TEST("DeviceHistogram::Histogram* large levels", "[histogram][device]", c2h::remove<types, float>)
+CUB_TEST("DeviceHistogram::Histogram* large levels", "[histogram][device]", CUB_SMALL, c2h::remove<types, float>)
 {
   using sample_t             = c2h::get<0, TestType>;
   using level_t              = sample_t;
@@ -538,7 +538,7 @@ C2H_TEST("DeviceHistogram::Histogram* large levels", "[histogram][device]", c2h:
   test_even_and_range<sample_t, 4, 3, int>(max_level, max_level_count, 1920, 1080);
 }
 
-C2H_TEST("DeviceHistogram::Histogram* odd image sizes", "[histogram][device]")
+CUB_TEST("DeviceHistogram::Histogram* odd image sizes", "[histogram][device]", CUB_SMALL)
 {
   using sample_t                = int;
   using level_t                 = int;
@@ -550,7 +550,7 @@ C2H_TEST("DeviceHistogram::Histogram* odd image sizes", "[histogram][device]")
   test_even_and_range<sample_t, 4, 3, int, level_t, int>(max_level, max_level_count, p.first, p.second);
 }
 
-C2H_TEST("DeviceHistogram::Histogram* entropy", "[histogram][device]")
+CUB_TEST("DeviceHistogram::Histogram* entropy", "[histogram][device]", CUB_SMALL)
 {
   const int entropy_reduction = GENERATE(-1, 3, 5); // entropy_reduction = -1 -> all samples == 0
   test_even_and_range<int, 4, 3, int>(256, 256 + 1, 1920, 1080, entropy_reduction);
@@ -563,8 +563,9 @@ struct ChannelConfig
   static constexpr auto active_channels = ActiveChannels;
 };
 
-C2H_TEST_LIST("DeviceHistogram::Histogram* channel configs",
+CUB_TEST_LIST("DeviceHistogram::Histogram* channel configs",
               "[histogram][device]",
+              CUB_SMALL,
               ChannelConfig<1, 1>,
               ChannelConfig<3, 3>,
               ChannelConfig<4, 3>,
@@ -575,7 +576,7 @@ C2H_TEST_LIST("DeviceHistogram::Histogram* channel configs",
 
 // Testing only HistogramEven is fine, because HistogramRange shares the loading logic and the different binning
 // implementations are not affected by the iterator.
-C2H_TEST("DeviceHistogram::HistogramEven sample iterator", "[histogram_even][device]")
+CUB_TEST("DeviceHistogram::HistogramEven sample iterator", "[histogram_even][device]", CUB_SMALL)
 {
   using sample_t                 = int;
   const auto width               = 100;
@@ -612,12 +613,12 @@ C2H_TEST("DeviceHistogram::HistogramEven sample iterator", "[histogram_even][dev
 }
 
 // Regression: https://github.com/NVIDIA/cub/issues/479
-C2H_TEST("DeviceHistogram::Histogram* regression NVIDIA/cub#479", "[histogram][device]")
+CUB_TEST("DeviceHistogram::Histogram* regression NVIDIA/cub#479", "[histogram][device]", CUB_SMALL)
 {
   test_even_and_range<float, 4, 3, int>(12, 7, 1920, 1080);
 }
 
-C2H_TEST("DeviceHistogram::Histogram* down-conversion size_t to int", "[histogram][device]")
+CUB_TEST("DeviceHistogram::Histogram* down-conversion size_t to int", "[histogram][device]", CUB_SMALL)
 {
   if constexpr (sizeof(size_t) != sizeof(int))
   {
@@ -626,7 +627,7 @@ C2H_TEST("DeviceHistogram::Histogram* down-conversion size_t to int", "[histogra
   }
 }
 
-C2H_TEST("DeviceHistogram::HistogramRange levels/samples aliasing", "[histogram_range][device]")
+CUB_TEST("DeviceHistogram::HistogramRange levels/samples aliasing", "[histogram_range][device]", CUB_SMALL)
 {
   constexpr int num_levels = 7;
   constexpr int h_samples[]{
@@ -658,7 +659,7 @@ C2H_TEST("DeviceHistogram::HistogramRange levels/samples aliasing", "[histogram_
 
 // Limit this large-memory reproducer to the host launch path.
 #if TEST_LAUNCH == 0
-C2H_TEST("DeviceHistogram::MultiHistogramEven large privatized offsets", "[histogram_even][device]")
+CUB_TEST("DeviceHistogram::MultiHistogramEven large privatized offsets", "[histogram_even][device]", CUB_LARGE)
 try
 {
   using sample_t  = int64_t;
@@ -697,8 +698,9 @@ catch (const std::exception& e)
 
 // Our bin computation for HistogramEven is guaranteed only for when (max_level - min_level) * num_bins does not
 // overflow using uint64_t arithmetic. In case of overflow, we expect cudaErrorInvalidValue to be returned.
-C2H_TEST_LIST("DeviceHistogram::HistogramEven bin computation does not overflow",
+CUB_TEST_LIST("DeviceHistogram::HistogramEven bin computation does not overflow",
               "[histogram_even][device]",
+              CUB_SMALL,
               uint8_t,
               uint16_t,
               uint32_t,
@@ -750,8 +752,8 @@ C2H_TEST_LIST("DeviceHistogram::HistogramEven bin computation does not overflow"
 
 // When the number of bins exceeds what LevelT can represent, the bin computation will overflow
 // during the cast to CommonT. We expect cudaErrorInvalidValue to be returned.
-C2H_TEST_LIST(
-  "DeviceHistogram::HistogramEven num_bins exceeds LevelT range", "[histogram_even][device]", int8_t, int16_t)
+CUB_TEST_LIST(
+  "DeviceHistogram::HistogramEven num_bins exceeds LevelT range", "[histogram_even][device]", CUB_SMALL, int8_t, int16_t)
 {
   using level_t   = TestType;
   using sample_t  = level_t; // Common case: LevelT == SampleT
@@ -811,7 +813,7 @@ C2H_TEST_LIST(
 #endif // TEST_LAUNCH == 0
 
 // Regression test for https://github.com/NVIDIA/cub/issues/489: integer rounding errors lead to incorrect bin detection
-C2H_TEST("DeviceHistogram::HistogramEven bin calculation regression", "[histogram_even][device]")
+CUB_TEST("DeviceHistogram::HistogramEven bin calculation regression", "[histogram_even][device]", CUB_SMALL)
 {
   constexpr int num_levels   = 8;
   const auto h_histogram_ref = c2h::host_vector<int>{1, 5, 0, 2, 1, 0, 0};

--- a/cub/test/catch2_test_device_histogram_api.cu
+++ b/cub/test/catch2_test_device_histogram_api.cu
@@ -7,9 +7,9 @@
 
 #include <cuda/std/array>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceHistogram::HistogramEven non-env overload is not ambiguous", "[histogram][device]")
+CUB_TEST("cub::DeviceHistogram::HistogramEven non-env overload is not ambiguous", "[histogram][device]", CUB_SMALL)
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -18,7 +18,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramEven non-env overload is not ambiguous"
     nullptr, temp_storage_bytes, samples.begin(), thrust::raw_pointer_cast(histogram.data()), 2, 0, 10, 1);
 }
 
-C2H_TEST("cub::DeviceHistogram::HistogramEven 2D non-env overload is not ambiguous", "[histogram][device]")
+CUB_TEST("cub::DeviceHistogram::HistogramEven 2D non-env overload is not ambiguous", "[histogram][device]", CUB_SMALL)
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -36,7 +36,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramEven 2D non-env overload is not ambiguo
     sizeof(int));
 }
 
-C2H_TEST("cub::DeviceHistogram::MultiHistogramEven non-env overload is not ambiguous", "[histogram][device]")
+CUB_TEST("cub::DeviceHistogram::MultiHistogramEven non-env overload is not ambiguous", "[histogram][device]", CUB_SMALL)
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -49,7 +49,9 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramEven non-env overload is not ambig
     nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, lower_level, upper_level, 1);
 }
 
-C2H_TEST("cub::DeviceHistogram::MultiHistogramEven 2D non-env overload is not ambiguous", "[histogram][device]")
+CUB_TEST("cub::DeviceHistogram::MultiHistogramEven 2D non-env overload is not ambiguous",
+         "[histogram][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -62,7 +64,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramEven 2D non-env overload is not am
     nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, lower_level, upper_level, 1, 1, sizeof(int));
 }
 
-C2H_TEST("cub::DeviceHistogram::HistogramRange non-env overload is not ambiguous", "[histogram][device]")
+CUB_TEST("cub::DeviceHistogram::HistogramRange non-env overload is not ambiguous", "[histogram][device]", CUB_SMALL)
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -78,7 +80,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramRange non-env overload is not ambiguous
     1);
 }
 
-C2H_TEST("cub::DeviceHistogram::HistogramRange 2D non-env overload is not ambiguous", "[histogram][device]")
+CUB_TEST("cub::DeviceHistogram::HistogramRange 2D non-env overload is not ambiguous", "[histogram][device]", CUB_SMALL)
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -96,7 +98,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramRange 2D non-env overload is not ambigu
     sizeof(int));
 }
 
-C2H_TEST("cub::DeviceHistogram::MultiHistogramRange non-env overload is not ambiguous", "[histogram][device]")
+CUB_TEST("cub::DeviceHistogram::MultiHistogramRange non-env overload is not ambiguous", "[histogram][device]", CUB_SMALL)
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -109,7 +111,9 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramRange non-env overload is not ambi
     nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, d_levels, 1);
 }
 
-C2H_TEST("cub::DeviceHistogram::MultiHistogramRange 2D non-env overload is not ambiguous", "[histogram][device]")
+CUB_TEST("cub::DeviceHistogram::MultiHistogramRange 2D non-env overload is not ambiguous",
+         "[histogram][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);

--- a/cub/test/catch2_test_device_histogram_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_histogram_custom_policy_hub.cu
@@ -13,7 +13,7 @@
 #include <cuda/std/array>
 #include <cuda/std/type_traits>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -28,7 +28,7 @@ struct my_policy_hub
   };
 };
 
-C2H_TEST("DispatchHistogram::DispatchEven: custom policy hub", "[histogram][device]")
+CUB_TEST("DispatchHistogram::DispatchEven: custom policy hub", "[histogram][device]", CUB_SMALL)
 {
   using sample_t                                     = cuda::std::uint8_t;
   using counter_t                                    = int;

--- a/cub/test/catch2_test_device_histogram_env.cu
+++ b/cub/test/catch2_test_device_histogram_env.cu
@@ -37,13 +37,13 @@ DECLARE_TMPL_LAUNCH_WRAPPER(cub::DeviceHistogram::MultiHistogramRange,
 #include <cuda/__execution/require.h>
 #include <cuda/__execution/tune.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("DeviceHistogram::HistogramEven works with default environment", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::HistogramEven works with default environment", "[histogram][device]", CUB_SMALL)
 {
   auto d_samples   = c2h::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
   int num_samples  = static_cast<int>(d_samples.size());
@@ -66,7 +66,9 @@ TEST_CASE("DeviceHistogram::HistogramEven works with default environment", "[his
   REQUIRE(d_histogram == expected);
 }
 
-TEST_CASE("DeviceHistogram::HistogramEven works with user provided memory and environment", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::HistogramEven works with user provided memory and environment",
+              "[histogram][device]",
+              CUB_SMALL)
 {
   auto d_samples   = c2h::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
   int num_samples  = static_cast<int>(d_samples.size());
@@ -172,7 +174,7 @@ TEST_CASE("DeviceHistogram::HistogramEven works with user provided memory and en
   }
 }
 
-TEST_CASE("DeviceHistogram::HistogramRange works with default environment", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::HistogramRange works with default environment", "[histogram][device]", CUB_SMALL)
 {
   auto d_samples   = c2h::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
   int num_samples  = static_cast<int>(d_samples.size());
@@ -192,7 +194,9 @@ TEST_CASE("DeviceHistogram::HistogramRange works with default environment", "[hi
   REQUIRE(d_histogram == expected);
 }
 
-TEST_CASE("DeviceHistogram::HistogramRange works with user provided memory and environment", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::HistogramRange works with user provided memory and environment",
+              "[histogram][device]",
+              CUB_SMALL)
 {
   auto d_samples   = c2h::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
   int num_samples  = static_cast<int>(d_samples.size());
@@ -294,7 +298,7 @@ TEST_CASE("DeviceHistogram::HistogramRange works with user provided memory and e
   }
 }
 
-TEST_CASE("DeviceHistogram::MultiHistogramEven works with default environment", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven works with default environment", "[histogram][device]", CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -328,7 +332,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven works with default environment", 
   REQUIRE(d_histogram_b == expected_b);
 }
 
-TEST_CASE("DeviceHistogram::MultiHistogramRange works with default environment", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange works with default environment", "[histogram][device]", CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -369,7 +373,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange works with default environment",
   REQUIRE(d_histogram_b == expected_b);
 }
 
-TEST_CASE("DeviceHistogram::HistogramEven 2D works with default environment", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::HistogramEven 2D works with default environment", "[histogram][device]", CUB_SMALL)
 {
   // 2 rows, 3 samples per row, stride of 4 (1 padding element)
   auto d_samples          = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
@@ -397,7 +401,7 @@ TEST_CASE("DeviceHistogram::HistogramEven 2D works with default environment", "[
   REQUIRE(d_histogram == expected);
 }
 
-TEST_CASE("DeviceHistogram::HistogramRange 2D works with default environment", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::HistogramRange 2D works with default environment", "[histogram][device]", CUB_SMALL)
 {
   auto d_samples          = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
   auto d_levels           = c2h::device_vector<int>{0, 1, 2, 3};
@@ -422,7 +426,7 @@ TEST_CASE("DeviceHistogram::HistogramRange 2D works with default environment", "
   REQUIRE(d_histogram == expected);
 }
 
-TEST_CASE("DeviceHistogram::MultiHistogramEven 2D works with default environment", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven 2D works with default environment", "[histogram][device]", CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -473,7 +477,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven 2D works with default environment
   REQUIRE(d_histogram_b == expected_b);
 }
 
-TEST_CASE("DeviceHistogram::MultiHistogramRange 2D works with default environment", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange 2D works with default environment", "[histogram][device]", CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -530,7 +534,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange 2D works with default environmen
 
 #endif
 
-C2H_TEST("DeviceHistogram::HistogramEven uses environment", "[histogram][device]")
+CUB_TEST("DeviceHistogram::HistogramEven uses environment", "[histogram][device]", CUB_SMALL)
 {
   auto d_samples   = c2h::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
   int num_samples  = static_cast<int>(d_samples.size());
@@ -567,7 +571,7 @@ C2H_TEST("DeviceHistogram::HistogramEven uses environment", "[histogram][device]
   REQUIRE(d_histogram == expected);
 }
 
-TEST_CASE("DeviceHistogram::HistogramEven uses custom stream", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::HistogramEven uses custom stream", "[histogram][device]", CUB_SMALL)
 {
   auto d_samples   = c2h::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
   int num_samples  = static_cast<int>(d_samples.size());
@@ -612,7 +616,7 @@ TEST_CASE("DeviceHistogram::HistogramEven uses custom stream", "[histogram][devi
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-C2H_TEST("DeviceHistogram::HistogramRange uses environment", "[histogram][device]")
+CUB_TEST("DeviceHistogram::HistogramRange uses environment", "[histogram][device]", CUB_SMALL)
 {
   auto d_samples   = c2h::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
   int num_samples  = static_cast<int>(d_samples.size());
@@ -646,7 +650,7 @@ C2H_TEST("DeviceHistogram::HistogramRange uses environment", "[histogram][device
   REQUIRE(d_histogram == expected);
 }
 
-TEST_CASE("DeviceHistogram::HistogramRange uses custom stream", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::HistogramRange uses custom stream", "[histogram][device]", CUB_SMALL)
 {
   auto d_samples   = c2h::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
   int num_samples  = static_cast<int>(d_samples.size());
@@ -688,7 +692,7 @@ TEST_CASE("DeviceHistogram::HistogramRange uses custom stream", "[histogram][dev
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-C2H_TEST("DeviceHistogram::MultiHistogramEven uses environment", "[histogram][device]")
+CUB_TEST("DeviceHistogram::MultiHistogramEven uses environment", "[histogram][device]", CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -735,7 +739,7 @@ C2H_TEST("DeviceHistogram::MultiHistogramEven uses environment", "[histogram][de
   REQUIRE(d_histogram_b == expected_b);
 }
 
-TEST_CASE("DeviceHistogram::MultiHistogramEven uses custom stream", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven uses custom stream", "[histogram][device]", CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -791,7 +795,9 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven uses custom stream", "[histogram]
 }
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DeviceHistogram::MultiHistogramRange works with user provided memory and environment", "[histogram][device]")
+CUB_TEST("DeviceHistogram::MultiHistogramRange works with user provided memory and environment",
+         "[histogram][device]",
+         CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -911,7 +917,7 @@ C2H_TEST("DeviceHistogram::MultiHistogramRange works with user provided memory a
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DeviceHistogram::MultiHistogramRange uses environment", "[histogram][device]")
+CUB_TEST("DeviceHistogram::MultiHistogramRange uses environment", "[histogram][device]", CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -964,7 +970,7 @@ C2H_TEST("DeviceHistogram::MultiHistogramRange uses environment", "[histogram][d
   REQUIRE(d_histogram_b == expected_b);
 }
 
-TEST_CASE("DeviceHistogram::MultiHistogramRange uses custom stream", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange uses custom stream", "[histogram][device]", CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -1025,7 +1031,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange uses custom stream", "[histogram
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-C2H_TEST("DeviceHistogram::HistogramEven 2D uses environment", "[histogram][device]")
+CUB_TEST("DeviceHistogram::HistogramEven 2D uses environment", "[histogram][device]", CUB_SMALL)
 {
   auto d_samples          = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
   int num_levels          = 4;
@@ -1068,7 +1074,7 @@ C2H_TEST("DeviceHistogram::HistogramEven 2D uses environment", "[histogram][devi
   REQUIRE(d_histogram == expected);
 }
 
-TEST_CASE("DeviceHistogram::HistogramEven 2D uses custom stream", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::HistogramEven 2D uses custom stream", "[histogram][device]", CUB_SMALL)
 {
   auto d_samples          = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
   int num_levels          = 4;
@@ -1119,7 +1125,7 @@ TEST_CASE("DeviceHistogram::HistogramEven 2D uses custom stream", "[histogram][d
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-C2H_TEST("DeviceHistogram::HistogramRange 2D uses environment", "[histogram][device]")
+CUB_TEST("DeviceHistogram::HistogramRange 2D uses environment", "[histogram][device]", CUB_SMALL)
 {
   auto d_samples          = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
   auto d_levels           = c2h::device_vector<int>{0, 1, 2, 3};
@@ -1159,7 +1165,7 @@ C2H_TEST("DeviceHistogram::HistogramRange 2D uses environment", "[histogram][dev
   REQUIRE(d_histogram == expected);
 }
 
-TEST_CASE("DeviceHistogram::HistogramRange 2D uses custom stream", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::HistogramRange 2D uses custom stream", "[histogram][device]", CUB_SMALL)
 {
   auto d_samples          = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
   auto d_levels           = c2h::device_vector<int>{0, 1, 2, 3};
@@ -1207,7 +1213,7 @@ TEST_CASE("DeviceHistogram::HistogramRange 2D uses custom stream", "[histogram][
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-C2H_TEST("DeviceHistogram::MultiHistogramEven 2D uses environment", "[histogram][device]")
+CUB_TEST("DeviceHistogram::MultiHistogramEven 2D uses environment", "[histogram][device]", CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -1268,7 +1274,7 @@ C2H_TEST("DeviceHistogram::MultiHistogramEven 2D uses environment", "[histogram]
   REQUIRE(d_histogram_b == expected_b);
 }
 
-TEST_CASE("DeviceHistogram::MultiHistogramEven 2D uses custom stream", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven 2D uses custom stream", "[histogram][device]", CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -1338,7 +1344,9 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven 2D uses custom stream", "[histogr
 }
 
 #if TEST_LAUNCH == 0
-TEST_CASE("DeviceHistogram::MultiHistogramEven works with user provided memory and environment", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven works with user provided memory and environment",
+              "[histogram][device]",
+              CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -1471,7 +1479,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven works with user provided memory a
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DeviceHistogram::MultiHistogramRange 2D uses environment", "[histogram][device]")
+CUB_TEST("DeviceHistogram::MultiHistogramRange 2D uses environment", "[histogram][device]", CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -1537,7 +1545,7 @@ C2H_TEST("DeviceHistogram::MultiHistogramRange 2D uses environment", "[histogram
   REQUIRE(d_histogram_b == expected_b);
 }
 
-TEST_CASE("DeviceHistogram::MultiHistogramRange 2D uses custom stream", "[histogram][device]")
+CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange 2D uses custom stream", "[histogram][device]", CUB_SMALL)
 {
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
@@ -1625,7 +1633,7 @@ struct histogram_tuning
 using block_sizes =
   c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
 
-C2H_TEST("DeviceHistogram::HistogramEven can be tuned", "[histogram][device]", block_sizes)
+CUB_TEST("DeviceHistogram::HistogramEven can be tuned", "[histogram][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -1643,7 +1651,7 @@ C2H_TEST("DeviceHistogram::HistogramEven can be tuned", "[histogram][device]", b
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceHistogram::HistogramRange can be tuned", "[histogram][device]", block_sizes)
+CUB_TEST("DeviceHistogram::HistogramRange can be tuned", "[histogram][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -1665,7 +1673,7 @@ C2H_TEST("DeviceHistogram::HistogramRange can be tuned", "[histogram][device]", 
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceHistogram::MultiHistogramEven can be tuned", "[histogram][device]", block_sizes)
+CUB_TEST("DeviceHistogram::MultiHistogramEven can be tuned", "[histogram][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   constexpr int NUM_CHANNELS               = 4;
@@ -1695,7 +1703,7 @@ C2H_TEST("DeviceHistogram::MultiHistogramEven can be tuned", "[histogram][device
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceHistogram::MultiHistogramRange can be tuned", "[histogram][device]", block_sizes)
+CUB_TEST("DeviceHistogram::MultiHistogramRange can be tuned", "[histogram][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   constexpr int NUM_CHANNELS               = 4;
@@ -1735,7 +1743,7 @@ C2H_TEST("DeviceHistogram::MultiHistogramRange can be tuned", "[histogram][devic
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test HistogramPolicy properties", "[histogram][device]")
+CUB_TEST("Test HistogramPolicy properties", "[histogram][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::HistogramPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::HistogramPolicy>);

--- a/cub/test/catch2_test_device_histogram_env_api.cu
+++ b/cub/test/catch2_test_device_histogram_env_api.cu
@@ -14,9 +14,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream", "[histogram][env]")
+CUB_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream", "[histogram][env]", CUB_SMALL)
 {
   // example-begin histogram-even-env
   auto d_samples   = thrust::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
@@ -50,7 +50,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream", "[histog
   REQUIRE(d_histogram == expected);
 }
 
-C2H_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream (2D)", "[histogram][env]")
+CUB_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream (2D)", "[histogram][env]", CUB_SMALL)
 {
   // example-begin histogram-even-2d-env
   // 2D region of interest: 2 rows, 3 samples per row, row stride includes 1 padding element
@@ -92,7 +92,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream (2D)", "[h
   REQUIRE(d_histogram == expected);
 }
 
-C2H_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream", "[histogram][env]")
+CUB_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream", "[histogram][env]", CUB_SMALL)
 {
   // example-begin histogram-range-env
   auto d_samples   = thrust::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
@@ -124,7 +124,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream", "[histo
   REQUIRE(d_histogram == expected);
 }
 
-C2H_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream (2D)", "[histogram][env]")
+CUB_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream (2D)", "[histogram][env]", CUB_SMALL)
 {
   // example-begin histogram-range-2d-env
   // 2D region of interest: 2 rows, 3 samples per row, row stride includes 1 padding element
@@ -164,7 +164,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream (2D)", "[
   REQUIRE(d_histogram == expected);
 }
 
-C2H_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (1D)", "[histogram][env]")
+CUB_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (1D)", "[histogram][env]", CUB_SMALL)
 {
   // example-begin multi-histogram-even-1d-env
   // 4-channel RGBA pixels, histogram 3 active channels
@@ -222,7 +222,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (1D)"
   REQUIRE(d_histogram_b == expected_b);
 }
 
-C2H_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (2D)", "[histogram][env]")
+CUB_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (2D)", "[histogram][env]", CUB_SMALL)
 {
   // example-begin multi-histogram-even-2d-env
   // 4-channel RGBA pixels, histogram 3 active channels, 2D region
@@ -285,7 +285,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (2D)"
   REQUIRE(d_histogram_b == expected_b);
 }
 
-C2H_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (1D)", "[histogram][env]")
+CUB_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (1D)", "[histogram][env]", CUB_SMALL)
 {
   // example-begin multi-histogram-range-1d-env
   // 4-channel RGBA pixels, histogram 3 active channels
@@ -342,7 +342,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (1D)
   REQUIRE(d_histogram_b == expected_b);
 }
 
-C2H_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (2D)", "[histogram][env]")
+CUB_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (2D)", "[histogram][env]", CUB_SMALL)
 {
   // example-begin multi-histogram-range-2d-env
   // 4-channel RGBA pixels, histogram 3 active channels, 2D region
@@ -431,7 +431,7 @@ struct HistogramPolicySelector
 };
 // example-end histogram-even-policy-selector
 
-C2H_TEST("cub::DeviceHistogram::HistogramEven accepts a custom policy selector", "[histogram][env]")
+CUB_TEST("cub::DeviceHistogram::HistogramEven accepts a custom policy selector", "[histogram][env]", CUB_SMALL)
 {
   // example-begin histogram-even-tuning
   auto d_samples   = thrust::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};

--- a/cub/test/catch2_test_device_memcpy_batched.cu
+++ b/cub/test/catch2_test_device_memcpy_batched.cu
@@ -13,13 +13,13 @@
 
 #include "catch2_test_device_memcpy_batched_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceMemcpy::Batched, memcpy_batched);
 
-C2H_TEST("DeviceMemcpy::Batched works", "[memcpy]")
+CUB_TEST("DeviceMemcpy::Batched works", "[memcpy]", CUB_SMALL)
 try
 {
   using src_ptr_t = const uint8_t*;
@@ -112,8 +112,9 @@ catch (std::bad_alloc& e)
   std::cerr << "Caught bad_alloc: " << e.what() << '\n';
 }
 
-C2H_TEST("DeviceMemcpy::Batched works for a very large buffer",
-         "[memcpy][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
+CUB_TEST("DeviceMemcpy::Batched works for a very large buffer",
+         "[memcpy][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_LARGE)
 try
 {
   using data_t        = uint64_t;
@@ -144,8 +145,9 @@ catch (std::bad_alloc& e)
   std::cerr << "Caught bad_alloc: " << e.what() << '\n';
 }
 
-C2H_TEST("DeviceMemcpy::Batched works for a very large number of buffer",
-         "[memcpy][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]")
+CUB_TEST("DeviceMemcpy::Batched works for a very large number of buffer",
+         "[memcpy][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]",
+         CUB_LARGE)
 try
 {
   using src_ptr_t       = const cuda::std::uint8_t*;

--- a/cub/test/catch2_test_device_memcpy_env.cu
+++ b/cub/test/catch2_test_device_memcpy_env.cu
@@ -27,7 +27,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceMemcpy::Batched, device_memcpy_batched);
 
 #include <cuda/__execution/require.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
@@ -53,7 +53,7 @@ struct get_size
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("DeviceMemcpy::Batched works with default environment", "[memcpy][device]")
+CUB_TEST_CASE("DeviceMemcpy::Batched works with default environment", "[memcpy][device]", CUB_SMALL)
 {
   // 3 buffers: [10, 20], [30, 40, 50], [60]
   auto d_src     = c2h::device_vector<int>{10, 20, 30, 40, 50, 60};
@@ -76,7 +76,7 @@ TEST_CASE("DeviceMemcpy::Batched works with default environment", "[memcpy][devi
 
 #endif
 
-C2H_TEST("DeviceMemcpy::Batched uses environment", "[memcpy][device]")
+CUB_TEST("DeviceMemcpy::Batched uses environment", "[memcpy][device]", CUB_SMALL)
 {
   // 3 buffers: [10, 20], [30, 40, 50], [60]
   auto d_src     = c2h::device_vector<int>{10, 20, 30, 40, 50, 60};
@@ -103,7 +103,7 @@ C2H_TEST("DeviceMemcpy::Batched uses environment", "[memcpy][device]")
   REQUIRE(d_dst == d_src);
 }
 
-TEST_CASE("DeviceMemcpy::Batched uses custom stream", "[memcpy][device]")
+CUB_TEST_CASE("DeviceMemcpy::Batched uses custom stream", "[memcpy][device]", CUB_SMALL)
 {
   // 3 buffers: [10, 20], [30, 40, 50], [60]
   auto d_src     = c2h::device_vector<int>{10, 20, 30, 40, 50, 60};
@@ -154,7 +154,7 @@ using block_sizes =
 
 #if TEST_LAUNCH != 1
 
-C2H_TEST("DeviceMemcpy::Batched can be tuned", "[memcpy][device]", block_sizes)
+CUB_TEST("DeviceMemcpy::Batched can be tuned", "[memcpy][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -186,7 +186,7 @@ C2H_TEST("DeviceMemcpy::Batched can be tuned", "[memcpy][device]", block_sizes)
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test BatchedCopyPolicy properties", "[memcpy][device]")
+CUB_TEST("Test BatchedCopyPolicy properties", "[memcpy][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::BatchedCopyPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::BatchedCopyPolicy>);

--- a/cub/test/catch2_test_device_memcpy_env_api.cu
+++ b/cub/test/catch2_test_device_memcpy_env_api.cu
@@ -14,9 +14,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceMemcpy::Batched accepts env with stream", "[memcpy][env]")
+CUB_TEST("cub::DeviceMemcpy::Batched accepts env with stream", "[memcpy][env]", CUB_SMALL)
 {
   // example-begin memcpy-batched-env
   // Source data: 3 buffers of different sizes laid out contiguously
@@ -101,7 +101,7 @@ struct BatchedMemcpyPolicySelector
 
 _CCCL_DIAG_POP
 
-C2H_TEST("cub::DeviceMemcpy::Batched accepts a custom policy selector", "[memcpy][env]")
+CUB_TEST("cub::DeviceMemcpy::Batched accepts a custom policy selector", "[memcpy][env]", CUB_SMALL)
 {
   // example-begin memcpy-batched-tuning
   // Source data: 3 buffers laid out contiguously

--- a/cub/test/catch2_test_device_merge.cu
+++ b/cub/test/catch2_test_device_merge.cu
@@ -15,7 +15,7 @@
 #include <test_util.h>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -61,15 +61,16 @@ void test_keys(Offset size1 = 3623, Offset size2 = 6346, CompareOp compare_op = 
   CHECK(reference_h == result_h);
 }
 
-C2H_TEST("DeviceMerge::MergeKeys key types", "[merge][device]", types)
+CUB_TEST("DeviceMerge::MergeKeys key types", "[merge][device]", CUB_SMALL, types)
 {
   using key_t    = c2h::get<0, TestType>;
   using offset_t = int;
   test_keys<key_t, offset_t>();
 }
 
-C2H_TEST("DeviceMerge::MergeKeys works for large number of items",
-         "[merge][device][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]")
+CUB_TEST("DeviceMerge::MergeKeys works for large number of items",
+         "[merge][device][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]",
+         CUB_LARGE)
 try
 {
   using key_t    = char;
@@ -92,7 +93,7 @@ catch (const std::bad_alloc&)
   SUCCEED("allocation failure is not a test failure");
 }
 
-C2H_TEST("DeviceMerge::MergeKeys input sizes", "[merge][device]")
+CUB_TEST("DeviceMerge::MergeKeys input sizes", "[merge][device]", CUB_SMALL)
 {
   using key_t    = int;
   using offset_t = int;
@@ -102,7 +103,7 @@ C2H_TEST("DeviceMerge::MergeKeys input sizes", "[merge][device]")
   test_keys<key_t>(size1, size2);
 }
 
-C2H_TEST("DeviceMerge::MergeKeys almost tile-sized input sizes", "[merge][device]")
+CUB_TEST("DeviceMerge::MergeKeys almost tile-sized input sizes", "[merge][device]", CUB_SMALL)
 {
   using key_t    = int;
   using offset_t = int;
@@ -129,7 +130,7 @@ struct order
   }
 };
 
-C2H_TEST("DeviceMerge::MergeKeys no operator<", "[merge][device]")
+CUB_TEST("DeviceMerge::MergeKeys no operator<", "[merge][device]", CUB_SMALL)
 {
   using key_t    = unordered_t;
   using offset_t = int;
@@ -241,7 +242,7 @@ void test_pairs(
   CHECK((detail::to_vec(reference_values_h) == detail::to_vec(c2h::host_vector<Value>(result_values_d))));
 }
 
-C2H_TEST("DeviceMerge::MergePairs key types", "[merge][device]", types)
+CUB_TEST("DeviceMerge::MergePairs key types", "[merge][device]", CUB_SMALL, types)
 {
   using key_t    = c2h::get<0, TestType>;
   using value_t  = int;
@@ -258,7 +259,7 @@ C2H_TEST("DeviceMerge::MergePairs key types", "[merge][device]", types)
 //   test_pairs<key_t, value_t, offset_t>();
 // }
 
-C2H_TEST("DeviceMerge::MergePairs value types", "[merge][device]", types)
+CUB_TEST("DeviceMerge::MergePairs value types", "[merge][device]", CUB_SMALL, types)
 {
   using key_t    = int;
   using value_t  = c2h::get<0, TestType>;
@@ -266,7 +267,7 @@ C2H_TEST("DeviceMerge::MergePairs value types", "[merge][device]", types)
   test_pairs<key_t, value_t, offset_t>();
 }
 
-C2H_TEST("DeviceMerge::MergePairs input sizes", "[merge][device]")
+CUB_TEST("DeviceMerge::MergePairs input sizes", "[merge][device]", CUB_SMALL)
 {
   using key_t      = int;
   using value_t    = int;
@@ -277,8 +278,9 @@ C2H_TEST("DeviceMerge::MergePairs input sizes", "[merge][device]")
 }
 
 // this test exceeds 4GiB of memory and the range of 32-bit integers
-C2H_TEST("DeviceMerge::MergePairs really large input",
-         "[merge][device][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]")
+CUB_TEST("DeviceMerge::MergePairs really large input",
+         "[merge][device][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]",
+         CUB_LARGE)
 try
 {
   using key_t     = char;
@@ -292,7 +294,7 @@ catch (const std::bad_alloc&)
   SUCCEED("allocation failure is not a test failure");
 }
 
-C2H_TEST("DeviceMerge::MergePairs iterators", "[merge][device]")
+CUB_TEST("DeviceMerge::MergePairs iterators", "[merge][device]", CUB_SMALL)
 {
   using key_t             = int;
   using value_t           = int;

--- a/cub/test/catch2_test_device_merge_api.cu
+++ b/cub/test/catch2_test_device_merge_api.cu
@@ -8,9 +8,9 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("DeviceMerge::MergeKeys API example", "[merge][device]")
+CUB_TEST("DeviceMerge::MergeKeys API example", "[merge][device]", CUB_SMALL)
 {
   // example-begin merge-keys
   c2h::device_vector<int> keys1{0, 2, 5};
@@ -46,7 +46,7 @@ C2H_TEST("DeviceMerge::MergeKeys API example", "[merge][device]")
   CHECK(result == expected);
 }
 
-C2H_TEST("DeviceMerge::MergePairs API example", "[merge][device]")
+CUB_TEST("DeviceMerge::MergePairs API example", "[merge][device]", CUB_SMALL)
 {
   // example-begin merge-pairs
   c2h::device_vector<int> keys1{0, 2, 5};

--- a/cub/test/catch2_test_device_merge_env.cu
+++ b/cub/test/catch2_test_device_merge_env.cu
@@ -22,7 +22,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceMerge::MergePairs, merge_pairs);
 
 #include <cuda/__execution/require.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
@@ -42,7 +42,7 @@ using block_sizes =
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("DeviceMerge::MergeKeys works with default environment", "[merge][device]")
+CUB_TEST_CASE("DeviceMerge::MergeKeys works with default environment", "[merge][device]", CUB_SMALL)
 {
   auto keys1  = c2h::device_vector<int>{0, 2, 5};
   auto keys2  = c2h::device_vector<int>{0, 3, 3, 4};
@@ -57,7 +57,7 @@ TEST_CASE("DeviceMerge::MergeKeys works with default environment", "[merge][devi
   REQUIRE(result == expected);
 }
 
-TEST_CASE("DeviceMerge::MergePairs works with default environment", "[merge][device]")
+CUB_TEST_CASE("DeviceMerge::MergePairs works with default environment", "[merge][device]", CUB_SMALL)
 {
   auto keys1   = c2h::device_vector<int>{0, 2, 5};
   auto values1 = c2h::device_vector<char>{'a', 'b', 'c'};
@@ -87,7 +87,7 @@ TEST_CASE("DeviceMerge::MergePairs works with default environment", "[merge][dev
 
 #endif
 
-C2H_TEST("DeviceMerge::MergeKeys can be tuned", "[merge][device]", block_sizes)
+CUB_TEST("DeviceMerge::MergeKeys can be tuned", "[merge][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto keys1                               = c2h::device_vector<int>{0, 2, 5};
@@ -115,7 +115,7 @@ C2H_TEST("DeviceMerge::MergeKeys can be tuned", "[merge][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceMerge::MergePairs can be tuned", "[merge][device]", block_sizes)
+CUB_TEST("DeviceMerge::MergePairs can be tuned", "[merge][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto keys1                               = c2h::device_vector<int>{0, 2, 5};
@@ -151,7 +151,7 @@ C2H_TEST("DeviceMerge::MergePairs can be tuned", "[merge][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceMerge::MergeKeys uses environment", "[merge][device]")
+CUB_TEST("DeviceMerge::MergeKeys uses environment", "[merge][device]", CUB_SMALL)
 {
   auto keys1  = c2h::device_vector<int>{0, 2, 5};
   auto keys2  = c2h::device_vector<int>{0, 3, 3, 4};
@@ -183,7 +183,7 @@ C2H_TEST("DeviceMerge::MergeKeys uses environment", "[merge][device]")
   REQUIRE(result == expected);
 }
 
-TEST_CASE("DeviceMerge::MergeKeys uses custom stream", "[merge][device]")
+CUB_TEST_CASE("DeviceMerge::MergeKeys uses custom stream", "[merge][device]", CUB_SMALL)
 {
   auto keys1  = c2h::device_vector<int>{0, 2, 5};
   auto keys2  = c2h::device_vector<int>{0, 3, 3, 4};
@@ -223,7 +223,7 @@ TEST_CASE("DeviceMerge::MergeKeys uses custom stream", "[merge][device]")
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-C2H_TEST("DeviceMerge::MergePairs uses environment", "[merge][device]")
+CUB_TEST("DeviceMerge::MergePairs uses environment", "[merge][device]", CUB_SMALL)
 {
   auto keys1   = c2h::device_vector<int>{0, 2, 5};
   auto values1 = c2h::device_vector<char>{'a', 'b', 'c'};
@@ -268,7 +268,7 @@ C2H_TEST("DeviceMerge::MergePairs uses environment", "[merge][device]")
   REQUIRE(result_values == expected_values);
 }
 
-TEST_CASE("DeviceMerge::MergePairs uses custom stream", "[merge][device]")
+CUB_TEST_CASE("DeviceMerge::MergePairs uses custom stream", "[merge][device]", CUB_SMALL)
 {
   auto keys1   = c2h::device_vector<int>{0, 2, 5};
   auto values1 = c2h::device_vector<char>{'a', 'b', 'c'};
@@ -329,7 +329,7 @@ struct no_unroll_tuning
   }
 };
 
-TEST_CASE("DeviceMerge::MergeKeys works with unroll disabled", "[merge][device]")
+CUB_TEST_CASE("DeviceMerge::MergeKeys works with unroll disabled", "[merge][device]", CUB_SMALL)
 {
   auto keys1  = c2h::device_vector<int>{0, 2, 5};
   auto keys2  = c2h::device_vector<int>{0, 3, 3, 4};
@@ -351,7 +351,7 @@ TEST_CASE("DeviceMerge::MergeKeys works with unroll disabled", "[merge][device]"
   REQUIRE(result == expected);
 }
 
-TEST_CASE("DeviceMerge::MergePairs works with unroll disabled", "[merge][device]")
+CUB_TEST_CASE("DeviceMerge::MergePairs works with unroll disabled", "[merge][device]", CUB_SMALL)
 {
   auto keys1   = c2h::device_vector<int>{0, 2, 5};
   auto values1 = c2h::device_vector<char>{'a', 'b', 'c'};
@@ -383,7 +383,7 @@ TEST_CASE("DeviceMerge::MergePairs works with unroll disabled", "[merge][device]
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test MergePolicy properties", "[merge][device]")
+CUB_TEST("Test MergePolicy properties", "[merge][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::MergePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::MergePolicy>);

--- a/cub/test/catch2_test_device_merge_env_api.cu
+++ b/cub/test/catch2_test_device_merge_env_api.cu
@@ -13,9 +13,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceMerge::MergeKeys accepts env with stream", "[merge][env]")
+CUB_TEST("cub::DeviceMerge::MergeKeys accepts env with stream", "[merge][env]", CUB_SMALL)
 {
   // example-begin merge-keys-env
   auto keys1  = thrust::device_vector<int>{0, 2, 5};
@@ -46,7 +46,7 @@ C2H_TEST("cub::DeviceMerge::MergeKeys accepts env with stream", "[merge][env]")
   REQUIRE(result == expected);
 }
 
-C2H_TEST("cub::DeviceMerge::MergePairs accepts env with stream", "[merge][env]")
+CUB_TEST("cub::DeviceMerge::MergePairs accepts env with stream", "[merge][env]", CUB_SMALL)
 {
   // example-begin merge-pairs-env
   auto keys1   = thrust::device_vector<int>{0, 2, 5};
@@ -103,7 +103,7 @@ struct MergePolicySelector
 };
 // example-end merge-keys-policy-selector
 
-C2H_TEST("cub::DeviceMerge::MergeKeys accepts a custom policy selector", "[merge][env]")
+CUB_TEST("cub::DeviceMerge::MergeKeys accepts a custom policy selector", "[merge][env]", CUB_SMALL)
 {
   // example-begin merge-keys-tuning
   auto keys1  = thrust::device_vector<int>{0, 2, 5};

--- a/cub/test/catch2_test_device_merge_no_unroll.cu
+++ b/cub/test/catch2_test_device_merge_no_unroll.cu
@@ -17,7 +17,7 @@
 #include <test_util.h>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -70,7 +70,10 @@ struct fixed_policy_selector
   }
 };
 
-C2H_TEST("DeviceMerge::MergeKeys large key types", "[merge][device]", c2h::type_list<large_type_vsmem, large_type_fallb>)
+CUB_TEST("DeviceMerge::MergeKeys large key types",
+         "[merge][device]",
+         CUB_LARGE,
+         c2h::type_list<large_type_vsmem, large_type_fallb>)
 {
   using key_t    = c2h::get<0, TestType>;
   using offset_t = int;

--- a/cub/test/catch2_test_device_merge_sort.cu
+++ b/cub/test/catch2_test_device_merge_sort.cu
@@ -21,7 +21,7 @@
 #include "catch2_large_array_sort_helper.cuh"
 #include "catch2_test_device_merge_sort_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -194,8 +194,9 @@ c2h::device_vector<OffsetT> make_shuffled_key_ranks_vector(OffsetT num_items, c2
   return key_ranks;
 }
 
-C2H_TEST("DeviceMergeSort::SortKeysCopy works",
+CUB_TEST("DeviceMergeSort::SortKeysCopy works",
          "[merge][sort][device][skip-cs-racecheck][skip-cs-memcheck]",
+         CUB_SMALL,
          wide_key_types)
 {
   using key_t    = typename c2h::get<0, TestType>;
@@ -222,7 +223,7 @@ C2H_TEST("DeviceMergeSort::SortKeysCopy works",
   REQUIRE(results_equal == true);
 }
 
-C2H_TEST("DeviceMergeSort::SortKeys works", "[merge][sort][device]", wide_key_types)
+CUB_TEST("DeviceMergeSort::SortKeys works", "[merge][sort][device]", CUB_SMALL, wide_key_types)
 {
   using key_t    = typename c2h::get<0, TestType>;
   using offset_t = std::int32_t;
@@ -246,9 +247,10 @@ C2H_TEST("DeviceMergeSort::SortKeys works", "[merge][sort][device]", wide_key_ty
   REQUIRE(results_equal == true);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortKeysCopy works and performs a stable sort when there are a lot sort-keys that "
+CUB_TEST("DeviceMergeSort::StableSortKeysCopy works and performs a stable sort when there are a lot sort-keys that "
          "compare equal",
-         "[merge][sort][device][skip-cs-racecheck][skip-cs-memcheck]")
+         "[merge][sort][device][skip-cs-racecheck][skip-cs-memcheck]",
+         CUB_SMALL)
 {
   using key_t    = c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t>;
   using offset_t = std::size_t;
@@ -277,7 +279,7 @@ C2H_TEST("DeviceMergeSort::StableSortKeysCopy works and performs a stable sort w
   REQUIRE(keys_expected == keys_out);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortKeys works", "[merge][sort][device]")
+CUB_TEST("DeviceMergeSort::StableSortKeys works", "[merge][sort][device]", CUB_SMALL)
 {
   using key_t    = c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t>;
   using offset_t = std::int32_t;
@@ -299,8 +301,9 @@ C2H_TEST("DeviceMergeSort::StableSortKeys works", "[merge][sort][device]")
   REQUIRE(keys_expected == keys_in_out);
 }
 
-C2H_TEST("DeviceMergeSort::SortPairsCopy works",
+CUB_TEST("DeviceMergeSort::SortPairsCopy works",
          "[merge][sort][device][skip-cs-racecheck][skip-cs-memcheck]",
+         CUB_SMALL,
          wide_key_types)
 {
   using key_t    = typename c2h::get<0, TestType>;
@@ -336,7 +339,7 @@ C2H_TEST("DeviceMergeSort::SortPairsCopy works",
   REQUIRE(values_equal == true);
 }
 
-C2H_TEST("DeviceMergeSort::SortPairs works", "[merge][sort][device]", wide_key_types)
+CUB_TEST("DeviceMergeSort::SortPairs works", "[merge][sort][device]", CUB_SMALL, wide_key_types)
 {
   using key_t    = typename c2h::get<0, TestType>;
   using offset_t = std::int32_t;
@@ -366,8 +369,11 @@ C2H_TEST("DeviceMergeSort::SortPairs works", "[merge][sort][device]", wide_key_t
   REQUIRE(values_equal == true);
 }
 
-C2H_TEST(
-  "DeviceMergeSort::StableSortPairs works and performs a stable sort", "[merge][sort][device]", key_types, value_types)
+CUB_TEST("DeviceMergeSort::StableSortPairs works and performs a stable sort",
+         "[merge][sort][device]",
+         CUB_SMALL,
+         key_types,
+         value_types)
 {
   using key_t    = typename c2h::get<0, TestType>;
   using data_t   = typename c2h::get<1, TestType>;
@@ -401,8 +407,9 @@ C2H_TEST(
   REQUIRE(values_expected == values_in_out);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortPairs works for large inputs",
+CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs",
          "[merge][sort][device][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_LARGE,
          offset_types)
 {
   using testing_types_tuple = c2h::get<0, TestType>;

--- a/cub/test/catch2_test_device_merge_sort_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_api.cu
@@ -5,9 +5,9 @@
 
 #include <thrust/device_vector.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceMergeSort::SortPairs non-env overload is not ambiguous", "[merge_sort][device]")
+CUB_TEST("cub::DeviceMergeSort::SortPairs non-env overload is not ambiguous", "[merge_sort][device]", CUB_SMALL)
 {
   thrust::device_vector<int> keys(1);
   thrust::device_vector<int> values(1);
@@ -15,7 +15,7 @@ C2H_TEST("cub::DeviceMergeSort::SortPairs non-env overload is not ambiguous", "[
   cub::DeviceMergeSort::SortPairs(nullptr, temp_storage_bytes, keys.begin(), values.begin(), 1, cuda::std::less<>{});
 }
 
-C2H_TEST("cub::DeviceMergeSort::SortPairsCopy non-env overload is not ambiguous", "[merge_sort][device]")
+CUB_TEST("cub::DeviceMergeSort::SortPairsCopy non-env overload is not ambiguous", "[merge_sort][device]", CUB_SMALL)
 {
   thrust::device_vector<int> keys_in(1);
   thrust::device_vector<int> values_in(1);
@@ -33,14 +33,14 @@ C2H_TEST("cub::DeviceMergeSort::SortPairsCopy non-env overload is not ambiguous"
     cuda::std::less<>{});
 }
 
-C2H_TEST("cub::DeviceMergeSort::SortKeys non-env overload is not ambiguous", "[merge_sort][device]")
+CUB_TEST("cub::DeviceMergeSort::SortKeys non-env overload is not ambiguous", "[merge_sort][device]", CUB_SMALL)
 {
   thrust::device_vector<int> keys(1);
   size_t temp_storage_bytes = 0;
   cub::DeviceMergeSort::SortKeys(nullptr, temp_storage_bytes, keys.begin(), 1, cuda::std::less<>{});
 }
 
-C2H_TEST("cub::DeviceMergeSort::SortKeysCopy non-env overload is not ambiguous", "[merge_sort][device]")
+CUB_TEST("cub::DeviceMergeSort::SortKeysCopy non-env overload is not ambiguous", "[merge_sort][device]", CUB_SMALL)
 {
   thrust::device_vector<int> keys_in(1);
   thrust::device_vector<int> keys_out(1);
@@ -49,7 +49,7 @@ C2H_TEST("cub::DeviceMergeSort::SortKeysCopy non-env overload is not ambiguous",
     nullptr, temp_storage_bytes, keys_in.begin(), keys_out.begin(), 1, cuda::std::less<>{});
 }
 
-C2H_TEST("cub::DeviceMergeSort::StableSortPairs non-env overload is not ambiguous", "[merge_sort][device]")
+CUB_TEST("cub::DeviceMergeSort::StableSortPairs non-env overload is not ambiguous", "[merge_sort][device]", CUB_SMALL)
 {
   thrust::device_vector<int> keys(1);
   thrust::device_vector<int> values(1);
@@ -58,14 +58,14 @@ C2H_TEST("cub::DeviceMergeSort::StableSortPairs non-env overload is not ambiguou
     nullptr, temp_storage_bytes, keys.begin(), values.begin(), 1, cuda::std::less<>{});
 }
 
-C2H_TEST("cub::DeviceMergeSort::StableSortKeys non-env overload is not ambiguous", "[merge_sort][device]")
+CUB_TEST("cub::DeviceMergeSort::StableSortKeys non-env overload is not ambiguous", "[merge_sort][device]", CUB_SMALL)
 {
   thrust::device_vector<int> keys(1);
   size_t temp_storage_bytes = 0;
   cub::DeviceMergeSort::StableSortKeys(nullptr, temp_storage_bytes, keys.begin(), 1, cuda::std::less<>{});
 }
 
-C2H_TEST("cub::DeviceMergeSort::StableSortKeysCopy non-env overload is not ambiguous", "[merge_sort][device]")
+CUB_TEST("cub::DeviceMergeSort::StableSortKeysCopy non-env overload is not ambiguous", "[merge_sort][device]", CUB_SMALL)
 {
   thrust::device_vector<int> keys_in(1);
   thrust::device_vector<int> keys_out(1);

--- a/cub/test/catch2_test_device_merge_sort_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_merge_sort_custom_policy_hub.cu
@@ -15,7 +15,7 @@
 #include <algorithm>
 
 #include "catch2_test_device_merge_sort_common.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -36,7 +36,7 @@ struct my_policy_hub
   };
 };
 
-C2H_TEST("DispatchMergeSort::Dispatch: custom policy hub", "[merge][sort][device]")
+CUB_TEST("DispatchMergeSort::Dispatch: custom policy hub", "[merge][sort][device]", CUB_SMALL)
 {
   using key_t              = int;
   using offset_t           = unsigned;

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -30,7 +30,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceMergeSort::StableSortKeysCopy, device_merge_st
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
@@ -45,7 +45,7 @@ struct merge_sort_tuning
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("DeviceMergeSort::SortPairs works with default environment", "[merge_sort][device]")
+CUB_TEST_CASE("DeviceMergeSort::SortPairs works with default environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_values = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
@@ -60,7 +60,7 @@ TEST_CASE("DeviceMergeSort::SortPairs works with default environment", "[merge_s
   REQUIRE(d_values == expected_values);
 }
 
-TEST_CASE("DeviceMergeSort::SortKeys works with default environment", "[merge_sort][device]")
+CUB_TEST_CASE("DeviceMergeSort::SortKeys works with default environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
 
@@ -72,7 +72,7 @@ TEST_CASE("DeviceMergeSort::SortKeys works with default environment", "[merge_so
   REQUIRE(d_keys == expected_keys);
 }
 
-TEST_CASE("DeviceMergeSort::StableSortPairs works with default environment", "[merge_sort][device]")
+CUB_TEST_CASE("DeviceMergeSort::StableSortPairs works with default environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys   = c2h::device_vector<int>{8, 6, 6, 5, 3, 0, 9};
   auto d_values = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
@@ -87,7 +87,7 @@ TEST_CASE("DeviceMergeSort::StableSortPairs works with default environment", "[m
   REQUIRE(d_values == expected_values);
 }
 
-TEST_CASE("DeviceMergeSort::StableSortKeys works with default environment", "[merge_sort][device]")
+CUB_TEST_CASE("DeviceMergeSort::StableSortKeys works with default environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
 
@@ -99,7 +99,7 @@ TEST_CASE("DeviceMergeSort::StableSortKeys works with default environment", "[me
   REQUIRE(d_keys == expected_keys);
 }
 
-TEST_CASE("DeviceMergeSort::SortPairsCopy works with default environment", "[merge_sort][device]")
+CUB_TEST_CASE("DeviceMergeSort::SortPairsCopy works with default environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_values_in  = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
@@ -122,7 +122,7 @@ TEST_CASE("DeviceMergeSort::SortPairsCopy works with default environment", "[mer
   REQUIRE(d_values_out == expected_values);
 }
 
-TEST_CASE("DeviceMergeSort::SortKeysCopy works with default environment", "[merge_sort][device]")
+CUB_TEST_CASE("DeviceMergeSort::SortKeysCopy works with default environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_keys_out = c2h::device_vector<int>(7);
@@ -136,7 +136,7 @@ TEST_CASE("DeviceMergeSort::SortKeysCopy works with default environment", "[merg
   REQUIRE(d_keys_out == expected_keys);
 }
 
-TEST_CASE("DeviceMergeSort::StableSortKeysCopy works with default environment", "[merge_sort][device]")
+CUB_TEST_CASE("DeviceMergeSort::StableSortKeysCopy works with default environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_keys_out = c2h::device_vector<int>(7);
@@ -152,7 +152,7 @@ TEST_CASE("DeviceMergeSort::StableSortKeysCopy works with default environment", 
 
 #endif
 
-C2H_TEST("DeviceMergeSort::SortPairs uses environment", "[merge_sort][device]")
+CUB_TEST("DeviceMergeSort::SortPairs uses environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_values = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
@@ -179,7 +179,7 @@ C2H_TEST("DeviceMergeSort::SortPairs uses environment", "[merge_sort][device]")
   REQUIRE(d_values == expected_values);
 }
 
-C2H_TEST("DeviceMergeSort::SortKeys uses environment", "[merge_sort][device]")
+CUB_TEST("DeviceMergeSort::SortKeys uses environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
 
@@ -197,7 +197,7 @@ C2H_TEST("DeviceMergeSort::SortKeys uses environment", "[merge_sort][device]")
   REQUIRE(d_keys == expected_keys);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortPairs uses environment", "[merge_sort][device]")
+CUB_TEST("DeviceMergeSort::StableSortPairs uses environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys   = c2h::device_vector<int>{8, 6, 6, 5, 3, 0, 9};
   auto d_values = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
@@ -224,7 +224,7 @@ C2H_TEST("DeviceMergeSort::StableSortPairs uses environment", "[merge_sort][devi
   REQUIRE(d_values == expected_values);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortKeys uses environment", "[merge_sort][device]")
+CUB_TEST("DeviceMergeSort::StableSortKeys uses environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
 
@@ -242,7 +242,7 @@ C2H_TEST("DeviceMergeSort::StableSortKeys uses environment", "[merge_sort][devic
   REQUIRE(d_keys == expected_keys);
 }
 
-TEST_CASE("DeviceMergeSort::SortPairs uses custom stream", "[merge_sort][device]")
+CUB_TEST_CASE("DeviceMergeSort::SortPairs uses custom stream", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_values = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
@@ -276,7 +276,7 @@ TEST_CASE("DeviceMergeSort::SortPairs uses custom stream", "[merge_sort][device]
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-TEST_CASE("DeviceMergeSort::StableSortKeys uses custom stream", "[merge_sort][device]")
+CUB_TEST_CASE("DeviceMergeSort::StableSortKeys uses custom stream", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
 
@@ -301,7 +301,7 @@ TEST_CASE("DeviceMergeSort::StableSortKeys uses custom stream", "[merge_sort][de
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-C2H_TEST("DeviceMergeSort::SortPairsCopy uses environment", "[merge_sort][device]")
+CUB_TEST("DeviceMergeSort::SortPairsCopy uses environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_values_in  = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
@@ -338,7 +338,7 @@ C2H_TEST("DeviceMergeSort::SortPairsCopy uses environment", "[merge_sort][device
   REQUIRE(d_values_out == expected_values);
 }
 
-C2H_TEST("DeviceMergeSort::SortKeysCopy uses environment", "[merge_sort][device]")
+CUB_TEST("DeviceMergeSort::SortKeysCopy uses environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_keys_out = c2h::device_vector<int>(7);
@@ -363,7 +363,7 @@ C2H_TEST("DeviceMergeSort::SortKeysCopy uses environment", "[merge_sort][device]
   REQUIRE(d_keys_out == expected_keys);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortKeysCopy uses environment", "[merge_sort][device]")
+CUB_TEST("DeviceMergeSort::StableSortKeysCopy uses environment", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_keys_out = c2h::device_vector<int>(7);
@@ -388,7 +388,7 @@ C2H_TEST("DeviceMergeSort::StableSortKeysCopy uses environment", "[merge_sort][d
   REQUIRE(d_keys_out == expected_keys);
 }
 
-TEST_CASE("DeviceMergeSort::SortKeysCopy uses custom stream", "[merge_sort][device]")
+CUB_TEST_CASE("DeviceMergeSort::SortKeysCopy uses custom stream", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_keys_out = c2h::device_vector<int>(7);
@@ -418,7 +418,7 @@ TEST_CASE("DeviceMergeSort::SortKeysCopy uses custom stream", "[merge_sort][devi
   REQUIRE(d_keys_out == expected_keys);
 }
 
-TEST_CASE("DeviceMergeSort::StableSortKeysCopy uses custom stream", "[merge_sort][device]")
+CUB_TEST_CASE("DeviceMergeSort::StableSortKeysCopy uses custom stream", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_keys_out = c2h::device_vector<int>(7);
@@ -453,7 +453,7 @@ using block_size_compare_t = block_size_extracting_op<cuda::std::less<>>;
 using block_sizes =
   c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
 
-C2H_TEST("DeviceMergeSort::SortPairs can be tuned", "[merge_sort][device]", block_sizes)
+CUB_TEST("DeviceMergeSort::SortPairs can be tuned", "[merge_sort][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys{4, 1, 3, 2};
@@ -470,7 +470,7 @@ C2H_TEST("DeviceMergeSort::SortPairs can be tuned", "[merge_sort][device]", bloc
 
 #if TEST_LAUNCH != 1
 
-C2H_TEST("DeviceMergeSort::SortPairsCopy can be tuned", "[merge_sort][device]", block_sizes)
+CUB_TEST("DeviceMergeSort::SortPairsCopy can be tuned", "[merge_sort][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys_in{4, 1, 3, 2};
@@ -492,7 +492,7 @@ C2H_TEST("DeviceMergeSort::SortPairsCopy can be tuned", "[merge_sort][device]", 
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceMergeSort::SortKeys can be tuned", "[merge_sort][device]", block_sizes)
+CUB_TEST("DeviceMergeSort::SortKeys can be tuned", "[merge_sort][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys{4, 1, 3, 2};
@@ -504,7 +504,7 @@ C2H_TEST("DeviceMergeSort::SortKeys can be tuned", "[merge_sort][device]", block
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceMergeSort::SortKeysCopy can be tuned", "[merge_sort][device]", block_sizes)
+CUB_TEST("DeviceMergeSort::SortKeysCopy can be tuned", "[merge_sort][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys_in{4, 1, 3, 2};
@@ -518,7 +518,7 @@ C2H_TEST("DeviceMergeSort::SortKeysCopy can be tuned", "[merge_sort][device]", b
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortPairs can be tuned", "[merge_sort][device]", block_sizes)
+CUB_TEST("DeviceMergeSort::StableSortPairs can be tuned", "[merge_sort][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys{4, 1, 3, 2};
@@ -532,7 +532,7 @@ C2H_TEST("DeviceMergeSort::StableSortPairs can be tuned", "[merge_sort][device]"
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortKeys can be tuned", "[merge_sort][device]", block_sizes)
+CUB_TEST("DeviceMergeSort::StableSortKeys can be tuned", "[merge_sort][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys{4, 1, 3, 2};
@@ -544,7 +544,7 @@ C2H_TEST("DeviceMergeSort::StableSortKeys can be tuned", "[merge_sort][device]",
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortKeysCopy can be tuned", "[merge_sort][device]", block_sizes)
+CUB_TEST("DeviceMergeSort::StableSortKeysCopy can be tuned", "[merge_sort][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys_in{4, 1, 3, 2};
@@ -566,7 +566,7 @@ struct no_unroll_tuning
   }
 };
 
-TEST_CASE("DeviceMergeSort::SortKeys works with unroll disabled", "[merge_sort][device]")
+CUB_TEST_CASE("DeviceMergeSort::SortKeys works with unroll disabled", "[merge_sort][device]", CUB_SMALL)
 {
   auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto env    = cuda::execution::tune(no_unroll_tuning{});
@@ -580,7 +580,7 @@ TEST_CASE("DeviceMergeSort::SortKeys works with unroll disabled", "[merge_sort][
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test MergeSortPolicy properties", "[merge_sort][device]")
+CUB_TEST("Test MergeSortPolicy properties", "[merge_sort][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::MergeSortPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::MergeSortPolicy>);

--- a/cub/test/catch2_test_device_merge_sort_env_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_env_api.cu
@@ -13,9 +13,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API", "[merge_sort][env]")
+CUB_TEST("cub::DeviceMergeSort::SortPairs env-based API", "[merge_sort][env]", CUB_SMALL)
 {
   // example-begin sort-pairs-env
   auto d_keys   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -37,7 +37,7 @@ C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API", "[merge_sort][env]")
   REQUIRE(d_values == expected_values);
 }
 
-C2H_TEST("cub::DeviceMergeSort::SortKeys env-based API", "[merge_sort][env]")
+CUB_TEST("cub::DeviceMergeSort::SortKeys env-based API", "[merge_sort][env]", CUB_SMALL)
 {
   // example-begin sort-keys-env
   auto d_keys = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -56,7 +56,7 @@ C2H_TEST("cub::DeviceMergeSort::SortKeys env-based API", "[merge_sort][env]")
   REQUIRE(d_keys == expected_keys);
 }
 
-C2H_TEST("cub::DeviceMergeSort::StableSortPairs env-based API", "[merge_sort][env]")
+CUB_TEST("cub::DeviceMergeSort::StableSortPairs env-based API", "[merge_sort][env]", CUB_SMALL)
 {
   // example-begin stable-sort-pairs-env
   auto d_keys   = thrust::device_vector<int>{8, 6, 6, 5, 3, 0, 9};
@@ -78,7 +78,7 @@ C2H_TEST("cub::DeviceMergeSort::StableSortPairs env-based API", "[merge_sort][en
   REQUIRE(d_values == expected_values);
 }
 
-C2H_TEST("cub::DeviceMergeSort::StableSortKeys env-based API", "[merge_sort][env]")
+CUB_TEST("cub::DeviceMergeSort::StableSortKeys env-based API", "[merge_sort][env]", CUB_SMALL)
 {
   // example-begin stable-sort-keys-env
   auto d_keys = thrust::device_vector<int>{8, 6, 7, 5, 5, 3, 0, 9};
@@ -97,7 +97,7 @@ C2H_TEST("cub::DeviceMergeSort::StableSortKeys env-based API", "[merge_sort][env
   REQUIRE(d_keys == expected_keys);
 }
 
-C2H_TEST("cub::DeviceMergeSort::SortPairsCopy env-based API", "[merge_sort][env]")
+CUB_TEST("cub::DeviceMergeSort::SortPairsCopy env-based API", "[merge_sort][env]", CUB_SMALL)
 {
   // example-begin sort-pairs-copy-env
   auto d_keys_in    = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -131,7 +131,7 @@ C2H_TEST("cub::DeviceMergeSort::SortPairsCopy env-based API", "[merge_sort][env]
   REQUIRE(d_values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceMergeSort::SortKeysCopy env-based API", "[merge_sort][env]")
+CUB_TEST("cub::DeviceMergeSort::SortKeysCopy env-based API", "[merge_sort][env]", CUB_SMALL)
 {
   // example-begin sort-keys-copy-env
   auto d_keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -159,7 +159,7 @@ C2H_TEST("cub::DeviceMergeSort::SortKeysCopy env-based API", "[merge_sort][env]"
   REQUIRE(d_keys_out == expected_keys);
 }
 
-C2H_TEST("cub::DeviceMergeSort::StableSortKeysCopy env-based API", "[merge_sort][env]")
+CUB_TEST("cub::DeviceMergeSort::StableSortKeysCopy env-based API", "[merge_sort][env]", CUB_SMALL)
 {
   // example-begin stable-sort-keys-copy-env
   auto d_keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 5, 3, 0, 9};
@@ -187,7 +187,7 @@ C2H_TEST("cub::DeviceMergeSort::StableSortKeysCopy env-based API", "[merge_sort]
   REQUIRE(d_keys_out == expected_keys);
 }
 
-C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API with greater comparator", "[merge_sort][env]")
+CUB_TEST("cub::DeviceMergeSort::SortPairs env-based API with greater comparator", "[merge_sort][env]", CUB_SMALL)
 {
   auto d_keys   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_values = thrust::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
@@ -223,7 +223,7 @@ struct MergeSortPolicySelector
 };
 // example-end sort-pairs-policy-selector
 
-C2H_TEST("cub::DeviceMergeSort::SortPairs accepts a custom policy selector", "[merge_sort][env]")
+CUB_TEST("cub::DeviceMergeSort::SortPairs accepts a custom policy selector", "[merge_sort][env]", CUB_SMALL)
 {
   // example-begin sort-pairs-tuning
   auto d_keys   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};

--- a/cub/test/catch2_test_device_merge_sort_iterators.cu
+++ b/cub/test/catch2_test_device_merge_sort_iterators.cu
@@ -17,7 +17,7 @@
 
 #include "catch2_test_device_merge_sort_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -30,7 +30,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceMergeSort::SortKeysCopy, sort_keys_copy);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceMergeSort::StableSortKeys, stable_sort_keys);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceMergeSort::StableSortKeysCopy, stable_sort_keys_copy);
 
-C2H_TEST("DeviceMergeSort::SortKeysCopy works with iterators", "[merge][sort][device]")
+CUB_TEST("DeviceMergeSort::SortKeysCopy works with iterators", "[merge][sort][device]", CUB_SMALL)
 {
   using key_t    = std::uint32_t;
   using offset_t = std::int32_t;
@@ -50,7 +50,7 @@ C2H_TEST("DeviceMergeSort::SortKeysCopy works with iterators", "[merge][sort][de
   REQUIRE(keys_equal == true);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortKeysCopy works with iterators and is stable", "[merge][sort][device]")
+CUB_TEST("DeviceMergeSort::StableSortKeysCopy works with iterators and is stable", "[merge][sort][device]", CUB_SMALL)
 {
   using key_t    = std::uint32_t;
   using offset_t = std::int32_t;
@@ -74,7 +74,7 @@ C2H_TEST("DeviceMergeSort::StableSortKeysCopy works with iterators and is stable
   REQUIRE(keys_expected == keys_out);
 }
 
-C2H_TEST("DeviceMergeSort::SortKeys works with iterators", "[merge][sort][device]")
+CUB_TEST("DeviceMergeSort::SortKeys works with iterators", "[merge][sort][device]", CUB_SMALL)
 {
   using key_t    = std::uint32_t;
   using offset_t = std::int32_t;
@@ -95,7 +95,7 @@ C2H_TEST("DeviceMergeSort::SortKeys works with iterators", "[merge][sort][device
   REQUIRE(keys_equal == true);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortKeys works with iterators", "[merge][sort][device]")
+CUB_TEST("DeviceMergeSort::StableSortKeys works with iterators", "[merge][sort][device]", CUB_SMALL)
 {
   using key_t    = std::uint32_t;
   using offset_t = std::int32_t;
@@ -116,7 +116,7 @@ C2H_TEST("DeviceMergeSort::StableSortKeys works with iterators", "[merge][sort][
   REQUIRE(keys_equal == true);
 }
 
-C2H_TEST("DeviceMergeSort::SortPairsCopy works with iterators", "[merge][sort][device]")
+CUB_TEST("DeviceMergeSort::SortPairsCopy works with iterators", "[merge][sort][device]", CUB_SMALL)
 {
   using key_t    = std::uint32_t;
   using data_t   = std::uint64_t;
@@ -142,7 +142,7 @@ C2H_TEST("DeviceMergeSort::SortPairsCopy works with iterators", "[merge][sort][d
   REQUIRE(values_equal == true);
 }
 
-C2H_TEST("DeviceMergeSort::SortPairs works with iterators", "[merge][sort][device]")
+CUB_TEST("DeviceMergeSort::SortPairs works with iterators", "[merge][sort][device]", CUB_SMALL)
 {
   using key_t    = std::uint32_t;
   using data_t   = std::uint64_t;
@@ -171,7 +171,7 @@ C2H_TEST("DeviceMergeSort::SortPairs works with iterators", "[merge][sort][devic
   REQUIRE(values_equal == true);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortPairs works with iterators", "[merge][sort][device]")
+CUB_TEST("DeviceMergeSort::StableSortPairs works with iterators", "[merge][sort][device]", CUB_SMALL)
 {
   using key_t    = std::uint32_t;
   using data_t   = std::uint64_t;

--- a/cub/test/catch2_test_device_merge_sort_vsmem.cu
+++ b/cub/test/catch2_test_device_merge_sort_vsmem.cu
@@ -12,7 +12,7 @@
 
 #include "catch2_test_device_merge_sort_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -23,7 +23,7 @@ using key_types =
   c2h::type_list<c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t, c2h::huge_data<512>::type>,
                  c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t, c2h::huge_data<1024>::type>>;
 
-C2H_TEST("DeviceMergeSort::StableSortKeys works for large types", "[merge][sort][device]", key_types)
+CUB_TEST("DeviceMergeSort::StableSortKeys works for large types", "[merge][sort][device]", CUB_SMALL, key_types)
 {
   using key_t    = typename c2h::get<0, TestType>;
   using offset_t = std::int32_t;
@@ -44,7 +44,7 @@ C2H_TEST("DeviceMergeSort::StableSortKeys works for large types", "[merge][sort]
   REQUIRE(keys_expected == keys_in_out);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortPairs works for large types", "[merge][sort][device]", key_types)
+CUB_TEST("DeviceMergeSort::StableSortPairs works for large types", "[merge][sort][device]", CUB_SMALL, key_types)
 {
   using key_t    = typename c2h::get<0, TestType>;
   using data_t   = std::uint32_t;

--- a/cub/test/catch2_test_device_partition_api.cu
+++ b/cub/test/catch2_test_device_partition_api.cu
@@ -5,14 +5,14 @@
 
 #include <cub/device/device_partition.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // Guard: the legacy memory-size query call with all defaults (no explicit stream)
 // must resolve unambiguously to the legacy temp-storage overload when the env
 // passthrough overload is also visible. If the env overload's SFINAE is too loose,
 // this becomes "ambiguous overload" or silently dispatches to env.
 
-C2H_TEST("DevicePartition::Flagged legacy size-query is unambiguous", "[partition][device]")
+CUB_TEST("DevicePartition::Flagged legacy size-query is unambiguous", "[partition][device]", CUB_SMALL)
 {
   int* d_in           = nullptr;
   int* d_flags        = nullptr;
@@ -24,7 +24,7 @@ C2H_TEST("DevicePartition::Flagged legacy size-query is unambiguous", "[partitio
   REQUIRE(cudaSuccess == cub::DevicePartition::Flagged(nullptr, bytes, d_in, d_flags, d_out, d_num_selected, n));
 }
 
-C2H_TEST("DevicePartition::If legacy size-query is unambiguous", "[partition][device]")
+CUB_TEST("DevicePartition::If legacy size-query is unambiguous", "[partition][device]", CUB_SMALL)
 {
   int* d_in           = nullptr;
   int* d_out          = nullptr;
@@ -36,7 +36,7 @@ C2H_TEST("DevicePartition::If legacy size-query is unambiguous", "[partition][de
     cudaSuccess == cub::DevicePartition::If(nullptr, bytes, d_in, d_out, d_num_selected, n, ::cuda::always_true{}));
 }
 
-C2H_TEST("DevicePartition::If three-way legacy size-query is unambiguous", "[partition][device]")
+CUB_TEST("DevicePartition::If three-way legacy size-query is unambiguous", "[partition][device]", CUB_SMALL)
 {
   int* d_in           = nullptr;
   int* d_first_part   = nullptr;

--- a/cub/test/catch2_test_device_partition_env.cu
+++ b/cub/test/catch2_test_device_partition_env.cu
@@ -25,7 +25,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DevicePartition::Flagged, device_partition_flagged);
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
@@ -42,7 +42,7 @@ struct greater_than_t
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("Device partition works with default environment", "[partition][device]")
+CUB_TEST_CASE("Device partition works with default environment", "[partition][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -65,7 +65,7 @@ TEST_CASE("Device partition works with default environment", "[partition][device
   REQUIRE(d_out == expected_output);
 }
 
-TEST_CASE("Device partition flagged works with default environment", "[partition][device]")
+CUB_TEST_CASE("Device partition flagged works with default environment", "[partition][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -88,7 +88,7 @@ TEST_CASE("Device partition flagged works with default environment", "[partition
   REQUIRE(d_out == expected_output);
 }
 
-TEST_CASE("Device partition three-way works with default environment", "[partition][device]")
+CUB_TEST_CASE("Device partition three-way works with default environment", "[partition][device]", CUB_SMALL)
 {
   auto d_in             = c2h::device_vector<int>{0, 2, 3, 9, 5, 2, 81, 8};
   auto d_small_out      = c2h::device_vector<int>(8);
@@ -122,7 +122,7 @@ TEST_CASE("Device partition three-way works with default environment", "[partiti
 
 #endif
 
-C2H_TEST("Device partition uses environment", "[partition][device]")
+CUB_TEST("Device partition uses environment", "[partition][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -153,7 +153,7 @@ C2H_TEST("Device partition uses environment", "[partition][device]")
   REQUIRE(d_out == expected_output);
 }
 
-C2H_TEST("Device partition flagged uses environment", "[partition][device]")
+CUB_TEST("Device partition flagged uses environment", "[partition][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -188,7 +188,7 @@ C2H_TEST("Device partition flagged uses environment", "[partition][device]")
   REQUIRE(d_out == expected_output);
 }
 
-C2H_TEST("Device partition three-way uses environment", "[partition][device]")
+CUB_TEST("Device partition three-way uses environment", "[partition][device]", CUB_SMALL)
 {
   auto d_in             = c2h::device_vector<int>{0, 2, 3, 9, 5, 2, 81, 8};
   auto d_small_out      = c2h::device_vector<int>(8);
@@ -237,7 +237,7 @@ C2H_TEST("Device partition three-way uses environment", "[partition][device]")
   REQUIRE(d_large_out == expected_large);
 }
 
-TEST_CASE("Device partition uses custom stream", "[partition][device]")
+CUB_TEST_CASE("Device partition uses custom stream", "[partition][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -317,7 +317,7 @@ struct three_way_partition_policy_selector
 using block_sizes =
   c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
 
-C2H_TEST("DevicePartition::If can be tuned", "[partition][device]", block_sizes)
+CUB_TEST("DevicePartition::If can be tuned", "[partition][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto d_in                                = c2h::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -334,7 +334,7 @@ C2H_TEST("DevicePartition::If can be tuned", "[partition][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DevicePartition::Flagged can be tuned", "[partition][device]", block_sizes)
+CUB_TEST("DevicePartition::Flagged can be tuned", "[partition][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto d_in                                = c2h::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -359,7 +359,7 @@ struct less_than_7_t
   }
 };
 
-C2H_TEST("DevicePartition::If three-way can be tuned", "[partition][device]", block_sizes)
+CUB_TEST("DevicePartition::If three-way can be tuned", "[partition][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto d_in                                = c2h::device_vector<int>{0, 2, 3, 9, 5, 2, 81, 8};
@@ -392,7 +392,7 @@ C2H_TEST("DevicePartition::If three-way can be tuned", "[partition][device]", bl
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test ThreeWayPartitionPolicy properties", "[partition][device]")
+CUB_TEST("Test ThreeWayPartitionPolicy properties", "[partition][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ThreeWayPartitionPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ThreeWayPartitionPolicy>);
@@ -441,7 +441,7 @@ C2H_TEST("Test ThreeWayPartitionPolicy properties", "[partition][device]")
              ", .delay = 350, .l2_write_latency = 450 } } }");
 }
 
-C2H_TEST("Test PartitionPolicy properties", "[partition][device]")
+CUB_TEST("Test PartitionPolicy properties", "[partition][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::PartitionPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::PartitionPolicy>);

--- a/cub/test/catch2_test_device_partition_env_api.cu
+++ b/cub/test/catch2_test_device_partition_env_api.cu
@@ -14,7 +14,7 @@
 #include <iostream>
 
 #include "catch2_test_device_select_common.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <typename T>
 struct greater_than_t
@@ -27,7 +27,7 @@ struct greater_than_t
   }
 };
 
-C2H_TEST("cub::DevicePartition::If accepts env with stream", "[partition][env]")
+CUB_TEST("cub::DevicePartition::If accepts env with stream", "[partition][env]", CUB_SMALL)
 {
   // example-begin partition-if-env
   auto input        = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -56,7 +56,7 @@ C2H_TEST("cub::DevicePartition::If accepts env with stream", "[partition][env]")
   REQUIRE(num_selected == expected_num_selected);
 }
 
-C2H_TEST("cub::DevicePartition::Flagged accepts env with stream", "[partition][env]")
+CUB_TEST("cub::DevicePartition::Flagged accepts env with stream", "[partition][env]", CUB_SMALL)
 {
   // example-begin partition-flagged-env
   auto input        = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -85,7 +85,7 @@ C2H_TEST("cub::DevicePartition::Flagged accepts env with stream", "[partition][e
   REQUIRE(num_selected == expected_num_selected);
 }
 
-C2H_TEST("cub::DevicePartition::If three-way accepts env with stream", "[partition][env]")
+CUB_TEST("cub::DevicePartition::If three-way accepts env with stream", "[partition][env]", CUB_SMALL)
 {
   // example-begin partition-three-way-env
   auto input            = thrust::device_vector<int>{0, 2, 3, 9, 5, 2, 81, 8};
@@ -147,7 +147,7 @@ struct PartitionPolicySelector
 };
 // example-end partition-if-policy-selector
 
-C2H_TEST("cub::DevicePartition::If accepts a custom policy selector", "[partition][env]")
+CUB_TEST("cub::DevicePartition::If accepts a custom policy selector", "[partition][env]", CUB_SMALL)
 {
   // example-begin partition-if-tuning
   auto d_in           = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -194,7 +194,7 @@ struct ThreeWayPartitionPolicySelector
 };
 // example-end partition-three-way-policy-selector
 
-C2H_TEST("cub::DevicePartition::If three-way accepts a custom policy selector", "[partition][env]")
+CUB_TEST("cub::DevicePartition::If three-way accepts a custom policy selector", "[partition][env]", CUB_SMALL)
 {
   // example-begin partition-three-way-tuning
   auto d_in             = thrust::device_vector<int>{0, 2, 3, 9, 5, 2, 81, 8, 63};

--- a/cub/test/catch2_test_device_partition_flagged.cu
+++ b/cub/test/catch2_test_device_partition_flagged.cu
@@ -20,7 +20,7 @@
 #include "catch2_large_problem_helper.cuh"
 #include "catch2_test_device_select_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <class T, class FlagT>
 static c2h::host_vector<T> get_reference(const c2h::device_vector<T>& in, const c2h::device_vector<FlagT>& flags)
@@ -89,7 +89,7 @@ using types =
 // List of offset types to be used for testing large number of items
 using offset_types = c2h::type_list<std::int32_t, std::uint32_t, std::uint64_t>;
 
-C2H_TEST("DevicePartition::Flagged can run with empty input", "[device][partition_flagged]", types)
+CUB_TEST("DevicePartition::Flagged can run with empty input", "[device][partition_flagged]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -107,7 +107,7 @@ C2H_TEST("DevicePartition::Flagged can run with empty input", "[device][partitio
   REQUIRE(num_selected_out[0] == 0);
 }
 
-C2H_TEST("DevicePartition::Flagged handles all matched", "[device][partition_flagged]", types)
+CUB_TEST("DevicePartition::Flagged handles all matched", "[device][partition_flagged]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -128,7 +128,7 @@ C2H_TEST("DevicePartition::Flagged handles all matched", "[device][partition_fla
   REQUIRE(out == in);
 }
 
-C2H_TEST("DevicePartition::Flagged handles no matched", "[device][partition_flagged]", types)
+CUB_TEST("DevicePartition::Flagged handles no matched", "[device][partition_flagged]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -152,7 +152,7 @@ C2H_TEST("DevicePartition::Flagged handles no matched", "[device][partition_flag
   REQUIRE(out == in);
 }
 
-C2H_TEST("DevicePartition::Flagged does not change input", "[device][partition_flagged]", types)
+CUB_TEST("DevicePartition::Flagged does not change input", "[device][partition_flagged]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -179,7 +179,7 @@ C2H_TEST("DevicePartition::Flagged does not change input", "[device][partition_f
   REQUIRE(reference == in);
 }
 
-C2H_TEST("DevicePartition::Flagged is stable", "[device][partition_flagged]")
+CUB_TEST("DevicePartition::Flagged is stable", "[device][partition_flagged]", CUB_SMALL)
 {
   using type = c2h::custom_type_t<c2h::equal_comparable_t>;
 
@@ -205,8 +205,9 @@ C2H_TEST("DevicePartition::Flagged is stable", "[device][partition_flagged]")
 }
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DevicePartition::Flagged works with user provided memory and environment",
+CUB_TEST("DevicePartition::Flagged works with user provided memory and environment",
          "[device][partition_flagged]",
+         CUB_SMALL,
          types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -305,7 +306,7 @@ C2H_TEST("DevicePartition::Flagged works with user provided memory and environme
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DevicePartition::Flagged works with iterators", "[device][partition_flagged]", all_types)
+CUB_TEST("DevicePartition::Flagged works with iterators", "[device][partition_flagged]", CUB_SMALL, all_types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -330,7 +331,7 @@ C2H_TEST("DevicePartition::Flagged works with iterators", "[device][partition_fl
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DevicePartition::Flagged works with pointers", "[device][partition_flagged]", types)
+CUB_TEST("DevicePartition::Flagged works with pointers", "[device][partition_flagged]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -383,7 +384,9 @@ struct convertible_to_bool
   }
 };
 
-C2H_TEST("DevicePartition::Flagged works with flags that are convertible to bool", "[device][partition_flagged]")
+CUB_TEST("DevicePartition::Flagged works with flags that are convertible to bool",
+         "[device][partition_flagged]",
+         CUB_SMALL)
 {
   using type = c2h::custom_type_t<c2h::equal_comparable_t>;
 
@@ -409,7 +412,7 @@ C2H_TEST("DevicePartition::Flagged works with flags that are convertible to bool
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DevicePartition::Flagged works with flags that alias input", "[device][partition_flagged]")
+CUB_TEST("DevicePartition::Flagged works with flags that alias input", "[device][partition_flagged]", CUB_SMALL)
 {
   using type = int;
 
@@ -460,7 +463,7 @@ struct convertible_from_T
   }
 };
 
-C2H_TEST("DevicePartition::Flagged works with different output type", "[device][partition_flagged]")
+CUB_TEST("DevicePartition::Flagged works with different output type", "[device][partition_flagged]", CUB_SMALL)
 {
   using type = c2h::custom_type_t<c2h::equal_comparable_t>;
 
@@ -485,8 +488,9 @@ C2H_TEST("DevicePartition::Flagged works with different output type", "[device][
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DevicePartition::Flagged works for very large number of items",
+CUB_TEST("DevicePartition::Flagged works for very large number of items",
          "[device][partition_flagged][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_SMALL,
          offset_types)
 try
 {

--- a/cub/test/catch2_test_device_partition_if.cu
+++ b/cub/test/catch2_test_device_partition_if.cu
@@ -22,7 +22,7 @@
 #include "catch2_large_problem_helper.cuh"
 #include "catch2_test_device_select_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DevicePartition::If, partition_if);
 
@@ -62,7 +62,7 @@ using types =
 // List of offset types to be used for testing large number of items
 using offset_types = c2h::type_list<std::int32_t, std::uint32_t, std::uint64_t>;
 
-C2H_TEST("DevicePartition::If can run with empty input", "[device][partition_if]", types)
+CUB_TEST("DevicePartition::If can run with empty input", "[device][partition_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -79,7 +79,7 @@ C2H_TEST("DevicePartition::If can run with empty input", "[device][partition_if]
   REQUIRE(num_selected_out[0] == 0);
 }
 
-C2H_TEST("DevicePartition::If handles all matched", "[device][partition_if]", types)
+CUB_TEST("DevicePartition::If handles all matched", "[device][partition_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -98,7 +98,7 @@ C2H_TEST("DevicePartition::If handles all matched", "[device][partition_if]", ty
   REQUIRE(out == in);
 }
 
-C2H_TEST("DevicePartition::If handles no matched", "[device][partition_if]", types)
+CUB_TEST("DevicePartition::If handles no matched", "[device][partition_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -120,7 +120,7 @@ C2H_TEST("DevicePartition::If handles no matched", "[device][partition_if]", typ
   REQUIRE(out == in);
 }
 
-C2H_TEST("DevicePartition::If does not change input", "[device][partition_if]", types)
+CUB_TEST("DevicePartition::If does not change input", "[device][partition_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -144,7 +144,7 @@ C2H_TEST("DevicePartition::If does not change input", "[device][partition_if]", 
   REQUIRE(reference == in);
 }
 
-C2H_TEST("DevicePartition::If is stable", "[device][partition_if]")
+CUB_TEST("DevicePartition::If is stable", "[device][partition_if]", CUB_SMALL)
 {
   using type = c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>;
 
@@ -174,7 +174,8 @@ C2H_TEST("DevicePartition::If is stable", "[device][partition_if]")
 }
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DevicePartition::If works with user provided memory and environment", "[device][partition_if]", types)
+CUB_TEST(
+  "DevicePartition::If works with user provided memory and environment", "[device][partition_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -276,7 +277,7 @@ C2H_TEST("DevicePartition::If works with user provided memory and environment", 
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DevicePartition::If works with iterators", "[device][partition_if]", all_types)
+CUB_TEST("DevicePartition::If works with iterators", "[device][partition_if]", CUB_SMALL, all_types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -305,7 +306,7 @@ C2H_TEST("DevicePartition::If works with iterators", "[device][partition_if]", a
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DevicePartition::If works with pointers", "[device][partition_if]", types)
+CUB_TEST("DevicePartition::If works with pointers", "[device][partition_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -355,7 +356,7 @@ struct convertible_from_T
   }
 };
 
-C2H_TEST("DevicePartition::If works with a different output type", "[device][partition_if]")
+CUB_TEST("DevicePartition::If works with a different output type", "[device][partition_if]", CUB_SMALL)
 {
   using type = c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>;
 
@@ -384,8 +385,9 @@ C2H_TEST("DevicePartition::If works with a different output type", "[device][par
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DevicePartition::If works for very large number of items",
+CUB_TEST("DevicePartition::If works for very large number of items",
          "[device][partition_if][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_SMALL,
          offset_types)
 try
 {

--- a/cub/test/catch2_test_device_radix_sort_custom.cu
+++ b/cub/test/catch2_test_device_radix_sort_custom.cu
@@ -19,7 +19,7 @@
 #include "catch2_radix_sort_helper.cuh"
 #include "catch2_test_launch_helper.h"
 #include "cub/util_type.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceRadixSort::SortKeys, sort_keys);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceRadixSort::SortPairs, sort_pairs);
@@ -147,7 +147,7 @@ static std::pair<c2h::device_vector<key>, c2h::device_vector<value>> reference_s
   return std::make_pair(result_keys, result_values);
 }
 
-C2H_TEST("Device radix sort works with parts of custom i128_t", "[radix][sort][device]")
+CUB_TEST("Device radix sort works with parts of custom i128_t", "[radix][sort][device]", CUB_SMALL)
 {
   constexpr int max_items = 1 << 18;
   // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
@@ -164,7 +164,7 @@ C2H_TEST("Device radix sort works with parts of custom i128_t", "[radix][sort][d
   REQUIRE(reference_keys == out_keys);
 }
 
-C2H_TEST("Device radix descending sort works with custom i128_t", "[radix][sort][device]")
+CUB_TEST("Device radix descending sort works with custom i128_t", "[radix][sort][device]", CUB_SMALL)
 {
   constexpr int max_items = 1 << 18;
   // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
@@ -196,7 +196,7 @@ C2H_TEST("Device radix descending sort works with custom i128_t", "[radix][sort]
   REQUIRE(reference_keys == out_keys);
 }
 
-C2H_TEST("Device radix sort can sort pairs with custom i128_t keys", "[radix][sort][device]")
+CUB_TEST("Device radix sort can sort pairs with custom i128_t keys", "[radix][sort][device]", CUB_SMALL)
 {
   constexpr int max_items = 1 << 18;
   // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
@@ -237,7 +237,7 @@ C2H_TEST("Device radix sort can sort pairs with custom i128_t keys", "[radix][so
   REQUIRE(reference.second == out_values);
 }
 
-C2H_TEST("Device radix sort works with custom i128_t (db)", "[radix][sort][device]")
+CUB_TEST("Device radix sort works with custom i128_t (db)", "[radix][sort][device]", CUB_SMALL)
 {
   constexpr int max_items = 1 << 18;
   // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
@@ -267,7 +267,7 @@ C2H_TEST("Device radix sort works with custom i128_t (db)", "[radix][sort][devic
   REQUIRE(reference_keys == out_keys);
 }
 
-C2H_TEST("Device radix sort works with custom i128_t keys (db)", "[radix][sort][device]")
+CUB_TEST("Device radix sort works with custom i128_t keys (db)", "[radix][sort][device]", CUB_SMALL)
 {
   constexpr int max_items = 1 << 18;
   // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
@@ -309,7 +309,7 @@ C2H_TEST("Device radix sort works with custom i128_t keys (db)", "[radix][sort][
   REQUIRE(reference_keys.second == out_values);
 }
 
-C2H_TEST("Device radix descending sort works with bits of custom i128_t", "[radix][sort][device]")
+CUB_TEST("Device radix descending sort works with bits of custom i128_t", "[radix][sort][device]", CUB_SMALL)
 {
   constexpr int max_items = 1 << 18;
 
@@ -348,7 +348,7 @@ C2H_TEST("Device radix descending sort works with bits of custom i128_t", "[radi
   REQUIRE(reference_keys == out_keys);
 }
 
-C2H_TEST("Device radix sort can sort pairs with bits of custom i128_t keys", "[radix][sort][device]")
+CUB_TEST("Device radix sort can sort pairs with bits of custom i128_t keys", "[radix][sort][device]", CUB_SMALL)
 {
   constexpr int max_items = 1 << 18;
 
@@ -397,7 +397,7 @@ C2H_TEST("Device radix sort can sort pairs with bits of custom i128_t keys", "[r
   REQUIRE(reference.second == out_values);
 }
 
-C2H_TEST("Device radix sort works with bits of custom i128_t (db)", "[radix][sort][device]")
+CUB_TEST("Device radix sort works with bits of custom i128_t (db)", "[radix][sort][device]", CUB_SMALL)
 {
   constexpr int max_items = 1 << 18;
   // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
@@ -430,7 +430,7 @@ C2H_TEST("Device radix sort works with bits of custom i128_t (db)", "[radix][sor
   REQUIRE(reference_keys == out_keys);
 }
 
-C2H_TEST("Device radix sort works with bits of custom i128_t keys (db)", "[radix][sort][device]")
+CUB_TEST("Device radix sort works with bits of custom i128_t keys (db)", "[radix][sort][device]", CUB_SMALL)
 {
   constexpr int max_items = 1 << 18;
   // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
@@ -509,7 +509,7 @@ __host__ __device__ bool operator==(const custom_t& lhs, const custom_t& rhs)
   return lhs.f == rhs.f && lhs.lli == rhs.lli;
 }
 
-C2H_TEST("Device radix sort works against some corner cases", "[radix][sort][device]")
+CUB_TEST("Device radix sort works against some corner cases", "[radix][sort][device]", CUB_SMALL)
 {
   SECTION("Keys")
   {
@@ -705,7 +705,7 @@ C2H_TEST("Device radix sort works against some corner cases", "[radix][sort][dev
   }
 }
 
-C2H_TEST("Device radix sort works against some corner cases (db)", "[radix][sort][device]")
+CUB_TEST("Device radix sort works against some corner cases (db)", "[radix][sort][device]", CUB_SMALL)
 {
   SECTION("Keys")
   {
@@ -924,7 +924,7 @@ C2H_TEST("Device radix sort works against some corner cases (db)", "[radix][sort
   }
 }
 
-C2H_TEST("Device radix sort works against some corner cases (bits)", "[radix][sort][device]")
+CUB_TEST("Device radix sort works against some corner cases (bits)", "[radix][sort][device]", CUB_SMALL)
 {
   SECTION("Keys")
   {
@@ -1196,7 +1196,7 @@ C2H_TEST("Device radix sort works against some corner cases (bits)", "[radix][so
   }
 }
 
-C2H_TEST("Device radix sort works against some corner cases (bits) (db)", "[radix][sort][device]")
+CUB_TEST("Device radix sort works against some corner cases (bits) (db)", "[radix][sort][device]", CUB_SMALL)
 {
   SECTION("Keys")
   {

--- a/cub/test/catch2_test_device_radix_sort_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_radix_sort_custom_policy_hub.cu
@@ -11,6 +11,7 @@
 #include <cub/device/device_radix_sort.cuh>
 
 #include "catch2_radix_sort_helper.cuh"
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -97,7 +98,7 @@ struct my_policy_hub
   };
 };
 
-C2H_TEST("DispatchRadixSort::Dispatch: custom policy hub", "[keys][radix][sort][device]")
+CUB_TEST("DispatchRadixSort::Dispatch: custom policy hub", "[keys][radix][sort][device]", CUB_SMALL)
 {
   using key_t              = int;
   using offset_t           = unsigned;

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -25,7 +25,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceRadixSort::SortKeysDescending, device_radix_so
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
@@ -88,7 +88,7 @@ struct pairs_decomposer_t
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("Device radix sort pairs works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs works with default environment", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -110,7 +110,7 @@ TEST_CASE("Device radix sort pairs works with default environment", "[radix_sort
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("Device radix sort pairs descending works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs descending works with default environment", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -132,7 +132,7 @@ TEST_CASE("Device radix sort pairs descending works with default environment", "
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("Device radix sort keys works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys works with default environment", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -150,7 +150,7 @@ TEST_CASE("Device radix sort keys works with default environment", "[radix_sort]
   REQUIRE(keys_out == expected_keys);
 }
 
-TEST_CASE("Device radix sort keys descending works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys descending works with default environment", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -164,7 +164,7 @@ TEST_CASE("Device radix sort keys descending works with default environment", "[
   REQUIRE(keys_out == expected_keys);
 }
 
-TEST_CASE("Device radix sort keys decomposer+bits works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys decomposer+bits works with default environment", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
@@ -183,7 +183,7 @@ TEST_CASE("Device radix sort keys decomposer+bits works with default environment
   REQUIRE(keys_out == expected);
 }
 
-TEST_CASE("Device radix sort keys decomposer works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys decomposer works with default environment", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
@@ -196,7 +196,7 @@ TEST_CASE("Device radix sort keys decomposer works with default environment", "[
   REQUIRE(keys_out == expected);
 }
 
-TEST_CASE("Device radix sort keys DB decomposer works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys DB decomposer works with default environment", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_buf1 = c2h::device_vector<custom_key_t>(7);
@@ -211,7 +211,9 @@ TEST_CASE("Device radix sort keys DB decomposer works with default environment",
   REQUIRE(keys == expected);
 }
 
-TEST_CASE("Device radix sort keys DB decomposer+bits works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys DB decomposer+bits works with default environment",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_buf1 = c2h::device_vector<custom_key_t>(7);
@@ -227,7 +229,7 @@ TEST_CASE("Device radix sort keys DB decomposer+bits works with default environm
   REQUIRE(keys == expected);
 }
 
-TEST_CASE("Device radix sort pairs decomposer works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs decomposer works with default environment", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<custom_pair_key_t>{{3, 100}, {1, 200}, {2, 300}};
   auto keys_out   = c2h::device_vector<custom_pair_key_t>(3);
@@ -250,7 +252,9 @@ TEST_CASE("Device radix sort pairs decomposer works with default environment", "
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("Device radix sort pairs decomposer with bits works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs decomposer with bits works with default environment",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<custom_pair_key_t>{{3, 100}, {1, 200}, {2, 300}};
   auto keys_out   = c2h::device_vector<custom_pair_key_t>(3);
@@ -275,7 +279,9 @@ TEST_CASE("Device radix sort pairs decomposer with bits works with default envir
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("Device radix sort keys descending decomposer+bits works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys descending decomposer+bits works with default environment",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
@@ -294,7 +300,9 @@ TEST_CASE("Device radix sort keys descending decomposer+bits works with default 
   REQUIRE(keys_out == expected);
 }
 
-TEST_CASE("Device radix sort keys descending decomposer works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys descending decomposer works with default environment",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
@@ -307,7 +315,9 @@ TEST_CASE("Device radix sort keys descending decomposer works with default envir
   REQUIRE(keys_out == expected);
 }
 
-TEST_CASE("Device radix sort keys descending DB decomposer works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys descending DB decomposer works with default environment",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_buf1 = c2h::device_vector<custom_key_t>(7);
@@ -322,7 +332,9 @@ TEST_CASE("Device radix sort keys descending DB decomposer works with default en
   REQUIRE(keys == expected);
 }
 
-TEST_CASE("Device radix sort keys descending DB decomposer+bits works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys descending DB decomposer+bits works with default environment",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_buf1 = c2h::device_vector<custom_key_t>(7);
@@ -338,7 +350,9 @@ TEST_CASE("Device radix sort keys descending DB decomposer+bits works with defau
   REQUIRE(keys == expected);
 }
 
-TEST_CASE("Device radix sort pairs descending decomposer+bits works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs descending decomposer+bits works with default environment",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out   = c2h::device_vector<custom_key_t>(7);
@@ -363,7 +377,9 @@ TEST_CASE("Device radix sort pairs descending decomposer+bits works with default
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("Device radix sort pairs descending decomposer works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs descending decomposer works with default environment",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out   = c2h::device_vector<custom_key_t>(7);
@@ -386,7 +402,9 @@ TEST_CASE("Device radix sort pairs descending decomposer works with default envi
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("Device radix sort pairs descending DB decomposer works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs descending DB decomposer works with default environment",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_buf0   = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_buf1   = c2h::device_vector<custom_key_t>(7);
@@ -408,8 +426,9 @@ TEST_CASE("Device radix sort pairs descending DB decomposer works with default e
   REQUIRE(values == expected_values);
 }
 
-TEST_CASE("Device radix sort pairs descending DB decomposer+bits works with default environment",
-          "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs descending DB decomposer+bits works with default environment",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_buf0   = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_buf1   = c2h::device_vector<custom_key_t>(7);
@@ -434,7 +453,7 @@ TEST_CASE("Device radix sort pairs descending DB decomposer+bits works with defa
 
 #endif
 
-C2H_TEST("Device radix sort pairs uses environment", "[radix_sort][device]")
+CUB_TEST("Device radix sort pairs uses environment", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -473,7 +492,7 @@ C2H_TEST("Device radix sort pairs uses environment", "[radix_sort][device]")
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("Device radix sort pairs descending uses environment", "[radix_sort][device]")
+CUB_TEST("Device radix sort pairs descending uses environment", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -511,7 +530,7 @@ C2H_TEST("Device radix sort pairs descending uses environment", "[radix_sort][de
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("Device radix sort keys uses environment", "[radix_sort][device]")
+CUB_TEST("Device radix sort keys uses environment", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -537,7 +556,7 @@ C2H_TEST("Device radix sort keys uses environment", "[radix_sort][device]")
   REQUIRE(keys_out == expected_keys);
 }
 
-C2H_TEST("Device radix sort keys descending uses environment", "[radix_sort][device]")
+CUB_TEST("Device radix sort keys descending uses environment", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -569,7 +588,7 @@ C2H_TEST("Device radix sort keys descending uses environment", "[radix_sort][dev
   REQUIRE(keys_out == expected_keys);
 }
 
-TEST_CASE("Device radix sort pairs uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -612,7 +631,7 @@ TEST_CASE("Device radix sort pairs uses custom stream", "[radix_sort][device]")
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("Device radix sort pairs descending uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs descending uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -655,7 +674,7 @@ TEST_CASE("Device radix sort pairs descending uses custom stream", "[radix_sort]
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("Device radix sort keys uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -684,7 +703,7 @@ TEST_CASE("Device radix sort keys uses custom stream", "[radix_sort][device]")
   REQUIRE(keys_out == expected_keys);
 }
 
-TEST_CASE("Device radix sort keys descending uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys descending uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -713,7 +732,7 @@ TEST_CASE("Device radix sort keys descending uses custom stream", "[radix_sort][
   REQUIRE(keys_out == expected_keys);
 }
 
-TEST_CASE("Device radix sort pairs decomposer uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs decomposer uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<custom_pair_key_t>{{3, 100}, {1, 200}, {2, 300}};
   auto keys_out   = c2h::device_vector<custom_pair_key_t>(3);
@@ -744,7 +763,7 @@ TEST_CASE("Device radix sort pairs decomposer uses custom stream", "[radix_sort]
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("Device radix sort pairs DB decomposer works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs DB decomposer works with default environment", "[radix_sort][device]", CUB_SMALL)
 {
   c2h::device_vector<custom_pair_key_t> keys_buf0{{3, 100}, {1, 200}, {2, 300}};
   c2h::device_vector<custom_pair_key_t> keys_buf1(3);
@@ -766,7 +785,9 @@ TEST_CASE("Device radix sort pairs DB decomposer works with default environment"
   REQUIRE(values == expected_values);
 }
 
-TEST_CASE("Device radix sort pairs DB decomposer with bits works with default environment", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs DB decomposer with bits works with default environment",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   c2h::device_vector<custom_pair_key_t> keys_buf0{{3, 100}, {1, 200}, {2, 300}};
   c2h::device_vector<custom_pair_key_t> keys_buf1(3);
@@ -790,7 +811,7 @@ TEST_CASE("Device radix sort pairs DB decomposer with bits works with default en
 
 #endif
 
-TEST_CASE("Device radix sort pairs DB decomposer uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs DB decomposer uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   c2h::device_vector<custom_pair_key_t> keys_buf0{{3, 100}, {1, 200}, {2, 300}};
   c2h::device_vector<custom_pair_key_t> keys_buf1(3);
@@ -817,7 +838,7 @@ TEST_CASE("Device radix sort pairs DB decomposer uses custom stream", "[radix_so
   REQUIRE(values == expected_values);
 }
 
-TEST_CASE("Device radix sort keys decomposer+bits uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys decomposer+bits uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
@@ -842,7 +863,7 @@ TEST_CASE("Device radix sort keys decomposer+bits uses custom stream", "[radix_s
   REQUIRE(keys_out == expected);
 }
 
-TEST_CASE("Device radix sort keys decomposer uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys decomposer uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
@@ -860,7 +881,7 @@ TEST_CASE("Device radix sort keys decomposer uses custom stream", "[radix_sort][
   REQUIRE(keys_out == expected);
 }
 
-TEST_CASE("Device radix sort keys DB decomposer uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys DB decomposer uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_buf1 = c2h::device_vector<custom_key_t>(7);
@@ -880,7 +901,7 @@ TEST_CASE("Device radix sort keys DB decomposer uses custom stream", "[radix_sor
   REQUIRE(keys == expected);
 }
 
-TEST_CASE("Device radix sort keys DB decomposer+bits uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys DB decomposer+bits uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_buf1 = c2h::device_vector<custom_key_t>(7);
@@ -902,7 +923,7 @@ TEST_CASE("Device radix sort keys DB decomposer+bits uses custom stream", "[radi
   REQUIRE(keys == expected);
 }
 
-TEST_CASE("Device radix sort keys descending decomposer+bits uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys descending decomposer+bits uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
@@ -927,7 +948,7 @@ TEST_CASE("Device radix sort keys descending decomposer+bits uses custom stream"
   REQUIRE(keys_out == expected);
 }
 
-TEST_CASE("Device radix sort keys descending decomposer uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys descending decomposer uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
@@ -945,7 +966,7 @@ TEST_CASE("Device radix sort keys descending decomposer uses custom stream", "[r
   REQUIRE(keys_out == expected);
 }
 
-TEST_CASE("Device radix sort keys descending DB decomposer uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys descending DB decomposer uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_buf1 = c2h::device_vector<custom_key_t>(7);
@@ -966,7 +987,9 @@ TEST_CASE("Device radix sort keys descending DB decomposer uses custom stream", 
   REQUIRE(keys == expected);
 }
 
-TEST_CASE("Device radix sort keys descending DB decomposer+bits uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort keys descending DB decomposer+bits uses custom stream",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_buf1 = c2h::device_vector<custom_key_t>(7);
@@ -988,7 +1011,7 @@ TEST_CASE("Device radix sort keys descending DB decomposer+bits uses custom stre
   REQUIRE(keys == expected);
 }
 
-TEST_CASE("Device radix sort pairs descending decomposer+bits uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs descending decomposer+bits uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out   = c2h::device_vector<custom_key_t>(7);
@@ -1019,7 +1042,7 @@ TEST_CASE("Device radix sort pairs descending decomposer+bits uses custom stream
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("Device radix sort pairs descending decomposer uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs descending decomposer uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out   = c2h::device_vector<custom_key_t>(7);
@@ -1048,7 +1071,7 @@ TEST_CASE("Device radix sort pairs descending decomposer uses custom stream", "[
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("Device radix sort pairs descending DB decomposer uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs descending DB decomposer uses custom stream", "[radix_sort][device]", CUB_SMALL)
 {
   auto keys_buf0   = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_buf1   = c2h::device_vector<custom_key_t>(7);
@@ -1075,7 +1098,9 @@ TEST_CASE("Device radix sort pairs descending DB decomposer uses custom stream",
   REQUIRE(values == expected_values);
 }
 
-TEST_CASE("Device radix sort pairs descending DB decomposer+bits uses custom stream", "[radix_sort][device]")
+CUB_TEST_CASE("Device radix sort pairs descending DB decomposer+bits uses custom stream",
+              "[radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_buf0   = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_buf1   = c2h::device_vector<custom_key_t>(7);
@@ -1152,7 +1177,7 @@ std::size_t measure_allocated_bytes(CallableT&& run, PolicySelector policy_selec
   return bytes_allocated;
 }
 
-TEST_CASE("DeviceRadixSort::SortPairs can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortPairs can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto data = c2h::device_vector<int>(10'000); // must be larger than the single tile path
@@ -1172,7 +1197,7 @@ TEST_CASE("DeviceRadixSort::SortPairs can be tuned", "[radix_sort][device]")
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortPairs DoubleBuffer can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortPairs DoubleBuffer can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto data = c2h::device_vector<int>(10'000); // must be larger than the single tile path
@@ -1185,7 +1210,7 @@ TEST_CASE("DeviceRadixSort::SortPairs DoubleBuffer can be tuned", "[radix_sort][
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortPairsDescending can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortPairsDescending can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto data = c2h::device_vector<int>(10'000); // must be larger than the single tile path
@@ -1205,7 +1230,7 @@ TEST_CASE("DeviceRadixSort::SortPairsDescending can be tuned", "[radix_sort][dev
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortPairsDescending DoubleBuffer can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortPairsDescending DoubleBuffer can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto data = c2h::device_vector<int>(10'000); // must be larger than the single tile path
@@ -1218,7 +1243,7 @@ TEST_CASE("DeviceRadixSort::SortPairsDescending DoubleBuffer can be tuned", "[ra
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortKeys can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortKeys can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto data = c2h::device_vector<int>(10'000); // must be larger than the single tile path
@@ -1231,7 +1256,7 @@ TEST_CASE("DeviceRadixSort::SortKeys can be tuned", "[radix_sort][device]")
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortKeys DoubleBuffer can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortKeys DoubleBuffer can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto data = c2h::device_vector<int>(10'000); // must be larger than the single tile path
@@ -1244,7 +1269,7 @@ TEST_CASE("DeviceRadixSort::SortKeys DoubleBuffer can be tuned", "[radix_sort][d
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortKeysDescending can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortKeysDescending can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto data = c2h::device_vector<int>(10'000); // must be larger than the single tile path
@@ -1257,7 +1282,7 @@ TEST_CASE("DeviceRadixSort::SortKeysDescending can be tuned", "[radix_sort][devi
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortKeysDescending DoubleBuffer can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortKeysDescending DoubleBuffer can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto data = c2h::device_vector<int>(10'000); // must be larger than the single tile path
@@ -1272,7 +1297,7 @@ TEST_CASE("DeviceRadixSort::SortKeysDescending DoubleBuffer can be tuned", "[rad
 
 // decomposer variants: keys
 
-TEST_CASE("DeviceRadixSort::SortKeys decomposer+bits can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortKeys decomposer+bits can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto data = c2h::device_vector<custom_key_t>(10'000);
@@ -1285,7 +1310,7 @@ TEST_CASE("DeviceRadixSort::SortKeys decomposer+bits can be tuned", "[radix_sort
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortKeys decomposer can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortKeys decomposer can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto data = c2h::device_vector<custom_key_t>(10'000);
@@ -1298,7 +1323,7 @@ TEST_CASE("DeviceRadixSort::SortKeys decomposer can be tuned", "[radix_sort][dev
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortKeys DB decomposer can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortKeys DB decomposer can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto buf0 = c2h::device_vector<custom_key_t>(10'000);
@@ -1312,7 +1337,7 @@ TEST_CASE("DeviceRadixSort::SortKeys DB decomposer can be tuned", "[radix_sort][
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortKeys DB decomposer+bits can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortKeys DB decomposer+bits can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto buf0 = c2h::device_vector<custom_key_t>(10'000);
@@ -1328,7 +1353,7 @@ TEST_CASE("DeviceRadixSort::SortKeys DB decomposer+bits can be tuned", "[radix_s
 
 // decomposer variants: keys descending
 
-TEST_CASE("DeviceRadixSort::SortKeysDescending decomposer+bits can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortKeysDescending decomposer+bits can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto data = c2h::device_vector<custom_key_t>(10'000);
@@ -1341,7 +1366,7 @@ TEST_CASE("DeviceRadixSort::SortKeysDescending decomposer+bits can be tuned", "[
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortKeysDescending decomposer can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortKeysDescending decomposer can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto data = c2h::device_vector<custom_key_t>(10'000);
@@ -1354,7 +1379,7 @@ TEST_CASE("DeviceRadixSort::SortKeysDescending decomposer can be tuned", "[radix
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortKeysDescending DB decomposer can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortKeysDescending DB decomposer can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto buf0 = c2h::device_vector<custom_key_t>(10'000);
@@ -1368,7 +1393,7 @@ TEST_CASE("DeviceRadixSort::SortKeysDescending DB decomposer can be tuned", "[ra
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortKeysDescending DB decomposer+bits can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortKeysDescending DB decomposer+bits can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto buf0 = c2h::device_vector<custom_key_t>(10'000);
@@ -1385,7 +1410,7 @@ TEST_CASE("DeviceRadixSort::SortKeysDescending DB decomposer+bits can be tuned",
 
 // decomposer variants: pairs
 
-TEST_CASE("DeviceRadixSort::SortPairs decomposer+bits can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortPairs decomposer+bits can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto kbuf0 = c2h::device_vector<custom_pair_key_t>(10'000);
@@ -1403,7 +1428,7 @@ TEST_CASE("DeviceRadixSort::SortPairs decomposer+bits can be tuned", "[radix_sor
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortPairs decomposer can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortPairs decomposer can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto keys = c2h::device_vector<custom_pair_key_t>(10'000);
@@ -1423,7 +1448,7 @@ TEST_CASE("DeviceRadixSort::SortPairs decomposer can be tuned", "[radix_sort][de
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortPairs DB decomposer can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortPairs DB decomposer can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto kbuf0 = c2h::device_vector<custom_pair_key_t>(10'000);
@@ -1440,7 +1465,7 @@ TEST_CASE("DeviceRadixSort::SortPairs DB decomposer can be tuned", "[radix_sort]
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortPairs DB decomposer+bits can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortPairs DB decomposer+bits can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto kbuf0 = c2h::device_vector<custom_pair_key_t>(10'000);
@@ -1460,7 +1485,7 @@ TEST_CASE("DeviceRadixSort::SortPairs DB decomposer+bits can be tuned", "[radix_
 
 // decomposer variants: pairs descending
 
-TEST_CASE("DeviceRadixSort::SortPairsDescending decomposer+bits can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortPairsDescending decomposer+bits can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto keys = c2h::device_vector<custom_pair_key_t>(10'000);
@@ -1482,7 +1507,7 @@ TEST_CASE("DeviceRadixSort::SortPairsDescending decomposer+bits can be tuned", "
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortPairsDescending decomposer can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortPairsDescending decomposer can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto keys = c2h::device_vector<custom_pair_key_t>(10'000);
@@ -1502,7 +1527,7 @@ TEST_CASE("DeviceRadixSort::SortPairsDescending decomposer can be tuned", "[radi
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortPairsDescending DB decomposer can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortPairsDescending DB decomposer can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto kbuf0 = c2h::device_vector<custom_pair_key_t>(10'000);
@@ -1520,7 +1545,7 @@ TEST_CASE("DeviceRadixSort::SortPairsDescending DB decomposer can be tuned", "[r
   CHECK(bytes32 != bytes128);
 }
 
-TEST_CASE("DeviceRadixSort::SortPairsDescending DB decomposer+bits can be tuned", "[radix_sort][device]")
+CUB_TEST_CASE("DeviceRadixSort::SortPairsDescending DB decomposer+bits can be tuned", "[radix_sort][device]", CUB_SMALL)
 {
   auto l = [&](auto env) {
     auto kbuf0 = c2h::device_vector<custom_pair_key_t>(10'000);
@@ -1541,7 +1566,7 @@ TEST_CASE("DeviceRadixSort::SortPairsDescending DB decomposer+bits can be tuned"
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test RadixSortPolicy properties", "[radix_sort][device]")
+CUB_TEST("Test RadixSortPolicy properties", "[radix_sort][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::RadixSortPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RadixSortPolicy>);

--- a/cub/test/catch2_test_device_radix_sort_env_api.cu
+++ b/cub/test/catch2_test_device_radix_sort_env_api.cu
@@ -15,7 +15,7 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // example-begin radix-sort-keys-custom-decomposer
 struct custom_key_t
@@ -78,7 +78,7 @@ struct pairs_decomposer_t
 };
 // example-end radix-sort-pairs-custom-decomposer
 
-C2H_TEST("cub::DeviceRadixSort::SortPairs env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortPairs env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-pairs-env
   auto keys_in    = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -107,7 +107,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairs env-based API", "[radix_sort][env]")
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortPairsDescending env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortPairsDescending env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-pairs-descending-env
   auto keys_in    = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -136,7 +136,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairsDescending env-based API", "[radix_sort
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortKeys env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeys env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-env
   auto keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -157,7 +157,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys env-based API", "[radix_sort][env]")
   REQUIRE(keys_out == expected_keys);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortKeys DoubleBuffer env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeys DoubleBuffer env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-db-env
   thrust::device_vector<int> keys_buf0{8, 6, 7, 5, 3, 0, 9};
@@ -180,7 +180,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys DoubleBuffer env-based API", "[radix_so
   REQUIRE(keys == expected_keys);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortKeysDescending env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeysDescending env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-descending-env
   auto keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -201,7 +201,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending env-based API", "[radix_sort]
   REQUIRE(keys_out == expected_keys);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortKeysDescending DoubleBuffer env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeysDescending DoubleBuffer env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-descending-db-env
   thrust::device_vector<int> keys_buf0{8, 6, 7, 5, 3, 0, 9};
@@ -224,7 +224,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending DoubleBuffer env-based API", 
   REQUIRE(keys == expected_keys);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortPairs decomposer with bits env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortPairs decomposer with bits env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-pairs-decomposer-bits-env
   auto keys_in    = thrust::device_vector<custom_pair_key_t>{{3, 100}, {1, 200}, {2, 300}};
@@ -259,7 +259,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairs decomposer with bits env-based API", "
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortPairs decomposer env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortPairs decomposer env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-pairs-decomposer-env
   auto keys_in    = thrust::device_vector<custom_pair_key_t>{{3, 100}, {1, 200}, {2, 300}};
@@ -292,7 +292,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairs decomposer env-based API", "[radix_sor
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-pairs-db-decomposer-env
   thrust::device_vector<custom_pair_key_t> keys_buf0{{3, 100}, {1, 200}, {2, 300}};
@@ -324,7 +324,9 @@ C2H_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer env-based API"
   REQUIRE(values == expected_values);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer with bits env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer with bits env-based API",
+         "[radix_sort][env]",
+         CUB_SMALL)
 {
   // example-begin radix-sort-pairs-db-decomposer-bits-env
   thrust::device_vector<custom_pair_key_t> keys_buf0{{3, 100}, {1, 200}, {2, 300}};
@@ -356,7 +358,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer with bits env-
   REQUIRE(values == expected_values);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortKeys decomposer+bits env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeys decomposer+bits env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-decomposer-bits-env
   thrust::device_vector<custom_key_t> keys_in{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
@@ -382,7 +384,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys decomposer+bits env-based API", "[radix
   REQUIRE(keys_out == expected);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortKeys decomposer env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeys decomposer env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-decomposer-env
   thrust::device_vector<custom_key_t> keys_in{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
@@ -402,7 +404,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys decomposer env-based API", "[radix_sort
   REQUIRE(keys_out == expected);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortKeys DB decomposer env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeys DB decomposer env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-db-decomposer-env
   thrust::device_vector<custom_key_t> keys_buf0{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
@@ -425,7 +427,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys DB decomposer env-based API", "[radix_s
   REQUIRE(keys == expected);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortKeys DB decomposer+bits env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeys DB decomposer+bits env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-db-decomposer-bits-env
   thrust::device_vector<custom_key_t> keys_buf0{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
@@ -448,7 +450,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys DB decomposer+bits env-based API", "[ra
   REQUIRE(keys == expected);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortKeysDescending decomposer+bits env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeysDescending decomposer+bits env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-descending-decomposer-bits-env
   thrust::device_vector<custom_key_t> keys_in{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
@@ -474,7 +476,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending decomposer+bits env-based API
   REQUIRE(keys_out == expected);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortKeysDescending decomposer env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeysDescending decomposer env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-descending-decomposer-env
   thrust::device_vector<custom_key_t> keys_in{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
@@ -494,7 +496,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending decomposer env-based API", "[
   REQUIRE(keys_out == expected);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortKeysDescending DB decomposer env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeysDescending DB decomposer env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-descending-db-decomposer-env
   thrust::device_vector<custom_key_t> keys_buf0{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
@@ -517,7 +519,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending DB decomposer env-based API",
   REQUIRE(keys == expected);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortKeysDescending DB decomposer+bits env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeysDescending DB decomposer+bits env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-descending-db-decomposer-bits-env
   thrust::device_vector<custom_key_t> keys_buf0{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
@@ -540,7 +542,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending DB decomposer+bits env-based 
   REQUIRE(keys == expected);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortPairsDescending decomposer+bits env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortPairsDescending decomposer+bits env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-pairs-descending-decomposer-bits-env
   thrust::device_vector<custom_key_t> keys_in{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
@@ -572,7 +574,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairsDescending decomposer+bits env-based AP
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortPairsDescending decomposer env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortPairsDescending decomposer env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-pairs-descending-decomposer-env
   thrust::device_vector<custom_key_t> keys_in{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
@@ -602,7 +604,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairsDescending decomposer env-based API", "
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortPairsDescending DB decomposer env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortPairsDescending DB decomposer env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-pairs-descending-db-decomposer-env
   thrust::device_vector<custom_key_t> keys_buf0{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
@@ -631,7 +633,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairsDescending DB decomposer env-based API"
   REQUIRE(values == expected_values);
 }
 
-C2H_TEST("cub::DeviceRadixSort::SortPairsDescending DB decomposer+bits env-based API", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortPairsDescending DB decomposer+bits env-based API", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-pairs-descending-db-decomposer-bits-env
   thrust::device_vector<custom_key_t> keys_buf0{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
@@ -717,7 +719,7 @@ struct RadixSortKeysPolicySelector
 };
 // example-end radix-sort-keys-policy-selector
 
-C2H_TEST("cub::DeviceRadixSort::SortKeys accepts a custom policy selector", "[radix_sort][env]")
+CUB_TEST("cub::DeviceRadixSort::SortKeys accepts a custom policy selector", "[radix_sort][env]", CUB_SMALL)
 {
   // example-begin radix-sort-keys-tuning
   auto keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};

--- a/cub/test/catch2_test_device_radix_sort_keys.cu
+++ b/cub/test/catch2_test_device_radix_sort_keys.cu
@@ -22,7 +22,7 @@
 #include "catch2_large_array_sort_helper.cuh"
 #include "catch2_radix_sort_helper.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/extended_types.h>
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
@@ -72,7 +72,7 @@ using single_key_type = c2h::type_list<c2h::get<0, key_types>>;
 // Index types used for NumItemsT testing. cub::detail::ChooseOffsetT only selects 32/64 bit unsigned types:
 using num_items_types = c2h::type_list<cuda::std::uint32_t, cuda::std::uint64_t>;
 
-C2H_TEST("DeviceRadixSort::SortKeys: basic testing", "[keys][radix][sort][device]", key_types)
+CUB_TEST("DeviceRadixSort::SortKeys: basic testing", "[keys][radix][sort][device]", CUB_SMALL, key_types)
 {
   using key_t = c2h::get<0, TestType>;
 
@@ -112,7 +112,7 @@ C2H_TEST("DeviceRadixSort::SortKeys: basic testing", "[keys][radix][sort][device
   REQUIRE(ref_keys == out_keys);
 }
 
-C2H_TEST("DeviceRadixSort::SortKeys: bit windows", "[keys][radix][sort][device]", bit_window_key_types)
+CUB_TEST("DeviceRadixSort::SortKeys: bit windows", "[keys][radix][sort][device]", CUB_SMALL, bit_window_key_types)
 {
   using key_t = c2h::get<0, TestType>;
 
@@ -162,7 +162,7 @@ C2H_TEST("DeviceRadixSort::SortKeys: bit windows", "[keys][radix][sort][device]"
 
 #ifndef NO_FP_KEY_TYPES
 
-C2H_TEST("DeviceRadixSort::SortKeys: negative zero handling", "[keys][radix][sort][device]", fp_key_types)
+CUB_TEST("DeviceRadixSort::SortKeys: negative zero handling", "[keys][radix][sort][device]", CUB_SMALL, fp_key_types)
 {
   using key_t  = c2h::get<0, TestType>;
   using bits_t = typename cub::Traits<key_t>::UnsignedBits;
@@ -218,7 +218,7 @@ C2H_TEST("DeviceRadixSort::SortKeys: negative zero handling", "[keys][radix][sor
   REQUIRE_BITWISE_EQ(ref_keys, out_keys);
 }
 
-C2H_TEST("DeviceRadixSort::SortKeys: NaN handling", "[keys][radix][sort][device]", fp_key_types)
+CUB_TEST("DeviceRadixSort::SortKeys: NaN handling", "[keys][radix][sort][device]", CUB_SMALL, fp_key_types)
 {
   using key_t    = c2h::get<0, TestType>;
   using limits_t = cuda::std::numeric_limits<key_t>;
@@ -284,7 +284,7 @@ C2H_TEST("DeviceRadixSort::SortKeys: NaN handling", "[keys][radix][sort][device]
 
 #endif // !NO_FP_KEY_TYPES
 
-C2H_TEST("DeviceRadixSort::SortKeys: entropy reduction", "[keys][radix][sort][device]", single_key_type)
+CUB_TEST("DeviceRadixSort::SortKeys: entropy reduction", "[keys][radix][sort][device]", CUB_SMALL, single_key_type)
 {
   using key_t = c2h::get<0, TestType>;
 
@@ -339,7 +339,7 @@ C2H_TEST("DeviceRadixSort::SortKeys: entropy reduction", "[keys][radix][sort][de
   REQUIRE(ref_keys == out_keys);
 }
 
-C2H_TEST("DeviceRadixSort::SortKeys: uniform values", "[keys][radix][sort][device]", key_types)
+CUB_TEST("DeviceRadixSort::SortKeys: uniform values", "[keys][radix][sort][device]", CUB_SMALL, key_types)
 {
   using key_t = c2h::get<0, TestType>;
 
@@ -373,7 +373,8 @@ C2H_TEST("DeviceRadixSort::SortKeys: uniform values", "[keys][radix][sort][devic
   REQUIRE(ref_keys == out_keys);
 }
 
-C2H_TEST("DeviceRadixSort::SortKeys: NumItemsT", "[keys][radix][sort][device]", single_key_type, num_items_types)
+CUB_TEST(
+  "DeviceRadixSort::SortKeys: NumItemsT", "[keys][radix][sort][device]", CUB_SMALL, single_key_type, num_items_types)
 {
   using key_t       = c2h::get<0, TestType>;
   using num_items_t = c2h::get<1, TestType>;
@@ -414,7 +415,7 @@ C2H_TEST("DeviceRadixSort::SortKeys: NumItemsT", "[keys][radix][sort][device]", 
   REQUIRE(ref_keys == out_keys);
 }
 
-C2H_TEST("DeviceRadixSort::SortKeys: DoubleBuffer API", "[keys][radix][sort][device]", single_key_type)
+CUB_TEST("DeviceRadixSort::SortKeys: DoubleBuffer API", "[keys][radix][sort][device]", CUB_SMALL, single_key_type)
 {
   using key_t = c2h::get<0, TestType>;
 
@@ -484,8 +485,9 @@ void do_large_offset_test(std::size_t num_items)
   }
 }
 
-C2H_TEST("DeviceRadixSort::SortKeys: 32-bit overflow check",
+CUB_TEST("DeviceRadixSort::SortKeys: 32-bit overflow check",
          "[large][keys][radix][sort][device][skip-cs-synccheck][skip-cs-initcheck][skip-cs-racecheck]",
+         CUB_LARGE,
          single_key_type)
 {
   using key_t       = c2h::get<0, TestType>;
@@ -501,8 +503,9 @@ C2H_TEST("DeviceRadixSort::SortKeys: 32-bit overflow check",
   do_large_offset_test<key_t, num_items_t>(num_items);
 }
 
-C2H_TEST("DeviceRadixSort::SortKeys: Large Offsets",
+CUB_TEST("DeviceRadixSort::SortKeys: Large Offsets",
          "[large][keys][radix][sort][device][skip-cs-synccheck][skip-cs-initcheck][skip-cs-racecheck]",
+         CUB_LARGE,
          single_key_type)
 {
   using key_t       = c2h::get<0, TestType>;

--- a/cub/test/catch2_test_device_radix_sort_pairs.cu
+++ b/cub/test/catch2_test_device_radix_sort_pairs.cu
@@ -18,7 +18,7 @@
 #include "catch2_large_array_sort_helper.cuh"
 #include "catch2_radix_sort_helper.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -31,7 +31,8 @@ using value_types    = c2h::type_list<cuda::std::uint8_t, cuda::std::uint64_t, c
 // cub::detail::ChooseOffsetsT only selected 32/64 bit unsigned types:
 using num_items_types = c2h::type_list<cuda::std::uint32_t, cuda::std::uint64_t>;
 
-C2H_TEST("DeviceRadixSort::SortPairs: Basic testing", "[pairs][radix][sort][device]", value_types, num_items_types)
+CUB_TEST(
+  "DeviceRadixSort::SortPairs: Basic testing", "[pairs][radix][sort][device]", CUB_SMALL, value_types, num_items_types)
 {
   using key_t       = cuda::std::uint32_t;
   using value_t     = c2h::get<0, TestType>;
@@ -85,7 +86,7 @@ C2H_TEST("DeviceRadixSort::SortPairs: Basic testing", "[pairs][radix][sort][devi
   REQUIRE(ref_values == out_values);
 }
 
-C2H_TEST("DeviceRadixSort::SortPairs: DoubleBuffer API", "[pairs][radix][sort][device]", value_types)
+CUB_TEST("DeviceRadixSort::SortPairs: DoubleBuffer API", "[pairs][radix][sort][device]", CUB_SMALL, value_types)
 {
   using key_t   = cuda::std::uint32_t;
   using value_t = c2h::get<0, TestType>;
@@ -171,8 +172,9 @@ void do_large_offset_test(std::size_t num_items)
   }
 }
 
-C2H_TEST("DeviceRadixSort::SortPairs: 32-bit overflow check",
-         "[large][pairs][radix][sort][device][skip-cs-initcheck][skip-cs-racecheck]")
+CUB_TEST("DeviceRadixSort::SortPairs: 32-bit overflow check",
+         "[large][pairs][radix][sort][device][skip-cs-initcheck][skip-cs-racecheck]",
+         CUB_LARGE)
 {
   using key_t       = std::uint8_t;
   using value_t     = std::uint8_t;
@@ -184,8 +186,9 @@ C2H_TEST("DeviceRadixSort::SortPairs: 32-bit overflow check",
   do_large_offset_test<key_t, value_t, num_items_t>(num_items);
 }
 
-C2H_TEST("DeviceRadixSort::SortPairs: Large Offsets",
-         "[large][pairs][radix][sort][device][skip-cs-initcheck][skip-cs-racecheck]")
+CUB_TEST("DeviceRadixSort::SortPairs: Large Offsets",
+         "[large][pairs][radix][sort][device][skip-cs-initcheck][skip-cs-racecheck]",
+         CUB_LARGE)
 {
   using key_t       = std::uint8_t;
   using value_t     = std::uint8_t;

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -16,7 +16,7 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 #include <c2h/extended_types.h>
 
@@ -95,7 +95,7 @@ struct abs_less_t
   }
 };
 
-C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", full_type_list)
+CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", CUB_SMALL, full_type_list)
 {
   using params   = params_t<TestType>;
   using item_t   = typename params::item_t;
@@ -541,7 +541,7 @@ struct non_copy_assignable_less
   }
 };
 
-C2H_TEST("Device reduce works with a non copy assignable reduction operator", "[reduce][device]")
+CUB_TEST("Device reduce works with a non copy assignable reduction operator", "[reduce][device]", CUB_SMALL)
 {
   using item_t   = int;
   using output_t = int;
@@ -589,7 +589,7 @@ struct faulting_reduce
   }
 };
 
-C2H_TEST("Device reduce works without initial value", "[reduce][device]")
+CUB_TEST("Device reduce works without initial value", "[reduce][device]", CUB_SMALL)
 {
   constexpr int num_items = 1000;
   c2h::device_vector<int> input(num_items, checking_reduce::sentinel);

--- a/cub/test/catch2_test_device_reduce_by_key.cu
+++ b/cub/test/catch2_test_device_reduce_by_key.cu
@@ -7,7 +7,7 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 #include <c2h/extended_types.h>
 
@@ -51,7 +51,7 @@ type_triple<custom_t>
 // clang-format on
 #endif
 
-C2H_TEST("Device reduce-by-key works", "[by_key][reduce][device]", full_type_list)
+CUB_TEST("Device reduce-by-key works", "[by_key][reduce][device]", CUB_SMALL, full_type_list)
 {
   using params   = params_t<TestType>;
   using value_t  = typename params::item_t;

--- a/cub/test/catch2_test_device_reduce_by_key_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_reduce_by_key_custom_policy_hub.cu
@@ -11,7 +11,7 @@
 
 #include <cuda/std/functional>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -31,7 +31,7 @@ struct my_policy_hub
   };
 };
 
-C2H_TEST("DispatchReduceByKey::Dispatch: custom policy hub", "[reduce_by_key][device]")
+CUB_TEST("DispatchReduceByKey::Dispatch: custom policy hub", "[reduce_by_key][device]", CUB_SMALL)
 {
   using key_t          = int;
   using value_t        = int;

--- a/cub/test/catch2_test_device_reduce_by_key_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_by_key_env_api.cu
@@ -11,7 +11,7 @@
 #include <cuda/devices>
 #include <cuda/stream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 #if _CCCL_STD_VER >= 2020
 
@@ -32,7 +32,7 @@ struct ReduceByKeyPolicySelector
 };
 // example-end reduce-by-key-policy-selector
 
-C2H_TEST("cub::DeviceReduce::ReduceByKey accepts a custom policy selector", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::ReduceByKey accepts a custom policy selector", "[reduce][env]", CUB_SMALL)
 {
   // example-begin reduce-by-key-tuning
   auto d_keys_in        = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
@@ -70,7 +70,7 @@ C2H_TEST("cub::DeviceReduce::ReduceByKey accepts a custom policy selector", "[re
 #else // _CCCL_STD_VER >= 2020
 
 // we need a dummy test for C++17, otherwise the return code of the test executable is 2 (not 0)
-C2H_TEST("cub::DeviceReduce::ReduceByKey dummy test", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::ReduceByKey dummy test", "[reduce][env]", CUB_SMALL)
 {
   SUCCEED();
 }

--- a/cub/test/catch2_test_device_reduce_by_key_iterators.cu
+++ b/cub/test/catch2_test_device_reduce_by_key_iterators.cu
@@ -11,7 +11,7 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ReduceByKey, device_reduce_by_key);
@@ -22,7 +22,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ReduceByKey, device_reduce_by_key);
 using custom_t           = c2h::custom_type_t<c2h::accumulateable_t, c2h::equal_comparable_t>;
 using iterator_type_list = c2h::type_list<type_triple<custom_t>, type_triple<std::int64_t, std::int64_t, custom_t>>;
 
-C2H_TEST("Device reduce-by-key works with iterators", "[by_key][reduce][device]", iterator_type_list)
+CUB_TEST("Device reduce-by-key works with iterators", "[by_key][reduce][device]", CUB_SMALL, iterator_type_list)
 {
   using params   = params_t<TestType>;
   using value_t  = typename params::item_t;

--- a/cub/test/catch2_test_device_reduce_by_key_vsmem.cu
+++ b/cub/test/catch2_test_device_reduce_by_key_vsmem.cu
@@ -7,7 +7,7 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 #include <c2h/extended_types.h>
 
@@ -19,7 +19,7 @@ using large_type_list =
   c2h::type_list<c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t, c2h::huge_data<256>::type>,
                  c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t, c2h::huge_data<512>::type>>;
 
-C2H_TEST("Device reduce-by-key works with huge keys", "[by_key][reduce][device]", large_type_list)
+CUB_TEST("Device reduce-by-key works with huge keys", "[by_key][reduce][device]", CUB_SMALL, large_type_list)
 {
   using key_t    = typename c2h::get<0, TestType>;
   using value_t  = std::uint32_t;

--- a/cub/test/catch2_test_device_reduce_deferred.cu
+++ b/cub/test/catch2_test_device_reduce_deferred.cu
@@ -31,7 +31,7 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/generators.h>
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Reduce, device_reduce);
@@ -229,7 +229,7 @@ struct select_then_reduce_t
 
 using count_types = c2h::type_list<int32_t, uint32_t, int64_t, uint64_t>;
 
-C2H_TEST("DeviceReduce::Reduce accepts deferred num_items", "[device][reduce][deferred]", count_types)
+CUB_TEST("DeviceReduce::Reduce accepts deferred num_items", "[device][reduce][deferred]", CUB_SMALL, count_types)
 {
   using value_t = int64_t;
   using count_t = typename c2h::get<0, TestType>;
@@ -254,8 +254,9 @@ C2H_TEST("DeviceReduce::Reduce accepts deferred num_items", "[device][reduce][de
   REQUIRE(output[0] == expected);
 }
 
-C2H_TEST("DeviceReduce::Reduce with deferred num_items is run-to-run reproducible",
-         "[device][reduce][deferred][run_to_run]")
+CUB_TEST("DeviceReduce::Reduce with deferred num_items is run-to-run reproducible",
+         "[device][reduce][deferred][run_to_run]",
+         CUB_SMALL)
 {
   using value_t = float;
   using count_t = int32_t;
@@ -282,7 +283,7 @@ C2H_TEST("DeviceReduce::Reduce with deferred num_items is run-to-run reproducibl
   }
 }
 
-C2H_TEST("DeviceReduce::Reduce with a deferred size handles grid boundaries", "[device][reduce][deferred]")
+CUB_TEST("DeviceReduce::Reduce with a deferred size handles grid boundaries", "[device][reduce][deferred]", CUB_SMALL)
 {
   using value_t = int64_t;
   using count_t = int32_t;
@@ -311,8 +312,9 @@ C2H_TEST("DeviceReduce::Reduce with a deferred size handles grid boundaries", "[
   REQUIRE(output[0] == value_t{7} + num_items);
 }
 
-C2H_TEST("DeviceReduce atomic dispatch with a deferred size handles grid boundaries",
-         "[device][reduce][deferred][not_guaranteed]")
+CUB_TEST("DeviceReduce atomic dispatch with a deferred size handles grid boundaries",
+         "[device][reduce][deferred][not_guaranteed]",
+         CUB_SMALL)
 {
   using value_t = float;
   using count_t = int32_t;
@@ -347,8 +349,9 @@ C2H_TEST("DeviceReduce atomic dispatch with a deferred size handles grid boundar
   REQUIRE(output[0] == init + static_cast<value_t>(num_items));
 }
 
-C2H_TEST("DeviceReduce deterministic dispatch with a deferred size handles grid boundaries",
-         "[device][reduce][deferred][gpu_to_gpu]")
+CUB_TEST("DeviceReduce deterministic dispatch with a deferred size handles grid boundaries",
+         "[device][reduce][deferred][gpu_to_gpu]",
+         CUB_SMALL)
 {
   using value_t = float;
   using count_t = int32_t;
@@ -376,7 +379,9 @@ C2H_TEST("DeviceReduce deterministic dispatch with a deferred size handles grid 
   REQUIRE(output[0] == init + static_cast<value_t>(num_items));
 }
 
-C2H_TEST("DeviceReduce::Reduce accepts deferred span and fancy-iterator sources", "[device][reduce][deferred]")
+CUB_TEST("DeviceReduce::Reduce accepts deferred span and fancy-iterator sources",
+         "[device][reduce][deferred]",
+         CUB_SMALL)
 {
   using value_t = int64_t;
   using count_t = int32_t;
@@ -413,7 +418,9 @@ C2H_TEST("DeviceReduce::Reduce accepts deferred span and fancy-iterator sources"
   REQUIRE(output[0] == num_items);
 }
 
-C2H_TEST("DeviceReduce entry points sharing reduce dispatch accept deferred num_items", "[device][reduce][deferred]")
+CUB_TEST("DeviceReduce entry points sharing reduce dispatch accept deferred num_items",
+         "[device][reduce][deferred]",
+         CUB_SMALL)
 {
   using value_t = int64_t;
   using count_t = int32_t;
@@ -449,7 +456,7 @@ C2H_TEST("DeviceReduce entry points sharing reduce dispatch accept deferred num_
   REQUIRE(output[0] == value_t{4} * num_items);
 }
 
-C2H_TEST("DeviceReduce::Reduce consumes a count produced by DeviceSelect::If", "[device][reduce][deferred]")
+CUB_TEST("DeviceReduce::Reduce consumes a count produced by DeviceSelect::If", "[device][reduce][deferred]", CUB_SMALL)
 {
   using value_t = int64_t;
   using count_t = int32_t;
@@ -485,8 +492,9 @@ C2H_TEST("DeviceReduce::Reduce consumes a count produced by DeviceSelect::If", "
 }
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DeviceReduce::Reduce consumes a deferred count produced in another stream after an event",
-         "[device][reduce][deferred]")
+CUB_TEST("DeviceReduce::Reduce consumes a deferred count produced in another stream after an event",
+         "[device][reduce][deferred]",
+         CUB_SMALL)
 {
   using value_t = int64_t;
   using count_t = int32_t;
@@ -563,7 +571,7 @@ C2H_TEST("DeviceReduce::Reduce consumes a deferred count produced in another str
   REQUIRE(output[0] == expected_sum);
 }
 
-C2H_TEST("DeviceReduce environment entry points accept deferred num_items", "[device][reduce][deferred]")
+CUB_TEST("DeviceReduce environment entry points accept deferred num_items", "[device][reduce][deferred]", CUB_SMALL)
 {
   using value_t = int64_t;
   using count_t = int32_t;
@@ -604,8 +612,9 @@ C2H_TEST("DeviceReduce environment entry points accept deferred num_items", "[de
   REQUIRE(output[0] == value_t{4} * num_items);
 }
 
-C2H_TEST("DeviceReduce::Reduce supports deferred num_items with not_guaranteed determinism",
-         "[device][reduce][deferred]")
+CUB_TEST("DeviceReduce::Reduce supports deferred num_items with not_guaranteed determinism",
+         "[device][reduce][deferred]",
+         CUB_SMALL)
 {
   using value_t = float;
   using count_t = int32_t;
@@ -627,9 +636,10 @@ C2H_TEST("DeviceReduce::Reduce supports deferred num_items with not_guaranteed d
 
 using gpu_to_gpu_count_types = c2h::type_list<int32_t, uint32_t, int64_t, uint64_t>;
 
-C2H_TEST("DeviceReduce::Reduce with deferred num_items matches the immediate result bitwise with gpu_to_gpu "
+CUB_TEST("DeviceReduce::Reduce with deferred num_items matches the immediate result bitwise with gpu_to_gpu "
          "determinism",
          "[device][reduce][deferred][gpu_to_gpu]",
+         CUB_SMALL,
          gpu_to_gpu_count_types)
 {
   using value_t = float;
@@ -658,9 +668,10 @@ C2H_TEST("DeviceReduce::Reduce with deferred num_items matches the immediate res
 
 using gpu_to_gpu_large_count_types = c2h::type_list<uint32_t, int64_t, uint64_t>;
 
-C2H_TEST("DeviceReduce::Reduce with a large deferred num_items matches the immediate result bitwise with gpu_to_gpu "
+CUB_TEST("DeviceReduce::Reduce with a large deferred num_items matches the immediate result bitwise with gpu_to_gpu "
          "determinism",
          "[device][reduce][deferred][gpu_to_gpu]",
+         CUB_SMALL,
          gpu_to_gpu_large_count_types)
 {
   using value_t = float;
@@ -689,8 +700,9 @@ C2H_TEST("DeviceReduce::Reduce with a large deferred num_items matches the immed
 #endif // TEST_LAUNCH == 0
 
 #if TEST_LAUNCH == 2
-C2H_TEST("captured DeviceReduce atomic dispatch replays with zero and nonzero deferred counts",
-         "[device][reduce][deferred][not_guaranteed]")
+CUB_TEST("captured DeviceReduce atomic dispatch replays with zero and nonzero deferred counts",
+         "[device][reduce][deferred][not_guaranteed]",
+         CUB_SMALL)
 {
   using value_t = float;
   using count_t = int32_t;
@@ -742,8 +754,9 @@ C2H_TEST("captured DeviceReduce atomic dispatch replays with zero and nonzero de
   REQUIRE(cudaSuccess == cudaStreamDestroy(stream));
 }
 
-C2H_TEST("captured DeviceReduce deterministic dispatch replays with zero and nonzero deferred counts",
-         "[device][reduce][deferred][gpu_to_gpu]")
+CUB_TEST("captured DeviceReduce deterministic dispatch replays with zero and nonzero deferred counts",
+         "[device][reduce][deferred][gpu_to_gpu]",
+         CUB_SMALL)
 {
   using value_t = float;
   using count_t = int32_t;
@@ -791,8 +804,9 @@ C2H_TEST("captured DeviceReduce deterministic dispatch replays with zero and non
   REQUIRE(cudaSuccess == cudaStreamDestroy(stream));
 }
 
-C2H_TEST("captured DeviceSelect::If to DeviceReduce::Reduce pipeline replays with changing counts",
-         "[device][reduce][deferred]")
+CUB_TEST("captured DeviceSelect::If to DeviceReduce::Reduce pipeline replays with changing counts",
+         "[device][reduce][deferred]",
+         CUB_SMALL)
 {
   using value_t  = int64_t;
   using count_t  = int32_t;

--- a/cub/test/catch2_test_device_reduce_deterministic.cu
+++ b/cub/test/catch2_test_device_reduce_deterministic.cu
@@ -15,7 +15,7 @@
 #include <numeric>
 
 #include "catch2_test_device_reduce.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/extended_types.h>
 #include <c2h/generators.h>
 
@@ -31,7 +31,10 @@ struct custom_policy_selector
   }
 };
 
-C2H_TEST("Deterministic Device reduce works with float and double on gpu", "[reduce][deterministic]", float_type_list)
+CUB_TEST("Deterministic Device reduce works with float and double on gpu",
+         "[reduce][deterministic]",
+         CUB_SMALL,
+         float_type_list)
 {
   using type          = typename c2h::get<0, TestType>;
   const int num_items = 1 << 20;
@@ -76,8 +79,9 @@ struct cyclic_chunk_accessor
 };
 
 using large_offset_type_list = c2h::type_list<double>;
-C2H_TEST("Deterministic Device reduce works with float and double on gpu with large offset types and num_items",
+CUB_TEST("Deterministic Device reduce works with float and double on gpu with large offset types and num_items",
          "[reduce][deterministic]",
+         CUB_SMALL,
          large_offset_type_list)
 {
   using type                    = typename c2h::get<0, TestType>;
@@ -120,8 +124,9 @@ C2H_TEST("Deterministic Device reduce works with float and double on gpu with la
   REQUIRE_APPROX_EQ_ABS(h_expected, h_output, type{1e-10});
 }
 
-C2H_TEST("Deterministic Device reduce works with float and double and is deterministic on gpu with different policies ",
+CUB_TEST("Deterministic Device reduce works with float and double and is deterministic on gpu with different policies ",
          "[reduce][deterministic]",
+         CUB_SMALL,
          float_type_list)
 {
   using type              = typename c2h::get<0, TestType>;
@@ -171,8 +176,9 @@ C2H_TEST("Deterministic Device reduce works with float and double and is determi
   REQUIRE(d_output_p1 == d_output_p2);
 }
 
-C2H_TEST("Deterministic Device reduce works with float and double on gpu with different iterators",
+CUB_TEST("Deterministic Device reduce works with float and double on gpu with different iterators",
          "[reduce][deterministic]",
+         CUB_SMALL,
          float_type_list)
 {
   using type = typename c2h::get<0, TestType>;
@@ -231,8 +237,9 @@ struct square_t
   }
 };
 
-C2H_TEST("Deterministic Device reduce works with float and double on gpu with different transform operators",
+CUB_TEST("Deterministic Device reduce works with float and double on gpu with different transform operators",
          "[reduce][deterministic]",
+         CUB_SMALL,
          float_type_list)
 {
   using type = typename c2h::get<0, TestType>;
@@ -259,8 +266,9 @@ C2H_TEST("Deterministic Device reduce works with float and double on gpu with di
   REQUIRE_APPROX_EQ_EPSILON(h_expected, d_output, type{0.01});
 }
 
-C2H_TEST("Deterministic Device reduce works with float and double on gpu with different init values",
+CUB_TEST("Deterministic Device reduce works with float and double on gpu with different init values",
          "[reduce][deterministic]",
+         CUB_SMALL,
          float_type_list)
 {
   using type = typename c2h::get<0, TestType>;
@@ -302,8 +310,9 @@ using test_types =
 #endif
                  >;
 
-C2H_TEST("Deterministic Device reduce works with integral types on gpu with different reduction operators",
+CUB_TEST("Deterministic Device reduce works with integral types on gpu with different reduction operators",
          "[reduce][deterministic]",
+         CUB_SMALL,
          test_types)
 {
   using type         = typename c2h::get<0, TestType>;

--- a/cub/test/catch2_test_device_reduce_dispatcher.cu
+++ b/cub/test/catch2_test_device_reduce_dispatcher.cu
@@ -14,7 +14,7 @@
 #include <cstdint>
 
 #include "catch2_test_device_reduce.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using value_types = c2h::type_list<std::int8_t, std::int16_t, std::int32_t, std::int64_t, float, double>;
 
@@ -42,7 +42,7 @@ struct policy_hub_t
   using MaxPolicy = policy_t;
 };
 
-C2H_TEST("Dispatch reduce can be called with custom policy_hub", "[reduce][device]", value_types)
+CUB_TEST("Dispatch reduce can be called with custom policy_hub", "[reduce][device]", CUB_SMALL, value_types)
 {
   using T            = c2h::get<0, TestType>;
   using offset_t     = int32_t;

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -33,7 +33,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMax, device_arg_max);
 
 #include <sstream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 using cuda::execution::determinism::__determinism_t;
@@ -70,7 +70,7 @@ using block_size_check_plus_t = block_size_extracting_op<cuda::std::plus<>>;
 // We need a test of simple use to check if default environment works.
 // ifdef it out not to spend time compiling and running it twice.
 #if TEST_LAUNCH == 0
-TEST_CASE("Device reduce works with default environment", "[reduce][device]")
+CUB_TEST_CASE("Device reduce works with default environment", "[reduce][device]", CUB_SMALL)
 {
   using num_items_t = int;
   using value_t     = int;
@@ -99,7 +99,7 @@ TEST_CASE("Device reduce works with default environment", "[reduce][device]")
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-TEST_CASE("Device Sum works with default environment", "[reduce][device]")
+CUB_TEST_CASE("Device Sum works with default environment", "[reduce][device]", CUB_SMALL)
 {
   using num_items_t     = int;
   using value_t         = int;
@@ -114,7 +114,7 @@ TEST_CASE("Device Sum works with default environment", "[reduce][device]")
 #endif
 
 #if TEST_LAUNCH != 1
-C2H_TEST("Device reduce can be tuned", "[reduce][device]", block_sizes)
+CUB_TEST("Device reduce can be tuned", "[reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -129,7 +129,7 @@ C2H_TEST("Device reduce can be tuned", "[reduce][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device reduce not_guaranteed can be tuned", "[reduce][device]", block_sizes)
+CUB_TEST("Device reduce not_guaranteed can be tuned", "[reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -144,7 +144,7 @@ C2H_TEST("Device reduce not_guaranteed can be tuned", "[reduce][device]", block_
   REQUIRE(d_out[0] == 1);
   REQUIRE(d_block_size[0] == target_block_size);
 }
-C2H_TEST("Device reduce run_to_run can be tuned", "[reduce][device]", block_sizes)
+CUB_TEST("Device reduce run_to_run can be tuned", "[reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -160,7 +160,7 @@ C2H_TEST("Device reduce run_to_run can be tuned", "[reduce][device]", block_size
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device reduce gpu_to_gpu can be tuned", "[reduce][device]", block_sizes)
+CUB_TEST("Device reduce gpu_to_gpu can be tuned", "[reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -176,7 +176,7 @@ C2H_TEST("Device reduce gpu_to_gpu can be tuned", "[reduce][device]", block_size
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device Sum can be tuned", "[reduce][device]", block_sizes)
+CUB_TEST("Device Sum can be tuned", "[reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -191,7 +191,7 @@ C2H_TEST("Device Sum can be tuned", "[reduce][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device Min can be tuned", "[reduce][device]", block_sizes)
+CUB_TEST("Device Min can be tuned", "[reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -206,7 +206,7 @@ C2H_TEST("Device Min can be tuned", "[reduce][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device Max can be tuned", "[reduce][device]", block_sizes)
+CUB_TEST("Device Max can be tuned", "[reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -221,7 +221,7 @@ C2H_TEST("Device Max can be tuned", "[reduce][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device TransformReduce can be tuned", "[reduce][device]", block_sizes)
+CUB_TEST("Device TransformReduce can be tuned", "[reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -236,7 +236,7 @@ C2H_TEST("Device TransformReduce can be tuned", "[reduce][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device ArgMin can be tuned", "[reduce][device]", block_sizes)
+CUB_TEST("Device ArgMin can be tuned", "[reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -256,7 +256,7 @@ C2H_TEST("Device ArgMin can be tuned", "[reduce][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device ArgMax can be tuned", "[reduce][device]", block_sizes)
+CUB_TEST("Device ArgMax can be tuned", "[reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -295,7 +295,7 @@ using reduce_by_key_block_sizes =
 
 using block_size_extracting_minimum_t = block_size_extracting_op<cuda::minimum<int>>;
 
-C2H_TEST("Device ReduceByKey can be tuned", "[reduce][device]", reduce_by_key_block_sizes)
+CUB_TEST("Device ReduceByKey can be tuned", "[reduce][device]", CUB_SMALL, reduce_by_key_block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto d_keys_in                           = c2h::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
@@ -335,7 +335,7 @@ using requirements =
                  cuda::execution::determinism::run_to_run_t,
                  cuda::execution::determinism::not_guaranteed_t>;
 
-C2H_TEST("Device reduce uses environment", "[reduce][device]", requirements)
+CUB_TEST("Device reduce uses environment", "[reduce][device]", CUB_SMALL, requirements)
 {
   using determinism_t = c2h::get<0, TestType>;
   using accumulator_t = float;
@@ -477,7 +477,7 @@ C2H_TEST("Device reduce uses environment", "[reduce][device]", requirements)
   REQUIRE(d_out[0] == num_items);
 }
 
-C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
+CUB_TEST("Device sum uses environment", "[reduce][device]", CUB_SMALL, requirements)
 {
   using determinism_t = c2h::get<0, TestType>;
   using accumulator_t = float;
@@ -617,7 +617,9 @@ C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
   REQUIRE(d_out[0] == num_items);
 }
 
-C2H_TEST("Device reduce not_guaranteed falls back when output type differs from accumulator", "[reduce][device]")
+CUB_TEST("Device reduce not_guaranteed falls back when output type differs from accumulator",
+         "[reduce][device]",
+         CUB_SMALL)
 {
   using input_t       = cuda::std::uint8_t;
   using output_t      = cuda::std::uint8_t;
@@ -681,7 +683,7 @@ C2H_TEST("Device reduce not_guaranteed falls back when output type differs from 
   REQUIRE(d_out[0] == output_t{6});
 }
 
-C2H_TEST("Device sum not_guaranteed falls back when output type differs from accumulator", "[reduce][device]")
+CUB_TEST("Device sum not_guaranteed falls back when output type differs from accumulator", "[reduce][device]", CUB_SMALL)
 {
   using input_t       = cuda::std::uint8_t;
   using output_t      = cuda::std::uint8_t;
@@ -745,7 +747,7 @@ C2H_TEST("Device sum not_guaranteed falls back when output type differs from acc
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("Device Min works with default environment", "[reduce][device]")
+CUB_TEST_CASE("Device Min works with default environment", "[reduce][device]", CUB_SMALL)
 {
   auto input  = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto output = c2h::device_vector<float>(1);
@@ -755,7 +757,7 @@ TEST_CASE("Device Min works with default environment", "[reduce][device]")
   REQUIRE(output[0] == 0.0f);
 }
 
-TEST_CASE("Device Max works with default environment", "[reduce][device]")
+CUB_TEST_CASE("Device Max works with default environment", "[reduce][device]", CUB_SMALL)
 {
   auto input  = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto output = c2h::device_vector<float>(1);
@@ -765,7 +767,7 @@ TEST_CASE("Device Max works with default environment", "[reduce][device]")
   REQUIRE(output[0] == 4.0f);
 }
 
-TEST_CASE("Device TransformReduce works with default environment", "[reduce][device]")
+CUB_TEST_CASE("Device TransformReduce works with default environment", "[reduce][device]", CUB_SMALL)
 {
   auto d_in  = c2h::device_vector<int>{1, 2, 3, 4};
   auto d_out = thrust::device_vector<int>(1);
@@ -779,7 +781,7 @@ TEST_CASE("Device TransformReduce works with default environment", "[reduce][dev
   REQUIRE(d_out[0] == -10);
 }
 
-TEST_CASE("Device ReduceByKey works with default environment", "[reduce][device]")
+CUB_TEST_CASE("Device ReduceByKey works with default environment", "[reduce][device]", CUB_SMALL)
 {
   auto d_keys_in        = c2h::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
   auto d_values_in      = c2h::device_vector<int>{0, 7, 1, 6, 2, 5, 3, 4};
@@ -807,7 +809,7 @@ TEST_CASE("Device ReduceByKey works with default environment", "[reduce][device]
   REQUIRE(d_aggregates_out == expected_aggregates);
 }
 
-TEST_CASE("Device ArgMin works with default environment", "[reduce][device]")
+CUB_TEST_CASE("Device ArgMin works with default environment", "[reduce][device]", CUB_SMALL)
 {
   auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto min_output   = c2h::device_vector<float>(1);
@@ -820,7 +822,7 @@ TEST_CASE("Device ArgMin works with default environment", "[reduce][device]")
   REQUIRE(index_output[0] == 3);
 }
 
-TEST_CASE("Device ArgMax works with default environment", "[reduce][device]")
+CUB_TEST_CASE("Device ArgMax works with default environment", "[reduce][device]", CUB_SMALL)
 {
   auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto max_output   = c2h::device_vector<float>(1);
@@ -833,7 +835,7 @@ TEST_CASE("Device ArgMax works with default environment", "[reduce][device]")
   REQUIRE(index_output[0] == 2);
 }
 
-TEST_CASE("Device ArgMin with compare_op works with default environment", "[reduce][device]")
+CUB_TEST_CASE("Device ArgMin with compare_op works with default environment", "[reduce][device]", CUB_SMALL)
 {
   auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto min_output   = c2h::device_vector<float>(1);
@@ -846,7 +848,7 @@ TEST_CASE("Device ArgMin with compare_op works with default environment", "[redu
   REQUIRE(index_output[0] == 3);
 }
 
-TEST_CASE("Device ArgMax with compare_op works with default environment", "[reduce][device]")
+CUB_TEST_CASE("Device ArgMax with compare_op works with default environment", "[reduce][device]", CUB_SMALL)
 {
   auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto max_output   = c2h::device_vector<float>(1);
@@ -861,7 +863,7 @@ TEST_CASE("Device ArgMax with compare_op works with default environment", "[redu
 
 #endif
 
-C2H_TEST("Device TransformReduce uses environment", "[reduce][device]")
+CUB_TEST("Device TransformReduce uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto d_in  = c2h::device_vector<int>{1, 2, 3, 4};
   auto d_out = thrust::device_vector<int>(1);
@@ -889,7 +891,7 @@ C2H_TEST("Device TransformReduce uses environment", "[reduce][device]")
   REQUIRE(d_out[0] == -10);
 }
 
-C2H_TEST("Device Min uses environment", "[reduce][device]")
+CUB_TEST("Device Min uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto input  = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto output = c2h::device_vector<float>(1);
@@ -906,7 +908,7 @@ C2H_TEST("Device Min uses environment", "[reduce][device]")
   REQUIRE(output[0] == 0.0f);
 }
 
-C2H_TEST("Device Max uses environment", "[reduce][device]")
+CUB_TEST("Device Max uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto input  = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto output = c2h::device_vector<float>(1);
@@ -923,7 +925,7 @@ C2H_TEST("Device Max uses environment", "[reduce][device]")
   REQUIRE(output[0] == 4.0f);
 }
 
-C2H_TEST("Device ReduceByKey uses environment", "[reduce][device]")
+CUB_TEST("Device ReduceByKey uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto d_keys_in        = c2h::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
   auto d_values_in      = c2h::device_vector<int>{0, 7, 1, 6, 2, 5, 3, 4};
@@ -966,7 +968,7 @@ C2H_TEST("Device ReduceByKey uses environment", "[reduce][device]")
   REQUIRE(d_aggregates_out == expected_aggregates);
 }
 
-C2H_TEST("Device ArgMin uses environment", "[reduce][device]")
+CUB_TEST("Device ArgMin uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto min_output   = c2h::device_vector<float>(1);
@@ -991,7 +993,7 @@ C2H_TEST("Device ArgMin uses environment", "[reduce][device]")
   REQUIRE(index_output[0] == 3);
 }
 
-C2H_TEST("Device ArgMin with compare_op uses environment", "[reduce][device]")
+CUB_TEST("Device ArgMin with compare_op uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto min_output   = c2h::device_vector<float>(1);
@@ -1018,7 +1020,7 @@ C2H_TEST("Device ArgMin with compare_op uses environment", "[reduce][device]")
   REQUIRE(index_output[0] == 3);
 }
 
-C2H_TEST("Device ArgMax uses environment", "[reduce][device]")
+CUB_TEST("Device ArgMax uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto max_output   = c2h::device_vector<float>(1);
@@ -1043,7 +1045,7 @@ C2H_TEST("Device ArgMax uses environment", "[reduce][device]")
   REQUIRE(index_output[0] == 2);
 }
 
-C2H_TEST("Device ArgMax with compare_op uses environment", "[reduce][device]")
+CUB_TEST("Device ArgMax with compare_op uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto max_output   = c2h::device_vector<float>(1);
@@ -1070,7 +1072,7 @@ C2H_TEST("Device ArgMax with compare_op uses environment", "[reduce][device]")
   REQUIRE(index_output[0] == 2);
 }
 
-C2H_TEST("cub::DeviceReduce::Reduce allows no_init in env overloads", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Reduce allows no_init in env overloads", "[reduce][env]", CUB_SMALL)
 {
   auto input  = thrust::device_vector<int>{1, 2, 3, 4, 5};
   auto output = thrust::device_vector<int>(1, thrust::no_init);
@@ -1094,7 +1096,7 @@ C2H_TEST("cub::DeviceReduce::Reduce allows no_init in env overloads", "[reduce][
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test ReducePolicy properties", "[reduce][device]")
+CUB_TEST("Test ReducePolicy properties", "[reduce][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ReducePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ReducePolicy>);
@@ -1160,7 +1162,7 @@ C2H_TEST("Test ReducePolicy properties", "[reduce][device]")
              ", .reduce_algorithm = BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, .load_modifier = LOAD_DEFAULT } }");
 }
 
-C2H_TEST("Test ReduceByKeyPolicy properties", "[reduce][device]")
+CUB_TEST("Test ReduceByKeyPolicy properties", "[reduce][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ReduceByKeyPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ReduceByKeyPolicy>);

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -15,9 +15,9 @@
 #include <cuda/stream>
 
 #include "catch2_test_memory_resources.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceReduce::Reduce accepts run_to_run determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Reduce accepts run_to_run determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // TODO(srinivas): replace with gpu_to_gpu once offset size restriction is relaxed
   // example-begin reduce-env-determinism
@@ -41,7 +41,7 @@ C2H_TEST("cub::DeviceReduce::Reduce accepts run_to_run determinism requirements"
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::Reduce accepts not_guaranteed determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Reduce accepts not_guaranteed determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin reduce-env-non-determinism
   auto op     = cuda::std::plus{};
@@ -64,7 +64,7 @@ C2H_TEST("cub::DeviceReduce::Reduce accepts not_guaranteed determinism requireme
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::Reduce accepts stream", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Reduce accepts stream", "[reduce][env]", CUB_SMALL)
 {
   // example-begin reduce-env-stream
   auto op     = cuda::std::plus{};
@@ -89,7 +89,7 @@ C2H_TEST("cub::DeviceReduce::Reduce accepts stream", "[reduce][env]")
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::Sum accepts run_to_run determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Sum accepts run_to_run determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // TODO(srinivas): replace with gpu_to_gpu once offset size restriction is relaxed
   // example-begin sum-env-determinism
@@ -111,7 +111,7 @@ C2H_TEST("cub::DeviceReduce::Sum accepts run_to_run determinism requirements", "
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::Sum accepts not_guaranteed determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Sum accepts not_guaranteed determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin sum-env-non-determinism
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
@@ -132,7 +132,7 @@ C2H_TEST("cub::DeviceReduce::Sum accepts not_guaranteed determinism requirements
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::Sum accepts stream", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Sum accepts stream", "[reduce][env]", CUB_SMALL)
 {
   // example-begin sum-env-stream
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
@@ -155,7 +155,7 @@ C2H_TEST("cub::DeviceReduce::Sum accepts stream", "[reduce][env]")
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::Min accepts run_to_run determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Min accepts run_to_run determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin min-env-determinism
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
@@ -176,7 +176,7 @@ C2H_TEST("cub::DeviceReduce::Min accepts run_to_run determinism requirements", "
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::Min accepts not_guaranteed determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Min accepts not_guaranteed determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin min-env-non-determinism
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
@@ -197,7 +197,7 @@ C2H_TEST("cub::DeviceReduce::Min accepts not_guaranteed determinism requirements
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::Min accepts stream", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Min accepts stream", "[reduce][env]", CUB_SMALL)
 {
   // example-begin min-env-stream
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
@@ -220,7 +220,7 @@ C2H_TEST("cub::DeviceReduce::Min accepts stream", "[reduce][env]")
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::Max accepts run_to_run determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Max accepts run_to_run determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin max-env-determinism
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
@@ -241,7 +241,7 @@ C2H_TEST("cub::DeviceReduce::Max accepts run_to_run determinism requirements", "
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::Max accepts not_guaranteed determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Max accepts not_guaranteed determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin max-env-non-determinism
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
@@ -262,7 +262,7 @@ C2H_TEST("cub::DeviceReduce::Max accepts not_guaranteed determinism requirements
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::Max accepts stream", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Max accepts stream", "[reduce][env]", CUB_SMALL)
 {
   // example-begin max-env-stream
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
@@ -285,7 +285,7 @@ C2H_TEST("cub::DeviceReduce::Max accepts stream", "[reduce][env]")
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::ArgMin accepts run_to_run determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::ArgMin accepts run_to_run determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin argmin-env-determinism
   auto input        = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
@@ -310,7 +310,7 @@ C2H_TEST("cub::DeviceReduce::ArgMin accepts run_to_run determinism requirements"
   REQUIRE(index_output == expected_index);
 }
 
-C2H_TEST("cub::DeviceReduce::ArgMin accepts not_guaranteed determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::ArgMin accepts not_guaranteed determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin argmin-env-non-determinism
   auto input        = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
@@ -335,7 +335,7 @@ C2H_TEST("cub::DeviceReduce::ArgMin accepts not_guaranteed determinism requireme
   REQUIRE(index_output == expected_index);
 }
 
-C2H_TEST("cub::DeviceReduce::ArgMin accepts stream", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::ArgMin accepts stream", "[reduce][env]", CUB_SMALL)
 {
   // example-begin argmin-env-stream
   auto input        = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
@@ -366,7 +366,7 @@ C2H_TEST("cub::DeviceReduce::ArgMin accepts stream", "[reduce][env]")
   REQUIRE(index_output == expected_index);
 }
 
-C2H_TEST("cub::DeviceReduce::ArgMax accepts run_to_run determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::ArgMax accepts run_to_run determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin argmax-env-determinism
   auto input        = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
@@ -391,7 +391,7 @@ C2H_TEST("cub::DeviceReduce::ArgMax accepts run_to_run determinism requirements"
   REQUIRE(index_output == expected_index);
 }
 
-C2H_TEST("cub::DeviceReduce::ArgMax accepts not_guaranteed determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::ArgMax accepts not_guaranteed determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin argmax-env-non-determinism
   auto input        = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
@@ -416,7 +416,7 @@ C2H_TEST("cub::DeviceReduce::ArgMax accepts not_guaranteed determinism requireme
   REQUIRE(index_output == expected_index);
 }
 
-C2H_TEST("cub::DeviceReduce::ArgMax accepts stream", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::ArgMax accepts stream", "[reduce][env]", CUB_SMALL)
 {
   // example-begin argmax-env-stream
   auto input        = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
@@ -446,7 +446,7 @@ C2H_TEST("cub::DeviceReduce::ArgMax accepts stream", "[reduce][env]")
   REQUIRE(index_output == expected_index);
 }
 
-C2H_TEST("cub::DeviceReduce::TransformReduce accepts determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::TransformReduce accepts determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin transform-reduce-env-determinism
   auto op        = cuda::std::plus{};
@@ -471,7 +471,9 @@ C2H_TEST("cub::DeviceReduce::TransformReduce accepts determinism requirements", 
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::TransformReduce accepts not_guaranteed determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::TransformReduce accepts not_guaranteed determinism requirements",
+         "[reduce][env]",
+         CUB_SMALL)
 {
   // example-begin transform-reduce-env-non-determinism
   auto op        = cuda::std::plus{};
@@ -496,7 +498,7 @@ C2H_TEST("cub::DeviceReduce::TransformReduce accepts not_guaranteed determinism 
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::TransformReduce accepts stream", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::TransformReduce accepts stream", "[reduce][env]", CUB_SMALL)
 {
   // example-begin transform-reduce-env-stream
   auto op        = cuda::std::plus{};
@@ -523,7 +525,7 @@ C2H_TEST("cub::DeviceReduce::TransformReduce accepts stream", "[reduce][env]")
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin reduce-by-key-env
   auto keys_in         = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
@@ -560,7 +562,7 @@ C2H_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run determinism requirem
   REQUIRE(aggregates_out == expected_aggregates);
 }
 
-C2H_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed determinism requirements", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed determinism requirements", "[reduce][env]", CUB_SMALL)
 {
   // example-begin reduce-by-key-env-non-determinism
   auto keys_in         = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
@@ -597,7 +599,7 @@ C2H_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed determinism requ
   REQUIRE(aggregates_out == expected_aggregates);
 }
 
-C2H_TEST("cub::DeviceReduce::ReduceByKey accepts stream", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::ReduceByKey accepts stream", "[reduce][env]", CUB_SMALL)
 {
   // example-begin reduce-by-key-env-stream
   auto keys_in         = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
@@ -636,7 +638,7 @@ C2H_TEST("cub::DeviceReduce::ReduceByKey accepts stream", "[reduce][env]")
   REQUIRE(aggregates_out == expected_aggregates);
 }
 
-C2H_TEST("cub::DeviceReduce::Sum queries both stream and resource from composed env", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Sum queries both stream and resource from composed env", "[reduce][env]", CUB_SMALL)
 {
   auto input  = thrust::device_vector<int>{1, 2, 3, 4, 5};
   auto output = thrust::device_vector<int>(1);
@@ -676,7 +678,7 @@ struct ReducePolicySelector
 };
 // example-end reduce-policy-selector
 
-C2H_TEST("cub::DeviceReduce::Reduce accepts a custom policy selector", "[reduce][env]")
+CUB_TEST("cub::DeviceReduce::Reduce accepts a custom policy selector", "[reduce][env]", CUB_SMALL)
 {
   // example-begin reduce-tuning
   auto input  = thrust::device_vector<int>{1, 2, 3, 4, 5};

--- a/cub/test/catch2_test_device_reduce_fp_inf.cu
+++ b/cub/test/catch2_test_device_reduce_fp_inf.cu
@@ -8,7 +8,7 @@
 #include <cuda/std/limits>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMin, device_arg_min);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMax, device_arg_max);
@@ -21,7 +21,7 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 
 // %PARAM% TEST_LAUNCH lid 0:1
 
-C2H_TEST("Device reduce arg{min,max} works with inf items", "[reduce][device]")
+CUB_TEST("Device reduce arg{min,max} works with inf items", "[reduce][device]", CUB_SMALL)
 {
   using in_t     = float;
   using offset_t = int;

--- a/cub/test/catch2_test_device_reduce_iterators.cu
+++ b/cub/test/catch2_test_device_reduce_iterators.cu
@@ -11,7 +11,7 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Reduce, device_reduce);
@@ -39,7 +39,7 @@ void test_big_indices_helper(offset_t num_items)
   REQUIRE(result == num_items);
 }
 
-C2H_TEST("Device sum works for big indices", "[reduce][device]")
+CUB_TEST("Device sum works for big indices", "[reduce][device]", CUB_SMALL)
 {
   test_big_indices_helper<std::size_t, std::uint32_t>(1ull << 30);
   test_big_indices_helper<std::size_t, std::uint32_t>(1ull << 31);
@@ -47,7 +47,7 @@ C2H_TEST("Device sum works for big indices", "[reduce][device]")
   test_big_indices_helper<std::size_t, std::uint64_t>(1ull << 33);
 }
 
-C2H_TEST("Device reduce works with fancy input iterators", "[reduce][device]", iterator_type_list)
+CUB_TEST("Device reduce works with fancy input iterators", "[reduce][device]", CUB_SMALL, iterator_type_list)
 {
   using params   = params_t<TestType>;
   using item_t   = typename params::item_t;
@@ -90,7 +90,7 @@ C2H_TEST("Device reduce works with fancy input iterators", "[reduce][device]", i
   REQUIRE(expected_result == out_result[0]);
 }
 
-C2H_TEST("Device reduce compiles with discard output iterator", "[reduce][device]", iterator_type_list)
+CUB_TEST("Device reduce compiles with discard output iterator", "[reduce][device]", CUB_SMALL, iterator_type_list)
 {
   using params   = params_t<TestType>;
   using item_t   = typename params::item_t;

--- a/cub/test/catch2_test_device_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_reduce_large_offsets.cu
@@ -14,7 +14,7 @@
 #include "catch2_large_problem_helper.cuh"
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Reduce, device_reduce);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Sum, device_sum);
@@ -60,7 +60,7 @@ struct custom_sum_op
   }
 };
 
-C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", offset_types)
+CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", CUB_SMALL, offset_types)
 {
   using index_t  = uint64_t;
   using offset_t = typename c2h::get<0, TestType>;

--- a/cub/test/catch2_test_device_reduce_nondeterministic.cu
+++ b/cub/test/catch2_test_device_reduce_nondeterministic.cu
@@ -18,7 +18,7 @@
 #include <numeric>
 
 #include "catch2_test_device_reduce.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/generators.h>
 
 using float_type_list =
@@ -44,8 +44,9 @@ struct custom_policy_selector
   }
 };
 
-C2H_TEST("Nondeterministic Device reduce works with float and double on gpu",
+CUB_TEST("Nondeterministic Device reduce works with float and double on gpu",
          "[reduce][nondeterministic]",
+         CUB_SMALL,
          float_type_list)
 {
   using type          = typename c2h::get<0, TestType>;
@@ -86,8 +87,9 @@ C2H_TEST("Nondeterministic Device reduce works with float and double on gpu",
   REQUIRE_APPROX_EQ_ABS(h_expected, h_actual, abs_err);
 }
 
-C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with NaN",
+CUB_TEST("Nondeterministic Device reduce works with float and double on gpu with NaN",
          "[reduce][nondeterministic]",
+         CUB_SMALL,
          float_type_list)
 {
   using type     = typename c2h::get<0, TestType>;
@@ -149,8 +151,9 @@ C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with
   REQUIRE_EQ_WITH_NAN_MATCHING(d_output_p1, d_output_p2);
 }
 
-C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with different iterators",
+CUB_TEST("Nondeterministic Device reduce works with float and double on gpu with different iterators",
          "[reduce][nondeterministic]",
+         CUB_SMALL,
          float_type_list)
 {
   using type = typename c2h::get<0, TestType>;
@@ -202,8 +205,9 @@ struct square_t
   }
 };
 
-C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with different transform operators",
+CUB_TEST("Nondeterministic Device reduce works with float and double on gpu with different transform operators",
          "[reduce][nondeterministic]",
+         CUB_SMALL,
          float_type_list)
 {
   using type = typename c2h::get<0, TestType>;
@@ -258,8 +262,9 @@ C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with
   REQUIRE_APPROX_EQ_EPSILON(h_expected, d_output, type{0.01});
 }
 
-C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with different init values",
+CUB_TEST("Nondeterministic Device reduce works with float and double on gpu with different init values",
          "[reduce][nondeterministic]",
+         CUB_SMALL,
          float_type_list)
 {
   using type = typename c2h::get<0, TestType>;
@@ -296,8 +301,9 @@ using test_types =
 #endif
                  >;
 
-C2H_TEST("Nondeterministic Device reduce works with various types on gpu with different input types",
+CUB_TEST("Nondeterministic Device reduce works with various types on gpu with different input types",
          "[reduce][nondeterministic]",
+         CUB_SMALL,
          test_types)
 {
   using type = typename c2h::get<0, TestType>;

--- a/cub/test/catch2_test_device_rle_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_rle_custom_policy_hub.cu
@@ -14,7 +14,7 @@
 
 #include <cuda/std/functional>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -34,7 +34,7 @@ struct my_policy_hub
   };
 };
 
-C2H_TEST("DeviceRleDispatch::Dispatch: custom policy hub", "[device][run_length_encode]")
+CUB_TEST("DeviceRleDispatch::Dispatch: custom policy hub", "[device][run_length_encode]", CUB_SMALL)
 {
   using input_t  = int;
   using offset_t = int;

--- a/cub/test/catch2_test_device_run_length_encode.cu
+++ b/cub/test/catch2_test_device_run_length_encode.cu
@@ -15,7 +15,7 @@
 
 #include "catch2_large_problem_helper.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceRunLengthEncode::Encode, run_length_encode);
 
@@ -34,7 +34,7 @@ using types = c2h::type_list<std::uint32_t, std::int8_t>;
 // List of offset types to be used for testing large number of items
 using offset_types = c2h::type_list<std::int64_t, std::int32_t>;
 
-C2H_TEST("DeviceRunLengthEncode::Encode can handle empty input", "[device][run_length_encode]")
+CUB_TEST("DeviceRunLengthEncode::Encode can handle empty input", "[device][run_length_encode]", CUB_SMALL)
 {
   constexpr int num_items = 0;
   c2h::device_vector<int> in(num_items);
@@ -90,7 +90,7 @@ public:
   }
 };
 
-C2H_TEST("DeviceRunLengthEncode::Encode can handle a single element", "[device][run_length_encode]")
+CUB_TEST("DeviceRunLengthEncode::Encode can handle a single element", "[device][run_length_encode]", CUB_SMALL)
 {
   constexpr int num_items = 1;
   c2h::device_vector<int> in(num_items, 42);
@@ -105,7 +105,7 @@ C2H_TEST("DeviceRunLengthEncode::Encode can handle a single element", "[device][
   REQUIRE(out_num_runs.front() == num_items);
 }
 
-C2H_TEST("DeviceRunLengthEncode::Encode can handle different counting types", "[device][run_length_encode]")
+CUB_TEST("DeviceRunLengthEncode::Encode can handle different counting types", "[device][run_length_encode]", CUB_SMALL)
 {
   constexpr int num_items = 1;
   c2h::device_vector<int> in(num_items, 42);
@@ -120,7 +120,7 @@ C2H_TEST("DeviceRunLengthEncode::Encode can handle different counting types", "[
   REQUIRE(out_num_runs.front() == static_cast<std::int16_t>(num_items));
 }
 
-C2H_TEST("DeviceRunLengthEncode::Encode can handle all unique", "[device][run_length_encode]", types)
+CUB_TEST("DeviceRunLengthEncode::Encode can handle all unique", "[device][run_length_encode]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -143,7 +143,7 @@ C2H_TEST("DeviceRunLengthEncode::Encode can handle all unique", "[device][run_le
   REQUIRE(out_num_runs == reference_num_runs);
 }
 
-C2H_TEST("DeviceRunLengthEncode::Encode can handle all equal", "[device][run_length_encode]", types)
+CUB_TEST("DeviceRunLengthEncode::Encode can handle all equal", "[device][run_length_encode]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -164,7 +164,7 @@ C2H_TEST("DeviceRunLengthEncode::Encode can handle all equal", "[device][run_len
   REQUIRE(out_num_runs == reference_num_runs);
 }
 
-C2H_TEST("DeviceRunLengthEncode::Encode can handle iterators", "[device][run_length_encode]", all_types)
+CUB_TEST("DeviceRunLengthEncode::Encode can handle iterators", "[device][run_length_encode]", CUB_SMALL, all_types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -186,7 +186,7 @@ C2H_TEST("DeviceRunLengthEncode::Encode can handle iterators", "[device][run_len
   REQUIRE(out_unique == reference_out);
 }
 
-C2H_TEST("DeviceRunLengthEncode::Encode can handle pointers", "[device][run_length_encode]", types)
+CUB_TEST("DeviceRunLengthEncode::Encode can handle pointers", "[device][run_length_encode]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -227,7 +227,7 @@ struct convertible_from_T {
   __host__ __device__ operator T() const noexcept { return val_; }
 };
 
-C2H_TEST("DeviceRunLengthEncode::Encode works with a different output type", "[device][run_length_encode]")
+CUB_TEST("DeviceRunLengthEncode::Encode works with a different output type", "[device][run_length_encode]", CUB_SMALL)
 {
   using type = c2h::custom_type_t<c2h::equal_comparable_t>;
 
@@ -253,7 +253,7 @@ C2H_TEST("DeviceRunLengthEncode::Encode works with a different output type", "[d
 }
 #endif // https://github.com/NVIDIA/cccl/issues/400
 
-C2H_TEST("DeviceRunLengthEncode::Encode can handle leading NaN", "[device][run_length_encode]")
+CUB_TEST("DeviceRunLengthEncode::Encode can handle leading NaN", "[device][run_length_encode]", CUB_SMALL)
 {
   using type = double;
 
@@ -281,8 +281,9 @@ C2H_TEST("DeviceRunLengthEncode::Encode can handle leading NaN", "[device][run_l
   REQUIRE(out_num_runs == reference_num_runs);
 }
 
-C2H_TEST("DeviceRunLengthEncode::Encode works with non-default constructible iterators",
+CUB_TEST("DeviceRunLengthEncode::Encode works with non-default constructible iterators",
          "[device][run_length_encode]",
+         CUB_SMALL,
          offset_types)
 {
   // This is a smoke test to ensure that the algorithm works with iterators that are not default-constructible, as was
@@ -309,8 +310,9 @@ C2H_TEST("DeviceRunLengthEncode::Encode works with non-default constructible ite
   REQUIRE(out_num_runs == reference_num_runs);
 }
 
-C2H_TEST("DeviceRunLengthEncode::Encode works for a large number of items",
+CUB_TEST("DeviceRunLengthEncode::Encode works for a large number of items",
          "[device][run_length_encode][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_LARGE,
          offset_types)
 try
 {
@@ -368,8 +370,9 @@ catch (std::bad_alloc& e)
   std::cerr << "Caught bad_alloc: " << e.what() << '\n';
 }
 
-C2H_TEST("DeviceRunLengthEncode::Encode works for large runs of equal items",
+CUB_TEST("DeviceRunLengthEncode::Encode works for large runs of equal items",
          "[device][run_length_encode][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_SMALL,
          offset_types)
 try
 {

--- a/cub/test/catch2_test_device_run_length_encode_api.cu
+++ b/cub/test/catch2_test_device_run_length_encode_api.cu
@@ -5,14 +5,14 @@
 
 #include <cub/device/device_run_length_encode.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // Guard: the legacy memory-size query call with all defaults (no explicit stream)
 // must resolve unambiguously to the legacy temp-storage overload when the env
 // passthrough overload is also visible. If the env overload's SFINAE is too loose,
 // this becomes "ambiguous overload" or silently dispatches to env.
 
-C2H_TEST("DeviceRunLengthEncode::Encode legacy size-query is unambiguous", "[run_length_encode][device]")
+CUB_TEST("DeviceRunLengthEncode::Encode legacy size-query is unambiguous", "[run_length_encode][device]", CUB_SMALL)
 {
   int* d_in       = nullptr;
   int* d_unique   = nullptr;
@@ -24,7 +24,9 @@ C2H_TEST("DeviceRunLengthEncode::Encode legacy size-query is unambiguous", "[run
   REQUIRE(cudaSuccess == cub::DeviceRunLengthEncode::Encode(nullptr, bytes, d_in, d_unique, d_lengths, d_num_runs, n));
 }
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns legacy size-query is unambiguous", "[run_length_encode][device]")
+CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns legacy size-query is unambiguous",
+         "[run_length_encode][device]",
+         CUB_SMALL)
 {
   int* d_in       = nullptr;
   int* d_offsets  = nullptr;

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -26,7 +26,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceRunLengthEncode::NonTrivialRuns, non_trivial_r
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
@@ -55,7 +55,7 @@ using block_sizes =
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("DeviceRunLengthEncode::Encode works with default environment", "[run_length_encode][device]")
+CUB_TEST_CASE("DeviceRunLengthEncode::Encode works with default environment", "[run_length_encode][device]", CUB_SMALL)
 {
   auto d_in           = c2h::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
   auto d_unique_out   = c2h::device_vector<int>(8);
@@ -77,7 +77,9 @@ TEST_CASE("DeviceRunLengthEncode::Encode works with default environment", "[run_
   REQUIRE(d_counts_out == expected_counts);
 }
 
-TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns works with default environment", "[run_length_encode][device]")
+CUB_TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns works with default environment",
+              "[run_length_encode][device]",
+              CUB_SMALL)
 {
   auto d_in           = c2h::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
   auto d_offsets_out  = c2h::device_vector<int>(8);
@@ -101,7 +103,7 @@ TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns works with default environment"
 
 #endif
 
-C2H_TEST("DeviceRunLengthEncode::Encode uses environment", "[run_length_encode][device]")
+CUB_TEST("DeviceRunLengthEncode::Encode uses environment", "[run_length_encode][device]", CUB_SMALL)
 {
   auto d_in           = c2h::device_vector<int>{1, 1, 1, 2, 2, 3, 4, 4, 4, 4};
   auto d_unique_out   = c2h::device_vector<int>(10);
@@ -137,7 +139,7 @@ C2H_TEST("DeviceRunLengthEncode::Encode uses environment", "[run_length_encode][
   REQUIRE(d_counts_out == expected_counts);
 }
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns uses environment", "[run_length_encode][device]")
+CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns uses environment", "[run_length_encode][device]", CUB_SMALL)
 {
   auto d_in           = c2h::device_vector<int>{1, 1, 1, 2, 2, 3, 4, 4, 4, 4};
   auto d_offsets_out  = c2h::device_vector<int>(10);
@@ -173,7 +175,7 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns uses environment", "[run_length_
   REQUIRE(d_lengths_out == expected_lengths);
 }
 
-TEST_CASE("DeviceRunLengthEncode::Encode uses custom stream", "[run_length_encode][device]")
+CUB_TEST_CASE("DeviceRunLengthEncode::Encode uses custom stream", "[run_length_encode][device]", CUB_SMALL)
 {
   auto d_in           = c2h::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
   auto d_unique_out   = c2h::device_vector<int>(8);
@@ -215,7 +217,7 @@ TEST_CASE("DeviceRunLengthEncode::Encode uses custom stream", "[run_length_encod
   REQUIRE(d_counts_out == expected_counts);
 }
 
-TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns uses custom stream", "[run_length_encode][device]")
+CUB_TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns uses custom stream", "[run_length_encode][device]", CUB_SMALL)
 {
   auto d_in           = c2h::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
   auto d_offsets_out  = c2h::device_vector<int>(8);
@@ -259,7 +261,7 @@ TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns uses custom stream", "[run_leng
 
 #if TEST_LAUNCH != 1
 
-C2H_TEST("DeviceRunLengthEncode::Encode can be tuned", "[run_length_encode][device]", block_sizes)
+CUB_TEST("DeviceRunLengthEncode::Encode can be tuned", "[run_length_encode][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   constexpr int num_items                  = 256;
@@ -281,7 +283,7 @@ C2H_TEST("DeviceRunLengthEncode::Encode can be tuned", "[run_length_encode][devi
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can be tuned", "[run_length_encode][device]", block_sizes)
+CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns can be tuned", "[run_length_encode][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   constexpr int num_items                  = 256;
@@ -306,7 +308,7 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can be tuned", "[run_length_enco
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test RleEncodePolicy properties", "[run_length_encode][device]")
+CUB_TEST("Test RleEncodePolicy properties", "[run_length_encode][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::RleEncodePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RleEncodePolicy>);
@@ -357,7 +359,7 @@ C2H_TEST("Test RleEncodePolicy properties", "[run_length_encode][device]")
 #endif // _CCCL_COMPILER(GCC, >=, 8)
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test RleNonTrivialRunsPolicy properties", "[run_length_encode][device]")
+CUB_TEST("Test RleNonTrivialRunsPolicy properties", "[run_length_encode][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::RleNonTrivialRunsPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RleNonTrivialRunsPolicy>);

--- a/cub/test/catch2_test_device_run_length_encode_env_api.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env_api.cu
@@ -13,9 +13,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceRunLengthEncode::Encode accepts env with stream", "[run_length_encode][env]")
+CUB_TEST("cub::DeviceRunLengthEncode::Encode accepts env with stream", "[run_length_encode][env]", CUB_SMALL)
 {
   // example-begin encode-env
   auto input        = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
@@ -47,7 +47,7 @@ C2H_TEST("cub::DeviceRunLengthEncode::Encode accepts env with stream", "[run_len
   REQUIRE(num_runs_out == expected_num_runs);
 }
 
-C2H_TEST("cub::DeviceRunLengthEncode::NonTrivialRuns accepts env with stream", "[run_length_encode][env]")
+CUB_TEST("cub::DeviceRunLengthEncode::NonTrivialRuns accepts env with stream", "[run_length_encode][env]", CUB_SMALL)
 {
   // example-begin non-trivial-runs-env
   auto input        = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
@@ -98,7 +98,9 @@ struct RleNonTrivialRunsPolicySelector
 };
 // example-end non-trivial-runs-policy-selector
 
-C2H_TEST("cub::DeviceRunLengthEncode::NonTrivialRuns accepts a custom policy selector", "[run_length_encode][env]")
+CUB_TEST("cub::DeviceRunLengthEncode::NonTrivialRuns accepts a custom policy selector",
+         "[run_length_encode][env]",
+         CUB_SMALL)
 {
   // example-begin non-trivial-runs-tuning
   auto input        = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};

--- a/cub/test/catch2_test_device_run_length_encode_non_trivial_runs.cu
+++ b/cub/test/catch2_test_device_run_length_encode_non_trivial_runs.cu
@@ -16,7 +16,7 @@
 
 #include "catch2_large_problem_helper.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceRunLengthEncode::NonTrivialRuns, run_length_encode);
 
@@ -68,7 +68,7 @@ struct run_index_to_offset_op
   }
 };
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle empty input", "[device][run_length_encode]")
+CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle empty input", "[device][run_length_encode]", CUB_SMALL)
 {
   constexpr int num_items = 0;
   c2h::device_vector<int> out_num_runs(1, 42);
@@ -84,7 +84,7 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle empty input", "[devic
   REQUIRE(out_num_runs.front() == 0);
 }
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle a single element", "[device][run_length_encode]")
+CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle a single element", "[device][run_length_encode]", CUB_SMALL)
 {
   constexpr int num_items = 1;
   c2h::device_vector<int> out_num_runs(1, 42);
@@ -100,7 +100,9 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle a single element", "[
   REQUIRE(out_num_runs.front() == 0);
 }
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle different counting types", "[device][run_length_encode]")
+CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle different counting types",
+         "[device][run_length_encode]",
+         CUB_SMALL)
 {
   constexpr int num_items = 1;
   c2h::device_vector<int> in(num_items, 42);
@@ -118,7 +120,7 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle different counting ty
   REQUIRE(out_num_runs.front() == 0);
 }
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle all unique", "[device][run_length_encode]", types)
+CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle all unique", "[device][run_length_encode]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -135,7 +137,7 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle all unique", "[device
   REQUIRE(out_num_runs.front() == 0);
 }
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle all equal", "[device][run_length_encode]", types)
+CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle all equal", "[device][run_length_encode]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -204,7 +206,8 @@ bool validate_results(
   return true;
 }
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle iterators", "[device][run_length_encode]", all_types)
+CUB_TEST(
+  "DeviceRunLengthEncode::NonTrivialRuns can handle iterators", "[device][run_length_encode]", CUB_SMALL, all_types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -222,7 +225,7 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle iterators", "[device]
   REQUIRE(validate_results(in, out_offsets, out_lengths, out_num_runs, num_items));
 }
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle pointers", "[device][run_length_encode]", types)
+CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns can handle pointers", "[device][run_length_encode]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -295,7 +298,10 @@ DECLARE_LAUNCH_WRAPPER(CustomDeviceRunLengthEncode::NonTrivialRuns<false>, run_l
 
 using time_slicing = c2h::type_list<std::true_type, std::false_type>;
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns does not run out of memory", "[device][run_length_encode]", time_slicing)
+CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns does not run out of memory",
+         "[device][run_length_encode]",
+         CUB_SMALL,
+         time_slicing)
 {
   using type         = typename c2h::get<0, TestType>;
   using policy_sel_t = device_rle_policy_selector<type::value>;
@@ -355,8 +361,9 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns does not run out of memory", "[d
   REQUIRE(out_offsets.front() == magic_number);
 }
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns works for a large number of items",
+CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns works for a large number of items",
          "[device][run_length_encode][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck][!mayfail]",
+         CUB_SMALL,
          offset_types)
 try
 {
@@ -400,8 +407,9 @@ catch (const std::bad_alloc& e)
   std::cerr << "Caught bad_alloc: " << e.what() << '\n';
 }
 
-C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns works for large runs of equal items",
+CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns works for large runs of equal items",
          "[device][run_length_encode][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck][!mayfail]",
+         CUB_SMALL,
          offset_types)
 try
 {

--- a/cub/test/catch2_test_device_scan.cu
+++ b/cub/test/catch2_test_device_scan.cu
@@ -10,7 +10,7 @@
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_device_scan.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::InclusiveScanInit, device_inclusive_scan_with_init);
@@ -68,7 +68,7 @@ enum class gen_data_t : int
   GEN_TYPE_CONST
 };
 
-C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_type_list)
+CUB_TEST("Device scan works with all device interfaces", "[scan][device]", CUB_SMALL, full_type_list)
 {
   using params   = params_t<TestType>;
   using input_t  = typename params::item_t;

--- a/cub/test/catch2_test_device_scan_alignment.cu
+++ b/cub/test/catch2_test_device_scan_alignment.cu
@@ -18,7 +18,7 @@
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_device_scan.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 
 // %PARAM% TEST_LAUNCH lid 0
@@ -28,7 +28,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::InclusiveScan, device_inclusive_scan);
 // We cover types of various sizes smaller than 16 byte
 using value_types = c2h::type_list<uint8_t, uint16_t, uint32_t, uint64_t>;
 
-C2H_TEST("Device scan works with all device interfaces", "[scan][device]", value_types)
+CUB_TEST("Device scan works with all device interfaces", "[scan][device]", CUB_SMALL, value_types)
 {
   using input_t  = c2h::get<0, TestType>;
   using output_t = input_t;

--- a/cub/test/catch2_test_device_scan_api.cu
+++ b/cub/test/catch2_test_device_scan_api.cu
@@ -6,9 +6,9 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("Device inclusive scan works", "[scan][device]")
+CUB_TEST("Device inclusive scan works", "[scan][device]", CUB_SMALL)
 {
   // example-begin device-inclusive-scan
   thrust::device_vector<int> input{0, -1, 2, -3, 4, -5, 6};
@@ -39,7 +39,7 @@ C2H_TEST("Device inclusive scan works", "[scan][device]")
   REQUIRE(expected == out);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveSum non-env overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::ExclusiveSum non-env overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -47,14 +47,14 @@ C2H_TEST("cub::DeviceScan::ExclusiveSum non-env overload is not ambiguous", "[sc
   cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes, input.begin(), out.begin(), 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveSum non-env in-place overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::ExclusiveSum non-env in-place overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> data(1);
   size_t temp_storage_bytes = 0;
   cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes, data.begin(), 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan non-env overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::ExclusiveScan non-env overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -62,14 +62,14 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan non-env overload is not ambiguous", "[s
   cub::DeviceScan::ExclusiveScan(nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, 5, 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan non-env in-place overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::ExclusiveScan non-env in-place overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> data(1);
   size_t temp_storage_bytes = 0;
   cub::DeviceScan::ExclusiveScan(nullptr, temp_storage_bytes, data.begin(), cuda::std::plus<>{}, 5, 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -80,7 +80,9 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env overload is not amb
     nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, future_init, 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env in-place overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env in-place overload is not ambiguous",
+         "[scan][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> data(1);
   thrust::device_vector<int> init_storage(1, 5);
@@ -89,7 +91,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env in-place overload i
   cub::DeviceScan::ExclusiveScan(nullptr, temp_storage_bytes, data.begin(), cuda::std::plus<>{}, future_init, 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveSum non-env overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::InclusiveSum non-env overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -97,14 +99,14 @@ C2H_TEST("cub::DeviceScan::InclusiveSum non-env overload is not ambiguous", "[sc
   cub::DeviceScan::InclusiveSum(nullptr, temp_storage_bytes, input.begin(), out.begin(), 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveSum non-env in-place overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::InclusiveSum non-env in-place overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> data(1);
   size_t temp_storage_bytes = 0;
   cub::DeviceScan::InclusiveSum(nullptr, temp_storage_bytes, data.begin(), 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScan non-env overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::InclusiveScan non-env overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -112,14 +114,14 @@ C2H_TEST("cub::DeviceScan::InclusiveScan non-env overload is not ambiguous", "[s
   cub::DeviceScan::InclusiveScan(nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScan non-env in-place overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::InclusiveScan non-env in-place overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> data(1);
   size_t temp_storage_bytes = 0;
   cub::DeviceScan::InclusiveScan(nullptr, temp_storage_bytes, data.begin(), cuda::std::plus<>{}, 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScanInit non-env overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::InclusiveScanInit non-env overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -127,7 +129,9 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit non-env overload is not ambiguous",
   cub::DeviceScan::InclusiveScanInit(nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, 5, 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScanInit args::deferred non-env overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::InclusiveScanInit args::deferred non-env overload is not ambiguous",
+         "[scan][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -138,7 +142,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit args::deferred non-env overload is 
     nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, deferred_init, 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScanInit args::deferred non-env overload works", "[scan][device]")
+CUB_TEST("cub::DeviceScan::InclusiveScanInit args::deferred non-env overload works", "[scan][device]", CUB_SMALL)
 {
   // example-begin device-inclusive-scan-init-deferred
   thrust::device_vector<int> input{0, -1, 2, -3, 4, -5, 6};
@@ -173,7 +177,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit args::deferred non-env overload wor
   REQUIRE(expected == out);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveSumByKey non-env overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::ExclusiveSumByKey non-env overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> keys(1);
   thrust::device_vector<int> values_in(1);
@@ -183,7 +187,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSumByKey non-env overload is not ambiguous",
     nullptr, temp_storage_bytes, keys.begin(), values_in.begin(), values_out.begin(), 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScanByKey non-env overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::ExclusiveScanByKey non-env overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> keys(1);
   thrust::device_vector<int> values_in(1);
@@ -193,7 +197,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScanByKey non-env overload is not ambiguous"
     nullptr, temp_storage_bytes, keys.begin(), values_in.begin(), values_out.begin(), cuda::std::plus<>{}, 5, 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveSumByKey non-env overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::InclusiveSumByKey non-env overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> keys(1);
   thrust::device_vector<int> values_in(1);
@@ -203,7 +207,7 @@ C2H_TEST("cub::DeviceScan::InclusiveSumByKey non-env overload is not ambiguous",
     nullptr, temp_storage_bytes, keys.begin(), values_in.begin(), values_out.begin(), 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScanByKey non-env overload is not ambiguous", "[scan][device]")
+CUB_TEST("cub::DeviceScan::InclusiveScanByKey non-env overload is not ambiguous", "[scan][device]", CUB_SMALL)
 {
   thrust::device_vector<int> keys(1);
   thrust::device_vector<int> values_in(1);

--- a/cub/test/catch2_test_device_scan_by_key.cu
+++ b/cub/test/catch2_test_device_scan_by_key.cu
@@ -11,7 +11,7 @@
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_device_scan.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 #include <c2h/extended_types.h>
 #include <c2h/generators.h>
@@ -65,7 +65,7 @@ type_quad<custom_t, custom_t, custom_t>
 // clang-format on
 #endif
 
-C2H_TEST("Device scan works with all device interfaces", "[by_key][scan][device]", full_type_list)
+CUB_TEST("Device scan works with all device interfaces", "[by_key][scan][device]", CUB_SMALL, full_type_list)
 {
   using params   = params_t<TestType>;
   using key_t    = typename params::type_pair_t::key_t;
@@ -258,8 +258,9 @@ using key_alias_type_list = c2h::type_list<float>;
 using key_alias_type_list = c2h::type_list<custom_t>;
 #endif
 
-C2H_TEST("Device scan works when memory for keys and results alias one another",
+CUB_TEST("Device scan works when memory for keys and results alias one another",
          "[by_key][scan][device]",
+         CUB_SMALL,
          key_alias_type_list)
 {
   using key_t    = typename c2h::get<0, TestType>;

--- a/cub/test/catch2_test_device_scan_by_key_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_scan_by_key_custom_policy_hub.cu
@@ -14,7 +14,7 @@
 #include <cuda/std/type_traits>
 
 #include "catch2_test_device_scan.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -37,7 +37,7 @@ struct my_policy_hub
   };
 };
 
-C2H_TEST("DispatchScanByKey::Dispatch: custom policy hub", "[scan_by_key][device]")
+CUB_TEST("DispatchScanByKey::Dispatch: custom policy hub", "[scan_by_key][device]", CUB_SMALL)
 {
   using key_t     = int;
   using value_t   = int;

--- a/cub/test/catch2_test_device_scan_by_key_env.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env.cu
@@ -27,14 +27,14 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::InclusiveScanByKey, device_scan_inclusiv
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
 #if TEST_LAUNCH == 0
 using block_size_check_t = block_size_extracting_op<cuda::std::plus<>>;
 
-TEST_CASE("Device scan exclusive-sum-by-key works with default environment", "[scan][by_key][device]")
+CUB_TEST_CASE("Device scan exclusive-sum-by-key works with default environment", "[scan][by_key][device]", CUB_SMALL)
 {
   auto num_items = 7;
   auto d_keys    = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
@@ -47,7 +47,7 @@ TEST_CASE("Device scan exclusive-sum-by-key works with default environment", "[s
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device scan exclusive-scan-by-key works with default environment", "[scan][by_key][device]")
+CUB_TEST_CASE("Device scan exclusive-scan-by-key works with default environment", "[scan][by_key][device]", CUB_SMALL)
 {
   using num_items_t = int;
   using key_t       = int;
@@ -81,7 +81,7 @@ TEST_CASE("Device scan exclusive-scan-by-key works with default environment", "[
   REQUIRE(d_block_size[0] == static_cast<unsigned int>(target_block_size));
 }
 
-TEST_CASE("Device scan inclusive-sum-by-key works with default environment", "[scan][by_key][device]")
+CUB_TEST_CASE("Device scan inclusive-sum-by-key works with default environment", "[scan][by_key][device]", CUB_SMALL)
 {
   auto num_items = 7;
   auto d_keys    = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
@@ -94,7 +94,7 @@ TEST_CASE("Device scan inclusive-sum-by-key works with default environment", "[s
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device scan inclusive-scan-by-key works with default environment", "[scan][by_key][device]")
+CUB_TEST_CASE("Device scan inclusive-scan-by-key works with default environment", "[scan][by_key][device]", CUB_SMALL)
 {
   using num_items_t = int;
   using key_t       = int;
@@ -151,7 +151,7 @@ using block_sizes =
 using block_size_extracting_scan_op_t  = block_size_extracting_op<cuda::std::plus<>>;
 using block_size_extracting_equality_t = block_size_extracting_op<cuda::std::equal_to<>>;
 
-C2H_TEST("DeviceScan::ExclusiveSumByKey can be tuned", "[scan][by_key][device]", block_sizes)
+CUB_TEST("DeviceScan::ExclusiveSumByKey can be tuned", "[scan][by_key][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys{0, 0, 1, 1, 1, 2, 2};
@@ -169,7 +169,7 @@ C2H_TEST("DeviceScan::ExclusiveSumByKey can be tuned", "[scan][by_key][device]",
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceScan::ExclusiveScanByKey can be tuned", "[scan][by_key][device]", block_sizes)
+CUB_TEST("DeviceScan::ExclusiveScanByKey can be tuned", "[scan][by_key][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys{0, 0, 1, 1, 1, 2, 2};
@@ -188,7 +188,7 @@ C2H_TEST("DeviceScan::ExclusiveScanByKey can be tuned", "[scan][by_key][device]"
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceScan::InclusiveSumByKey can be tuned", "[scan][by_key][device]", block_sizes)
+CUB_TEST("DeviceScan::InclusiveSumByKey can be tuned", "[scan][by_key][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys{0, 0, 1, 1, 1, 2, 2};
@@ -206,7 +206,7 @@ C2H_TEST("DeviceScan::InclusiveSumByKey can be tuned", "[scan][by_key][device]",
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceScan::InclusiveScanByKey can be tuned", "[scan][by_key][device]", block_sizes)
+CUB_TEST("DeviceScan::InclusiveScanByKey can be tuned", "[scan][by_key][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys{0, 0, 1, 1, 1, 2, 2};
@@ -227,7 +227,7 @@ C2H_TEST("DeviceScan::InclusiveScanByKey can be tuned", "[scan][by_key][device]"
 
 #endif // TEST_LAUNCH != 1
 
-C2H_TEST("Device scan exclusive-sum-by-key uses environment", "[scan][by_key][device]")
+CUB_TEST("Device scan exclusive-sum-by-key uses environment", "[scan][by_key][device]", CUB_SMALL)
 {
   using num_items_t = int;
 
@@ -256,7 +256,7 @@ C2H_TEST("Device scan exclusive-sum-by-key uses environment", "[scan][by_key][de
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device scan exclusive-scan-by-key uses environment", "[scan][by_key][device]")
+CUB_TEST("Device scan exclusive-scan-by-key uses environment", "[scan][by_key][device]", CUB_SMALL)
 {
   using scan_op_t   = cuda::std::plus<>;
   using num_items_t = int;
@@ -290,7 +290,7 @@ C2H_TEST("Device scan exclusive-scan-by-key uses environment", "[scan][by_key][d
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device scan inclusive-sum-by-key uses environment", "[scan][by_key][device]")
+CUB_TEST("Device scan inclusive-sum-by-key uses environment", "[scan][by_key][device]", CUB_SMALL)
 {
   using num_items_t = int;
 
@@ -319,7 +319,7 @@ C2H_TEST("Device scan inclusive-sum-by-key uses environment", "[scan][by_key][de
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device scan inclusive-scan-by-key uses environment", "[scan][by_key][device]")
+CUB_TEST("Device scan inclusive-scan-by-key uses environment", "[scan][by_key][device]", CUB_SMALL)
 {
   using scan_op_t   = cuda::std::plus<>;
   using num_items_t = int;
@@ -352,7 +352,7 @@ C2H_TEST("Device scan inclusive-scan-by-key uses environment", "[scan][by_key][d
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test ScanByKeyPolicy properties", "[scan][by_key][device]")
+CUB_TEST("Test ScanByKeyPolicy properties", "[scan][by_key][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ScanByKeyPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ScanByKeyPolicy>);

--- a/cub/test/catch2_test_device_scan_by_key_env_api.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env_api.cu
@@ -12,9 +12,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceScan::ExclusiveSumByKey accepts stream environment", "[scan][by_key][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveSumByKey accepts stream environment", "[scan][by_key][env]", CUB_SMALL)
 {
   // example-begin exclusive-sum-by-key-env
   auto keys   = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
@@ -39,7 +39,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSumByKey accepts stream environment", "[scan
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScanByKey accepts stream environment", "[scan][by_key][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveScanByKey accepts stream environment", "[scan][by_key][env]", CUB_SMALL)
 {
   // example-begin exclusive-scan-by-key-env
   auto op     = cuda::std::plus{};
@@ -73,7 +73,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScanByKey accepts stream environment", "[sca
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveSumByKey accepts stream environment", "[scan][by_key][env]")
+CUB_TEST("cub::DeviceScan::InclusiveSumByKey accepts stream environment", "[scan][by_key][env]", CUB_SMALL)
 {
   // example-begin inclusive-sum-by-key-env
   auto keys   = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
@@ -98,7 +98,7 @@ C2H_TEST("cub::DeviceScan::InclusiveSumByKey accepts stream environment", "[scan
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScanByKey accepts stream environment", "[scan][by_key][env]")
+CUB_TEST("cub::DeviceScan::InclusiveScanByKey accepts stream environment", "[scan][by_key][env]", CUB_SMALL)
 {
   // example-begin inclusive-scan-by-key-env
   auto op     = cuda::std::plus{};
@@ -151,7 +151,7 @@ struct ScanByKeyPolicySelector
 };
 // example-end exclusive-sum-by-key-policy-selector
 
-C2H_TEST("cub::DeviceScan::ExclusiveSumByKey accepts a custom policy selector", "[scan][by_key][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveSumByKey accepts a custom policy selector", "[scan][by_key][env]", CUB_SMALL)
 {
   // example-begin exclusive-sum-by-key-tuning
   auto keys   = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};

--- a/cub/test/catch2_test_device_scan_by_key_iterators.cu
+++ b/cub/test/catch2_test_device_scan_by_key_iterators.cu
@@ -12,7 +12,7 @@
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_device_scan.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 #include <c2h/extended_types.h>
 
@@ -67,7 +67,7 @@ enum class gen_data_t : int
   GEN_TYPE_CONST
 };
 
-C2H_TEST("Device scan works with fancy iterators", "[by_key][scan][device]", full_type_list)
+CUB_TEST("Device scan works with fancy iterators", "[by_key][scan][device]", CUB_SMALL, full_type_list)
 {
   using params   = params_t<TestType>;
   using key_t    = typename params::type_pair_t::key_t;

--- a/cub/test/catch2_test_device_scan_by_key_large_offsets.cu
+++ b/cub/test/catch2_test_device_scan_by_key_large_offsets.cu
@@ -11,7 +11,7 @@
 
 #include "catch2_large_problem_helper.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::ExclusiveScanByKey, device_exclusive_scan_by_key);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::InclusiveScanByKey, device_inclusive_scan_by_key);
@@ -72,7 +72,7 @@ struct div_op
   }
 };
 
-C2H_TEST("DeviceScan::ScanByKey works for very large number of items", "[by_key][scan][device]", offset_types)
+CUB_TEST("DeviceScan::ScanByKey works for very large number of items", "[by_key][scan][device]", CUB_LARGE, offset_types)
 try
 {
   using op_t     = cuda::std::plus<>;

--- a/cub/test/catch2_test_device_scan_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_scan_custom_policy_hub.cu
@@ -15,7 +15,7 @@
 #include <cuda/std/functional>
 
 #include "catch2_test_device_scan.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -30,7 +30,7 @@ struct my_policy_hub
   };
 };
 
-C2H_TEST("DispatchScan::Dispatch: custom policy hub", "[scan][device]")
+CUB_TEST("DispatchScan::Dispatch: custom policy hub", "[scan][device]", CUB_SMALL)
 {
   using value_t            = int;
   using offset_t           = unsigned;

--- a/cub/test/catch2_test_device_scan_deterministic.cu
+++ b/cub/test/catch2_test_device_scan_deterministic.cu
@@ -10,13 +10,14 @@
 #include <cuda/std/functional>
 
 #include "catch2_test_device_scan.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/generators.h>
 
 using float_type_list = c2h::type_list<float, double>;
 
-C2H_TEST("DeviceScan::ExclusiveScan with run_to_run determinism is bit-reproducible",
+CUB_TEST("DeviceScan::ExclusiveScan with run_to_run determinism is bit-reproducible",
          "[scan][deterministic][run_to_run]",
+         CUB_SMALL,
          float_type_list)
 {
   using type = typename c2h::get<0, TestType>;
@@ -72,8 +73,9 @@ C2H_TEST("DeviceScan::ExclusiveScan with run_to_run determinism is bit-reproduci
   }
 }
 
-C2H_TEST("DeviceScan::ExclusiveScan with run_to_run determinism matches host reference",
+CUB_TEST("DeviceScan::ExclusiveScan with run_to_run determinism matches host reference",
          "[scan][deterministic][run_to_run]",
+         CUB_SMALL,
          float_type_list)
 {
   using type = typename c2h::get<0, TestType>;

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -34,7 +34,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::InclusiveScanInit, device_scan_inclusive
 #include <cuda/__execution/determinism.h>
 #include <cuda/__execution/require.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
@@ -45,7 +45,7 @@ using block_size_check_t = block_size_extracting_op<cuda::std::plus<>>;
 // ifdef it out not to spend time compiling and running it twice.
 #if TEST_LAUNCH == 0
 
-TEST_CASE("Device scan exclusive scan works with default environment", "[scan][device]")
+CUB_TEST_CASE("Device scan exclusive scan works with default environment", "[scan][device]", CUB_SMALL)
 {
   using num_items_t = int;
   using value_t     = int;
@@ -74,7 +74,7 @@ TEST_CASE("Device scan exclusive scan works with default environment", "[scan][d
   REQUIRE(d_block_size[0] == static_cast<unsigned int>(target_block_size));
 }
 
-TEST_CASE("Device scan exclusive scan with FutureValue works with default environment", "[scan][device]")
+CUB_TEST_CASE("Device scan exclusive scan with FutureValue works with default environment", "[scan][device]", CUB_SMALL)
 {
   using num_items_t = int;
 
@@ -93,7 +93,7 @@ TEST_CASE("Device scan exclusive scan with FutureValue works with default enviro
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device scan exclusive sum works with default environment", "[sum][device]")
+CUB_TEST_CASE("Device scan exclusive sum works with default environment", "[sum][device]", CUB_SMALL)
 {
   using num_items_t = int;
   using value_t     = int;
@@ -108,7 +108,7 @@ TEST_CASE("Device scan exclusive sum works with default environment", "[sum][dev
   REQUIRE(d_out[1] == value_t{} + d_in[0]);
 }
 
-TEST_CASE("Device scan inclusive-scan-init works with default environment", "[scan][device]")
+CUB_TEST_CASE("Device scan inclusive-scan-init works with default environment", "[scan][device]", CUB_SMALL)
 {
   using num_items_t = int;
   using value_t     = int;
@@ -160,7 +160,7 @@ struct unrelated_tuning
 using block_sizes =
   c2h::type_list<cuda::std::integral_constant<unsigned int, 32>, cuda::std::integral_constant<unsigned int, 64>>;
 
-C2H_TEST("Device scan exclusive-scan can be tuned", "[scan][device]", block_sizes)
+CUB_TEST("Device scan exclusive-scan can be tuned", "[scan][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -180,7 +180,7 @@ C2H_TEST("Device scan exclusive-scan can be tuned", "[scan][device]", block_size
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device scan exclusive-sum can be tuned", "[scan][device]", block_sizes)
+CUB_TEST("Device scan exclusive-sum can be tuned", "[scan][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -200,7 +200,7 @@ C2H_TEST("Device scan exclusive-sum can be tuned", "[scan][device]", block_sizes
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-TEST_CASE("Device scan inclusive sum works with default environment", "[sum][device]")
+CUB_TEST_CASE("Device scan inclusive sum works with default environment", "[sum][device]", CUB_SMALL)
 {
   using num_items_t = int;
   using value_t     = int;
@@ -216,7 +216,7 @@ TEST_CASE("Device scan inclusive sum works with default environment", "[sum][dev
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device scan inclusive-scan works with default environment", "[scan][device]")
+CUB_TEST_CASE("Device scan inclusive-scan works with default environment", "[scan][device]", CUB_SMALL)
 {
   using num_items_t = int;
   using value_t     = int;
@@ -244,7 +244,7 @@ TEST_CASE("Device scan inclusive-scan works with default environment", "[scan][d
   REQUIRE(d_block_size[0] == static_cast<unsigned int>(target_block_size));
 }
 
-C2H_TEST("Device scan inclusive-scan can be tuned", "[scan][device]", block_sizes)
+CUB_TEST("Device scan inclusive-scan can be tuned", "[scan][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -263,7 +263,7 @@ C2H_TEST("Device scan inclusive-scan can be tuned", "[scan][device]", block_size
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device scan inclusive-scan-init can be tuned", "[scan][device]", block_sizes)
+CUB_TEST("Device scan inclusive-scan-init can be tuned", "[scan][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
@@ -285,7 +285,7 @@ C2H_TEST("Device scan inclusive-scan-init can be tuned", "[scan][device]", block
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-TEST_CASE("Device scan exclusive sum in-place works with default environment", "[scan][device]")
+CUB_TEST_CASE("Device scan exclusive sum in-place works with default environment", "[scan][device]", CUB_SMALL)
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
@@ -296,7 +296,7 @@ TEST_CASE("Device scan exclusive sum in-place works with default environment", "
   REQUIRE(d_data == expected);
 }
 
-TEST_CASE("Device scan exclusive scan in-place works with default environment", "[scan][device]")
+CUB_TEST_CASE("Device scan exclusive scan in-place works with default environment", "[scan][device]", CUB_SMALL)
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
@@ -307,7 +307,7 @@ TEST_CASE("Device scan exclusive scan in-place works with default environment", 
   REQUIRE(d_data == expected);
 }
 
-TEST_CASE("Device scan inclusive sum in-place works with default environment", "[scan][device]")
+CUB_TEST_CASE("Device scan inclusive sum in-place works with default environment", "[scan][device]", CUB_SMALL)
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
@@ -318,7 +318,7 @@ TEST_CASE("Device scan inclusive sum in-place works with default environment", "
   REQUIRE(d_data == expected);
 }
 
-TEST_CASE("Device scan inclusive scan in-place works with default environment", "[scan][device]")
+CUB_TEST_CASE("Device scan inclusive scan in-place works with default environment", "[scan][device]", CUB_SMALL)
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
@@ -329,7 +329,9 @@ TEST_CASE("Device scan inclusive scan in-place works with default environment", 
   REQUIRE(d_data == expected);
 }
 
-TEST_CASE("Device scan exclusive scan with FutureValue in-place works with default environment", "[scan][device]")
+CUB_TEST_CASE("Device scan exclusive scan with FutureValue in-place works with default environment",
+              "[scan][device]",
+              CUB_SMALL)
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
@@ -346,7 +348,7 @@ TEST_CASE("Device scan exclusive scan with FutureValue in-place works with defau
 
 #endif // TEST_LAUNCH != 1
 
-C2H_TEST("Device scan exclusive-scan uses environment", "[scan][device]")
+CUB_TEST("Device scan exclusive-scan uses environment", "[scan][device]", CUB_SMALL)
 {
   using scan_op_t   = cuda::std::plus<>;
   using num_items_t = int;
@@ -372,7 +374,7 @@ C2H_TEST("Device scan exclusive-scan uses environment", "[scan][device]")
   REQUIRE(thrust::equal(d_out.begin(), d_out.end(), thrust::counting_iterator<int>(static_cast<int>(init))));
 }
 
-C2H_TEST("Device scan exclusive-scan with FutureValue uses environment", "[scan][device]")
+CUB_TEST("Device scan exclusive-scan with FutureValue uses environment", "[scan][device]", CUB_SMALL)
 {
   using scan_op_t   = cuda::std::plus<>;
   using num_items_t = int;
@@ -397,7 +399,7 @@ C2H_TEST("Device scan exclusive-scan with FutureValue uses environment", "[scan]
   REQUIRE(thrust::equal(d_out.begin(), d_out.end(), thrust::counting_iterator<int>(42)));
 }
 
-C2H_TEST("Device scan exclusive-sum uses environment", "[scan][device]")
+CUB_TEST("Device scan exclusive-sum uses environment", "[scan][device]", CUB_SMALL)
 {
   using scan_op_t   = cuda::std::plus<>;
   using num_items_t = int;
@@ -418,7 +420,7 @@ C2H_TEST("Device scan exclusive-sum uses environment", "[scan][device]")
   REQUIRE(thrust::equal(d_out.begin(), d_out.end(), thrust::counting_iterator<int>(0)));
 }
 
-C2H_TEST("Device scan inclusive-sum uses environment", "[scan][device]")
+CUB_TEST("Device scan inclusive-sum uses environment", "[scan][device]", CUB_SMALL)
 {
   using num_items_t = int;
 
@@ -444,7 +446,7 @@ C2H_TEST("Device scan inclusive-sum uses environment", "[scan][device]")
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device scan inclusive-scan uses environment", "[scan][device]")
+CUB_TEST("Device scan inclusive-scan uses environment", "[scan][device]", CUB_SMALL)
 {
   using scan_op_t   = cuda::std::plus<>;
   using num_items_t = int;
@@ -465,7 +467,7 @@ C2H_TEST("Device scan inclusive-scan uses environment", "[scan][device]")
   REQUIRE(thrust::equal(d_out.begin(), d_out.end(), thrust::counting_iterator<int>(1)));
 }
 
-C2H_TEST("Device scan inclusive-scan-init uses environment", "[scan][device]")
+CUB_TEST("Device scan inclusive-scan-init uses environment", "[scan][device]", CUB_SMALL)
 {
   using num_items_t = int;
 
@@ -487,7 +489,7 @@ C2H_TEST("Device scan inclusive-scan-init uses environment", "[scan][device]")
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device scan exclusive-sum in-place uses environment", "[scan][device]")
+CUB_TEST("Device scan exclusive-sum in-place uses environment", "[scan][device]", CUB_SMALL)
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
@@ -504,7 +506,7 @@ C2H_TEST("Device scan exclusive-sum in-place uses environment", "[scan][device]"
   REQUIRE(d_data == expected);
 }
 
-C2H_TEST("Device scan exclusive-scan in-place uses environment", "[scan][device]")
+CUB_TEST("Device scan exclusive-scan in-place uses environment", "[scan][device]", CUB_SMALL)
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
@@ -528,7 +530,7 @@ C2H_TEST("Device scan exclusive-scan in-place uses environment", "[scan][device]
   REQUIRE(d_data == expected);
 }
 
-C2H_TEST("Device scan exclusive-scan with FutureValue in-place uses environment", "[scan][device]")
+CUB_TEST("Device scan exclusive-scan with FutureValue in-place uses environment", "[scan][device]", CUB_SMALL)
 {
   auto d_data = c2h::device_vector<int>{1, 1, 1, 1};
 
@@ -555,7 +557,7 @@ C2H_TEST("Device scan exclusive-scan with FutureValue in-place uses environment"
   REQUIRE(d_data == expected);
 }
 
-C2H_TEST("Device scan inclusive-sum in-place uses environment", "[scan][device]")
+CUB_TEST("Device scan inclusive-sum in-place uses environment", "[scan][device]", CUB_SMALL)
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
@@ -572,7 +574,7 @@ C2H_TEST("Device scan inclusive-sum in-place uses environment", "[scan][device]"
   REQUIRE(d_data == expected);
 }
 
-C2H_TEST("Device scan inclusive-scan in-place uses environment", "[scan][device]")
+CUB_TEST("Device scan inclusive-scan in-place uses environment", "[scan][device]", CUB_SMALL)
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
@@ -596,7 +598,7 @@ C2H_TEST("Device scan inclusive-scan in-place uses environment", "[scan][device]
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test ScanPolicy properties", "[scan][device]")
+CUB_TEST("Test ScanPolicy properties", "[scan][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ScanPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ScanPolicy>);

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -15,9 +15,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan accepts run_to_run determinism requirements", "[scan][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveScan accepts run_to_run determinism requirements", "[scan][env]", CUB_SMALL)
 {
   // example-begin exclusive-scan-env-determinism
   auto op     = cuda::std::plus{};
@@ -40,7 +40,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan accepts run_to_run determinism requirem
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan accepts stream and not_guaranteed determinism", "[scan][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveScan accepts stream and not_guaranteed determinism", "[scan][env]", CUB_SMALL)
 {
   // example-begin exclusive-scan-env-stream
   auto op     = cuda::std::plus{};
@@ -67,7 +67,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan accepts stream and not_guaranteed deter
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveSum accepts run_to_run determinism requirements", "[scan][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveSum accepts run_to_run determinism requirements", "[scan][env]", CUB_SMALL)
 {
   // example-begin exclusive-sum-env-determinism
   auto input  = thrust::device_vector<int>{0, 1, 2, 3};
@@ -88,7 +88,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSum accepts run_to_run determinism requireme
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveSum accepts stream and not_guaranteed determinism", "[scan][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveSum accepts stream and not_guaranteed determinism", "[scan][env]", CUB_SMALL)
 {
   // example-begin exclusive-sum-env-stream
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
@@ -113,7 +113,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSum accepts stream and not_guaranteed determ
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveSum accepts run_to_run determinism requirements", "[scan][env]")
+CUB_TEST("cub::DeviceScan::InclusiveSum accepts run_to_run determinism requirements", "[scan][env]", CUB_SMALL)
 {
   // example-begin inclusive-sum-env-determinism
   auto input  = thrust::device_vector<int>{1, 2, 3, 4};
@@ -134,7 +134,7 @@ C2H_TEST("cub::DeviceScan::InclusiveSum accepts run_to_run determinism requireme
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveSum accepts stream and not_guaranteed determinism", "[scan][env]")
+CUB_TEST("cub::DeviceScan::InclusiveSum accepts stream and not_guaranteed determinism", "[scan][env]", CUB_SMALL)
 {
   // example-begin inclusive-sum-env-stream
   auto input  = thrust::device_vector<float>{1.0f, 2.0f, 3.0f, 4.0f};
@@ -159,7 +159,7 @@ C2H_TEST("cub::DeviceScan::InclusiveSum accepts stream and not_guaranteed determ
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan with FutureValue accepts environment", "[scan][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveScan with FutureValue accepts environment", "[scan][env]", CUB_SMALL)
 {
   // example-begin exclusive-scan-future-env
   auto input  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -184,7 +184,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan with FutureValue accepts environment", 
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan with FutureValue accepts stream environment", "[scan][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveScan with FutureValue accepts stream environment", "[scan][env]", CUB_SMALL)
 {
   // example-begin exclusive-scan-future-env-stream
   auto input  = thrust::device_vector<int>{1, 2, 3, 4};
@@ -211,7 +211,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan with FutureValue accepts stream environ
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScan accepts environment", "[scan][env]")
+CUB_TEST("cub::DeviceScan::InclusiveScan accepts environment", "[scan][env]", CUB_SMALL)
 {
   // example-begin inclusive-scan-env
   auto op     = cuda::std::plus{};
@@ -231,7 +231,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScan accepts environment", "[scan][env]")
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScan accepts stream environment", "[scan][env]")
+CUB_TEST("cub::DeviceScan::InclusiveScan accepts stream environment", "[scan][env]", CUB_SMALL)
 {
   // example-begin inclusive-scan-env-stream
   auto op     = cuda::std::plus{};
@@ -255,7 +255,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScan accepts stream environment", "[scan][en
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScanInit accepts environment", "[scan][env]")
+CUB_TEST("cub::DeviceScan::InclusiveScanInit accepts environment", "[scan][env]", CUB_SMALL)
 {
   // example-begin inclusive-scan-init-env
   auto op     = cuda::std::plus{};
@@ -276,7 +276,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit accepts environment", "[scan][env]"
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScanInit with args::deferred accepts environment", "[scan][env]")
+CUB_TEST("cub::DeviceScan::InclusiveScanInit with args::deferred accepts environment", "[scan][env]", CUB_SMALL)
 {
   // example-begin inclusive-scan-future-init-env
   auto op     = cuda::std::plus{};
@@ -301,7 +301,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit with args::deferred accepts environ
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScanInit accepts stream environment", "[scan][env]")
+CUB_TEST("cub::DeviceScan::InclusiveScanInit accepts stream environment", "[scan][env]", CUB_SMALL)
 {
   // example-begin inclusive-scan-init-env-stream
   auto op     = cuda::std::plus{};
@@ -326,7 +326,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit accepts stream environment", "[scan
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveSum in-place accepts stream", "[scan][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveSum in-place accepts stream", "[scan][env]", CUB_SMALL)
 {
   // example-begin exclusive-sum-inplace-env
   auto data = thrust::device_vector<int>{1, 2, 3, 4};
@@ -348,7 +348,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSum in-place accepts stream", "[scan][env]")
   REQUIRE(data == expected);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan in-place accepts stream", "[scan][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveScan in-place accepts stream", "[scan][env]", CUB_SMALL)
 {
   // example-begin exclusive-scan-inplace-env
   auto data = thrust::device_vector<int>{1, 2, 3, 4};
@@ -371,7 +371,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan in-place accepts stream", "[scan][env]"
   REQUIRE(data == expected);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan with FutureValue in-place accepts stream", "[scan][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveScan with FutureValue in-place accepts stream", "[scan][env]", CUB_SMALL)
 {
   // example-begin exclusive-scan-future-inplace-env
   auto data = thrust::device_vector<int>{1, 2, 3, 4};
@@ -397,7 +397,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan with FutureValue in-place accepts strea
   REQUIRE(data == expected);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveSum in-place accepts stream", "[scan][env]")
+CUB_TEST("cub::DeviceScan::InclusiveSum in-place accepts stream", "[scan][env]", CUB_SMALL)
 {
   // example-begin inclusive-sum-inplace-env
   auto data = thrust::device_vector<int>{1, 2, 3, 4};
@@ -419,7 +419,7 @@ C2H_TEST("cub::DeviceScan::InclusiveSum in-place accepts stream", "[scan][env]")
   REQUIRE(data == expected);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScan in-place accepts stream", "[scan][env]")
+CUB_TEST("cub::DeviceScan::InclusiveScan in-place accepts stream", "[scan][env]", CUB_SMALL)
 {
   // example-begin inclusive-scan-inplace-env
   auto data = thrust::device_vector<int>{1, 2, 3, 4};
@@ -468,7 +468,7 @@ struct ScanPolicySelector
 };
 // example-end exclusive-sum-policy-selector
 
-C2H_TEST("cub::DeviceScan::ExclusiveSum accepts a custom policy selector", "[scan][env]")
+CUB_TEST("cub::DeviceScan::ExclusiveSum accepts a custom policy selector", "[scan][env]", CUB_SMALL)
 {
   // example-begin exclusive-sum-tuning
   auto input  = thrust::device_vector<int>{1, 2, 3, 4};

--- a/cub/test/catch2_test_device_scan_invalid.cu
+++ b/cub/test/catch2_test_device_scan_invalid.cu
@@ -16,7 +16,7 @@
 
 #include "catch2_test_device_scan.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 #include <c2h/vector.h>
 
@@ -144,7 +144,8 @@ struct merge_segments_op
 };
 
 // Expected to fail for the current implementation.
-C2H_TEST("Device scan avoids invalid data with all device interfaces", "[scan][device][!mayfail]", element_types)
+CUB_TEST(
+  "Device scan avoids invalid data with all device interfaces", "[scan][device][!mayfail]", CUB_SMALL, element_types)
 {
   using input_t  = c2h::get<0, TestType>;
   using output_t = input_t;

--- a/cub/test/catch2_test_device_scan_iterators.cu
+++ b/cub/test/catch2_test_device_scan_iterators.cu
@@ -15,7 +15,7 @@
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_device_scan.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 #include <c2h/extended_types.h>
 
@@ -35,7 +35,7 @@ using custom_t =
 
 using iterator_type_list = c2h::type_list<type_pair<std::int8_t>, type_pair<custom_t>, type_pair<uchar3>>;
 
-C2H_TEST("Device scan works with iterators", "[scan][device]", iterator_type_list)
+CUB_TEST("Device scan works with iterators", "[scan][device]", CUB_SMALL, iterator_type_list)
 {
   using params   = params_t<TestType>;
   using input_t  = typename params::item_t;
@@ -296,7 +296,7 @@ struct index_to_custom_output_op
   }
 };
 
-C2H_TEST("Device scan works complex accumulator types", "[scan][device]")
+CUB_TEST("Device scan works complex accumulator types", "[scan][device]", CUB_SMALL)
 {
   constexpr int num_items = 2 * 1024 * 1024;
 

--- a/cub/test/catch2_test_device_scan_large_offsets.cu
+++ b/cub/test/catch2_test_device_scan_large_offsets.cu
@@ -11,7 +11,7 @@
 
 #include "catch2_large_problem_helper.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::ExclusiveScan, device_exclusive_scan);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::InclusiveScan, device_inclusive_scan);
@@ -72,7 +72,7 @@ struct mod_op
   }
 };
 
-C2H_TEST("DeviceScan works for very large number of items", "[scan][device]", offset_types)
+CUB_TEST("DeviceScan works for very large number of items", "[scan][device]", CUB_LARGE, offset_types)
 try
 {
   using op_t     = cuda::std::plus<>;
@@ -116,7 +116,7 @@ catch (std::bad_alloc&)
   SUCCEED("exceeding memory is not a failure");
 }
 
-C2H_TEST("DeviceScan works for very large number of items", "[scan][device]", offset_types)
+CUB_TEST("DeviceScan works for very large number of items", "[scan][device]", CUB_LARGE, offset_types)
 try
 {
   using op_t     = cuda::std::plus<>;

--- a/cub/test/catch2_test_device_scan_noncommutative.cu
+++ b/cub/test/catch2_test_device_scan_noncommutative.cu
@@ -3,7 +3,7 @@
 
 #include <cub/device/device_scan.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <catch2_test_device_scan.cuh>
 
 /* Consider free monoid with two generators, ``q`` and ``p``, modulo defining relationship (``p * q == 1``).
@@ -47,7 +47,7 @@ struct bicyclic_monoid_op
 };
 }; // namespace impl
 
-C2H_TEST("Device inclusive scan works with non-commutative operator", "[scan][device]")
+CUB_TEST("Device inclusive scan works with non-commutative operator", "[scan][device]", CUB_SMALL)
 {
   using pair_t = cuda::std::pair<unsigned, unsigned>;
   using op_t   = impl::bicyclic_monoid_op<unsigned>;

--- a/cub/test/catch2_test_device_segmented_radix_sort_api.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_api.cu
@@ -5,7 +5,7 @@
 
 #include <cub/device/device_segmented_radix_sort.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // Guard tests: each public DeviceSegmentedRadixSort method must resolve unambiguously
 // to the legacy temp-storage overload when called in its minimal form (no explicit
@@ -13,7 +13,9 @@
 // scope. If env-overload SFINAE drifts in the future, these become "ambiguous
 // overload" compile errors.
 
-C2H_TEST("DeviceSegmentedRadixSort::SortPairs legacy size-query is unambiguous", "[segmented_radix_sort][device]")
+CUB_TEST("DeviceSegmentedRadixSort::SortPairs legacy size-query is unambiguous",
+         "[segmented_radix_sort][device]",
+         CUB_SMALL)
 {
   void* d_temp_storage        = nullptr;
   size_t temp_storage_bytes   = 0;
@@ -40,8 +42,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairs legacy size-query is unambiguous",
       d_offsets));
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending legacy size-query is unambiguous",
-         "[segmented_radix_sort][device]")
+CUB_TEST("DeviceSegmentedRadixSort::SortPairsDescending legacy size-query is unambiguous",
+         "[segmented_radix_sort][device]",
+         CUB_SMALL)
 {
   void* d_temp_storage        = nullptr;
   size_t temp_storage_bytes   = 0;
@@ -68,7 +71,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending legacy size-query is una
       d_offsets));
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys legacy size-query is unambiguous", "[segmented_radix_sort][device]")
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys legacy size-query is unambiguous",
+         "[segmented_radix_sort][device]",
+         CUB_SMALL)
 {
   void* d_temp_storage        = nullptr;
   size_t temp_storage_bytes   = 0;
@@ -83,8 +88,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys legacy size-query is unambiguous", 
             d_temp_storage, temp_storage_bytes, d_keys_in, d_keys_out, n, n_segs, d_offsets, d_offsets));
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending legacy size-query is unambiguous",
-         "[segmented_radix_sort][device]")
+CUB_TEST("DeviceSegmentedRadixSort::SortKeysDescending legacy size-query is unambiguous",
+         "[segmented_radix_sort][device]",
+         CUB_SMALL)
 {
   void* d_temp_storage        = nullptr;
   size_t temp_storage_bytes   = 0;

--- a/cub/test/catch2_test_device_segmented_radix_sort_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_custom_policy_hub.cu
@@ -13,7 +13,7 @@
 #include <thrust/detail/raw_pointer_cast.h>
 
 #include "catch2_radix_sort_helper.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -98,7 +98,7 @@ struct my_policy_hub
   };
 };
 
-C2H_TEST("DispatchSegmentedRadixSort::Dispatch: custom policy hub", "[keys][segmented][radix][sort][device]")
+CUB_TEST("DispatchSegmentedRadixSort::Dispatch: custom policy hub", "[keys][segmented][radix][sort][device]", CUB_SMALL)
 {
   using key_t          = int;
   using value_t        = NullType;

--- a/cub/test/catch2_test_device_segmented_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env.cu
@@ -22,13 +22,15 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedRadixSort::SortKeysDescending, sort_k
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("DeviceSegmentedRadixSort::SortPairs works with default environment", "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairs works with default environment",
+              "[segmented_radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -54,8 +56,9 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairs works with default environment", 
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending works with default environment",
-          "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending works with default environment",
+              "[segmented_radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -81,7 +84,9 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending works with default envi
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("DeviceSegmentedRadixSort::SortKeys works with default environment", "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortKeys works with default environment",
+              "[segmented_radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -101,8 +106,9 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeys works with default environment", "
   REQUIRE(keys_out == expected_keys);
 }
 
-TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending works with default environment",
-          "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending works with default environment",
+              "[segmented_radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -122,8 +128,9 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending works with default envir
   REQUIRE(keys_out == expected_keys);
 }
 
-TEST_CASE("DeviceSegmentedRadixSort::SortKeys DoubleBuffer works with default environment",
-          "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortKeys DoubleBuffer works with default environment",
+              "[segmented_radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_buf = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_alt = c2h::device_vector<int>(7);
@@ -142,8 +149,9 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeys DoubleBuffer works with default en
   REQUIRE(result_keys == expected_keys);
 }
 
-TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer works with default environment",
-          "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer works with default environment",
+              "[segmented_radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_buf = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_alt = c2h::device_vector<int>(7);
@@ -164,7 +172,7 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer works with 
 
 #endif
 
-C2H_TEST("DeviceSegmentedRadixSort::SortPairs uses environment", "[segmented_radix_sort][device]")
+CUB_TEST("DeviceSegmentedRadixSort::SortPairs uses environment", "[segmented_radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -208,7 +216,7 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairs uses environment", "[segmented_rad
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending uses environment", "[segmented_radix_sort][device]")
+CUB_TEST("DeviceSegmentedRadixSort::SortPairsDescending uses environment", "[segmented_radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -252,7 +260,7 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending uses environment", "[seg
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys uses environment", "[segmented_radix_sort][device]")
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys uses environment", "[segmented_radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -288,7 +296,7 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys uses environment", "[segmented_radi
   REQUIRE(keys_out == expected_keys);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending uses environment", "[segmented_radix_sort][device]")
+CUB_TEST("DeviceSegmentedRadixSort::SortKeysDescending uses environment", "[segmented_radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -324,7 +332,7 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending uses environment", "[segm
   REQUIRE(keys_out == expected_keys);
 }
 
-TEST_CASE("DeviceSegmentedRadixSort::SortPairs uses custom stream", "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairs uses custom stream", "[segmented_radix_sort][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -376,7 +384,9 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairs uses custom stream", "[segmented_
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending uses custom stream", "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending uses custom stream",
+              "[segmented_radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -428,7 +438,7 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending uses custom stream", "[
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-TEST_CASE("DeviceSegmentedRadixSort::SortKeys uses custom stream", "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortKeys uses custom stream", "[segmented_radix_sort][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -472,7 +482,9 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeys uses custom stream", "[segmented_r
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending uses custom stream", "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending uses custom stream",
+              "[segmented_radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -516,7 +528,7 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending uses custom stream", "[s
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys DoubleBuffer uses environment", "[segmented_radix_sort][device]")
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys DoubleBuffer uses environment", "[segmented_radix_sort][device]", CUB_SMALL)
 {
   auto keys_buf = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_alt = c2h::device_vector<int>(7);
@@ -555,7 +567,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys DoubleBuffer uses environment", "[s
   REQUIRE(result_keys == expected_keys);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer uses environment", "[segmented_radix_sort][device]")
+CUB_TEST("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer uses environment",
+         "[segmented_radix_sort][device]",
+         CUB_SMALL)
 {
   auto keys_buf = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_alt = c2h::device_vector<int>(7);
@@ -594,8 +608,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer uses environ
   REQUIRE(result_keys == expected_keys);
 }
 
-TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer works with default environment",
-          "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer works with default environment",
+              "[segmented_radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_buf   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_alt   = c2h::device_vector<int>(7);
@@ -622,8 +637,9 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer works with default e
   REQUIRE(result_values == expected_values);
 }
 
-TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer works with default environment",
-          "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer works with default environment",
+              "[segmented_radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_buf   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_alt   = c2h::device_vector<int>(7);
@@ -650,7 +666,9 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer works with
   REQUIRE(result_values == expected_values);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses environment", "[segmented_radix_sort][device]")
+CUB_TEST("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses environment",
+         "[segmented_radix_sort][device]",
+         CUB_SMALL)
 {
   auto keys_buf   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_alt   = c2h::device_vector<int>(7);
@@ -699,8 +717,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses environment", "[
   REQUIRE(result_values == expected_values);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer uses environment",
-         "[segmented_radix_sort][device]")
+CUB_TEST("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer uses environment",
+         "[segmented_radix_sort][device]",
+         CUB_SMALL)
 {
   auto keys_buf   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_alt   = c2h::device_vector<int>(7);
@@ -749,7 +768,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer uses enviro
   REQUIRE(result_values == expected_values);
 }
 
-TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses custom stream", "[segmented_radix_sort][device]")
+CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses custom stream",
+              "[segmented_radix_sort][device]",
+              CUB_SMALL)
 {
   auto keys_buf   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_alt   = c2h::device_vector<int>(7);
@@ -828,7 +849,7 @@ struct segmented_radix_sort_block_size_tuning
 using block_sizes =
   c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
 
-C2H_TEST("DeviceSegmentedRadixSort::SortPairs can be tuned", "[segmented_radix_sort][device]", block_sizes)
+CUB_TEST("DeviceSegmentedRadixSort::SortPairs can be tuned", "[segmented_radix_sort][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -858,7 +879,10 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairs can be tuned", "[segmented_radix_s
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending can be tuned", "[segmented_radix_sort][device]", block_sizes)
+CUB_TEST("DeviceSegmentedRadixSort::SortPairsDescending can be tuned",
+         "[segmented_radix_sort][device]",
+         CUB_SMALL,
+         block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -888,7 +912,7 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending can be tuned", "[segment
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys can be tuned", "[segmented_radix_sort][device]", block_sizes)
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys can be tuned", "[segmented_radix_sort][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -914,7 +938,8 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys can be tuned", "[segmented_radix_so
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending can be tuned", "[segmented_radix_sort][device]", block_sizes)
+CUB_TEST(
+  "DeviceSegmentedRadixSort::SortKeysDescending can be tuned", "[segmented_radix_sort][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -940,7 +965,10 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending can be tuned", "[segmente
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortPairs DoubleBuffer can be tuned", "[segmented_radix_sort][device]", block_sizes)
+CUB_TEST("DeviceSegmentedRadixSort::SortPairs DoubleBuffer can be tuned",
+         "[segmented_radix_sort][device]",
+         CUB_SMALL,
+         block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -971,8 +999,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairs DoubleBuffer can be tuned", "[segm
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer can be tuned",
+CUB_TEST("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer can be tuned",
          "[segmented_radix_sort][device]",
+         CUB_SMALL,
          block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
@@ -1004,7 +1033,10 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer can be tune
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys DoubleBuffer can be tuned", "[segmented_radix_sort][device]", block_sizes)
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys DoubleBuffer can be tuned",
+         "[segmented_radix_sort][device]",
+         CUB_SMALL,
+         block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -1031,8 +1063,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys DoubleBuffer can be tuned", "[segme
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer can be tuned",
+CUB_TEST("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer can be tuned",
          "[segmented_radix_sort][device]",
+         CUB_SMALL,
          block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
@@ -1063,7 +1096,7 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer can be tuned
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test SegmentedRadixSortPolicy properties", "[segmented_radix_sort][device]")
+CUB_TEST("Test SegmentedRadixSortPolicy properties", "[segmented_radix_sort][device]", CUB_SMALL)
 {
   // no need to test RadixSortDownsweepPolicy, already covered by the radix sort tests
 

--- a/cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
@@ -13,9 +13,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairs env with stream", "[segmented_radix_sort][env]")
+CUB_TEST("cub::DeviceSegmentedRadixSort::SortPairs env with stream", "[segmented_radix_sort][env]", CUB_SMALL)
 {
   // example-begin segmented-radix-sort-pairs-env
   auto keys_in    = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -54,7 +54,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairs env with stream", "[segmented
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending env with stream", "[segmented_radix_sort][env]")
+CUB_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending env with stream", "[segmented_radix_sort][env]", CUB_SMALL)
 {
   // example-begin segmented-radix-sort-pairs-descending-env
   auto keys_in    = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -93,7 +93,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending env with stream", "
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeys env with stream", "[segmented_radix_sort][env]")
+CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeys env with stream", "[segmented_radix_sort][env]", CUB_SMALL)
 {
   // example-begin segmented-radix-sort-keys-env
   auto keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -126,7 +126,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeys env with stream", "[segmented_
   REQUIRE(keys_out == expected_keys);
 }
 
-C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending env with stream", "[segmented_radix_sort][env]")
+CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending env with stream", "[segmented_radix_sort][env]", CUB_SMALL)
 {
   // example-begin segmented-radix-sort-keys-descending-env
   auto keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -159,7 +159,9 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending env with stream", "[
   REQUIRE(keys_out == expected_keys);
 }
 
-C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeys DoubleBuffer env with stream", "[segmented_radix_sort][env]")
+CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeys DoubleBuffer env with stream",
+         "[segmented_radix_sort][env]",
+         CUB_SMALL)
 {
   // example-begin segmented-radix-sort-keys-db-env
   auto keys_buf = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -189,8 +191,9 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeys DoubleBuffer env with stream",
   REQUIRE(result_keys == expected_keys);
 }
 
-C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer env with stream",
-         "[segmented_radix_sort][env]")
+CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer env with stream",
+         "[segmented_radix_sort][env]",
+         CUB_SMALL)
 {
   // example-begin segmented-radix-sort-keys-descending-db-env
   auto keys_buf = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -221,7 +224,9 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer env wit
   REQUIRE(result_keys == expected_keys);
 }
 
-C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairs DoubleBuffer env with stream", "[segmented_radix_sort][env]")
+CUB_TEST("cub::DeviceSegmentedRadixSort::SortPairs DoubleBuffer env with stream",
+         "[segmented_radix_sort][env]",
+         CUB_SMALL)
 {
   // example-begin segmented-radix-sort-pairs-db-env
   auto keys_buf   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -267,8 +272,9 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairs DoubleBuffer env with stream"
   REQUIRE(result_values == expected_values);
 }
 
-C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer env with stream",
-         "[segmented_radix_sort][env]")
+CUB_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer env with stream",
+         "[segmented_radix_sort][env]",
+         CUB_SMALL)
 {
   // example-begin segmented-radix-sort-pairs-descending-db-env
   auto keys_buf   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -352,7 +358,9 @@ struct SegmentedRadixSortPolicySelector
 
 _CCCL_DIAG_POP
 
-C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeys accepts a custom policy selector", "[segmented_radix_sort][env]")
+CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeys accepts a custom policy selector",
+         "[segmented_radix_sort][env]",
+         CUB_SMALL)
 {
   // example-begin segmented-radix-sort-keys-tuning
   auto keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};

--- a/cub/test/catch2_test_device_segmented_radix_sort_keys.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_keys.cu
@@ -19,7 +19,7 @@
 #include "catch2_radix_sort_helper.cuh"
 #include "catch2_segmented_sort_helper.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/extended_types.h>
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
@@ -66,8 +66,9 @@ using fp_key_types         = c2h::type_list<double>;
 // Used for tests that just need a single type for testing:
 using single_key_type = c2h::type_list<c2h::get<0, key_types>>;
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys: basic testing",
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys: basic testing",
          "[keys][segmented][radix][sort][device]",
+         CUB_SMALL,
          key_types,
          offset_types)
 {
@@ -131,7 +132,10 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys: basic testing",
 
 #if defined(SINGLE_TEST_CASE_INSTANTIATION)
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys: empty data", "[keys][segmented][radix][sort][device]", single_key_type)
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys: empty data",
+         "[keys][segmented][radix][sort][device]",
+         CUB_SMALL,
+         single_key_type)
 {
   using key_t    = c2h::get<0, TestType>;
   using offset_t = cuda::std::int32_t;
@@ -187,8 +191,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys: empty data", "[keys][segmented][ra
 
 #endif // defined(SINGLE_TEST_CASE_INSTANTIATION)
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys: bit windows",
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys: bit windows",
          "[keys][segmented][radix][sort][device]",
+         CUB_SMALL,
          bit_window_key_types)
 {
   using key_t    = c2h::get<0, TestType>;
@@ -259,7 +264,10 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys: bit windows",
 
 #if defined(SINGLE_TEST_CASE_INSTANTIATION)
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys: large segments", "[keys][segmented][radix][sort][device]", single_key_type)
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys: large segments",
+         "[keys][segmented][radix][sort][device]",
+         CUB_SMALL,
+         single_key_type)
 {
   using key_t    = c2h::get<0, TestType>;
   using offset_t = cuda::std::int32_t;
@@ -317,8 +325,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys: large segments", "[keys][segmented
   REQUIRE((ref_keys == out_keys) == true);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys: DoubleBuffer API",
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys: DoubleBuffer API",
          "[keys][segmented][radix][sort][device]",
+         CUB_SMALL,
          single_key_type)
 {
   using key_t    = c2h::get<0, TestType>;
@@ -369,8 +378,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys: DoubleBuffer API",
   REQUIRE((ref_keys == keys) == true);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys: unspecified ranges",
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys: unspecified ranges",
          "[keys][segmented][radix][sort][device]",
+         CUB_SMALL,
          single_key_type)
 {
   using key_t    = c2h::get<0, TestType>;
@@ -443,8 +453,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys: unspecified ranges",
   REQUIRE((ref_keys == out_keys) == true);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys: very large num. items and num. segments",
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys: very large num. items and num. segments",
          "[keys][segmented][radix][sort][device][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_LARGE,
          all_offset_types)
 try
 {
@@ -492,8 +503,9 @@ catch (std::bad_alloc& e)
 
 // Currently, size of a single segment in DeviceRadixSort is limited to INT_MAX
 #  if defined(CCCL_TEST_ENABLE_LARGE_SEGMENTED_SORT)
-C2H_TEST("DeviceSegmentedRadixSort::SortKeys: very large segments",
+CUB_TEST("DeviceSegmentedRadixSort::SortKeys: very large segments",
          "[keys][segmented][radix][sort][device][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_LARGE,
          all_offset_types)
 try
 {

--- a/cub/test/catch2_test_device_segmented_radix_sort_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_pairs.cu
@@ -16,8 +16,8 @@
 #include "catch2_radix_sort_helper.cuh"
 #include "catch2_segmented_sort_helper.cuh"
 #include "catch2_test_launch_helper.h"
+#include "cub_test_macros.h"
 #include "thrust/detail/raw_pointer_cast.h"
-#include <c2h/catch2_test_helper.h>
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -28,8 +28,9 @@ using custom_value_t = c2h::custom_type_t<c2h::equal_comparable_t>;
 using value_types    = c2h::type_list<cuda::std::uint8_t, cuda::std::uint64_t, custom_value_t>;
 
 // Index types used for OffsetsT testing
-C2H_TEST("DeviceSegmentedRadixSort::SortPairs: Basic testing",
+CUB_TEST("DeviceSegmentedRadixSort::SortPairs: Basic testing",
          "[pairs][segmented][radix][sort][device]",
+         CUB_SMALL,
          value_types,
          offset_types)
 {
@@ -105,7 +106,10 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairs: Basic testing",
   REQUIRE(ref_values == out_values);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortPairs: DoubleBuffer API", "[pairs][segmented][radix][sort][device]", value_types)
+CUB_TEST("DeviceSegmentedRadixSort::SortPairs: DoubleBuffer API",
+         "[pairs][segmented][radix][sort][device]",
+         CUB_SMALL,
+         value_types)
 {
   using key_t    = cuda::std::uint32_t;
   using value_t  = c2h::get<0, TestType>;
@@ -169,8 +173,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairs: DoubleBuffer API", "[pairs][segme
   REQUIRE(ref_values == values);
 }
 
-C2H_TEST("DeviceSegmentedRadixSort::SortPairs: unspecified ranges",
+CUB_TEST("DeviceSegmentedRadixSort::SortPairs: unspecified ranges",
          "[pairs][segmented][radix][sort][device]",
+         CUB_SMALL,
          value_types)
 {
   using key_t    = cuda::std::uint32_t;
@@ -256,8 +261,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairs: unspecified ranges",
   REQUIRE((ref_values == out_values) == true);
 }
 
-C2H_TEST("DeviceSegmentedSortPairs: very large num. items and num. segments",
+CUB_TEST("DeviceSegmentedSortPairs: very large num. items and num. segments",
          "[pairs][segmented][sort][device][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_LARGE,
          all_offset_types)
 try
 {
@@ -316,8 +322,9 @@ catch (std::bad_alloc& e)
 
 // Currently, size of a single segment in DeviceRadixSort is limited to INT_MAX
 #if defined(CCCL_TEST_ENABLE_LARGE_SEGMENTED_SORT)
-C2H_TEST("DeviceSegmentedSort::SortPairs: very large segments",
+CUB_TEST("DeviceSegmentedSort::SortPairs: very large segments",
          "[pairs][segmented][sort][device][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_LARGE,
          all_offset_types)
 try
 {

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -12,7 +12,7 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 #include <c2h/extended_types.h>
 
@@ -63,7 +63,8 @@ type_pair<custom_t>
 
 using offsets = c2h::type_list<std::int32_t, std::uint32_t>;
 
-C2H_TEST("Device reduce works with all device interfaces", "[segmented][reduce][device]", full_type_list, offsets)
+CUB_TEST(
+  "Device reduce works with all device interfaces", "[segmented][reduce][device]", CUB_SMALL, full_type_list, offsets)
 {
   using type_pair_t = typename c2h::get<0, TestType>;
   using input_t     = typename type_pair_t::input_t;
@@ -222,8 +223,9 @@ C2H_TEST("Device reduce works with all device interfaces", "[segmented][reduce][
   }
 }
 
-C2H_TEST("Device fixed size segmented reduce works with all device interfaces",
+CUB_TEST("Device fixed size segmented reduce works with all device interfaces",
          "[segmented][reduce][device]",
+         CUB_SMALL,
          full_type_list)
 {
   using type_pair_t    = typename c2h::get<0, TestType>;

--- a/cub/test/catch2_test_device_segmented_reduce_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_api.cu
@@ -14,8 +14,8 @@
 #include <climits>
 #include <cstddef>
 
+#include "cub_test_macros.h"
 #include "thrust/detail/raw_pointer_cast.h"
-#include <c2h/catch2_test_helper.h>
 
 // example-begin segmented-reduce-custommin
 struct CustomMin
@@ -42,7 +42,7 @@ struct is_equal
   }
 };
 
-C2H_TEST("cub::DeviceSegmentedReduce::Reduce works with int data elements", "[segmented_reduce][device]")
+CUB_TEST("cub::DeviceSegmentedReduce::Reduce works with int data elements", "[segmented_reduce][device]", CUB_SMALL)
 {
   // example-begin segmented-reduce-reduce
   int num_segments                  = 3;
@@ -88,7 +88,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce works with int data elements", "[se
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Sum works with int data elements", "[segmented_reduce][device]")
+CUB_TEST("cub::DeviceSegmentedReduce::Sum works with int data elements", "[segmented_reduce][device]", CUB_SMALL)
 {
   // example-begin segmented-reduce-sum
   int num_segments                  = 3;
@@ -116,7 +116,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum works with int data elements", "[segme
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Min works with int data elements", "[segmented_reduce][device]")
+CUB_TEST("cub::DeviceSegmentedReduce::Min works with int data elements", "[segmented_reduce][device]", CUB_SMALL)
 {
   // example-begin segmented-reduce-min
   int num_segments                  = 3;
@@ -144,7 +144,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min works with int data elements", "[segme
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::ArgMin works with int data elements", "[segmented_reduce][device]")
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMin works with int data elements", "[segmented_reduce][device]", CUB_SMALL)
 {
   // example-begin segmented-reduce-argmin
   int num_segments                  = 3;
@@ -172,7 +172,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMin works with int data elements", "[se
   REQUIRE(thrust::equal(d_out.begin(), d_out.end(), expected.begin(), is_equal()));
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Max works with int data elements", "[segmented_reduce][device]")
+CUB_TEST("cub::DeviceSegmentedReduce::Max works with int data elements", "[segmented_reduce][device]", CUB_SMALL)
 {
   // example-begin segmented-reduce-max
   int num_segments                  = 3;
@@ -200,7 +200,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max works with int data elements", "[segme
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::ArgMax works with int data elements", "[segmented_reduce][device]")
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMax works with int data elements", "[segmented_reduce][device]", CUB_SMALL)
 {
   // example-begin segmented-reduce-argmax
   int num_segments                  = 3;
@@ -228,8 +228,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMax works with int data elements", "[se
   REQUIRE(thrust::equal(d_out.begin(), d_out.end(), expected.begin(), is_equal()));
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Reduce Fixed Segment Size works with int data elements",
-         "[segmented_reduce][device]")
+CUB_TEST("cub::DeviceSegmentedReduce::Reduce Fixed Segment Size works with int data elements",
+         "[segmented_reduce][device]",
+         CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-reduce
   int num_segments = 3;
@@ -258,8 +259,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce Fixed Segment Size works with int d
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Sum Fixed Segment Size works with int data elements",
-         "[segmented_reduce][device]")
+CUB_TEST("cub::DeviceSegmentedReduce::Sum Fixed Segment Size works with int data elements",
+         "[segmented_reduce][device]",
+         CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-sum
   int num_segments = 3;
@@ -286,8 +288,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum Fixed Segment Size works with int data
   REQUIRE(d_expected == d_out);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Min Fixed Segment Size works with int data elements",
-         "[segmented_reduce][device]")
+CUB_TEST("cub::DeviceSegmentedReduce::Min Fixed Segment Size works with int data elements",
+         "[segmented_reduce][device]",
+         CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-min
   int num_segments = 3;
@@ -314,8 +317,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min Fixed Segment Size works with int data
   REQUIRE(d_expected == d_out);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::ArgMin Fixed Segment Size works with int data elements",
-         "[segmented_reduce][device]")
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMin Fixed Segment Size works with int data elements",
+         "[segmented_reduce][device]",
+         CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-argmin
   int num_segments = 3;
@@ -344,8 +348,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMin Fixed Segment Size works with int d
   REQUIRE(h_expected == h_out);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Max Fixed Segment Size works with int data elements",
-         "[segmented_reduce][device]")
+CUB_TEST("cub::DeviceSegmentedReduce::Max Fixed Segment Size works with int data elements",
+         "[segmented_reduce][device]",
+         CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-max
   int num_segments = 3;
@@ -373,8 +378,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max Fixed Segment Size works with int data
   REQUIRE(d_expected == d_out);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::ArgMax Fixed Segment Size works with int data elements",
-         "[segmented_reduce][device]")
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMax Fixed Segment Size works with int data elements",
+         "[segmented_reduce][device]",
+         CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-argmax
   int num_segments = 3;
@@ -415,7 +421,7 @@ struct segmented_reduce_plus_t
   }
 };
 
-C2H_TEST("DeviceSegmentedReduce::Reduce legacy size-query is unambiguous", "[segmented_reduce][device]")
+CUB_TEST("DeviceSegmentedReduce::Reduce legacy size-query is unambiguous", "[segmented_reduce][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -429,7 +435,7 @@ C2H_TEST("DeviceSegmentedReduce::Reduce legacy size-query is unambiguous", "[seg
             d_temp_storage, temp_storage_bytes, d_in, d_out, n, d_offsets, d_offsets, segmented_reduce_plus_t{}, 0));
 }
 
-C2H_TEST("DeviceSegmentedReduce::Sum legacy size-query is unambiguous", "[segmented_reduce][device]")
+CUB_TEST("DeviceSegmentedReduce::Sum legacy size-query is unambiguous", "[segmented_reduce][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -442,7 +448,7 @@ C2H_TEST("DeviceSegmentedReduce::Sum legacy size-query is unambiguous", "[segmen
           == cub::DeviceSegmentedReduce::Sum(d_temp_storage, temp_storage_bytes, d_in, d_out, n, d_offsets, d_offsets));
 }
 
-C2H_TEST("DeviceSegmentedReduce::Min legacy size-query is unambiguous", "[segmented_reduce][device]")
+CUB_TEST("DeviceSegmentedReduce::Min legacy size-query is unambiguous", "[segmented_reduce][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -455,7 +461,7 @@ C2H_TEST("DeviceSegmentedReduce::Min legacy size-query is unambiguous", "[segmen
           == cub::DeviceSegmentedReduce::Min(d_temp_storage, temp_storage_bytes, d_in, d_out, n, d_offsets, d_offsets));
 }
 
-C2H_TEST("DeviceSegmentedReduce::Max legacy size-query is unambiguous", "[segmented_reduce][device]")
+CUB_TEST("DeviceSegmentedReduce::Max legacy size-query is unambiguous", "[segmented_reduce][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -468,7 +474,7 @@ C2H_TEST("DeviceSegmentedReduce::Max legacy size-query is unambiguous", "[segmen
           == cub::DeviceSegmentedReduce::Max(d_temp_storage, temp_storage_bytes, d_in, d_out, n, d_offsets, d_offsets));
 }
 
-C2H_TEST("DeviceSegmentedReduce::ArgMin legacy size-query is unambiguous", "[segmented_reduce][device]")
+CUB_TEST("DeviceSegmentedReduce::ArgMin legacy size-query is unambiguous", "[segmented_reduce][device]", CUB_SMALL)
 {
   void* d_temp_storage               = nullptr;
   size_t temp_storage_bytes          = 0;
@@ -482,7 +488,7 @@ C2H_TEST("DeviceSegmentedReduce::ArgMin legacy size-query is unambiguous", "[seg
     == cub::DeviceSegmentedReduce::ArgMin(d_temp_storage, temp_storage_bytes, d_in, d_out, n, d_offsets, d_offsets));
 }
 
-C2H_TEST("DeviceSegmentedReduce::ArgMax legacy size-query is unambiguous", "[segmented_reduce][device]")
+CUB_TEST("DeviceSegmentedReduce::ArgMax legacy size-query is unambiguous", "[segmented_reduce][device]", CUB_SMALL)
 {
   void* d_temp_storage               = nullptr;
   size_t temp_storage_bytes          = 0;

--- a/cub/test/catch2_test_device_segmented_reduce_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_custom_policy_hub.cu
@@ -15,7 +15,7 @@
 #include <cuda/std/functional>
 
 #include "catch2_test_device_reduce.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -31,7 +31,7 @@ struct my_policy_hub
   };
 };
 
-C2H_TEST("DispatchSegmentedReduce::Dispatch: custom policy hub", "[segmented][reduce][device]")
+CUB_TEST("DispatchSegmentedReduce::Dispatch: custom policy hub", "[segmented][reduce][device]", CUB_SMALL)
 {
   using input_t     = int;
   using output_t    = int;

--- a/cub/test/catch2_test_device_segmented_reduce_env.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env.cu
@@ -27,7 +27,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::ArgMax, device_segmented_redu
 
 #include <cuda/__execution/require.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
@@ -35,7 +35,7 @@ namespace stdexec = cuda::std::execution;
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("Device segmented reduce works with default environment", "[segmented_reduce][device]")
+CUB_TEST_CASE("Device segmented reduce works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -51,7 +51,7 @@ TEST_CASE("Device segmented reduce works with default environment", "[segmented_
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented sum works with default environment", "[segmented_reduce][device]")
+CUB_TEST_CASE("Device segmented sum works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -67,7 +67,7 @@ TEST_CASE("Device segmented sum works with default environment", "[segmented_red
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented min works with default environment", "[segmented_reduce][device]")
+CUB_TEST_CASE("Device segmented min works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -83,7 +83,7 @@ TEST_CASE("Device segmented min works with default environment", "[segmented_red
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented max works with default environment", "[segmented_reduce][device]")
+CUB_TEST_CASE("Device segmented max works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -99,7 +99,7 @@ TEST_CASE("Device segmented max works with default environment", "[segmented_red
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented argmin works with default environment", "[segmented_reduce][device]")
+CUB_TEST_CASE("Device segmented argmin works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -120,7 +120,7 @@ TEST_CASE("Device segmented argmin works with default environment", "[segmented_
   REQUIRE(h_out[2].value == 1);
 }
 
-TEST_CASE("Device segmented argmax works with default environment", "[segmented_reduce][device]")
+CUB_TEST_CASE("Device segmented argmax works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -141,7 +141,9 @@ TEST_CASE("Device segmented argmax works with default environment", "[segmented_
   REQUIRE(h_out[2].value == 2);
 }
 
-TEST_CASE("Device fixed-size segmented reduce works with default environment", "[segmented_reduce][device]")
+CUB_TEST_CASE("Device fixed-size segmented reduce works with default environment",
+              "[segmented_reduce][device]",
+              CUB_SMALL)
 {
   int num_segments = 2;
   int segment_size = 3;
@@ -156,7 +158,7 @@ TEST_CASE("Device fixed-size segmented reduce works with default environment", "
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device fixed-size segmented sum works with default environment", "[segmented_reduce][device]")
+CUB_TEST_CASE("Device fixed-size segmented sum works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments = 2;
   int segment_size = 3;
@@ -169,7 +171,7 @@ TEST_CASE("Device fixed-size segmented sum works with default environment", "[se
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device fixed-size segmented min works with default environment", "[segmented_reduce][device]")
+CUB_TEST_CASE("Device fixed-size segmented min works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments = 2;
   int segment_size = 3;
@@ -182,7 +184,7 @@ TEST_CASE("Device fixed-size segmented min works with default environment", "[se
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device fixed-size segmented max works with default environment", "[segmented_reduce][device]")
+CUB_TEST_CASE("Device fixed-size segmented max works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments = 2;
   int segment_size = 3;
@@ -195,7 +197,9 @@ TEST_CASE("Device fixed-size segmented max works with default environment", "[se
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device fixed-size segmented argmin works with default environment", "[segmented_reduce][device]")
+CUB_TEST_CASE("Device fixed-size segmented argmin works with default environment",
+              "[segmented_reduce][device]",
+              CUB_SMALL)
 {
   int num_segments = 2;
   int segment_size = 3;
@@ -208,7 +212,9 @@ TEST_CASE("Device fixed-size segmented argmin works with default environment", "
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device fixed-size segmented argmax works with default environment", "[segmented_reduce][device]")
+CUB_TEST_CASE("Device fixed-size segmented argmax works with default environment",
+              "[segmented_reduce][device]",
+              CUB_SMALL)
 {
   int num_segments = 2;
   int segment_size = 3;
@@ -223,7 +229,7 @@ TEST_CASE("Device fixed-size segmented argmax works with default environment", "
 
 #endif
 
-C2H_TEST("Device segmented reduce uses environment", "[segmented_reduce][device]")
+CUB_TEST("Device segmented reduce uses environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -254,7 +260,7 @@ C2H_TEST("Device segmented reduce uses environment", "[segmented_reduce][device]
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented sum uses environment", "[segmented_reduce][device]")
+CUB_TEST("Device segmented sum uses environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -276,7 +282,7 @@ C2H_TEST("Device segmented sum uses environment", "[segmented_reduce][device]")
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented min uses environment", "[segmented_reduce][device]")
+CUB_TEST("Device segmented min uses environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -298,7 +304,7 @@ C2H_TEST("Device segmented min uses environment", "[segmented_reduce][device]")
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented max uses environment", "[segmented_reduce][device]")
+CUB_TEST("Device segmented max uses environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -320,7 +326,7 @@ C2H_TEST("Device segmented max uses environment", "[segmented_reduce][device]")
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented argmin uses environment", "[segmented_reduce][device]")
+CUB_TEST("Device segmented argmin uses environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -342,7 +348,7 @@ C2H_TEST("Device segmented argmin uses environment", "[segmented_reduce][device]
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented argmax uses environment", "[segmented_reduce][device]")
+CUB_TEST("Device segmented argmax uses environment", "[segmented_reduce][device]", CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -382,7 +388,7 @@ using block_sizes = c2h::type_list<cuda::std::integral_constant<int, 64>, cuda::
 
 #if TEST_LAUNCH != 1
 
-C2H_TEST("DeviceSegmentedReduce::Reduce can be tuned", "[segmented_reduce][device]", block_sizes)
+CUB_TEST("DeviceSegmentedReduce::Reduce can be tuned", "[segmented_reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -405,7 +411,7 @@ C2H_TEST("DeviceSegmentedReduce::Reduce can be tuned", "[segmented_reduce][devic
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Fixed-size DeviceSegmentedReduce::Reduce can be tuned", "[segmented_reduce][device]", block_sizes)
+CUB_TEST("Fixed-size DeviceSegmentedReduce::Reduce can be tuned", "[segmented_reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -426,7 +432,7 @@ C2H_TEST("Fixed-size DeviceSegmentedReduce::Reduce can be tuned", "[segmented_re
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedReduce::Sum can be tuned", "[segmented_reduce][device]", block_sizes)
+CUB_TEST("DeviceSegmentedReduce::Sum can be tuned", "[segmented_reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -449,7 +455,7 @@ C2H_TEST("DeviceSegmentedReduce::Sum can be tuned", "[segmented_reduce][device]"
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Fixed-size DeviceSegmentedReduce::Sum can be tuned", "[segmented_reduce][device]", block_sizes)
+CUB_TEST("Fixed-size DeviceSegmentedReduce::Sum can be tuned", "[segmented_reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -471,7 +477,7 @@ C2H_TEST("Fixed-size DeviceSegmentedReduce::Sum can be tuned", "[segmented_reduc
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedReduce::Min can be tuned", "[segmented_reduce][device]", block_sizes)
+CUB_TEST("DeviceSegmentedReduce::Min can be tuned", "[segmented_reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -491,7 +497,7 @@ C2H_TEST("DeviceSegmentedReduce::Min can be tuned", "[segmented_reduce][device]"
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Fixed-size DeviceSegmentedReduce::Min can be tuned", "[segmented_reduce][device]", block_sizes)
+CUB_TEST("Fixed-size DeviceSegmentedReduce::Min can be tuned", "[segmented_reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -510,7 +516,7 @@ C2H_TEST("Fixed-size DeviceSegmentedReduce::Min can be tuned", "[segmented_reduc
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedReduce::Max can be tuned", "[segmented_reduce][device]", block_sizes)
+CUB_TEST("DeviceSegmentedReduce::Max can be tuned", "[segmented_reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -530,7 +536,7 @@ C2H_TEST("DeviceSegmentedReduce::Max can be tuned", "[segmented_reduce][device]"
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Fixed-size DeviceSegmentedReduce::Max can be tuned", "[segmented_reduce][device]", block_sizes)
+CUB_TEST("Fixed-size DeviceSegmentedReduce::Max can be tuned", "[segmented_reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -549,7 +555,7 @@ C2H_TEST("Fixed-size DeviceSegmentedReduce::Max can be tuned", "[segmented_reduc
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedReduce::ArgMin can be tuned", "[segmented_reduce][device]", block_sizes)
+CUB_TEST("DeviceSegmentedReduce::ArgMin can be tuned", "[segmented_reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -573,7 +579,7 @@ C2H_TEST("DeviceSegmentedReduce::ArgMin can be tuned", "[segmented_reduce][devic
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Fixed-size DeviceSegmentedReduce::ArgMin can be tuned", "[segmented_reduce][device]", block_sizes)
+CUB_TEST("Fixed-size DeviceSegmentedReduce::ArgMin can be tuned", "[segmented_reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -592,7 +598,7 @@ C2H_TEST("Fixed-size DeviceSegmentedReduce::ArgMin can be tuned", "[segmented_re
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_reduce][device]", block_sizes)
+CUB_TEST("DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -616,7 +622,7 @@ C2H_TEST("DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_reduce][devic
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Fixed-size DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_reduce][device]", block_sizes)
+CUB_TEST("Fixed-size DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_reduce][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
@@ -638,7 +644,7 @@ C2H_TEST("Fixed-size DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_re
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test SegmentedReducePolicy properties", "[segmented_reduce][device]")
+CUB_TEST("Test SegmentedReducePolicy properties", "[segmented_reduce][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::SegmentedReducePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedReducePolicy>);

--- a/cub/test/catch2_test_device_segmented_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env_api.cu
@@ -14,10 +14,11 @@
 #include <cuda/devices>
 #include <cuda/stream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts env with stream and determinism requirements",
-         "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts env with stream and determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   // example-begin segmented-reduce-sum-env
   int num_segments                     = 3;
@@ -46,7 +47,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts env with stream and determinis
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts stream", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts stream", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-sum-env-stream
   int num_segments                     = 3;
@@ -73,7 +74,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts stream", "[segmented_reduce][e
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts run_to_run determinism requirements", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts run_to_run determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   // example-begin segmented-reduce-sum-env-determinism
   int num_segments                     = 3;
@@ -98,7 +101,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts run_to_run determinism require
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts not_guaranteed determinism requirements", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts not_guaranteed determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   // example-begin segmented-reduce-sum-env-non-determinism
   int num_segments                     = 3;
@@ -123,7 +128,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts not_guaranteed determinism req
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Reduce env-based API", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Reduce env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-reduce-env
   int num_segments                     = 3;
@@ -150,7 +155,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce env-based API", "[segmented_reduce]
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Min env-based API", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Min env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-min-env
   int num_segments                     = 3;
@@ -177,7 +182,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min env-based API", "[segmented_reduce][en
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Max env-based API", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Max env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-max-env
   int num_segments                     = 3;
@@ -204,7 +209,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max env-based API", "[segmented_reduce][en
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::ArgMin env-based API", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMin env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-argmin-env
   int num_segments                     = 3;
@@ -230,7 +235,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMin env-based API", "[segmented_reduce]
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::ArgMax env-based API", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMax env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-argmax-env
   int num_segments                     = 3;
@@ -256,7 +261,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMax env-based API", "[segmented_reduce]
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Min accepts run_to_run determinism requirements", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Min accepts run_to_run determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
@@ -274,7 +281,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min accepts run_to_run determinism require
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Min accepts not_guaranteed determinism requirements", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Min accepts not_guaranteed determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
@@ -292,7 +301,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min accepts not_guaranteed determinism req
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Max accepts run_to_run determinism requirements", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Max accepts run_to_run determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
@@ -310,7 +321,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max accepts run_to_run determinism require
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Max accepts not_guaranteed determinism requirements", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Max accepts not_guaranteed determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
@@ -328,7 +341,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max accepts not_guaranteed determinism req
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::ArgMin accepts run_to_run determinism requirements", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMin accepts run_to_run determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
@@ -347,8 +362,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMin accepts run_to_run determinism requ
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::ArgMin accepts not_guaranteed determinism requirements",
-         "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMin accepts not_guaranteed determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
@@ -367,7 +383,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMin accepts not_guaranteed determinism 
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::ArgMax accepts run_to_run determinism requirements", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMax accepts run_to_run determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
@@ -386,8 +404,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMax accepts run_to_run determinism requ
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::ArgMax accepts not_guaranteed determinism requirements",
-         "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMax accepts not_guaranteed determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
@@ -406,7 +425,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMax accepts not_guaranteed determinism 
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Reduce accepts run_to_run determinism requirements", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Reduce accepts run_to_run determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   // example-begin segmented-reduce-reduce-env-determinism
   int num_segments                     = 3;
@@ -431,8 +452,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce accepts run_to_run determinism requ
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Reduce accepts not_guaranteed determinism requirements",
-         "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Reduce accepts not_guaranteed determinism requirements",
+         "[segmented_reduce][env]",
+         CUB_SMALL)
 {
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
@@ -454,7 +476,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce accepts not_guaranteed determinism 
   REQUIRE(d_out == expected);
   REQUIRE(error == cudaSuccess);
 }
-C2H_TEST("cub::DeviceSegmentedReduce::Reduce fixed-size env-based API", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Reduce fixed-size env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-reduce-env
   int num_segments = 2;
@@ -480,7 +502,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce fixed-size env-based API", "[segmen
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Sum fixed-size env-based API", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Sum fixed-size env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-sum-env
   int num_segments = 2;
@@ -505,7 +527,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum fixed-size env-based API", "[segmented
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Min fixed-size env-based API", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Min fixed-size env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-min-env
   int num_segments = 2;
@@ -530,7 +552,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min fixed-size env-based API", "[segmented
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::Max fixed-size env-based API", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Max fixed-size env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-max-env
   int num_segments = 2;
@@ -555,7 +577,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max fixed-size env-based API", "[segmented
   REQUIRE(error == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::ArgMin fixed-size env-based API", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMin fixed-size env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-argmin-env
   int num_segments = 2;
@@ -579,7 +601,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMin fixed-size env-based API", "[segmen
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedReduce::ArgMax fixed-size env-based API", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMax fixed-size env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-argmax-env
   int num_segments = 2;
@@ -632,7 +654,7 @@ struct SegmentedReducePolicySelector
 };
 // example-end segmented-reduce-sum-policy-selector
 
-C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts a custom policy selector", "[segmented_reduce][env]")
+CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts a custom policy selector", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-sum-tuning
   int num_segments                     = 3;

--- a/cub/test/catch2_test_device_segmented_reduce_iterators.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_iterators.cu
@@ -11,7 +11,7 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::Reduce, device_segmented_reduce);
@@ -24,7 +24,11 @@ using custom_t           = c2h::custom_type_t<c2h::accumulateable_t, c2h::equal_
 using iterator_type_list = c2h::type_list<type_pair<custom_t>, type_pair<std::int64_t>>;
 using offsets            = c2h::type_list<std::int32_t, std::uint32_t>;
 
-C2H_TEST("Device segmented reduce works with fancy input iterators", "[reduce][device]", iterator_type_list, offsets)
+CUB_TEST("Device segmented reduce works with fancy input iterators",
+         "[reduce][device]",
+         CUB_SMALL,
+         iterator_type_list,
+         offsets)
 {
   using type_pair_t = typename c2h::get<0, TestType>;
   using item_t      = typename type_pair_t::input_t;

--- a/cub/test/catch2_test_device_segmented_reduce_iterators_64bit.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_iterators_64bit.cu
@@ -10,7 +10,7 @@
 #include <cstdint>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::Reduce, device_segmented_reduce);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::Sum, device_segmented_sum);
@@ -20,7 +20,8 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::Sum, device_segmented_sum);
 // List of types to test
 using offsets = c2h::type_list<std::ptrdiff_t, std::size_t>;
 
-C2H_TEST("Device segmented reduce works with fancy input iterators and 64-bit offsets", "[reduce][device]", offsets)
+CUB_TEST(
+  "Device segmented reduce works with fancy input iterators and 64-bit offsets", "[reduce][device]", CUB_SMALL, offsets)
 {
   using offset_t = typename c2h::get<0, TestType>;
   using op_t     = cuda::std::plus<>;

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -12,7 +12,7 @@
 #include "catch2_large_problem_helper.cuh"
 #include "catch2_segmented_sort_helper.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <catch2/generators/catch_generators.hpp>
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::Reduce, device_segmented_reduce);
@@ -79,7 +79,7 @@ struct custom_sum_op
   }
 };
 
-C2H_TEST("Device reduce works with a very large number of segments", "[reduce][device]")
+CUB_TEST("Device reduce works with a very large number of segments", "[reduce][device]", CUB_SMALL)
 {
   using offset_t        = cuda::std::int64_t;
   using segment_index_t = cuda::std::int64_t;
@@ -284,7 +284,7 @@ void test_fixed_size_segmented_reduce(
   }
 }
 
-C2H_TEST("Device fixed size segmented reduce works with a very large number of segments", "[reduce][device]")
+CUB_TEST("Device fixed size segmented reduce works with a very large number of segments", "[reduce][device]", CUB_SMALL)
 {
   using segment_index_t = cuda::std::int64_t;
   using offset_t        = segment_index_t;

--- a/cub/test/catch2_test_device_segmented_reduce_max_seg_size.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_max_seg_size.cu
@@ -9,7 +9,7 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // only lid 0 is enabled, as this test only tests max_segment_size functionality through dispatch directly
 
@@ -18,8 +18,9 @@
 using full_type_list = c2h::type_list<uint8_t, int16_t, uint32_t, int64_t>;
 using offsets        = c2h::type_list<std::int32_t, std::uint64_t>;
 
-C2H_TEST("Device segmented reduce works with dynamic max segment sizes",
+CUB_TEST("Device segmented reduce works with dynamic max segment sizes",
          "[segmented][reduce][device]",
+         CUB_SMALL,
          full_type_list,
          offsets)
 {

--- a/cub/test/catch2_test_device_segmented_scan.cu
+++ b/cub/test/catch2_test_device_segmented_scan.cu
@@ -12,7 +12,7 @@
 #include "catch2_test_device_reduce.cuh" // for reference_extended_fp
 #include "catch2_test_device_scan.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 #include <c2h/extended_types.h>
 
@@ -111,7 +111,11 @@ bool check_segment(const c2h::host_vector<ValueT>& h_output,
 
 using offsets = c2h::type_list<std::int32_t, std::uint64_t>;
 
-C2H_TEST("Device segmented_scan works with all device interfaces", "[segmented][scan][device]", full_type_list, offsets)
+CUB_TEST("Device segmented_scan works with all device interfaces",
+         "[segmented][scan][device]",
+         CUB_SMALL,
+         full_type_list,
+         offsets)
 {
   using params   = params_t<TestType>;
   using input_t  = typename params::item_t;

--- a/cub/test/catch2_test_device_segmented_scan_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_api.cu
@@ -18,7 +18,7 @@
 #include <vector>
 
 #include "catch2_test_device_scan.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 void check_execution_status(cudaError_t status, const std::string& algo_name)
 {
@@ -28,8 +28,9 @@ void check_execution_status(cudaError_t status, const std::string& algo_name)
   }
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum API with two offsets works",
-         "[segmented][exclusive_sum][two_offsets]")
+CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum API with two offsets works",
+         "[segmented][exclusive_sum][two_offsets]",
+         CUB_SMALL)
 {
   const std::string& algo_name = "cub::DeviceSegmentedScan::ExclusiveSegmentedSum[2 offsets]";
 
@@ -79,8 +80,9 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum API with two offsets w
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum API with three offsets works",
-         "[segmented][exclusive_sum][three_offsets]")
+CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum API with three offsets works",
+         "[segmented][exclusive_sum][three_offsets]",
+         CUB_SMALL)
 {
   const std::string& algo_name = "cub::DeviceSegmentedScan::ExclusiveSegmentedSum[3 offsets]";
 
@@ -145,8 +147,9 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum API with three offsets
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum API with two offsets works inplace",
-         "[segmented][inclusive_sum][two_offsets]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum API with two offsets works inplace",
+         "[segmented][inclusive_sum][two_offsets]",
+         CUB_SMALL)
 {
   const std::string& algo_name = "cub::DeviceSegmentedScan::InclusiveSegmentedSum[2 offsets]";
   // example-begin inclusive-segmented-sum-two-offsets
@@ -195,8 +198,9 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum API with two offsets w
   REQUIRE(input == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum API with three offsets works",
-         "[segmented][inclusive_sum][three_offsets]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum API with three offsets works",
+         "[segmented][inclusive_sum][three_offsets]",
+         CUB_SMALL)
 {
   const std::string& algo_name = "cub::DeviceSegmentedScan::InclusiveSegmentedSum[3 offsets]";
   // example-begin inclusive-segmented-sum-three-offsets
@@ -267,8 +271,9 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum API with three offsets
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit API with two offsets works",
-         "[segmented][inclusive_scan_init][two_offsets]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit API with two offsets works",
+         "[segmented][inclusive_scan_init][two_offsets]",
+         CUB_SMALL)
 {
   const std::string& algo_name = "cub::DeviceSegmentedScan::InclusiveSegmentedScanInit[2 offsets]";
   // example-begin inclusive-segmented-scan-init-two-offsets
@@ -329,8 +334,9 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit API with two offs
   REQUIRE(expected == output);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan API with two offsets works",
-         "[segmented][exclusive_scan][two-offsets]")
+CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan API with two offsets works",
+         "[segmented][exclusive_scan][two-offsets]",
+         CUB_SMALL)
 {
   const std::string& algo_name = "cub::DeviceSegmentedScan::ExclusiveSegmentedScan[2 offsets]";
   auto input                   = thrust::device_vector<unsigned>{
@@ -404,8 +410,9 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan API with two offsets 
   REQUIRE(output == h_input);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan API with three offsets works",
-         "[segmented][exclusive_scan][three-offsets]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan API with three offsets works",
+         "[segmented][exclusive_scan][three-offsets]",
+         CUB_SMALL)
 
 {
   /*
@@ -466,8 +473,9 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan API with three offset
   REQUIRE(status == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env overload is not ambiguous (2 offsets)",
-         "[segmented_scan][device]")
+CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env overload is not ambiguous (2 offsets)",
+         "[segmented_scan][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -477,8 +485,9 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env overload is no
     nullptr, temp_storage_bytes, in.begin(), out.begin(), offsets.begin(), offsets.begin() + 1, 1);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env overload is not ambiguous (3 offsets)",
-         "[segmented_scan][device]")
+CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env overload is not ambiguous (3 offsets)",
+         "[segmented_scan][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -496,8 +505,9 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env overload is no
     1);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env overload is not ambiguous (2 offsets)",
-         "[segmented_scan][device]")
+CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env overload is not ambiguous (2 offsets)",
+         "[segmented_scan][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -515,8 +525,9 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env overload is n
     5);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env overload is not ambiguous (3 offsets)",
-         "[segmented_scan][device]")
+CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env overload is not ambiguous (3 offsets)",
+         "[segmented_scan][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -536,8 +547,9 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env overload is n
     5);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env overload is not ambiguous (2 offsets)",
-         "[segmented_scan][device]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env overload is not ambiguous (2 offsets)",
+         "[segmented_scan][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -547,8 +559,9 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env overload is no
     nullptr, temp_storage_bytes, in.begin(), out.begin(), offsets.begin(), offsets.begin() + 1, 1);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env overload is not ambiguous (3 offsets)",
-         "[segmented_scan][device]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env overload is not ambiguous (3 offsets)",
+         "[segmented_scan][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -566,8 +579,9 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env overload is no
     1);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env overload is not ambiguous (2 offsets)",
-         "[segmented_scan][device]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env overload is not ambiguous (2 offsets)",
+         "[segmented_scan][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -577,8 +591,9 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env overload is n
     nullptr, temp_storage_bytes, in.begin(), out.begin(), offsets.begin(), offsets.begin() + 1, 1, cuda::std::plus<>{});
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env overload is not ambiguous (3 offsets)",
-         "[segmented_scan][device]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env overload is not ambiguous (3 offsets)",
+         "[segmented_scan][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -597,8 +612,9 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env overload is n
     cuda::std::plus<>{});
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit non-env overload is not ambiguous (2 offsets)",
-         "[segmented_scan][device]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit non-env overload is not ambiguous (2 offsets)",
+         "[segmented_scan][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -616,8 +632,9 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit non-env overload 
     5);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit non-env overload is not ambiguous (3 offsets)",
-         "[segmented_scan][device]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit non-env overload is not ambiguous (3 offsets)",
+         "[segmented_scan][device]",
+         CUB_SMALL)
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);

--- a/cub/test/catch2_test_device_segmented_scan_env.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env.cu
@@ -28,7 +28,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedScan::InclusiveSegmentedScanInit, dev
 #include <cuda/__execution/require.h>
 #include <cuda/__execution/tune.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
@@ -38,7 +38,7 @@ namespace stdexec = cuda::std::execution;
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("Device segmented exclusive sum works with default environment", "[segmented_scan][device]")
+CUB_TEST_CASE("Device segmented exclusive sum works with default environment", "[segmented_scan][device]", CUB_SMALL)
 {
   ::cuda::std::int64_t num_segments    = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -54,7 +54,7 @@ TEST_CASE("Device segmented exclusive sum works with default environment", "[seg
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented exclusive scan works with default environment", "[segmented_scan][device]")
+CUB_TEST_CASE("Device segmented exclusive scan works with default environment", "[segmented_scan][device]", CUB_SMALL)
 {
   ::cuda::std::int64_t num_segments    = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -70,7 +70,7 @@ TEST_CASE("Device segmented exclusive scan works with default environment", "[se
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented inclusive sum works with default environment", "[segmented_scan][device]")
+CUB_TEST_CASE("Device segmented inclusive sum works with default environment", "[segmented_scan][device]", CUB_SMALL)
 {
   ::cuda::std::int64_t num_segments    = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -86,7 +86,7 @@ TEST_CASE("Device segmented inclusive sum works with default environment", "[seg
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented inclusive scan works with default environment", "[segmented_scan][device]")
+CUB_TEST_CASE("Device segmented inclusive scan works with default environment", "[segmented_scan][device]", CUB_SMALL)
 {
   ::cuda::std::int64_t num_segments    = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -102,7 +102,9 @@ TEST_CASE("Device segmented inclusive scan works with default environment", "[se
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented inclusive scan init works with default environment", "[segmented_scan][device]")
+CUB_TEST_CASE("Device segmented inclusive scan init works with default environment",
+              "[segmented_scan][device]",
+              CUB_SMALL)
 {
   ::cuda::std::int64_t num_segments    = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -118,8 +120,9 @@ TEST_CASE("Device segmented inclusive scan init works with default environment",
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented exclusive sum with separate offsets works with default environment",
-          "[segmented_scan][device]")
+CUB_TEST_CASE("Device segmented exclusive sum with separate offsets works with default environment",
+              "[segmented_scan][device]",
+              CUB_SMALL)
 {
   const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
@@ -138,8 +141,9 @@ TEST_CASE("Device segmented exclusive sum with separate offsets works with defau
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented exclusive scan with separate offsets works with default environment",
-          "[segmented_scan][device]")
+CUB_TEST_CASE("Device segmented exclusive scan with separate offsets works with default environment",
+              "[segmented_scan][device]",
+              CUB_SMALL)
 {
   const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
@@ -159,8 +163,9 @@ TEST_CASE("Device segmented exclusive scan with separate offsets works with defa
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented inclusive sum with separate offsets works with default environment",
-          "[segmented_scan][device]")
+CUB_TEST_CASE("Device segmented inclusive sum with separate offsets works with default environment",
+              "[segmented_scan][device]",
+              CUB_SMALL)
 {
   const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
@@ -179,8 +184,9 @@ TEST_CASE("Device segmented inclusive sum with separate offsets works with defau
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented inclusive scan with separate offsets works with default environment",
-          "[segmented_scan][device]")
+CUB_TEST_CASE("Device segmented inclusive scan with separate offsets works with default environment",
+              "[segmented_scan][device]",
+              CUB_SMALL)
 {
   const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
@@ -200,8 +206,9 @@ TEST_CASE("Device segmented inclusive scan with separate offsets works with defa
   REQUIRE(d_out == expected);
 }
 
-TEST_CASE("Device segmented inclusive scan init with separate offsets works with default environment",
-          "[segmented_scan][device]")
+CUB_TEST_CASE("Device segmented inclusive scan init with separate offsets works with default environment",
+              "[segmented_scan][device]",
+              CUB_SMALL)
 {
   const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
@@ -223,7 +230,7 @@ TEST_CASE("Device segmented inclusive scan init with separate offsets works with
 
 #endif
 
-C2H_TEST("Device segmented exclusive sum uses environment", "[segmented_scan][device]")
+CUB_TEST("Device segmented exclusive sum uses environment", "[segmented_scan][device]", CUB_SMALL)
 {
   ::cuda::std::int64_t num_segments    = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -245,7 +252,7 @@ C2H_TEST("Device segmented exclusive sum uses environment", "[segmented_scan][de
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented exclusive scan uses environment", "[segmented_scan][device]")
+CUB_TEST("Device segmented exclusive scan uses environment", "[segmented_scan][device]", CUB_SMALL)
 {
   ::cuda::std::int64_t num_segments    = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -276,7 +283,7 @@ C2H_TEST("Device segmented exclusive scan uses environment", "[segmented_scan][d
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented inclusive sum uses environment", "[segmented_scan][device]")
+CUB_TEST("Device segmented inclusive sum uses environment", "[segmented_scan][device]", CUB_SMALL)
 {
   ::cuda::std::int64_t num_segments    = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -298,7 +305,7 @@ C2H_TEST("Device segmented inclusive sum uses environment", "[segmented_scan][de
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented inclusive scan uses environment", "[segmented_scan][device]")
+CUB_TEST("Device segmented inclusive scan uses environment", "[segmented_scan][device]", CUB_SMALL)
 {
   ::cuda::std::int64_t num_segments    = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -328,7 +335,7 @@ C2H_TEST("Device segmented inclusive scan uses environment", "[segmented_scan][d
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented inclusive scan init uses environment", "[segmented_scan][device]")
+CUB_TEST("Device segmented inclusive scan init uses environment", "[segmented_scan][device]", CUB_SMALL)
 {
   ::cuda::std::int64_t num_segments    = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
@@ -359,7 +366,7 @@ C2H_TEST("Device segmented inclusive scan init uses environment", "[segmented_sc
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented exclusive sum with separate offsets uses environment", "[segmented_scan][device]")
+CUB_TEST("Device segmented exclusive sum with separate offsets uses environment", "[segmented_scan][device]", CUB_SMALL)
 {
   const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
@@ -392,7 +399,7 @@ C2H_TEST("Device segmented exclusive sum with separate offsets uses environment"
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented exclusive scan with separate offsets uses environment", "[segmented_scan][device]")
+CUB_TEST("Device segmented exclusive scan with separate offsets uses environment", "[segmented_scan][device]", CUB_SMALL)
 {
   const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
@@ -435,7 +442,7 @@ C2H_TEST("Device segmented exclusive scan with separate offsets uses environment
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented inclusive sum with separate offsets uses environment", "[segmented_scan][device]")
+CUB_TEST("Device segmented inclusive sum with separate offsets uses environment", "[segmented_scan][device]", CUB_SMALL)
 {
   const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
@@ -468,7 +475,7 @@ C2H_TEST("Device segmented inclusive sum with separate offsets uses environment"
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented inclusive scan with separate offsets uses environment", "[segmented_scan][device]")
+CUB_TEST("Device segmented inclusive scan with separate offsets uses environment", "[segmented_scan][device]", CUB_SMALL)
 {
   const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
@@ -502,7 +509,9 @@ C2H_TEST("Device segmented inclusive scan with separate offsets uses environment
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("Device segmented inclusive scan init with separate offsets uses environment", "[segmented_scan][device]")
+CUB_TEST("Device segmented inclusive scan init with separate offsets uses environment",
+         "[segmented_scan][device]",
+         CUB_SMALL)
 {
   const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
@@ -572,7 +581,7 @@ using block_sizes =
 // (block_size_extracting_constant_iterator). The "Scan" APIs take a user scan operator, so we wrap a plus<> in
 // block_size_extracting_op which both records the block size and computes the expected result.
 
-C2H_TEST("Device segmented exclusive sum can be tuned", "[segmented_scan][device]", block_sizes)
+CUB_TEST("Device segmented exclusive sum can be tuned", "[segmented_scan][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   ::cuda::std::int64_t num_segments        = 3;
@@ -587,7 +596,7 @@ C2H_TEST("Device segmented exclusive sum can be tuned", "[segmented_scan][device
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device segmented inclusive sum can be tuned", "[segmented_scan][device]", block_sizes)
+CUB_TEST("Device segmented inclusive sum can be tuned", "[segmented_scan][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   ::cuda::std::int64_t num_segments        = 3;
@@ -602,7 +611,7 @@ C2H_TEST("Device segmented inclusive sum can be tuned", "[segmented_scan][device
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device segmented exclusive scan can be tuned", "[segmented_scan][device]", block_sizes)
+CUB_TEST("Device segmented exclusive scan can be tuned", "[segmented_scan][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   ::cuda::std::int64_t num_segments        = 3;
@@ -622,7 +631,7 @@ C2H_TEST("Device segmented exclusive scan can be tuned", "[segmented_scan][devic
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device segmented inclusive scan can be tuned", "[segmented_scan][device]", block_sizes)
+CUB_TEST("Device segmented inclusive scan can be tuned", "[segmented_scan][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   ::cuda::std::int64_t num_segments        = 3;
@@ -642,7 +651,7 @@ C2H_TEST("Device segmented inclusive scan can be tuned", "[segmented_scan][devic
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("Device segmented inclusive scan init can be tuned", "[segmented_scan][device]", block_sizes)
+CUB_TEST("Device segmented inclusive scan init can be tuned", "[segmented_scan][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   ::cuda::std::int64_t num_segments        = 3;
@@ -665,7 +674,7 @@ C2H_TEST("Device segmented inclusive scan init can be tuned", "[segmented_scan][
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test SegmentedScanPolicy properties", "[segmented_scan][device]")
+CUB_TEST("Test SegmentedScanPolicy properties", "[segmented_scan][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::SegmentedScanPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedScanPolicy>);

--- a/cub/test/catch2_test_device_segmented_scan_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env_api.cu
@@ -14,9 +14,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum accepts stream", "[segmented_scan][env]")
+CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum accepts stream", "[segmented_scan][env]", CUB_SMALL)
 {
   // example-begin exclusive-segmented-sum-env
   ::cuda::std::int64_t num_segments    = 3;
@@ -43,7 +43,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum accepts stream", "[seg
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan accepts stream", "[segmented_scan][env]")
+CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan accepts stream", "[segmented_scan][env]", CUB_SMALL)
 {
   // example-begin exclusive-segmented-scan-env
   ::cuda::std::int64_t num_segments    = 3;
@@ -70,7 +70,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan accepts stream", "[se
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum accepts stream", "[segmented_scan][env]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum accepts stream", "[segmented_scan][env]", CUB_SMALL)
 {
   // example-begin inclusive-segmented-sum-env
   ::cuda::std::int64_t num_segments    = 3;
@@ -97,7 +97,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum accepts stream", "[seg
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan accepts stream", "[segmented_scan][env]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan accepts stream", "[segmented_scan][env]", CUB_SMALL)
 {
   // example-begin inclusive-segmented-scan-env
   ::cuda::std::int64_t num_segments    = 3;
@@ -124,7 +124,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan accepts stream", "[se
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit accepts stream", "[segmented_scan][env]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit accepts stream", "[segmented_scan][env]", CUB_SMALL)
 {
   // example-begin inclusive-segmented-scan-init-env
   ::cuda::std::int64_t num_segments    = 3;
@@ -151,7 +151,9 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit accepts stream", 
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum (separate offsets) accepts stream", "[segmented_scan][env]")
+CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum (separate offsets) accepts stream",
+         "[segmented_scan][env]",
+         CUB_SMALL)
 {
   // example-begin exclusive-segmented-sum-separate-env
   const auto sentinel               = -1;
@@ -181,7 +183,9 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum (separate offsets) acc
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) accepts stream", "[segmented_scan][env]")
+CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) accepts stream",
+         "[segmented_scan][env]",
+         CUB_SMALL)
 {
   // example-begin exclusive-segmented-scan-separate-env
   const auto sentinel               = -1;
@@ -219,7 +223,9 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) ac
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum (separate offsets) accepts stream", "[segmented_scan][env]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum (separate offsets) accepts stream",
+         "[segmented_scan][env]",
+         CUB_SMALL)
 {
   // example-begin inclusive-segmented-sum-separate-env
   const auto sentinel               = -1;
@@ -249,7 +255,9 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum (separate offsets) acc
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan (separate offsets) accepts stream", "[segmented_scan][env]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan (separate offsets) accepts stream",
+         "[segmented_scan][env]",
+         CUB_SMALL)
 {
   // example-begin inclusive-segmented-scan-separate-env
   const auto sentinel               = -1;
@@ -279,8 +287,9 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan (separate offsets) ac
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit (separate offsets) accepts stream",
-         "[segmented_scan][env]")
+CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit (separate offsets) accepts stream",
+         "[segmented_scan][env]",
+         CUB_SMALL)
 {
   // example-begin inclusive-segmented-scan-init-separate-env
   const auto sentinel               = -1;
@@ -336,7 +345,9 @@ struct SegmentedScanPolicySelector
 };
 // example-end segmented-scan-policy-selector
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan accepts a custom policy selector", "[segmented_scan][env]")
+CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan accepts a custom policy selector",
+         "[segmented_scan][env]",
+         CUB_SMALL)
 {
   // example-begin segmented-scan-tuning
   ::cuda::std::int64_t num_segments    = 3;

--- a/cub/test/catch2_test_device_segmented_scan_multi_segment.cu
+++ b/cub/test/catch2_test_device_segmented_scan_multi_segment.cu
@@ -18,6 +18,7 @@
 
 #include "catch2_test_device_scan.cuh"
 #include "catch2_test_launch_helper.h"
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -224,8 +225,9 @@ struct constant_value_op
 };
 } // namespace
 
-C2H_TEST("segmented inclusive scan works correctly for pairs with noncommutative op",
-         "[multi_segment][segmented][scan]")
+CUB_TEST("segmented inclusive scan works correctly for pairs with noncommutative op",
+         "[multi_segment][segmented][scan]",
+         CUB_SMALL)
 {
   using op_t     = impl::bicyclic_monoid_op<unsigned int>;
   using pair_t   = typename op_t::pair_t;
@@ -319,7 +321,8 @@ C2H_TEST("segmented inclusive scan works correctly for pairs with noncommutative
   }
 }
 
-C2H_TEST("segmented exclusive scan works for integer types", "[multi_segment][segmented][scan]", integral_types)
+CUB_TEST(
+  "segmented exclusive scan works for integer types", "[multi_segment][segmented][scan]", CUB_SMALL, integral_types)
 {
   using value_t  = c2h::get<0, TestType>;
   using op_t     = numeric_op<value_t>;
@@ -405,8 +408,9 @@ C2H_TEST("segmented exclusive scan works for integer types", "[multi_segment][se
   }
 }
 
-C2H_TEST("Segmented inclusive scan works correctly for integer types",
+CUB_TEST("Segmented inclusive scan works correctly for integer types",
          "[multi_segment][segmented][scan]",
+         CUB_SMALL,
          integral_types)
 {
   using value_t  = c2h::get<0, TestType>;
@@ -481,8 +485,9 @@ C2H_TEST("Segmented inclusive scan works correctly for integer types",
   }
 }
 
-C2H_TEST("Segmented inclusive scan with init works for integer types",
+CUB_TEST("Segmented inclusive scan with init works for integer types",
          "[multi_segment][segmented][scan]",
+         CUB_SMALL,
          integral_types)
 {
   using value_t  = c2h::get<0, TestType>;
@@ -608,7 +613,7 @@ make_in_out_offsets(const std::vector<OffsetT>& sizes, OffsetT gap)
   return {offsets, offsets_with_gaps};
 }
 
-C2H_TEST("Segmented inclusive scan skips empty segments", "[multi_segment][segmented][scan]", itp_list)
+CUB_TEST("Segmented inclusive scan skips empty segments", "[multi_segment][segmented][scan]", CUB_SMALL, itp_list)
 {
   using op_t     = cuda::std::plus<>;
   using value_t  = unsigned int;
@@ -700,7 +705,7 @@ C2H_TEST("Segmented inclusive scan skips empty segments", "[multi_segment][segme
   }
 }
 
-C2H_TEST("Segmented inclusive scan handles end_offset < begin_offset", "[multi_segment][segmented][scan]")
+CUB_TEST("Segmented inclusive scan handles end_offset < begin_offset", "[multi_segment][segmented][scan]", CUB_SMALL)
 {
   using op_t     = cuda::std::plus<>;
   using value_t  = unsigned int;
@@ -846,7 +851,7 @@ void run_dispatch_scan_iterator(
   );
 }
 
-C2H_TEST("segmented inclusive scan works correctly with fancy iterators", "[multi_segment][segmented][scan]")
+CUB_TEST("segmented inclusive scan works correctly with fancy iterators", "[multi_segment][segmented][scan]", CUB_SMALL)
 {
   using op_t     = cuda::std::plus<>;
   using value_t  = unsigned int;

--- a/cub/test/catch2_test_device_segmented_scan_noncommutative.cu
+++ b/cub/test/catch2_test_device_segmented_scan_noncommutative.cu
@@ -5,7 +5,7 @@
 
 #include <thrust/tabulate.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <catch2_test_device_scan.cuh>
 
 /* Consider free monoid with two generators, ``q`` and ``p``, modulo defining relationship (``p * q == 1``).
@@ -73,7 +73,7 @@ struct populate_input
 };
 }; // namespace impl
 
-C2H_TEST("Device inclusive segmented scan works with non-commutative operator", "[segmented][scan][device]")
+CUB_TEST("Device inclusive segmented scan works with non-commutative operator", "[segmented][scan][device]", CUB_SMALL)
 {
   using op_t   = impl::bicyclic_monoid_op<unsigned>;
   using pair_t = typename op_t::pair_t;

--- a/cub/test/catch2_test_device_segmented_sort_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_segmented_sort_custom_policy_hub.cu
@@ -14,7 +14,7 @@
 
 #include <algorithm>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -53,7 +53,7 @@ struct my_policy_hub
   };
 };
 
-C2H_TEST("DispatchSegmentedSort::Dispatch: custom policy hub", "[segmented][sort][device]")
+CUB_TEST("DispatchSegmentedSort::Dispatch: custom policy hub", "[segmented][sort][device]", CUB_SMALL)
 {
   using key_t                    = int;
   using value_t                  = NullType;

--- a/cub/test/catch2_test_device_segmented_sort_keys.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys.cu
@@ -10,8 +10,8 @@
 
 #include "catch2_radix_sort_helper.cuh"
 #include "catch2_segmented_sort_helper.cuh"
+#include "cub_test_macros.h"
 #include <c2h/bfloat16.cuh>
-#include <c2h/catch2_test_helper.h>
 #include <c2h/half.cuh>
 
 // FIXME: Graph launch disabled, algorithm syncs internally. WAR exists for device-launch, figure out how to enable for
@@ -39,7 +39,7 @@ using key_types =
 
 #if TEST_TYPES == 0
 
-C2H_TEST("DeviceSegmentedSortKeys: No segments", "[keys][segmented][sort][device]")
+CUB_TEST("DeviceSegmentedSortKeys: No segments", "[keys][segmented][sort][device]", CUB_SMALL)
 {
   // Type doesn't affect the escape logic, so it should be fine
   // to test only one set of types here.
@@ -72,7 +72,7 @@ C2H_TEST("DeviceSegmentedSortKeys: No segments", "[keys][segmented][sort][device
   REQUIRE(values_buffer.selector == 1);
 }
 
-C2H_TEST("DeviceSegmentedSortKeys: Empty segments", "[keys][segmented][sort][device]")
+CUB_TEST("DeviceSegmentedSortKeys: Empty segments", "[keys][segmented][sort][device]", CUB_SMALL)
 {
   // Type doesn't affect the escape logic, so it should be fine
   // to test only one set of types here.
@@ -111,8 +111,9 @@ C2H_TEST("DeviceSegmentedSortKeys: Empty segments", "[keys][segmented][sort][dev
 
 #endif // TEST_TYPES == 0
 
-C2H_TEST("DeviceSegmentedSortKeys: Same size segments, derived keys",
+CUB_TEST("DeviceSegmentedSortKeys: Same size segments, derived keys",
          "[keys][segmented][sort][device][skip-cs-racecheck]",
+         CUB_SMALL,
          key_types)
 {
   using KeyT = c2h::get<0, TestType>;
@@ -130,8 +131,9 @@ C2H_TEST("DeviceSegmentedSortKeys: Same size segments, derived keys",
   test_same_size_segments_derived<KeyT>(segment_size, segments);
 }
 
-C2H_TEST("DeviceSegmentedSortKeys: Randomly sized segments, derived keys",
+CUB_TEST("DeviceSegmentedSortKeys: Randomly sized segments, derived keys",
          "[keys][segmented][sort][device][skip-cs-racecheck]",
+         CUB_SMALL,
          key_types)
 {
   using KeyT = c2h::get<0, TestType>;
@@ -149,8 +151,9 @@ C2H_TEST("DeviceSegmentedSortKeys: Randomly sized segments, derived keys",
   test_random_size_segments_derived<KeyT>(C2H_SEED(1), max_items, max_segment, segments);
 }
 
-C2H_TEST("DeviceSegmentedSortKeys: Randomly sized segments, random keys",
+CUB_TEST("DeviceSegmentedSortKeys: Randomly sized segments, random keys",
          "[keys][segmented][sort][device][skip-cs-initcheck][skip-cs-racecheck]",
+         CUB_SMALL,
          key_types)
 {
   using KeyT = c2h::get<0, TestType>;
@@ -164,13 +167,15 @@ C2H_TEST("DeviceSegmentedSortKeys: Randomly sized segments, random keys",
   test_random_size_segments_random<KeyT>(C2H_SEED(1), max_items, max_segment, segments);
 }
 
-C2H_TEST("DeviceSegmentedSortKeys: Edge case segments, random keys", "[keys][segmented][sort][device]", key_types)
+CUB_TEST(
+  "DeviceSegmentedSortKeys: Edge case segments, random keys", "[keys][segmented][sort][device]", CUB_SMALL, key_types)
 {
   using KeyT = c2h::get<0, TestType>;
   test_edge_case_segments_random<KeyT>(C2H_SEED(4));
 }
 
-C2H_TEST("DeviceSegmentedSortKeys: Unspecified segments, random keys", "[keys][segmented][sort][device]", key_types)
+CUB_TEST(
+  "DeviceSegmentedSortKeys: Unspecified segments, random keys", "[keys][segmented][sort][device]", CUB_SMALL, key_types)
 {
   using KeyT = c2h::get<0, TestType>;
   test_unspecified_segments_random<KeyT>(C2H_SEED(4));
@@ -178,8 +183,9 @@ C2H_TEST("DeviceSegmentedSortKeys: Unspecified segments, random keys", "[keys][s
 
 #if TEST_TYPES == 0
 
-C2H_TEST("DeviceSegmentedSortKeys: very large number of segments",
+CUB_TEST("DeviceSegmentedSortKeys: very large number of segments",
          "[keys][segmented][sort][device][skip-cs-memcheck][skip-cs-racecheck][skip-cs-initcheck]",
+         CUB_LARGE,
          all_offset_types)
 try
 {
@@ -223,8 +229,9 @@ catch (std::bad_alloc& e)
   std::cerr << "Skipping segmented sort test, insufficient GPU memory. " << e.what() << "\n";
 }
 
-C2H_TEST("DeviceSegmentedSort::SortKeys: very large segments",
+CUB_TEST("DeviceSegmentedSort::SortKeys: very large segments",
          "[keys][segmented][sort][device][skip-cs-memcheck][skip-cs-racecheck][skip-cs-initcheck]",
+         CUB_LARGE,
          all_offset_types)
 try
 {

--- a/cub/test/catch2_test_device_segmented_sort_keys_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env.cu
@@ -24,13 +24,15 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedSort::StableSortKeysDescending, stabl
 
 // %PARAM% TEST_LAUNCH lid 0:1
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("DeviceSegmentedSort::SortKeys works with default environment", "[segmented_sort][keys][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::SortKeys works with default environment",
+              "[segmented_sort][keys][device]",
+              CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -50,7 +52,9 @@ TEST_CASE("DeviceSegmentedSort::SortKeys works with default environment", "[segm
   REQUIRE(keys_out == expected);
 }
 
-TEST_CASE("DeviceSegmentedSort::SortKeysDescending works with default environment", "[segmented_sort][keys][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::SortKeysDescending works with default environment",
+              "[segmented_sort][keys][device]",
+              CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -70,7 +74,9 @@ TEST_CASE("DeviceSegmentedSort::SortKeysDescending works with default environmen
   REQUIRE(keys_out == expected);
 }
 
-TEST_CASE("DeviceSegmentedSort::StableSortKeys works with default environment", "[segmented_sort][keys][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::StableSortKeys works with default environment",
+              "[segmented_sort][keys][device]",
+              CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -90,8 +96,9 @@ TEST_CASE("DeviceSegmentedSort::StableSortKeys works with default environment", 
   REQUIRE(keys_out == expected);
 }
 
-TEST_CASE("DeviceSegmentedSort::StableSortKeysDescending works with default environment",
-          "[segmented_sort][keys][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::StableSortKeysDescending works with default environment",
+              "[segmented_sort][keys][device]",
+              CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -111,7 +118,9 @@ TEST_CASE("DeviceSegmentedSort::StableSortKeysDescending works with default envi
   REQUIRE(keys_out == expected);
 }
 
-TEST_CASE("DeviceSegmentedSort::SortKeys DoubleBuffer works with default environment", "[segmented_sort][keys][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::SortKeys DoubleBuffer works with default environment",
+              "[segmented_sort][keys][device]",
+              CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1 = c2h::device_vector<int>(7);
@@ -132,8 +141,9 @@ TEST_CASE("DeviceSegmentedSort::SortKeys DoubleBuffer works with default environ
   REQUIRE(result == expected);
 }
 
-TEST_CASE("DeviceSegmentedSort::SortKeysDescending DoubleBuffer works with default environment",
-          "[segmented_sort][keys][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::SortKeysDescending DoubleBuffer works with default environment",
+              "[segmented_sort][keys][device]",
+              CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1 = c2h::device_vector<int>(7);
@@ -154,8 +164,9 @@ TEST_CASE("DeviceSegmentedSort::SortKeysDescending DoubleBuffer works with defau
   REQUIRE(result == expected);
 }
 
-TEST_CASE("DeviceSegmentedSort::StableSortKeys DoubleBuffer works with default environment",
-          "[segmented_sort][keys][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::StableSortKeys DoubleBuffer works with default environment",
+              "[segmented_sort][keys][device]",
+              CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1 = c2h::device_vector<int>(7);
@@ -176,8 +187,9 @@ TEST_CASE("DeviceSegmentedSort::StableSortKeys DoubleBuffer works with default e
   REQUIRE(result == expected);
 }
 
-TEST_CASE("DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer works with default environment",
-          "[segmented_sort][keys][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer works with default environment",
+              "[segmented_sort][keys][device]",
+              CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1 = c2h::device_vector<int>(7);
@@ -200,7 +212,7 @@ TEST_CASE("DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer works with
 
 #endif
 
-C2H_TEST("DeviceSegmentedSort::SortKeys uses environment", "[segmented_sort][keys][device]")
+CUB_TEST("DeviceSegmentedSort::SortKeys uses environment", "[segmented_sort][keys][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -233,7 +245,7 @@ C2H_TEST("DeviceSegmentedSort::SortKeys uses environment", "[segmented_sort][key
   REQUIRE(keys_out == expected);
 }
 
-C2H_TEST("DeviceSegmentedSort::SortKeysDescending uses environment", "[segmented_sort][keys][device]")
+CUB_TEST("DeviceSegmentedSort::SortKeysDescending uses environment", "[segmented_sort][keys][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -267,7 +279,7 @@ C2H_TEST("DeviceSegmentedSort::SortKeysDescending uses environment", "[segmented
   REQUIRE(keys_out == expected);
 }
 
-C2H_TEST("DeviceSegmentedSort::StableSortKeys uses environment", "[segmented_sort][keys][device]")
+CUB_TEST("DeviceSegmentedSort::StableSortKeys uses environment", "[segmented_sort][keys][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -301,7 +313,7 @@ C2H_TEST("DeviceSegmentedSort::StableSortKeys uses environment", "[segmented_sor
   REQUIRE(keys_out == expected);
 }
 
-C2H_TEST("DeviceSegmentedSort::StableSortKeysDescending uses environment", "[segmented_sort][keys][device]")
+CUB_TEST("DeviceSegmentedSort::StableSortKeysDescending uses environment", "[segmented_sort][keys][device]", CUB_SMALL)
 {
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
@@ -335,7 +347,7 @@ C2H_TEST("DeviceSegmentedSort::StableSortKeysDescending uses environment", "[seg
   REQUIRE(keys_out == expected);
 }
 
-C2H_TEST("DeviceSegmentedSort::SortKeys DoubleBuffer uses environment", "[segmented_sort][keys][device]")
+CUB_TEST("DeviceSegmentedSort::SortKeys DoubleBuffer uses environment", "[segmented_sort][keys][device]", CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1 = c2h::device_vector<int>(7);
@@ -369,7 +381,9 @@ C2H_TEST("DeviceSegmentedSort::SortKeys DoubleBuffer uses environment", "[segmen
   REQUIRE(result == expected);
 }
 
-C2H_TEST("DeviceSegmentedSort::SortKeysDescending DoubleBuffer uses environment", "[segmented_sort][keys][device]")
+CUB_TEST("DeviceSegmentedSort::SortKeysDescending DoubleBuffer uses environment",
+         "[segmented_sort][keys][device]",
+         CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1 = c2h::device_vector<int>(7);
@@ -404,7 +418,9 @@ C2H_TEST("DeviceSegmentedSort::SortKeysDescending DoubleBuffer uses environment"
   REQUIRE(result == expected);
 }
 
-C2H_TEST("DeviceSegmentedSort::StableSortKeys DoubleBuffer uses environment", "[segmented_sort][keys][device]")
+CUB_TEST("DeviceSegmentedSort::StableSortKeys DoubleBuffer uses environment",
+         "[segmented_sort][keys][device]",
+         CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1 = c2h::device_vector<int>(7);
@@ -439,8 +455,9 @@ C2H_TEST("DeviceSegmentedSort::StableSortKeys DoubleBuffer uses environment", "[
   REQUIRE(result == expected);
 }
 
-C2H_TEST("DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer uses environment",
-         "[segmented_sort][keys][device]")
+CUB_TEST("DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer uses environment",
+         "[segmented_sort][keys][device]",
+         CUB_SMALL)
 {
   auto keys_buf0 = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1 = c2h::device_vector<int>(7);
@@ -496,7 +513,7 @@ using block_sizes =
 
 #if TEST_LAUNCH != 1
 
-C2H_TEST("DeviceSegmentedSort::SortKeys can be tuned", "[segmented_sort][keys][device]", block_sizes)
+CUB_TEST("DeviceSegmentedSort::SortKeys can be tuned", "[segmented_sort][keys][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto keys_in                             = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -521,7 +538,8 @@ C2H_TEST("DeviceSegmentedSort::SortKeys can be tuned", "[segmented_sort][keys][d
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedSort::SortKeysDescending can be tuned", "[segmented_sort][keys][device]", block_sizes)
+CUB_TEST(
+  "DeviceSegmentedSort::SortKeysDescending can be tuned", "[segmented_sort][keys][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto keys_in                             = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -547,7 +565,7 @@ C2H_TEST("DeviceSegmentedSort::SortKeysDescending can be tuned", "[segmented_sor
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedSort::StableSortKeys can be tuned", "[segmented_sort][keys][device]", block_sizes)
+CUB_TEST("DeviceSegmentedSort::StableSortKeys can be tuned", "[segmented_sort][keys][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto keys_in                             = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -573,7 +591,10 @@ C2H_TEST("DeviceSegmentedSort::StableSortKeys can be tuned", "[segmented_sort][k
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedSort::StableSortKeysDescending can be tuned", "[segmented_sort][keys][device]", block_sizes)
+CUB_TEST("DeviceSegmentedSort::StableSortKeysDescending can be tuned",
+         "[segmented_sort][keys][device]",
+         CUB_SMALL,
+         block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto keys_in                             = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -602,7 +623,7 @@ C2H_TEST("DeviceSegmentedSort::StableSortKeysDescending can be tuned", "[segment
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test SegmentedSortPolicy properties", "[segmented_sort][device]")
+CUB_TEST("Test SegmentedSortPolicy properties", "[segmented_sort][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::SegmentedSortPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedSortPolicy>);

--- a/cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
@@ -13,9 +13,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceSegmentedSort::SortKeys env-based API", "[segmented_sort][keys][env]")
+CUB_TEST("cub::DeviceSegmentedSort::SortKeys env-based API", "[segmented_sort][keys][env]", CUB_SMALL)
 {
   // example-begin sort-keys-env
   auto keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -46,7 +46,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeys env-based API", "[segmented_sort][k
   REQUIRE(keys_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::SortKeysDescending env-based API", "[segmented_sort][keys][env]")
+CUB_TEST("cub::DeviceSegmentedSort::SortKeysDescending env-based API", "[segmented_sort][keys][env]", CUB_SMALL)
 {
   // example-begin sort-keys-descending-env
   auto keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -77,7 +77,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeysDescending env-based API", "[segment
   REQUIRE(keys_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::SortKeys DoubleBuffer env-based API", "[segmented_sort][keys][env]")
+CUB_TEST("cub::DeviceSegmentedSort::SortKeys DoubleBuffer env-based API", "[segmented_sort][keys][env]", CUB_SMALL)
 {
   // example-begin sort-keys-db-env
   auto keys_buf0 = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -110,7 +110,9 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeys DoubleBuffer env-based API", "[segm
   REQUIRE(result == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::SortKeysDescending DoubleBuffer env-based API", "[segmented_sort][keys][env]")
+CUB_TEST("cub::DeviceSegmentedSort::SortKeysDescending DoubleBuffer env-based API",
+         "[segmented_sort][keys][env]",
+         CUB_SMALL)
 {
   // example-begin sort-keys-descending-db-env
   auto keys_buf0 = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -143,7 +145,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeysDescending DoubleBuffer env-based AP
   REQUIRE(result == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::StableSortKeys env-based API", "[segmented_sort][keys][env]")
+CUB_TEST("cub::DeviceSegmentedSort::StableSortKeys env-based API", "[segmented_sort][keys][env]", CUB_SMALL)
 {
   // example-begin stable-sort-keys-env
   auto keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -174,7 +176,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeys env-based API", "[segmented_s
   REQUIRE(keys_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending env-based API", "[segmented_sort][keys][env]")
+CUB_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending env-based API", "[segmented_sort][keys][env]", CUB_SMALL)
 {
   // example-begin stable-sort-keys-descending-env
   auto keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -205,7 +207,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending env-based API", "[s
   REQUIRE(keys_out == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::StableSortKeys DoubleBuffer env-based API", "[segmented_sort][keys][env]")
+CUB_TEST("cub::DeviceSegmentedSort::StableSortKeys DoubleBuffer env-based API", "[segmented_sort][keys][env]", CUB_SMALL)
 {
   // example-begin stable-sort-keys-db-env
   auto keys_buf0 = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -238,7 +240,9 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeys DoubleBuffer env-based API", 
   REQUIRE(result == expected);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer env-based API", "[segmented_sort][keys][env]")
+CUB_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer env-based API",
+         "[segmented_sort][keys][env]",
+         CUB_SMALL)
 {
   // example-begin stable-sort-keys-descending-db-env
   auto keys_buf0 = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -309,7 +313,7 @@ struct SegmentedSortPolicySelector
 };
 // example-end sort-keys-custom-policy-selector
 
-C2H_TEST("cub::DeviceSegmentedSort::SortKeys with custom policy selector", "[segmented_sort][keys][env]")
+CUB_TEST("cub::DeviceSegmentedSort::SortKeys with custom policy selector", "[segmented_sort][keys][env]", CUB_SMALL)
 {
   // example-begin sort-keys-custom-policy
   auto keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};

--- a/cub/test/catch2_test_device_segmented_sort_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs.cu
@@ -5,7 +5,7 @@
 
 #include "catch2_radix_sort_helper.cuh"
 #include "catch2_segmented_sort_helper.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // FIXME: Graph launch disabled, algorithm syncs internally. WAR exists for device-launch, figure out how to enable for
 // graph launch.
@@ -33,7 +33,7 @@ using pair_types =
 
 #if TEST_TYPES == 0
 
-C2H_TEST("DeviceSegmentedSortPairs: No segments", "[pairs][segmented][sort][device]")
+CUB_TEST("DeviceSegmentedSortPairs: No segments", "[pairs][segmented][sort][device]", CUB_SMALL)
 {
   // Type doesn't affect the escape logic, so it should be fine
   // to test only one set of types here.
@@ -67,7 +67,7 @@ C2H_TEST("DeviceSegmentedSortPairs: No segments", "[pairs][segmented][sort][devi
   REQUIRE(values_buffer.selector == 1);
 }
 
-C2H_TEST("DeviceSegmentedSortPairs: Empty segments", "[pairs][segmented][sort][device]")
+CUB_TEST("DeviceSegmentedSortPairs: Empty segments", "[pairs][segmented][sort][device]", CUB_SMALL)
 {
   // Type doesn't affect the escape logic, so it should be fine
   // to test only one set of types here.
@@ -107,8 +107,9 @@ C2H_TEST("DeviceSegmentedSortPairs: Empty segments", "[pairs][segmented][sort][d
 
 #endif // TEST_TYPES == 0
 
-C2H_TEST("DeviceSegmentedSortPairs: Same size segments, derived keys/values",
+CUB_TEST("DeviceSegmentedSortPairs: Same size segments, derived keys/values",
          "[pairs][segmented][sort][device][skip-cs-racecheck]",
+         CUB_SMALL,
          pair_types)
 {
   using PairT  = c2h::get<0, TestType>;
@@ -128,8 +129,9 @@ C2H_TEST("DeviceSegmentedSortPairs: Same size segments, derived keys/values",
   test_same_size_segments_derived<KeyT, ValueT>(segment_size, segments);
 }
 
-C2H_TEST("DeviceSegmentedSortPairs: Randomly sized segments, derived keys/values",
+CUB_TEST("DeviceSegmentedSortPairs: Randomly sized segments, derived keys/values",
          "[pairs][segmented][sort][device][skip-cs-racecheck]",
+         CUB_SMALL,
          pair_types)
 {
   using PairT  = c2h::get<0, TestType>;
@@ -149,8 +151,9 @@ C2H_TEST("DeviceSegmentedSortPairs: Randomly sized segments, derived keys/values
   test_random_size_segments_derived<KeyT, ValueT>(C2H_SEED(1), max_items, max_segment, segments);
 }
 
-C2H_TEST("DeviceSegmentedSortPairs: Randomly sized segments, random keys/values",
+CUB_TEST("DeviceSegmentedSortPairs: Randomly sized segments, random keys/values",
          "[pairs][segmented][sort][device][skip-cs-racecheck]",
+         CUB_SMALL,
          pair_types)
 {
   using PairT  = c2h::get<0, TestType>;
@@ -166,8 +169,9 @@ C2H_TEST("DeviceSegmentedSortPairs: Randomly sized segments, random keys/values"
   test_random_size_segments_random<KeyT, ValueT>(C2H_SEED(1), max_items, max_segment, segments);
 }
 
-C2H_TEST("DeviceSegmentedSortPairs: Edge case segments, random keys/values",
+CUB_TEST("DeviceSegmentedSortPairs: Edge case segments, random keys/values",
          "[pairs][segmented][sort][device]",
+         CUB_SMALL,
          pair_types)
 {
   using PairT  = c2h::get<0, TestType>;
@@ -177,8 +181,9 @@ C2H_TEST("DeviceSegmentedSortPairs: Edge case segments, random keys/values",
   test_edge_case_segments_random<KeyT, ValueT>(C2H_SEED(4));
 }
 
-C2H_TEST("DeviceSegmentedSortPairs: Unspecified segments, random key/values",
+CUB_TEST("DeviceSegmentedSortPairs: Unspecified segments, random key/values",
          "[pairs][segmented][sort][device]",
+         CUB_SMALL,
          pair_types)
 {
   using PairT  = c2h::get<0, TestType>;
@@ -190,8 +195,9 @@ C2H_TEST("DeviceSegmentedSortPairs: Unspecified segments, random key/values",
 
 #if TEST_TYPES == 0
 
-C2H_TEST("DeviceSegmentedSortPairs: very large num. items and num. segments",
+CUB_TEST("DeviceSegmentedSortPairs: very large num. items and num. segments",
          "[pairs][segmented][sort][device][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]",
+         CUB_LARGE,
          all_offset_types)
 try
 {
@@ -246,8 +252,9 @@ catch (std::bad_alloc& e)
   std::cerr << "Skipping segmented sort test, insufficient GPU memory. " << e.what() << "\n";
 }
 
-C2H_TEST("DeviceSegmentedSort::SortPairs: very large segments",
+CUB_TEST("DeviceSegmentedSort::SortPairs: very large segments",
          "[pairs][segmented][sort][device][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]",
+         CUB_LARGE,
          all_offset_types)
 try
 {

--- a/cub/test/catch2_test_device_segmented_sort_pairs_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs_env.cu
@@ -25,13 +25,15 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedSort::SortPairsDescending, sort_pairs
 
 // %PARAM% TEST_LAUNCH lid 0:1
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
 #if TEST_LAUNCH == 0
 
-TEST_CASE("DeviceSegmentedSort::StableSortPairs works with default environment", "[segmented_sort][pairs][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::StableSortPairs works with default environment",
+              "[segmented_sort][pairs][device]",
+              CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -57,8 +59,9 @@ TEST_CASE("DeviceSegmentedSort::StableSortPairs works with default environment",
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("DeviceSegmentedSort::StableSortPairsDescending works with default environment",
-          "[segmented_sort][pairs][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::StableSortPairsDescending works with default environment",
+              "[segmented_sort][pairs][device]",
+              CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -84,7 +87,9 @@ TEST_CASE("DeviceSegmentedSort::StableSortPairsDescending works with default env
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("DeviceSegmentedSort::SortPairs nonstable works with default environment", "[segmented_sort][pairs][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::SortPairs nonstable works with default environment",
+              "[segmented_sort][pairs][device]",
+              CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -110,8 +115,9 @@ TEST_CASE("DeviceSegmentedSort::SortPairs nonstable works with default environme
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable works with default environment",
-          "[segmented_sort][pairs][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable works with default environment",
+              "[segmented_sort][pairs][device]",
+              CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -137,8 +143,9 @@ TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable works with default
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer works with default environment",
-          "[segmented_sort][pairs][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer works with default environment",
+              "[segmented_sort][pairs][device]",
+              CUB_SMALL)
 {
   auto keys_buf0   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1   = c2h::device_vector<int>(7);
@@ -168,8 +175,9 @@ TEST_CASE("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer works with defa
   REQUIRE(result_values == expected_values);
 }
 
-TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer works with default environment",
-          "[segmented_sort][pairs][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer works with default environment",
+              "[segmented_sort][pairs][device]",
+              CUB_SMALL)
 {
   auto keys_buf0   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1   = c2h::device_vector<int>(7);
@@ -201,7 +209,9 @@ TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer works
 
 #endif
 
-TEST_CASE("DeviceSegmentedSort::SortPairs nonstable uses custom stream", "[segmented_sort][pairs][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::SortPairs nonstable uses custom stream",
+              "[segmented_sort][pairs][device]",
+              CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -248,7 +258,9 @@ TEST_CASE("DeviceSegmentedSort::SortPairs nonstable uses custom stream", "[segme
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable uses custom stream", "[segmented_sort][pairs][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable uses custom stream",
+              "[segmented_sort][pairs][device]",
+              CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -295,7 +307,9 @@ TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable uses custom stream
   REQUIRE(values_out == expected_values);
 }
 
-TEST_CASE("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer uses custom stream", "[segmented_sort][pairs][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer uses custom stream",
+              "[segmented_sort][pairs][device]",
+              CUB_SMALL)
 {
   auto keys_buf0   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1   = c2h::device_vector<int>(7);
@@ -343,8 +357,9 @@ TEST_CASE("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer uses custom str
   REQUIRE(result_values == expected_values);
 }
 
-TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer uses custom stream",
-          "[segmented_sort][pairs][device]")
+CUB_TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer uses custom stream",
+              "[segmented_sort][pairs][device]",
+              CUB_SMALL)
 {
   auto keys_buf0   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1   = c2h::device_vector<int>(7);
@@ -393,7 +408,7 @@ TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer uses 
   REQUIRE(result_values == expected_values);
 }
 
-C2H_TEST("DeviceSegmentedSort::StableSortPairs uses environment", "[segmented_sort][pairs][device]")
+CUB_TEST("DeviceSegmentedSort::StableSortPairs uses environment", "[segmented_sort][pairs][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -435,7 +450,7 @@ C2H_TEST("DeviceSegmentedSort::StableSortPairs uses environment", "[segmented_so
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("DeviceSegmentedSort::StableSortPairsDescending uses environment", "[segmented_sort][pairs][device]")
+CUB_TEST("DeviceSegmentedSort::StableSortPairsDescending uses environment", "[segmented_sort][pairs][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -477,7 +492,9 @@ C2H_TEST("DeviceSegmentedSort::StableSortPairsDescending uses environment", "[se
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("DeviceSegmentedSort::StableSortPairs DoubleBuffer uses environment", "[segmented_sort][pairs][device]")
+CUB_TEST("DeviceSegmentedSort::StableSortPairs DoubleBuffer uses environment",
+         "[segmented_sort][pairs][device]",
+         CUB_SMALL)
 {
   auto keys_buf0   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1   = c2h::device_vector<int>(7);
@@ -521,8 +538,9 @@ C2H_TEST("DeviceSegmentedSort::StableSortPairs DoubleBuffer uses environment", "
   REQUIRE(result_values == expected_values);
 }
 
-C2H_TEST("DeviceSegmentedSort::StableSortPairsDescending DoubleBuffer uses environment",
-         "[segmented_sort][pairs][device]")
+CUB_TEST("DeviceSegmentedSort::StableSortPairsDescending DoubleBuffer uses environment",
+         "[segmented_sort][pairs][device]",
+         CUB_SMALL)
 {
   auto keys_buf0   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1   = c2h::device_vector<int>(7);
@@ -566,7 +584,7 @@ C2H_TEST("DeviceSegmentedSort::StableSortPairsDescending DoubleBuffer uses envir
   REQUIRE(result_values == expected_values);
 }
 
-C2H_TEST("DeviceSegmentedSort::SortPairs nonstable uses environment", "[segmented_sort][pairs][device]")
+CUB_TEST("DeviceSegmentedSort::SortPairs nonstable uses environment", "[segmented_sort][pairs][device]", CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -608,7 +626,9 @@ C2H_TEST("DeviceSegmentedSort::SortPairs nonstable uses environment", "[segmente
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("DeviceSegmentedSort::SortPairsDescending nonstable uses environment", "[segmented_sort][pairs][device]")
+CUB_TEST("DeviceSegmentedSort::SortPairsDescending nonstable uses environment",
+         "[segmented_sort][pairs][device]",
+         CUB_SMALL)
 {
   auto keys_in    = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out   = c2h::device_vector<int>(7);
@@ -650,7 +670,9 @@ C2H_TEST("DeviceSegmentedSort::SortPairsDescending nonstable uses environment", 
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer uses environment", "[segmented_sort][pairs][device]")
+CUB_TEST("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer uses environment",
+         "[segmented_sort][pairs][device]",
+         CUB_SMALL)
 {
   auto keys_buf0   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1   = c2h::device_vector<int>(7);
@@ -693,8 +715,9 @@ C2H_TEST("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer uses environment
   REQUIRE(result_values == expected_values);
 }
 
-C2H_TEST("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer uses environment",
-         "[segmented_sort][pairs][device]")
+CUB_TEST("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer uses environment",
+         "[segmented_sort][pairs][device]",
+         CUB_SMALL)
 {
   auto keys_buf0   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_buf1   = c2h::device_vector<int>(7);
@@ -759,7 +782,7 @@ using block_sizes =
 
 #if TEST_LAUNCH != 1
 
-C2H_TEST("DeviceSegmentedSort::SortPairs can be tuned", "[segmented_sort][pairs][device]", block_sizes)
+CUB_TEST("DeviceSegmentedSort::SortPairs can be tuned", "[segmented_sort][pairs][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto keys_in                             = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -791,7 +814,8 @@ C2H_TEST("DeviceSegmentedSort::SortPairs can be tuned", "[segmented_sort][pairs]
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedSort::SortPairsDescending can be tuned", "[segmented_sort][pairs][device]", block_sizes)
+CUB_TEST(
+  "DeviceSegmentedSort::SortPairsDescending can be tuned", "[segmented_sort][pairs][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto keys_in                             = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -823,7 +847,7 @@ C2H_TEST("DeviceSegmentedSort::SortPairsDescending can be tuned", "[segmented_so
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedSort::StableSortPairs can be tuned", "[segmented_sort][pairs][device]", block_sizes)
+CUB_TEST("DeviceSegmentedSort::StableSortPairs can be tuned", "[segmented_sort][pairs][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto keys_in                             = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -855,7 +879,10 @@ C2H_TEST("DeviceSegmentedSort::StableSortPairs can be tuned", "[segmented_sort][
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSegmentedSort::StableSortPairsDescending can be tuned", "[segmented_sort][pairs][device]", block_sizes)
+CUB_TEST("DeviceSegmentedSort::StableSortPairsDescending can be tuned",
+         "[segmented_sort][pairs][device]",
+         CUB_SMALL,
+         block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto keys_in                             = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};

--- a/cub/test/catch2_test_device_segmented_sort_pairs_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs_env_api.cu
@@ -12,9 +12,9 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceSegmentedSort::StableSortPairs env-based API", "[segmented_sort][pairs][env]")
+CUB_TEST("cub::DeviceSegmentedSort::StableSortPairs env-based API", "[segmented_sort][pairs][env]", CUB_SMALL)
 {
   // example-begin stable-sort-pairs-env
   auto keys_in       = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -52,7 +52,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortPairs env-based API", "[segmented_
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::StableSortPairsDescending env-based API", "[segmented_sort][pairs][env]")
+CUB_TEST("cub::DeviceSegmentedSort::StableSortPairsDescending env-based API", "[segmented_sort][pairs][env]", CUB_SMALL)
 {
   // example-begin stable-sort-pairs-descending-env
   auto keys_in       = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -90,7 +90,9 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortPairsDescending env-based API", "[
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::StableSortPairs DoubleBuffer env-based API", "[segmented_sort][pairs][env]")
+CUB_TEST("cub::DeviceSegmentedSort::StableSortPairs DoubleBuffer env-based API",
+         "[segmented_sort][pairs][env]",
+         CUB_SMALL)
 {
   // example-begin stable-sort-pairs-db-env
   auto keys_buf0     = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -132,8 +134,9 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortPairs DoubleBuffer env-based API",
   REQUIRE(result_values == expected_values);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::StableSortPairsDescending DoubleBuffer env-based API",
-         "[segmented_sort][pairs][env]")
+CUB_TEST("cub::DeviceSegmentedSort::StableSortPairsDescending DoubleBuffer env-based API",
+         "[segmented_sort][pairs][env]",
+         CUB_SMALL)
 {
   // example-begin stable-sort-pairs-descending-db-env
   auto keys_buf0     = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -176,7 +179,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortPairsDescending DoubleBuffer env-b
   REQUIRE(result_values == expected_values);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::SortPairs nonstable env-based API", "[segmented_sort][pairs][env]")
+CUB_TEST("cub::DeviceSegmentedSort::SortPairs nonstable env-based API", "[segmented_sort][pairs][env]", CUB_SMALL)
 {
   // example-begin sort-pairs-env
   auto keys_in       = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -214,7 +217,9 @@ C2H_TEST("cub::DeviceSegmentedSort::SortPairs nonstable env-based API", "[segmen
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable env-based API", "[segmented_sort][pairs][env]")
+CUB_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable env-based API",
+         "[segmented_sort][pairs][env]",
+         CUB_SMALL)
 {
   // example-begin sort-pairs-descending-env
   auto keys_in       = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -252,7 +257,9 @@ C2H_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable env-based API"
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::SortPairs nonstable DoubleBuffer env-based API", "[segmented_sort][pairs][env]")
+CUB_TEST("cub::DeviceSegmentedSort::SortPairs nonstable DoubleBuffer env-based API",
+         "[segmented_sort][pairs][env]",
+         CUB_SMALL)
 {
   // example-begin sort-pairs-db-env
   auto keys_buf0     = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
@@ -294,8 +301,9 @@ C2H_TEST("cub::DeviceSegmentedSort::SortPairs nonstable DoubleBuffer env-based A
   REQUIRE(result_values == expected_values);
 }
 
-C2H_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer env-based API",
-         "[segmented_sort][pairs][env]")
+CUB_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer env-based API",
+         "[segmented_sort][pairs][env]",
+         CUB_SMALL)
 {
   // example-begin sort-pairs-descending-db-env
   auto keys_buf0     = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};

--- a/cub/test/catch2_test_device_segmented_topk_keys.cu
+++ b/cub/test/catch2_test_device_segmented_topk_keys.cu
@@ -18,7 +18,7 @@
 
 #include "catch2_test_device_topk_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/extended_types.h>
 #include <catch2/generators/catch_generators.hpp>
 
@@ -101,8 +101,9 @@ using key_types =
 using select_direction_list =
   c2h::enum_type_list<cub::detail::topk::select, cub::detail::topk::select::min, cub::detail::topk::select::max>;
 
-C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with small fixed-size segments",
+CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with small fixed-size segments",
          "[keys][segmented][topk][device]",
+         CUB_SMALL,
          key_types,
          max_segment_size_list,
          max_num_k_list,
@@ -181,8 +182,9 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with small fixed-size segments",
   REQUIRE(expected_keys == keys_out_buffer);
 }
 
-C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with small variable-size segments",
+CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with small variable-size segments",
          "[keys][segmented][topk][device]",
+         CUB_SMALL,
          key_types,
          max_segment_size_list,
          max_num_k_list,
@@ -279,8 +281,9 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with small variable-size segment
   REQUIRE(expected_keys == keys_out_buffer);
 }
 
-C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with fixed-size segments and per-segment k",
+CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with fixed-size segments and per-segment k",
          "[keys][segmented][topk][device]",
+         CUB_SMALL,
          key_types,
          max_segment_size_list,
          max_num_k_list,
@@ -376,8 +379,9 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with fixed-size segments and per
   REQUIRE(expected_keys == keys_out_buffer);
 }
 
-C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with variable-size segments and per-segment k",
+CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with variable-size segments and per-segment k",
          "[keys][segmented][topk][device]",
+         CUB_SMALL,
          key_types,
          max_segment_size_list,
          max_num_k_list,
@@ -475,8 +479,9 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with variable-size segments and 
 }
 
 // Regression test: top-k must preserve -0.0f in the output (not normalize to +0.0f).
-C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys preserve -0.0f in output",
+CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys preserve -0.0f in output",
          "[keys][segmented][topk][device][float]",
+         CUB_SMALL,
          select_direction_list)
 {
   constexpr cuda::std::int64_t segment_size                      = 8;
@@ -511,8 +516,9 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys preserve -0.0f in output",
 
 // Users may pass `k` and `num_segments` un-annotated. A plain integral value is taken as a uniform immediate with no
 // compile-time bound.
-C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys accept unwrapped (plain integral) k and num_segments",
+CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys accept unwrapped (plain integral) k and num_segments",
          "[keys][segmented][topk][device]",
+         CUB_SMALL,
          key_types,
          max_segment_size_list,
          max_num_k_list,

--- a/cub/test/catch2_test_device_segmented_topk_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_topk_pairs.cu
@@ -17,7 +17,7 @@
 
 #include "catch2_test_device_topk_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/extended_types.h>
 #include <catch2/generators/catch_generators.hpp>
 
@@ -212,8 +212,9 @@ bool verify_unique_indices(const c2h::device_vector<ValueT>& values_compacted,
   return num_duplicates == 0;
 }
 
-C2H_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with small fixed-size segments",
+CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with small fixed-size segments",
          "[pairs][segmented][topk][device]",
+         CUB_SMALL,
          key_types,
          max_segment_size_list,
          max_num_k_list,
@@ -313,8 +314,9 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with small fixed-size segments"
   REQUIRE(expected_keys == keys_out_buffer);
 }
 
-C2H_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with small variable-size segments",
+CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with small variable-size segments",
          "[pairs][segmented][topk][device]",
+         CUB_SMALL,
          key_types,
          max_segment_size_list,
          max_num_k_list,
@@ -432,8 +434,9 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with small variable-size segmen
   REQUIRE(expected_keys == keys_out_buffer);
 }
 
-C2H_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with fixed-size segments and per-segment k",
+CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with fixed-size segments and per-segment k",
          "[pairs][segmented][topk][device]",
+         CUB_SMALL,
          key_types,
          max_segment_size_list,
          max_num_k_list,
@@ -549,8 +552,9 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with fixed-size segments and pe
   REQUIRE(expected_keys == keys_out_buffer);
 }
 
-C2H_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with variable-size segments and per-segment k",
+CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with variable-size segments and per-segment k",
          "[pairs][segmented][topk][device]",
+         CUB_SMALL,
          key_types,
          max_segment_size_list,
          max_num_k_list,

--- a/cub/test/catch2_test_device_select_api.cu
+++ b/cub/test/catch2_test_device_select_api.cu
@@ -11,7 +11,7 @@
 
 #include <cstddef>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // example-begin segmented-select-iseven
 struct is_even_t
@@ -23,7 +23,7 @@ struct is_even_t
 };
 // example-end segmented-select-iseven
 
-C2H_TEST("cub::DeviceSelect::FlaggedIf works with int data elements", "[select][device]")
+CUB_TEST("cub::DeviceSelect::FlaggedIf works with int data elements", "[select][device]", CUB_SMALL)
 {
   // example-begin segmented-select-flaggedif
   constexpr int num_items         = 8;
@@ -67,7 +67,7 @@ C2H_TEST("cub::DeviceSelect::FlaggedIf works with int data elements", "[select][
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceSelect::FlaggedIf in-place works with int data elements", "[select][device]")
+CUB_TEST("cub::DeviceSelect::FlaggedIf in-place works with int data elements", "[select][device]", CUB_SMALL)
 {
   // example-begin segmented-select-flaggedif-inplace
   constexpr int num_items         = 8;
@@ -102,7 +102,7 @@ C2H_TEST("cub::DeviceSelect::FlaggedIf in-place works with int data elements", "
   REQUIRE(d_data == expected);
 }
 
-C2H_TEST("cub::DeviceSelect::Unique in-place works with int data elements", "[select][device]")
+CUB_TEST("cub::DeviceSelect::Unique in-place works with int data elements", "[select][device]", CUB_SMALL)
 {
   // example-begin select-unique-inplace
   constexpr int num_items                       = 8;
@@ -144,7 +144,9 @@ struct my_equality_op
 };
 // example-end select-unique-inplace-eqop-myequalityop
 
-C2H_TEST("cub::DeviceSelect::Unique in-place with equality_op works with int data elements", "[select][device]")
+CUB_TEST("cub::DeviceSelect::Unique in-place with equality_op works with int data elements",
+         "[select][device]",
+         CUB_SMALL)
 {
   // example-begin select-unique-inplace-eqop
   constexpr int num_items                       = 8;
@@ -193,7 +195,7 @@ struct select_always_true_t
   }
 };
 
-C2H_TEST("DeviceSelect::Flagged legacy size-query is unambiguous", "[select][device]")
+CUB_TEST("DeviceSelect::Flagged legacy size-query is unambiguous", "[select][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -207,7 +209,7 @@ C2H_TEST("DeviceSelect::Flagged legacy size-query is unambiguous", "[select][dev
           == cub::DeviceSelect::Flagged(d_temp_storage, temp_storage_bytes, d_in, d_flags, d_out, d_num_selected, n));
 }
 
-C2H_TEST("DeviceSelect::Flagged in-place legacy size-query is unambiguous", "[select][device]")
+CUB_TEST("DeviceSelect::Flagged in-place legacy size-query is unambiguous", "[select][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -220,7 +222,7 @@ C2H_TEST("DeviceSelect::Flagged in-place legacy size-query is unambiguous", "[se
     cudaSuccess == cub::DeviceSelect::Flagged(d_temp_storage, temp_storage_bytes, d_data, d_flags, d_num_selected, n));
 }
 
-C2H_TEST("DeviceSelect::If legacy size-query is unambiguous", "[select][device]")
+CUB_TEST("DeviceSelect::If legacy size-query is unambiguous", "[select][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -234,7 +236,7 @@ C2H_TEST("DeviceSelect::If legacy size-query is unambiguous", "[select][device]"
             d_temp_storage, temp_storage_bytes, d_in, d_out, d_num_selected, n, select_always_true_t{}));
 }
 
-C2H_TEST("DeviceSelect::If in-place legacy size-query is unambiguous", "[select][device]")
+CUB_TEST("DeviceSelect::If in-place legacy size-query is unambiguous", "[select][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -247,7 +249,7 @@ C2H_TEST("DeviceSelect::If in-place legacy size-query is unambiguous", "[select]
     == cub::DeviceSelect::If(d_temp_storage, temp_storage_bytes, d_data, d_num_selected, n, select_always_true_t{}));
 }
 
-C2H_TEST("DeviceSelect::FlaggedIf legacy size-query is unambiguous", "[select][device]")
+CUB_TEST("DeviceSelect::FlaggedIf legacy size-query is unambiguous", "[select][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -262,7 +264,7 @@ C2H_TEST("DeviceSelect::FlaggedIf legacy size-query is unambiguous", "[select][d
             d_temp_storage, temp_storage_bytes, d_in, d_flags, d_out, d_num_selected, n, select_always_true_t{}));
 }
 
-C2H_TEST("DeviceSelect::FlaggedIf in-place legacy size-query is unambiguous", "[select][device]")
+CUB_TEST("DeviceSelect::FlaggedIf in-place legacy size-query is unambiguous", "[select][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -276,7 +278,7 @@ C2H_TEST("DeviceSelect::FlaggedIf in-place legacy size-query is unambiguous", "[
             d_temp_storage, temp_storage_bytes, d_data, d_flags, d_num_selected, n, select_always_true_t{}));
 }
 
-C2H_TEST("DeviceSelect::Unique legacy size-query is unambiguous", "[select][device]")
+CUB_TEST("DeviceSelect::Unique legacy size-query is unambiguous", "[select][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -288,7 +290,7 @@ C2H_TEST("DeviceSelect::Unique legacy size-query is unambiguous", "[select][devi
   REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_temp_storage, temp_storage_bytes, d_in, d_out, d_num_selected, n));
 }
 
-C2H_TEST("DeviceSelect::UniqueByKey legacy size-query is unambiguous", "[select][device]")
+CUB_TEST("DeviceSelect::UniqueByKey legacy size-query is unambiguous", "[select][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -32,7 +32,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSelect::UniqueByKey, device_select_unique_by_k
 
 #include <cuda/__execution/require.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;
 
@@ -40,7 +40,7 @@ namespace stdexec = cuda::std::execution;
 
 using block_size_check_t = block_size_extracting_op<cuda::std::equal_to<>>;
 
-TEST_CASE("Device select works with default environment", "[select][device]")
+CUB_TEST_CASE("Device select works with default environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -64,7 +64,7 @@ TEST_CASE("Device select works with default environment", "[select][device]")
   REQUIRE(d_out == expected_output);
 }
 
-TEST_CASE("Device select flagged works with default environment", "[select][device]")
+CUB_TEST_CASE("Device select flagged works with default environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -88,7 +88,7 @@ TEST_CASE("Device select flagged works with default environment", "[select][devi
   REQUIRE(d_out == expected_output);
 }
 
-TEST_CASE("Device select flagged_if works with default environment", "[select][device]")
+CUB_TEST_CASE("Device select flagged_if works with default environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -113,7 +113,7 @@ TEST_CASE("Device select flagged_if works with default environment", "[select][d
   REQUIRE(d_out == expected_output);
 }
 
-TEST_CASE("Device select flagged in-place works with default environment", "[select][device]")
+CUB_TEST_CASE("Device select flagged in-place works with default environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -134,7 +134,7 @@ TEST_CASE("Device select flagged in-place works with default environment", "[sel
   REQUIRE(d_data == expected_output);
 }
 
-TEST_CASE("Device select if in-place works with default environment", "[select][device]")
+CUB_TEST_CASE("Device select if in-place works with default environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -155,7 +155,7 @@ TEST_CASE("Device select if in-place works with default environment", "[select][
   REQUIRE(d_data == expected_output);
 }
 
-TEST_CASE("Device select flagged_if in-place works with default environment", "[select][device]")
+CUB_TEST_CASE("Device select flagged_if in-place works with default environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -179,7 +179,7 @@ TEST_CASE("Device select flagged_if in-place works with default environment", "[
   REQUIRE(d_data == expected_output);
 }
 
-TEST_CASE("Device select unique works with default environment", "[select][device]")
+CUB_TEST_CASE("Device select unique works with default environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -199,7 +199,9 @@ TEST_CASE("Device select unique works with default environment", "[select][devic
   REQUIRE(d_out == expected_output);
 }
 
-TEST_CASE("Device select unique with custom equality_op works with default environment", "[select][device]")
+CUB_TEST_CASE("Device select unique with custom equality_op works with default environment",
+              "[select][device]",
+              CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -222,7 +224,7 @@ TEST_CASE("Device select unique with custom equality_op works with default envir
   REQUIRE(d_out == expected_output);
 }
 
-TEST_CASE("Device select unique in-place works with default environment", "[select][device]")
+CUB_TEST_CASE("Device select unique in-place works with default environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -241,7 +243,9 @@ TEST_CASE("Device select unique in-place works with default environment", "[sele
   REQUIRE(d_data == expected_output);
 }
 
-TEST_CASE("Device select unique in-place with custom equality_op works with default environment", "[select][device]")
+CUB_TEST_CASE("Device select unique in-place with custom equality_op works with default environment",
+              "[select][device]",
+              CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -262,7 +266,7 @@ TEST_CASE("Device select unique in-place with custom equality_op works with defa
   REQUIRE(d_data == expected_output);
 }
 
-TEST_CASE("Device select unique_by_key works with default environment", "[select][device]")
+CUB_TEST_CASE("Device select unique_by_key works with default environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -295,7 +299,9 @@ TEST_CASE("Device select unique_by_key works with default environment", "[select
   REQUIRE(d_values_out == expected_values);
 }
 
-TEST_CASE("Device select unique_by_key works with default environment and explicit env", "[select][device]")
+CUB_TEST_CASE("Device select unique_by_key works with default environment and explicit env",
+              "[select][device]",
+              CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -331,7 +337,7 @@ TEST_CASE("Device select unique_by_key works with default environment and explic
   REQUIRE(d_values_out == expected_values);
 }
 
-TEST_CASE("Device select unique_by_key default tuning chooses target block size", "[select][device]")
+CUB_TEST_CASE("Device select unique_by_key default tuning chooses target block size", "[select][device]", CUB_SMALL)
 {
   using num_items_t = int;
   using key_t       = int;
@@ -375,7 +381,7 @@ TEST_CASE("Device select unique_by_key default tuning chooses target block size"
 
 #endif
 
-C2H_TEST("Device select uses environment", "[select][device]")
+CUB_TEST("Device select uses environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -406,7 +412,7 @@ C2H_TEST("Device select uses environment", "[select][device]")
   REQUIRE(d_out == expected_output);
 }
 
-C2H_TEST("Device select flagged uses environment", "[select][device]")
+CUB_TEST("Device select flagged uses environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -441,7 +447,7 @@ C2H_TEST("Device select flagged uses environment", "[select][device]")
   REQUIRE(d_out == expected_output);
 }
 
-C2H_TEST("Device select flagged_if uses environment", "[select][device]")
+CUB_TEST("Device select flagged_if uses environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -480,7 +486,7 @@ C2H_TEST("Device select flagged_if uses environment", "[select][device]")
   REQUIRE(d_out == expected_output);
 }
 
-C2H_TEST("Device select flagged in-place uses environment", "[select][device]")
+CUB_TEST("Device select flagged in-place uses environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -515,7 +521,7 @@ C2H_TEST("Device select flagged in-place uses environment", "[select][device]")
   REQUIRE(d_data == expected_output);
 }
 
-C2H_TEST("Device select if in-place uses environment", "[select][device]")
+CUB_TEST("Device select if in-place uses environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -544,7 +550,7 @@ C2H_TEST("Device select if in-place uses environment", "[select][device]")
   REQUIRE(d_data == expected_output);
 }
 
-C2H_TEST("Device select flagged_if in-place uses environment", "[select][device]")
+CUB_TEST("Device select flagged_if in-place uses environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -583,7 +589,7 @@ C2H_TEST("Device select flagged_if in-place uses environment", "[select][device]
   REQUIRE(d_data == expected_output);
 }
 
-C2H_TEST("Device select unique uses environment", "[select][device]")
+CUB_TEST("Device select unique uses environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -610,7 +616,7 @@ C2H_TEST("Device select unique uses environment", "[select][device]")
   REQUIRE(d_out == expected_output);
 }
 
-C2H_TEST("Device select unique with custom equality_op uses environment", "[select][device]")
+CUB_TEST("Device select unique with custom equality_op uses environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -640,7 +646,7 @@ C2H_TEST("Device select unique with custom equality_op uses environment", "[sele
   REQUIRE(d_out == expected_output);
 }
 
-C2H_TEST("Device select unique in-place uses environment", "[select][device]")
+CUB_TEST("Device select unique in-place uses environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -666,7 +672,7 @@ C2H_TEST("Device select unique in-place uses environment", "[select][device]")
   REQUIRE(d_data == expected_output);
 }
 
-C2H_TEST("Device select unique in-place with custom equality_op uses environment", "[select][device]")
+CUB_TEST("Device select unique in-place with custom equality_op uses environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -694,7 +700,7 @@ C2H_TEST("Device select unique in-place with custom equality_op uses environment
   REQUIRE(d_data == expected_output);
 }
 
-C2H_TEST("Device select unique_by_key uses environment", "[select][device]")
+CUB_TEST("Device select unique_by_key uses environment", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -742,7 +748,7 @@ C2H_TEST("Device select unique_by_key uses environment", "[select][device]")
   REQUIRE(d_values_out == expected_values);
 }
 
-C2H_TEST("Device select unique_by_key uses environment without equality_op", "[select][device]")
+CUB_TEST("Device select unique_by_key uses environment without equality_op", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -789,7 +795,7 @@ C2H_TEST("Device select unique_by_key uses environment without equality_op", "[s
   REQUIRE(d_values_out == expected_values);
 }
 
-TEST_CASE("Device select uses custom stream", "[select][device]")
+CUB_TEST_CASE("Device select uses custom stream", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -827,7 +833,7 @@ TEST_CASE("Device select uses custom stream", "[select][device]")
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-TEST_CASE("Device select flagged uses custom stream", "[select][device]")
+CUB_TEST_CASE("Device select flagged uses custom stream", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -870,7 +876,7 @@ TEST_CASE("Device select flagged uses custom stream", "[select][device]")
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-TEST_CASE("Device select flagged_if uses custom stream", "[select][device]")
+CUB_TEST_CASE("Device select flagged_if uses custom stream", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -917,7 +923,7 @@ TEST_CASE("Device select flagged_if uses custom stream", "[select][device]")
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-TEST_CASE("Device select unique uses custom stream", "[select][device]")
+CUB_TEST_CASE("Device select unique uses custom stream", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -952,7 +958,7 @@ TEST_CASE("Device select unique uses custom stream", "[select][device]")
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-TEST_CASE("Device select unique in-place uses custom stream", "[select][device]")
+CUB_TEST_CASE("Device select unique in-place uses custom stream", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -986,7 +992,7 @@ TEST_CASE("Device select unique in-place uses custom stream", "[select][device]"
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-TEST_CASE("Device select unique in-place with custom equality_op uses custom stream", "[select][device]")
+CUB_TEST_CASE("Device select unique in-place with custom equality_op uses custom stream", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -1022,7 +1028,7 @@ TEST_CASE("Device select unique in-place with custom equality_op uses custom str
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
-TEST_CASE("Device select unique_by_key uses custom stream", "[select][device]")
+CUB_TEST_CASE("Device select unique_by_key uses custom stream", "[select][device]", CUB_SMALL)
 {
   using value_t     = int;
   using num_items_t = int;
@@ -1128,7 +1134,7 @@ struct unique_by_key_tuning
 using block_sizes =
   c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
 
-C2H_TEST("DeviceSelect::If can be tuned", "[select][device]", block_sizes)
+CUB_TEST("DeviceSelect::If can be tuned", "[select][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto d_in                                = c2h::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -1145,7 +1151,7 @@ C2H_TEST("DeviceSelect::If can be tuned", "[select][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSelect::If in-place can be tuned", "[select][device]", block_sizes)
+CUB_TEST("DeviceSelect::If in-place can be tuned", "[select][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto d_data                              = c2h::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -1161,7 +1167,7 @@ C2H_TEST("DeviceSelect::If in-place can be tuned", "[select][device]", block_siz
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSelect::Flagged can be tuned", "[select][device]", block_sizes)
+CUB_TEST("DeviceSelect::Flagged can be tuned", "[select][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto d_in                                = c2h::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -1178,7 +1184,7 @@ C2H_TEST("DeviceSelect::Flagged can be tuned", "[select][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSelect::Flagged in-place can be tuned", "[select][device]", block_sizes)
+CUB_TEST("DeviceSelect::Flagged in-place can be tuned", "[select][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto d_data                              = c2h::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -1194,7 +1200,7 @@ C2H_TEST("DeviceSelect::Flagged in-place can be tuned", "[select][device]", bloc
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSelect::FlaggedIf can be tuned", "[select][device]", block_sizes)
+CUB_TEST("DeviceSelect::FlaggedIf can be tuned", "[select][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto d_in                                = c2h::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -1212,7 +1218,7 @@ C2H_TEST("DeviceSelect::FlaggedIf can be tuned", "[select][device]", block_sizes
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSelect::FlaggedIf in-place can be tuned", "[select][device]", block_sizes)
+CUB_TEST("DeviceSelect::FlaggedIf in-place can be tuned", "[select][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto d_data                              = c2h::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -1230,7 +1236,7 @@ C2H_TEST("DeviceSelect::FlaggedIf in-place can be tuned", "[select][device]", bl
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSelect::Unique can be tuned", "[select][device]", block_sizes)
+CUB_TEST("DeviceSelect::Unique can be tuned", "[select][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto d_in                                = c2h::device_vector<int>{0, 0, 1, 1, 2, 2, 3, 3};
@@ -1248,7 +1254,7 @@ C2H_TEST("DeviceSelect::Unique can be tuned", "[select][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceSelect::UniqueByKey can be tuned", "[select][device]", block_sizes)
+CUB_TEST("DeviceSelect::UniqueByKey can be tuned", "[select][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto d_keys_in                           = c2h::device_vector<int>{0, 0, 1, 1, 2, 2, 3, 3};
@@ -1277,7 +1283,7 @@ C2H_TEST("DeviceSelect::UniqueByKey can be tuned", "[select][device]", block_siz
 }
 
 #  if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test UniqueByKeyPolicy properties", "[select_unique_by_key][device]")
+CUB_TEST("Test UniqueByKeyPolicy properties", "[select_unique_by_key][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::UniqueByKeyPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::UniqueByKeyPolicy>);
@@ -1326,7 +1332,7 @@ C2H_TEST("Test UniqueByKeyPolicy properties", "[select_unique_by_key][device]")
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test SelectPolicy properties", "[select][device]")
+CUB_TEST("Test SelectPolicy properties", "[select][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::SelectPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SelectPolicy>);

--- a/cub/test/catch2_test_device_select_env_api.cu
+++ b/cub/test/catch2_test_device_select_env_api.cu
@@ -14,9 +14,9 @@
 #include <iostream>
 
 #include "catch2_test_device_select_common.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("cub::DeviceSelect::If accepts env with stream", "[select][env]")
+CUB_TEST("cub::DeviceSelect::If accepts env with stream", "[select][env]", CUB_SMALL)
 {
   // example-begin select-if-env
   auto input        = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -49,7 +49,7 @@ C2H_TEST("cub::DeviceSelect::If accepts env with stream", "[select][env]")
   REQUIRE(num_selected == expected_num_selected);
 }
 
-C2H_TEST("cub::DeviceSelect::Flagged accepts env with stream", "[select][env]")
+CUB_TEST("cub::DeviceSelect::Flagged accepts env with stream", "[select][env]", CUB_SMALL)
 {
   // example-begin select-flagged-env
   auto input        = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -82,7 +82,7 @@ C2H_TEST("cub::DeviceSelect::Flagged accepts env with stream", "[select][env]")
   REQUIRE(num_selected == expected_num_selected);
 }
 
-C2H_TEST("cub::DeviceSelect::FlaggedIf accepts env with stream", "[select][env]")
+CUB_TEST("cub::DeviceSelect::FlaggedIf accepts env with stream", "[select][env]", CUB_SMALL)
 {
   // example-begin select-flaggedif-env
   auto input        = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -117,7 +117,7 @@ C2H_TEST("cub::DeviceSelect::FlaggedIf accepts env with stream", "[select][env]"
   REQUIRE(num_selected == expected_num_selected);
 }
 
-C2H_TEST("cub::DeviceSelect::Flagged in-place accepts env with stream", "[select][env]")
+CUB_TEST("cub::DeviceSelect::Flagged in-place accepts env with stream", "[select][env]", CUB_SMALL)
 {
   // example-begin select-flagged-inplace-env
   auto data         = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -145,7 +145,7 @@ C2H_TEST("cub::DeviceSelect::Flagged in-place accepts env with stream", "[select
   REQUIRE(data == expected_output);
 }
 
-C2H_TEST("cub::DeviceSelect::If in-place accepts env with stream", "[select][env]")
+CUB_TEST("cub::DeviceSelect::If in-place accepts env with stream", "[select][env]", CUB_SMALL)
 {
   // example-begin select-if-inplace-env
   auto data         = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -173,7 +173,7 @@ C2H_TEST("cub::DeviceSelect::If in-place accepts env with stream", "[select][env
   REQUIRE(data == expected_output);
 }
 
-C2H_TEST("cub::DeviceSelect::FlaggedIf in-place accepts env with stream", "[select][env]")
+CUB_TEST("cub::DeviceSelect::FlaggedIf in-place accepts env with stream", "[select][env]", CUB_SMALL)
 {
   // example-begin select-flaggedif-inplace-env
   auto data         = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -207,7 +207,7 @@ C2H_TEST("cub::DeviceSelect::FlaggedIf in-place accepts env with stream", "[sele
   REQUIRE(data == expected_output);
 }
 
-C2H_TEST("cub::DeviceSelect::Unique accepts env with stream", "[select][env]")
+CUB_TEST("cub::DeviceSelect::Unique accepts env with stream", "[select][env]", CUB_SMALL)
 {
   // example-begin select-unique-env
   auto input        = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
@@ -234,7 +234,7 @@ C2H_TEST("cub::DeviceSelect::Unique accepts env with stream", "[select][env]")
   REQUIRE(num_selected == expected_num_selected);
 }
 
-C2H_TEST("cub::DeviceSelect::Unique with custom equality_op accepts env with stream", "[select][env]")
+CUB_TEST("cub::DeviceSelect::Unique with custom equality_op accepts env with stream", "[select][env]", CUB_SMALL)
 {
   // example-begin select-unique-eqop-env
   // Unique modulo 3 — consecutive elements are "equal" if they have the same remainder mod 3
@@ -272,7 +272,7 @@ C2H_TEST("cub::DeviceSelect::Unique with custom equality_op accepts env with str
   REQUIRE(output == expected_output);
 }
 
-C2H_TEST("cub::DeviceSelect::Unique in-place accepts env with stream", "[select][env]")
+CUB_TEST("cub::DeviceSelect::Unique in-place accepts env with stream", "[select][env]", CUB_SMALL)
 {
   // example-begin select-unique-inplace-env
   auto data         = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
@@ -299,7 +299,9 @@ C2H_TEST("cub::DeviceSelect::Unique in-place accepts env with stream", "[select]
   REQUIRE(data == expected_output);
 }
 
-C2H_TEST("cub::DeviceSelect::Unique in-place with custom equality_op accepts env with stream", "[select][env]")
+CUB_TEST("cub::DeviceSelect::Unique in-place with custom equality_op accepts env with stream",
+         "[select][env]",
+         CUB_SMALL)
 {
   // example-begin select-unique-inplace-eqop-env
   // Unique modulo 3 — consecutive elements are "equal" if they have the same remainder mod 3
@@ -331,7 +333,7 @@ C2H_TEST("cub::DeviceSelect::Unique in-place with custom equality_op accepts env
   REQUIRE(data == expected_output);
 }
 
-C2H_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream", "[select][env]")
+CUB_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream", "[select][env]", CUB_SMALL)
 {
   // example-begin select-uniquebykey-env
   auto keys_in      = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
@@ -369,7 +371,7 @@ C2H_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream", "[select][env
   REQUIRE(num_selected == expected_num_selected);
 }
 
-C2H_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream without equality_op", "[select][env]")
+CUB_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream without equality_op", "[select][env]", CUB_SMALL)
 {
   // example-begin select-uniquebykey-default-eq-env
   // Same setup/expectations as the explicit equality_op test above, but relying on default equality.
@@ -408,7 +410,7 @@ C2H_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream without equalit
   REQUIRE(num_selected == expected_num_selected);
 }
 
-C2H_TEST("cub::DeviceSelect::UniqueByKey accepts default env without equality_op", "[select][env]")
+CUB_TEST("cub::DeviceSelect::UniqueByKey accepts default env without equality_op", "[select][env]", CUB_SMALL)
 {
   // Same expectations as other UniqueByKey tests, but call the 6-arg overload.
   auto keys_in      = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
@@ -453,7 +455,7 @@ struct SelectPolicySelector
 };
 // example-end select-if-policy-selector
 
-C2H_TEST("cub::DeviceSelect::If accepts a custom policy selector", "[select][env]")
+CUB_TEST("cub::DeviceSelect::If accepts a custom policy selector", "[select][env]", CUB_SMALL)
 {
   // example-begin select-if-tuning
   auto d_in           = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
@@ -499,7 +501,7 @@ struct UniqueByKeyPolicySelector
 };
 // example-end unique-by-key-policy-selector
 
-C2H_TEST("cub::DeviceSelect::UniqueByKey accepts a custom policy selector", "[select_unique_by_key][env]")
+CUB_TEST("cub::DeviceSelect::UniqueByKey accepts a custom policy selector", "[select_unique_by_key][env]", CUB_SMALL)
 {
   // example-begin unique-by-key-tuning
   auto keys_in          = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};

--- a/cub/test/catch2_test_device_select_flagged.cu
+++ b/cub/test/catch2_test_device_select_flagged.cu
@@ -17,7 +17,7 @@
 
 #include "catch2_test_device_select_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <class T, class FlagT>
 static c2h::host_vector<T> get_reference(const c2h::device_vector<T>& in, const c2h::device_vector<FlagT>& flags)
@@ -83,7 +83,7 @@ using types =
 #endif // !(NVCC 12.0 and GCC 11.4 and C++20)
                  c2h::custom_type_t<c2h::equal_comparable_t>>;
 
-C2H_TEST("DeviceSelect::Flagged can run with empty input", "[device][select_flagged]", types)
+CUB_TEST("DeviceSelect::Flagged can run with empty input", "[device][select_flagged]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -101,7 +101,7 @@ C2H_TEST("DeviceSelect::Flagged can run with empty input", "[device][select_flag
   REQUIRE(num_selected_out[0] == 0);
 }
 
-C2H_TEST("DeviceSelect::Flagged handles all matched", "[device][select_flagged]", types)
+CUB_TEST("DeviceSelect::Flagged handles all matched", "[device][select_flagged]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -122,7 +122,7 @@ C2H_TEST("DeviceSelect::Flagged handles all matched", "[device][select_flagged]"
   REQUIRE(out == in);
 }
 
-C2H_TEST("DeviceSelect::Flagged handles no matched", "[device][select_flagged]", types)
+CUB_TEST("DeviceSelect::Flagged handles no matched", "[device][select_flagged]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -142,7 +142,7 @@ C2H_TEST("DeviceSelect::Flagged handles no matched", "[device][select_flagged]",
   REQUIRE(num_selected_out[0] == 0);
 }
 
-C2H_TEST("DeviceSelect::Flagged does not change input", "[device][select_flagged]", types)
+CUB_TEST("DeviceSelect::Flagged does not change input", "[device][select_flagged]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -168,8 +168,9 @@ C2H_TEST("DeviceSelect::Flagged does not change input", "[device][select_flagged
   REQUIRE(reference == in);
 }
 
-C2H_TEST("DeviceSelect::Flagged is stable",
+CUB_TEST("DeviceSelect::Flagged is stable",
          "[device][select_flagged]",
+         CUB_SMALL,
          c2h::type_list<c2h::custom_type_t<c2h::equal_comparable_t>>)
 {
   using type = typename c2h::get<0, TestType>;
@@ -196,7 +197,10 @@ C2H_TEST("DeviceSelect::Flagged is stable",
 }
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DeviceSelect::Flagged works with user provided memory and environment", "[device][select_flagged]", all_types)
+CUB_TEST("DeviceSelect::Flagged works with user provided memory and environment",
+         "[device][select_flagged]",
+         CUB_SMALL,
+         all_types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -294,7 +298,7 @@ C2H_TEST("DeviceSelect::Flagged works with user provided memory and environment"
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DeviceSelect::Flagged works with iterators", "[device][select_flagged]", all_types)
+CUB_TEST("DeviceSelect::Flagged works with iterators", "[device][select_flagged]", CUB_SMALL, all_types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -319,7 +323,7 @@ C2H_TEST("DeviceSelect::Flagged works with iterators", "[device][select_flagged]
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DeviceSelect::Flagged works with pointers", "[device][select_flagged]", types)
+CUB_TEST("DeviceSelect::Flagged works with pointers", "[device][select_flagged]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -372,7 +376,7 @@ struct convertible_to_bool
   }
 };
 
-C2H_TEST("DeviceSelect::Flagged works with flags that are convertible to bool", "[device][select_flagged]")
+CUB_TEST("DeviceSelect::Flagged works with flags that are convertible to bool", "[device][select_flagged]", CUB_SMALL)
 {
   using type = c2h::custom_type_t<c2h::equal_comparable_t>;
 
@@ -399,7 +403,7 @@ C2H_TEST("DeviceSelect::Flagged works with flags that are convertible to bool", 
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DeviceSelect::Flagged works with flags that alias input", "[device][select_flagged]")
+CUB_TEST("DeviceSelect::Flagged works with flags that alias input", "[device][select_flagged]", CUB_SMALL)
 {
   using type = int;
 
@@ -422,7 +426,7 @@ C2H_TEST("DeviceSelect::Flagged works with flags that alias input", "[device][se
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DeviceSelect::Flagged works in place", "[device][select_flagged]", types)
+CUB_TEST("DeviceSelect::Flagged works in place", "[device][select_flagged]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -445,7 +449,7 @@ C2H_TEST("DeviceSelect::Flagged works in place", "[device][select_flagged]", typ
   REQUIRE(reference == in);
 }
 
-C2H_TEST("DeviceSelect::Flagged works in place with flags that alias input", "[device][select_flagged]")
+CUB_TEST("DeviceSelect::Flagged works in place with flags that alias input", "[device][select_flagged]", CUB_SMALL)
 {
   using type = int;
 
@@ -488,7 +492,7 @@ struct convertible_from_T
   }
 };
 
-C2H_TEST("DeviceSelect::Flagged works with a different output type", "[device][select_flagged]")
+CUB_TEST("DeviceSelect::Flagged works with a different output type", "[device][select_flagged]", CUB_SMALL)
 {
   using type = c2h::custom_type_t<c2h::equal_comparable_t>;
 
@@ -514,8 +518,9 @@ C2H_TEST("DeviceSelect::Flagged works with a different output type", "[device][s
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DeviceSelect::Flagged works for very large number of items",
-         "[device][select_flagged][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
+CUB_TEST("DeviceSelect::Flagged works for very large number of items",
+         "[device][select_flagged][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_SMALL)
 try
 {
   using type     = std::int64_t;

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -16,7 +16,7 @@
 #include <algorithm>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <typename PredOpT>
 struct predicate_op_wrapper_t
@@ -105,7 +105,7 @@ using types =
 
 using flag_types = c2h::type_list<std::uint8_t, std::uint64_t, custom_t>;
 
-C2H_TEST("DeviceSelect::FlaggedIf can run with empty input", "[device][select_flagged_if]", types)
+CUB_TEST("DeviceSelect::FlaggedIf can run with empty input", "[device][select_flagged_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -123,7 +123,7 @@ C2H_TEST("DeviceSelect::FlaggedIf can run with empty input", "[device][select_fl
   REQUIRE(num_selected_out[0] == 0);
 }
 
-C2H_TEST("DeviceSelect::FlaggedIf handles all matched", "[device][select_flagged_if]", types)
+CUB_TEST("DeviceSelect::FlaggedIf handles all matched", "[device][select_flagged_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -143,7 +143,7 @@ C2H_TEST("DeviceSelect::FlaggedIf handles all matched", "[device][select_flagged
   REQUIRE(out == in);
 }
 
-C2H_TEST("DeviceSelect::FlaggedIf handles no matched", "[device][select_flagged_if]", types)
+CUB_TEST("DeviceSelect::FlaggedIf handles no matched", "[device][select_flagged_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -163,8 +163,9 @@ C2H_TEST("DeviceSelect::FlaggedIf handles no matched", "[device][select_flagged_
   REQUIRE(num_selected_out[0] == 0);
 }
 
-C2H_TEST("DeviceSelect::FlaggedIf does not change input and is stable",
+CUB_TEST("DeviceSelect::FlaggedIf does not change input and is stable",
          "[device][select_flagged_if]",
+         CUB_SMALL,
          c2h::type_list<std::uint8_t, std::uint64_t>,
          flag_types)
 {
@@ -204,8 +205,9 @@ C2H_TEST("DeviceSelect::FlaggedIf does not change input and is stable",
 }
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DeviceSelect::FlaggedIf works with user provided memory and environment",
+CUB_TEST("DeviceSelect::FlaggedIf works with user provided memory and environment",
          "[device][select_if]",
+         CUB_SMALL,
          all_types,
          flag_types)
 {
@@ -316,8 +318,9 @@ C2H_TEST("DeviceSelect::FlaggedIf works with user provided memory and environmen
   }
 }
 
-C2H_TEST("DeviceSelect::FlaggedIf works in place with user provided memory and environment",
+CUB_TEST("DeviceSelect::FlaggedIf works in place with user provided memory and environment",
          "[device][select_if]",
+         CUB_SMALL,
          all_types,
          flag_types)
 {
@@ -426,7 +429,7 @@ C2H_TEST("DeviceSelect::FlaggedIf works in place with user provided memory and e
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DeviceSelect::FlaggedIf works with iterators", "[device][select_if]", all_types, flag_types)
+CUB_TEST("DeviceSelect::FlaggedIf works with iterators", "[device][select_if]", CUB_SMALL, all_types, flag_types)
 {
   using input_type = typename c2h::get<0, TestType>;
   using flag_type  = typename c2h::get<1, TestType>;
@@ -454,7 +457,7 @@ C2H_TEST("DeviceSelect::FlaggedIf works with iterators", "[device][select_if]", 
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DeviceSelect::FlaggedIf works with pointers", "[device][select_flagged]", types, flag_types)
+CUB_TEST("DeviceSelect::FlaggedIf works with pointers", "[device][select_flagged]", CUB_SMALL, types, flag_types)
 {
   using input_type = typename c2h::get<0, TestType>;
   using flag_type  = typename c2h::get<1, TestType>;

--- a/cub/test/catch2_test_device_select_if.cu
+++ b/cub/test/catch2_test_device_select_if.cu
@@ -23,7 +23,7 @@
 
 #include "catch2_test_device_select_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSelect::If, select_if);
 
@@ -60,7 +60,7 @@ using types =
 #endif // !(NVCC 12.0 and GCC 11.4 and C++20)
                  c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>>;
 
-C2H_TEST("DeviceSelect::If can run with empty input", "[device][select_if]", types)
+CUB_TEST("DeviceSelect::If can run with empty input", "[device][select_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -77,7 +77,7 @@ C2H_TEST("DeviceSelect::If can run with empty input", "[device][select_if]", typ
   REQUIRE(num_selected_out[0] == 0);
 }
 
-C2H_TEST("DeviceSelect::If handles all matched", "[device][select_if]", types)
+CUB_TEST("DeviceSelect::If handles all matched", "[device][select_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -96,7 +96,7 @@ C2H_TEST("DeviceSelect::If handles all matched", "[device][select_if]", types)
   REQUIRE(out == in);
 }
 
-C2H_TEST("DeviceSelect::If handles no matched", "[device][select_if]", types)
+CUB_TEST("DeviceSelect::If handles no matched", "[device][select_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -114,7 +114,7 @@ C2H_TEST("DeviceSelect::If handles no matched", "[device][select_if]", types)
   REQUIRE(num_selected_out[0] == 0);
 }
 
-C2H_TEST("DeviceSelect::If does not change input", "[device][select_if]", types)
+CUB_TEST("DeviceSelect::If does not change input", "[device][select_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -138,7 +138,7 @@ C2H_TEST("DeviceSelect::If does not change input", "[device][select_if]", types)
   REQUIRE(reference == in);
 }
 
-C2H_TEST("DeviceSelect::If is stable", "[device][select_if]")
+CUB_TEST("DeviceSelect::If is stable", "[device][select_if]", CUB_SMALL)
 {
   using type = c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>;
 
@@ -170,7 +170,7 @@ C2H_TEST("DeviceSelect::If is stable", "[device][select_if]")
 }
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DeviceSelect::If works with user provided memory and environment", "[device][select_if]", all_types)
+CUB_TEST("DeviceSelect::If works with user provided memory and environment", "[device][select_if]", CUB_SMALL, all_types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -265,7 +265,10 @@ C2H_TEST("DeviceSelect::If works with user provided memory and environment", "[d
   }
 }
 
-C2H_TEST("DeviceSelect::If works in place with user provided memory and environment", "[device][select_if]", all_types)
+CUB_TEST("DeviceSelect::If works in place with user provided memory and environment",
+         "[device][select_if]",
+         CUB_SMALL,
+         all_types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -352,7 +355,7 @@ C2H_TEST("DeviceSelect::If works in place with user provided memory and environm
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DeviceSelect::If works with iterators", "[device][select_if]", all_types)
+CUB_TEST("DeviceSelect::If works with iterators", "[device][select_if]", CUB_SMALL, all_types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -375,7 +378,7 @@ C2H_TEST("DeviceSelect::If works with iterators", "[device][select_if]", all_typ
   REQUIRE(thrust::all_of(c2h::device_policy, boundary, out.end(), cuda::equal_to_value{type{}}));
 }
 
-C2H_TEST("DeviceSelect::If works with pointers", "[device][select_if]", types)
+CUB_TEST("DeviceSelect::If works with pointers", "[device][select_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -399,7 +402,7 @@ C2H_TEST("DeviceSelect::If works with pointers", "[device][select_if]", types)
   REQUIRE(thrust::all_of(c2h::device_policy, boundary, out.end(), cuda::equal_to_value{type{}}));
 }
 
-C2H_TEST("DeviceSelect::If works in place", "[device][select_if]", types)
+CUB_TEST("DeviceSelect::If works in place", "[device][select_if]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -445,7 +448,7 @@ struct convertible_from_T
   }
 };
 
-C2H_TEST("DeviceSelect::If works with a different output type", "[device][select_if]")
+CUB_TEST("DeviceSelect::If works with a different output type", "[device][select_if]", CUB_SMALL)
 {
   using type = c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>;
 
@@ -468,8 +471,9 @@ C2H_TEST("DeviceSelect::If works with a different output type", "[device][select
   REQUIRE(thrust::all_of(c2h::device_policy, boundary, out.end(), cuda::equal_to_value{type{}}));
 }
 
-C2H_TEST("DeviceSelect::If works for very large number of items",
-         "[device][select_if][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
+CUB_TEST("DeviceSelect::If works for very large number of items",
+         "[device][select_if][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_SMALL)
 try
 {
   using type     = std::int64_t;
@@ -514,8 +518,9 @@ catch (std::bad_alloc&)
   SUCCEED("exceeding memory is not a failure");
 }
 
-C2H_TEST("DeviceSelect::If works for very large number of output items",
-         "[device][select_if][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
+CUB_TEST("DeviceSelect::If works for very large number of output items",
+         "[device][select_if][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_LARGE)
 try
 {
   using type     = std::uint8_t;
@@ -563,7 +568,7 @@ catch (std::bad_alloc&)
   SUCCEED("exceeding memory is not a failure");
 }
 
-C2H_TEST("DeviceSelect::If works with iterators", "[device][select_if]")
+CUB_TEST("DeviceSelect::If works with iterators", "[device][select_if]", CUB_SMALL)
 {
   using type = int;
 

--- a/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
@@ -13,7 +13,7 @@
 
 #include <cuda/std/functional>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -43,7 +43,7 @@ struct is_even_t
   }
 };
 
-C2H_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]")
+CUB_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]", CUB_SMALL)
 {
   using value_t  = int;
   using offset_t = int;

--- a/cub/test/catch2_test_device_select_if_vsmem.cu
+++ b/cub/test/catch2_test_device_select_if_vsmem.cu
@@ -8,7 +8,7 @@
 #include <algorithm>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/vector.h>
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
@@ -36,7 +36,7 @@ struct less_than_t
   }
 };
 
-C2H_TEST("DeviceSelect::If works for large types", "[select_if][vsmem][device]", types)
+CUB_TEST("DeviceSelect::If works for large types", "[select_if][vsmem][device]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -16,7 +16,7 @@
 #include "catch2_large_problem_helper.cuh"
 #include "catch2_test_device_select_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 struct fake_equal_to
 {
@@ -92,7 +92,7 @@ using all_types =
 
 using types = c2h::type_list<std::uint8_t, std::uint32_t>;
 
-C2H_TEST("DeviceSelect::Unique can run with empty input", "[device][select_unique]", types)
+CUB_TEST("DeviceSelect::Unique can run with empty input", "[device][select_unique]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -113,7 +113,7 @@ C2H_TEST("DeviceSelect::Unique can run with empty input", "[device][select_uniqu
   REQUIRE(num_selected_out[0] == 0);
 }
 
-C2H_TEST("DeviceSelect::Unique handles none equal", "[device][select_unique]", types)
+CUB_TEST("DeviceSelect::Unique handles none equal", "[device][select_unique]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -141,7 +141,7 @@ C2H_TEST("DeviceSelect::Unique handles none equal", "[device][select_unique]", t
   REQUIRE(num_selected_out[0] == 1);
 }
 
-C2H_TEST("DeviceSelect::Unique handles all equal", "[device][select_unique]", types)
+CUB_TEST("DeviceSelect::Unique handles all equal", "[device][select_unique]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -168,7 +168,7 @@ C2H_TEST("DeviceSelect::Unique handles all equal", "[device][select_unique]", ty
   REQUIRE(out[0] == in[0]);
 }
 
-C2H_TEST("DeviceSelect::Unique does not change input", "[device][select_unique]", types)
+CUB_TEST("DeviceSelect::Unique does not change input", "[device][select_unique]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -194,7 +194,8 @@ C2H_TEST("DeviceSelect::Unique does not change input", "[device][select_unique]"
 }
 
 #if TEST_LAUNCH == 0
-C2H_TEST("DeviceSelect::Unique works with user provided memory and environments", "[device][select_unique]", types)
+CUB_TEST(
+  "DeviceSelect::Unique works with user provided memory and environments", "[device][select_unique]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -317,7 +318,7 @@ C2H_TEST("DeviceSelect::Unique works with user provided memory and environments"
 }
 #endif // TEST_LAUNCH == 0
 
-C2H_TEST("DeviceSelect::Unique works with iterators", "[device][select_unique]", all_types)
+CUB_TEST("DeviceSelect::Unique works with iterators", "[device][select_unique]", CUB_SMALL, all_types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -348,7 +349,7 @@ C2H_TEST("DeviceSelect::Unique works with iterators", "[device][select_unique]",
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DeviceSelect::Unique works with pointers", "[device][select_unique]", types)
+CUB_TEST("DeviceSelect::Unique works with pointers", "[device][select_unique]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -404,7 +405,7 @@ struct convertible_from_T
   }
 };
 
-C2H_TEST("DeviceSelect::Unique works with a different output type", "[device][select_unique]", types)
+CUB_TEST("DeviceSelect::Unique works with a different output type", "[device][select_unique]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -435,7 +436,7 @@ C2H_TEST("DeviceSelect::Unique works with a different output type", "[device][se
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DeviceSelect::Unique in-place empty and uniform data", "[device][select_unique]", types)
+CUB_TEST("DeviceSelect::Unique in-place empty and uniform data", "[device][select_unique]", CUB_SMALL, types)
 {
   using type         = typename c2h::get<0, TestType>;
   constexpr auto val = static_cast<type>(1);
@@ -476,7 +477,7 @@ C2H_TEST("DeviceSelect::Unique in-place empty and uniform data", "[device][selec
   }
 }
 
-C2H_TEST("DeviceSelect::Unique in-place random data", "[device][select_unique]", all_types)
+CUB_TEST("DeviceSelect::Unique in-place random data", "[device][select_unique]", CUB_SMALL, all_types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -509,8 +510,9 @@ C2H_TEST("DeviceSelect::Unique in-place random data", "[device][select_unique]",
   }
 }
 
-C2H_TEST("DeviceSelect::Unique works for very large number of items",
-         "[device][select_unique][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
+CUB_TEST("DeviceSelect::Unique works for very large number of items",
+         "[device][select_unique][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_SMALL)
 try
 {
   using type     = std::int64_t;

--- a/cub/test/catch2_test_device_select_unique_by_key.cu
+++ b/cub/test/catch2_test_device_select_unique_by_key.cu
@@ -12,7 +12,7 @@
 #include <algorithm>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <class T>
 inline T to_bound(const unsigned long long bound)
@@ -112,7 +112,7 @@ using huge_types = c2h::type_list<c2h::custom_type_t<c2h::equal_comparable_t, c2
 
 using types = c2h::type_list<std::uint8_t, std::uint32_t>;
 
-C2H_TEST("DeviceSelect::UniqueByKey can run with empty input", "[device][select_unique_by_key]", types)
+CUB_TEST("DeviceSelect::UniqueByKey can run with empty input", "[device][select_unique_by_key]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -128,7 +128,7 @@ C2H_TEST("DeviceSelect::UniqueByKey can run with empty input", "[device][select_
   REQUIRE(num_selected_out[0] == 0);
 }
 
-C2H_TEST("DeviceSelect::UniqueByKey handles none equal", "[device][select_unique_by_key]", types)
+CUB_TEST("DeviceSelect::UniqueByKey handles none equal", "[device][select_unique_by_key]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -155,7 +155,7 @@ C2H_TEST("DeviceSelect::UniqueByKey handles none equal", "[device][select_unique
   REQUIRE(vals_in == vals_out);
 }
 
-C2H_TEST("DeviceSelect::UniqueByKey handles all equal", "[device][select_unique_by_key]", types)
+CUB_TEST("DeviceSelect::UniqueByKey handles all equal", "[device][select_unique_by_key]", CUB_SMALL, types)
 {
   using type     = typename c2h::get<0, TestType>;
   using val_type = c2h::custom_type_t<c2h::equal_comparable_t>;
@@ -182,7 +182,7 @@ C2H_TEST("DeviceSelect::UniqueByKey handles all equal", "[device][select_unique_
   REQUIRE(vals_in[0] == vals_out[0]);
 }
 
-C2H_TEST("DeviceSelect::UniqueByKey does not change input", "[device][select_unique_by_key]", types)
+CUB_TEST("DeviceSelect::UniqueByKey does not change input", "[device][select_unique_by_key]", CUB_SMALL, types)
 {
   using type     = typename c2h::get<0, TestType>;
   using val_type = c2h::custom_type_t<c2h::equal_comparable_t>;
@@ -234,7 +234,7 @@ struct custom_equality_op
   }
 };
 
-C2H_TEST("DeviceSelect::UniqueByKey works with iterators", "[device][select_unique_by_key]", all_types)
+CUB_TEST("DeviceSelect::UniqueByKey works with iterators", "[device][select_unique_by_key]", CUB_SMALL, all_types)
 {
   using type     = typename c2h::get<0, TestType>;
   using val_type = c2h::custom_type_t<c2h::equal_comparable_t>;
@@ -270,7 +270,7 @@ C2H_TEST("DeviceSelect::UniqueByKey works with iterators", "[device][select_uniq
   REQUIRE(reference_vals == vals_out);
 }
 
-C2H_TEST("DeviceSelect::UniqueByKey works with pointers", "[device][select_unique_by_key]", types)
+CUB_TEST("DeviceSelect::UniqueByKey works with pointers", "[device][select_unique_by_key]", CUB_SMALL, types)
 {
   using type     = typename c2h::get<0, TestType>;
   using val_type = c2h::custom_type_t<c2h::equal_comparable_t>;
@@ -331,7 +331,8 @@ struct convertible_from_T
   }
 };
 
-C2H_TEST("DeviceSelect::UniqueByKey works with a different output type", "[device][select_unique_by_key]", types)
+CUB_TEST(
+  "DeviceSelect::UniqueByKey works with a different output type", "[device][select_unique_by_key]", CUB_SMALL, types)
 {
   using type     = typename c2h::get<0, TestType>;
   using val_type = c2h::custom_type_t<c2h::equal_comparable_t>;
@@ -367,8 +368,9 @@ C2H_TEST("DeviceSelect::UniqueByKey works with a different output type", "[devic
   REQUIRE(reference_vals == vals_out);
 }
 
-C2H_TEST("DeviceSelect::UniqueByKey works and uses vsmem for large types",
+CUB_TEST("DeviceSelect::UniqueByKey works and uses vsmem for large types",
          "[device][select_unique_by_key][vsmem]",
+         CUB_SMALL,
          huge_types)
 {
   using type     = std::uint32_t;
@@ -412,8 +414,9 @@ C2H_TEST("DeviceSelect::UniqueByKey works and uses vsmem for large types",
   REQUIRE(reference_vals == vals_out);
 }
 
-C2H_TEST("DeviceSelect::UniqueByKey works for very large input that need 64-bit offset types",
-         "[device][select_unique_by_key]")
+CUB_TEST("DeviceSelect::UniqueByKey works for very large input that need 64-bit offset types",
+         "[device][select_unique_by_key]",
+         CUB_SMALL)
 {
   using type       = std::int32_t;
   using index_type = std::int64_t;
@@ -440,8 +443,9 @@ C2H_TEST("DeviceSelect::UniqueByKey works for very large input that need 64-bit 
   REQUIRE(reference_values == values_out);
 }
 
-C2H_TEST("DeviceSelect::UniqueByKey works for very large outputs that needs 64-bit offset types",
-         "[device][select_unique_by_key]")
+CUB_TEST("DeviceSelect::UniqueByKey works for very large outputs that needs 64-bit offset types",
+         "[device][select_unique_by_key]",
+         CUB_SMALL)
 {
   using type       = std::int32_t;
   using index_type = std::int64_t;
@@ -463,7 +467,7 @@ C2H_TEST("DeviceSelect::UniqueByKey works for very large outputs that needs 64-b
   REQUIRE(num_items == static_cast<std::size_t>(num_selected_out[0]));
 }
 
-C2H_TEST("DeviceSelect::UniqueByKey works with a custom equality operator", "[device][select_unique_by_key]")
+CUB_TEST("DeviceSelect::UniqueByKey works with a custom equality operator", "[device][select_unique_by_key]", CUB_SMALL)
 {
   using type        = std::int32_t;
   using custom_op_t = custom_equality_op<type>;

--- a/cub/test/catch2_test_device_select_unique_by_key_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_select_unique_by_key_custom_policy_hub.cu
@@ -13,7 +13,7 @@
 
 #include <cuda/std/functional>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -33,7 +33,7 @@ struct my_policy_hub
   };
 };
 
-C2H_TEST("DispatchUniqueByKey::Dispatch: custom policy hub", "[select_unique_by_key][device]")
+CUB_TEST("DispatchUniqueByKey::Dispatch: custom policy hub", "[select_unique_by_key][device]", CUB_SMALL)
 {
   using key_t    = int;
   using value_t  = int;

--- a/cub/test/catch2_test_device_select_unique_by_key_env.cu
+++ b/cub/test/catch2_test_device_select_unique_by_key_env.cu
@@ -13,7 +13,7 @@
 
 #include <algorithm>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <class T>
 inline T to_bound(const unsigned long long bound)
@@ -79,7 +79,9 @@ struct custom_equality_op
   }
 };
 
-C2H_TEST("DeviceSelect::UniqueByKey works with user provided memory and environment", "[device][select_unique_by_key]")
+CUB_TEST("DeviceSelect::UniqueByKey works with user provided memory and environment",
+         "[device][select_unique_by_key]",
+         CUB_SMALL)
 {
   using type     = int;
   using val_type = c2h::custom_type_t<c2h::equal_comparable_t>;
@@ -204,8 +206,9 @@ C2H_TEST("DeviceSelect::UniqueByKey works with user provided memory and environm
   }
 }
 
-C2H_TEST("DeviceSelect::UniqueByKey works with user provided operator, memory and environment",
-         "[device][select_unique_by_key]")
+CUB_TEST("DeviceSelect::UniqueByKey works with user provided operator, memory and environment",
+         "[device][select_unique_by_key]",
+         CUB_SMALL)
 {
   using type        = int;
   using custom_op_t = custom_equality_op<type>;

--- a/cub/test/catch2_test_device_three_way_partition.cu
+++ b/cub/test/catch2_test_device_three_way_partition.cu
@@ -19,7 +19,7 @@
 #include "catch2_test_device_select_common.cuh"
 #include "catch2_test_launch_helper.h"
 #include "cub/util_type.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DevicePartition::If, partition);
 
@@ -78,7 +78,7 @@ struct multiply_and_add
   }
 };
 
-C2H_TEST("Device three-way partition can handle empty problems", "[partition][device]", types)
+CUB_TEST("Device three-way partition can handle empty problems", "[partition][device]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -201,7 +201,7 @@ thrust_partition(FirstPartSelectionOp first_selector, SecondPartSelectionOp seco
   return result;
 }
 
-C2H_TEST("Device three-way partition is stable", "[partition][device]", types)
+CUB_TEST("Device three-way partition is stable", "[partition][device]", CUB_SMALL, types)
 {
   using type      = typename c2h::get<0, TestType>;
   using pair_type = cuda::std::pair<type, std::uint32_t>;
@@ -224,7 +224,7 @@ C2H_TEST("Device three-way partition is stable", "[partition][device]", types)
   REQUIRE(cub_result == thrust_result);
 }
 
-C2H_TEST("Device three-way partition handles empty first part", "[partition][device]", types)
+CUB_TEST("Device three-way partition handles empty first part", "[partition][device]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -245,7 +245,7 @@ C2H_TEST("Device three-way partition handles empty first part", "[partition][dev
   REQUIRE(cub_result.num_items_in_first_part == 0);
 }
 
-C2H_TEST("Device three-way partition handles empty second part", "[partition][device]", types)
+CUB_TEST("Device three-way partition handles empty second part", "[partition][device]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -266,7 +266,7 @@ C2H_TEST("Device three-way partition handles empty second part", "[partition][de
   REQUIRE(cub_result.num_items_in_second_part == 0);
 }
 
-C2H_TEST("Device three-way partition handles empty unselected part", "[partition][device]", types)
+CUB_TEST("Device three-way partition handles empty unselected part", "[partition][device]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -286,7 +286,7 @@ C2H_TEST("Device three-way partition handles empty unselected part", "[partition
   REQUIRE(cub_result.num_unselected_items == 0);
 }
 
-C2H_TEST("Device three-way partition handles only unselected items", "[partition][device]", types)
+CUB_TEST("Device three-way partition handles only unselected items", "[partition][device]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -307,7 +307,7 @@ C2H_TEST("Device three-way partition handles only unselected items", "[partition
   REQUIRE(cub_result.num_items_in_second_part == 0);
 }
 
-C2H_TEST("Device three-way partition handles reverse iterator", "[partition][device]", types)
+CUB_TEST("Device three-way partition handles reverse iterator", "[partition][device]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -363,7 +363,7 @@ C2H_TEST("Device three-way partition handles reverse iterator", "[partition][dev
   REQUIRE(actual_num_items_in_first_part == num_items_in_first_part);
 }
 
-C2H_TEST("Device three-way partition handles single output", "[partition][device]", types)
+CUB_TEST("Device three-way partition handles single output", "[partition][device]", CUB_SMALL, types)
 {
   using type = typename c2h::get<0, TestType>;
 
@@ -420,8 +420,9 @@ C2H_TEST("Device three-way partition handles single output", "[partition][device
   REQUIRE(actual_num_items_in_second_part == num_items_in_second_part);
 }
 
-C2H_TEST("Device three-way partition works for very large number of items",
+CUB_TEST("Device three-way partition works for very large number of items",
          "[device][partition][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_SMALL,
          offset_types)
 try
 {

--- a/cub/test/catch2_test_device_three_way_partition_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_three_way_partition_custom_policy_hub.cu
@@ -11,7 +11,7 @@
 
 #include <thrust/detail/raw_pointer_cast.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace cub;
 
@@ -50,7 +50,7 @@ struct equal_zero_t
   }
 };
 
-C2H_TEST("DispatchThreeWayPartitionIf::Dispatch: custom policy hub", "[partition][device]")
+CUB_TEST("DispatchThreeWayPartitionIf::Dispatch: custom policy hub", "[partition][device]", CUB_SMALL)
 {
   using value_t  = int;
   using offset_t = int;

--- a/cub/test/catch2_test_device_topk_api.cu
+++ b/cub/test/catch2_test_device_topk_api.cu
@@ -14,9 +14,11 @@
 #include <cuda/std/functional>
 #include <cuda/stream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("DeviceTopK::MinKeys API example for non-deterministic, unsorted results", "[device][device_transform]")
+CUB_TEST("DeviceTopK::MinKeys API example for non-deterministic, unsorted results",
+         "[device][device_transform]",
+         CUB_SMALL)
 {
   // example-begin topk-min-keys-non-deterministic-unsorted
   const int k = 4;
@@ -59,7 +61,9 @@ C2H_TEST("DeviceTopK::MinKeys API example for non-deterministic, unsorted result
   REQUIRE(output == expected);
 }
 
-C2H_TEST("DeviceTopK::MaxKeys API example for non-deterministic, unsorted results", "[device][device_transform]")
+CUB_TEST("DeviceTopK::MaxKeys API example for non-deterministic, unsorted results",
+         "[device][device_transform]",
+         CUB_SMALL)
 {
   // example-begin topk-max-keys-non-deterministic-unsorted
   const int k = 4;
@@ -102,7 +106,9 @@ C2H_TEST("DeviceTopK::MaxKeys API example for non-deterministic, unsorted result
   REQUIRE(output == expected);
 }
 
-C2H_TEST("DeviceTopK::MinPairs API example for non-deterministic, unsorted results", "[device][device_transform]")
+CUB_TEST("DeviceTopK::MinPairs API example for non-deterministic, unsorted results",
+         "[device][device_transform]",
+         CUB_SMALL)
 {
   // example-begin topk-min-pairs-non-deterministic-unsorted
   const int k     = 4;
@@ -152,7 +158,9 @@ C2H_TEST("DeviceTopK::MinPairs API example for non-deterministic, unsorted resul
   REQUIRE(values_out == expected_values);
 }
 
-C2H_TEST("DeviceTopK::MaxPairs API example for non-deterministic, unsorted results", "[device][device_transform]")
+CUB_TEST("DeviceTopK::MaxPairs API example for non-deterministic, unsorted results",
+         "[device][device_transform]",
+         CUB_SMALL)
 {
   // example-begin topk-max-pairs-non-deterministic-unsorted
   const int k     = 4;
@@ -246,7 +254,7 @@ __host__ __device__ bool operator>(const custom_t& lhs, const custom_t& rhs)
   return rhs < lhs;
 }
 
-C2H_TEST("DeviceTopK works with custom types and decomposer", "[device][topk]")
+CUB_TEST("DeviceTopK works with custom types and decomposer", "[device][topk]", CUB_SMALL)
 {
   SECTION("MaxKeys")
   {

--- a/cub/test/catch2_test_device_topk_env.cu
+++ b/cub/test/catch2_test_device_topk_env.cu
@@ -27,7 +27,7 @@ struct stream_registry_factory_t;
 
 // %PARAM% TEST_LAUNCH lid 0:2
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // TODO(bgruber): the tests below should be refactored to call an env-overload that uses a memory resource to allocate
 // temporary storage
@@ -54,7 +54,7 @@ using block_sizes =
 
 #if TEST_LAUNCH != 1
 
-C2H_TEST("DeviceTopK::MaxKeys can be tuned", "[topk][device]", block_sizes)
+CUB_TEST("DeviceTopK::MaxKeys can be tuned", "[topk][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size{0};
@@ -83,7 +83,7 @@ C2H_TEST("DeviceTopK::MaxKeys can be tuned", "[topk][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceTopK::MinKeys can be tuned", "[topk][device]", block_sizes)
+CUB_TEST("DeviceTopK::MinKeys can be tuned", "[topk][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size{0};
@@ -112,7 +112,7 @@ C2H_TEST("DeviceTopK::MinKeys can be tuned", "[topk][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceTopK::MaxPairs can be tuned", "[topk][device]", block_sizes)
+CUB_TEST("DeviceTopK::MaxPairs can be tuned", "[topk][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size{0};
@@ -145,7 +145,7 @@ C2H_TEST("DeviceTopK::MaxPairs can be tuned", "[topk][device]", block_sizes)
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-C2H_TEST("DeviceTopK::MinPairs can be tuned", "[topk][device]", block_sizes)
+CUB_TEST("DeviceTopK::MinPairs can be tuned", "[topk][device]", CUB_SMALL, block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size{0};
@@ -205,7 +205,7 @@ c2h::host_vector<int> sorted_top_k(const c2h::host_vector<int>& h_in, int k, boo
 }
 } // namespace
 
-C2H_TEST("DeviceTopK::MaxKeys env-alloc returns correct top K", "[topk][env]")
+CUB_TEST("DeviceTopK::MaxKeys env-alloc returns correct top K", "[topk][env]", CUB_SMALL)
 {
   const int num_items = 256;
   c2h::device_vector<int> d_in(num_items);
@@ -223,7 +223,7 @@ C2H_TEST("DeviceTopK::MaxKeys env-alloc returns correct top K", "[topk][env]")
   REQUIRE(h_out == expected);
 }
 
-C2H_TEST("DeviceTopK::MinKeys env-alloc returns correct bottom K", "[topk][env]")
+CUB_TEST("DeviceTopK::MinKeys env-alloc returns correct bottom K", "[topk][env]", CUB_SMALL)
 {
   const int num_items = 256;
   c2h::device_vector<int> d_in(num_items);
@@ -241,7 +241,7 @@ C2H_TEST("DeviceTopK::MinKeys env-alloc returns correct bottom K", "[topk][env]"
   REQUIRE(h_out == expected);
 }
 
-C2H_TEST("DeviceTopK::MaxPairs env-alloc returns correct top K", "[topk][env]")
+CUB_TEST("DeviceTopK::MaxPairs env-alloc returns correct top K", "[topk][env]", CUB_SMALL)
 {
   const int num_items = 256;
   c2h::device_vector<int> d_keys_in(num_items);
@@ -276,7 +276,7 @@ C2H_TEST("DeviceTopK::MaxPairs env-alloc returns correct top K", "[topk][env]")
   REQUIRE(h_keys_out == expected);
 }
 
-C2H_TEST("DeviceTopK::MinPairs env-alloc returns correct bottom K", "[topk][env]")
+CUB_TEST("DeviceTopK::MinPairs env-alloc returns correct bottom K", "[topk][env]", CUB_SMALL)
 {
   const int num_items = 256;
   c2h::device_vector<int> d_keys_in(num_items);
@@ -311,7 +311,7 @@ C2H_TEST("DeviceTopK::MinPairs env-alloc returns correct bottom K", "[topk][env]
   REQUIRE(h_keys_out == expected);
 }
 
-C2H_TEST("DeviceTopK::MaxKeys env-alloc handles K equal to num_items", "[topk][env]")
+CUB_TEST("DeviceTopK::MaxKeys env-alloc handles K equal to num_items", "[topk][env]", CUB_SMALL)
 {
   c2h::device_vector<int> d_in{5, 2, 9, 1, 7};
   c2h::device_vector<int> d_out(d_in.size());

--- a/cub/test/catch2_test_device_topk_env_api.cu
+++ b/cub/test/catch2_test_device_topk_env_api.cu
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // Simple user-defined key type for the decomposer-based examples.
 struct topk_custom_t
@@ -42,7 +42,7 @@ struct topk_custom_decomposer_t
   }
 };
 
-C2H_TEST("cub::DeviceTopK::MaxKeys env-alloc accepts stream_ref", "[topk][env]")
+CUB_TEST("cub::DeviceTopK::MaxKeys env-alloc accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-max-keys-env
   auto d_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9, 1, 4, 2};
@@ -72,7 +72,7 @@ C2H_TEST("cub::DeviceTopK::MaxKeys env-alloc accepts stream_ref", "[topk][env]")
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceTopK::MinKeys env-alloc accepts stream_ref", "[topk][env]")
+CUB_TEST("cub::DeviceTopK::MinKeys env-alloc accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-min-keys-env
   auto d_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9, 1, 4, 2};
@@ -101,7 +101,7 @@ C2H_TEST("cub::DeviceTopK::MinKeys env-alloc accepts stream_ref", "[topk][env]")
   REQUIRE(d_out == expected);
 }
 
-C2H_TEST("cub::DeviceTopK::MaxPairs env-alloc accepts stream_ref", "[topk][env]")
+CUB_TEST("cub::DeviceTopK::MaxPairs env-alloc accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-max-pairs-env
   auto d_keys_in    = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9, 1, 4, 2};
@@ -139,7 +139,7 @@ C2H_TEST("cub::DeviceTopK::MaxPairs env-alloc accepts stream_ref", "[topk][env]"
   REQUIRE(d_keys_out == expected_keys);
 }
 
-C2H_TEST("cub::DeviceTopK::MinPairs env-alloc accepts stream_ref", "[topk][env]")
+CUB_TEST("cub::DeviceTopK::MinPairs env-alloc accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-min-pairs-env
   auto d_keys_in    = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9, 1, 4, 2};
@@ -177,7 +177,7 @@ C2H_TEST("cub::DeviceTopK::MinPairs env-alloc accepts stream_ref", "[topk][env]"
   REQUIRE(d_keys_out == expected_keys);
 }
 
-C2H_TEST("cub::DeviceTopK::MaxKeys env-alloc with decomposer accepts stream_ref", "[topk][env]")
+CUB_TEST("cub::DeviceTopK::MaxKeys env-alloc with decomposer accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-max-keys-decomposer-env
   thrust::host_vector<topk_custom_t> h_in{
@@ -213,7 +213,7 @@ C2H_TEST("cub::DeviceTopK::MaxKeys env-alloc with decomposer accepts stream_ref"
   REQUIRE(actual_ranks == expected_ranks);
 }
 
-C2H_TEST("cub::DeviceTopK::MinKeys env-alloc with decomposer accepts stream_ref", "[topk][env]")
+CUB_TEST("cub::DeviceTopK::MinKeys env-alloc with decomposer accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-min-keys-decomposer-env
   thrust::host_vector<topk_custom_t> h_in{
@@ -249,7 +249,7 @@ C2H_TEST("cub::DeviceTopK::MinKeys env-alloc with decomposer accepts stream_ref"
   REQUIRE(actual_ranks == expected_ranks);
 }
 
-C2H_TEST("cub::DeviceTopK::MaxPairs env-alloc with decomposer accepts stream_ref", "[topk][env]")
+CUB_TEST("cub::DeviceTopK::MaxPairs env-alloc with decomposer accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-max-pairs-decomposer-env
   thrust::host_vector<topk_custom_t> h_keys_in{
@@ -294,7 +294,7 @@ C2H_TEST("cub::DeviceTopK::MaxPairs env-alloc with decomposer accepts stream_ref
   REQUIRE(actual_ranks == expected_ranks);
 }
 
-C2H_TEST("cub::DeviceTopK::MinPairs env-alloc with decomposer accepts stream_ref", "[topk][env]")
+CUB_TEST("cub::DeviceTopK::MinPairs env-alloc with decomposer accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-min-pairs-decomposer-env
   thrust::host_vector<topk_custom_t> h_keys_in{

--- a/cub/test/catch2_test_device_topk_keys.cu
+++ b/cub/test/catch2_test_device_topk_keys.cu
@@ -18,8 +18,8 @@
 #include "catch2_radix_sort_helper.cuh"
 #include "catch2_test_device_topk_common.cuh"
 #include "catch2_test_launch_helper.h"
+#include "cub_test_macros.h"
 #include "cuda/__iterator/tabulate_output_iterator.h"
-#include <c2h/catch2_test_helper.h>
 #include <c2h/extended_types.h>
 
 template <cub::detail::topk::select SelectDirection,
@@ -70,7 +70,7 @@ using key_types =
 
 using custom_key_types = c2h::type_list<topk_custom_key_t>;
 
-C2H_TEST("DeviceTopK::{Min,Max}Keys work as expected", "[keys][topk][device]", key_types, directions)
+CUB_TEST("DeviceTopK::{Min,Max}Keys work as expected", "[keys][topk][device]", CUB_SMALL, key_types, directions)
 {
   using key_t              = c2h::get<0, TestType>;
   constexpr auto direction = c2h::get<1, TestType>::value;
@@ -111,7 +111,7 @@ C2H_TEST("DeviceTopK::{Min,Max}Keys work as expected", "[keys][topk][device]", k
   REQUIRE(expected_keys == keys_out);
 }
 
-C2H_TEST("DeviceTopK::{Min,Max}Keys work with iterators", "[keys][topk][device]", key_types)
+CUB_TEST("DeviceTopK::{Min,Max}Keys work with iterators", "[keys][topk][device]", CUB_SMALL, key_types)
 {
   using key_t              = c2h::get<0, TestType>;
   using num_items_t        = cuda::std::uint32_t;
@@ -152,7 +152,8 @@ C2H_TEST("DeviceTopK::{Min,Max}Keys work with iterators", "[keys][topk][device]"
   }
 }
 
-C2H_TEST("DeviceTopK::{Min,Max}Keys works with a large number of items", "[keys][topk][device]", num_items_types)
+CUB_TEST(
+  "DeviceTopK::{Min,Max}Keys works with a large number of items", "[keys][topk][device]", CUB_LARGE, num_items_types)
 try
 {
   using key_t              = cuda::std::uint32_t;
@@ -193,8 +194,9 @@ catch (std::bad_alloc& e)
   std::cerr << "Caught bad_alloc: " << e.what() << '\n';
 }
 
-C2H_TEST("DeviceTopK::{Min,Max}Keys works with custom keys and decomposers",
+CUB_TEST("DeviceTopK::{Min,Max}Keys works with custom keys and decomposers",
          "[keys][topk][device]",
+         CUB_SMALL,
          custom_key_types,
          directions)
 {
@@ -265,8 +267,9 @@ C2H_TEST("DeviceTopK::{Min,Max}Keys works with custom keys and decomposers",
   REQUIRE(expected_keys == keys_out);
 }
 
-C2H_TEST("DeviceTopK::{Min,Max}Keys works for different offset types for num_items and k",
+CUB_TEST("DeviceTopK::{Min,Max}Keys works for different offset types for num_items and k",
          "[keys][topk][device]",
+         CUB_SMALL,
          k_items_types)
 try
 {

--- a/cub/test/catch2_test_device_topk_keys.cu
+++ b/cub/test/catch2_test_device_topk_keys.cu
@@ -269,7 +269,7 @@ CUB_TEST("DeviceTopK::{Min,Max}Keys works with custom keys and decomposers",
 
 CUB_TEST("DeviceTopK::{Min,Max}Keys works for different offset types for num_items and k",
          "[keys][topk][device]",
-         CUB_SMALL,
+         CUB_LARGE,
          k_items_types)
 try
 {

--- a/cub/test/catch2_test_device_topk_pairs.cu
+++ b/cub/test/catch2_test_device_topk_pairs.cu
@@ -17,7 +17,7 @@
 #include "catch2_large_problem_helper.cuh"
 #include "catch2_test_device_topk_common.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <cub::detail::topk::select SelectDirection,
           typename KeyInputIteratorT,
@@ -119,7 +119,7 @@ using k_items_types   = c2h::type_list<cuda::std::uint32_t, cuda::std::uint64_t>
 
 using custom_value_t = cuda::std::uint32_t;
 
-C2H_TEST("DeviceTopK::MaxPairs: Basic testing", "[pairs][topk][device]", key_types, value_types, directions)
+CUB_TEST("DeviceTopK::MaxPairs: Basic testing", "[pairs][topk][device]", CUB_SMALL, key_types, value_types, directions)
 {
   using key_t              = c2h::get<0, TestType>;
   using value_t            = c2h::get<1, TestType>;
@@ -177,7 +177,7 @@ C2H_TEST("DeviceTopK::MaxPairs: Basic testing", "[pairs][topk][device]", key_typ
   REQUIRE(res == true);
 }
 
-C2H_TEST("DeviceTopK::MaxPairs: Works with iterators", "[pairs][topk][device]", key_types, value_types)
+CUB_TEST("DeviceTopK::MaxPairs: Works with iterators", "[pairs][topk][device]", CUB_SMALL, key_types, value_types)
 {
   using key_t              = c2h::get<0, TestType>;
   using value_t            = c2h::get<1, TestType>;
@@ -218,7 +218,7 @@ C2H_TEST("DeviceTopK::MaxPairs: Works with iterators", "[pairs][topk][device]", 
   REQUIRE(res == true);
 }
 
-C2H_TEST("DeviceTopK::MaxPairs: Test for large num_items", "[pairs][topk][device]", num_items_types)
+CUB_TEST("DeviceTopK::MaxPairs: Test for large num_items", "[pairs][topk][device]", CUB_LARGE, num_items_types)
 {
   using key_t              = cuda::std::uint32_t;
   using value_t            = cuda::std::uint32_t;
@@ -262,7 +262,8 @@ C2H_TEST("DeviceTopK::MaxPairs: Test for large num_items", "[pairs][topk][device
   REQUIRE(res == true);
 }
 
-C2H_TEST("DeviceTopK::{Min,Max}Pairs works with custom keys and decomposers", "[pairs][topk][device]", directions)
+CUB_TEST(
+  "DeviceTopK::{Min,Max}Pairs works with custom keys and decomposers", "[pairs][topk][device]", CUB_SMALL, directions)
 {
   using key_t              = topk_custom_key_t;
   using value_t            = custom_value_t;

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -19,7 +19,7 @@
 
 #include "catch2_large_problem_helper.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 #include <c2h/test_util_vec.h>
 
@@ -30,8 +30,9 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceTransform::TransformStableArgumentAddresses, t
 DECLARE_LAUNCH_WRAPPER(cub::DeviceTransform::Generate, generate);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceTransform::Fill, fill);
 
-C2H_TEST("DeviceTransform::Transform BabelStream add",
+CUB_TEST("DeviceTransform::Transform BabelStream add",
          "[device][transform]",
+         CUB_SMALL,
          c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t, uchar3>)
 {
   using type     = c2h::get<0, TestType>;
@@ -58,8 +59,9 @@ C2H_TEST("DeviceTransform::Transform BabelStream add",
 }
 
 // note: because this uses a fancy iterator type, it will only test the fallback kernel
-C2H_TEST("DeviceTransform::Transform works for large number of items",
-         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
+CUB_TEST("DeviceTransform::Transform works for large number of items",
+         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_SMALL)
 {
   using offset_t = cuda::std::int64_t;
   CAPTURE(c2h::type_name<offset_t>());
@@ -77,8 +79,9 @@ C2H_TEST("DeviceTransform::Transform works for large number of items",
   check_result_helper.check_all_results_correct();
 }
 
-C2H_TEST("DeviceTransform::Transform with multiple inputs works for large number of items",
-         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
+CUB_TEST("DeviceTransform::Transform with multiple inputs works for large number of items",
+         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_SMALL)
 {
   using offset_t = cuda::std::int64_t;
   CAPTURE(c2h::type_name<offset_t>());
@@ -110,8 +113,9 @@ struct times_seven
 // num_items = 2^30 +/- a few thread blocks: combined with sizeof(type) = 4, byte product
 // straddles 4 GiB (negative delta -> just under, positive -> just over). Both deltas fit in I32
 // and I64 offset types.
-C2H_TEST("DeviceTransform::Transform works with large input",
-         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
+CUB_TEST("DeviceTransform::Transform works with large input",
+         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         CUB_LARGE)
 try
 {
   using type     = std::uint32_t;
@@ -221,7 +225,7 @@ struct uncommon_plus
   }
 };
 
-C2H_TEST("DeviceTransform::Transform uncommon types", "[device][transform]", uncommon_types)
+CUB_TEST("DeviceTransform::Transform uncommon types", "[device][transform]", CUB_SMALL, uncommon_types)
 {
   using type = c2h::get<0, TestType>;
   CAPTURE(c2h::type_name<type>());
@@ -266,7 +270,7 @@ static_assert(!cuda::std::is_default_constructible_v<non_default_constructible>)
 static_assert(cuda::std::is_trivially_copyable_v<non_default_constructible>); // as required by the standard
 static_assert(thrust::is_trivially_relocatable_v<non_default_constructible>); // CUB uses this check internally
 
-C2H_TEST("DeviceTransform::Transform non-default constructible types", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform non-default constructible types", "[device][transform]", CUB_SMALL)
 {
   using type          = non_default_constructible;
   const int num_items = GENERATE(0, 1, 100, 1'000, 100'000); // try to hit the small and full tile code paths
@@ -292,8 +296,9 @@ struct nstream_kernel
 };
 
 // overwrites one input stream
-C2H_TEST("DeviceTransform::Transform BabelStream nstream",
+CUB_TEST("DeviceTransform::Transform BabelStream nstream",
          "[device][transform]",
+         CUB_SMALL,
          c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t>)
 {
   using type     = c2h::get<0, TestType>;
@@ -330,7 +335,7 @@ struct sum_five
   }
 };
 
-C2H_TEST("DeviceTransform::Transform add five streams", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform add five streams", "[device][transform]", CUB_SMALL)
 {
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
   c2h::device_vector<std::int8_t> a(num_items, thrust::no_init);
@@ -369,7 +374,7 @@ struct give_me_five
   }
 };
 
-C2H_TEST("DeviceTransform::Generate", "[device][transform]")
+CUB_TEST("DeviceTransform::Generate", "[device][transform]", CUB_SMALL)
 {
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
   c2h::device_vector<int> result(num_items, thrust::no_init);
@@ -380,7 +385,7 @@ C2H_TEST("DeviceTransform::Generate", "[device][transform]")
   REQUIRE(reference == result);
 }
 
-C2H_TEST("DeviceTransform::Fill", "[device][transform]")
+CUB_TEST("DeviceTransform::Fill", "[device][transform]", CUB_SMALL)
 {
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
   c2h::device_vector<int> result(num_items, thrust::no_init);
@@ -391,7 +396,7 @@ C2H_TEST("DeviceTransform::Fill", "[device][transform]")
   REQUIRE(reference == result);
 }
 
-C2H_TEST("DeviceTransform::Transform fancy input iterator types", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform fancy input iterator types", "[device][transform]", CUB_SMALL)
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -407,7 +412,7 @@ C2H_TEST("DeviceTransform::Transform fancy input iterator types", "[device][tran
   REQUIRE(reference_h == result);
 }
 
-C2H_TEST("DeviceTransform::Transform fancy output iterator type", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform fancy output iterator type", "[device][transform]", CUB_SMALL)
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -421,7 +426,7 @@ C2H_TEST("DeviceTransform::Transform fancy output iterator type", "[device][tran
   REQUIRE(result == c2h::device_vector<type>(num_items, (13 + 35) + 4));
 }
 
-C2H_TEST("DeviceTransform::Transform fancy output iterator type with void value type", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform fancy output iterator type with void value type", "[device][transform]", CUB_SMALL)
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -445,7 +450,7 @@ struct plus_mul_neg
   }
 };
 
-C2H_TEST("DeviceTransform::Transform mixed iterator types 2 -> 3", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform mixed iterator types 2 -> 3", "[device][transform]", CUB_SMALL)
 {
   using type          = unsigned; // overflow is defined
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -486,7 +491,7 @@ struct plus_needs_stable_address
   }
 };
 
-C2H_TEST("DeviceTransform::Transform address stability", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform address stability", "[device][transform]", CUB_SMALL)
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -550,7 +555,7 @@ static_assert(!thrust::is_trivially_relocatable_v<non_trivial>); // CUB uses thi
 // (e.g. by tracking/counting invocations of those), since C++ allows (but not guarantees) elision of these operations.
 // Also thrust algorithms perform a lot of copies in-between, so the test needs to use only raw allocations and
 // iteration for setup and checking.
-C2H_TEST("DeviceTransform::Transform not trivially relocatable", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform not trivially relocatable", "[device][transform]", CUB_SMALL)
 {
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
   c2h::device_vector<non_trivial> input(num_items, non_trivial{42});
@@ -562,8 +567,9 @@ C2H_TEST("DeviceTransform::Transform not trivially relocatable", "[device][trans
   REQUIRE((reference == result));
 }
 
-C2H_TEST("DeviceTransform::Transform buffer start alignment",
+CUB_TEST("DeviceTransform::Transform buffer start alignment",
          "[device][transform]",
+         CUB_SMALL,
          c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t>)
 {
   using type          = c2h::get<0, TestType>;
@@ -617,7 +623,7 @@ struct StringMaker<cub::detail::transform::aligned_base_ptr<T>>
 } // namespace Catch
 
 // TODO(bgruber): rewrite this example using int3
-C2H_TEST("DeviceTransform::Transform aligned_base_ptr", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform aligned_base_ptr", "[device][transform]", CUB_SMALL)
 {
   alignas(128) int arr[256];
   using namespace cub::detail::transform;
@@ -632,7 +638,7 @@ C2H_TEST("DeviceTransform::Transform aligned_base_ptr", "[device][transform]")
   CHECK(make_aligned_base_ptr(&arr[129], 128) == aligned_base_ptr<int>{reinterpret_cast<char*>(&arr[128]), 4});
 }
 
-C2H_TEST("DeviceTransform::Transform aligned_base_ptr", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform aligned_base_ptr", "[device][transform]", CUB_SMALL)
 {
   using It         = cuda::std::reverse_iterator<thrust::detail::normal_iterator<thrust::device_ptr<int>>>;
   using kernel_arg = cub::detail::transform::kernel_arg<It>;
@@ -642,7 +648,7 @@ C2H_TEST("DeviceTransform::Transform aligned_base_ptr", "[device][transform]")
 }
 
 // See discussion on: https://github.com/NVIDIA/cccl/pull/4815
-C2H_TEST("DeviceTransform::Transform vectorized output bug", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform vectorized output bug", "[device][transform]", CUB_SMALL)
 {
   using thrust::placeholders::_1;
 
@@ -703,7 +709,7 @@ struct BtoC
   }
 };
 
-C2H_TEST("DeviceTransform::Transform function/output_iter return type not convertible", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform function/output_iter return type not convertible", "[device][transform]", CUB_SMALL)
 {
   using thrust::placeholders::_1;
 
@@ -726,7 +732,9 @@ __global__ void unrelated_kernel()
   asm("" : "+r"(dsmem[0]));
 }
 
-C2H_TEST("DeviceTransform::Transform does not effect unrelated kernel's static SMEM consumption", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform does not effect unrelated kernel's static SMEM consumption",
+         "[device][transform]",
+         CUB_SMALL)
 {
   cudaFuncAttributes attrs;
   REQUIRE(cudaFuncGetAttributes(&attrs, unrelated_kernel) == cudaSuccess);
@@ -772,7 +780,7 @@ void fill_pdl(T* data, size_t n, T value)
     .doit(fill_pdl_kernel<threads_per_block, items_per_thread, T>, data, n, value);
 }
 
-C2H_TEST("DeviceTransform::Transform PDL overlap check", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform PDL overlap check", "[device][transform]", CUB_SMALL)
 {
   using type = int;
   // need a warmup run to lazy load kernels and perform some setup, then a problem size that occupies 1/2 of all SMs

--- a/cub/test/catch2_test_device_transform_api.cu
+++ b/cub/test/catch2_test_device_transform_api.cu
@@ -8,7 +8,7 @@
 
 #include <cuda/iterator>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // need a separate function because the ext. lambda needs to be enclosed by a function with external linkage on Windows
 void test_transform_many_many_api()
@@ -36,7 +36,7 @@ void test_transform_many_many_api()
   CHECK(result2 == expected2);
 }
 
-C2H_TEST("DeviceTransform::Transform many->many API example", "[device][device_transform]")
+CUB_TEST("DeviceTransform::Transform many->many API example", "[device][device_transform]", CUB_SMALL)
 {
   test_transform_many_many_api();
 }
@@ -61,7 +61,7 @@ void test_transform_api()
   CHECK(result == expected);
 }
 
-C2H_TEST("DeviceTransform::Transform API example", "[device][device_transform]")
+CUB_TEST("DeviceTransform::Transform API example", "[device][device_transform]", CUB_SMALL)
 {
   test_transform_api();
 }
@@ -85,7 +85,7 @@ void test_transform_if_api()
   CHECK(result == expected);
 }
 
-C2H_TEST("DeviceTransform::TransformIf API example", "[device][device_transform]")
+CUB_TEST("DeviceTransform::TransformIf API example", "[device][device_transform]", CUB_SMALL)
 {
   test_transform_if_api();
 }
@@ -109,7 +109,7 @@ void test_transform_if_single_api()
   CHECK(result == expected);
 }
 
-C2H_TEST("DeviceTransform::TransformIf single-input API example", "[device][device_transform]")
+CUB_TEST("DeviceTransform::TransformIf single-input API example", "[device][device_transform]", CUB_SMALL)
 {
   test_transform_if_single_api();
 }
@@ -138,7 +138,7 @@ void test_transform_stable_api()
   CHECK(result == expected);
 }
 
-C2H_TEST("DeviceTransform::TransformStableArgumentAddresses API example", "[device][device_transform]")
+CUB_TEST("DeviceTransform::TransformStableArgumentAddresses API example", "[device][device_transform]", CUB_SMALL)
 {
   test_transform_stable_api();
 }
@@ -173,7 +173,7 @@ struct always_true_pred_t
   }
 };
 
-C2H_TEST("DeviceTransform::Transform legacy size-query is unambiguous", "[device_transform][device]")
+CUB_TEST("DeviceTransform::Transform legacy size-query is unambiguous", "[device_transform][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -185,7 +185,7 @@ C2H_TEST("DeviceTransform::Transform legacy size-query is unambiguous", "[device
           == cub::DeviceTransform::Transform(d_temp_storage, temp_storage_bytes, d_in, d_out, n, transform_noop_t{}));
 }
 
-C2H_TEST("DeviceTransform::Generate legacy size-query is unambiguous", "[device_transform][device]")
+CUB_TEST("DeviceTransform::Generate legacy size-query is unambiguous", "[device_transform][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -196,7 +196,7 @@ C2H_TEST("DeviceTransform::Generate legacy size-query is unambiguous", "[device_
     cudaSuccess == cub::DeviceTransform::Generate(d_temp_storage, temp_storage_bytes, d_out, n, generate_zero_t{}));
 }
 
-C2H_TEST("DeviceTransform::Fill legacy size-query is unambiguous", "[device_transform][device]")
+CUB_TEST("DeviceTransform::Fill legacy size-query is unambiguous", "[device_transform][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -207,7 +207,7 @@ C2H_TEST("DeviceTransform::Fill legacy size-query is unambiguous", "[device_tran
   REQUIRE(cudaSuccess == cub::DeviceTransform::Fill(d_temp_storage, temp_storage_bytes, d_out, n, value));
 }
 
-C2H_TEST("DeviceTransform::TransformIf legacy size-query is unambiguous", "[device_transform][device]")
+CUB_TEST("DeviceTransform::TransformIf legacy size-query is unambiguous", "[device_transform][device]", CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -220,8 +220,9 @@ C2H_TEST("DeviceTransform::TransformIf legacy size-query is unambiguous", "[devi
             d_temp_storage, temp_storage_bytes, d_in, d_out, n, always_true_pred_t{}, transform_noop_t{}));
 }
 
-C2H_TEST("DeviceTransform::TransformStableArgumentAddresses legacy size-query is unambiguous",
-         "[device_transform][device]")
+CUB_TEST("DeviceTransform::TransformStableArgumentAddresses legacy size-query is unambiguous",
+         "[device_transform][device]",
+         CUB_SMALL)
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;

--- a/cub/test/catch2_test_device_transform_env.cu
+++ b/cub/test/catch2_test_device_transform_env.cu
@@ -11,7 +11,7 @@
 
 #include <sstream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using namespace thrust::placeholders;
 
@@ -131,7 +131,7 @@ void check_graph_nodes_with_different_streams(F call_cub_api)
   REQUIRE(cudaGraphDestroy(graph) == cudaSuccess);
 }
 
-C2H_TEST("DeviceTransform::Transform custom stream", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform custom stream", "[device][transform]", CUB_SMALL)
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -146,7 +146,7 @@ C2H_TEST("DeviceTransform::Transform custom stream", "[device][transform]")
   CHECK(thrust::equal(result.begin(), result.end(), cuda::counting_iterator<type>{42 + 13}));
 }
 
-C2H_TEST("DeviceTransform::Transform (single argument) custom stream", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform (single argument) custom stream", "[device][transform]", CUB_SMALL)
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -160,7 +160,7 @@ C2H_TEST("DeviceTransform::Transform (single argument) custom stream", "[device]
   CHECK(thrust::equal(result.begin(), result.end(), cuda::counting_iterator<type>{42 + 13}));
 }
 
-C2H_TEST("DeviceTransform::Generate custom stream", "[device][transform]")
+CUB_TEST("DeviceTransform::Generate custom stream", "[device][transform]", CUB_SMALL)
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -177,7 +177,7 @@ C2H_TEST("DeviceTransform::Generate custom stream", "[device][transform]")
   CHECK(thrust::equal(result.begin(), result.end(), cuda::constant_iterator<type>{1337}));
 }
 
-C2H_TEST("DeviceTransform::Fill custom stream", "[device][transform]")
+CUB_TEST("DeviceTransform::Fill custom stream", "[device][transform]", CUB_SMALL)
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -199,7 +199,7 @@ struct reference_func
   }
 };
 
-C2H_TEST("DeviceTransform::TransformIf custom stream", "[device][transform]")
+CUB_TEST("DeviceTransform::TransformIf custom stream", "[device][transform]", CUB_SMALL)
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -216,7 +216,7 @@ C2H_TEST("DeviceTransform::TransformIf custom stream", "[device][transform]")
   CHECK(thrust::equal(result.begin(), result.end(), reference_it));
 }
 
-C2H_TEST("DeviceTransform::TransformIf (single argument) custom stream", "[device][transform]")
+CUB_TEST("DeviceTransform::TransformIf (single argument) custom stream", "[device][transform]", CUB_SMALL)
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -231,7 +231,7 @@ C2H_TEST("DeviceTransform::TransformIf (single argument) custom stream", "[devic
   CHECK(thrust::equal(result.begin(), result.end(), reference_it));
 }
 
-C2H_TEST("DeviceTransform::TransformStableArgumentAddresses custom stream", "[device][transform]")
+CUB_TEST("DeviceTransform::TransformStableArgumentAddresses custom stream", "[device][transform]", CUB_SMALL)
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -267,7 +267,7 @@ struct get_thread_id
   }
 };
 
-C2H_TEST("DeviceTransform::Transform can be tuned", "[reduce][device]")
+CUB_TEST("DeviceTransform::Transform can be tuned", "[reduce][device]", CUB_SMALL)
 {
   c2h::device_vector<unsigned> result(3 * 8, thrust::no_init);
 
@@ -280,7 +280,7 @@ C2H_TEST("DeviceTransform::Transform can be tuned", "[reduce][device]")
   REQUIRE(result == expected);
 }
 
-C2H_TEST("DeviceTransform::Transform can be tuned with custom stream", "[reduce][device]")
+CUB_TEST("DeviceTransform::Transform can be tuned with custom stream", "[reduce][device]", CUB_SMALL)
 {
   c2h::device_vector<unsigned> result(3 * 8, thrust::no_init);
 
@@ -295,7 +295,7 @@ C2H_TEST("DeviceTransform::Transform can be tuned with custom stream", "[reduce]
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test TransformPolicy properties", "[transform][device]")
+CUB_TEST("Test TransformPolicy properties", "[transform][device]", CUB_SMALL)
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::TransformPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::TransformPolicy>);

--- a/cub/test/catch2_test_device_transform_env_api.cu
+++ b/cub/test/catch2_test_device_transform_env_api.cu
@@ -11,7 +11,7 @@
 
 #include <iostream>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 #if _CCCL_STD_VER >= 2020
 
@@ -37,7 +37,7 @@ struct TransformPolicySelector
 
 _CCCL_DIAG_POP
 
-C2H_TEST("cub::DeviceTransform::Transform accepts a custom policy selector", "[transform][env]")
+CUB_TEST("cub::DeviceTransform::Transform accepts a custom policy selector", "[transform][env]", CUB_SMALL)
 {
   // example-begin transform-tuning
   auto d_input  = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7};
@@ -64,7 +64,7 @@ C2H_TEST("cub::DeviceTransform::Transform accepts a custom policy selector", "[t
 #else // _CCCL_STD_VER >= 2020
 
 // we need a dummy test for C++17, otherwise the return code of the test executable is 2 (not 0)
-C2H_TEST("cub::DeviceTransform::Transform dummy test", "[transform][env]")
+CUB_TEST("cub::DeviceTransform::Transform dummy test", "[transform][env]", CUB_SMALL)
 {
   SUCCEED();
 }

--- a/cub/test/catch2_test_device_transform_if.cu
+++ b/cub/test/catch2_test_device_transform_if.cu
@@ -6,15 +6,16 @@
 #include <cub/device/device_transform.cuh>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/test_util_vec.h>
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceTransform::TransformIf, transform_if);
 
-C2H_TEST("DeviceTransform::TransformIf conditional BabelStream add",
+CUB_TEST("DeviceTransform::TransformIf conditional BabelStream add",
          "[device][transform_if]",
+         CUB_SMALL,
          c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t>)
 {
   using type     = c2h::get<0, TestType>;

--- a/cub/test/catch2_test_device_transform_reduce.cu
+++ b/cub/test/catch2_test_device_transform_reduce.cu
@@ -9,7 +9,7 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 #include <c2h/extended_types.h>
 
@@ -28,7 +28,7 @@ struct square_t
   }
 };
 
-C2H_TEST("Device transform reduce works with pointers", "[reduce][device]", types)
+CUB_TEST("Device transform reduce works with pointers", "[reduce][device]", CUB_SMALL, types)
 {
   using item_t         = c2h::get<0, TestType>;
   using init_value_t   = item_t;
@@ -75,7 +75,7 @@ C2H_TEST("Device transform reduce works with pointers", "[reduce][device]", type
   }
 }
 
-C2H_TEST("Device transform reduce works with iterators", "[reduce][device]", types)
+CUB_TEST("Device transform reduce works with iterators", "[reduce][device]", CUB_SMALL, types)
 {
   using item_t         = c2h::get<0, TestType>;
   using init_value_t   = item_t;
@@ -187,7 +187,7 @@ struct reduction_op_t
   }
 };
 
-C2H_TEST("Device transform reduce doesn't let input type into reduction op", "[reduce][device]")
+CUB_TEST("Device transform reduce doesn't let input type into reduction op", "[reduce][device]", CUB_SMALL)
 {
   constexpr int max_items = 5000000;
   constexpr int min_items = 1;

--- a/cub/test/catch2_test_device_transform_tile.cu
+++ b/cub/test/catch2_test_device_transform_tile.cu
@@ -5,7 +5,7 @@
 
 #include <cub/device/device_transform.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // The tile dispatch path only exists when nvcc is invoked with --enable-tile and the user opts in via
 // CCCL_ENABLE_EXPERIMENTAL_TILE_TRANSFORM_DISPATCH. In any other build this file compiles to a single skipped test.
@@ -72,8 +72,9 @@ using tile_types = c2h::type_list<::cuda::std::uint32_t, ::cuda::std::uint64_t>;
 // kernel; the others fall back to the standard CUB dispatch. Both must produce identical results.
 #  define TILE_TRANSFORM_SIZES GENERATE(::cuda::std::int64_t{0}, 16, 32, 128, 1024, 4096, 65536, 17, 127, 1000)
 
-C2H_TEST("DeviceTransform tile dispatch: unary scalar op routed through its tile_operator substitute",
+CUB_TEST("DeviceTransform tile dispatch: unary scalar op routed through its tile_operator substitute",
          "[device][transform][tile]",
+         CUB_SMALL,
          tile_types)
 {
   using type                           = c2h::get<0, TestType>;
@@ -92,8 +93,9 @@ C2H_TEST("DeviceTransform tile dispatch: unary scalar op routed through its tile
   REQUIRE(reference_h == result);
 }
 
-C2H_TEST("DeviceTransform tile dispatch: binary scalar op routed through its tile_operator substitute",
+CUB_TEST("DeviceTransform tile dispatch: binary scalar op routed through its tile_operator substitute",
          "[device][transform][tile]",
+         CUB_SMALL,
          tile_types)
 {
   using type                           = c2h::get<0, TestType>;
@@ -117,7 +119,7 @@ C2H_TEST("DeviceTransform tile dispatch: binary scalar op routed through its til
 
 #else // !_CCCL_CUB_TILE_TRANSFORM_DISPATCH_ENABLED()
 
-C2H_TEST("DeviceTransform tile dispatch requires --enable-tile", "[device][transform][tile]")
+CUB_TEST("DeviceTransform tile dispatch requires --enable-tile", "[device][transform][tile]", CUB_SMALL)
 {
   SUCCEED("tile transform dispatch not enabled in this build");
 }

--- a/cub/test/catch2_test_device_transform_vectorized.cu
+++ b/cub/test/catch2_test_device_transform_vectorized.cu
@@ -8,7 +8,7 @@
 #include <algorithm>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -30,8 +30,9 @@ struct cast_to
 
 // Narrowing widths (e.g. uint32 -> uint8) drive the multi-int4-load gather; widening (uint8 -> uint32) drives the
 // sub-16-byte load. Same-width is already covered by catch2_test_device_transform.cu's BabelStream add.
-C2H_TEST("DeviceTransform::Transform vectorized store narrowing to uint8",
+CUB_TEST("DeviceTransform::Transform vectorized store narrowing to uint8",
          "[device][transform]",
+         CUB_SMALL,
          c2h::type_list<std::uint16_t, std::uint32_t, std::uint64_t>)
 {
   using in_t               = c2h::get<0, TestType>;
@@ -52,8 +53,9 @@ C2H_TEST("DeviceTransform::Transform vectorized store narrowing to uint8",
   REQUIRE(reference_h == result);
 }
 
-C2H_TEST("DeviceTransform::Transform vectorized store widening from uint8",
+CUB_TEST("DeviceTransform::Transform vectorized store widening from uint8",
          "[device][transform]",
+         CUB_SMALL,
          c2h::type_list<std::uint16_t, std::uint32_t, std::uint64_t>)
 {
   using in_t               = std::uint8_t;
@@ -88,7 +90,7 @@ struct ublkcp_store_vec_size_2_selector
   }
 };
 
-C2H_TEST("DeviceTransform::Transform tunable narrower store_vec_size", "[device][transform]")
+CUB_TEST("DeviceTransform::Transform tunable narrower store_vec_size", "[device][transform]", CUB_SMALL)
 {
   using in_t                         = std::uint32_t;
   using out_t                        = std::uint8_t;

--- a/cub/test/catch2_test_enum_formatting.cu
+++ b/cub/test/catch2_test_enum_formatting.cu
@@ -10,7 +10,7 @@
 #  include <format>
 #endif // __cpp_lib_format >= 201907L
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 struct OStreamOperatorTester
 {
@@ -195,7 +195,7 @@ void do_test(const Tester& tester)
   }
 }
 
-C2H_TEST("Enum formatting", "")
+CUB_TEST("Enum formatting", "", CUB_SMALL)
 {
   do_test(OStreamOperatorTester{});
 #if __cpp_lib_format >= 201907L

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -26,7 +26,7 @@
 //! // arguments as the CUB API. The wrapper name is provided as the second argument.
 //! DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Sum, cub_reduce_sum);
 //!
-//! C2H_TEST("Reduce test", "[device][reduce]")
+//! CUB_TEST("Reduce test", "[device][reduce]", CUB_SMALL)
 //! {
 //!   // ...
 //!   // Invoke the wrapper from the test. It'll allocate temporary storage and

--- a/cub/test/catch2_test_grid_even_share.cu
+++ b/cub/test/catch2_test_grid_even_share.cu
@@ -7,12 +7,13 @@
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/type_traits>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/generators.h>
 
 using offset_types = c2h::type_list<std::int32_t, std::int64_t, std::uint32_t, std::uint64_t>;
 
-C2H_TEST("GridEvenShare handles edge cases (zero/negative items)", "[grid][even_share][edge_cases]", offset_types)
+CUB_TEST(
+  "GridEvenShare handles edge cases (zero/negative items)", "[grid][even_share][edge_cases]", CUB_SMALL, offset_types)
 {
   using offset_t = typename c2h::get<0, TestType>;
 
@@ -46,7 +47,7 @@ C2H_TEST("GridEvenShare handles edge cases (zero/negative items)", "[grid][even_
   CHECK(grid_share.block_end == 0);
 }
 
-C2H_TEST("GridEvenShare works with num_items > 0", "[grid][even_share]", offset_types)
+CUB_TEST("GridEvenShare works with num_items > 0", "[grid][even_share]", CUB_SMALL, offset_types)
 {
   using offset_t = typename c2h::get<0, TestType>;
 

--- a/cub/test/catch2_test_iterator.cu
+++ b/cub/test/catch2_test_iterator.cu
@@ -21,7 +21,7 @@ _CCCL_SUPPRESS_DEPRECATED_NVRTC_DIAG
 
 #include <cstdint>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_VEC_SIZE types 1:2:3:4
 
@@ -127,7 +127,7 @@ struct transform_op_t
   }
 };
 
-C2H_TEST("Test tex-obj texture iterator", "[iterator]", types)
+CUB_TEST("Test tex-obj texture iterator", "[iterator]", CUB_SMALL, types)
 {
   using T                            = c2h::get<0, TestType>;
   constexpr unsigned int TEST_VALUES = 11000;
@@ -145,7 +145,7 @@ C2H_TEST("Test tex-obj texture iterator", "[iterator]", types)
   test_iterator(d_obj_itr, h_reference);
 }
 
-C2H_TEST("Test texture transform iterator", "[iterator]", types)
+CUB_TEST("Test texture transform iterator", "[iterator]", CUB_SMALL, types)
 {
   using T                   = c2h::get<0, TestType>;
   constexpr int TEST_VALUES = 11000;

--- a/cub/test/catch2_test_launch_helper.h
+++ b/cub/test/catch2_test_launch_helper.h
@@ -22,7 +22,7 @@
 //! // arguments as the CUB API. The wrapper name is provided as the second argument.
 //! DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Sum, cub_reduce_sum);
 //!
-//! C2H_TEST("Reduce test", "[device][reduce]")
+//! CUB_TEST("Reduce test", "[device][reduce]", CUB_SMALL)
 //! {
 //!   // ...
 //!   // Invoke the wrapper from the test. It'll allocate temporary storage and

--- a/cub/test/catch2_test_launch_wrapper.cu
+++ b/cub/test/catch2_test_launch_wrapper.cu
@@ -6,7 +6,7 @@
 #include <cuda/std/tuple>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -108,7 +108,7 @@ struct cub_api_example_t
 DECLARE_LAUNCH_WRAPPER(cub_api_example_t::x2_0, x2_0);
 DECLARE_LAUNCH_WRAPPER(cub_api_example_t::x0_5, x0_5);
 
-C2H_TEST("Launch wrapper works with predefined invocables", "[test][utils]")
+CUB_TEST("Launch wrapper works with predefined invocables", "[test][utils]", CUB_SMALL)
 {
   INFO("Launch = " << TEST_LAUNCH);
 
@@ -168,7 +168,7 @@ struct custom_x0_5_invocable
   }
 };
 
-C2H_TEST("Launch wrapper works with custom invocables", "[test][utils]")
+CUB_TEST("Launch wrapper works with custom invocables", "[test][utils]", CUB_SMALL)
 {
   int n = 42;
   c2h::device_vector<int> in(n, 21);

--- a/cub/test/catch2_test_memcpy_bitpacked_counter.cu
+++ b/cub/test/catch2_test_memcpy_bitpacked_counter.cu
@@ -5,7 +5,7 @@
 
 #include <thrust/fill.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <std::uint32_t NumItems,
           std::uint32_t MaxItemValue,
@@ -50,7 +50,8 @@ using test_combinations =
                  test_spec<32, 1>,
                  test_spec<32, 256>>;
 
-C2H_TEST("The bit_packed_counter used by DeviceMemcpy works", "[memcpy]", test_combinations, use_power_of_two_bits)
+CUB_TEST(
+  "The bit_packed_counter used by DeviceMemcpy works", "[memcpy]", CUB_SMALL, test_combinations, use_power_of_two_bits)
 {
   constexpr std::uint32_t num_items       = c2h::get<0, TestType>::num_items;
   constexpr std::uint32_t max_item_value  = c2h::get<0, TestType>::max_item_value;

--- a/cub/test/catch2_test_memcpy_vectorized_copy.cu
+++ b/cub/test/catch2_test_memcpy_vectorized_copy.cu
@@ -8,7 +8,7 @@
 #include <thrust/fill.h>
 #include <thrust/sequence.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <int LocigalWarpSize, typename VectorT, typename ByteOffsetT>
 __global__ void test_vectorized_copy_kernel(const void* d_in, void* d_out, ByteOffsetT copy_size)
@@ -18,7 +18,7 @@ __global__ void test_vectorized_copy_kernel(const void* d_in, void* d_out, ByteO
 
 using vector_type_list = c2h::type_list<uint32_t, uint4>;
 
-C2H_TEST("The vectorized copy used by DeviceMemcpy works", "[memcpy]", vector_type_list)
+CUB_TEST("The vectorized copy used by DeviceMemcpy works", "[memcpy]", CUB_SMALL, vector_type_list)
 {
   using vector_t                            = typename c2h::get<0, TestType>;
   constexpr std::uint32_t threads_per_block = 8;

--- a/cub/test/catch2_test_nvrtc.cu
+++ b/cub/test/catch2_test_nvrtc.cu
@@ -7,9 +7,9 @@
 #include <nvrtc.h>
 #include <nvrtc_args.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-TEST_CASE("Test nvrtc", "[test][nvrtc]")
+CUB_TEST_CASE("Test nvrtc", "[test][nvrtc]", CUB_SMALL)
 {
   nvrtcProgram prog{};
 

--- a/cub/test/catch2_test_printing.cu
+++ b/cub/test/catch2_test_printing.cu
@@ -3,8 +3,8 @@
 
 #include <sstream>
 
+#include "cub_test_macros.h"
 #include "test_util.h"
-#include <c2h/catch2_test_helper.h>
 
 template <typename T>
 std::string print(T val)
@@ -15,7 +15,7 @@ std::string print(T val)
 }
 
 #if TEST_INT128()
-TEST_CASE("Test utils can print __int128", "[test][utils]")
+CUB_TEST_CASE("Test utils can print __int128", "[test][utils]", CUB_SMALL)
 {
   REQUIRE(print(__int128_t{0}) == "0");
   REQUIRE(print(__int128_t{42}) == "42");
@@ -24,7 +24,7 @@ TEST_CASE("Test utils can print __int128", "[test][utils]")
   REQUIRE(print(-1 * (__int128_t{1} << 120)) == "-1329227995784915872903807060280344576");
 }
 
-TEST_CASE("Test utils can print __uint128", "[test][utils]")
+CUB_TEST_CASE("Test utils can print __uint128", "[test][utils]", CUB_SMALL)
 {
   REQUIRE(print(__uint128_t{0}) == "0");
   REQUIRE(print(__uint128_t{1}) == "1");
@@ -33,7 +33,7 @@ TEST_CASE("Test utils can print __uint128", "[test][utils]")
 }
 #endif
 
-TEST_CASE("Test utils can print KeyValuePair", "[test][utils]")
+CUB_TEST_CASE("Test utils can print KeyValuePair", "[test][utils]", CUB_SMALL)
 {
   REQUIRE(print(cub::KeyValuePair<int, int>{42, -42}) == "(42,-42)");
 }

--- a/cub/test/catch2_test_radix_operations.cu
+++ b/cub/test/catch2_test_radix_operations.cu
@@ -10,7 +10,7 @@
 #include <limits>
 #include <type_traits>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <typename KeyT>
 struct fundamental_extractor_t
@@ -71,7 +71,7 @@ using a_few_fundamental_types = c2h::type_list<std::uint8_t, std::uint64_t>;
  *    dst: 0 0 0 0 0 0 1 0 0 1
  *
  */
-C2H_TEST("Radix operations extract digits from fundamental types", "[radix][operations]", fundamental_types)
+CUB_TEST("Radix operations extract digits from fundamental types", "[radix][operations]", CUB_SMALL, fundamental_types)
 {
   using key_t        = typename c2h::get<0, TestType>;
   using traits       = cub::detail::radix::traits_t<key_t>;
@@ -284,14 +284,16 @@ void test_tuple()
   }
 }
 
-C2H_TEST("Radix operations extract digits from pairs", "[radix][operations]", fundamental_types, fundamental_types)
+CUB_TEST(
+  "Radix operations extract digits from pairs", "[radix][operations]", CUB_SMALL, fundamental_types, fundamental_types)
 {
   test_tuple<typename c2h::get<0, TestType>, //
              typename c2h::get<1, TestType>>();
 }
 
-C2H_TEST("Radix operations extract digits from triples",
+CUB_TEST("Radix operations extract digits from triples",
          "[radix][operations]",
+         CUB_SMALL,
          fundamental_types,
          fundamental_types,
          fundamental_types)
@@ -301,8 +303,9 @@ C2H_TEST("Radix operations extract digits from triples",
              typename c2h::get<2, TestType>>();
 }
 
-C2H_TEST("Radix operations extract digits from tetrads",
+CUB_TEST("Radix operations extract digits from tetrads",
          "[radix][operations]",
+         CUB_SMALL,
          a_few_fundamental_types,
          a_few_fundamental_types,
          a_few_fundamental_types,
@@ -321,7 +324,7 @@ C2H_TEST("Radix operations extract digits from tetrads",
  *    dst: 0 0 1 1 0 0 1 1 0 0
  *
  */
-C2H_TEST("Radix operations inverse fundamental types", "[radix][operations]", fundamental_types)
+CUB_TEST("Radix operations inverse fundamental types", "[radix][operations]", CUB_SMALL, fundamental_types)
 {
   using key_t        = typename c2h::get<0, TestType>;
   using traits       = cub::detail::radix::traits_t<key_t>;
@@ -361,7 +364,7 @@ C2H_TEST("Radix operations inverse fundamental types", "[radix][operations]", fu
  *      <           <----  higher bits  /  lower bits  ---->           >
  *
  */
-C2H_TEST("Radix operations inverse pairs", "[radix][operations]", fundamental_types, fundamental_types)
+CUB_TEST("Radix operations inverse pairs", "[radix][operations]", CUB_SMALL, fundamental_types, fundamental_types)
 {
   using tpl_t = cuda::std::tuple<typename c2h::get<0, TestType>, //
                                  typename c2h::get<1, TestType>>;
@@ -396,7 +399,8 @@ C2H_TEST("Radix operations inverse pairs", "[radix][operations]", fundamental_ty
  * This tests checks that radix operations can get a value that when converted
  * to binary-comparable representation, yields smallest possible value.
  */
-C2H_TEST("Radix operations infere minimal value for fundamental types", "[radix][operations]", fundamental_types)
+CUB_TEST(
+  "Radix operations infere minimal value for fundamental types", "[radix][operations]", CUB_SMALL, fundamental_types)
 {
   using key_t        = typename c2h::get<0, TestType>;
   using traits       = cub::detail::radix::traits_t<key_t>;
@@ -411,8 +415,11 @@ C2H_TEST("Radix operations infere minimal value for fundamental types", "[radix]
   REQUIRE(ref == val);
 }
 
-C2H_TEST(
-  "Radix operations infere minimal value for pair types", "[radix][operations]", fundamental_types, fundamental_types)
+CUB_TEST("Radix operations infere minimal value for pair types",
+         "[radix][operations]",
+         CUB_SMALL,
+         fundamental_types,
+         fundamental_types)
 {
   using tpl_t = cuda::std::tuple<typename c2h::get<0, TestType>, //
                                  typename c2h::get<1, TestType>>;
@@ -432,7 +439,8 @@ C2H_TEST(
  * This tests checks that radix operations can get a value that when converted
  * to binary-comparable representation, yields largest possible value.
  */
-C2H_TEST("Radix operations infere maximal value for fundamental types", "[radix][operations]", fundamental_types)
+CUB_TEST(
+  "Radix operations infere maximal value for fundamental types", "[radix][operations]", CUB_SMALL, fundamental_types)
 {
   using key_t        = typename c2h::get<0, TestType>;
   using traits       = cub::detail::radix::traits_t<key_t>;
@@ -444,8 +452,11 @@ C2H_TEST("Radix operations infere maximal value for fundamental types", "[radix]
   REQUIRE(ref == val);
 }
 
-C2H_TEST(
-  "Radix operations infere maximal value for pair types", "[radix][operations]", fundamental_types, fundamental_types)
+CUB_TEST("Radix operations infere maximal value for pair types",
+         "[radix][operations]",
+         CUB_SMALL,
+         fundamental_types,
+         fundamental_types)
 {
   using tpl_t = cuda::std::tuple<typename c2h::get<0, TestType>, //
                                  typename c2h::get<1, TestType>>;
@@ -473,8 +484,9 @@ using fundamental_signed_types = c2h::type_list<std::int8_t, std::int16_t, std::
  * -42.0f: 11000010001010000000000000000000
  *
  */
-C2H_TEST("Radix operations reorder values for pair types",
+CUB_TEST("Radix operations reorder values for pair types",
          "[radix][operations]",
+         CUB_SMALL,
          fundamental_signed_types,
          fundamental_signed_types)
 {
@@ -567,7 +579,7 @@ struct flipped_fp_aggregate_decomposer_t
 /**
  * This tests checks radix sort guarantees to treat +0/-0 as the same value.
  */
-TEST_CASE("Radix operations treat -0/+0 as being equal", "[radix][operations]")
+CUB_TEST_CASE("Radix operations treat -0/+0 as being equal", "[radix][operations]", CUB_SMALL)
 {
   using traits            = cub::detail::radix::traits_t<fp_aggregate_t>;
   using conversion_policy = typename traits::bit_ordered_conversion_policy;
@@ -596,7 +608,7 @@ TEST_CASE("Radix operations treat -0/+0 as being equal", "[radix][operations]")
  * This tests checks that radix operations respect the order of fields in the
  * tuple instead of looking at the binary key representation.
  */
-TEST_CASE("Radix operations allow fields permutation", "[radix][operations]")
+CUB_TEST_CASE("Radix operations allow fields permutation", "[radix][operations]", CUB_SMALL)
 {
   using traits            = cub::detail::radix::traits_t<fp_aggregate_t>;
   using conversion_policy = typename traits::bit_ordered_conversion_policy;

--- a/cub/test/catch2_test_temporary_storage_layout.cu
+++ b/cub/test/catch2_test_temporary_storage_layout.cu
@@ -8,7 +8,7 @@
 #include <memory>
 
 #include "cub/detail/temporary_storage.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using num_storage_slots = c2h::enum_type_list<int, 1, 4, 42>;
 
@@ -28,14 +28,14 @@ std::size_t get_actual_zero()
   return get_temporary_storage_size(sizes);
 }
 
-C2H_TEST("Test empty storage", "[temporary_storage_layout]", num_storage_slots)
+CUB_TEST("Test empty storage", "[temporary_storage_layout]", CUB_SMALL, num_storage_slots)
 {
   constexpr auto storage_slots = c2h::get<0, TestType>::value;
   cub::detail::temporary_storage::layout<storage_slots> temporary_storage;
   CHECK(temporary_storage.get_size() == get_actual_zero());
 }
 
-C2H_TEST("Test partially filled storage", "[temporary_storage_layout]", num_storage_slots)
+CUB_TEST("Test partially filled storage", "[temporary_storage_layout]", CUB_SMALL, num_storage_slots)
 {
   constexpr auto storage_slots             = c2h::get<0, TestType>::value;
   using target_type                        = std::uint64_t;
@@ -80,7 +80,7 @@ C2H_TEST("Test partially filled storage", "[temporary_storage_layout]", num_stor
   }
 }
 
-C2H_TEST("Test grow", "[temporary_storage_layout]", num_storage_slots)
+CUB_TEST("Test grow", "[temporary_storage_layout]", CUB_SMALL, num_storage_slots)
 {
   constexpr auto StorageSlots                  = c2h::get<0, TestType>::value;
   using target_type                            = std::uint64_t;
@@ -119,7 +119,7 @@ C2H_TEST("Test grow", "[temporary_storage_layout]", num_storage_slots)
   }
 }
 
-C2H_TEST("Test double grow", "[temporary_storage_layout]", num_storage_slots)
+CUB_TEST("Test double grow", "[temporary_storage_layout]", CUB_SMALL, num_storage_slots)
 {
   constexpr auto storage_slots                 = c2h::get<0, TestType>::value;
   using target_type                            = std::uint64_t;

--- a/cub/test/catch2_test_thread_operators.cu
+++ b/cub/test/catch2_test_thread_operators.cu
@@ -3,8 +3,8 @@
 
 #include <cub/thread/thread_operators.cuh>
 
+#include "cub_test_macros.h"
 #include "test_util.h"
-#include <c2h/catch2_test_helper.h>
 
 template <class T>
 T Make(int val)
@@ -59,7 +59,7 @@ public:
 
 CUSTOM_TYPE_FACTORY(Eq, bool, ==, false);
 
-C2H_TEST("InequalityWrapper", "[thread_operator]")
+CUB_TEST("InequalityWrapper", "[thread_operator]", CUB_SMALL)
 {
   cuda::std::equal_to<> wrapped_op{};
   cub::InequalityWrapper<cuda::std::equal_to<>> op{wrapped_op};

--- a/cub/test/catch2_test_thread_scan_exclusive_partial.cu
+++ b/cub/test/catch2_test_thread_scan_exclusive_partial.cu
@@ -11,8 +11,8 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_device_scan.cuh"
+#include "cub_test_macros.h"
 #include "thread_reduce/catch2_test_thread_reduce_helper.cuh"
-#include <c2h/catch2_test_helper.h>
 #include <c2h/extended_types.h>
 #include <c2h/generators.h>
 #include <c2h/operator.cuh>
@@ -141,8 +141,9 @@ using items_per_thread_list = c2h::enum_type_list<int, 1, 3, max_size - 1, max_s
  * Test cases
  **********************************************************************************************************************/
 
-C2H_TEST("ThreadScanExclusive Integral Type Tests",
+CUB_TEST("ThreadScanExclusive Integral Type Tests",
          "[scan][thread]",
+         CUB_SMALL,
          integral_type_list,
          cub_operator_integral_list,
          items_per_thread_list)
@@ -198,8 +199,9 @@ C2H_TEST("ThreadScanExclusive Integral Type Tests",
   REQUIRE(reference_result == d_out);
 }
 
-C2H_TEST("ThreadScanExclusive Floating-Point Type Tests",
+CUB_TEST("ThreadScanExclusive Floating-Point Type Tests",
          "[scan][thread]",
+         CUB_SMALL,
          fp_type_list,
          cub_operator_fp_list,
          items_per_thread_list)
@@ -257,8 +259,9 @@ C2H_TEST("ThreadScanExclusive Floating-Point Type Tests",
 
 #if TEST_HALF_T() || TEST_BF_T()
 
-C2H_TEST("ThreadScanExclusive Narrow PrecisionType Tests",
+CUB_TEST("ThreadScanExclusive Narrow PrecisionType Tests",
          "[scan][thread][narrow]",
+         CUB_SMALL,
          narrow_precision_type_list,
          cub_operator_fp_list,
          items_per_thread_list)
@@ -319,7 +322,7 @@ C2H_TEST("ThreadScanExclusive Narrow PrecisionType Tests",
 
 #endif // TEST_HALF_T() || TEST_BF_T()
 
-C2H_TEST("ThreadScanExclusive Container Tests", "[scan][thread]")
+CUB_TEST("ThreadScanExclusive Container Tests", "[scan][thread]", CUB_SMALL)
 {
   c2h::device_vector<int> d_in(max_size, thrust::no_init);
   c2h::device_vector<int> d_out(max_size, thrust::no_init);
@@ -371,7 +374,7 @@ C2H_TEST("ThreadScanExclusive Container Tests", "[scan][thread]")
   REQUIRE(reference_result == d_out);
 }
 
-C2H_TEST("ThreadScanExclusive Invalid Test", "[scan][thread]")
+CUB_TEST("ThreadScanExclusive Invalid Test", "[scan][thread]", CUB_SMALL)
 {
   const auto in_it = cuda::make_transform_iterator(
     thrust::make_zip_iterator(cuda::counting_iterator<segment::offset_t>{1},

--- a/cub/test/catch2_test_thread_scan_inclusive_partial.cu
+++ b/cub/test/catch2_test_thread_scan_inclusive_partial.cu
@@ -11,8 +11,8 @@
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_device_scan.cuh"
+#include "cub_test_macros.h"
 #include "thread_reduce/catch2_test_thread_reduce_helper.cuh"
-#include <c2h/catch2_test_helper.h>
 #include <c2h/extended_types.h>
 #include <c2h/generators.h>
 #include <c2h/operator.cuh>
@@ -141,8 +141,9 @@ using items_per_thread_list = c2h::enum_type_list<int, 1, 3, max_size - 1, max_s
  * Test cases
  **********************************************************************************************************************/
 
-C2H_TEST("ThreadScanInclusive Integral Type Tests",
+CUB_TEST("ThreadScanInclusive Integral Type Tests",
          "[scan][thread]",
+         CUB_SMALL,
          integral_type_list,
          cub_operator_integral_list,
          items_per_thread_list)
@@ -201,8 +202,9 @@ C2H_TEST("ThreadScanInclusive Integral Type Tests",
   REQUIRE(reference_result == d_out);
 }
 
-C2H_TEST("ThreadScanInclusive Floating-Point Type Tests",
+CUB_TEST("ThreadScanInclusive Floating-Point Type Tests",
          "[scan][thread]",
+         CUB_SMALL,
          fp_type_list,
          cub_operator_fp_list,
          items_per_thread_list)
@@ -263,8 +265,9 @@ C2H_TEST("ThreadScanInclusive Floating-Point Type Tests",
 
 #if TEST_HALF_T() || TEST_BF_T()
 
-C2H_TEST("ThreadScanInclusive Narrow PrecisionType Tests",
+CUB_TEST("ThreadScanInclusive Narrow PrecisionType Tests",
          "[scan][thread][narrow]",
+         CUB_SMALL,
          narrow_precision_type_list,
          cub_operator_fp_list,
          items_per_thread_list)
@@ -319,7 +322,7 @@ C2H_TEST("ThreadScanInclusive Narrow PrecisionType Tests",
 
 #endif // TEST_HALF_T() || TEST_BF_T()
 
-C2H_TEST("ThreadScanInclusive Container Tests", "[scan][thread]")
+CUB_TEST("ThreadScanInclusive Container Tests", "[scan][thread]", CUB_SMALL)
 {
   c2h::device_vector<int> d_in(max_size, thrust::no_init);
   c2h::device_vector<int> d_out(max_size, thrust::no_init);
@@ -371,7 +374,7 @@ C2H_TEST("ThreadScanInclusive Container Tests", "[scan][thread]")
   REQUIRE(reference_result == d_out);
 }
 
-C2H_TEST("ThreadScanInclusive Invalid Test", "[scan][thread]")
+CUB_TEST("ThreadScanInclusive Invalid Test", "[scan][thread]", CUB_SMALL)
 {
   const auto in_it = cuda::make_transform_iterator(
     thrust::make_zip_iterator(cuda::counting_iterator<segment::offset_t>{1},

--- a/cub/test/catch2_test_thread_sort.cu
+++ b/cub/test/catch2_test_thread_sort.cu
@@ -9,7 +9,7 @@
 #include <thrust/sort.h>
 
 #include "cub/thread/thread_sort.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 struct CustomLess
 {
@@ -50,7 +50,7 @@ __global__ void kernel(const KeyT* keys_in, KeyT* keys_out, const ValueT* values
 using value_types           = c2h::type_list<std::uint32_t, std::uint64_t>;
 using items_per_thread_list = c2h::enum_type_list<int, 2, 3, 4, 5, 7, 8, 9, 11>;
 
-C2H_TEST("Test", "[thread_sort]", value_types, items_per_thread_list)
+CUB_TEST("Test", "[thread_sort]", CUB_SMALL, value_types, items_per_thread_list)
 {
   using key_t                             = std::uint32_t;
   using value_t                           = c2h::get<0, TestType>;

--- a/cub/test/catch2_test_util_arch.cu
+++ b/cub/test/catch2_test_util_arch.cu
@@ -3,7 +3,7 @@
 
 #include <cub/util_arch.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <auto V>
 struct show;
@@ -30,7 +30,7 @@ void check_mem_bound_scaling()
   STATIC_REQUIRE(mbs::BLOCK_THREADS == ExpectedThreadsPerBlock);
 }
 
-C2H_TEST("MemBoundScaling", "[util][arch]")
+CUB_TEST("MemBoundScaling", "[util][arch]", CUB_SMALL)
 {
   check_mem_bound_scaling<256, 1, char, 256, 2>();
   check_mem_bound_scaling<256, 16, char, 256, 32>();
@@ -84,7 +84,7 @@ void check_reg_bound_scaling()
   STATIC_REQUIRE(mbs::BLOCK_THREADS == ExpectedThreadsPerBlock);
 }
 
-C2H_TEST("RegBoundScaling", "[util][arch]")
+CUB_TEST("RegBoundScaling", "[util][arch]", CUB_SMALL)
 {
   check_reg_bound_scaling<256, 1, char, 256, 1>();
   check_reg_bound_scaling<256, 16, char, 256, 16>();

--- a/cub/test/catch2_test_util_choose_offset.cu
+++ b/cub/test/catch2_test_util_choose_offset.cu
@@ -7,9 +7,9 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("Tests choose_offset", "[util][type]")
+CUB_TEST("Tests choose_offset", "[util][type]", CUB_SMALL)
 {
   // Uses unsigned 32-bit type for signed 32-bit type
   STATIC_REQUIRE(cuda::std::is_same_v<cub::detail::choose_offset_t<std::int32_t>, std::uint32_t>);
@@ -21,7 +21,7 @@ C2H_TEST("Tests choose_offset", "[util][type]")
   STATIC_REQUIRE(cuda::std::is_same_v<cub::detail::choose_offset_t<std::int64_t>, unsigned long long>);
 }
 
-C2H_TEST("Tests choose_signed_offset", "[util][type]")
+CUB_TEST("Tests choose_signed_offset", "[util][type]", CUB_SMALL)
 {
   // Uses signed 64-bit type for unsigned signed 32-bit type
   STATIC_REQUIRE(cuda::std::is_same_v<cub::detail::choose_signed_offset_t<std::uint32_t>, std::int64_t>);
@@ -51,7 +51,7 @@ C2H_TEST("Tests choose_signed_offset", "[util][type]")
             cuda::std::numeric_limits<std::uint64_t>::max()));
 }
 
-C2H_TEST("Tests promote_small_offset", "[util][type]")
+CUB_TEST("Tests promote_small_offset", "[util][type]", CUB_SMALL)
 {
   // Uses input type for types of at least 32 bits
   STATIC_REQUIRE(cuda::std::is_same_v<typename cub::detail::promote_small_offset_t<std::int32_t>, std::int32_t>);

--- a/cub/test/catch2_test_util_device.cu
+++ b/cub/test/catch2_test_util_device.cu
@@ -13,7 +13,7 @@
 #include <cuda/std/array>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 CUB_NAMESPACE_BEGIN
 
@@ -43,7 +43,7 @@ CUB_NAMESPACE_END
 // %PARAM% TEST_LAUNCH lid 0:1:2
 DECLARE_LAUNCH_WRAPPER(cub::get_cuda_cc_from_kernel, get_cuda_cc_from_kernel);
 
-C2H_TEST("CUB correctly identifies the ptx version the kernel was compiled for", "[util][dispatch]")
+CUB_TEST("CUB correctly identifies the ptx version the kernel was compiled for", "[util][dispatch]", CUB_SMALL)
 {
   constexpr std::size_t single_item = 1;
   c2h::device_vector<int> cuda_cc(single_item);
@@ -81,7 +81,7 @@ C2H_TEST("CUB correctly identifies the ptx version the kernel was compiled for",
 #endif
 
 #ifdef CUDA_SM_LIST
-C2H_TEST("PtxVersion returns a value from __CUDA_ARCH_LIST__/NV_TARGET_SM_INTEGER_LIST", "[util][dispatch]")
+CUB_TEST("PtxVersion returns a value from __CUDA_ARCH_LIST__/NV_TARGET_SM_INTEGER_LIST", "[util][dispatch]", CUB_SMALL)
 {
   int ptx_version = 0;
   REQUIRE(cub::PtxVersion(ptx_version) == cudaSuccess);
@@ -176,7 +176,7 @@ check_chained_policy_prunes_to_cc_list(void* d_temp_storage, size_t& temp_storag
 DECLARE_LAUNCH_WRAPPER(check_chained_policy_prunes_to_cc_list, check_wrapper_all);
 
 // TODO(bgruber): drop in CCCL 4.0
-C2H_TEST("ChainedPolicy prunes based on __CUDA_ARCH_LIST__/NV_TARGET_SM_INTEGER_LIST", "[util][dispatch]")
+CUB_TEST("ChainedPolicy prunes based on __CUDA_ARCH_LIST__/NV_TARGET_SM_INTEGER_LIST", "[util][dispatch]", CUB_SMALL)
 {
   check_wrapper_all();
 }
@@ -266,7 +266,7 @@ struct policy_hub_minimal
 };
 
 // TODO(bgruber): drop in CCCL 4.0
-C2H_TEST("ChainedPolicy invokes correct policy", "[util][dispatch]")
+CUB_TEST("ChainedPolicy invokes correct policy", "[util][dispatch]", CUB_SMALL)
 {
   SECTION("policy_hub_some")
   {
@@ -296,7 +296,7 @@ __global__ void test_max_potential_dynamic_smem_bytes_device(int* result)
 }
 #endif // CUB_RDC_ENABLED
 
-C2H_TEST("MaxPotentialDynamicSmemBytes", "[util][launch]")
+CUB_TEST("MaxPotentialDynamicSmemBytes", "[util][launch]", CUB_SMALL)
 {
   cuda::device_ref device{0};
 

--- a/cub/test/catch2_test_util_math.cu
+++ b/cub/test/catch2_test_util_math.cu
@@ -5,9 +5,9 @@
 
 #include <cuda/std/type_traits>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
-C2H_TEST("Tests safe_add_bound_to_max", "[util][math]")
+CUB_TEST("Tests safe_add_bound_to_max", "[util][math]", CUB_SMALL)
 {
   REQUIRE(cub::detail::safe_add_bound_to_max(0U, cuda::std::numeric_limits<std::uint32_t>::max())
           == cuda::std::numeric_limits<std::uint32_t>::max());

--- a/cub/test/catch2_test_util_type.cu
+++ b/cub/test/catch2_test_util_type.cu
@@ -6,10 +6,10 @@
 #include <cuda/iterator>
 #include <cuda/std/type_traits>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/extended_types.h>
 
-C2H_TEST("Tests non_void_value_t", "[util][type]")
+CUB_TEST("Tests non_void_value_t", "[util][type]", CUB_SMALL)
 {
   using fallback_t        = float;
   using void_fancy_it     = cuda::discard_iterator;
@@ -49,7 +49,7 @@ struct HasDog
   using dog = int;
 };
 
-C2H_TEST("Test CUB_DEFINE_DETECT_NESTED_TYPE", "[util][type]")
+CUB_TEST("Test CUB_DEFINE_DETECT_NESTED_TYPE", "[util][type]", CUB_SMALL)
 {
   STATIC_REQUIRE(cat_detect<HasCat>::value);
   STATIC_REQUIRE(!cat_detect<HasDog>::value);
@@ -61,7 +61,7 @@ struct CustomHalf
   int16_t payload;
 };
 
-C2H_TEST("Test CustomHalf", "[util][type]")
+CUB_TEST("Test CustomHalf", "[util][type]", CUB_SMALL)
 {
   // type not registered with cub::Traits
   STATIC_REQUIRE(!cub::detail::is_primitive<CustomHalf>::value);
@@ -82,7 +82,7 @@ C2H_TEST("Test CustomHalf", "[util][type]")
   CHECK(cuda::std::numeric_limits<half_t>::lowest() == half_t::lowest());
 }
 
-C2H_TEST("Test FutureValue", "[util][type]")
+CUB_TEST("Test FutureValue", "[util][type]", CUB_SMALL)
 {
   // read
   int value;

--- a/cub/test/catch2_test_vsmem.cu
+++ b/cub/test/catch2_test_vsmem.cu
@@ -10,7 +10,7 @@
 #include <cub/util_vsmem.cuh>
 
 #include "catch2_test_launch_helper.h"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 //----------------------------------------------------------------------------
 // Helper section
@@ -381,7 +381,7 @@ DECLARE_LAUNCH_WRAPPER(device_dummy_algorithm, dummy_algorithm);
 
 using type_list = c2h::type_list<large_custom_t<1>, large_custom_t<80>, large_custom_t<128>, large_custom_t<512>>;
 
-C2H_TEST("Virtual shared memory works within algorithms", "[util][vsmem]", type_list)
+CUB_TEST("Virtual shared memory works within algorithms", "[util][vsmem]", CUB_SMALL, type_list)
 {
   using item_t   = typename c2h::get<0, TestType>;
   using offset_t = int32_t;

--- a/cub/test/catch2_test_warp_exchange_shfl.cu
+++ b/cub/test/catch2_test_warp_exchange_shfl.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3
 
 #include "catch2_test_warp_exchange.cuh"
+#include "cub_test_macros.h"
 
 namespace
 {
@@ -23,7 +24,7 @@ struct params_t
 };
 } // namespace
 
-C2H_TEST("Blocked to striped works", "[exchange][warp][shfl]", inout_types, items_per_thread)
+CUB_TEST("Blocked to striped works", "[exchange][warp][shfl]", CUB_SMALL, inout_types, items_per_thread)
 {
   using params   = params_t<TestType>;
   using in_type  = typename params::in_type;
@@ -43,7 +44,7 @@ C2H_TEST("Blocked to striped works", "[exchange][warp][shfl]", inout_types, item
   REQUIRE(h_expected_output == d_out);
 }
 
-C2H_TEST("Striped to blocked works", "[exchange][warp][shfl]", inout_types, items_per_thread)
+CUB_TEST("Striped to blocked works", "[exchange][warp][shfl]", CUB_SMALL, inout_types, items_per_thread)
 {
   using params   = params_t<TestType>;
   using in_type  = typename params::in_type;

--- a/cub/test/catch2_test_warp_exchange_smem.cu
+++ b/cub/test/catch2_test_warp_exchange_smem.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3
 
 #include "catch2_test_warp_exchange.cuh"
+#include "cub_test_macros.h"
 
 namespace
 {
@@ -39,7 +40,8 @@ struct params_t
 };
 } // namespace
 
-C2H_TEST("Scatter to striped works", "[exchange][warp][smem]", inout_types, logical_warp_threads, items_per_thread)
+CUB_TEST(
+  "Scatter to striped works", "[exchange][warp][smem]", CUB_SMALL, inout_types, logical_warp_threads, items_per_thread)
 {
   using params   = params_t<TestType>;
   using in_type  = typename params::in_type;
@@ -58,7 +60,8 @@ C2H_TEST("Scatter to striped works", "[exchange][warp][smem]", inout_types, logi
   REQUIRE(h_expected_output == d_out);
 }
 
-C2H_TEST("Blocked to striped works", "[exchange][warp][smem]", inout_types, logical_warp_threads, items_per_thread)
+CUB_TEST(
+  "Blocked to striped works", "[exchange][warp][smem]", CUB_SMALL, inout_types, logical_warp_threads, items_per_thread)
 {
   using params   = params_t<TestType>;
   using in_type  = typename params::in_type;
@@ -78,7 +81,8 @@ C2H_TEST("Blocked to striped works", "[exchange][warp][smem]", inout_types, logi
   REQUIRE(h_expected_output == d_out);
 }
 
-C2H_TEST("Striped to blocked works", "[exchange][warp][smem]", inout_types, logical_warp_threads, items_per_thread)
+CUB_TEST(
+  "Striped to blocked works", "[exchange][warp][smem]", CUB_SMALL, inout_types, logical_warp_threads, items_per_thread)
 {
   using params   = params_t<TestType>;
   using in_type  = typename params::in_type;

--- a/cub/test/catch2_test_warp_load.cu
+++ b/cub/test/catch2_test_warp_load.cu
@@ -7,7 +7,7 @@
 
 #include <thrust/sequence.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/fill_striped.h>
 
 template <cub::WarpLoadAlgorithm LoadAlgorithm,
@@ -217,8 +217,13 @@ struct params_t
   static constexpr int total_item_count             = total_warps * tile_size;
 };
 
-C2H_TEST(
-  "Warp load guarded range works with pointer", "[load][warp]", types, logical_warp_threads, items_per_thread, algorithm)
+CUB_TEST("Warp load guarded range works with pointer",
+         "[load][warp]",
+         CUB_SMALL,
+         types,
+         logical_warp_threads,
+         items_per_thread,
+         algorithm)
 {
   using params     = params_t<TestType>;
   using type       = typename params::type;
@@ -241,8 +246,9 @@ C2H_TEST(
   REQUIRE(num_errors == expected_error_count);
 }
 
-C2H_TEST("Warp load guarded range works with cache modified iterator",
+CUB_TEST("Warp load guarded range works with cache modified iterator",
          "[load][warp]",
+         CUB_SMALL,
          types,
          logical_warp_threads,
          items_per_thread,
@@ -270,8 +276,9 @@ C2H_TEST("Warp load guarded range works with cache modified iterator",
   REQUIRE(num_errors == expected_error_count);
 }
 
-C2H_TEST("Warp load unguarded range works with pointer",
+CUB_TEST("Warp load unguarded range works with pointer",
          "[load][warp]",
+         CUB_SMALL,
          types,
          logical_warp_threads,
          items_per_thread,
@@ -293,8 +300,9 @@ C2H_TEST("Warp load unguarded range works with pointer",
   REQUIRE(num_errors == expected_error_count);
 }
 
-C2H_TEST("Warp load unguarded range works with cache modified iterator",
+CUB_TEST("Warp load unguarded range works with cache modified iterator",
          "[load][warp]",
+         CUB_SMALL,
          types,
          logical_warp_threads,
          items_per_thread,
@@ -320,8 +328,9 @@ C2H_TEST("Warp load unguarded range works with cache modified iterator",
 }
 
 #if ALGO_TYPE == 3 // Test for cub::WarpLoadAlgorithm::WARP_LOAD_VECTORIZE;
-C2H_TEST("Vectorized warp load with const and non-const datatype and different alignment cases",
+CUB_TEST("Vectorized warp load with const and non-const datatype and different alignment cases",
          "[store][warp]",
+         CUB_SMALL,
          c2h::type_list<const int*, int*>,
          logical_warp_threads,
          items_per_thread,

--- a/cub/test/catch2_test_warp_mask.cu
+++ b/cub/test/catch2_test_warp_mask.cu
@@ -6,7 +6,7 @@
 
 #include <cuda/__cmath/pow2.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <int logical_warp_threads>
 struct total_warps_t
@@ -30,7 +30,7 @@ bool is_lane_involved(unsigned int member_mask, unsigned int lane)
 using logical_warp_threads      = c2h::iota<1, 32>;
 using power_of_two_warp_threads = c2h::enum_type_list<int, 1, 2, 4, 8, 16, 32>;
 
-C2H_TEST("Warp mask ignores lanes before current logical warp", "[mask][warp]", power_of_two_warp_threads)
+CUB_TEST("Warp mask ignores lanes before current logical warp", "[mask][warp]", CUB_SMALL, power_of_two_warp_threads)
 {
   constexpr int logical_warp_thread  = c2h::get<0, TestType>::value;
   constexpr unsigned int total_warps = total_warps_t<logical_warp_thread>::value();
@@ -47,7 +47,7 @@ C2H_TEST("Warp mask ignores lanes before current logical warp", "[mask][warp]", 
   }
 }
 
-C2H_TEST("Warp mask involves lanes of current logical warp", "[mask][warp]", logical_warp_threads)
+CUB_TEST("Warp mask involves lanes of current logical warp", "[mask][warp]", CUB_SMALL, logical_warp_threads)
 {
   constexpr int logical_warp_thread  = c2h::get<0, TestType>::value;
   constexpr unsigned int total_warps = total_warps_t<logical_warp_thread>::value();
@@ -65,7 +65,7 @@ C2H_TEST("Warp mask involves lanes of current logical warp", "[mask][warp]", log
   }
 }
 
-C2H_TEST("Warp mask ignores lanes after current logical warp", "[mask][warp]", logical_warp_threads)
+CUB_TEST("Warp mask ignores lanes after current logical warp", "[mask][warp]", CUB_SMALL, logical_warp_threads)
 {
   constexpr int logical_warp_thread  = c2h::get<0, TestType>::value;
   constexpr unsigned int total_warps = total_warps_t<logical_warp_thread>::value();

--- a/cub/test/catch2_test_warp_merge_sort.cu
+++ b/cub/test/catch2_test_warp_merge_sort.cu
@@ -12,7 +12,7 @@
 
 #include <algorithm>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 
 struct CustomLess
@@ -378,8 +378,13 @@ struct params_t
   static constexpr bool is_stable           = c2h::get<3, TestType>::value == stability::stable;
 };
 
-C2H_TEST(
-  "Warp sort on keys-only works", "[sort][warp]", key_types, logical_warp_threads, items_per_thread_list, stability_list)
+CUB_TEST("Warp sort on keys-only works",
+         "[sort][warp]",
+         CUB_SMALL,
+         key_types,
+         logical_warp_threads,
+         items_per_thread_list,
+         stability_list)
 {
   using params             = params_t<TestType>;
   using type               = typename params::type;
@@ -404,8 +409,9 @@ C2H_TEST(
   REQUIRE(h_in_out == d_out);
 }
 
-C2H_TEST("Warp sort keys-only on partial warp-tile works",
+CUB_TEST("Warp sort keys-only on partial warp-tile works",
          "[sort][warp]",
+         CUB_SMALL,
          key_types,
          logical_warp_threads,
          items_per_thread_list,
@@ -437,8 +443,9 @@ C2H_TEST("Warp sort keys-only on partial warp-tile works",
   REQUIRE(h_in_out == d_out);
 }
 
-C2H_TEST("Warp sort on keys-value pairs works",
+CUB_TEST("Warp sort on keys-value pairs works",
          "[sort][warp]",
+         CUB_SMALL,
          key_types,
          logical_warp_threads,
          items_per_thread_list,
@@ -479,8 +486,9 @@ C2H_TEST("Warp sort on keys-value pairs works",
   REQUIRE(h_values_in_out == d_values_out);
 }
 
-C2H_TEST("Warp sort on key-value pairs of a partial warp-tile works",
+CUB_TEST("Warp sort on key-value pairs of a partial warp-tile works",
          "[sort][warp]",
+         CUB_SMALL,
          key_types,
          logical_warp_threads,
          items_per_thread_list,

--- a/cub/test/catch2_test_warp_scan.cu
+++ b/cub/test/catch2_test_warp_scan.cu
@@ -7,7 +7,7 @@
 
 #include <cuda/cmath>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 template <int LOGICAL_WARP_THREADS, int TOTAL_WARPS, class T, class ActionT>
 __global__ void warp_combine_scan_kernel(T* in, T* inclusive_out, T* exclusive_out, ActionT action)
@@ -346,7 +346,7 @@ struct params_t
   static constexpr int tile_size            = total_warps * logical_warp_threads;
 };
 
-C2H_TEST("Warp scan works with sum", "[scan][warp]", types, logical_warp_threads, modes)
+CUB_TEST("Warp scan works with sum", "[scan][warp]", CUB_SMALL, types, logical_warp_threads, modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -363,7 +363,7 @@ C2H_TEST("Warp scan works with sum", "[scan][warp]", types, logical_warp_threads
   REQUIRE_APPROX_EQ(h_out, d_out);
 }
 
-C2H_TEST("Warp scan works with vec_types", "[scan][warp]", vec_types, logical_warp_threads, modes)
+CUB_TEST("Warp scan works with vec_types", "[scan][warp]", CUB_SMALL, vec_types, logical_warp_threads, modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -380,8 +380,9 @@ C2H_TEST("Warp scan works with vec_types", "[scan][warp]", vec_types, logical_wa
   REQUIRE(h_out == d_out);
 }
 
-C2H_TEST("Warp scan works with custom types",
+CUB_TEST("Warp scan works with custom types",
          "[scan][warp]",
+         CUB_SMALL,
          c2h::type_list<c2h::custom_type_t<c2h::accumulateable_t, c2h::equal_comparable_t>>,
          logical_warp_threads,
          modes)
@@ -401,8 +402,9 @@ C2H_TEST("Warp scan works with custom types",
   REQUIRE(h_out == d_out);
 }
 
-C2H_TEST("Warp scan returns valid warp aggregate",
+CUB_TEST("Warp scan returns valid warp aggregate",
          "[scan][warp]",
+         CUB_SMALL,
          c2h::type_list<c2h::custom_type_t<c2h::accumulateable_t, c2h::equal_comparable_t>>,
          logical_warp_threads,
          modes)
@@ -430,7 +432,7 @@ C2H_TEST("Warp scan returns valid warp aggregate",
 }
 
 // TODO : Do we need all the types?
-C2H_TEST("Warp scan works with custom scan op", "[scan][warp]", types, logical_warp_threads, modes)
+CUB_TEST("Warp scan works with custom scan op", "[scan][warp]", CUB_SMALL, types, logical_warp_threads, modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -470,7 +472,8 @@ C2H_TEST("Warp scan works with custom scan op", "[scan][warp]", types, logical_w
   REQUIRE_APPROX_EQ(h_out, d_out);
 }
 
-C2H_TEST("Warp custom op scan returns valid warp aggregate", "[scan][warp]", types, logical_warp_threads, modes)
+CUB_TEST(
+  "Warp custom op scan returns valid warp aggregate", "[scan][warp]", CUB_SMALL, types, logical_warp_threads, modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -517,7 +520,7 @@ C2H_TEST("Warp custom op scan returns valid warp aggregate", "[scan][warp]", typ
   REQUIRE(h_warp_aggregates == d_warp_aggregates);
 }
 
-C2H_TEST("Warp custom op scan works with initial value", "[scan][warp]", types, logical_warp_threads, modes)
+CUB_TEST("Warp custom op scan works with initial value", "[scan][warp]", CUB_SMALL, types, logical_warp_threads, modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -545,8 +548,9 @@ C2H_TEST("Warp custom op scan works with initial value", "[scan][warp]", types, 
   REQUIRE_APPROX_EQ(h_out, d_out);
 }
 
-C2H_TEST("Warp custom op scan with initial value returns valid warp aggregate",
+CUB_TEST("Warp custom op scan with initial value returns valid warp aggregate",
          "[scan][warp]",
+         CUB_SMALL,
          types,
          logical_warp_threads,
          modes)
@@ -583,7 +587,7 @@ C2H_TEST("Warp custom op scan with initial value returns valid warp aggregate",
   REQUIRE(h_warp_aggregates == d_warp_aggregates);
 }
 
-C2H_TEST("Warp combination scan works with custom scan op", "[scan][warp]", logical_warp_threads)
+CUB_TEST("Warp combination scan works with custom scan op", "[scan][warp]", CUB_SMALL, logical_warp_threads)
 {
   constexpr int logical_warp_threads = c2h::get<0, TestType>();
   constexpr int total_warps          = total_warps_t<logical_warp_threads>::value();
@@ -633,7 +637,7 @@ C2H_TEST("Warp combination scan works with custom scan op", "[scan][warp]", logi
   REQUIRE(h_exclusive_out == d_exclusive_out);
 }
 
-C2H_TEST("Warp combination custom scan works with initial value", "[scan][warp]", logical_warp_threads)
+CUB_TEST("Warp combination custom scan works with initial value", "[scan][warp]", CUB_SMALL, logical_warp_threads)
 {
   constexpr int logical_warp_threads = c2h::get<0, TestType>();
   constexpr int total_warps          = total_warps_t<logical_warp_threads>::value();

--- a/cub/test/catch2_test_warp_scan_api.cu
+++ b/cub/test/catch2_test_warp_scan_api.cu
@@ -12,7 +12,7 @@
 #include <cuda/std/__numeric/inclusive_scan.h>
 #include <cuda/std/__numeric/iota.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 constexpr int num_warps = 4;
 
@@ -61,7 +61,7 @@ __global__ void InclusiveWarpScanKernel(int* output)
 }
 // example-end inclusive-warp-scan-init-value
 
-C2H_TEST("Warp array-based inclusive scan works with initial value", "[scan][warp]")
+CUB_TEST("Warp array-based inclusive scan works with initial value", "[scan][warp]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(num_warps * 32);
 
@@ -116,7 +116,7 @@ __global__ void InclusiveWarpScanKernelAggr(int* output, int* d_warp_aggregate)
 }
 // example-end inclusive-warp-scan-init-value-aggregate
 
-C2H_TEST("Warp array-based inclusive scan aggregate works with initial value", "[scan][warp]")
+CUB_TEST("Warp array-based inclusive scan aggregate works with initial value", "[scan][warp]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(num_warps * 32);
   c2h::device_vector<int> d_warp_aggregate(num_warps);
@@ -194,7 +194,7 @@ __global__ void InclusiveWarpScanPartialKernel(int* output)
 }
 // example-end inclusive-warp-scan-init-value-partial
 
-C2H_TEST("Warp array-based partial inclusive scan works with initial value", "[scan][warp]")
+CUB_TEST("Warp array-based partial inclusive scan works with initial value", "[scan][warp]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(num_warps * 32);
 
@@ -270,7 +270,7 @@ __global__ void InclusiveWarpScanPartialKernelAggr(int* output, int* d_warp_aggr
 }
 // example-end inclusive-warp-scan-init-value-aggregate-partial
 
-C2H_TEST("Warp array-based partial inclusive scan aggregate works with initial value", "[scan][warp]")
+CUB_TEST("Warp array-based partial inclusive scan aggregate works with initial value", "[scan][warp]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(num_warps * 32);
   c2h::device_vector<int> d_warp_aggregate(num_warps);

--- a/cub/test/catch2_test_warp_scan_partial.cu
+++ b/cub/test/catch2_test_warp_scan_partial.cu
@@ -8,7 +8,7 @@
 #include <cuda/std/limits>
 
 #include "catch2_test_warp_scan_partial_helper.cuh"
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 using types                = c2h::type_list<std::uint8_t, std::uint16_t, std::int32_t, std::int64_t>;
 using logical_warp_threads = c2h::enum_type_list<int, 32, 16, 9, 2>;
@@ -190,7 +190,7 @@ struct min_init_value_scan_op_t
   }
 };
 
-C2H_TEST("Partial warp scan works with sum", "[scan][warp]", types, logical_warp_threads, modes)
+CUB_TEST("Partial warp scan works with sum", "[scan][warp]", CUB_SMALL, types, logical_warp_threads, modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -225,7 +225,7 @@ C2H_TEST("Partial warp scan works with sum", "[scan][warp]", types, logical_warp
   REQUIRE_APPROX_EQ(h_out, d_out);
 }
 
-C2H_TEST("Partial warp scan works with vec_types", "[scan][warp]", vec_types, logical_warp_threads, modes)
+CUB_TEST("Partial warp scan works with vec_types", "[scan][warp]", CUB_SMALL, vec_types, logical_warp_threads, modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -261,8 +261,9 @@ C2H_TEST("Partial warp scan works with vec_types", "[scan][warp]", vec_types, lo
   REQUIRE(h_out == d_out);
 }
 
-C2H_TEST("Partial warp scan works with custom types",
+CUB_TEST("Partial warp scan works with custom types",
          "[scan][warp]",
+         CUB_SMALL,
          c2h::type_list<c2h::custom_type_t<c2h::accumulateable_t, c2h::equal_comparable_t>>,
          logical_warp_threads,
          modes)
@@ -301,8 +302,9 @@ C2H_TEST("Partial warp scan works with custom types",
   REQUIRE(h_out == d_out);
 }
 
-C2H_TEST("Partial warp scan returns valid warp aggregate",
+CUB_TEST("Partial warp scan returns valid warp aggregate",
          "[scan][warp]",
+         CUB_SMALL,
          c2h::type_list<c2h::custom_type_t<c2h::accumulateable_t, c2h::equal_comparable_t>>,
          logical_warp_threads,
          modes)
@@ -355,7 +357,7 @@ C2H_TEST("Partial warp scan returns valid warp aggregate",
 }
 
 // TODO : Do we need all the types?
-C2H_TEST("Partial warp scan works with custom scan op", "[scan][warp]", types, logical_warp_threads, modes)
+CUB_TEST("Partial warp scan works with custom scan op", "[scan][warp]", CUB_SMALL, types, logical_warp_threads, modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -400,7 +402,12 @@ C2H_TEST("Partial warp scan works with custom scan op", "[scan][warp]", types, l
   REQUIRE_APPROX_EQ(h_out, d_out);
 }
 
-C2H_TEST("Partial warp custom op scan returns valid warp aggregate", "[scan][warp]", types, logical_warp_threads, modes)
+CUB_TEST("Partial warp custom op scan returns valid warp aggregate",
+         "[scan][warp]",
+         CUB_SMALL,
+         types,
+         logical_warp_threads,
+         modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -456,7 +463,8 @@ C2H_TEST("Partial warp custom op scan returns valid warp aggregate", "[scan][war
   }
 }
 
-C2H_TEST("Partial warp custom op scan works with initial value", "[scan][warp]", types, logical_warp_threads, modes)
+CUB_TEST(
+  "Partial warp custom op scan works with initial value", "[scan][warp]", CUB_SMALL, types, logical_warp_threads, modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -492,8 +500,9 @@ C2H_TEST("Partial warp custom op scan works with initial value", "[scan][warp]",
   REQUIRE_APPROX_EQ(h_out, d_out);
 }
 
-C2H_TEST("Partial warp custom op scan with initial value returns valid warp aggregate",
+CUB_TEST("Partial warp custom op scan with initial value returns valid warp aggregate",
          "[scan][warp]",
+         CUB_SMALL,
          types,
          logical_warp_threads,
          modes)
@@ -541,7 +550,7 @@ C2H_TEST("Partial warp custom op scan with initial value returns valid warp aggr
   }
 }
 
-C2H_TEST("Partial warp combination scan works with custom scan op", "[scan][warp]", logical_warp_threads)
+CUB_TEST("Partial warp combination scan works with custom scan op", "[scan][warp]", CUB_SMALL, logical_warp_threads)
 {
   constexpr int logical_warp_threads = c2h::get<0, TestType>();
   constexpr int total_warps          = total_warps_t<logical_warp_threads>::value();
@@ -611,7 +620,8 @@ C2H_TEST("Partial warp combination scan works with custom scan op", "[scan][warp
   REQUIRE(h_exclusive_out == d_exclusive_out);
 }
 
-C2H_TEST("Partial warp combination custom scan works with initial value", "[scan][warp]", logical_warp_threads)
+CUB_TEST(
+  "Partial warp combination custom scan works with initial value", "[scan][warp]", CUB_SMALL, logical_warp_threads)
 {
   constexpr int logical_warp_threads = c2h::get<0, TestType>();
   constexpr int total_warps          = total_warps_t<logical_warp_threads>::value();

--- a/cub/test/catch2_test_warp_scan_partial_invalid.cu
+++ b/cub/test/catch2_test_warp_scan_partial_invalid.cu
@@ -9,8 +9,8 @@
 #include <cuda/std/limits>
 
 #include "catch2_test_warp_scan_partial_helper.cuh"
+#include "cub_test_macros.h"
 #include "thread_reduce/catch2_test_thread_reduce_helper.cuh"
-#include <c2h/catch2_test_helper.h>
 
 using invalid_types        = c2h::type_list<segment>;
 using logical_warp_threads = c2h::enum_type_list<int, 32, 16, 9, 2>;
@@ -149,8 +149,12 @@ struct merge_init_value_scan_op_t
   }
 };
 
-C2H_TEST(
-  "Partial warp scan does not apply op to invalid elements", "[scan][warp]", invalid_types, logical_warp_threads, modes)
+CUB_TEST("Partial warp scan does not apply op to invalid elements",
+         "[scan][warp]",
+         CUB_SMALL,
+         invalid_types,
+         logical_warp_threads,
+         modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -198,8 +202,9 @@ C2H_TEST(
   REQUIRE(h_out == d_out);
 }
 
-C2H_TEST("Partial warp scan does not apply op to invalid elements and returns valid warp aggregate",
+CUB_TEST("Partial warp scan does not apply op to invalid elements and returns valid warp aggregate",
          "[scan][warp]",
+         CUB_SMALL,
          invalid_types,
          logical_warp_threads,
          modes)
@@ -262,8 +267,9 @@ C2H_TEST("Partial warp scan does not apply op to invalid elements and returns va
   }
 }
 
-C2H_TEST("Partial warp scan does not apply op to invalid elements and works with initial value",
+CUB_TEST("Partial warp scan does not apply op to invalid elements and works with initial value",
          "[scan][warp]",
+         CUB_SMALL,
          invalid_types,
          logical_warp_threads,
          modes)
@@ -307,8 +313,9 @@ C2H_TEST("Partial warp scan does not apply op to invalid elements and works with
   REQUIRE(h_out == d_out);
 }
 
-C2H_TEST("Partial warp scan with initial value does not apply op to invalid elements and returns valid warp aggregate",
+CUB_TEST("Partial warp scan with initial value does not apply op to invalid elements and returns valid warp aggregate",
          "[scan][warp]",
+         CUB_SMALL,
          invalid_types,
          logical_warp_threads,
          modes)
@@ -362,7 +369,10 @@ C2H_TEST("Partial warp scan with initial value does not apply op to invalid elem
   }
 }
 
-C2H_TEST("Partial warp combination scan does not apply op to invalid elements", "[scan][warp]", logical_warp_threads)
+CUB_TEST("Partial warp combination scan does not apply op to invalid elements",
+         "[scan][warp]",
+         CUB_SMALL,
+         logical_warp_threads)
 {
   constexpr int logical_warp_threads = c2h::get<0, TestType>();
   constexpr int total_warps          = total_warps_t<logical_warp_threads>::value();
@@ -421,8 +431,9 @@ C2H_TEST("Partial warp combination scan does not apply op to invalid elements", 
   REQUIRE(h_exclusive_out == d_exclusive_out);
 }
 
-C2H_TEST("Partial warp combination custom scan does not apply op to invalid elements and works with initial value",
+CUB_TEST("Partial warp combination custom scan does not apply op to invalid elements and works with initial value",
          "[scan][warp]",
+         CUB_SMALL,
          logical_warp_threads)
 {
   constexpr int logical_warp_threads = c2h::get<0, TestType>();

--- a/cub/test/catch2_test_warp_store.cu
+++ b/cub/test/catch2_test_warp_store.cu
@@ -5,7 +5,7 @@
 #include <cub/util_arch.cuh>
 #include <cub/warp/warp_store.cuh>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/fill_striped.h>
 
 template <cub::WarpStoreAlgorithm StoreAlgorithm,
@@ -170,8 +170,9 @@ struct params_t
   static constexpr int total_item_count              = total_warps * tile_size;
 };
 
-C2H_TEST("Warp store guarded range works with pointer",
+CUB_TEST("Warp store guarded range works with pointer",
          "[store][warp]",
+         CUB_SMALL,
          types,
          logical_warp_threads,
          items_per_thread,
@@ -191,8 +192,9 @@ C2H_TEST("Warp store guarded range works with pointer",
   REQUIRE(d_expected_output == d_out);
 }
 
-C2H_TEST("Warp store guarded range works with cache modified iterator",
+CUB_TEST("Warp store guarded range works with cache modified iterator",
          "[store][warp]",
+         CUB_SMALL,
          types,
          logical_warp_threads,
          items_per_thread,
@@ -214,8 +216,9 @@ C2H_TEST("Warp store guarded range works with cache modified iterator",
   REQUIRE(d_expected_output == d_out);
 }
 
-C2H_TEST("Warp store unguarded range works with pointer",
+CUB_TEST("Warp store unguarded range works with pointer",
          "[store][warp]",
+         CUB_SMALL,
          types,
          logical_warp_threads,
          items_per_thread,
@@ -235,8 +238,9 @@ C2H_TEST("Warp store unguarded range works with pointer",
   REQUIRE(d_expected_output == d_out);
 }
 
-C2H_TEST("Warp store unguarded range works with cache modified iterator",
+CUB_TEST("Warp store unguarded range works with cache modified iterator",
          "[store][warp]",
+         CUB_SMALL,
          types,
          logical_warp_threads,
          items_per_thread,
@@ -259,8 +263,9 @@ C2H_TEST("Warp store unguarded range works with cache modified iterator",
 }
 
 #if ALGO_TYPE == 3 // cub::WarpStoreAlgorithm::WARP_STORE_VECTORIZE
-C2H_TEST("Vectorized warp store with different alignment cases",
+CUB_TEST("Vectorized warp store with different alignment cases",
          "[store][warp]",
+         CUB_SMALL,
          c2h::type_list<std::int32_t>,
          logical_warp_threads,
          items_per_thread,

--- a/cub/test/cub_test_macros.h
+++ b/cub/test/cub_test_macros.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <c2h/catch2_test_helper.h>
+
+// Every CUB Catch2 test must specify CUB_SMALL or CUB_LARGE.
+// Small tests may share a GPU; large tests run alone. Use CUB_LARGE when unsure.
+
+#define CUB_TEST_MEMORY_TAG_CUB_SMALL "[small-mem]"
+#define CUB_TEST_MEMORY_TAG_CUB_LARGE "[large-mem]"
+#define CUB_TEST_MEMORY_TAG(MEMORY)   C2H_TEST_CONCAT(CUB_TEST_MEMORY_TAG_, MEMORY)
+
+#define CUB_TEST(NAME, TAGS, MEMORY, ...) C2H_TEST(NAME, TAGS CUB_TEST_MEMORY_TAG(MEMORY), __VA_ARGS__)
+
+#define CUB_TEST_CASE(NAME, TAGS, MEMORY) TEST_CASE(NAME, TAGS CUB_TEST_MEMORY_TAG(MEMORY))
+
+#define CUB_TEST_LIST(NAME, TAGS, MEMORY, ...) C2H_TEST_LIST(NAME, TAGS CUB_TEST_MEMORY_TAG(MEMORY), __VA_ARGS__)

--- a/cub/test/internal/catch2_test_fast_div_mod.cu
+++ b/cub/test/internal/catch2_test_fast_div_mod.cu
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <cub/config.cuh>
 
-#include "c2h/catch2_test_helper.h"
 #include "c2h/utility.h"
+#include "cub_test_macros.h"
 
 /***********************************************************************************************************************
  * TEST CASES
@@ -23,7 +23,7 @@ using index_types =
 #endif
                  >;
 
-C2H_TEST("FastDivMod random", "[FastDivMod][Random]", index_types)
+CUB_TEST("FastDivMod random", "[FastDivMod][Random]", CUB_SMALL, index_types)
 {
   using cub::detail::fast_div_mod;
   using index_type         = c2h::get<0, TestType>;
@@ -38,7 +38,7 @@ C2H_TEST("FastDivMod random", "[FastDivMod][Random]", index_types)
   REQUIRE(dividend % divisor == div_mod(dividend).remainder);
 }
 
-C2H_TEST("FastDivMod edge cases", "[FastDivMod][EdgeCases]", index_types)
+CUB_TEST("FastDivMod edge cases", "[FastDivMod][EdgeCases]", CUB_SMALL, index_types)
 {
   using cub::detail::fast_div_mod;
   using index_type         = c2h::get<0, TestType>;

--- a/cub/test/thread_reduce/catch2_test_thread_reduce.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce.cu
@@ -16,9 +16,9 @@
 #include <limits>
 #include <numeric>
 
-#include "c2h/catch2_test_helper.h"
 #include "c2h/extended_types.h"
 #include "c2h/generators.h"
+#include "cub_test_macros.h"
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 /***********************************************************************************************************************
@@ -263,7 +263,8 @@ constexpr int num_seeds = 10;
  * Test cases
  **********************************************************************************************************************/
 
-C2H_TEST("ThreadReduce Integral Type Tests", "[reduce][thread]", integral_type_list, cub_operator_integral_list)
+CUB_TEST(
+  "ThreadReduce Integral Type Tests", "[reduce][thread]", CUB_SMALL, integral_type_list, cub_operator_integral_list)
 {
   using value_t                    = c2h::get<0, TestType>;
   using op_t                       = c2h::get<1, TestType>;
@@ -283,7 +284,7 @@ C2H_TEST("ThreadReduce Integral Type Tests", "[reduce][thread]", integral_type_l
   }
 }
 
-C2H_TEST("ThreadReduce Floating-Point Type Tests", "[reduce][thread]", fp_type_list, cub_operator_fp_list)
+CUB_TEST("ThreadReduce Floating-Point Type Tests", "[reduce][thread]", CUB_SMALL, fp_type_list, cub_operator_fp_list)
 {
   using value_t                = c2h::get<0, TestType>;
   using op_t                   = c2h::get<1, TestType>;
@@ -305,8 +306,9 @@ C2H_TEST("ThreadReduce Floating-Point Type Tests", "[reduce][thread]", fp_type_l
 
 #if TEST_HALF_T() || TEST_BF_T()
 
-C2H_TEST("ThreadReduce Narrow PrecisionType Tests",
+CUB_TEST("ThreadReduce Narrow PrecisionType Tests",
          "[reduce][thread][narrow]",
+         CUB_SMALL,
          narrow_precision_type_list,
          cub_operator_fp_list)
 {
@@ -331,7 +333,7 @@ C2H_TEST("ThreadReduce Narrow PrecisionType Tests",
 
 #endif // TEST_HALF_T() || TEST_BF_T()
 
-C2H_TEST("ThreadReduce Container Tests", "[reduce][thread]")
+CUB_TEST("ThreadReduce Container Tests", "[reduce][thread]", CUB_SMALL)
 {
   c2h::device_vector<int> d_in(max_size);
   c2h::device_vector<int> d_out(1);

--- a/cub/test/thread_reduce/catch2_test_thread_reduce_check_sass.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce_check_sass.cu
@@ -18,7 +18,7 @@
 #  include <limits>
 #  include <numeric>
 
-#  include "../catch2_test_macros.h"
+#  include "../cub_test_macros.h"
 #  include "c2h/extended_types.h"
 #  include "c2h/generators.h"
 #  include <catch2/matchers/catch_matchers_floating_point.hpp>

--- a/cub/test/thread_reduce/catch2_test_thread_reduce_check_sass.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce_check_sass.cu
@@ -201,7 +201,7 @@ CUB_TEST("ThreadReduce Narrow PrecisionType Tests",
 
 #else
 
-#  include "c2h/catch2_test_helper.h"
+#  include "../cub_test_macros.h"
 
 CUB_TEST("ThreadReduce Empty Test", "[reduce][thread][empty]", CUB_SMALL) {}
 

--- a/cub/test/thread_reduce/catch2_test_thread_reduce_check_sass.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce_check_sass.cu
@@ -18,7 +18,7 @@
 #  include <limits>
 #  include <numeric>
 
-#  include "c2h/catch2_test_helper.h"
+#  include "../catch2_test_macros.h"
 #  include "c2h/extended_types.h"
 #  include "c2h/generators.h"
 #  include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -138,7 +138,8 @@ void run_thread_reduce_kernel(
 
 constexpr int size = 16;
 
-C2H_TEST("ThreadReduce Integral Type Tests", "[reduce][thread]", integral_type_list, cub_operator_integral_list)
+CUB_TEST(
+  "ThreadReduce Integral Type Tests", "[reduce][thread]", CUB_SMALL, integral_type_list, cub_operator_integral_list)
 {
   using value_t                    = c2h::get<0, TestType>;
   using op_t                       = c2h::get<1, TestType>;
@@ -155,7 +156,7 @@ C2H_TEST("ThreadReduce Integral Type Tests", "[reduce][thread]", integral_type_l
   verify_results(reference_result, c2h::host_vector<value_t>(d_out)[0]);
 }
 
-C2H_TEST("ThreadReduce Floating-Point Type Tests", "[reduce][thread]", fp_type_list, cub_operator_fp_list)
+CUB_TEST("ThreadReduce Floating-Point Type Tests", "[reduce][thread]", CUB_SMALL, fp_type_list, cub_operator_fp_list)
 {
   using value_t                = c2h::get<0, TestType>;
   using op_t                   = c2h::get<1, TestType>;
@@ -174,8 +175,9 @@ C2H_TEST("ThreadReduce Floating-Point Type Tests", "[reduce][thread]", fp_type_l
 
 #  if TEST_HALF_T() || TEST_BF_T()
 
-C2H_TEST("ThreadReduce Narrow PrecisionType Tests",
+CUB_TEST("ThreadReduce Narrow PrecisionType Tests",
          "[reduce][thread][narrow]",
+         CUB_SMALL,
          narrow_precision_type_list,
          cub_operator_fp_list)
 {
@@ -201,6 +203,6 @@ C2H_TEST("ThreadReduce Narrow PrecisionType Tests",
 
 #  include "c2h/catch2_test_helper.h"
 
-C2H_TEST("ThreadReduce Empty Test", "[reduce][thread][empty]") {}
+CUB_TEST("ThreadReduce Empty Test", "[reduce][thread][empty]", CUB_SMALL) {}
 
 #endif // CCCL_CHECK_SASS

--- a/cub/test/thread_reduce/catch2_test_thread_reduce_partial.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce_partial.cu
@@ -13,8 +13,8 @@
 #include <cuda/std/type_traits>
 
 #include "catch2_test_device_reduce.cuh"
+#include "cub_test_macros.h"
 #include "thread_reduce/catch2_test_thread_reduce_helper.cuh"
-#include <c2h/catch2_test_helper.h>
 #include <c2h/extended_types.h>
 #include <c2h/generators.h>
 #include <c2h/operator.cuh>
@@ -115,8 +115,9 @@ using items_per_thread_list = c2h::enum_type_list<int, 1, 3, max_size - 1, max_s
  * Test cases
  **********************************************************************************************************************/
 
-C2H_TEST("ThreadReduce Integral Type Tests",
+CUB_TEST("ThreadReduce Integral Type Tests",
          "[reduce][thread]",
+         CUB_SMALL,
          integral_type_list,
          cub_operator_integral_list,
          items_per_thread_list)
@@ -147,8 +148,9 @@ C2H_TEST("ThreadReduce Integral Type Tests",
   REQUIRE(reference_result == c2h::host_vector<accum_t>(d_out)[0]);
 }
 
-C2H_TEST("ThreadReduce Floating-Point Type Tests",
+CUB_TEST("ThreadReduce Floating-Point Type Tests",
          "[reduce][thread]",
+         CUB_SMALL,
          fp_type_list,
          cub_operator_fp_list,
          items_per_thread_list)
@@ -181,8 +183,9 @@ C2H_TEST("ThreadReduce Floating-Point Type Tests",
 
 #if TEST_HALF_T() || TEST_BF_T()
 
-C2H_TEST("ThreadReduce Narrow PrecisionType Tests",
+CUB_TEST("ThreadReduce Narrow PrecisionType Tests",
          "[reduce][thread][narrow]",
+         CUB_SMALL,
          narrow_precision_type_list,
          cub_operator_fp_list,
          items_per_thread_list)
@@ -220,7 +223,7 @@ C2H_TEST("ThreadReduce Narrow PrecisionType Tests",
 
 #endif // TEST_HALF_T() || TEST_BF_T()
 
-C2H_TEST("ThreadReduce Container Tests", "[reduce][thread]")
+CUB_TEST("ThreadReduce Container Tests", "[reduce][thread]", CUB_SMALL)
 {
   using op_t       = cuda::std::plus<>;
   using dist_param = dist_interval<int, op_t, max_size>;
@@ -255,7 +258,7 @@ C2H_TEST("ThreadReduce Container Tests", "[reduce][thread]")
   REQUIRE(reference_result == c2h::host_vector<int>(d_out)[0]);
 }
 
-C2H_TEST("ThreadReducePartial does not invoke the reduction operator on invalid elements", "[reduce][thread]")
+CUB_TEST("ThreadReducePartial does not invoke the reduction operator on invalid elements", "[reduce][thread]", CUB_SMALL)
 {
   const auto in_it = cuda::make_transform_iterator(
     thrust::make_zip_iterator(cuda::counting_iterator<segment::offset_t>{1},

--- a/cub/test/warp/catch2_test_warp_reduce.cu
+++ b/cub/test/warp/catch2_test_warp_reduce.cu
@@ -18,7 +18,7 @@
 
 #include <test_util.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/check_results.cuh>
 #include <c2h/custom_type.h>
 #include <c2h/operator.cuh>
@@ -239,7 +239,11 @@ std::array<unsigned, 3> get_test_config(unsigned logical_warp_threads, unsigned 
  * Test cases
  **********************************************************************************************************************/
 
-C2H_TEST("WarpReduce::Sum, full_type_list", "[reduce][warp][predefined_op][full]", full_type_list, logical_warp_threads)
+CUB_TEST("WarpReduce::Sum, full_type_list",
+         "[reduce][warp][predefined_op][full]",
+         CUB_SMALL,
+         full_type_list,
+         logical_warp_threads)
 {
   using T                                       = c2h::get<0, TestType>;
   constexpr auto logical_warp_threads           = c2h::get<1, TestType>::value;
@@ -256,8 +260,9 @@ C2H_TEST("WarpReduce::Sum, full_type_list", "[reduce][warp][predefined_op][full]
   verify_results(h_out, d_out);
 }
 
-C2H_TEST("WarpReduce::Sum/Max/Min, builtin types",
+CUB_TEST("WarpReduce::Sum/Max/Min, builtin types",
          "[reduce][warp][predefined_op][full]",
+         CUB_SMALL,
          builtin_type_list,
          predefined_op_list,
          logical_warp_threads)
@@ -278,8 +283,9 @@ C2H_TEST("WarpReduce::Sum/Max/Min, builtin types",
   verify_results(h_out, d_out);
 }
 
-C2H_TEST("WarpReduce::Max/Min, floating-point redux types",
+CUB_TEST("WarpReduce::Max/Min, floating-point redux types",
          "[reduce][warp][predefined_op][redux]",
+         CUB_SMALL,
          floating_point_redux_type_list,
          predefined_min_max_op_list,
          logical_warp_threads)
@@ -307,7 +313,7 @@ C2H_TEST("WarpReduce::Max/Min, floating-point redux types",
   }
 }
 
-C2H_TEST("WarpReduce::CustomSum", "[reduce][warp][generic][full]", full_type_list, logical_warp_threads)
+CUB_TEST("WarpReduce::CustomSum", "[reduce][warp][generic][full]", CUB_SMALL, full_type_list, logical_warp_threads)
 {
   using T                                       = c2h::get<0, TestType>;
   constexpr auto logical_warp_threads           = c2h::get<1, TestType>::value;
@@ -327,8 +333,9 @@ C2H_TEST("WarpReduce::CustomSum", "[reduce][warp][generic][full]", full_type_lis
 //----------------------------------------------------------------------------------------------------------------------
 // partial
 
-C2H_TEST("WarpReduce::Sum/Max/Min Partial",
+CUB_TEST("WarpReduce::Sum/Max/Min Partial",
          "[reduce][warp][predefined_op][partial]",
+         CUB_SMALL,
          builtin_type_list,
          predefined_op_list,
          logical_warp_threads)
@@ -350,7 +357,7 @@ C2H_TEST("WarpReduce::Sum/Max/Min Partial",
   verify_results(h_out, d_out);
 }
 
-C2H_TEST("WarpReduce::Sum", "[reduce][warp][generic][partial]", full_type_list, logical_warp_threads)
+CUB_TEST("WarpReduce::Sum", "[reduce][warp][generic][partial]", CUB_SMALL, full_type_list, logical_warp_threads)
 {
   using T                                       = c2h::get<0, TestType>;
   constexpr auto logical_warp_threads           = c2h::get<1, TestType>::value;
@@ -371,8 +378,9 @@ C2H_TEST("WarpReduce::Sum", "[reduce][warp][generic][partial]", full_type_list, 
 //----------------------------------------------------------------------------------------------------------------------
 // multiple items per thread
 
-C2H_TEST("WarpReduce::Sum/Max/Min Multiple Items Per Thread",
+CUB_TEST("WarpReduce::Sum/Max/Min Multiple Items Per Thread",
          "[reduce][warp][predefined_op][full]",
+         CUB_SMALL,
          builtin_type_list,
          predefined_op_list,
          logical_warp_threads)

--- a/cub/test/warp/catch2_test_warp_reduce_batched.cu
+++ b/cub/test/warp/catch2_test_warp_reduce_batched.cu
@@ -19,7 +19,7 @@
 
 #include <test_util.h>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/check_results.cuh>
 #include <c2h/custom_type.h>
 #include <c2h/operator.cuh>
@@ -363,7 +363,7 @@ using sub_warp_unequal_configs = c2h::type_list<int_pair<3, 16>, int_pair<4, 8>,
 
 using unequal_nm_single_out_configs = c2h::type_list<int_pair<1, 32>, int_pair<3, 16>, int_pair<4, 8>, int_pair<1, 2>>;
 
-C2H_TEST("WarpReduceBatched::Reduce N=M sum", "[warp][reduce][batched]", full_type_list, equal_nm_configs)
+CUB_TEST("WarpReduceBatched::Reduce N=M sum", "[warp][reduce][batched]", CUB_SMALL, full_type_list, equal_nm_configs)
 {
   using value_t                          = c2h::get<0, TestType>;
   using op_t                             = cuda::std::plus<>;
@@ -372,8 +372,11 @@ C2H_TEST("WarpReduceBatched::Reduce N=M sum", "[warp][reduce][batched]", full_ty
   test_warp_reduce_batched<WarpReduceBatchedMode::SingleOut, num_batches, logical_warp_num_threads, value_t, op_t>();
 }
 
-C2H_TEST(
-  "WarpReduceBatched::Reduce N!=M sum", "[warp][reduce][batched]", builtin_type_list, unequal_nm_single_out_configs)
+CUB_TEST("WarpReduceBatched::Reduce N!=M sum",
+         "[warp][reduce][batched]",
+         CUB_SMALL,
+         builtin_type_list,
+         unequal_nm_single_out_configs)
 {
   using value_t                          = c2h::get<0, TestType>;
   using op_t                             = cuda::std::plus<>;
@@ -382,8 +385,11 @@ C2H_TEST(
   test_warp_reduce_batched<WarpReduceBatchedMode::SingleOut, num_batches, logical_warp_num_threads, value_t, op_t>();
 }
 
-C2H_TEST(
-  "WarpReduceBatched::Reduce max with over-syncing", "[warp][reduce][batched]", builtin_type_list, equal_nm_configs)
+CUB_TEST("WarpReduceBatched::Reduce max with over-syncing",
+         "[warp][reduce][batched]",
+         CUB_SMALL,
+         builtin_type_list,
+         equal_nm_configs)
 {
   using value_t                          = c2h::get<0, TestType>;
   using op_t                             = cuda::maximum<>;
@@ -402,8 +408,9 @@ C2H_TEST(
                            sync_physical_warp>();
 }
 
-C2H_TEST("WarpReduceBatched::Reduce min with over-syncing",
+CUB_TEST("WarpReduceBatched::Reduce min with over-syncing",
          "[warp][reduce][batched]",
+         CUB_SMALL,
          builtin_type_list,
          unequal_nm_single_out_configs)
 {
@@ -424,7 +431,8 @@ C2H_TEST("WarpReduceBatched::Reduce min with over-syncing",
                            sync_physical_warp>();
 }
 
-C2H_TEST("WarpReduceBatched::Sum", "[warp][reduce][batched][convenience]", builtin_type_list, equal_nm_configs)
+CUB_TEST(
+  "WarpReduceBatched::Sum", "[warp][reduce][batched][convenience]", CUB_SMALL, builtin_type_list, equal_nm_configs)
 {
   using value_t                          = c2h::get<0, TestType>;
   using op_t                             = cuda::std::plus<>;
@@ -439,26 +447,35 @@ C2H_TEST("WarpReduceBatched::Sum", "[warp][reduce][batched][convenience]", built
                            convenience_overload>();
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToStriped N=M sum", "[warp][reduce][batched]", builtin_type_list, equal_nm_configs)
-{
-  using value_t                          = c2h::get<0, TestType>;
-  using op_t                             = cuda::std::plus<>;
-  constexpr int num_batches              = c2h::get<1, TestType>::x;
-  constexpr int logical_warp_num_threads = c2h::get<1, TestType>::y;
-  test_warp_reduce_batched<WarpReduceBatchedMode::ToStriped, num_batches, logical_warp_num_threads, value_t, op_t>();
-}
-
-C2H_TEST("WarpReduceBatched::ReduceToStriped N!=M sum", "[warp][reduce][batched]", builtin_type_list, unequal_nm_configs)
-{
-  using value_t                          = c2h::get<0, TestType>;
-  using op_t                             = cuda::std::plus<>;
-  constexpr int num_batches              = c2h::get<1, TestType>::x;
-  constexpr int logical_warp_num_threads = c2h::get<1, TestType>::y;
-  test_warp_reduce_batched<WarpReduceBatchedMode::ToStriped, num_batches, logical_warp_num_threads, value_t, op_t>();
-}
-
-C2H_TEST("WarpReduceBatched::ReduceToStriped max with over-syncing",
+CUB_TEST("WarpReduceBatched::ReduceToStriped N=M sum",
          "[warp][reduce][batched]",
+         CUB_SMALL,
+         builtin_type_list,
+         equal_nm_configs)
+{
+  using value_t                          = c2h::get<0, TestType>;
+  using op_t                             = cuda::std::plus<>;
+  constexpr int num_batches              = c2h::get<1, TestType>::x;
+  constexpr int logical_warp_num_threads = c2h::get<1, TestType>::y;
+  test_warp_reduce_batched<WarpReduceBatchedMode::ToStriped, num_batches, logical_warp_num_threads, value_t, op_t>();
+}
+
+CUB_TEST("WarpReduceBatched::ReduceToStriped N!=M sum",
+         "[warp][reduce][batched]",
+         CUB_SMALL,
+         builtin_type_list,
+         unequal_nm_configs)
+{
+  using value_t                          = c2h::get<0, TestType>;
+  using op_t                             = cuda::std::plus<>;
+  constexpr int num_batches              = c2h::get<1, TestType>::x;
+  constexpr int logical_warp_num_threads = c2h::get<1, TestType>::y;
+  test_warp_reduce_batched<WarpReduceBatchedMode::ToStriped, num_batches, logical_warp_num_threads, value_t, op_t>();
+}
+
+CUB_TEST("WarpReduceBatched::ReduceToStriped max with over-syncing",
+         "[warp][reduce][batched]",
+         CUB_SMALL,
          builtin_type_list,
          equal_nm_configs)
 {
@@ -479,8 +496,9 @@ C2H_TEST("WarpReduceBatched::ReduceToStriped max with over-syncing",
                            sync_physical_warp>();
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToStriped min with over-syncing",
+CUB_TEST("WarpReduceBatched::ReduceToStriped min with over-syncing",
          "[warp][reduce][batched]",
+         CUB_SMALL,
          builtin_type_list,
          unequal_nm_configs)
 {
@@ -501,7 +519,11 @@ C2H_TEST("WarpReduceBatched::ReduceToStriped min with over-syncing",
                            sync_physical_warp>();
 }
 
-C2H_TEST("WarpReduceBatched::SumToStriped", "[warp][reduce][batched][convenience]", builtin_type_list, equal_nm_configs)
+CUB_TEST("WarpReduceBatched::SumToStriped",
+         "[warp][reduce][batched][convenience]",
+         CUB_SMALL,
+         builtin_type_list,
+         equal_nm_configs)
 {
   using value_t                          = c2h::get<0, TestType>;
   using op_t                             = cuda::std::plus<>;
@@ -516,8 +538,9 @@ C2H_TEST("WarpReduceBatched::SumToStriped", "[warp][reduce][batched][convenience
                            convenience_overload>();
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToStriped with conditional participation N=M sum",
+CUB_TEST("WarpReduceBatched::ReduceToStriped with conditional participation N=M sum",
          "[warp][reduce][batched][lane_mask]",
+         CUB_SMALL,
          builtin_type_list,
          sub_warp_equal_configs)
 {
@@ -536,8 +559,9 @@ C2H_TEST("WarpReduceBatched::ReduceToStriped with conditional participation N=M 
                            cond_participation>();
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToStriped with conditional participation N!=M sum",
+CUB_TEST("WarpReduceBatched::ReduceToStriped with conditional participation N!=M sum",
          "[warp][reduce][batched][lane_mask]",
+         CUB_SMALL,
          builtin_type_list,
          sub_warp_unequal_configs)
 {
@@ -556,8 +580,9 @@ C2H_TEST("WarpReduceBatched::ReduceToStriped with conditional participation N!=M
                            cond_participation>();
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToStriped with conditional participation and over-syncing N=M sum",
+CUB_TEST("WarpReduceBatched::ReduceToStriped with conditional participation and over-syncing N=M sum",
          "[warp][reduce][batched][lane_mask]",
+         CUB_SMALL,
          builtin_type_list,
          sub_warp_equal_configs)
 {
@@ -578,8 +603,9 @@ C2H_TEST("WarpReduceBatched::ReduceToStriped with conditional participation and 
                            sync_physical_warp>();
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToStriped with conditional participation and over-syncing N!=M sum",
+CUB_TEST("WarpReduceBatched::ReduceToStriped with conditional participation and over-syncing N!=M sum",
          "[warp][reduce][batched][lane_mask]",
+         CUB_SMALL,
          builtin_type_list,
          sub_warp_unequal_configs)
 {
@@ -600,26 +626,35 @@ C2H_TEST("WarpReduceBatched::ReduceToStriped with conditional participation and 
                            sync_physical_warp>();
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToBlocked N=M sum", "[warp][reduce][batched]", builtin_type_list, equal_nm_configs)
-{
-  using value_t                          = c2h::get<0, TestType>;
-  using op_t                             = cuda::std::plus<>;
-  constexpr int num_batches              = c2h::get<1, TestType>::x;
-  constexpr int logical_warp_num_threads = c2h::get<1, TestType>::y;
-  test_warp_reduce_batched<WarpReduceBatchedMode::ToBlocked, num_batches, logical_warp_num_threads, value_t, op_t>();
-}
-
-C2H_TEST("WarpReduceBatched::ReduceToBlocked N!=M sum", "[warp][reduce][batched]", builtin_type_list, unequal_nm_configs)
-{
-  using value_t                          = c2h::get<0, TestType>;
-  using op_t                             = cuda::std::plus<>;
-  constexpr int num_batches              = c2h::get<1, TestType>::x;
-  constexpr int logical_warp_num_threads = c2h::get<1, TestType>::y;
-  test_warp_reduce_batched<WarpReduceBatchedMode::ToBlocked, num_batches, logical_warp_num_threads, value_t, op_t>();
-}
-
-C2H_TEST("WarpReduceBatched::ReduceToBlocked max with over-syncing",
+CUB_TEST("WarpReduceBatched::ReduceToBlocked N=M sum",
          "[warp][reduce][batched]",
+         CUB_SMALL,
+         builtin_type_list,
+         equal_nm_configs)
+{
+  using value_t                          = c2h::get<0, TestType>;
+  using op_t                             = cuda::std::plus<>;
+  constexpr int num_batches              = c2h::get<1, TestType>::x;
+  constexpr int logical_warp_num_threads = c2h::get<1, TestType>::y;
+  test_warp_reduce_batched<WarpReduceBatchedMode::ToBlocked, num_batches, logical_warp_num_threads, value_t, op_t>();
+}
+
+CUB_TEST("WarpReduceBatched::ReduceToBlocked N!=M sum",
+         "[warp][reduce][batched]",
+         CUB_SMALL,
+         builtin_type_list,
+         unequal_nm_configs)
+{
+  using value_t                          = c2h::get<0, TestType>;
+  using op_t                             = cuda::std::plus<>;
+  constexpr int num_batches              = c2h::get<1, TestType>::x;
+  constexpr int logical_warp_num_threads = c2h::get<1, TestType>::y;
+  test_warp_reduce_batched<WarpReduceBatchedMode::ToBlocked, num_batches, logical_warp_num_threads, value_t, op_t>();
+}
+
+CUB_TEST("WarpReduceBatched::ReduceToBlocked max with over-syncing",
+         "[warp][reduce][batched]",
+         CUB_SMALL,
          builtin_type_list,
          equal_nm_configs)
 {
@@ -640,8 +675,9 @@ C2H_TEST("WarpReduceBatched::ReduceToBlocked max with over-syncing",
                            sync_physical_warp>();
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToBlocked min with over-syncing",
+CUB_TEST("WarpReduceBatched::ReduceToBlocked min with over-syncing",
          "[warp][reduce][batched]",
+         CUB_SMALL,
          builtin_type_list,
          unequal_nm_configs)
 {
@@ -662,7 +698,11 @@ C2H_TEST("WarpReduceBatched::ReduceToBlocked min with over-syncing",
                            sync_physical_warp>();
 }
 
-C2H_TEST("WarpReduceBatched::SumToBlocked", "[warp][reduce][batched][convenience]", builtin_type_list, equal_nm_configs)
+CUB_TEST("WarpReduceBatched::SumToBlocked",
+         "[warp][reduce][batched][convenience]",
+         CUB_SMALL,
+         builtin_type_list,
+         equal_nm_configs)
 {
   using value_t                          = c2h::get<0, TestType>;
   using op_t                             = cuda::std::plus<>;
@@ -677,8 +717,9 @@ C2H_TEST("WarpReduceBatched::SumToBlocked", "[warp][reduce][batched][convenience
                            convenience_overload>();
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToBlocked with conditional participation N=M sum",
+CUB_TEST("WarpReduceBatched::ReduceToBlocked with conditional participation N=M sum",
          "[warp][reduce][batched][lane_mask]",
+         CUB_SMALL,
          builtin_type_list,
          sub_warp_equal_configs)
 {
@@ -697,8 +738,9 @@ C2H_TEST("WarpReduceBatched::ReduceToBlocked with conditional participation N=M 
                            cond_participation>();
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToBlocked with conditional participation N!=M sum",
+CUB_TEST("WarpReduceBatched::ReduceToBlocked with conditional participation N!=M sum",
          "[warp][reduce][batched][lane_mask]",
+         CUB_SMALL,
          builtin_type_list,
          sub_warp_unequal_configs)
 {
@@ -717,8 +759,9 @@ C2H_TEST("WarpReduceBatched::ReduceToBlocked with conditional participation N!=M
                            cond_participation>();
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToBlocked with conditional participation and over-syncing N=M sum",
+CUB_TEST("WarpReduceBatched::ReduceToBlocked with conditional participation and over-syncing N=M sum",
          "[warp][reduce][batched][lane_mask]",
+         CUB_SMALL,
          builtin_type_list,
          sub_warp_equal_configs)
 {
@@ -739,8 +782,9 @@ C2H_TEST("WarpReduceBatched::ReduceToBlocked with conditional participation and 
                            sync_physical_warp>();
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToBlocked with conditional participation and over-syncing N!=M sum",
+CUB_TEST("WarpReduceBatched::ReduceToBlocked with conditional participation and over-syncing N!=M sum",
          "[warp][reduce][batched][lane_mask]",
+         CUB_SMALL,
          builtin_type_list,
          sub_warp_unequal_configs)
 {

--- a/cub/test/warp/catch2_test_warp_reduce_batched_api.cu
+++ b/cub/test/warp/catch2_test_warp_reduce_batched_api.cu
@@ -11,7 +11,7 @@
 #include <cuda/std/array>
 #include <cuda/std/span>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 
 __global__ __launch_bounds__(64) void WarpReduceBatchedOverviewKernel(int* out)
 {
@@ -42,7 +42,7 @@ __global__ __launch_bounds__(64) void WarpReduceBatchedOverviewKernel(int* out)
   }
 }
 
-C2H_TEST("WarpReduceBatched overview documentation kernel", "[warp][reduce][batched]")
+CUB_TEST("WarpReduceBatched overview documentation kernel", "[warp][reduce][batched]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(6);
 
@@ -85,7 +85,7 @@ __global__ void WarpReduceBatchedReduceApiKernel(int* out)
   }
 }
 
-C2H_TEST("WarpReduceBatched::Reduce documentation kernel", "[warp][reduce][batched]")
+CUB_TEST("WarpReduceBatched::Reduce documentation kernel", "[warp][reduce][batched]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(3);
 
@@ -145,7 +145,7 @@ __global__ __launch_bounds__(8) void WarpReduceBatchedReduceToStripedApiKernel(i
   }
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToStriped documentation kernel", "[warp][reduce][batched]")
+CUB_TEST("WarpReduceBatched::ReduceToStriped documentation kernel", "[warp][reduce][batched]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(6);
 
@@ -206,7 +206,7 @@ __global__ __launch_bounds__(8) void WarpReduceBatchedReduceToBlockedApiKernel(i
   }
 }
 
-C2H_TEST("WarpReduceBatched::ReduceToBlocked documentation kernel", "[warp][reduce][batched]")
+CUB_TEST("WarpReduceBatched::ReduceToBlocked documentation kernel", "[warp][reduce][batched]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(6);
 
@@ -245,7 +245,7 @@ __global__ __launch_bounds__(8) void WarpReduceBatchedSumApiKernel(int* out)
   }
 }
 
-C2H_TEST("WarpReduceBatched::Sum documentation kernel", "[warp][reduce][batched]")
+CUB_TEST("WarpReduceBatched::Sum documentation kernel", "[warp][reduce][batched]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(6);
 
@@ -293,7 +293,7 @@ __global__ __launch_bounds__(8) void WarpReduceBatchedSumToStripedApiKernel(int*
   }
 }
 
-C2H_TEST("WarpReduceBatched::SumToStriped documentation kernel", "[warp][reduce][batched]")
+CUB_TEST("WarpReduceBatched::SumToStriped documentation kernel", "[warp][reduce][batched]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(20);
 
@@ -341,7 +341,7 @@ __global__ __launch_bounds__(8) void WarpReduceBatchedSumToBlockedApiKernel(int*
   }
 }
 
-C2H_TEST("WarpReduceBatched::SumToBlocked documentation kernel", "[warp][reduce][batched]")
+CUB_TEST("WarpReduceBatched::SumToBlocked documentation kernel", "[warp][reduce][batched]", CUB_SMALL)
 {
   c2h::device_vector<int> d_out(20);
 

--- a/cub/test/warp/catch2_test_warp_segmented_reduce.cu
+++ b/cub/test/warp/catch2_test_warp_segmented_reduce.cu
@@ -8,7 +8,7 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
-#include <c2h/catch2_test_helper.h>
+#include "cub_test_macros.h"
 #include <c2h/custom_type.h>
 
 template <int LOGICAL_WARP_THREADS, int TOTAL_WARPS, typename T, typename ActionT>
@@ -260,7 +260,7 @@ struct params_t
   static constexpr int tile_size            = total_warps * logical_warp_threads;
 };
 
-C2H_TEST("Warp segmented sum works", "[reduce][warp]", full_type_list, logical_warp_threads, segmented_modes)
+CUB_TEST("Warp segmented sum works", "[reduce][warp]", CUB_SMALL, full_type_list, logical_warp_threads, segmented_modes)
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
@@ -303,7 +303,12 @@ C2H_TEST("Warp segmented sum works", "[reduce][warp]", full_type_list, logical_w
   verify_results(h_out, d_out);
 }
 
-C2H_TEST("Warp segmented reduction works", "[reduce][warp]", builtin_type_list, logical_warp_threads, segmented_modes)
+CUB_TEST("Warp segmented reduction works",
+         "[reduce][warp]",
+         CUB_SMALL,
+         builtin_type_list,
+         logical_warp_threads,
+         segmented_modes)
 {
   using params   = params_t<TestType>;
   using type     = typename params::type;


### PR DESCRIPTION
## This PR is a prerequisite for #9550 and #10030
## Summary

The [`cub_test_macros.h`](https://github.com/NVIDIA/cccl/blob/8e3ab45445bab91b761bbc3b7915ef3dd800d544/cub/test/cub_test_macros.h) helper owns the CUB test wrappers and their required memory classification. It replaces the test-registration macros used under `cub/test` as follows:

- `C2H_TEST` becomes `CUB_TEST`
- `C2H_TEST_LIST` becomes `CUB_TEST_LIST`
- `TEST_CASE` becomes `CUB_TEST_CASE`

Each wrapper requires the test to specify `CUB_SMALL` or `CUB_LARGE` and adds the matching `[small-mem]` or `[large-mem]` tag. Keeping the classification with the test makes a missing or invalid class a compile error. Small tests may share a GPU, while large tests run alone. When the right class is unclear, contributors should choose `CUB_LARGE`.

All existing CUB Catch2 tests have been migrated. The remaining non-Catch2 tests are unchanged for now.

## Validation

A regex comparison against `main` confirmed that all 1,522 existing test registrations were migrated to the CUB wrappers, with no direct C2H or Catch2 registrations remaining under `cub/test`.