### PR TITLE
Fixup _CCCL_HOST_API and inline constexpr variables in memory land

### DIFF
--- a/libcudacxx/include/cuda/__device/attributes.h
+++ b/libcudacxx/include/cuda/__device/attributes.h
@@ -266,7 +266,7 @@ struct __dev_attr<::cudaDevAttrMemoryPoolSupportedHandleTypes> //
 #  if _CCCL_CTK_AT_LEAST(12, 4)
   static constexpr type fabric = ::cudaMemHandleTypeFabric;
 #  else // ^^^ _CCCL_CTK_AT_LEAST(12, 4) ^^^ / vvv _CCCL_CTK_BELOW(12, 4) vvv
-  static inline const type fabric = static_cast<::cudaMemAllocationHandleType>(0x8);
+  static constexpr type fabric = static_cast<::cudaMemAllocationHandleType>(0x8);
 #  endif // ^^^ _CCCL_CTK_BELOW(12, 4) ^^^
 };
 #  if _CCCL_CTK_AT_LEAST(12, 2)
@@ -296,467 +296,467 @@ namespace device_attributes
 {
 // Maximum number of threads per block
 using max_threads_per_block_t = __dev_attr<::cudaDevAttrMaxThreadsPerBlock>;
-static constexpr max_threads_per_block_t max_threads_per_block{};
+inline constexpr max_threads_per_block_t max_threads_per_block{};
 
 // Maximum x-dimension of a block
 using max_block_dim_x_t = __dev_attr<::cudaDevAttrMaxBlockDimX>;
-static constexpr max_block_dim_x_t max_block_dim_x{};
+inline constexpr max_block_dim_x_t max_block_dim_x{};
 
 // Maximum y-dimension of a block
 using max_block_dim_y_t = __dev_attr<::cudaDevAttrMaxBlockDimY>;
-static constexpr max_block_dim_y_t max_block_dim_y{};
+inline constexpr max_block_dim_y_t max_block_dim_y{};
 
 // Maximum z-dimension of a block
 using max_block_dim_z_t = __dev_attr<::cudaDevAttrMaxBlockDimZ>;
-static constexpr max_block_dim_z_t max_block_dim_z{};
+inline constexpr max_block_dim_z_t max_block_dim_z{};
 
 // Maximum x-dimension of a grid
 using max_grid_dim_x_t = __dev_attr<::cudaDevAttrMaxGridDimX>;
-static constexpr max_grid_dim_x_t max_grid_dim_x{};
+inline constexpr max_grid_dim_x_t max_grid_dim_x{};
 
 // Maximum y-dimension of a grid
 using max_grid_dim_y_t = __dev_attr<::cudaDevAttrMaxGridDimY>;
-static constexpr max_grid_dim_y_t max_grid_dim_y{};
+inline constexpr max_grid_dim_y_t max_grid_dim_y{};
 
 // Maximum z-dimension of a grid
 using max_grid_dim_z_t = __dev_attr<::cudaDevAttrMaxGridDimZ>;
-static constexpr max_grid_dim_z_t max_grid_dim_z{};
+inline constexpr max_grid_dim_z_t max_grid_dim_z{};
 
 // Maximum amount of shared memory available to a thread block in bytes
 using max_shared_memory_per_block_t = __dev_attr<::cudaDevAttrMaxSharedMemoryPerBlock>;
-static constexpr max_shared_memory_per_block_t max_shared_memory_per_block{};
+inline constexpr max_shared_memory_per_block_t max_shared_memory_per_block{};
 
 // Memory available on device for __constant__ variables in a CUDA C kernel in bytes
 using total_constant_memory_t = __dev_attr<::cudaDevAttrTotalConstantMemory>;
-static constexpr total_constant_memory_t total_constant_memory{};
+inline constexpr total_constant_memory_t total_constant_memory{};
 
 // Warp size in threads
 using warp_size_t = __dev_attr<::cudaDevAttrWarpSize>;
-static constexpr warp_size_t warp_size{};
+inline constexpr warp_size_t warp_size{};
 
 // Maximum pitch in bytes allowed by the memory copy functions that involve
 // memory regions allocated through cudaMallocPitch()
 using max_pitch_t = __dev_attr<::cudaDevAttrMaxPitch>;
-static constexpr max_pitch_t max_pitch{};
+inline constexpr max_pitch_t max_pitch{};
 
 // Maximum 1D texture width
 using max_texture_1d_width_t = __dev_attr<::cudaDevAttrMaxTexture1DWidth>;
-static constexpr max_texture_1d_width_t max_texture_1d_width{};
+inline constexpr max_texture_1d_width_t max_texture_1d_width{};
 
 // Maximum width for a 1D texture bound to linear memory
 using max_texture_1d_linear_width_t = __dev_attr<::cudaDevAttrMaxTexture1DLinearWidth>;
-static constexpr max_texture_1d_linear_width_t max_texture_1d_linear_width{};
+inline constexpr max_texture_1d_linear_width_t max_texture_1d_linear_width{};
 
 // Maximum mipmapped 1D texture width
 using max_texture_1d_mipmapped_width_t = __dev_attr<::cudaDevAttrMaxTexture1DMipmappedWidth>;
-static constexpr max_texture_1d_mipmapped_width_t max_texture_1d_mipmapped_width{};
+inline constexpr max_texture_1d_mipmapped_width_t max_texture_1d_mipmapped_width{};
 
 // Maximum 2D texture width
 using max_texture_2d_width_t = __dev_attr<::cudaDevAttrMaxTexture2DWidth>;
-static constexpr max_texture_2d_width_t max_texture_2d_width{};
+inline constexpr max_texture_2d_width_t max_texture_2d_width{};
 
 // Maximum 2D texture height
 using max_texture_2d_height_t = __dev_attr<::cudaDevAttrMaxTexture2DHeight>;
-static constexpr max_texture_2d_height_t max_texture_2d_height{};
+inline constexpr max_texture_2d_height_t max_texture_2d_height{};
 
 // Maximum width for a 2D texture bound to linear memory
 using max_texture_2d_linear_width_t = __dev_attr<::cudaDevAttrMaxTexture2DLinearWidth>;
-static constexpr max_texture_2d_linear_width_t max_texture_2d_linear_width{};
+inline constexpr max_texture_2d_linear_width_t max_texture_2d_linear_width{};
 
 // Maximum height for a 2D texture bound to linear memory
 using max_texture_2d_linear_height_t = __dev_attr<::cudaDevAttrMaxTexture2DLinearHeight>;
-static constexpr max_texture_2d_linear_height_t max_texture_2d_linear_height{};
+inline constexpr max_texture_2d_linear_height_t max_texture_2d_linear_height{};
 
 // Maximum pitch in bytes for a 2D texture bound to linear memory
 using max_texture_2d_linear_pitch_t = __dev_attr<::cudaDevAttrMaxTexture2DLinearPitch>;
-static constexpr max_texture_2d_linear_pitch_t max_texture_2d_linear_pitch{};
+inline constexpr max_texture_2d_linear_pitch_t max_texture_2d_linear_pitch{};
 
 // Maximum mipmapped 2D texture width
 using max_texture_2d_mipmapped_width_t = __dev_attr<::cudaDevAttrMaxTexture2DMipmappedWidth>;
-static constexpr max_texture_2d_mipmapped_width_t max_texture_2d_mipmapped_width{};
+inline constexpr max_texture_2d_mipmapped_width_t max_texture_2d_mipmapped_width{};
 
 // Maximum mipmapped 2D texture height
 using max_texture_2d_mipmapped_height_t = __dev_attr<::cudaDevAttrMaxTexture2DMipmappedHeight>;
-static constexpr max_texture_2d_mipmapped_height_t max_texture_2d_mipmapped_height{};
+inline constexpr max_texture_2d_mipmapped_height_t max_texture_2d_mipmapped_height{};
 
 // Maximum 3D texture width
 using max_texture_3d_width_t = __dev_attr<::cudaDevAttrMaxTexture3DWidth>;
-static constexpr max_texture_3d_width_t max_texture_3d_width{};
+inline constexpr max_texture_3d_width_t max_texture_3d_width{};
 
 // Maximum 3D texture height
 using max_texture_3d_height_t = __dev_attr<::cudaDevAttrMaxTexture3DHeight>;
-static constexpr max_texture_3d_height_t max_texture_3d_height{};
+inline constexpr max_texture_3d_height_t max_texture_3d_height{};
 
 // Maximum 3D texture depth
 using max_texture_3d_depth_t = __dev_attr<::cudaDevAttrMaxTexture3DDepth>;
-static constexpr max_texture_3d_depth_t max_texture_3d_depth{};
+inline constexpr max_texture_3d_depth_t max_texture_3d_depth{};
 
 // Alternate maximum 3D texture width, 0 if no alternate maximum 3D texture size is supported
 using max_texture_3d_width_alt_t = __dev_attr<::cudaDevAttrMaxTexture3DWidthAlt>;
-static constexpr max_texture_3d_width_alt_t max_texture_3d_width_alt{};
+inline constexpr max_texture_3d_width_alt_t max_texture_3d_width_alt{};
 
 // Alternate maximum 3D texture height, 0 if no alternate maximum 3D texture size is supported
 using max_texture_3d_height_alt_t = __dev_attr<::cudaDevAttrMaxTexture3DHeightAlt>;
-static constexpr max_texture_3d_height_alt_t max_texture_3d_height_alt{};
+inline constexpr max_texture_3d_height_alt_t max_texture_3d_height_alt{};
 
 // Alternate maximum 3D texture depth, 0 if no alternate maximum 3D texture size is supported
 using max_texture_3d_depth_alt_t = __dev_attr<::cudaDevAttrMaxTexture3DDepthAlt>;
-static constexpr max_texture_3d_depth_alt_t max_texture_3d_depth_alt{};
+inline constexpr max_texture_3d_depth_alt_t max_texture_3d_depth_alt{};
 
 // Maximum cubemap texture width or height
 using max_texture_cubemap_width_t = __dev_attr<::cudaDevAttrMaxTextureCubemapWidth>;
-static constexpr max_texture_cubemap_width_t max_texture_cubemap_width{};
+inline constexpr max_texture_cubemap_width_t max_texture_cubemap_width{};
 
 // Maximum 1D layered texture width
 using max_texture_1d_layered_width_t = __dev_attr<::cudaDevAttrMaxTexture1DLayeredWidth>;
-static constexpr max_texture_1d_layered_width_t max_texture_1d_layered_width{};
+inline constexpr max_texture_1d_layered_width_t max_texture_1d_layered_width{};
 
 // Maximum layers in a 1D layered texture
 using max_texture_1d_layered_layers_t = __dev_attr<::cudaDevAttrMaxTexture1DLayeredLayers>;
-static constexpr max_texture_1d_layered_layers_t max_texture_1d_layered_layers{};
+inline constexpr max_texture_1d_layered_layers_t max_texture_1d_layered_layers{};
 
 // Maximum 2D layered texture width
 using max_texture_2d_layered_width_t = __dev_attr<::cudaDevAttrMaxTexture2DLayeredWidth>;
-static constexpr max_texture_2d_layered_width_t max_texture_2d_layered_width{};
+inline constexpr max_texture_2d_layered_width_t max_texture_2d_layered_width{};
 
 // Maximum 2D layered texture height
 using max_texture_2d_layered_height_t = __dev_attr<::cudaDevAttrMaxTexture2DLayeredHeight>;
-static constexpr max_texture_2d_layered_height_t max_texture_2d_layered_height{};
+inline constexpr max_texture_2d_layered_height_t max_texture_2d_layered_height{};
 
 // Maximum layers in a 2D layered texture
 using max_texture_2d_layered_layers_t = __dev_attr<::cudaDevAttrMaxTexture2DLayeredLayers>;
-static constexpr max_texture_2d_layered_layers_t max_texture_2d_layered_layers{};
+inline constexpr max_texture_2d_layered_layers_t max_texture_2d_layered_layers{};
 
 // Maximum cubemap layered texture width or height
 using max_texture_cubemap_layered_width_t = __dev_attr<::cudaDevAttrMaxTextureCubemapLayeredWidth>;
-static constexpr max_texture_cubemap_layered_width_t max_texture_cubemap_layered_width{};
+inline constexpr max_texture_cubemap_layered_width_t max_texture_cubemap_layered_width{};
 
 // Maximum layers in a cubemap layered texture
 using max_texture_cubemap_layered_layers_t = __dev_attr<::cudaDevAttrMaxTextureCubemapLayeredLayers>;
-static constexpr max_texture_cubemap_layered_layers_t max_texture_cubemap_layered_layers{};
+inline constexpr max_texture_cubemap_layered_layers_t max_texture_cubemap_layered_layers{};
 
 // Maximum 1D surface width
 using max_surface_1d_width_t = __dev_attr<::cudaDevAttrMaxSurface1DWidth>;
-static constexpr max_surface_1d_width_t max_surface_1d_width{};
+inline constexpr max_surface_1d_width_t max_surface_1d_width{};
 
 // Maximum 2D surface width
 using max_surface_2d_width_t = __dev_attr<::cudaDevAttrMaxSurface2DWidth>;
-static constexpr max_surface_2d_width_t max_surface_2d_width{};
+inline constexpr max_surface_2d_width_t max_surface_2d_width{};
 
 // Maximum 2D surface height
 using max_surface_2d_height_t = __dev_attr<::cudaDevAttrMaxSurface2DHeight>;
-static constexpr max_surface_2d_height_t max_surface_2d_height{};
+inline constexpr max_surface_2d_height_t max_surface_2d_height{};
 
 // Maximum 3D surface width
 using max_surface_3d_width_t = __dev_attr<::cudaDevAttrMaxSurface3DWidth>;
-static constexpr max_surface_3d_width_t max_surface_3d_width{};
+inline constexpr max_surface_3d_width_t max_surface_3d_width{};
 
 // Maximum 3D surface height
 using max_surface_3d_height_t = __dev_attr<::cudaDevAttrMaxSurface3DHeight>;
-static constexpr max_surface_3d_height_t max_surface_3d_height{};
+inline constexpr max_surface_3d_height_t max_surface_3d_height{};
 
 // Maximum 3D surface depth
 using max_surface_3d_depth_t = __dev_attr<::cudaDevAttrMaxSurface3DDepth>;
-static constexpr max_surface_3d_depth_t max_surface_3d_depth{};
+inline constexpr max_surface_3d_depth_t max_surface_3d_depth{};
 
 // Maximum 1D layered surface width
 using max_surface_1d_layered_width_t = __dev_attr<::cudaDevAttrMaxSurface1DLayeredWidth>;
-static constexpr max_surface_1d_layered_width_t max_surface_1d_layered_width{};
+inline constexpr max_surface_1d_layered_width_t max_surface_1d_layered_width{};
 
 // Maximum layers in a 1D layered surface
 using max_surface_1d_layered_layers_t = __dev_attr<::cudaDevAttrMaxSurface1DLayeredLayers>;
-static constexpr max_surface_1d_layered_layers_t max_surface_1d_layered_layers{};
+inline constexpr max_surface_1d_layered_layers_t max_surface_1d_layered_layers{};
 
 // Maximum 2D layered surface width
 using max_surface_2d_layered_width_t = __dev_attr<::cudaDevAttrMaxSurface2DLayeredWidth>;
-static constexpr max_surface_2d_layered_width_t max_surface_2d_layered_width{};
+inline constexpr max_surface_2d_layered_width_t max_surface_2d_layered_width{};
 
 // Maximum 2D layered surface height
 using max_surface_2d_layered_height_t = __dev_attr<::cudaDevAttrMaxSurface2DLayeredHeight>;
-static constexpr max_surface_2d_layered_height_t max_surface_2d_layered_height{};
+inline constexpr max_surface_2d_layered_height_t max_surface_2d_layered_height{};
 
 // Maximum layers in a 2D layered surface
 using max_surface_2d_layered_layers_t = __dev_attr<::cudaDevAttrMaxSurface2DLayeredLayers>;
-static constexpr max_surface_2d_layered_layers_t max_surface_2d_layered_layers{};
+inline constexpr max_surface_2d_layered_layers_t max_surface_2d_layered_layers{};
 
 // Maximum cubemap surface width
 using max_surface_cubemap_width_t = __dev_attr<::cudaDevAttrMaxSurfaceCubemapWidth>;
-static constexpr max_surface_cubemap_width_t max_surface_cubemap_width{};
+inline constexpr max_surface_cubemap_width_t max_surface_cubemap_width{};
 
 // Maximum cubemap layered surface width
 using max_surface_cubemap_layered_width_t = __dev_attr<::cudaDevAttrMaxSurfaceCubemapLayeredWidth>;
-static constexpr max_surface_cubemap_layered_width_t max_surface_cubemap_layered_width{};
+inline constexpr max_surface_cubemap_layered_width_t max_surface_cubemap_layered_width{};
 
 // Maximum layers in a cubemap layered surface
 using max_surface_cubemap_layered_layers_t = __dev_attr<::cudaDevAttrMaxSurfaceCubemapLayeredLayers>;
-static constexpr max_surface_cubemap_layered_layers_t max_surface_cubemap_layered_layers{};
+inline constexpr max_surface_cubemap_layered_layers_t max_surface_cubemap_layered_layers{};
 
 // Maximum number of 32-bit registers available to a thread block
 using max_registers_per_block_t = __dev_attr<::cudaDevAttrMaxRegistersPerBlock>;
-static constexpr max_registers_per_block_t max_registers_per_block{};
+inline constexpr max_registers_per_block_t max_registers_per_block{};
 
 // Peak clock frequency in kilohertz
 using clock_rate_t = __dev_attr<::cudaDevAttrClockRate>;
-static constexpr clock_rate_t clock_rate{};
+inline constexpr clock_rate_t clock_rate{};
 
 // Alignment requirement; texture base addresses aligned to textureAlign bytes
 // do not need an offset applied to texture fetches
 using texture_alignment_t = __dev_attr<::cudaDevAttrTextureAlignment>;
-static constexpr texture_alignment_t texture_alignment{};
+inline constexpr texture_alignment_t texture_alignment{};
 
 // Pitch alignment requirement for 2D texture references bound to pitched memory
 using texture_pitch_alignment_t = __dev_attr<::cudaDevAttrTexturePitchAlignment>;
-static constexpr texture_pitch_alignment_t texture_pitch_alignment{};
+inline constexpr texture_pitch_alignment_t texture_pitch_alignment{};
 
 // true if the device can concurrently copy memory between host and device
 // while executing a kernel, or false if not
 using gpu_overlap_t = __dev_attr<::cudaDevAttrGpuOverlap>;
-static constexpr gpu_overlap_t gpu_overlap{};
+inline constexpr gpu_overlap_t gpu_overlap{};
 
 // Number of multiprocessors on the device
 using multiprocessor_count_t = __dev_attr<::cudaDevAttrMultiProcessorCount>;
-static constexpr multiprocessor_count_t multiprocessor_count{};
+inline constexpr multiprocessor_count_t multiprocessor_count{};
 
 // true if there is a run time limit for kernels executed on the device, or
 // false if not
 using kernel_exec_timeout_t = __dev_attr<::cudaDevAttrKernelExecTimeout>;
-static constexpr kernel_exec_timeout_t kernel_exec_timeout{};
+inline constexpr kernel_exec_timeout_t kernel_exec_timeout{};
 
 // true if the device is integrated with the memory subsystem, or false if not
 using integrated_t = __dev_attr<::cudaDevAttrIntegrated>;
-static constexpr integrated_t integrated{};
+inline constexpr integrated_t integrated{};
 
 // true if the device can map host memory into CUDA address space
 using can_map_host_memory_t = __dev_attr<::cudaDevAttrCanMapHostMemory>;
-static constexpr can_map_host_memory_t can_map_host_memory{};
+inline constexpr can_map_host_memory_t can_map_host_memory{};
 
 // Compute mode is the compute mode that the device is currently in.
 using compute_mode_t = __dev_attr<::cudaDevAttrComputeMode>;
-static constexpr compute_mode_t compute_mode{};
+inline constexpr compute_mode_t compute_mode{};
 
 // true if the device supports executing multiple kernels within the same
 // context simultaneously, or false if not. It is not guaranteed that multiple
 // kernels will be resident on the device concurrently so this feature should
 // not be relied upon for correctness.
 using concurrent_kernels_t = __dev_attr<::cudaDevAttrConcurrentKernels>;
-static constexpr concurrent_kernels_t concurrent_kernels{};
+inline constexpr concurrent_kernels_t concurrent_kernels{};
 
 // true if error correction is enabled on the device, 0 if error correction is
 // disabled or not supported by the device
 using ecc_enabled_t = __dev_attr<::cudaDevAttrEccEnabled>;
-static constexpr ecc_enabled_t ecc_enabled{};
+inline constexpr ecc_enabled_t ecc_enabled{};
 
 // PCI bus identifier of the device
 using pci_bus_id_t = __dev_attr<::cudaDevAttrPciBusId>;
-static constexpr pci_bus_id_t pci_bus_id{};
+inline constexpr pci_bus_id_t pci_bus_id{};
 
 // PCI device (also known as slot) identifier of the device
 using pci_device_id_t = __dev_attr<::cudaDevAttrPciDeviceId>;
-static constexpr pci_device_id_t pci_device_id{};
+inline constexpr pci_device_id_t pci_device_id{};
 
 // true if the device is using a TCC driver. TCC is only available on Tesla
 // hardware running Windows Vista or later.
 using tcc_driver_t = __dev_attr<::cudaDevAttrTccDriver>;
-static constexpr tcc_driver_t tcc_driver{};
+inline constexpr tcc_driver_t tcc_driver{};
 
 // Peak memory clock frequency in kilohertz
 using memory_clock_rate_t = __dev_attr<::cudaDevAttrMemoryClockRate>;
-static constexpr memory_clock_rate_t memory_clock_rate{};
+inline constexpr memory_clock_rate_t memory_clock_rate{};
 
 // Global memory bus width in bits
 using global_memory_bus_width_t = __dev_attr<::cudaDevAttrGlobalMemoryBusWidth>;
-static constexpr global_memory_bus_width_t global_memory_bus_width{};
+inline constexpr global_memory_bus_width_t global_memory_bus_width{};
 
 // Size of L2 cache in bytes. 0 if the device doesn't have L2 cache.
 using l2_cache_size_t = __dev_attr<::cudaDevAttrL2CacheSize>;
-static constexpr l2_cache_size_t l2_cache_size{};
+inline constexpr l2_cache_size_t l2_cache_size{};
 
 // Maximum resident threads per multiprocessor
 using max_threads_per_multiprocessor_t = __dev_attr<::cudaDevAttrMaxThreadsPerMultiProcessor>;
-static constexpr max_threads_per_multiprocessor_t max_threads_per_multiprocessor{};
+inline constexpr max_threads_per_multiprocessor_t max_threads_per_multiprocessor{};
 
 // true if the device shares a unified address space with the host, or false
 // if not
 using unified_addressing_t = __dev_attr<::cudaDevAttrUnifiedAddressing>;
-static constexpr unified_addressing_t unified_addressing{};
+inline constexpr unified_addressing_t unified_addressing{};
 
 // Major compute capability version number
 using compute_capability_major_t = __dev_attr<::cudaDevAttrComputeCapabilityMajor>;
-static constexpr compute_capability_major_t compute_capability_major{};
+inline constexpr compute_capability_major_t compute_capability_major{};
 
 // Minor compute capability version number
 using compute_capability_minor_t = __dev_attr<::cudaDevAttrComputeCapabilityMinor>;
-static constexpr compute_capability_minor_t compute_capability_minor{};
+inline constexpr compute_capability_minor_t compute_capability_minor{};
 
 // true if the device supports stream priorities, or false if not
 using stream_priorities_supported_t = __dev_attr<::cudaDevAttrStreamPrioritiesSupported>;
-static constexpr stream_priorities_supported_t stream_priorities_supported{};
+inline constexpr stream_priorities_supported_t stream_priorities_supported{};
 
 // true if device supports caching globals in L1 cache, false if not
 using global_l1_cache_supported_t = __dev_attr<::cudaDevAttrGlobalL1CacheSupported>;
-static constexpr global_l1_cache_supported_t global_l1_cache_supported{};
+inline constexpr global_l1_cache_supported_t global_l1_cache_supported{};
 
 // true if device supports caching locals in L1 cache, false if not
 using local_l1_cache_supported_t = __dev_attr<::cudaDevAttrLocalL1CacheSupported>;
-static constexpr local_l1_cache_supported_t local_l1_cache_supported{};
+inline constexpr local_l1_cache_supported_t local_l1_cache_supported{};
 
 // Maximum amount of shared memory available to a multiprocessor in bytes;
 // this amount is shared by all thread blocks simultaneously resident on a
 // multiprocessor
 using max_shared_memory_per_multiprocessor_t = __dev_attr<::cudaDevAttrMaxSharedMemoryPerMultiprocessor>;
-static constexpr max_shared_memory_per_multiprocessor_t max_shared_memory_per_multiprocessor{};
+inline constexpr max_shared_memory_per_multiprocessor_t max_shared_memory_per_multiprocessor{};
 
 // Maximum number of 32-bit registers available to a multiprocessor; this
 // number is shared by all thread blocks simultaneously resident on a
 // multiprocessor
 using max_registers_per_multiprocessor_t = __dev_attr<::cudaDevAttrMaxRegistersPerMultiprocessor>;
-static constexpr max_registers_per_multiprocessor_t max_registers_per_multiprocessor{};
+inline constexpr max_registers_per_multiprocessor_t max_registers_per_multiprocessor{};
 
 // true if device supports allocating managed memory, false if not
 using managed_memory_t = __dev_attr<::cudaDevAttrManagedMemory>;
-static constexpr managed_memory_t managed_memory{};
+inline constexpr managed_memory_t managed_memory{};
 
 // true if device is on a multi-GPU board, false if not
 using is_multi_gpu_board_t = __dev_attr<::cudaDevAttrIsMultiGpuBoard>;
-static constexpr is_multi_gpu_board_t is_multi_gpu_board{};
+inline constexpr is_multi_gpu_board_t is_multi_gpu_board{};
 
 // Unique identifier for a group of devices on the same multi-GPU board
 using multi_gpu_board_group_id_t = __dev_attr<::cudaDevAttrMultiGpuBoardGroupID>;
-static constexpr multi_gpu_board_group_id_t multi_gpu_board_group_id{};
+inline constexpr multi_gpu_board_group_id_t multi_gpu_board_group_id{};
 
 // true if the link between the device and the host supports native atomic
 // operations
 using host_native_atomic_supported_t = __dev_attr<::cudaDevAttrHostNativeAtomicSupported>;
-static constexpr host_native_atomic_supported_t host_native_atomic_supported{};
+inline constexpr host_native_atomic_supported_t host_native_atomic_supported{};
 
 // Ratio of single precision performance (in floating-point operations per
 // second) to double precision performance
 using single_to_double_precision_perf_ratio_t = __dev_attr<::cudaDevAttrSingleToDoublePrecisionPerfRatio>;
-static constexpr single_to_double_precision_perf_ratio_t single_to_double_precision_perf_ratio{};
+inline constexpr single_to_double_precision_perf_ratio_t single_to_double_precision_perf_ratio{};
 
 // true if the device supports coherently accessing pageable memory without
 // calling cudaHostRegister on it, and false otherwise
 using pageable_memory_access_t = __dev_attr<::cudaDevAttrPageableMemoryAccess>;
-static constexpr pageable_memory_access_t pageable_memory_access{};
+inline constexpr pageable_memory_access_t pageable_memory_access{};
 
 // true if the device can coherently access managed memory concurrently with
 // the CPU, and false otherwise
 using concurrent_managed_access_t = __dev_attr<::cudaDevAttrConcurrentManagedAccess>;
-static constexpr concurrent_managed_access_t concurrent_managed_access{};
+inline constexpr concurrent_managed_access_t concurrent_managed_access{};
 
 // true if the device supports Compute Preemption, false if not
 using compute_preemption_supported_t = __dev_attr<::cudaDevAttrComputePreemptionSupported>;
-static constexpr compute_preemption_supported_t compute_preemption_supported{};
+inline constexpr compute_preemption_supported_t compute_preemption_supported{};
 
 // true if the device can access host registered memory at the same virtual
 // address as the CPU, and false otherwise
 using can_use_host_pointer_for_registered_mem_t = __dev_attr<::cudaDevAttrCanUseHostPointerForRegisteredMem>;
-static constexpr can_use_host_pointer_for_registered_mem_t can_use_host_pointer_for_registered_mem{};
+inline constexpr can_use_host_pointer_for_registered_mem_t can_use_host_pointer_for_registered_mem{};
 
 // true if the device supports launching cooperative kernels via
 // cudaLaunchCooperativeKernel, and false otherwise
 using cooperative_launch_t = __dev_attr<::cudaDevAttrCooperativeLaunch>;
-static constexpr cooperative_launch_t cooperative_launch{};
+inline constexpr cooperative_launch_t cooperative_launch{};
 
 // true if the device supports flushing of outstanding remote writes, and
 // false otherwise
 using can_flush_remote_writes_t = __dev_attr<::cudaDevAttrCanFlushRemoteWrites>;
-static constexpr can_flush_remote_writes_t can_flush_remote_writes{};
+inline constexpr can_flush_remote_writes_t can_flush_remote_writes{};
 
 // true if the device supports host memory registration via cudaHostRegister,
 // and false otherwise
 using host_register_supported_t = __dev_attr<::cudaDevAttrHostRegisterSupported>;
-static constexpr host_register_supported_t host_register_supported{};
+inline constexpr host_register_supported_t host_register_supported{};
 
 // true if the device accesses pageable memory via the host's page tables, and
 // false otherwise
 using pageable_memory_access_uses_host_page_tables_t = __dev_attr<::cudaDevAttrPageableMemoryAccessUsesHostPageTables>;
-static constexpr pageable_memory_access_uses_host_page_tables_t pageable_memory_access_uses_host_page_tables{};
+inline constexpr pageable_memory_access_uses_host_page_tables_t pageable_memory_access_uses_host_page_tables{};
 
 // true if the host can directly access managed memory on the device without
 // migration, and false otherwise
 using direct_managed_mem_access_from_host_t = __dev_attr<::cudaDevAttrDirectManagedMemAccessFromHost>;
-static constexpr direct_managed_mem_access_from_host_t direct_managed_mem_access_from_host{};
+inline constexpr direct_managed_mem_access_from_host_t direct_managed_mem_access_from_host{};
 
 // Maximum per block shared memory size on the device. This value can be opted
 // into when using dynamic_shared_memory with NonPortableSize set to true
 using max_shared_memory_per_block_optin_t = __dev_attr<::cudaDevAttrMaxSharedMemoryPerBlockOptin>;
-static constexpr max_shared_memory_per_block_optin_t max_shared_memory_per_block_optin{};
+inline constexpr max_shared_memory_per_block_optin_t max_shared_memory_per_block_optin{};
 
 // Maximum number of thread blocks that can reside on a multiprocessor
 using max_blocks_per_multiprocessor_t = __dev_attr<::cudaDevAttrMaxBlocksPerMultiprocessor>;
-static constexpr max_blocks_per_multiprocessor_t max_blocks_per_multiprocessor{};
+inline constexpr max_blocks_per_multiprocessor_t max_blocks_per_multiprocessor{};
 
 // Maximum L2 persisting lines capacity setting in bytes
 using max_persisting_l2_cache_size_t = __dev_attr<::cudaDevAttrMaxPersistingL2CacheSize>;
-static constexpr max_persisting_l2_cache_size_t max_persisting_l2_cache_size{};
+inline constexpr max_persisting_l2_cache_size_t max_persisting_l2_cache_size{};
 
 // Maximum value of cudaAccessPolicyWindow::num_bytes
 using max_access_policy_window_size_t = __dev_attr<::cudaDevAttrMaxAccessPolicyWindowSize>;
-static constexpr max_access_policy_window_size_t max_access_policy_window_size{};
+inline constexpr max_access_policy_window_size_t max_access_policy_window_size{};
 
 // Shared memory reserved by CUDA driver per block in bytes
 using reserved_shared_memory_per_block_t = __dev_attr<::cudaDevAttrReservedSharedMemoryPerBlock>;
-static constexpr reserved_shared_memory_per_block_t reserved_shared_memory_per_block{};
+inline constexpr reserved_shared_memory_per_block_t reserved_shared_memory_per_block{};
 
 // true if the device supports sparse CUDA arrays and sparse CUDA mipmapped arrays.
 using sparse_cuda_array_supported_t = __dev_attr<::cudaDevAttrSparseCudaArraySupported>;
-static constexpr sparse_cuda_array_supported_t sparse_cuda_array_supported{};
+inline constexpr sparse_cuda_array_supported_t sparse_cuda_array_supported{};
 
 // Device supports using the cudaHostRegister flag cudaHostRegisterReadOnly to
 // register memory that must be mapped as read-only to the GPU
 using host_register_read_only_supported_t = __dev_attr<::cudaDevAttrHostRegisterReadOnlySupported>;
-static constexpr host_register_read_only_supported_t host_register_read_only_supported{};
+inline constexpr host_register_read_only_supported_t host_register_read_only_supported{};
 
 // true if the device supports using the cudaMallocAsync and cudaMemPool
 // family of APIs, and false otherwise
 using memory_pools_supported_t = __dev_attr<::cudaDevAttrMemoryPoolsSupported>;
-static constexpr memory_pools_supported_t memory_pools_supported{};
+inline constexpr memory_pools_supported_t memory_pools_supported{};
 
 // true if the device supports GPUDirect RDMA APIs, and false otherwise
 using gpu_direct_rdma_supported_t = __dev_attr<::cudaDevAttrGPUDirectRDMASupported>;
-static constexpr gpu_direct_rdma_supported_t gpu_direct_rdma_supported{};
+inline constexpr gpu_direct_rdma_supported_t gpu_direct_rdma_supported{};
 
 // bitmask to be interpreted according to the
 // cudaFlushGPUDirectRDMAWritesOptions enum
 using gpu_direct_rdma_flush_writes_options_t = __dev_attr<::cudaDevAttrGPUDirectRDMAFlushWritesOptions>;
-static constexpr gpu_direct_rdma_flush_writes_options_t gpu_direct_rdma_flush_writes_options{};
+inline constexpr gpu_direct_rdma_flush_writes_options_t gpu_direct_rdma_flush_writes_options{};
 
 // see the cudaGPUDirectRDMAWritesOrdering enum for numerical values
 using gpu_direct_rdma_writes_ordering_t = __dev_attr<::cudaDevAttrGPUDirectRDMAWritesOrdering>;
-static constexpr gpu_direct_rdma_writes_ordering_t gpu_direct_rdma_writes_ordering{};
+inline constexpr gpu_direct_rdma_writes_ordering_t gpu_direct_rdma_writes_ordering{};
 
 // Bitmask of handle types supported with mempool based IPC
 using memory_pool_supported_handle_types_t = __dev_attr<::cudaDevAttrMemoryPoolSupportedHandleTypes>;
-static constexpr memory_pool_supported_handle_types_t memory_pool_supported_handle_types{};
+inline constexpr memory_pool_supported_handle_types_t memory_pool_supported_handle_types{};
 
 // true if the device supports deferred mapping CUDA arrays and CUDA mipmapped
 // arrays.
 using deferred_mapping_cuda_array_supported_t = __dev_attr<::cudaDevAttrDeferredMappingCudaArraySupported>;
-static constexpr deferred_mapping_cuda_array_supported_t deferred_mapping_cuda_array_supported{};
+inline constexpr deferred_mapping_cuda_array_supported_t deferred_mapping_cuda_array_supported{};
 
 // true if the device supports IPC Events, false otherwise.
 using ipc_event_support_t = __dev_attr<::cudaDevAttrIpcEventSupport>;
-static constexpr ipc_event_support_t ipc_event_support{};
+inline constexpr ipc_event_support_t ipc_event_support{};
 
 #  if _CCCL_CTK_AT_LEAST(12, 2)
 // NUMA configuration of a device: value is of type cudaDeviceNumaConfig enum
 using numa_config_t = __dev_attr<::cudaDevAttrNumaConfig>;
-static constexpr numa_config_t numa_config{};
+inline constexpr numa_config_t numa_config{};
 
 // NUMA node ID of the GPU memory
 using numa_id_t = __dev_attr<::cudaDevAttrNumaId>;
-static constexpr numa_id_t numa_id{};
+inline constexpr numa_id_t numa_id{};
 #  endif // _CCCL_CTK_AT_LEAST(12, 2)
 
 #  if _CCCL_CTK_AT_LEAST(12, 9)
 using host_numa_memory_pools_supported_t = __dev_attr<::cudaDevAttrHostNumaMemoryPoolsSupported>;
-static constexpr host_numa_memory_pools_supported_t host_numa_memory_pools_supported{};
+inline constexpr host_numa_memory_pools_supported_t host_numa_memory_pools_supported{};
 #  endif // ^^^ _CCCL_CTK_AT_LEAST(12, 9) ^^^
 
 #  if _CCCL_CTK_AT_LEAST(13, 0)
 using host_memory_pools_supported_t = __dev_attr<::cudaDevAttrHostMemoryPoolsSupported>;
-static constexpr host_memory_pools_supported_t host_memory_pools_supported{};
+inline constexpr host_memory_pools_supported_t host_memory_pools_supported{};
 #  endif // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^
 
 // Total global memory available on the device in bytes
@@ -769,7 +769,7 @@ struct total_global_memory_t
     return ::cuda::__driver::__deviceTotalMem(__dev.get());
   }
 };
-static constexpr total_global_memory_t total_global_memory{};
+inline constexpr total_global_memory_t total_global_memory{};
 
 // Combines major and minor compute capability in a 100 * major + 10 * minor format, allows to query full compute
 // capability in a single query
@@ -783,7 +783,7 @@ struct compute_capability_t
                 ::cuda::device_attributes::compute_capability_minor(__dev_id)};
   }
 };
-static constexpr compute_capability_t compute_capability{};
+inline constexpr compute_capability_t compute_capability{};
 } // namespace device_attributes
 
 //! @brief For a given attribute, type of the attribute value.

--- a/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
@@ -143,7 +143,7 @@ static_assert(::cuda::std::is_trivially_destructible_v<device_memory_pool_ref>);
 //! @brief  Returns the default ``cudaMemPool_t`` from the specified device.
 //! @throws cuda_error if retrieving the default ``cudaMemPool_t`` fails.
 //! @returns The default memory pool of the specified device.
-[[nodiscard]] inline device_memory_pool_ref& device_default_memory_pool(::cuda::device_ref __device)
+[[nodiscard]] _CCCL_HOST_API inline device_memory_pool_ref& device_default_memory_pool(::cuda::device_ref __device)
 {
   static ::cuda::std::unique_ptr<__default_device_memory_pool[]> __pools_{
     ::new __default_device_memory_pool[::cuda::__physical_devices_count()]};

--- a/libcudacxx/include/cuda/__memory_pool/managed_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/managed_memory_pool.h
@@ -85,7 +85,7 @@ public:
 //! @brief Returns the default managed memory pool.
 //! @throws cuda_error if retrieving the default \c cudaMemPool_t fails.
 //! @returns The default managed memory pool.
-[[nodiscard]] inline managed_memory_pool_ref& managed_default_memory_pool()
+[[nodiscard]] _CCCL_HOST_API inline managed_memory_pool_ref& managed_default_memory_pool()
 {
   static managed_memory_pool_ref __pool{::cuda::__get_default_memory_pool(
     ::CUmemLocation{::CU_MEM_LOCATION_TYPE_NONE, 0}, ::CU_MEM_ALLOCATION_TYPE_MANAGED)};
@@ -129,7 +129,7 @@ struct managed_memory_pool : managed_memory_pool_ref
   // TODO add a constructor that accepts memory location one a type for it is
   // added
 
-  ~managed_memory_pool() noexcept
+  _CCCL_HOST_API ~managed_memory_pool() noexcept
   {
     if (__pool_ != nullptr)
     {
@@ -163,7 +163,7 @@ struct managed_memory_pool : managed_memory_pool_ref
   managed_memory_pool& operator=(const managed_memory_pool&) = delete;
 
 private:
-  managed_memory_pool(::cudaMemPool_t __pool) noexcept
+  _CCCL_HOST_API managed_memory_pool(::cudaMemPool_t __pool) noexcept
       : managed_memory_pool_ref(__pool)
   {}
 };

--- a/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
+++ b/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
@@ -69,7 +69,7 @@ struct __pool_attr_impl
     return static_cast<type>(__value);
   }
 
-  static void set(::cudaMemPool_t __pool, type __value)
+  _CCCL_HOST_API static void set(::cudaMemPool_t __pool, type __value)
   {
     size_t __value_copy = __value;
     if constexpr (_Settable == __pool_attr_settable{true})
@@ -112,7 +112,8 @@ struct __pool_attr<::cudaMemPoolAttrUsedMemCurrent>
     : __pool_attr_impl<::cudaMemPoolAttrUsedMemCurrent, size_t, __pool_attr_settable{false}>
 {};
 
-inline void __set_attribute_non_zero_only(::cudaMemPool_t __pool, ::CUmemPool_attribute __attr, size_t __value)
+_CCCL_HOST_API inline void
+__set_attribute_non_zero_only(::cudaMemPool_t __pool, ::CUmemPool_attribute __attr, size_t __value)
 {
   if (__value != 0)
   {
@@ -125,7 +126,7 @@ template <>
 struct __pool_attr<::cudaMemPoolAttrReservedMemHigh>
     : __pool_attr_impl<::cudaMemPoolAttrReservedMemHigh, size_t, __pool_attr_settable{true}>
 {
-  static void set(::cudaMemPool_t __pool, type __value)
+  _CCCL_HOST_API static void set(::cudaMemPool_t __pool, type __value)
   {
     ::cuda::__set_attribute_non_zero_only(__pool, ::CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH, __value);
   }
@@ -135,7 +136,7 @@ template <>
 struct __pool_attr<::cudaMemPoolAttrUsedMemHigh>
     : __pool_attr_impl<::cudaMemPoolAttrUsedMemHigh, size_t, __pool_attr_settable{true}>
 {
-  static void set(::cudaMemPool_t __pool, type __value)
+  _CCCL_HOST_API static void set(::cudaMemPool_t __pool, type __value)
   {
     ::cuda::__set_attribute_non_zero_only(__pool, ::CU_MEMPOOL_ATTR_USED_MEM_HIGH, __value);
   }
@@ -145,41 +146,41 @@ namespace memory_pool_attributes
 {
 // The threshold at which the pool will release memory.
 using release_threshold_t = __pool_attr<::cudaMemPoolAttrReleaseThreshold>;
-static constexpr release_threshold_t release_threshold{};
+inline constexpr release_threshold_t release_threshold{};
 
 // Allow the pool to reuse the memory across streams as long as there is a
 // stream ordering dependency between the streams.
 using reuse_follow_event_dependencies_t = __pool_attr<::cudaMemPoolReuseFollowEventDependencies>;
-static constexpr reuse_follow_event_dependencies_t reuse_follow_event_dependencies{};
+inline constexpr reuse_follow_event_dependencies_t reuse_follow_event_dependencies{};
 
 // Allow the pool to reuse already completed frees when there is no dependency
 // between the streams.
 using reuse_allow_opportunistic_t = __pool_attr<::cudaMemPoolReuseAllowOpportunistic>;
-static constexpr reuse_allow_opportunistic_t reuse_allow_opportunistic{};
+inline constexpr reuse_allow_opportunistic_t reuse_allow_opportunistic{};
 
 // Allow the pool to insert stream dependencies to reuse the memory across
 // streams.
 using reuse_allow_internal_dependencies_t = __pool_attr<::cudaMemPoolReuseAllowInternalDependencies>;
-static constexpr reuse_allow_internal_dependencies_t reuse_allow_internal_dependencies{};
+inline constexpr reuse_allow_internal_dependencies_t reuse_allow_internal_dependencies{};
 
 // The current amount of memory reserved in the pool.
 using reserved_mem_current_t = __pool_attr<::cudaMemPoolAttrReservedMemCurrent>;
-static constexpr reserved_mem_current_t reserved_mem_current{};
+inline constexpr reserved_mem_current_t reserved_mem_current{};
 
 // The high water mark for the reserved memory in the pool.
 using reserved_mem_high_t = __pool_attr<::cudaMemPoolAttrReservedMemHigh>;
-static constexpr reserved_mem_high_t reserved_mem_high{};
+inline constexpr reserved_mem_high_t reserved_mem_high{};
 
 // The current amount of memory used in the pool.
 using used_mem_current_t = __pool_attr<::cudaMemPoolAttrUsedMemCurrent>;
-static constexpr used_mem_current_t used_mem_current{};
+inline constexpr used_mem_current_t used_mem_current{};
 
 // The high water mark for the used memory in the pool.
 using used_mem_high_t = __pool_attr<::cudaMemPoolAttrUsedMemHigh>;
-static constexpr used_mem_high_t used_mem_high{};
+inline constexpr used_mem_high_t used_mem_high{};
 }; // namespace memory_pool_attributes
 
-inline bool __is_host_memory_pool_supported()
+_CCCL_HOST_API inline bool __is_host_memory_pool_supported()
 {
   // Both host_numa and host memory pool flags should agree, but check the one corresponding to the implementation
   // of the default pool just to be sure
@@ -197,7 +198,7 @@ inline bool __is_host_memory_pool_supported()
 //! @param __device The device for which to query support.
 //! @throws cuda_error if \c cudaDeviceGetAttribute failed.
 //! @returns true if \c cudaDevAttrMemoryPoolsSupported is not zero.
-inline void __verify_device_supports_stream_ordered_allocations(
+_CCCL_HOST_API inline void __verify_device_supports_stream_ordered_allocations(
   ::CUmemLocation __location, [[maybe_unused]] ::CUmemAllocationType __allocation_type)
 {
   auto __device =
@@ -227,7 +228,7 @@ inline void __verify_device_supports_stream_ordered_allocations(
 //! @param __handle_type An IPC export handle type to check for support.
 //! @throws cuda_error if the specified `cudaMemAllocationHandleType` is not
 //! supported on the specified device.
-inline void __verify_device_supports_export_handle_type(
+_CCCL_HOST_API inline void __verify_device_supports_export_handle_type(
   const device_ref __device, ::cudaMemAllocationHandleType __handle_type, ::CUmemLocation __location)
 {
   if (__handle_type == ::cudaMemAllocationHandleType::cudaMemHandleTypeNone)
@@ -281,7 +282,7 @@ __get_default_memory_pool(const CUmemLocation __location, [[maybe_unused]] const
 //! for
 //! @param __flags The access flags to set
 //! @throws cuda_error if ``cudaMemPoolSetAccess`` fails.
-inline void
+_CCCL_HOST_API inline void
 __mempool_set_access(::CUmemoryPool __pool, ::cuda::std::span<const device_ref> __devices, ::CUmemAccess_flags __flags)
 {
   ::std::vector<::CUmemAccessDesc> __descs;
@@ -298,7 +299,7 @@ __mempool_set_access(::CUmemoryPool __pool, ::cuda::std::span<const device_ref> 
 //! @param __pool The memory pool to query access for
 //! @param __dev The device to query access for
 //! @returns true if the memory pool is accessible from the device
-[[nodiscard]] inline bool __mempool_get_access(::cudaMemPool_t __pool, device_ref __dev)
+[[nodiscard]] _CCCL_HOST_API inline bool __mempool_get_access(::cudaMemPool_t __pool, device_ref __dev)
 {
   ::CUmemAccess_flags __result;
   ::CUmemLocation __loc;
@@ -322,7 +323,7 @@ struct memory_pool_properties
 //! @brief  Creates the CUDA memory pool from the passed in arguments.
 //! @throws cuda_error If the creation of the CUDA memory pool failed.
 //! @returns The created CUDA memory pool.
-[[nodiscard]] static cudaMemPool_t __create_cuda_mempool(
+[[nodiscard]] _CCCL_HOST_API static cudaMemPool_t __create_cuda_mempool(
   memory_pool_properties __properties, ::CUmemLocation __location, CUmemAllocationType __allocation_type)
 {
   ::CUmemPoolProps __pool_properties{};
@@ -406,7 +407,7 @@ public:
 
   //! @brief  Constructs the __memory_pool_base from a \c cudaMemPool_t.
   //! @param __pool The \c cudaMemPool_t used to allocate memory.
-  _CCCL_HOST_API explicit __memory_pool_base(::cudaMemPool_t __pool) noexcept
+  _CCCL_HOST_API explicit constexpr __memory_pool_base(::cudaMemPool_t __pool) noexcept
       : __pool_(__pool)
   {}
 

--- a/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
+++ b/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
@@ -289,7 +289,7 @@ __mempool_set_access(::CUmemoryPool __pool, ::cuda::std::span<const device_ref> 
   __descs.reserve(__devices.size());
   for (const auto& __dev : __devices)
   {
-    __descs.emplace_back(::CUmemLocation{::CU_MEM_LOCATION_TYPE_DEVICE, __dev.get()}, __flags);
+    __descs.push_back({::CUmemLocation{::CU_MEM_LOCATION_TYPE_DEVICE, __dev.get()}, __flags});
   }
   ::cuda::__driver::__mempoolSetAccess(__pool, __descs.data(), __descs.size());
 }

--- a/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
+++ b/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
@@ -323,8 +323,8 @@ struct memory_pool_properties
 //! @brief  Creates the CUDA memory pool from the passed in arguments.
 //! @throws cuda_error If the creation of the CUDA memory pool failed.
 //! @returns The created CUDA memory pool.
-[[nodiscard]] _CCCL_HOST_API static cudaMemPool_t __create_cuda_mempool(
-  memory_pool_properties __properties, ::CUmemLocation __location, CUmemAllocationType __allocation_type)
+[[nodiscard]] _CCCL_HOST_API inline cudaMemPool_t __create_cuda_mempool(
+  memory_pool_properties __properties, ::CUmemLocation __location, ::CUmemAllocationType __allocation_type)
 {
   ::CUmemPoolProps __pool_properties{};
   __pool_properties.allocType   = __allocation_type;

--- a/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
+++ b/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
@@ -180,14 +180,14 @@ using used_mem_high_t = __pool_attr<::cudaMemPoolAttrUsedMemHigh>;
 inline constexpr used_mem_high_t used_mem_high{};
 }; // namespace memory_pool_attributes
 
-_CCCL_HOST_API inline bool __is_host_memory_pool_supported()
+[[nodiscard]] _CCCL_HOST_API inline bool __is_host_memory_pool_supported()
 {
   // Both host_numa and host memory pool flags should agree, but check the one corresponding to the implementation
   // of the default pool just to be sure
 #  if _CCCL_CTK_AT_LEAST(13, 0)
-  return ::cuda::device_attributes::host_memory_pools_supported(cuda::device_ref{0});
+  return ::cuda::device_attributes::host_memory_pools_supported(::cuda::device_ref{0});
 #  elif _CCCL_CTK_AT_LEAST(12, 9)
-  return ::cuda::device_attributes::host_numa_memory_pools_supported(cuda::device_ref{0});
+  return ::cuda::device_attributes::host_numa_memory_pools_supported(::cuda::device_ref{0});
 #  else
   return false;
 #  endif
@@ -201,8 +201,8 @@ _CCCL_HOST_API inline bool __is_host_memory_pool_supported()
 _CCCL_HOST_API inline void __verify_device_supports_stream_ordered_allocations(
   ::CUmemLocation __location, [[maybe_unused]] ::CUmemAllocationType __allocation_type)
 {
-  auto __device =
-    __location.type == ::CU_MEM_LOCATION_TYPE_DEVICE ? cuda::device_ref{__location.id} : cuda::device_ref{0};
+  const auto __device =
+    __location.type == ::CU_MEM_LOCATION_TYPE_DEVICE ? ::cuda::device_ref{__location.id} : ::cuda::device_ref{0};
   if (!::cuda::device_attributes::memory_pools_supported(__device))
   {
     _CCCL_THROW(::cuda::cuda_error, ::cudaErrorNotSupported, "stream-ordered allocations are not supported");
@@ -250,12 +250,12 @@ _CCCL_HOST_API inline void __verify_device_supports_export_handle_type(
   if ((static_cast<int>(__handle_type) & __supported_handles) != static_cast<int>(__handle_type))
   {
     _CCCL_THROW(
-      cuda::cuda_error, ::cudaErrorNotSupported, "Requested IPC memory handle type not supported on a given device");
+      ::cuda::cuda_error, ::cudaErrorNotSupported, "Requested IPC memory handle type not supported on a given device");
   }
 }
 
-[[nodiscard]] _CCCL_HOST_API inline cudaMemPool_t
-__get_default_memory_pool(const CUmemLocation __location, [[maybe_unused]] const CUmemAllocationType __allocation_type)
+[[nodiscard]] _CCCL_HOST_API inline ::cudaMemPool_t __get_default_memory_pool(
+  const ::CUmemLocation __location, [[maybe_unused]] const ::CUmemAllocationType __allocation_type)
 {
   ::cuda::__verify_device_supports_stream_ordered_allocations(__location, __allocation_type);
 
@@ -289,7 +289,7 @@ __mempool_set_access(::CUmemoryPool __pool, ::cuda::std::span<const device_ref> 
   __descs.reserve(__devices.size());
   for (const auto& __dev : __devices)
   {
-    __descs.push_back({::CUmemLocation{::CU_MEM_LOCATION_TYPE_DEVICE, __dev.get()}, __flags});
+    __descs.emplace_back(::CUmemLocation{::CU_MEM_LOCATION_TYPE_DEVICE, __dev.get()}, __flags);
   }
   ::cuda::__driver::__mempoolSetAccess(__pool, __descs.data(), __descs.size());
 }
@@ -314,10 +314,10 @@ __mempool_set_access(::CUmemoryPool __pool, ::cuda::std::span<const device_ref> 
 //! set after the pool is created.
 struct memory_pool_properties
 {
-  size_t initial_pool_size                           = 0;
-  size_t release_threshold                           = ::cuda::std::numeric_limits<size_t>::max();
-  cudaMemAllocationHandleType allocation_handle_type = ::cudaMemAllocationHandleType::cudaMemHandleTypeNone;
-  size_t max_pool_size                               = 0;
+  size_t initial_pool_size                             = 0;
+  size_t release_threshold                             = ::cuda::std::numeric_limits<size_t>::max();
+  ::cudaMemAllocationHandleType allocation_handle_type = ::cudaMemAllocationHandleType::cudaMemHandleTypeNone;
+  size_t max_pool_size                                 = 0;
 };
 
 //! @brief  Creates the CUDA memory pool from the passed in arguments.

--- a/libcudacxx/include/cuda/__memory_pool/pinned_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/pinned_memory_pool.h
@@ -152,7 +152,7 @@ struct pinned_memory_pool : pinned_memory_pool_ref
     enable_access_from(cuda::devices);
   }
 
-  ~pinned_memory_pool() noexcept
+  _CCCL_HOST_API ~pinned_memory_pool() noexcept
   {
     if (__pool_ != nullptr)
     {
@@ -186,7 +186,7 @@ struct pinned_memory_pool : pinned_memory_pool_ref
   pinned_memory_pool& operator=(const pinned_memory_pool&) = delete;
 
 private:
-  pinned_memory_pool(::cudaMemPool_t __pool) noexcept
+  _CCCL_HOST_API pinned_memory_pool(::cudaMemPool_t __pool) noexcept
       : pinned_memory_pool_ref(__pool)
   {}
 };
@@ -200,7 +200,7 @@ static_assert(::cuda::mr::resource_with<pinned_memory_pool, ::cuda::mr::host_acc
 //! @brief Returns the default pinned memory pool.
 //! @throws cuda_error if retrieving the default \c cudaMemPool_t fails.
 //! @returns The default pinned memory pool.
-[[nodiscard]] inline pinned_memory_pool_ref& pinned_default_memory_pool()
+[[nodiscard]] _CCCL_HOST_API inline pinned_memory_pool_ref& pinned_default_memory_pool()
 {
 #    if _CCCL_CTK_AT_LEAST(13, 0)
   static pinned_memory_pool_ref __default_pool{[]() {

--- a/libcudacxx/include/cuda/__memory_resource/allocation_alignment.h
+++ b/libcudacxx/include/cuda/__memory_resource/allocation_alignment.h
@@ -91,7 +91,7 @@ __is_valid_allocation_alignment(::cuda::std::size_t __alignment, ::cuda::std::si
 
 //! @brief Throws std::invalid_argument if \p __alignment is not a valid allocation alignment
 //! (power of two and at least \p __min_alignment).
-_CCCL_HOST inline void
+_CCCL_HOST_API inline void
 __validate_allocation_alignment(::cuda::std::size_t __alignment, ::cuda::std::size_t __min_alignment)
 {
   if (!__is_valid_allocation_alignment(__alignment, __min_alignment))

--- a/libcudacxx/include/cuda/__memory_resource/any_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/any_resource.h
@@ -253,14 +253,14 @@ struct _CCCL_DECLSPEC_EMPTY_BASES any_synchronous_resource
   // any_resource is convertible to any_synchronous_resource
   _CCCL_TEMPLATE(class... _OtherProperties)
   _CCCL_REQUIRES((::cuda::std::__type_set_contains_v<::cuda::std::__type_set<_OtherProperties...>, _Properties...>) )
-  any_synchronous_resource(any_resource<_OtherProperties...> __other) noexcept
+  _CCCL_HOST_API any_synchronous_resource(any_resource<_OtherProperties...> __other) noexcept
       : __base(::cuda::std::move(__other.__get_base()))
   {}
 
   using default_queries = ::cuda::mr::properties_list<_Properties...>;
 
   //! @cond
-  explicit any_synchronous_resource(__from_base_tag, __base&& __b) noexcept
+  _CCCL_HOST_API explicit any_synchronous_resource(__from_base_tag, __base&& __b) noexcept
       : __base(::cuda::std::move(__b))
   {}
   //! @endcond

--- a/libcudacxx/include/cuda/__memory_resource/shared_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/shared_resource.h
@@ -61,7 +61,7 @@ struct shared_resource
   //! dynamically allocated with \c new.
   //! @param __args The arguments to be passed to the \c _Resource constructor.
   template <class... _Args>
-  explicit shared_resource(::cuda::std::in_place_type_t<_Resource>, _Args&&... __args)
+  _CCCL_HOST_API explicit shared_resource(::cuda::std::in_place_type_t<_Resource>, _Args&&... __args)
       : __block_(::cuda::std::in_place_type<_Resource>, ::cuda::std::forward<_Args>(__args)...)
   {}
 
@@ -254,7 +254,7 @@ private:
 //!
 //! @endrst
 template <class _Resource, class... _Args>
-auto make_shared_resource(_Args&&... __args) -> shared_resource<_Resource>
+_CCCL_HOST_API auto make_shared_resource(_Args&&... __args) -> shared_resource<_Resource>
 {
   static_assert(::cuda::mr::synchronous_resource<_Resource>,
                 "_Resource does not satisfy the cuda::mr::synchronous_resource concept");


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

- Several functions missing `_CCCL_HOST_API`
- Several `static constexpr` which should be `inline constexpr`

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
