### PR TITLE
[TILE] Add a workaround to make `invoke` work in tile mode

### DIFF
--- a/libcudacxx/include/cuda/__functional/proclaim_return_type.h
+++ b/libcudacxx/include/cuda/__functional/proclaim_return_type.h
@@ -43,6 +43,7 @@ public:
   __return_type_wrapper() = delete;
 
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fn)
   _CCCL_REQUIRES(::cuda::std::is_same_v<::cuda::std::decay_t<_Fn>, _DecayFn>)
   _CCCL_API constexpr explicit __return_type_wrapper(_Fn&& __fn) noexcept
@@ -50,6 +51,7 @@ public:
   {}
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class... _As>
   _CCCL_API constexpr _Ret operator()(_As&&... __as) & noexcept
   {
@@ -61,6 +63,7 @@ public:
     return ::cuda::std::__invoke(__fn_, ::cuda::std::forward<_As>(__as)...);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class... _As>
   _CCCL_API constexpr _Ret operator()(_As&&... __as) && noexcept
   {
@@ -72,6 +75,7 @@ public:
     return ::cuda::std::__invoke(::cuda::std::move(__fn_), ::cuda::std::forward<_As>(__as)...);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class... _As>
   _CCCL_API constexpr _Ret operator()(_As&&... __as) const& noexcept
   {
@@ -83,6 +87,7 @@ public:
     return ::cuda::std::__invoke(__fn_, ::cuda::std::forward<_As>(__as)...);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class... _As>
   _CCCL_API constexpr _Ret operator()(_As&&... __as) const&& noexcept
   {

--- a/libcudacxx/include/cuda/std/__functional/bind.h
+++ b/libcudacxx/include/cuda/std/__functional/bind.h
@@ -222,6 +222,7 @@ struct __bind_return<_Fp, const tuple<_BoundArgs...>, _TupleUj, true>
 template <class _Fp, class _BoundArgs, class _TupleUj>
 using __bind_return_t = typename __bind_return<_Fp, _BoundArgs, _TupleUj>::type;
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Fp, class _BoundArgs, size_t... _Indx, class _Args>
 _CCCL_API inline __bind_return_t<_Fp, _BoundArgs, _Args>
 __apply_functor(_Fp& __f, _BoundArgs& __bound_args, __tuple_indices<_Indx...>, _Args&& __args)

--- a/libcudacxx/include/cuda/std/__functional/invoke.h
+++ b/libcudacxx/include/cuda/std/__functional/invoke.h
@@ -108,8 +108,8 @@ _CCCL_API inline __nat __invoke(__any, _Args&&... __args);
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Fp, class _A0, class... _Args, class = __enable_if_bullet1<_Fp, _A0>>
-_CCCL_API constexpr decltype((::cuda::std::declval<_A0>()
-                              .*::cuda::std::declval<_Fp>())(::cuda::std::declval<_Args>()...))
+_CCCL_HOST_DEVICE_API constexpr decltype((::cuda::std::declval<_A0>()
+                                          .*::cuda::std::declval<_Fp>())(::cuda::std::declval<_Args>()...))
 __invoke(_Fp&& __f,
          _A0&& __a0,
          _Args&&... __args) noexcept(noexcept((static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...)))
@@ -119,8 +119,8 @@ __invoke(_Fp&& __f,
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Fp, class _A0, class... _Args, class = __enable_if_bullet2<_Fp, _A0>>
-_CCCL_API constexpr decltype((::cuda::std::declval<_A0>().get()
-                              .*::cuda::std::declval<_Fp>())(::cuda::std::declval<_Args>()...))
+_CCCL_HOST_DEVICE_API constexpr decltype((::cuda::std::declval<_A0>().get()
+                                          .*::cuda::std::declval<_Fp>())(::cuda::std::declval<_Args>()...))
 __invoke(_Fp&& __f, _A0&& __a0, _Args&&... __args) noexcept(noexcept((__a0.get().*__f)(static_cast<_Args&&>(__args)...)))
 {
   return (__a0.get().*__f)(static_cast<_Args&&>(__args)...);
@@ -128,8 +128,8 @@ __invoke(_Fp&& __f, _A0&& __a0, _Args&&... __args) noexcept(noexcept((__a0.get()
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Fp, class _A0, class... _Args, class = __enable_if_bullet3<_Fp, _A0>>
-_CCCL_API constexpr decltype(((*::cuda::std::declval<_A0>())
-                              .*::cuda::std::declval<_Fp>())(::cuda::std::declval<_Args>()...))
+_CCCL_HOST_DEVICE_API constexpr decltype(((*::cuda::std::declval<_A0>())
+                                          .*::cuda::std::declval<_Fp>())(::cuda::std::declval<_Args>()...))
 __invoke(_Fp&& __f,
          _A0&& __a0,
          _Args&&... __args) noexcept(noexcept(((*static_cast<_A0&&>(__a0)).*__f)(static_cast<_Args&&>(__args)...)))
@@ -141,7 +141,7 @@ __invoke(_Fp&& __f,
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Fp, class _A0, class = __enable_if_bullet4<_Fp, _A0>>
-_CCCL_API constexpr decltype(::cuda::std::declval<_A0>().*::cuda::std::declval<_Fp>())
+_CCCL_HOST_DEVICE_API constexpr decltype(::cuda::std::declval<_A0>().*::cuda::std::declval<_Fp>())
 __invoke(_Fp&& __f, _A0&& __a0) noexcept(noexcept(static_cast<_A0&&>(__a0).*__f))
 {
   return static_cast<_A0&&>(__a0).*__f;
@@ -149,7 +149,7 @@ __invoke(_Fp&& __f, _A0&& __a0) noexcept(noexcept(static_cast<_A0&&>(__a0).*__f)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Fp, class _A0, class = __enable_if_bullet5<_Fp, _A0>>
-_CCCL_API constexpr decltype(::cuda::std::declval<_A0>().get().*::cuda::std::declval<_Fp>())
+_CCCL_HOST_DEVICE_API constexpr decltype(::cuda::std::declval<_A0>().get().*::cuda::std::declval<_Fp>())
 __invoke(_Fp&& __f, _A0&& __a0) noexcept(noexcept(__a0.get().*__f))
 {
   return __a0.get().*__f;
@@ -157,7 +157,7 @@ __invoke(_Fp&& __f, _A0&& __a0) noexcept(noexcept(__a0.get().*__f))
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Fp, class _A0, class = __enable_if_bullet6<_Fp, _A0>>
-_CCCL_API constexpr decltype((*::cuda::std::declval<_A0>()).*::cuda::std::declval<_Fp>())
+_CCCL_HOST_DEVICE_API constexpr decltype((*::cuda::std::declval<_A0>()).*::cuda::std::declval<_Fp>())
 __invoke(_Fp&& __f, _A0&& __a0) noexcept(noexcept((*static_cast<_A0&&>(__a0)).*__f))
 {
   return (*static_cast<_A0&&>(__a0)).*__f;
@@ -266,6 +266,7 @@ is_nothrow_invocable_r : bool_constant<is_nothrow_invocable_r_v<_Ret, _Fn, _Args
 template <class _Fn, class... _Args>
 using invoke_result_t = typename invoke_result<_Fn, _Args...>::type;
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Fn, class... _Args>
 _CCCL_API constexpr invoke_result_t<_Fn, _Args...>
 invoke(_Fn&& __f, _Args&&... __args) noexcept(is_nothrow_invocable_v<_Fn, _Args...>)
@@ -273,6 +274,7 @@ invoke(_Fn&& __f, _Args&&... __args) noexcept(is_nothrow_invocable_v<_Fn, _Args.
   return ::cuda::std::__invoke(::cuda::std::forward<_Fn>(__f), ::cuda::std::forward<_Args>(__args)...);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 _CCCL_TEMPLATE(class _Ret, class _Fn, class... _Args)
 _CCCL_REQUIRES(is_invocable_r_v<_Ret, _Fn, _Args...>)
 _CCCL_API constexpr _Ret invoke_r(_Fn&& __f, _Args&&... __args) noexcept(is_nothrow_invocable_r_v<_Ret, _Fn, _Args...>)

--- a/libcudacxx/include/cuda/std/__functional/mem_fn.h
+++ b/libcudacxx/include/cuda/std/__functional/mem_fn.h
@@ -46,6 +46,7 @@ public:
   {}
 
   // invoke
+  _CCCL_EXEC_CHECK_DISABLE
   template <class... _ArgTypes>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 invoke_result_t<type, _ArgTypes...> operator()(_ArgTypes&&... __args) const
   {

--- a/libcudacxx/include/cuda/std/__tuple_dir/apply.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/apply.h
@@ -51,6 +51,7 @@ inline constexpr bool __can_apply<_Fn, _Tuple, true> = __can_apply_impl<_Fn, __m
     return __VA_ARGS__;                  \
   }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Fn, class _Tuple, size_t... _Id>
 _CCCL_API constexpr decltype(auto) __apply_tuple_impl(_Fn&& __f, _Tuple&& __t, __tuple_indices<_Id...>)
   _LIBCUDACXX_NOEXCEPT_RETURN(

--- a/libcudacxx/include/cuda/std/__variant/variant_visit.h
+++ b/libcudacxx/include/cuda/std/__variant/variant_visit.h
@@ -65,6 +65,7 @@ struct __variant
   }
 
   // Terminal function call with all indexes determined
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Visitor, class... _Vs, size_t... _ProcessedIndices>
   [[nodiscard]] _CCCL_API static constexpr decltype(auto) __visit_impl(
     index_sequence<_ProcessedIndices...>, integer_sequence<size_t>, const size_t, _Visitor&& __visitor, _Vs&&... __vs)
@@ -169,6 +170,7 @@ struct __variant
   template <class _Visitor>
   struct __value_visitor
   {
+    _CCCL_EXEC_CHECK_DISABLE
     template <class... _Alts>
     [[nodiscard]] _CCCL_API constexpr decltype(auto) operator()(_Alts&&... __alts) const
     {
@@ -182,6 +184,7 @@ struct __variant
   template <class _Rp, class _Visitor>
   struct __value_visitor_return_type
   {
+    _CCCL_EXEC_CHECK_DISABLE
     template <class... _Alts>
     [[nodiscard]] _CCCL_API constexpr _Rp operator()(_Alts&&... __alts) const
     {
@@ -195,6 +198,7 @@ struct __variant
   template <class _Visitor>
   struct __value_visitor_return_type<void, _Visitor>
   {
+    _CCCL_EXEC_CHECK_DISABLE
     template <class... _Alts>
     _CCCL_API constexpr void operator()(_Alts&&... __alts) const
     {


### PR DESCRIPTION
This one is ugly but I believe there is nothing we can do here.

The problem is that indirect function calls as well as pointer-to-member-functions and friends are unsupported in tile mode.

This is not going to change anytime soon and tile just hard crashes currently.
The compiler currently has no way of handling those cases gracefully, because the error happens too early in the stack.
Until the compiler team had time to work on this we need to mark those dispatch functions that actually invoke a
pointer-to-member-function as host device only. This is still safe, because forming those is already a compile error in tile mode.