### PR TITLE
[Tile] Add new tile test mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,8 @@ else()
   option(CCCL_ENABLE_BENCHMARKS "Enable CUDA C++ Core Library benchmarks." OFF)
 endif()
 
-option(CCCL_ENABLE_TILE "Enable tile support" OFF)
+option(CCCL_FORCE_TILE_TESTS "Force tests to be run as a tile program" OFF)
+option(CCCL_ENABLE_TILE "Enable tile support" ${CCCL_FORCE_TILE_TESTS})
 
 option(
   CCCL_ENABLE_UNSTABLE

--- a/cmake/CCCLBuildCompilerTargets.cmake
+++ b/cmake/CCCLBuildCompilerTargets.cmake
@@ -102,6 +102,9 @@ function(cccl_build_compiler_targets)
   if (CCCL_ENABLE_WERROR)
     list(APPEND cuda_compile_options "-Xcudafe=--promote_warnings")
   endif()
+  if (CCCL_ENABLE_TILE)
+    list(APPEND cuda_compile_options "--enable-tile")
+  endif()
 
   if (NOT CCCL_ENABLE_PRAGMA_SYSTEM_HEADER)
     # Ensure that we build our tests without treating ourself as system header

--- a/libcudacxx/cmake/LibcudacxxBuildCompilerTargets.cmake
+++ b/libcudacxx/cmake/LibcudacxxBuildCompilerTargets.cmake
@@ -30,8 +30,8 @@ function(libcudacxx_build_compiler_targets)
     "CCCL_IGNORE_DEPRECATED_STREAM_REF_HEADER"
   )
 
-  if (CCCL_ENABLE_TILE)
-    list(APPEND cuda_compile_options "--enable-tile")
+  if (CCCL_FORCE_TILE_TESTS)
+    list(APPEND cxx_compile_definitions "CCCL_FORCE_TILE_TESTS")
   endif()
 
   cccl_build_compiler_interface(

--- a/libcudacxx/test/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/test/libcudacxx/CMakeLists.txt
@@ -125,6 +125,12 @@ else()
   set(LIBCUDACXX_ENABLE_TILE False)
 endif()
 
+if (CCCL_FORCE_TILE_TESTS)
+  set(LIBCUDACXX_FORCE_TILE_TESTS True)
+else()
+  set(LIBCUDACXX_FORCE_TILE_TESTS False)
+endif()
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   string(APPEND LIBCUDACXX_TEST_LINKER_FLAGS " -latomic")
 endif()

--- a/libcudacxx/test/libcudacxx/force_include.h
+++ b/libcudacxx/test/libcudacxx/force_include.h
@@ -17,6 +17,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#if !defined(__CUDACC_TILE__) && defined(CCCL_FORCE_TILE_TESTS)
+#  error "Misconfiguration of lit tests. Cannot force tile tests without tile mode"
+#endif // !__CUDACC_TILE__ && CCCL_FORCE_TILE_TESTS
+
 void list_devices()
 {
   int device_count;
@@ -45,7 +49,7 @@ void list_devices()
   }
 }
 
-#ifdef __CUDACC_TILE__
+#if defined(__CUDACC_TILE__) && defined(CCCL_FORCE_TILE_TESTS)
 __tile__
 #endif // __CUDACC_TILE__
   __host__ __device__ int
@@ -54,7 +58,7 @@ __tile__
 int cuda_thread_count = 1;
 int cuda_cluster_size = 1;
 
-#ifdef __CUDACC_TILE__
+#if defined(__CUDACC_TILE__) && defined(CCCL_FORCE_TILE_TESTS)
 __tile_global__
 #else // ^^^ __CUDACC_TILE__ ^^^ / vvv !__CUDACC_TILE__ vvv
 __global__
@@ -133,7 +137,7 @@ int main(int argc, char** argv)
   return ret;
 }
 
-#ifdef __CUDACC_TILE__
+#if defined(__CUDACC_TILE__) && defined(CCCL_FORCE_TILE_TESTS)
 #  define main(...) __tile__ __host__ __device__ fake_main(__VA_ARGS__)
 #else // ^^^ __CUDACC_TILE__ ^^^ / vvv !__CUDACC_TILE__ vvv
 #  define main(...) __host__ __device__ fake_main(__VA_ARGS__)

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -7,6 +7,7 @@ config.libcudacxx_obj_root      = "@LIBCUDACXX_BINARY_DIR@"
 config.cxx_library_root         = "@LIBCUDACXX_LIBRARY_DIR@"
 config.std                      = "@LIBCUDACXX_TEST_STANDARD_VER@"
 config.enable_tile              = "@LIBCUDACXX_ENABLE_TILE@"
+config.force_tile               = "@LIBCUDACXX_FORCE_TILE_TESTS@"
 config.enable_exceptions        = True
 config.is_nvrtc                 = @LIBCUDACXX_CUDA_TEST_WITH_NVRTC@
 config.configuration_variant    = "libcudacxx"

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -667,6 +667,9 @@ class Configuration(object):
         if self.get_lit_bool("enable_tile", False):
             self.config.available_features.add("enable-tile")
 
+        if self.get_lit_bool("force_tile", False):
+            self.config.available_features.add("force-tile")
+
         if "msvc" not in self.config.available_features:
             macros = self._dump_macros_verbose()
             if "__cpp_if_constexpr" not in macros:
@@ -713,6 +716,8 @@ class Configuration(object):
         self.cxx.compile_flags += shlex.split(compile_flags_str)
         if self.get_lit_bool("enable_pedantic_warnings", default=True):
             self.cxx.compile_flags += ["-D_CCCL_NO_SYSTEM_HEADER"]
+        if self.get_lit_bool("force_tile", default=False):
+            self.cxx.compile_flags += ["-DCCCL_FORCE_TILE_TESTS"]
         if self.is_windows:
             # FIXME: Can we remove this?
             self.cxx.compile_flags += ["-D_CRT_SECURE_NO_WARNINGS"]


### PR DESCRIPTION
The current testing is not sufficient. We need to test classical SIMT with `--enable-tile` and also `--enable-tile` within a tile program

For the latter there is now `CCCL_FORCE_TILE_TESTS`  which changes lit to build a `__tile_global__` kernel

Also universally add `--enable-tile` to the cccl compile options so that we can ensure that all projects are build with it