### PR TITLE
[CUB] Strengthen DeviceHistogram benchmarks and correctness coverage

### DIFF
--- a/cub/benchmarks/bench/histogram/README_plots.md
+++ b/cub/benchmarks/bench/histogram/README_plots.md
@@ -1,0 +1,125 @@
+# Histogram benchmark input-shape & algorithm plots
+
+Two plotting scripts live here, next to the benchmark sources and the input-shape
+generators they visualize.
+
+## `histogram_input_design.py` — source of truth (shared module)
+A bit-exact host-side Python mirror of the input-shape generators in
+`histogram_inputs.cuh`. For a given `(shape, n, num_bins, seed)` it produces the
+same per-element bin indices the benchmark produces on device. Both plotting
+scripts import it; keep it in sync if `histogram_inputs.cuh` changes (run its
+`__main__` self-test to spot-check). It only needs `numpy`.
+
+## 1. `histogram_input_characterization.py` — what each InputShape looks like
+One figure per InputShape, three panels:
+- **value distribution** — count vs bin index on a **log y-axis**, one stem per
+  occupied bin. (A linear count-vs-index plot makes these look empty: a single
+  hot bin is a sub-pixel spike and a decaying tail is crushed flat under it. Log-y
+  stems show the spike(s) and the floor.)
+- **rank-frequency** — sorted count vs rank, log-log. Scale-free: a power law is a
+  straight line, a single hot bin one point over an empty floor, `hash_synonym` a
+  few high points over a flat floor. Reveals the shape regardless of bin count.
+- **position of values** — bin index vs position in the input sequence. Ordering
+  shapes (`temporal_phases`, `stale_resident`, `sawtooth`) show their structure here;
+  `concentrated:1.0` (uniform) is a random scatter.
+
+Each shape is drawn at its **natural bin count** (`CHAR_BINS_BY_SHAPE`), not one
+global value: the i.i.d. distribution shapes put their hot bin at `seed % num_bins`
+(= 42), so at a few hundred bins it sits visibly off zero (at 16384 bins it would
+read as "pinned to 0"); the cache-adversarial shapes need bins > 4096 to show their
+structure (hash_synonym's 4096-spaced synonyms; stale_resident's 4096-bin prefix).
+
+```
+python histogram_input_characterization.py --outdir histogram_input_figs
+# knobs: --elements --bins (override per-shape) --seed --shapes <subset>
+```
+
+## 2. `histogram_algo_perf.py` — algorithm performance vs #bins
+Reads a per-cell sweep JSON (each high-bin algorithm forced across
+`SampleT × Elements × Bins × InputShape`) and writes one image per InputShape into
+`<even|range>_<single|multi>_<I32|F64>/`. Each image has the shape's
+characterization (top row, drawn by the shared functions above so it matches the
+characterization figures exactly) and, below, GiB/s vs #bins — one connect-the-dots
+line per algorithm, per element count.
+
+> Note: if you change an InputShape's generator in `histogram_inputs.cuh` (e.g. the
+> `concentrated:1.0` uniform endpoint was changed from a sequential ramp to an
+> exact-count Feistel shuffle), the perf JSON's column for that shape is stale until
+> you re-run the sweep. The characterization top row reflects the current generator;
+> the perf grid reflects whatever the sweep last measured.
+
+A forced algorithm that does not apply at a given `(transform, channels)` simply
+has no measured points and is dropped from that panel.
+
+```
+python histogram_algo_perf.py --results sweep_results.json \
+    [--hitrate hitrate_results.json] --outdir algo_perf_figs
+```
+
+## 3. `histogram_algo_sweep.py` — produce the perf JSON (incl. upstream `main`)
+Drives the sweep the plot script consumes. For every
+`(binary, SampleT, Elements, Bins, InputShape)` cell it forces each high-bin
+algorithm via `CUB_HISTO_FORCE_ALGO` (the six gmem-privatized / direct-atomic
+variants) and also records the selector's own pick as `default`. Forcing is only
+honored above the high-bin threshold (bins > 4096); at/below it every forced algo
+falls back to `smem_privatized`, so low-bin cells are recorded once under
+`default`. `CUB_HISTO_DEBUG_SLOTS` is set so a direct-atomic kernel that actually
+ran prints a tell — recorded per cell (`dr=1`) to catch a silent fallback.
+
+Pass `--main-bin-dir` pointing at benchmark binaries built from upstream `main`
+to add a `main` column = main's default dispatch (main has no force hook).
+
+**For an all-shapes comparison, build the main baseline with THIS branch's
+input-shape generators.** The branch's two later input-shape commits
+(`0cf4594ba6` sawtooth/random-order/drop-capacity_cliff, `286a78e248` redefine
+concentrated/stale_resident) are **bench-only** — they touch no dispatch/kernel
+code — so overlaying this branch's `histogram_inputs.cuh` / `*.cu` onto a stock-`main`
+checkout yields *main's dispatch with identical generators*. Then every shape is
+apples-to-apples and only the dispatch differs (the comparison we want). Setup:
+
+```
+git worktree add ../main-baseline main
+cp cub/benchmarks/bench/histogram/{even,range,histogram_inputs}.cuh? \
+   ../main-baseline/cub/benchmarks/bench/histogram/         # + multi/{even,range}.cu
+# configure+build the 4 cub.bench.histogram.*.base targets in the main worktree
+```
+
+With that, the sweep compares **all** swept shapes by default (no restriction).
+
+If instead you point `--main-bin-dir` at UNMODIFIED upstream-main binaries (whose
+generators differ for `concentrated:*` / `stale_resident`, and which lack
+`sawtooth`), restrict the comparison to the generator-identical subset:
+`--main-comparable-shapes powerlaw:0.5 zipf:1.0 hash_synonym temporal_phases strided_sweep`.
+
+```
+python histogram_algo_sweep.py \
+    --branch-bin-dir build/autocuda/cub-benchmark/bin \
+    --main-bin-dir   ../main-baseline/build/cub-benchmark/bin \
+    --samples I32 F64 --out sweep_results.json
+# knobs: --bins --elements --samples --shapes --binaries --repeats --timeout
+#        --main-comparable-shapes (only for unmodified-main baselines)
+```
+
+This is the shipped, reproducible successor to the older scratch force-hook driver
+(it validated forced==launched from the `CUB_HISTO_DEBUG_SLOTS` tell). The two
+plotting scripts above only consume the resulting JSON.
+
+### Optional: SMEM-cache hit-rate panels (two-pass sweep)
+The cached high-bin kernels (`cuckoo`, `single_probe`) can be built with
+`-DCUB_HISTO_TRACK_HITRATE=1` to count, per launch, the contributions ABSORBED in
+the SMEM cache (a block-scope `atomicAdd` — a hit) vs SPILLED to a GMEM atomic (a
+miss), weighted by the warp-coalesced contribution so the rate is over input
+elements. The instrumentation is **zero-cost when the macro is off** (no extra
+`apply()` args, no accumulators — SASS-identical to the uninstrumented,
+register-pinned kernel); the host reads the grid-wide totals back via
+`cudaMemcpyFromSymbol` and prints `[hitrate] ...` under `CUB_HISTO_LOG_HITRATE=1`.
+
+Because the readback adds overhead, the parameter space is swept **twice**: once
+with the normal binaries for performance (`sweep_results.json`), and once with the
+`*.hitrate` binaries for hit rate (`hitrate_results.json`). The hit-rate pass uses
+NVBench `--profile` (one measured launch per cell — hit/miss counts are
+deterministic) and a single sample type (hit rate is sample-type-independent). When
+`--hitrate` is supplied, each per-shape image gains a bottom row: **cuckoo hit-rate
+vs #bins** and **single-probe hit-rate vs #bins**, each with **#elements as series**.
+
+Both scripts need `numpy` + `matplotlib`.

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -46,10 +46,14 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   state.add_global_memory_writes<CounterT>(num_bins);
 
   caching_allocator_t alloc;
-  // Demote persisting L2 lines outside the timed window so that no
-  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  // Force the persisting-L2 reservation back to 0 and demote any persisting
+  // lines outside the timed window, so neither cudaAccessPolicyWindow nor a
+  // bumped cudaLimitPersistingL2CacheSize can carry across iterations. The
+  // default reservation is 0; hardcoding 0 also clears any pollution left by
+  // a prior benchmark in the same nvbench process.
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
+               cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, 0);
                cudaCtxResetPersistingL2Cache();
                timer.start();
                auto env = cub_bench_env(

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -46,26 +46,32 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   state.add_global_memory_writes<CounterT>(num_bins);
 
   caching_allocator_t alloc;
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    auto env = cub_bench_env(
-      alloc,
-      launch
+  // Demote persisting L2 lines outside the timed window so that no
+  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
+             [&](nvbench::launch& launch, auto& timer) {
+               cudaCtxResetPersistingL2Cache();
+               timer.start();
+               auto env = cub_bench_env(
+                 alloc,
+                 launch
 #if !TUNE_BASE
-      ,
-      cuda::execution::tune(bench_policy_selector<key_t, 1, 1>{})
+                 ,
+                 cuda::execution::tune(bench_policy_selector<key_t, 1, 1>{})
 #endif // !TUNE_BASE
-    );
-    _CCCL_TRY_CUDA_API(
-      cub::DeviceHistogram::HistogramEven,
-      "HistogramEven failed",
-      d_input,
-      d_histogram,
-      num_levels,
-      lower_level,
-      upper_level,
-      static_cast<OffsetT>(elements),
-      env);
-  });
+               );
+               _CCCL_TRY_CUDA_API(
+                 cub::DeviceHistogram::HistogramEven,
+                 "HistogramEven failed",
+                 d_input,
+                 d_histogram,
+                 num_levels,
+                 lower_level,
+                 upper_level,
+                 static_cast<OffsetT>(elements),
+                 env);
+               timer.stop();
+             });
 }
 
 using counter_types     = nvbench::type_list<int32_t>;
@@ -80,6 +86,6 @@ using sample_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, float
 NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_offset_types))
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
+  .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
   .add_int64_axis("Bins", {32, 128, 2048, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -22,17 +22,18 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   const auto num_bins  = state.get_int64("Bins");
   const int num_levels = static_cast<int>(num_bins) + 1;
 
-  // Skip invalid configurations where LevelT (= SampleT) cannot represent the number of bins
-  if constexpr (cuda::std::is_integral_v<SampleT>)
+  // Skip invalid configurations where the SampleT range can't hold enough
+  // strictly-monotonic levels: bins + 1 levels require bins + 1 distinct
+  // SampleT values, and the bench's `[get_lower_level, get_upper_level]`
+  // range spans at most `max_representable_bins<SampleT>() + 1` distinct
+  // values.
+  if (num_bins > max_representable_bins<SampleT>())
   {
-    if (num_bins > static_cast<int64_t>(cuda::std::numeric_limits<SampleT>::max()))
-    {
-      state.skip("Number of bins exceeds what LevelT (= SampleT) can represent");
-      return;
-    }
+    state.skip("Number of bins exceeds what SampleT can represent");
+    return;
   }
 
-  const SampleT lower_level = 0;
+  const SampleT lower_level = get_lower_level<SampleT>();
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
   thrust::device_vector<SampleT> input = generate(elements, entropy, lower_level, upper_level);

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -87,5 +87,5 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_of
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
-  .add_int64_axis("Bins", {32, 128, 2048, 2097152})
+  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -4,6 +4,7 @@
 #include <nvbench_helper.cuh>
 
 #include "histogram_common.cuh"
+#include "histogram_inputs.cuh"
 
 // %RANGE% TUNE_ITEMS ipt 4:28:1
 // %RANGE% TUNE_THREADS tpb 128:1024:32
@@ -17,7 +18,7 @@
 template <typename SampleT, typename CounterT, typename OffsetT>
 static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, OffsetT>)
 {
-  const auto entropy   = str_to_entropy(state.get_string("Entropy"));
+  const auto shape     = parse_input_shape(state.get_string("InputShape"));
   const auto elements  = state.get_int64("Elements{io}");
   const auto num_bins  = state.get_int64("Bins");
   const int num_levels = static_cast<int>(num_bins) + 1;
@@ -36,7 +37,8 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   const SampleT lower_level = get_lower_level<SampleT>();
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
-  thrust::device_vector<SampleT> input = generate(elements, entropy, lower_level, upper_level);
+  thrust::device_vector<SampleT> input =
+    generate_histogram_input_even<SampleT>(shape, elements, static_cast<int>(num_bins), lower_level, upper_level);
   thrust::device_vector<CounterT> hist(num_bins);
 
   SampleT* d_input      = thrust::raw_pointer_cast(input.data());
@@ -145,4 +147,18 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_of
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
   .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
-  .add_string_axis("Entropy", {"0.201", "1.000"});
+  // One `concentrated` shape swept across entropy (1.0=uniform, 0.5=spike,
+  // 0.0=constant) plus the multi-hot and cache-adversarial shapes. Each value
+  // may carry an inline knob as "name:value"; see histogram_inputs.cuh.
+  .add_string_axis(
+    "InputShape",
+    {"concentrated:1.0",
+     "concentrated:0.5",
+     "concentrated:0.0",
+     "powerlaw:0.5",
+     "zipf:1.0",
+     "hash_synonym",
+     "capacity_cliff",
+     "stale_resident",
+     "temporal_phases",
+     "strided_sweep"});

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -91,5 +91,5 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_of
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
-  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
+  .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -45,7 +45,59 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   state.add_global_memory_reads<SampleT>(elements);
   state.add_global_memory_writes<CounterT>(num_bins);
 
+  // Warmup + correctness check: run HistogramEven once outside `state.exec`,
+  // checking the dispatch return code, then verify the produced histogram
+  // bin-by-bin against an independent reference. A failure here throws
+  // before any timed iteration runs, so a silent dispatch failure or a
+  // sample-loss bug can't inflate the measured bandwidth. Skipped when
+  // CUB_BENCH_HISTOGRAM_VERIFY=0|false|no|off.
+  if (bench_correctness_checks_enabled())
+  {
+    thrust::fill(hist.begin(), hist.end(), CounterT{0});
+    void* d_temp_storage      = nullptr;
+    size_t temp_storage_bytes = 0;
+    bench_check_cuda(
+      cub::DeviceHistogram::HistogramEven(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        d_histogram,
+        num_levels,
+        lower_level,
+        upper_level,
+        static_cast<OffsetT>(elements)),
+      "warmup HistogramEven temp-size");
+    thrust::device_vector<unsigned char> warmup_tmp(temp_storage_bytes);
+    d_temp_storage = thrust::raw_pointer_cast(warmup_tmp.data());
+    bench_check_cuda(
+      cub::DeviceHistogram::HistogramEven(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        d_histogram,
+        num_levels,
+        lower_level,
+        upper_level,
+        static_cast<OffsetT>(elements)),
+      "warmup HistogramEven");
+    bench_check_cuda(cudaDeviceSynchronize(), "warmup sync");
+
+    std::vector<thrust::device_vector<CounterT>> opt_hists_d;
+    opt_hists_d.emplace_back(std::move(hist));
+    bench_verify_histogram_even<1, 1, SampleT, CounterT, OffsetT>(
+      input,
+      opt_hists_d,
+      static_cast<OffsetT>(elements),
+      static_cast<int>(num_bins),
+      lower_level,
+      upper_level,
+      "even");
+    hist        = std::move(opt_hists_d[0]);
+    d_histogram = thrust::raw_pointer_cast(hist.data());
+  }
+
   caching_allocator_t alloc;
+
   // Force the persisting-L2 reservation back to 0 and demote any persisting
   // lines outside the timed window, so neither cudaAccessPolicyWindow nor a
   // bumped cudaLimitPersistingL2CacheSize can carry across iterations. The

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -158,7 +158,7 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_of
      "powerlaw:0.5",
      "zipf:1.0",
      "hash_synonym",
-     "capacity_cliff",
      "stale_resident",
      "temporal_phases",
-     "strided_sweep"});
+     "strided_sweep",
+     "sawtooth"});

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -88,13 +88,7 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
     std::vector<thrust::device_vector<CounterT>> opt_hists_d;
     opt_hists_d.emplace_back(std::move(hist));
     bench_verify_histogram_even<1, 1, SampleT, CounterT, OffsetT>(
-      input,
-      opt_hists_d,
-      static_cast<OffsetT>(elements),
-      static_cast<int>(num_bins),
-      lower_level,
-      upper_level,
-      "even");
+      input, opt_hists_d, static_cast<OffsetT>(elements), static_cast<int>(num_bins), lower_level, upper_level, "even");
     hist        = std::move(opt_hists_d[0]);
     d_histogram = thrust::raw_pointer_cast(hist.data());
   }

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -133,8 +133,19 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
              });
 }
 
-using counter_types     = nvbench::type_list<int32_t>;
+// CounterT / OffsetT overridable for the 64-bit-counter / 64-bit-offset baseline build
+// (matches the feature branch's bench guards). Inert when undefined -> baseline dispatch
+// semantics unchanged. A 64-bit OffsetT is required for >2^31 elements.
+#ifdef TUNE_CounterT
+using counter_types = nvbench::type_list<TUNE_CounterT>;
+#else
+using counter_types = nvbench::type_list<int32_t>;
+#endif
+#ifdef TUNE_OffsetT
+using some_offset_types = nvbench::type_list<TUNE_OffsetT>;
+#else
 using some_offset_types = nvbench::type_list<int32_t>;
+#endif
 
 #ifdef TUNE_SampleT
 using sample_types = nvbench::type_list<TUNE_SampleT>;

--- a/cub/benchmarks/bench/histogram/histogram_algo_perf.py
+++ b/cub/benchmarks/bench/histogram/histogram_algo_perf.py
@@ -38,9 +38,8 @@ import os
 import sys
 import textwrap
 
-import numpy as np
-
 import matplotlib
+import numpy as np
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
@@ -74,9 +73,21 @@ BINARY_META = {
 ALGO_STYLE = {
     "default": ("#000000", "*", "selector default (ships)", "-", 3.4),
     "main": ("#e6194B", "X", "UPSTREAM main (default)", "-.", 3.4),
-    "gmem_privatized_nocache": ("#9467bd", "^", "gmem-priv gather (no cache)", "-", 1.6),
+    "gmem_privatized_nocache": (
+        "#9467bd",
+        "^",
+        "gmem-priv gather (no cache)",
+        "-",
+        1.6,
+    ),
     "gmem_privatized_cuckoo": ("#1f77b4", "o", "gmem-priv + cuckoo", "-", 1.6),
-    "gmem_privatized_single_probe": ("#17becf", "s", "gmem-priv + single-probe", "-", 1.6),
+    "gmem_privatized_single_probe": (
+        "#17becf",
+        "s",
+        "gmem-priv + single-probe",
+        "-",
+        1.6,
+    ),
     "direct_cuckoo": ("#2ca02c", "o", "direct-atomic + cuckoo", "-", 1.6),
     "direct_single_probe": ("#8c8c00", "s", "direct-atomic + single-probe", "-", 1.6),
     "direct_nocache": ("#ff7f0e", "v", "direct atomics (no cache)", "-", 1.6),
@@ -126,7 +137,12 @@ def perf_series(per_algo_cells, sample, elements, shape, algos):
         pts = []
         for key, gibs in cells.items():
             s, e, b, sh = key.split("|")
-            if s == sample and int(e) == elements and sh == shape and int(b) >= MIN_PLOT_BINS:
+            if (
+                s == sample
+                and int(e) == elements
+                and sh == shape
+                and int(b) >= MIN_PLOT_BINS
+            ):
                 pts.append((int(b), gibs))
         pts.sort()
         if pts:
@@ -156,9 +172,18 @@ def draw_perf(ax, series, title):
         # Reference series (default, main) get larger markers, full opacity, and the
         # highest zorder so they read clearly over the candidate-algorithm cluster.
         is_ref = algo in ("default", "main")
-        ax.plot(xb, yv, color=color, marker=marker, markersize=10 if is_ref else 6,
-                lw=lw, linestyle=ls, alpha=1.0 if is_ref else 0.8,
-                label=label, zorder=(20 if is_ref else 3 + i))
+        ax.plot(
+            xb,
+            yv,
+            color=color,
+            marker=marker,
+            markersize=10 if is_ref else 6,
+            lw=lw,
+            linestyle=ls,
+            alpha=1.0 if is_ref else 0.8,
+            label=label,
+            zorder=(20 if is_ref else 3 + i),
+        )
     # Shade the speedup region between the upstream `main` baseline and the shipping
     # `default` so the gap reads even at small panel size (and where main's thin line
     # would otherwise hug the bottom). Only where both series share bin points.
@@ -172,11 +197,21 @@ def draw_perf(ax, series, title):
             xs = np.array(common)
             lo = np.array([mmap[x] for x in common])
             hi = np.array([dmap[x] for x in common])
-            ax.fill_between(xs, lo, hi, where=(hi >= lo), color="#e6194B", alpha=0.08,
-                            zorder=1, label="_nolegend_")
+            ax.fill_between(
+                xs,
+                lo,
+                hi,
+                where=(hi >= lo),
+                color="#e6194B",
+                alpha=0.08,
+                zorder=1,
+                label="_nolegend_",
+            )
     ax.grid(True, which="both", linestyle=":", alpha=0.4)
     ax.set_xticks(sorted({int(b) for s in series.values() for b in s[0]}))
-    ax.get_xaxis().set_major_formatter(plt.FuncFormatter(lambda v, _: fmt_bins(int(round(v)))))
+    ax.get_xaxis().set_major_formatter(
+        plt.FuncFormatter(lambda v, _: fmt_bins(int(round(v))))
+    )
     ax.tick_params(axis="x", labelsize=7, rotation=45)
     # log y: leave matplotlib's autoscaled positive limits (a bottom=0 is invalid).
     return any_pts
@@ -201,32 +236,60 @@ def draw_hitrate(ax, hr_algo_cells, shape, elements_list, title):
         pts.sort()
         if pts:
             any_pts = True
-            xb = [p[0] for p in pts]; yv = [p[1] for p in pts]
+            xb = [p[0] for p in pts]
+            yv = [p[1] for p in pts]
             all_bins.update(xb)
-            ax.plot(xb, yv, marker="o", ms=5, lw=1.8,
-                    color=cmap(0.1 + 0.8 * i / max(1, len(elements_list) - 1)),
-                    label=fmt_elements(elements))
+            ax.plot(
+                xb,
+                yv,
+                marker="o",
+                ms=5,
+                lw=1.8,
+                color=cmap(0.1 + 0.8 * i / max(1, len(elements_list) - 1)),
+                label=fmt_elements(elements),
+            )
     ax.grid(True, which="both", linestyle=":", alpha=0.4)
     if all_bins:
         ax.set_xticks(sorted(all_bins))
-        ax.get_xaxis().set_major_formatter(plt.FuncFormatter(lambda v, _: fmt_bins(int(round(v)))))
+        ax.get_xaxis().set_major_formatter(
+            plt.FuncFormatter(lambda v, _: fmt_bins(int(round(v))))
+        )
     ax.tick_params(axis="x", labelsize=7, rotation=45)
     if any_pts:
         ax.set_ylim(-2, 102)
         ax.legend(fontsize=7, title="# elements", title_fontsize=7)
     else:
-        ax.text(0.5, 0.5, "no hit-rate data", ha="center", va="center",
-                transform=ax.transAxes, fontsize=9, color="gray")
+        ax.text(
+            0.5,
+            0.5,
+            "no hit-rate data",
+            ha="center",
+            va="center",
+            transform=ax.transAxes,
+            fontsize=9,
+            color="gray",
+        )
     return any_pts
 
 
-def render_one(binary_label, per_algo_cells, sample, shape, elements_list, algos, outpath, hr_for_binary=None):
+def render_one(
+    binary_label,
+    per_algo_cells,
+    sample,
+    shape,
+    elements_list,
+    algos,
+    outpath,
+    hr_for_binary=None,
+):
     """One PNG: characterization top row + per-element-count perf grid, and (when
     hit-rate data is supplied) a final row with cuckoo and single-probe cache
     hit-rate vs #bins (one series per #elements)."""
     bins, counts, char_bins = C.char_input(shape)
     hr_for_binary = hr_for_binary or {}
-    has_hr = bool(hr_for_binary.get("direct_cuckoo") or hr_for_binary.get("direct_single_probe"))
+    has_hr = bool(
+        hr_for_binary.get("direct_cuckoo") or hr_for_binary.get("direct_single_probe")
+    )
 
     ncols = 3
     nperf = len(elements_list)
@@ -239,7 +302,11 @@ def render_one(binary_label, per_algo_cells, sample, shape, elements_list, algos
     transform, channels = BINARY_META[binary_label]
     head = f"{transform.upper()} · {channels}-channel · {sample}  —  InputShape: {shape}  ({C.SHAPE_BLURB.get(shape, '')})"
     head = "\n".join(textwrap.wrap(head, width=120))
-    hr_note = "   bottom row: SMEM-cache hit rate vs #bins (series = #elements)" if has_hr else ""
+    hr_note = (
+        "   bottom row: SMEM-cache hit rate vs #bins (series = #elements)"
+        if has_hr
+        else ""
+    )
     fig.suptitle(
         f"{head}\n"
         f"top: input characterization (N={C.fmt_int(C.CHAR_N)}, bins={C.fmt_bins(char_bins)})   "
@@ -252,32 +319,67 @@ def render_one(binary_label, per_algo_cells, sample, shape, elements_list, algos
     legend_ax = fig.add_subplot(gs[0, 2])
     legend_ax.axis("off")
     handles = [
-        plt.Line2D([0], [0], color=ALGO_STYLE[a][0], marker=ALGO_STYLE[a][1],
-                   linestyle=ALGO_STYLE[a][3], lw=ALGO_STYLE[a][4], label=ALGO_STYLE[a][2])
+        plt.Line2D(
+            [0],
+            [0],
+            color=ALGO_STYLE[a][0],
+            marker=ALGO_STYLE[a][1],
+            linestyle=ALGO_STYLE[a][3],
+            lw=ALGO_STYLE[a][4],
+            label=ALGO_STYLE[a][2],
+        )
         for a in algos
     ]
-    legend_ax.legend(handles=handles, loc="center", fontsize=11, title="algorithms", frameon=True)
+    legend_ax.legend(
+        handles=handles, loc="center", fontsize=11, title="algorithms", frameon=True
+    )
 
     for i, elements in enumerate(elements_list):
         r, c = 1 + i // ncols, i % ncols
         ax = fig.add_subplot(gs[r, c])
         series = perf_series(per_algo_cells, sample, elements, shape, algos)
         if not draw_perf(ax, series, f"N = {fmt_elements(elements)} elements"):
-            ax.text(0.5, 0.5, "no data\n(all cells skipped)", ha="center", va="center",
-                    transform=ax.transAxes, fontsize=9, color="gray")
+            ax.text(
+                0.5,
+                0.5,
+                "no data\n(all cells skipped)",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+                fontsize=9,
+                color="gray",
+            )
 
     if has_hr:
         hr_row = 1 + perf_rows
-        draw_hitrate(fig.add_subplot(gs[hr_row, 0]), hr_for_binary.get("direct_cuckoo", {}),
-                     shape, elements_list, "cuckoo cache — hit rate vs #bins")
-        draw_hitrate(fig.add_subplot(gs[hr_row, 1]), hr_for_binary.get("direct_single_probe", {}),
-                     shape, elements_list, "single-probe cache — hit rate vs #bins")
+        draw_hitrate(
+            fig.add_subplot(gs[hr_row, 0]),
+            hr_for_binary.get("direct_cuckoo", {}),
+            shape,
+            elements_list,
+            "cuckoo cache — hit rate vs #bins",
+        )
+        draw_hitrate(
+            fig.add_subplot(gs[hr_row, 1]),
+            hr_for_binary.get("direct_single_probe", {}),
+            shape,
+            elements_list,
+            "single-probe cache — hit rate vs #bins",
+        )
         # third column of the hit-rate row: short explainer
-        ax = fig.add_subplot(gs[hr_row, 2]); ax.axis("off")
-        ax.text(0.5, 0.5, "hit = contribution absorbed in the\nSMEM cache (block-scope add)\n"
-                          "miss = spilled to a GMEM atomic\n\n(hit rate is sample-type\nindependent; measured on a\n"
-                          "separate instrumented build)",
-                ha="center", va="center", fontsize=9, color="#333")
+        ax = fig.add_subplot(gs[hr_row, 2])
+        ax.axis("off")
+        ax.text(
+            0.5,
+            0.5,
+            "hit = contribution absorbed in the\nSMEM cache (block-scope add)\n"
+            "miss = spilled to a GMEM atomic\n\n(hit rate is sample-type\nindependent; measured on a\n"
+            "separate instrumented build)",
+            ha="center",
+            va="center",
+            fontsize=9,
+            color="#333",
+        )
 
     fig.tight_layout(rect=(0, 0, 1, 0.94))
     fig.savefig(outpath, dpi=110, bbox_inches="tight")
@@ -285,13 +387,25 @@ def render_one(binary_label, per_algo_cells, sample, shape, elements_list, algos
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--results", default="sweep_results_6shape.json",
-                    help="per-cell perf sweep JSON (binary -> algo -> 'SampleT|Elements|Bins|InputShape')")
-    ap.add_argument("--hitrate", default="hitrate_results.json",
-                    help="per-cell hit-rate sweep JSON (binary -> algo -> 'Bins|Elements|InputShape' -> {rate}); "
-                         "optional, adds two cache-hit-rate panels per image when present")
-    ap.add_argument("--outdir", default="algo_perf_figs", help="output directory for the per-shape PNGs")
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--results",
+        default="sweep_results_6shape.json",
+        help="per-cell perf sweep JSON (binary -> algo -> 'SampleT|Elements|Bins|InputShape')",
+    )
+    ap.add_argument(
+        "--hitrate",
+        default="hitrate_results.json",
+        help="per-cell hit-rate sweep JSON (binary -> algo -> 'Bins|Elements|InputShape' -> {rate}); "
+        "optional, adds two cache-hit-rate panels per image when present",
+    )
+    ap.add_argument(
+        "--outdir",
+        default="algo_perf_figs",
+        help="output directory for the per-shape PNGs",
+    )
     args = ap.parse_args()
 
     if not os.path.exists(args.results):
@@ -326,12 +440,23 @@ def main():
             folder = os.path.join(args.outdir, f"{transform}_{channels}_{sample}")
             os.makedirs(folder, exist_ok=True)
             # Render every shape present in the data for this binary.
-            shapes = sorted({k.split("|")[3] for cells in per_algo_cells.values() for k in cells},
-                            key=lambda s: (C.SHAPES.index(s) if s in C.SHAPES else 999, s))
+            shapes = sorted(
+                {k.split("|")[3] for cells in per_algo_cells.values() for k in cells},
+                key=lambda s: (C.SHAPES.index(s) if s in C.SHAPES else 999, s),
+            )
             hr_for_binary = hitrate.get(binary_label, {})
             for shape in shapes:
                 outpath = os.path.join(folder, f"{shape.replace(':', '_')}.png")
-                render_one(binary_label, per_algo_cells, sample, shape, elements, algos, outpath, hr_for_binary)
+                render_one(
+                    binary_label,
+                    per_algo_cells,
+                    sample,
+                    shape,
+                    elements,
+                    algos,
+                    outpath,
+                    hr_for_binary,
+                )
                 written.append(outpath)
 
     print(f"Wrote {len(written)} images under {args.outdir}")

--- a/cub/benchmarks/bench/histogram/histogram_algo_perf.py
+++ b/cub/benchmarks/bench/histogram/histogram_algo_perf.py
@@ -226,7 +226,7 @@ def render_one(binary_label, per_algo_cells, sample, shape, elements_list, algos
     hit-rate vs #bins (one series per #elements)."""
     bins, counts, char_bins = C.char_input(shape)
     hr_for_binary = hr_for_binary or {}
-    has_hr = bool(hr_for_binary.get("direct_atomic_cuckoo") or hr_for_binary.get("direct_atomic_single_probe"))
+    has_hr = bool(hr_for_binary.get("direct_cuckoo") or hr_for_binary.get("direct_single_probe"))
 
     ncols = 3
     nperf = len(elements_list)
@@ -268,9 +268,9 @@ def render_one(binary_label, per_algo_cells, sample, shape, elements_list, algos
 
     if has_hr:
         hr_row = 1 + perf_rows
-        draw_hitrate(fig.add_subplot(gs[hr_row, 0]), hr_for_binary.get("direct_atomic_cuckoo", {}),
+        draw_hitrate(fig.add_subplot(gs[hr_row, 0]), hr_for_binary.get("direct_cuckoo", {}),
                      shape, elements_list, "cuckoo cache — hit rate vs #bins")
-        draw_hitrate(fig.add_subplot(gs[hr_row, 1]), hr_for_binary.get("direct_atomic_single_probe", {}),
+        draw_hitrate(fig.add_subplot(gs[hr_row, 1]), hr_for_binary.get("direct_single_probe", {}),
                      shape, elements_list, "single-probe cache — hit rate vs #bins")
         # third column of the hit-rate row: short explainer
         ax = fig.add_subplot(gs[hr_row, 2]); ax.axis("off")

--- a/cub/benchmarks/bench/histogram/histogram_algo_perf.py
+++ b/cub/benchmarks/bench/histogram/histogram_algo_perf.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: BSD-3
+"""Performance comparison of the high-bin histogram algorithm candidates.
+
+Consumes a per-cell sweep JSON (each high-bin algorithm forced across
+SampleT x Elements x Bins x InputShape, per benchmark binary) and the
+source-of-truth input generators in `histogram_input_design.py`.
+
+Layout (one image per InputShape, inside a folder per transform/channels/type):
+  algo_perf_figs/<even|range>_<single|multi>_<I32|F64>/<input_shape>.png
+Each image:
+  * top row : input characterization for that shape -- distribution (log-y) and
+    position-in-sequence -- drawn by the SHARED functions in
+    histogram_input_characterization.py (so the characterization here matches the
+    standalone characterization figures exactly), plus an algorithm legend.
+  * below   : one performance graph per #input-elements; X = #bins (log2),
+    Y = GiB/s, one connect-the-dots line per algorithm present in the data
+    (markers = measured points, no fitted line). Two reference series stand out:
+    `default` (the shipping selector's pick, thick black) and `main` (upstream
+    main's default dispatch, dashed grey) -- the baseline this branch improves on.
+
+The `main` series is only drawn for InputShape generators that are byte-identical
+between upstream main and this branch (the sweep driver omits it elsewhere, since
+a reweighted/ reordered generator would not be an apples-to-apples comparison).
+
+The sweep JSON is produced by `histogram_algo_sweep.py` (the force-hook +
+upstream-main sweep driver); see the accompanying README. Run with a Python that
+has numpy + matplotlib:
+  python histogram_algo_perf.py --results sweep_results.json --outdir algo_perf_figs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import textwrap
+
+import numpy as np
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import histogram_input_characterization as C  # noqa: E402  (shared draw_* + char_input)
+
+# binary label in the sweep JSON -> (transform, channels)
+BINARY_META = {
+    "even": ("even", "single"),
+    "range": ("range", "single"),
+    "multi_even": ("even", "multi"),
+    "multi_range": ("range", "multi"),
+}
+
+# Algorithms + fixed colors/markers/linestyles (consistent across every plot).
+# Names match the post-rework algorithm enum / the CUB_HISTO_FORCE_ALGO values
+# the sweep driver (histogram_algo_sweep.py) forces, plus two reference series:
+#   default -- the shipping selector's own pick (select_algorithm), drawn as a
+#              thick black line so "what CUB actually does" stands out.
+#   main    -- upstream `main`'s default dispatch (the baseline this branch
+#              improves on), drawn dashed grey. Only present for InputShape
+#              generators that are byte-identical between main and this branch
+#              (see MAIN_COMPARABLE_SHAPES in the sweep driver).
+# (color, marker, label, linestyle, linewidth)
+# The two reference series are deliberately the most prominent marks on the plot:
+# `default` = thick solid black (what CUB ships), `main` = thick bright-red
+# dash-dot with big X markers (the upstream baseline we beat). They are drawn LAST
+# (highest zorder) so they sit on top of the candidate-algorithm cluster instead of
+# being buried under it.
+ALGO_STYLE = {
+    "default": ("#000000", "*", "selector default (ships)", "-", 3.4),
+    "main": ("#e6194B", "X", "UPSTREAM main (default)", "-.", 3.4),
+    "gmem_privatized_nocache": ("#9467bd", "^", "gmem-priv gather (no cache)", "-", 1.6),
+    "gmem_privatized_cuckoo": ("#1f77b4", "o", "gmem-priv + cuckoo", "-", 1.6),
+    "gmem_privatized_single_probe": ("#17becf", "s", "gmem-priv + single-probe", "-", 1.6),
+    "direct_cuckoo": ("#2ca02c", "o", "direct-atomic + cuckoo", "-", 1.6),
+    "direct_single_probe": ("#8c8c00", "s", "direct-atomic + single-probe", "-", 1.6),
+    "direct_nocache": ("#ff7f0e", "v", "direct atomics (no cache)", "-", 1.6),
+}
+# Draw order: reference series last (on top). gmem/direct candidates first.
+ALGO_ORDER = [
+    "gmem_privatized_nocache",
+    "gmem_privatized_cuckoo",
+    "gmem_privatized_single_probe",
+    "direct_cuckoo",
+    "direct_single_probe",
+    "direct_nocache",
+    "main",
+    "default",
+]
+
+# Plot the whole swept bin range. The force harness overrides both dispatch
+# gates (direct-atomic bin threshold and the hybrid kSplitBin guard) and every
+# forced run is launch-validated, so each algorithm -- including hybrid -- is
+# genuinely measured down to the smallest swept bin count.
+MIN_PLOT_BINS = 0
+
+
+def fmt_elements(e: int) -> str:
+    e = int(e)
+    if e % (1 << 30) == 0:
+        return f"{e >> 30}G"
+    if e % (1 << 20) == 0:
+        return f"{e >> 20}M"
+    if e >= 1 << 30:
+        return f"{e / (1 << 30):.2f}G"  # non-power-of-2 (e.g. 2e9 -> 1.86G)
+    if e >= 1 << 20:
+        return f"{e / (1 << 20):.1f}M"
+    return str(e)
+
+
+def fmt_bins(b: int) -> str:
+    b = int(b)
+    return f"{b // 1024}K" if b % 1024 == 0 else str(b)
+
+
+def perf_series(per_algo_cells, sample, elements, shape, algos):
+    """For a fixed (sample, elements, shape): {algo: (bins[], gibs[])}."""
+    out = {}
+    for algo in algos:
+        cells = per_algo_cells.get(algo, {})
+        pts = []
+        for key, gibs in cells.items():
+            s, e, b, sh = key.split("|")
+            if s == sample and int(e) == elements and sh == shape and int(b) >= MIN_PLOT_BINS:
+                pts.append((int(b), gibs))
+        pts.sort()
+        if pts:
+            out[algo] = (np.array([p[0] for p in pts]), np.array([p[1] for p in pts]))
+    return out
+
+
+def draw_perf(ax, series, title):
+    ax.set_title(title, fontsize=9)
+    ax.set_xlabel("# bins")
+    ax.set_ylabel("GiB/s (log)")
+    ax.set_xscale("log", base=2)
+    # Log y: the upstream `main` baseline can be 30x slower than the branch at high
+    # bins; on a linear axis it is pinned to ~0 and unreadable. Log y keeps the slow
+    # baseline visible AND makes the multiplicative speedup (vertical gap) the
+    # eye-level quantity.
+    ax.set_yscale("log")
+    any_pts = False
+    drawn = [a for a in ALGO_ORDER if a in series and len(series[a][0])]
+    # cuckoo / single-probe / no-cache often land on nearly the same curve, so each
+    # series carries its own color/marker/linestyle/linewidth (the reference series
+    # -- default, main -- are wider/dashed and drawn last so they sit on top).
+    for i, algo in enumerate(drawn):
+        color, marker, label, ls, lw = ALGO_STYLE[algo]
+        xb, yv = series[algo]
+        any_pts = True
+        # Reference series (default, main) get larger markers, full opacity, and the
+        # highest zorder so they read clearly over the candidate-algorithm cluster.
+        is_ref = algo in ("default", "main")
+        ax.plot(xb, yv, color=color, marker=marker, markersize=10 if is_ref else 6,
+                lw=lw, linestyle=ls, alpha=1.0 if is_ref else 0.8,
+                label=label, zorder=(20 if is_ref else 3 + i))
+    # Shade the speedup region between the upstream `main` baseline and the shipping
+    # `default` so the gap reads even at small panel size (and where main's thin line
+    # would otherwise hug the bottom). Only where both series share bin points.
+    if "main" in series and "default" in series:
+        mb, mv = series["main"]
+        db, dv = series["default"]
+        common = sorted(set(int(x) for x in mb) & set(int(x) for x in db))
+        if common:
+            mmap = {int(x): y for x, y in zip(mb, mv)}
+            dmap = {int(x): y for x, y in zip(db, dv)}
+            xs = np.array(common)
+            lo = np.array([mmap[x] for x in common])
+            hi = np.array([dmap[x] for x in common])
+            ax.fill_between(xs, lo, hi, where=(hi >= lo), color="#e6194B", alpha=0.08,
+                            zorder=1, label="_nolegend_")
+    ax.grid(True, which="both", linestyle=":", alpha=0.4)
+    ax.set_xticks(sorted({int(b) for s in series.values() for b in s[0]}))
+    ax.get_xaxis().set_major_formatter(plt.FuncFormatter(lambda v, _: fmt_bins(int(round(v)))))
+    ax.tick_params(axis="x", labelsize=7, rotation=45)
+    # log y: leave matplotlib's autoscaled positive limits (a bottom=0 is invalid).
+    return any_pts
+
+
+def draw_hitrate(ax, hr_algo_cells, shape, elements_list, title):
+    """Cache hit rate (%) vs #bins, one series per #elements. hr_algo_cells is
+    keyed 'Bins|Elements|InputShape' -> {rate,hits,misses}."""
+    ax.set_title(title, fontsize=9)
+    ax.set_xlabel("# bins")
+    ax.set_ylabel("cache hit rate (%)")
+    ax.set_xscale("log", base=2)
+    any_pts = False
+    all_bins = set()
+    cmap = plt.cm.viridis
+    for i, elements in enumerate(elements_list):
+        pts = []
+        for key, rec in hr_algo_cells.items():
+            b, e, sh = key.split("|")
+            if int(e) == elements and sh == shape:
+                pts.append((int(b), rec["rate"] * 100.0))
+        pts.sort()
+        if pts:
+            any_pts = True
+            xb = [p[0] for p in pts]; yv = [p[1] for p in pts]
+            all_bins.update(xb)
+            ax.plot(xb, yv, marker="o", ms=5, lw=1.8,
+                    color=cmap(0.1 + 0.8 * i / max(1, len(elements_list) - 1)),
+                    label=fmt_elements(elements))
+    ax.grid(True, which="both", linestyle=":", alpha=0.4)
+    if all_bins:
+        ax.set_xticks(sorted(all_bins))
+        ax.get_xaxis().set_major_formatter(plt.FuncFormatter(lambda v, _: fmt_bins(int(round(v)))))
+    ax.tick_params(axis="x", labelsize=7, rotation=45)
+    if any_pts:
+        ax.set_ylim(-2, 102)
+        ax.legend(fontsize=7, title="# elements", title_fontsize=7)
+    else:
+        ax.text(0.5, 0.5, "no hit-rate data", ha="center", va="center",
+                transform=ax.transAxes, fontsize=9, color="gray")
+    return any_pts
+
+
+def render_one(binary_label, per_algo_cells, sample, shape, elements_list, algos, outpath, hr_for_binary=None):
+    """One PNG: characterization top row + per-element-count perf grid, and (when
+    hit-rate data is supplied) a final row with cuckoo and single-probe cache
+    hit-rate vs #bins (one series per #elements)."""
+    bins, counts, char_bins = C.char_input(shape)
+    hr_for_binary = hr_for_binary or {}
+    has_hr = bool(hr_for_binary.get("direct_atomic_cuckoo") or hr_for_binary.get("direct_atomic_single_probe"))
+
+    ncols = 3
+    nperf = len(elements_list)
+    perf_rows = (nperf + ncols - 1) // ncols
+    nrows = 1 + perf_rows + (1 if has_hr else 0)
+
+    fig = plt.figure(figsize=(5.4 * ncols, 4.1 * nrows))
+    gs = fig.add_gridspec(nrows, ncols)
+
+    transform, channels = BINARY_META[binary_label]
+    head = f"{transform.upper()} · {channels}-channel · {sample}  —  InputShape: {shape}  ({C.SHAPE_BLURB.get(shape, '')})"
+    head = "\n".join(textwrap.wrap(head, width=120))
+    hr_note = "   bottom row: SMEM-cache hit rate vs #bins (series = #elements)" if has_hr else ""
+    fig.suptitle(
+        f"{head}\n"
+        f"top: input characterization (N={C.fmt_int(C.CHAR_N)}, bins={C.fmt_bins(char_bins)})   "
+        f"middle: GiB/s vs #bins per input size — one line per algorithm{hr_note}",
+        fontsize=12,
+    )
+
+    C.draw_distribution(fig.add_subplot(gs[0, 0]), counts, char_bins)
+    C.draw_sequence(fig.add_subplot(gs[0, 1]), bins, char_bins, shape=shape)
+    legend_ax = fig.add_subplot(gs[0, 2])
+    legend_ax.axis("off")
+    handles = [
+        plt.Line2D([0], [0], color=ALGO_STYLE[a][0], marker=ALGO_STYLE[a][1],
+                   linestyle=ALGO_STYLE[a][3], lw=ALGO_STYLE[a][4], label=ALGO_STYLE[a][2])
+        for a in algos
+    ]
+    legend_ax.legend(handles=handles, loc="center", fontsize=11, title="algorithms", frameon=True)
+
+    for i, elements in enumerate(elements_list):
+        r, c = 1 + i // ncols, i % ncols
+        ax = fig.add_subplot(gs[r, c])
+        series = perf_series(per_algo_cells, sample, elements, shape, algos)
+        if not draw_perf(ax, series, f"N = {fmt_elements(elements)} elements"):
+            ax.text(0.5, 0.5, "no data\n(all cells skipped)", ha="center", va="center",
+                    transform=ax.transAxes, fontsize=9, color="gray")
+
+    if has_hr:
+        hr_row = 1 + perf_rows
+        draw_hitrate(fig.add_subplot(gs[hr_row, 0]), hr_for_binary.get("direct_atomic_cuckoo", {}),
+                     shape, elements_list, "cuckoo cache — hit rate vs #bins")
+        draw_hitrate(fig.add_subplot(gs[hr_row, 1]), hr_for_binary.get("direct_atomic_single_probe", {}),
+                     shape, elements_list, "single-probe cache — hit rate vs #bins")
+        # third column of the hit-rate row: short explainer
+        ax = fig.add_subplot(gs[hr_row, 2]); ax.axis("off")
+        ax.text(0.5, 0.5, "hit = contribution absorbed in the\nSMEM cache (block-scope add)\n"
+                          "miss = spilled to a GMEM atomic\n\n(hit rate is sample-type\nindependent; measured on a\n"
+                          "separate instrumented build)",
+                ha="center", va="center", fontsize=9, color="#333")
+
+    fig.tight_layout(rect=(0, 0, 1, 0.94))
+    fig.savefig(outpath, dpi=110, bbox_inches="tight")
+    plt.close(fig)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--results", default="sweep_results_6shape.json",
+                    help="per-cell perf sweep JSON (binary -> algo -> 'SampleT|Elements|Bins|InputShape')")
+    ap.add_argument("--hitrate", default="hitrate_results.json",
+                    help="per-cell hit-rate sweep JSON (binary -> algo -> 'Bins|Elements|InputShape' -> {rate}); "
+                         "optional, adds two cache-hit-rate panels per image when present")
+    ap.add_argument("--outdir", default="algo_perf_figs", help="output directory for the per-shape PNGs")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.results):
+        raise SystemExit(f"missing results JSON: {args.results} (pass --results)")
+    data = json.load(open(args.results))
+    hitrate = {}
+    if args.hitrate and os.path.exists(args.hitrate):
+        hitrate = json.load(open(args.hitrate))
+        print(f"hit-rate data: {args.hitrate}")
+    else:
+        print(f"(no hit-rate JSON at {args.hitrate}; hit-rate panels skipped)")
+
+    os.makedirs(args.outdir, exist_ok=True)
+    written = []
+    for binary_label, per_algo_cells in data.items():
+        transform, channels = BINARY_META[binary_label]
+        # Plot every algorithm series actually present in the data for this binary
+        # (in canonical ALGO_ORDER). `main` appears only for the generator-identical
+        # shapes (the sweep driver omits it elsewhere); a forced algo absent at a
+        # given (transform, channels) simply has no points and is dropped per panel.
+        algos = [a for a in ALGO_ORDER if a in per_algo_cells]
+
+        samples, elements = set(), set()
+        for cells in per_algo_cells.values():
+            for key in cells:
+                s, e, _, _ = key.split("|")
+                samples.add(s)
+                elements.add(int(e))
+        elements = sorted(elements)
+
+        for sample in sorted(samples):
+            folder = os.path.join(args.outdir, f"{transform}_{channels}_{sample}")
+            os.makedirs(folder, exist_ok=True)
+            # Render every shape present in the data for this binary.
+            shapes = sorted({k.split("|")[3] for cells in per_algo_cells.values() for k in cells},
+                            key=lambda s: (C.SHAPES.index(s) if s in C.SHAPES else 999, s))
+            hr_for_binary = hitrate.get(binary_label, {})
+            for shape in shapes:
+                outpath = os.path.join(folder, f"{shape.replace(':', '_')}.png")
+                render_one(binary_label, per_algo_cells, sample, shape, elements, algos, outpath, hr_for_binary)
+                written.append(outpath)
+
+    print(f"Wrote {len(written)} images under {args.outdir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cub/benchmarks/bench/histogram/histogram_algo_sweep.py
+++ b/cub/benchmarks/bench/histogram/histogram_algo_sweep.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: BSD-3
+"""Exhaustive forced-algorithm histogram sweep, with an upstream-`main` baseline.
+
+For every (binary, SampleT, Elements, Bins, InputShape) cell this forces EACH
+high-bin algorithm via `CUB_HISTO_FORCE_ALGO` and records GiB/s, plus the
+selector's own pick ("default"). It ALSO runs the same cells on a second set of
+binaries built from upstream `main` (which has no force hook) and records main's
+default dispatch as a pseudo-algorithm column named `main`. The result is the
+apples-to-apples matrix `histogram_algo_perf.py` plots: every candidate algorithm
+AND the upstream baseline on one GiB/s-vs-#bins axis per (transform, channels,
+SampleT, InputShape).
+
+Forcing is only honored above the high-bin threshold (`max_num_output_bins >
+max_dynamic_smem_bins`, i.e. bins > 4096); at/below it every forced algo silently
+falls back to `smem_privatized`, so those low-bin cells are recorded once under
+`default` only (forcing there is a no-op). `CUB_HISTO_DEBUG_SLOTS` is set so a
+direct-atomic kernel that actually ran prints a tell on stderr; we record
+`direct_ran` per cell to catch a forced algo that silently fell back.
+
+Output JSON schema (consumed by histogram_algo_perf.py):
+  { binary: { algo: { "SampleT|Elements|Bins|InputShape": gibps_median } } }
+where `binary` in {even, range, multi_even, multi_range}, and `algo` includes the
+six forced names, "default", and "main".
+
+Run (substantial wall time -- scope with the flags):
+  python histogram_algo_sweep.py \
+      --branch-bin-dir build/autocuda/cub-benchmark/bin \
+      --main-bin-dir   ../main-baseline/build/cub-benchmark/bin \
+      --out sweep_results.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import statistics
+import subprocess
+import sys
+from io import StringIO
+from pathlib import Path
+
+# NVBench target name per logical binary label.
+BINARIES = {
+    "even": "cub.bench.histogram.even.base",
+    "range": "cub.bench.histogram.range.base",
+    "multi_even": "cub.bench.histogram.multi.even.base",
+    "multi_range": "cub.bench.histogram.multi.range.base",
+}
+
+# Forced high-bin algorithms (env values for CUB_HISTO_FORCE_ALGO). "" == the
+# selector's own pick, recorded under the "default" key. `main` is handled
+# separately (a different binary, no force hook).
+FORCED_ALGOS = [
+    "",  # default (selector)
+    "gmem_privatized_nocache",
+    "gmem_privatized_cuckoo",
+    "gmem_privatized_single_probe",
+    "direct_nocache",
+    "direct_cuckoo",
+    "direct_single_probe",
+]
+ALGO_KEY = {"": "default"}  # env value -> JSON key; others map to themselves.
+
+# Bins below this are the on-chip privatized-SMEM tier: forcing is a no-op there,
+# so the forced algos collapse onto `default`. We still sweep them (one default
+# run) so the plot's low-bin region is populated.
+HIGH_BIN_THRESHOLD = 4096
+
+# Default sweep grid. Bin counts straddle the SMEM tier (<=4096), the gather tier
+# (8192..65535), and the direct-atomic tiers (>=65536 cuckoo, >=262144 noprobe2).
+DEFAULT_BINS = [256, 2048, 8192, 32768, 65536, 262144, 1048576]
+DEFAULT_ELEMENTS = [1 << 24, 1 << 28]  # 16M, 256M
+DEFAULT_SAMPLES = ["I32"]
+DEFAULT_SHAPES = [
+    "concentrated:1.0",
+    "concentrated:0.0",
+    "powerlaw:0.5",
+    "zipf:1.0",
+    "hash_synonym",
+    "stale_resident",
+    "temporal_phases",
+    "strided_sweep",
+]
+
+# InputShape generators comparable against the `main` series. This is now ALL
+# shapes the run sweeps, PROVIDED the main-baseline binaries were built with this
+# branch's input-shape generators overlaid on stock-main dispatch (i.e. main's
+# `histogram_inputs.cuh` / `even.cu` / ... replaced by this branch's, which is a
+# bench-only change -- the two rework commits 0cf4594ba6 + 286a78e248 touch no
+# dispatch/kernel code). With identical generators every shape is apples-to-apples
+# and only the dispatch differs, which is exactly the comparison we want.
+#
+# Empty set (the default) means "no restriction -- compare every swept shape".
+# If you instead point --main-bin-dir at UNMODIFIED upstream-main binaries, set
+# this to the generator-identical subset to avoid an apples-to-oranges plot:
+#   {"powerlaw:0.5", "zipf:1.0", "hash_synonym", "temporal_phases", "strided_sweep"}
+# (the others changed generator on the branch: concentrated:* reweighted,
+# concentrated:1.0 reordered, stale_resident reparametrized; sawtooth is branch-only).
+MAIN_COMPARABLE_SHAPES: set[str] = set()
+
+
+def cell_key(sample: str, elements: int, bins: int, shape: str) -> str:
+    return f"{sample}|{elements}|{bins}|{shape}"
+
+
+def run_cell(binary_path, algo_env, sample, elements, bins, shapes, repeats, min_time, timeout):
+    """Run one NVBench invocation (all `shapes` in one go) `repeats` times; return
+    {shape: median_gibps}, direct_ran_bool, ok_bool. A single binary call sweeps
+    the InputShape axis, so we pass the whole shape list and split per shape."""
+    env = dict(os.environ)
+    env["CUB_HISTO_DEBUG_SLOTS"] = "1"
+    if algo_env:
+        env["CUB_HISTO_FORCE_ALGO"] = algo_env
+    else:
+        env.pop("CUB_HISTO_FORCE_ALGO", None)
+    # NVBench rejects range syntax for a single string-axis value, so always pass
+    # >= 2 shapes; callers ensure that (we sweep the full shape list at once).
+    shape_axis = "[" + ",".join(shapes) + "]"
+    cmd = [
+        str(binary_path), "--benchmark", "base",
+        "--axis", f"SampleT{{ct}}={sample}",
+        "--axis", f"Elements{{io}}=[{elements}]",
+        "--axis", f"Bins=[{bins}]",
+        "--axis", f"InputShape={shape_axis}",
+        "--min-samples", str(repeats), "--min-time", str(min_time),
+        "--timeout", str(timeout), "--csv", "stdout", "--quiet",
+    ]
+    per_shape = {}
+    direct_ran = False
+    for _ in range(repeats):
+        p = subprocess.run(cmd, env=env, text=True, capture_output=True)
+        direct_ran = direct_ran or ("[CUB_HISTO_DEBUG_SLOTS]" in p.stderr)
+        if p.returncode != 0:
+            return {}, direct_ran, False
+        for r in csv.DictReader(StringIO(p.stdout)):
+            if r.get("Skipped") == "Yes":
+                continue
+            bw = r.get("GlobalMem BW (bytes/sec)", "")
+            if bw:
+                per_shape.setdefault(r["InputShape"], []).append(float(bw) / 1024**3)
+    return {sh: statistics.median(v) for sh, v in per_shape.items() if v}, direct_ran, True
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--branch-bin-dir", default="build/autocuda/cub-benchmark/bin",
+                    help="dir with this branch's cub.bench.histogram.*.base binaries (force hook present)")
+    ap.add_argument("--main-bin-dir", default="",
+                    help="dir with upstream main's cub.bench.histogram.*.base binaries (default dispatch only); "
+                         "omit to skip the main baseline column")
+    ap.add_argument("--out", default="sweep_results.json", help="output per-cell JSON")
+    ap.add_argument("--bins", type=int, nargs="+", default=DEFAULT_BINS)
+    ap.add_argument("--elements", type=int, nargs="+", default=DEFAULT_ELEMENTS)
+    ap.add_argument("--samples", nargs="+", default=DEFAULT_SAMPLES, help="SampleT axis values, e.g. I32 F64")
+    ap.add_argument("--shapes", nargs="+", default=DEFAULT_SHAPES)
+    ap.add_argument("--binaries", nargs="+", default=list(BINARIES), choices=list(BINARIES))
+    ap.add_argument("--repeats", type=int, default=3)
+    ap.add_argument("--min-time", default="0.02")
+    ap.add_argument("--timeout", default="120")
+    ap.add_argument("--main-comparable-shapes", nargs="*", default=None,
+                    help="restrict the `main` baseline to these shapes (use when --main-bin-dir is "
+                         "UNMODIFIED upstream main, whose generators differ). Default: all swept shapes "
+                         "(correct when the main binaries carry this branch's generators -- see "
+                         "MAIN_COMPARABLE_SHAPES).")
+    args = ap.parse_args()
+
+    branch_dir = Path(args.branch_bin_dir)
+    main_dir = Path(args.main_bin_dir) if args.main_bin_dir else None
+    if main_dir and not main_dir.exists():
+        raise SystemExit(f"--main-bin-dir does not exist: {main_dir}")
+
+    # main has no force hook, so it contributes ONE column (its default dispatch).
+    # Comparable-shape set: CLI override, else MAIN_COMPARABLE_SHAPES, else (empty
+    # => no restriction) every swept shape -- correct when the main binaries were
+    # built with this branch's input-shape generators (the documented setup).
+    if args.main_comparable_shapes is not None:
+        comparable = set(args.main_comparable_shapes)
+    elif MAIN_COMPARABLE_SHAPES:
+        comparable = MAIN_COMPARABLE_SHAPES
+    else:
+        comparable = set(args.shapes)  # no restriction
+    main_shapes = [s for s in args.shapes if s in comparable] if main_dir else []
+    if main_dir:
+        skipped = [s for s in args.shapes if s not in comparable]
+        print(f"main baseline: comparing shapes {sorted(main_shapes)}", flush=True)
+        if skipped:
+            print(f"  SKIPPING (not in comparable set) {sorted(skipped)}", flush=True)
+
+    results: dict[str, dict[str, dict[str, float]]] = {}
+    total_calls = 0
+    for blabel in args.binaries:
+        target = BINARIES[blabel]
+        branch_bin = branch_dir / target
+        if not branch_bin.exists():
+            print(f"!! missing branch binary {branch_bin}; skipping {blabel}", flush=True)
+            continue
+        algo_cells: dict[str, dict[str, float]] = {}
+        for sample in args.samples:
+            for elements in args.elements:
+                for bins in args.bins:
+                    high = bins > HIGH_BIN_THRESHOLD
+                    # Below the high-bin threshold forcing is a no-op; record only default.
+                    algos = FORCED_ALGOS if high else [""]
+                    for algo_env in algos:
+                        akey = ALGO_KEY.get(algo_env, algo_env)
+                        med, dr, ok = run_cell(branch_bin, algo_env, sample, elements, bins,
+                                               args.shapes, args.repeats, args.min_time, args.timeout)
+                        total_calls += 1
+                        if not ok:
+                            print(f"  {blabel:11} {sample} N={elements:>10} bins={bins:>8} "
+                                  f"{akey:28} ABORT", flush=True)
+                            continue
+                        for sh, v in med.items():
+                            algo_cells.setdefault(akey, {})[cell_key(sample, elements, bins, sh)] = v
+                        line = "  ".join(f"{sh.split(':')[0][:5]}={med[sh]:.0f}" for sh in sorted(med))
+                        print(f"  {blabel:11} {sample} N={elements:>10} bins={bins:>8} "
+                              f"{akey:28} dr={int(dr)} {line}", flush=True)
+                # main baseline column for this (sample, elements): default dispatch only.
+                if main_dir and main_shapes:
+                    main_bin = main_dir / target
+                    if main_bin.exists():
+                        for elements in args.elements:
+                            for bins in args.bins:
+                                med, _, ok = run_cell(main_bin, "", sample, elements, bins,
+                                                      main_shapes, args.repeats, args.min_time, args.timeout)
+                                total_calls += 1
+                                if not ok:
+                                    print(f"  {blabel:11} {sample} N={elements:>10} bins={bins:>8} "
+                                          f"{'main':28} ABORT", flush=True)
+                                    continue
+                                for sh, v in med.items():
+                                    algo_cells.setdefault("main", {})[cell_key(sample, elements, bins, sh)] = v
+                                line = "  ".join(f"{sh.split(':')[0][:5]}={med[sh]:.0f}" for sh in sorted(med))
+                                print(f"  {blabel:11} {sample} N={elements:>10} bins={bins:>8} "
+                                      f"{'main':28}      {line}", flush=True)
+                    else:
+                        print(f"!! missing main binary {main_bin}; no main column for {blabel}", flush=True)
+        results[blabel] = algo_cells
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w") as fh:
+        json.dump(results, fh, indent=1)
+    print(f"\nwrote {args.out} ({total_calls} benchmark invocations)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/cub/benchmarks/bench/histogram/histogram_algo_sweep.py
+++ b/cub/benchmarks/bench/histogram/histogram_algo_sweep.py
@@ -39,7 +39,6 @@ import json
 import os
 import statistics
 import subprocess
-import sys
 from io import StringIO
 from pathlib import Path
 
@@ -107,7 +106,9 @@ def cell_key(sample: str, elements: int, bins: int, shape: str) -> str:
     return f"{sample}|{elements}|{bins}|{shape}"
 
 
-def run_cell(binary_path, algo_env, sample, elements, bins, shapes, repeats, min_time, timeout):
+def run_cell(
+    binary_path, algo_env, sample, elements, bins, shapes, repeats, min_time, timeout
+):
     """Run one NVBench invocation (all `shapes` in one go) `repeats` times; return
     {shape: median_gibps}, direct_ran_bool, ok_bool. A single binary call sweeps
     the InputShape axis, so we pass the whole shape list and split per shape."""
@@ -121,13 +122,26 @@ def run_cell(binary_path, algo_env, sample, elements, bins, shapes, repeats, min
     # >= 2 shapes; callers ensure that (we sweep the full shape list at once).
     shape_axis = "[" + ",".join(shapes) + "]"
     cmd = [
-        str(binary_path), "--benchmark", "base",
-        "--axis", f"SampleT{{ct}}={sample}",
-        "--axis", f"Elements{{io}}=[{elements}]",
-        "--axis", f"Bins=[{bins}]",
-        "--axis", f"InputShape={shape_axis}",
-        "--min-samples", str(repeats), "--min-time", str(min_time),
-        "--timeout", str(timeout), "--csv", "stdout", "--quiet",
+        str(binary_path),
+        "--benchmark",
+        "base",
+        "--axis",
+        f"SampleT{{ct}}={sample}",
+        "--axis",
+        f"Elements{{io}}=[{elements}]",
+        "--axis",
+        f"Bins=[{bins}]",
+        "--axis",
+        f"InputShape={shape_axis}",
+        "--min-samples",
+        str(repeats),
+        "--min-time",
+        str(min_time),
+        "--timeout",
+        str(timeout),
+        "--csv",
+        "stdout",
+        "--quiet",
     ]
     per_shape = {}
     direct_ran = False
@@ -142,30 +156,53 @@ def run_cell(binary_path, algo_env, sample, elements, bins, shapes, repeats, min
             bw = r.get("GlobalMem BW (bytes/sec)", "")
             if bw:
                 per_shape.setdefault(r["InputShape"], []).append(float(bw) / 1024**3)
-    return {sh: statistics.median(v) for sh, v in per_shape.items() if v}, direct_ran, True
+    return (
+        {sh: statistics.median(v) for sh, v in per_shape.items() if v},
+        direct_ran,
+        True,
+    )
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--branch-bin-dir", default="build/autocuda/cub-benchmark/bin",
-                    help="dir with this branch's cub.bench.histogram.*.base binaries (force hook present)")
-    ap.add_argument("--main-bin-dir", default="",
-                    help="dir with upstream main's cub.bench.histogram.*.base binaries (default dispatch only); "
-                         "omit to skip the main baseline column")
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--branch-bin-dir",
+        default="build/autocuda/cub-benchmark/bin",
+        help="dir with this branch's cub.bench.histogram.*.base binaries (force hook present)",
+    )
+    ap.add_argument(
+        "--main-bin-dir",
+        default="",
+        help="dir with upstream main's cub.bench.histogram.*.base binaries (default dispatch only); "
+        "omit to skip the main baseline column",
+    )
     ap.add_argument("--out", default="sweep_results.json", help="output per-cell JSON")
     ap.add_argument("--bins", type=int, nargs="+", default=DEFAULT_BINS)
     ap.add_argument("--elements", type=int, nargs="+", default=DEFAULT_ELEMENTS)
-    ap.add_argument("--samples", nargs="+", default=DEFAULT_SAMPLES, help="SampleT axis values, e.g. I32 F64")
+    ap.add_argument(
+        "--samples",
+        nargs="+",
+        default=DEFAULT_SAMPLES,
+        help="SampleT axis values, e.g. I32 F64",
+    )
     ap.add_argument("--shapes", nargs="+", default=DEFAULT_SHAPES)
-    ap.add_argument("--binaries", nargs="+", default=list(BINARIES), choices=list(BINARIES))
+    ap.add_argument(
+        "--binaries", nargs="+", default=list(BINARIES), choices=list(BINARIES)
+    )
     ap.add_argument("--repeats", type=int, default=3)
     ap.add_argument("--min-time", default="0.02")
     ap.add_argument("--timeout", default="120")
-    ap.add_argument("--main-comparable-shapes", nargs="*", default=None,
-                    help="restrict the `main` baseline to these shapes (use when --main-bin-dir is "
-                         "UNMODIFIED upstream main, whose generators differ). Default: all swept shapes "
-                         "(correct when the main binaries carry this branch's generators -- see "
-                         "MAIN_COMPARABLE_SHAPES).")
+    ap.add_argument(
+        "--main-comparable-shapes",
+        nargs="*",
+        default=None,
+        help="restrict the `main` baseline to these shapes (use when --main-bin-dir is "
+        "UNMODIFIED upstream main, whose generators differ). Default: all swept shapes "
+        "(correct when the main binaries carry this branch's generators -- see "
+        "MAIN_COMPARABLE_SHAPES).",
+    )
     args = ap.parse_args()
 
     branch_dir = Path(args.branch_bin_dir)
@@ -196,7 +233,9 @@ def main():
         target = BINARIES[blabel]
         branch_bin = branch_dir / target
         if not branch_bin.exists():
-            print(f"!! missing branch binary {branch_bin}; skipping {blabel}", flush=True)
+            print(
+                f"!! missing branch binary {branch_bin}; skipping {blabel}", flush=True
+            )
             continue
         algo_cells: dict[str, dict[str, float]] = {}
         for sample in args.samples:
@@ -207,38 +246,81 @@ def main():
                     algos = FORCED_ALGOS if high else [""]
                     for algo_env in algos:
                         akey = ALGO_KEY.get(algo_env, algo_env)
-                        med, dr, ok = run_cell(branch_bin, algo_env, sample, elements, bins,
-                                               args.shapes, args.repeats, args.min_time, args.timeout)
+                        med, dr, ok = run_cell(
+                            branch_bin,
+                            algo_env,
+                            sample,
+                            elements,
+                            bins,
+                            args.shapes,
+                            args.repeats,
+                            args.min_time,
+                            args.timeout,
+                        )
                         total_calls += 1
                         if not ok:
-                            print(f"  {blabel:11} {sample} N={elements:>10} bins={bins:>8} "
-                                  f"{akey:28} ABORT", flush=True)
+                            print(
+                                f"  {blabel:11} {sample} N={elements:>10} bins={bins:>8} "
+                                f"{akey:28} ABORT",
+                                flush=True,
+                            )
                             continue
                         for sh, v in med.items():
-                            algo_cells.setdefault(akey, {})[cell_key(sample, elements, bins, sh)] = v
-                        line = "  ".join(f"{sh.split(':')[0][:5]}={med[sh]:.0f}" for sh in sorted(med))
-                        print(f"  {blabel:11} {sample} N={elements:>10} bins={bins:>8} "
-                              f"{akey:28} dr={int(dr)} {line}", flush=True)
+                            algo_cells.setdefault(akey, {})[
+                                cell_key(sample, elements, bins, sh)
+                            ] = v
+                        line = "  ".join(
+                            f"{sh.split(':')[0][:5]}={med[sh]:.0f}"
+                            for sh in sorted(med)
+                        )
+                        print(
+                            f"  {blabel:11} {sample} N={elements:>10} bins={bins:>8} "
+                            f"{akey:28} dr={int(dr)} {line}",
+                            flush=True,
+                        )
                 # main baseline column for this (sample, elements): default dispatch only.
                 if main_dir and main_shapes:
                     main_bin = main_dir / target
                     if main_bin.exists():
                         for elements in args.elements:
                             for bins in args.bins:
-                                med, _, ok = run_cell(main_bin, "", sample, elements, bins,
-                                                      main_shapes, args.repeats, args.min_time, args.timeout)
+                                med, _, ok = run_cell(
+                                    main_bin,
+                                    "",
+                                    sample,
+                                    elements,
+                                    bins,
+                                    main_shapes,
+                                    args.repeats,
+                                    args.min_time,
+                                    args.timeout,
+                                )
                                 total_calls += 1
                                 if not ok:
-                                    print(f"  {blabel:11} {sample} N={elements:>10} bins={bins:>8} "
-                                          f"{'main':28} ABORT", flush=True)
+                                    print(
+                                        f"  {blabel:11} {sample} N={elements:>10} bins={bins:>8} "
+                                        f"{'main':28} ABORT",
+                                        flush=True,
+                                    )
                                     continue
                                 for sh, v in med.items():
-                                    algo_cells.setdefault("main", {})[cell_key(sample, elements, bins, sh)] = v
-                                line = "  ".join(f"{sh.split(':')[0][:5]}={med[sh]:.0f}" for sh in sorted(med))
-                                print(f"  {blabel:11} {sample} N={elements:>10} bins={bins:>8} "
-                                      f"{'main':28}      {line}", flush=True)
+                                    algo_cells.setdefault("main", {})[
+                                        cell_key(sample, elements, bins, sh)
+                                    ] = v
+                                line = "  ".join(
+                                    f"{sh.split(':')[0][:5]}={med[sh]:.0f}"
+                                    for sh in sorted(med)
+                                )
+                                print(
+                                    f"  {blabel:11} {sample} N={elements:>10} bins={bins:>8} "
+                                    f"{'main':28}      {line}",
+                                    flush=True,
+                                )
                     else:
-                        print(f"!! missing main binary {main_bin}; no main column for {blabel}", flush=True)
+                        print(
+                            f"!! missing main binary {main_bin}; no main column for {blabel}",
+                            flush=True,
+                        )
         results[blabel] = algo_cells
 
     Path(args.out).parent.mkdir(parents=True, exist_ok=True)

--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -76,15 +76,20 @@ SampleT get_upper_level(OffsetT bins, OffsetT elements)
 {
   if constexpr (cuda::std::is_integral_v<SampleT>)
   {
-    if constexpr (sizeof(SampleT) < sizeof(OffsetT))
-    {
-      const SampleT max_key = ::cuda::std::numeric_limits<SampleT>::max();
-      return static_cast<SampleT>(std::min(bins, static_cast<OffsetT>(max_key)));
-    }
-    else
-    {
-      return static_cast<SampleT>(bins);
-    }
+    // Widen the upper level to ~4 * num_bins so the range bench's
+    // jittered-uniform level construction (jitter amplitude is step / 4)
+    // produces genuinely non-uniform integer levels. With the previous
+    // upper_level == num_bins, step was exactly 1 for `int32_t` / `int64_t`,
+    // the integer cast in the level loop annihilated the jitter, and the
+    // dedup-by-1 step forced the array back to perfect uniform stride —
+    // which `DispatchHistogram`'s uniform-range detection (when present)
+    // would route through the fast EVEN classify path, defeating the
+    // purpose of the range bench. Clamp to the type max when 4 * bins
+    // overflows `SampleT`; those axes already have step < 1 and the level
+    // array is degenerate regardless of jitter.
+    const int64_t max_v = static_cast<int64_t>(::cuda::std::numeric_limits<SampleT>::max());
+    const int64_t want  = static_cast<int64_t>(bins) * int64_t{4};
+    return static_cast<SampleT>(std::min(want, max_v));
   }
 
   return static_cast<SampleT>(elements);

--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -4,8 +4,21 @@
 #pragma once
 
 #include <cub/device/device_histogram.cuh>
+#include <cub/thread/thread_search.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/for_each.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/counting_iterator.h>
 
 #include <cuda/std/type_traits>
+
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #if !TUNE_BASE
 
@@ -75,4 +88,268 @@ SampleT get_upper_level(OffsetT bins, OffsetT elements)
   }
 
   return static_cast<SampleT>(elements);
+}
+
+// Bench-side correctness checks that compare the CUB histogram result
+// bin-by-bin against an independent on-device reference computed with
+// `thrust::for_each` + global `atomicAdd`. The verifier is invoked once per
+// benchmark cell, outside NVBench's timed region, so it does not contribute
+// to the reported bandwidth. The reference does not share any kernels with
+// `cub::DeviceHistogram`, so a bug that leaves the optimized histogram
+// shaped correctly but counted incorrectly is still caught.
+//
+// Verification is on by default. To skip it (e.g. during a tuning sweep where
+// only relative throughput matters), set the environment variable
+// CUB_BENCH_HISTOGRAM_VERIFY to one of: 0, false, no, off (case-insensitive).
+
+inline bool bench_correctness_checks_enabled()
+{
+  static const bool enabled = []() {
+    const char* v = std::getenv("CUB_BENCH_HISTOGRAM_VERIFY");
+    if (v == nullptr)
+    {
+      return true;
+    }
+    std::string s(v);
+    for (char& c : s)
+    {
+      c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return !(s == "0" || s == "false" || s == "no" || s == "off");
+  }();
+  return enabled;
+}
+
+inline void bench_check_cuda(cudaError_t e, const char* what)
+{
+  if (e != cudaSuccess)
+  {
+    throw std::runtime_error(std::string{"bench correctness check: "} + what + " -> " + cudaGetErrorString(e));
+  }
+}
+
+// EVEN reference: closed-form bin index `(sample - lo) * num_bins / (hi - lo)`
+// computed in double precision, then a global `atomicAdd` per pixel per active
+// channel.
+template <int NumChannels, int NumActiveChannels, typename SampleT, typename CounterT, typename OffsetT>
+struct bench_ref_even_op
+{
+  const SampleT* d_input;
+  CounterT* d_hist[NumActiveChannels];
+  OffsetT num_pixels;
+  int num_bins;
+  SampleT lower_level;
+  SampleT upper_level;
+
+  __device__ void operator()(OffsetT pixel) const
+  {
+    if (pixel >= num_pixels)
+    {
+      return;
+    }
+
+    const double L     = static_cast<double>(lower_level);
+    const double U     = static_cast<double>(upper_level);
+    const double scale = static_cast<double>(num_bins) / (U - L);
+
+    const SampleT* px = d_input + static_cast<std::size_t>(pixel) * NumChannels;
+#pragma unroll
+    for (int c = 0; c < NumActiveChannels; ++c)
+    {
+      const SampleT s = px[c];
+      if (s < lower_level || s >= upper_level)
+      {
+        continue;
+      }
+      int bin = static_cast<int>((static_cast<double>(s) - L) * scale);
+      if (bin >= num_bins)
+      {
+        bin = num_bins - 1;
+      }
+      if (bin >= 0)
+      {
+        atomicAdd(d_hist[c] + bin, CounterT{1});
+      }
+    }
+  }
+};
+
+// RANGE reference: per-pixel `cub::UpperBound` on the per-channel level array,
+// then a global `atomicAdd`. Levels are arbitrary monotonic boundaries so the
+// closed-form EVEN index does not apply.
+template <int NumChannels, int NumActiveChannels, typename SampleT, typename CounterT, typename OffsetT>
+struct bench_ref_range_op
+{
+  const SampleT* d_input;
+  CounterT* d_hist[NumActiveChannels];
+  const SampleT* d_levels[NumActiveChannels];
+  OffsetT num_pixels;
+  int num_levels;
+
+  __device__ void operator()(OffsetT pixel) const
+  {
+    if (pixel >= num_pixels)
+    {
+      return;
+    }
+
+    const int num_bins = num_levels - 1;
+    const SampleT* px  = d_input + static_cast<std::size_t>(pixel) * NumChannels;
+
+#pragma unroll
+    for (int c = 0; c < NumActiveChannels; ++c)
+    {
+      const SampleT s = px[c];
+      const int idx   = cub::UpperBound(d_levels[c], num_levels, s);
+      const int bin   = idx - 1;
+      if (bin >= 0 && bin < num_bins)
+      {
+        atomicAdd(d_hist[c] + bin, CounterT{1});
+      }
+    }
+  }
+};
+
+template <typename CounterT>
+void bench_compare_histograms(
+  const std::vector<thrust::host_vector<CounterT>>& opt_hists,
+  const std::vector<thrust::host_vector<CounterT>>& ref_hists,
+  const char* bench_label,
+  int num_channels)
+{
+  for (int c = 0; c < num_channels; ++c)
+  {
+    const auto& opt = opt_hists[c];
+    const auto& ref = ref_hists[c];
+    if (opt.size() != ref.size())
+    {
+      throw std::runtime_error(std::string{"bench correctness check ["} + bench_label + "]: channel "
+                               + std::to_string(c) + " size mismatch: opt=" + std::to_string(opt.size())
+                               + " ref=" + std::to_string(ref.size()));
+    }
+    long long opt_total = 0;
+    long long ref_total = 0;
+    int first_mismatch  = -1;
+    for (std::size_t b = 0; b < opt.size(); ++b)
+    {
+      opt_total += static_cast<long long>(opt[b]);
+      ref_total += static_cast<long long>(ref[b]);
+      if (first_mismatch < 0 && opt[b] != ref[b])
+      {
+        first_mismatch = static_cast<int>(b);
+      }
+    }
+    if (opt_total != ref_total || first_mismatch >= 0)
+    {
+      char msg[512];
+      std::snprintf(
+        msg,
+        sizeof(msg),
+        "bench correctness check [%s]: channel=%d total opt=%lld ref=%lld; first mismatched bin=%d "
+        "(opt=%lld ref=%lld)",
+        bench_label,
+        c,
+        opt_total,
+        ref_total,
+        first_mismatch,
+        first_mismatch >= 0 ? static_cast<long long>(opt[first_mismatch]) : -1LL,
+        first_mismatch >= 0 ? static_cast<long long>(ref[first_mismatch]) : -1LL);
+      throw std::runtime_error(msg);
+    }
+  }
+}
+
+template <typename CounterT>
+std::vector<thrust::host_vector<CounterT>>
+bench_snapshot_histograms(const std::vector<thrust::device_vector<CounterT>>& d_hists)
+{
+  std::vector<thrust::host_vector<CounterT>> out;
+  out.reserve(d_hists.size());
+  for (const auto& d : d_hists)
+  {
+    out.emplace_back(d);
+  }
+  return out;
+}
+
+// Verifier entry point for EVEN benches. Caller passes the strided pixel-
+// major sample buffer and the per-channel optimized histograms it has
+// already produced; this function builds a per-channel reference and
+// compares bin-by-bin.
+template <int NumChannels,
+          int NumActiveChannels,
+          typename SampleT,
+          typename CounterT,
+          typename OffsetT>
+void bench_verify_histogram_even(
+  const thrust::device_vector<SampleT>& d_input,
+  const std::vector<thrust::device_vector<CounterT>>& opt_hists_d,
+  OffsetT num_pixels,
+  int num_bins,
+  SampleT lower_level,
+  SampleT upper_level,
+  const char* bench_label)
+{
+  static_assert(NumActiveChannels >= 1 && NumActiveChannels <= NumChannels);
+
+  std::vector<thrust::device_vector<CounterT>> ref_hists_d(NumActiveChannels);
+  bench_ref_even_op<NumChannels, NumActiveChannels, SampleT, CounterT, OffsetT> op{};
+  op.d_input     = thrust::raw_pointer_cast(d_input.data());
+  op.num_pixels  = num_pixels;
+  op.num_bins    = num_bins;
+  op.lower_level = lower_level;
+  op.upper_level = upper_level;
+  for (int c = 0; c < NumActiveChannels; ++c)
+  {
+    ref_hists_d[c].assign(num_bins, CounterT{0});
+    op.d_hist[c] = thrust::raw_pointer_cast(ref_hists_d[c].data());
+  }
+
+  thrust::for_each(
+    thrust::counting_iterator<OffsetT>(0), thrust::counting_iterator<OffsetT>(num_pixels), op);
+  bench_check_cuda(cudaGetLastError(), "ref-even launch");
+  bench_check_cuda(cudaDeviceSynchronize(), "ref-even sync");
+
+  const auto opt_hists = bench_snapshot_histograms(opt_hists_d);
+  const auto ref_hists = bench_snapshot_histograms(ref_hists_d);
+  bench_compare_histograms(opt_hists, ref_hists, bench_label, NumActiveChannels);
+}
+
+template <int NumChannels,
+          int NumActiveChannels,
+          typename SampleT,
+          typename CounterT,
+          typename OffsetT>
+void bench_verify_histogram_range(
+  const thrust::device_vector<SampleT>& d_input,
+  const std::vector<thrust::device_vector<CounterT>>& opt_hists_d,
+  const std::vector<thrust::device_vector<SampleT>>& d_levels_per_channel,
+  OffsetT num_pixels,
+  const char* bench_label)
+{
+  static_assert(NumActiveChannels >= 1 && NumActiveChannels <= NumChannels);
+
+  const int num_levels = static_cast<int>(d_levels_per_channel[0].size());
+  const int num_bins   = num_levels - 1;
+
+  std::vector<thrust::device_vector<CounterT>> ref_hists_d(NumActiveChannels);
+  bench_ref_range_op<NumChannels, NumActiveChannels, SampleT, CounterT, OffsetT> op{};
+  op.d_input    = thrust::raw_pointer_cast(d_input.data());
+  op.num_pixels = num_pixels;
+  op.num_levels = num_levels;
+  for (int c = 0; c < NumActiveChannels; ++c)
+  {
+    ref_hists_d[c].assign(num_bins, CounterT{0});
+    op.d_hist[c]   = thrust::raw_pointer_cast(ref_hists_d[c].data());
+    op.d_levels[c] = thrust::raw_pointer_cast(d_levels_per_channel[c].data());
+  }
+
+  thrust::for_each(
+    thrust::counting_iterator<OffsetT>(0), thrust::counting_iterator<OffsetT>(num_pixels), op);
+  bench_check_cuda(cudaGetLastError(), "ref-range launch");
+  bench_check_cuda(cudaDeviceSynchronize(), "ref-range sync");
+
+  const auto opt_hists = bench_snapshot_histograms(opt_hists_d);
+  const auto ref_hists = bench_snapshot_histograms(ref_hists_d);
+  bench_compare_histograms(opt_hists, ref_hists, bench_label, NumActiveChannels);
 }

--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -161,11 +161,26 @@ inline bool bench_correctness_checks_enabled()
   return enabled;
 }
 
+// A correctness-check failure MUST end the trial in a hard runtime failure, not
+// a silent skip. nvbench catches a thrown std::exception from the benchmark body
+// and merely marks the measurement `Skipped: Yes`, then exits 0 -- which lets an
+// incorrect kernel "pass" by having its failing cells silently dropped from any
+// downstream aggregation. To make a wrong result unambiguously fatal, we print
+// the diagnostic to stderr and `std::abort()`, which terminates the process with
+// a non-zero status that nvbench cannot swallow. Legitimate, expected skips
+// (e.g. row-stride overflow) use `state.skip(...)` instead and are unaffected.
+[[noreturn]] inline void bench_fatal(const std::string& msg)
+{
+  std::fprintf(stderr, "FATAL %s\n", msg.c_str());
+  std::fflush(stderr);
+  std::abort();
+}
+
 inline void bench_check_cuda(cudaError_t e, const char* what)
 {
   if (e != cudaSuccess)
   {
-    throw std::runtime_error(std::string{"bench correctness check: "} + what + " -> " + cudaGetErrorString(e));
+    bench_fatal(std::string{"bench correctness check: "} + what + " -> " + cudaGetErrorString(e));
   }
 }
 
@@ -264,9 +279,9 @@ void bench_compare_histograms(
     const auto& ref = ref_hists[c];
     if (opt.size() != ref.size())
     {
-      throw std::runtime_error(std::string{"bench correctness check ["} + bench_label + "]: channel "
-                               + std::to_string(c) + " size mismatch: opt=" + std::to_string(opt.size())
-                               + " ref=" + std::to_string(ref.size()));
+      bench_fatal(std::string{"bench correctness check ["} + bench_label + "]: channel "
+                  + std::to_string(c) + " size mismatch: opt=" + std::to_string(opt.size())
+                  + " ref=" + std::to_string(ref.size()));
     }
     long long opt_total = 0;
     long long ref_total = 0;
@@ -295,7 +310,7 @@ void bench_compare_histograms(
         first_mismatch,
         first_mismatch >= 0 ? static_cast<long long>(opt[first_mismatch]) : -1LL,
         first_mismatch >= 0 ? static_cast<long long>(ref[first_mismatch]) : -1LL);
-      throw std::runtime_error(msg);
+      bench_fatal(msg);
     }
   }
 }

--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -71,6 +71,22 @@ struct bench_policy_selector
 };
 #endif // !TUNE_BASE
 
+// Lower bound of the bench's level range. For signed integer SampleT we use
+// `numeric_limits<SampleT>::min()` so the level range spans the full type;
+// previously `lower_level = 0` clipped half the range, forcing a skip on
+// configurations like int8_t with bins > 127 even though the type can hold
+// 256 distinct values. For unsigned integer and floating-point SampleT,
+// `lower_level = 0` is the natural choice.
+template <class SampleT>
+SampleT get_lower_level()
+{
+  if constexpr (cuda::std::is_integral_v<SampleT> && cuda::std::is_signed_v<SampleT>)
+  {
+    return ::cuda::std::numeric_limits<SampleT>::min();
+  }
+  return SampleT{0};
+}
+
 template <class SampleT, class OffsetT>
 SampleT get_upper_level(OffsetT bins, OffsetT elements)
 {
@@ -93,6 +109,26 @@ SampleT get_upper_level(OffsetT bins, OffsetT elements)
   }
 
   return static_cast<SampleT>(elements);
+}
+
+// Maximum number of bins that can be represented by SampleT levels in this
+// bench's `[get_lower_level<SampleT>(), get_upper_level<SampleT>(...)]` range.
+// For integer SampleT this caps at the count of distinct values the type can
+// hold (`max - min`); strict-monotonic level construction needs `bins + 1`
+// distinct values. For floating-point SampleT it's effectively unbounded.
+template <class SampleT>
+int64_t max_representable_bins()
+{
+  if constexpr (cuda::std::is_integral_v<SampleT> && sizeof(SampleT) < sizeof(int64_t))
+  {
+    return static_cast<int64_t>(::cuda::std::numeric_limits<SampleT>::max())
+         - static_cast<int64_t>(::cuda::std::numeric_limits<SampleT>::min());
+  }
+  // For int64_t (and any wider type that we may add later) the bins axis tops
+  // out at ~10^6, which is many orders of magnitude below the type's range, so
+  // the skip never triggers. Avoid the int64_t overflow that
+  // `max() - min() = 2^64 - 1` would produce.
+  return ::cuda::std::numeric_limits<int64_t>::max();
 }
 
 // Bench-side correctness checks that compare the CUB histogram result

--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -279,9 +279,8 @@ void bench_compare_histograms(
     const auto& ref = ref_hists[c];
     if (opt.size() != ref.size())
     {
-      bench_fatal(std::string{"bench correctness check ["} + bench_label + "]: channel "
-                  + std::to_string(c) + " size mismatch: opt=" + std::to_string(opt.size())
-                  + " ref=" + std::to_string(ref.size()));
+      bench_fatal(std::string{"bench correctness check ["} + bench_label + "]: channel " + std::to_string(c)
+                  + " size mismatch: opt=" + std::to_string(opt.size()) + " ref=" + std::to_string(ref.size()));
     }
     long long opt_total = 0;
     long long ref_total = 0;
@@ -332,11 +331,7 @@ bench_snapshot_histograms(const std::vector<thrust::device_vector<CounterT>>& d_
 // major sample buffer and the per-channel optimized histograms it has
 // already produced; this function builds a per-channel reference and
 // compares bin-by-bin.
-template <int NumChannels,
-          int NumActiveChannels,
-          typename SampleT,
-          typename CounterT,
-          typename OffsetT>
+template <int NumChannels, int NumActiveChannels, typename SampleT, typename CounterT, typename OffsetT>
 void bench_verify_histogram_even(
   const thrust::device_vector<SampleT>& d_input,
   const std::vector<thrust::device_vector<CounterT>>& opt_hists_d,
@@ -361,8 +356,7 @@ void bench_verify_histogram_even(
     op.d_hist[c] = thrust::raw_pointer_cast(ref_hists_d[c].data());
   }
 
-  thrust::for_each(
-    thrust::counting_iterator<OffsetT>(0), thrust::counting_iterator<OffsetT>(num_pixels), op);
+  thrust::for_each(thrust::counting_iterator<OffsetT>(0), thrust::counting_iterator<OffsetT>(num_pixels), op);
   bench_check_cuda(cudaGetLastError(), "ref-even launch");
   bench_check_cuda(cudaDeviceSynchronize(), "ref-even sync");
 
@@ -371,11 +365,7 @@ void bench_verify_histogram_even(
   bench_compare_histograms(opt_hists, ref_hists, bench_label, NumActiveChannels);
 }
 
-template <int NumChannels,
-          int NumActiveChannels,
-          typename SampleT,
-          typename CounterT,
-          typename OffsetT>
+template <int NumChannels, int NumActiveChannels, typename SampleT, typename CounterT, typename OffsetT>
 void bench_verify_histogram_range(
   const thrust::device_vector<SampleT>& d_input,
   const std::vector<thrust::device_vector<CounterT>>& opt_hists_d,
@@ -400,8 +390,7 @@ void bench_verify_histogram_range(
     op.d_levels[c] = thrust::raw_pointer_cast(d_levels_per_channel[c].data());
   }
 
-  thrust::for_each(
-    thrust::counting_iterator<OffsetT>(0), thrust::counting_iterator<OffsetT>(num_pixels), op);
+  thrust::for_each(thrust::counting_iterator<OffsetT>(0), thrust::counting_iterator<OffsetT>(num_pixels), op);
   bench_check_cuda(cudaGetLastError(), "ref-range launch");
   bench_check_cuda(cudaDeviceSynchronize(), "ref-range sync");
 

--- a/cub/benchmarks/bench/histogram/histogram_input_characterization.py
+++ b/cub/benchmarks/bench/histogram/histogram_input_characterization.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: BSD-3
+"""Characterization plots for the CUB histogram benchmark InputShapes.
+
+For every InputShape (see `histogram_inputs.cuh`), draw what the input actually
+looks like, straight from the SOURCE OF TRUTH generators in
+`histogram_input_design.py` (the bit-exact host mirror of the .cuh). One figure
+per shape, three panels each:
+
+  1. value distribution  -- count vs bin index, on a LOG y-axis with a stem per
+     occupied bin. The earlier linear count-vs-index plot made these look empty:
+     a single hot bin is one sub-pixel-wide spike among thousands of bins, and a
+     decaying tail (counts 1..100) is crushed flat under a ~N-tall spike. Log-y
+     stems show both the spike(s) AND the floor; the hottest bins are annotated
+     with their real index (so e.g. `concentrated:0.0`'s hot bin reads as
+     "bin 42", which is `seed % num_bins` -- deliberately scattered off zero --
+     not "empty at zero").
+  2. rank-frequency       -- sorted count vs rank, log-log. Scale-free: a
+     power law is a straight line, Zipf a line of slope ~-1, a single hot bin one
+     point above an empty floor, hash_synonym a few high points over a flat
+     plateau. This panel reveals the distribution's shape regardless of bin
+     count, so it never "looks empty".
+  3. position of values   -- bin index vs position in the input sequence
+     (subsampled). i.i.d. shapes smear vertically over their occupied bins;
+     ORDERING shapes show their structure here (temporal_phases steps, stale's
+     cold prefix then a flat hot tail, the sawtooth's ramp-and-reset).
+
+This is the standalone characterization generator AND the home of the shared
+draw_* functions reused by `histogram_algo_perf.py` for its top-row context.
+
+Run with a Python that has numpy + matplotlib, e.g.:
+  python histogram_input_characterization.py --outdir histogram_input_figs
+"""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import os
+import sys
+import textwrap
+
+import numpy as np
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import histogram_input_design as D  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Shapes + human-readable blurbs. Mirrors the catalog in histogram_inputs.cuh.
+# ---------------------------------------------------------------------------
+SHAPES = [
+    "concentrated:1.0",
+    "concentrated:0.75",
+    "concentrated:0.5",
+    "concentrated:0.25",
+    "concentrated:0.0",
+    "powerlaw:0.75",
+    "powerlaw:0.5",
+    "powerlaw:0.25",
+    "zipf",
+    "temporal_phases",
+    "stale_resident",
+    "hash_synonym",
+    "sawtooth",
+]
+
+SHAPE_BLURB = {
+    "concentrated:1.0": "uniform endpoint (entropy 1.0): exact equal counts per bin, in random sequence order "
+    "(a Feistel shuffle of the tiling) — uniform counts, randomly distributed",
+    "concentrated:0.75": "entropy 0.75: random bin probabilities (softmax over random logits) — MOSTLY uniform, mild variation",
+    "concentrated:0.5": "entropy 0.5 (bare `concentrated` default): random bin probabilities dialed to medium entropy",
+    "concentrated:0.25": "entropy 0.25: random bin probabilities, now strongly skewed toward a few bins",
+    "concentrated:0.0": "single value (entropy 0.0): 100% on one bin, scattered to seed%bins (NOT bin 0)",
+    "powerlaw:0.75": "power-law warm set (entropy 0.75): gentle 1/rank^s decay over many bins",
+    "powerlaw:0.5": "power-law warm set (entropy 0.5): one dominant bin + a decaying tail",
+    "powerlaw:0.25": "power-law warm set (entropy 0.25): steep decay, a few bins dominate",
+    "zipf": "Zipf warm set: many hot bins, classic 1/rank decay (rank-frequency is ~a straight log-log line)",
+    "temporal_phases": "the hot bin steps to a new location each phase (multiple hot bins across the sequence)",
+    "stale_resident": "a cold working set (~2x cache slots) swept cyclically: recurs every block but overflows the "
+    "per-block cache so it cannot stay resident (thrashes it)",
+    "hash_synonym": "several bins spaced by the cache slot count (4096) collide on ONE cache slot, over a floor",
+    "sawtooth": "bin(i)=i%period: a monotonic ramp that resets periodically (sequential locality, bounded working set)",
+}
+
+# Characterization sample size. These are illustrative inputs, not the multi-GB
+# benchmark inputs.
+CHAR_N = 1_000_000
+CHAR_SEQ_SAMPLES = 4000
+CHAR_SEED = 42
+
+# Bin count is PER SHAPE, drawn at the shape's natural scale (the original design
+# figures did the same). Two reasons it must not be one global value:
+#  * the i.i.d. distribution shapes put their hot bin at seed % num_bins (= 42).
+#    At 16384 bins that is 0.3% from the left edge and reads as "pinned to 0";
+#    at a few hundred bins it sits visibly off zero where it belongs.
+#  * the cache-adversarial shapes are defined RELATIVE TO the 4096-slot SMEM
+#    cache, so their structure only appears for bins > 4096 (hash_synonym needs
+#    >= ~12289 to show its 4096-spaced synonyms; stale_resident a 4096 prefix).
+CHAR_BINS_DEFAULT = 16384
+CHAR_BINS_BY_SHAPE = {
+    "concentrated": 256,      # hot bin at 42 clearly off zero; floor legible
+    "powerlaw": 256,
+    "zipf": 256,
+    "temporal_phases": 256,   # the 8 phase locations are distinct
+    "sawtooth": 256,          # several ramp periods visible
+    "hash_synonym": 16384,    # synonyms at 42 / 4138 / 8234 / 12330 (spaced 4096)
+    "stale_resident": 8192,   # 4096-bin cold prefix + a hot bulk
+}
+
+
+def bins_for_shape(shape: str) -> int:
+    """The bin count this shape is characterized at (keyed by name, ignoring knob)."""
+    return CHAR_BINS_BY_SHAPE.get(shape.split(":")[0], CHAR_BINS_DEFAULT)
+
+
+def fmt_bins(b: int) -> str:
+    b = int(b)
+    return f"{b // 1024}K" if b >= 1024 and b % 1024 == 0 else str(b)
+
+DIST_COLOR = "#2b8cbe"
+RANK_COLOR = "#6a51a3"
+SEQ_COLOR = "#cb181d"
+
+
+def fmt_int(v: int) -> str:
+    return f"{int(v):,}"
+
+
+@functools.lru_cache(maxsize=None)
+def _counts_cached(shape: str, n: int, num_bins: int, seed: int):
+    """(bins, counts) for a shape. Cached so the perf script's 64 composites
+    regenerate each shape's input only once."""
+    bins = np.asarray(D.generate_bins(shape, n, num_bins, seed=seed), dtype=np.int64)
+    counts = np.bincount(bins, minlength=num_bins).astype(np.int64)
+    return bins, counts
+
+
+def char_input(shape: str, n: int = CHAR_N, num_bins: int | None = None, seed: int = CHAR_SEED):
+    """(bins, counts, num_bins) for a shape, at its natural per-shape bin count."""
+    if num_bins is None:
+        num_bins = bins_for_shape(shape)
+    bins, counts = _counts_cached(shape, n, num_bins, seed)
+    return bins, counts, num_bins
+
+
+# ---------------------------------------------------------------------------
+# Shared draw_* functions (reused by histogram_algo_perf.py).
+# ---------------------------------------------------------------------------
+
+def draw_distribution(ax, counts, num_bins):
+    """count vs bin index on a log y-axis, one stem per occupied bin.
+
+    Robust to the spiky, wide distributions here: a lone hot bin shows as a tall
+    stem with a marker (never sub-pixel-invisible), and a low floor shows as a
+    band well above the axis floor instead of being crushed to zero."""
+    nz = np.flatnonzero(counts)
+    if nz.size == 0:
+        ax.text(0.5, 0.5, "no samples", ha="center", va="center", transform=ax.transAxes)
+        return
+    cmax = int(counts[nz].max())
+    base = 0.7  # < 1 so a count of 1 still draws a short stem on the log axis
+    ax.set_yscale("log")
+    # Thin stems when nearly every bin is occupied (uniform / sawtooth),
+    # thicker when there are a few discrete spikes.
+    dense = nz.size > 2000
+    ax.vlines(nz, base, counts[nz], color=DIST_COLOR, lw=0.5 if dense else 1.6, alpha=0.9)
+    ax.scatter(nz, counts[nz], s=8 if dense else 22, color=DIST_COLOR, zorder=3, edgecolors="none")
+
+    ax.set_title(f"value distribution (count vs bin index, {fmt_bins(num_bins)} bins, log y)", fontsize=10)
+    ax.set_xlabel("bin index")
+    ax.set_ylabel("count (log)")
+    ax.set_xlim(-num_bins * 0.02, num_bins * 1.02)
+    ax.set_ylim(base, cmax * 2.5)
+    ax.grid(axis="y", which="both", linestyle=":", alpha=0.45)
+
+
+def draw_rankfreq(ax, counts):
+    """Sorted count vs rank, log-log. Scale-free view of the distribution shape."""
+    c = np.sort(counts[counts > 0])[::-1]
+    if c.size == 0:
+        ax.text(0.5, 0.5, "no samples", ha="center", va="center", transform=ax.transAxes)
+        return
+    ranks = np.arange(1, c.size + 1)
+    ax.loglog(ranks, c, marker=".", ms=4, lw=1.1, color=RANK_COLOR)
+    ax.set_title(f"rank-frequency (sorted count vs rank, log-log) — {c.size} occupied bins", fontsize=10)
+    ax.set_xlabel("rank (hottest = 1)")
+    ax.set_ylabel("count")
+    ax.grid(True, which="both", linestyle=":", alpha=0.45)
+
+
+# Shapes whose interesting sequence structure lives at the WHOLE-sequence scale
+# (e.g. the hot bin steps across the full input), so the panel must span all N.
+# Everything else is shown as a CONTIGUOUS prefix: a periodic shape (sawtooth, the
+# stale_resident cycle) aliases into garbage if you linspace-subsample N points at
+# a period that divides the step, but a contiguous window never aliases and shows
+# the true ramp/cycle. For i.i.d. shapes a contiguous window is just as
+# representative as a random subsample.
+_FULL_RANGE_SEQ_SHAPES = {"temporal_phases"}
+
+
+def draw_sequence(ax, bins, num_bins, shape=None):
+    """bin index vs position in the input sequence."""
+    n = len(bins)
+    full_range = shape is not None and shape.split(":")[0] in _FULL_RANGE_SEQ_SHAPES
+    if full_range:
+        idx = np.linspace(0, n - 1, CHAR_SEQ_SAMPLES).astype(np.int64) if n > CHAR_SEQ_SAMPLES else np.arange(n)
+        xlabel = "position in input sequence (full range, subsampled)"
+    else:
+        w = min(n, CHAR_SEQ_SAMPLES)
+        idx = np.arange(w)  # contiguous prefix — never aliases periodic shapes
+        xlabel = f"position in input sequence (first {w:,})"
+    ax.scatter(idx, bins[idx], s=5, alpha=0.45, color=SEQ_COLOR, edgecolors="none")
+    ax.set_title("position of values (bin index vs position in sequence)", fontsize=10)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel("bin index")
+    ax.set_ylim(-num_bins * 0.02, num_bins * 1.02)
+    ax.grid(axis="y", linestyle=":", alpha=0.4)
+
+
+# ---------------------------------------------------------------------------
+# Standalone per-shape characterization figure.
+# ---------------------------------------------------------------------------
+
+def render_shape(shape, outdir, n, num_bins, seed):
+    bins, counts, num_bins = char_input(shape, n, num_bins, seed)
+    fig, axes = plt.subplots(1, 3, figsize=(18, 4.8))
+    # Wrap the blurb so a long description does not run past the figure edge.
+    blurb = "\n".join(textwrap.wrap(f"InputShape: {shape}   —   {SHAPE_BLURB.get(shape, '')}", width=150))
+    fig.suptitle(
+        f"{blurb}\n(N={fmt_int(n)} samples, {fmt_bins(num_bins)} bins, seed={seed})",
+        fontsize=12,
+    )
+    draw_distribution(axes[0], counts, num_bins)
+    draw_rankfreq(axes[1], counts)
+    draw_sequence(axes[2], bins, num_bins, shape=shape)
+    fig.tight_layout(rect=(0, 0, 1, 0.88))
+    out = os.path.join(outdir, f"{shape.replace(':', '_')}.png")
+    fig.savefig(out, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    return out, num_bins, int(np.count_nonzero(counts)), int(counts.max())
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--outdir", default="histogram_input_figs", help="output directory for the per-shape PNGs")
+    ap.add_argument("--elements", type=int, default=CHAR_N, help="number of samples to characterize")
+    ap.add_argument("--bins", type=int, default=None,
+                    help="override the per-shape bin count (default: each shape's natural scale)")
+    ap.add_argument("--seed", type=int, default=CHAR_SEED, help="generator seed")
+    ap.add_argument("--shapes", nargs="*", default=SHAPES, help="subset of InputShapes to render")
+    args = ap.parse_args()
+
+    os.makedirs(args.outdir, exist_ok=True)
+    print(f"Characterizing {len(args.shapes)} shapes (N={fmt_int(args.elements)}, seed={args.seed})")
+    for shape in args.shapes:
+        out, nb, occupied, hottest = render_shape(shape, args.outdir, args.elements, args.bins, args.seed)
+        print(f"  {shape:<20} bins={fmt_bins(nb):<5} occupied={occupied:<6} hottest={fmt_int(hottest):<12} -> {out}")
+    print(f"Done. {len(args.shapes)} figures under {args.outdir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cub/benchmarks/bench/histogram/histogram_input_characterization.py
+++ b/cub/benchmarks/bench/histogram/histogram_input_characterization.py
@@ -41,9 +41,8 @@ import os
 import sys
 import textwrap
 
-import numpy as np
-
 import matplotlib
+import numpy as np
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
@@ -104,13 +103,13 @@ CHAR_SEED = 42
 #    >= ~12289 to show its 4096-spaced synonyms; stale_resident a 4096 prefix).
 CHAR_BINS_DEFAULT = 16384
 CHAR_BINS_BY_SHAPE = {
-    "concentrated": 256,      # hot bin at 42 clearly off zero; floor legible
+    "concentrated": 256,  # hot bin at 42 clearly off zero; floor legible
     "powerlaw": 256,
     "zipf": 256,
-    "temporal_phases": 256,   # the 8 phase locations are distinct
-    "sawtooth": 256,          # several ramp periods visible
-    "hash_synonym": 16384,    # synonyms at 42 / 4138 / 8234 / 12330 (spaced 4096)
-    "stale_resident": 8192,   # 4096-bin cold prefix + a hot bulk
+    "temporal_phases": 256,  # the 8 phase locations are distinct
+    "sawtooth": 256,  # several ramp periods visible
+    "hash_synonym": 16384,  # synonyms at 42 / 4138 / 8234 / 12330 (spaced 4096)
+    "stale_resident": 8192,  # 4096-bin cold prefix + a hot bulk
 }
 
 
@@ -122,6 +121,7 @@ def bins_for_shape(shape: str) -> int:
 def fmt_bins(b: int) -> str:
     b = int(b)
     return f"{b // 1024}K" if b >= 1024 and b % 1024 == 0 else str(b)
+
 
 DIST_COLOR = "#2b8cbe"
 RANK_COLOR = "#6a51a3"
@@ -141,7 +141,9 @@ def _counts_cached(shape: str, n: int, num_bins: int, seed: int):
     return bins, counts
 
 
-def char_input(shape: str, n: int = CHAR_N, num_bins: int | None = None, seed: int = CHAR_SEED):
+def char_input(
+    shape: str, n: int = CHAR_N, num_bins: int | None = None, seed: int = CHAR_SEED
+):
     """(bins, counts, num_bins) for a shape, at its natural per-shape bin count."""
     if num_bins is None:
         num_bins = bins_for_shape(shape)
@@ -153,6 +155,7 @@ def char_input(shape: str, n: int = CHAR_N, num_bins: int | None = None, seed: i
 # Shared draw_* functions (reused by histogram_algo_perf.py).
 # ---------------------------------------------------------------------------
 
+
 def draw_distribution(ax, counts, num_bins):
     """count vs bin index on a log y-axis, one stem per occupied bin.
 
@@ -161,7 +164,9 @@ def draw_distribution(ax, counts, num_bins):
     band well above the axis floor instead of being crushed to zero."""
     nz = np.flatnonzero(counts)
     if nz.size == 0:
-        ax.text(0.5, 0.5, "no samples", ha="center", va="center", transform=ax.transAxes)
+        ax.text(
+            0.5, 0.5, "no samples", ha="center", va="center", transform=ax.transAxes
+        )
         return
     cmax = int(counts[nz].max())
     base = 0.7  # < 1 so a count of 1 still draws a short stem on the log axis
@@ -169,10 +174,22 @@ def draw_distribution(ax, counts, num_bins):
     # Thin stems when nearly every bin is occupied (uniform / sawtooth),
     # thicker when there are a few discrete spikes.
     dense = nz.size > 2000
-    ax.vlines(nz, base, counts[nz], color=DIST_COLOR, lw=0.5 if dense else 1.6, alpha=0.9)
-    ax.scatter(nz, counts[nz], s=8 if dense else 22, color=DIST_COLOR, zorder=3, edgecolors="none")
+    ax.vlines(
+        nz, base, counts[nz], color=DIST_COLOR, lw=0.5 if dense else 1.6, alpha=0.9
+    )
+    ax.scatter(
+        nz,
+        counts[nz],
+        s=8 if dense else 22,
+        color=DIST_COLOR,
+        zorder=3,
+        edgecolors="none",
+    )
 
-    ax.set_title(f"value distribution (count vs bin index, {fmt_bins(num_bins)} bins, log y)", fontsize=10)
+    ax.set_title(
+        f"value distribution (count vs bin index, {fmt_bins(num_bins)} bins, log y)",
+        fontsize=10,
+    )
     ax.set_xlabel("bin index")
     ax.set_ylabel("count (log)")
     ax.set_xlim(-num_bins * 0.02, num_bins * 1.02)
@@ -184,11 +201,16 @@ def draw_rankfreq(ax, counts):
     """Sorted count vs rank, log-log. Scale-free view of the distribution shape."""
     c = np.sort(counts[counts > 0])[::-1]
     if c.size == 0:
-        ax.text(0.5, 0.5, "no samples", ha="center", va="center", transform=ax.transAxes)
+        ax.text(
+            0.5, 0.5, "no samples", ha="center", va="center", transform=ax.transAxes
+        )
         return
     ranks = np.arange(1, c.size + 1)
     ax.loglog(ranks, c, marker=".", ms=4, lw=1.1, color=RANK_COLOR)
-    ax.set_title(f"rank-frequency (sorted count vs rank, log-log) — {c.size} occupied bins", fontsize=10)
+    ax.set_title(
+        f"rank-frequency (sorted count vs rank, log-log) — {c.size} occupied bins",
+        fontsize=10,
+    )
     ax.set_xlabel("rank (hottest = 1)")
     ax.set_ylabel("count")
     ax.grid(True, which="both", linestyle=":", alpha=0.45)
@@ -209,7 +231,11 @@ def draw_sequence(ax, bins, num_bins, shape=None):
     n = len(bins)
     full_range = shape is not None and shape.split(":")[0] in _FULL_RANGE_SEQ_SHAPES
     if full_range:
-        idx = np.linspace(0, n - 1, CHAR_SEQ_SAMPLES).astype(np.int64) if n > CHAR_SEQ_SAMPLES else np.arange(n)
+        idx = (
+            np.linspace(0, n - 1, CHAR_SEQ_SAMPLES).astype(np.int64)
+            if n > CHAR_SEQ_SAMPLES
+            else np.arange(n)
+        )
         xlabel = "position in input sequence (full range, subsampled)"
     else:
         w = min(n, CHAR_SEQ_SAMPLES)
@@ -227,11 +253,16 @@ def draw_sequence(ax, bins, num_bins, shape=None):
 # Standalone per-shape characterization figure.
 # ---------------------------------------------------------------------------
 
+
 def render_shape(shape, outdir, n, num_bins, seed):
     bins, counts, num_bins = char_input(shape, n, num_bins, seed)
     fig, axes = plt.subplots(1, 3, figsize=(18, 4.8))
     # Wrap the blurb so a long description does not run past the figure edge.
-    blurb = "\n".join(textwrap.wrap(f"InputShape: {shape}   —   {SHAPE_BLURB.get(shape, '')}", width=150))
+    blurb = "\n".join(
+        textwrap.wrap(
+            f"InputShape: {shape}   —   {SHAPE_BLURB.get(shape, '')}", width=150
+        )
+    )
     fig.suptitle(
         f"{blurb}\n(N={fmt_int(n)} samples, {fmt_bins(num_bins)} bins, seed={seed})",
         fontsize=12,
@@ -247,20 +278,40 @@ def render_shape(shape, outdir, n, num_bins, seed):
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--outdir", default="histogram_input_figs", help="output directory for the per-shape PNGs")
-    ap.add_argument("--elements", type=int, default=CHAR_N, help="number of samples to characterize")
-    ap.add_argument("--bins", type=int, default=None,
-                    help="override the per-shape bin count (default: each shape's natural scale)")
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--outdir",
+        default="histogram_input_figs",
+        help="output directory for the per-shape PNGs",
+    )
+    ap.add_argument(
+        "--elements", type=int, default=CHAR_N, help="number of samples to characterize"
+    )
+    ap.add_argument(
+        "--bins",
+        type=int,
+        default=None,
+        help="override the per-shape bin count (default: each shape's natural scale)",
+    )
     ap.add_argument("--seed", type=int, default=CHAR_SEED, help="generator seed")
-    ap.add_argument("--shapes", nargs="*", default=SHAPES, help="subset of InputShapes to render")
+    ap.add_argument(
+        "--shapes", nargs="*", default=SHAPES, help="subset of InputShapes to render"
+    )
     args = ap.parse_args()
 
     os.makedirs(args.outdir, exist_ok=True)
-    print(f"Characterizing {len(args.shapes)} shapes (N={fmt_int(args.elements)}, seed={args.seed})")
+    print(
+        f"Characterizing {len(args.shapes)} shapes (N={fmt_int(args.elements)}, seed={args.seed})"
+    )
     for shape in args.shapes:
-        out, nb, occupied, hottest = render_shape(shape, args.outdir, args.elements, args.bins, args.seed)
-        print(f"  {shape:<20} bins={fmt_bins(nb):<5} occupied={occupied:<6} hottest={fmt_int(hottest):<12} -> {out}")
+        out, nb, occupied, hottest = render_shape(
+            shape, args.outdir, args.elements, args.bins, args.seed
+        )
+        print(
+            f"  {shape:<20} bins={fmt_bins(nb):<5} occupied={occupied:<6} hottest={fmt_int(hottest):<12} -> {out}"
+        )
     print(f"Done. {len(args.shapes)} figures under {args.outdir}")
 
 

--- a/cub/benchmarks/bench/histogram/histogram_input_design.py
+++ b/cub/benchmarks/bench/histogram/histogram_input_design.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Bit-exact Python mirror of the CUB histogram input-shape generators.
+
+SOURCE OF TRUTH: cub/benchmarks/bench/histogram/histogram_inputs.cuh (on `main`).
+This module is a faithful host-side port of that header, NOT an independent
+design sketch. Every shape, knob, default, and the RNG/scatter math below mirror
+the C++ exactly, so the bin indices produced here equal what the benchmark
+produces on device for the same (shape, n, num_bins, seed). Keep them in sync:
+if the .cuh changes, update this file.
+
+The C++ replaced the legacy bitwise-AND "entropy" knob with a tunable
+`InputShape` axis whose values are `name[:knob]`. There is ONE `concentrated`
+shape spanning uniform<->constant via its entropy knob (no separate
+uniform/constant/spike names), plus multi-hot (powerlaw/zipf) and
+cache-adversarial (hash_synonym/stale_resident) and ordering
+(temporal_phases/strided_sweep/sawtooth) shapes.
+
+Mechanism mirrored from the header:
+  * Every shape decides a per-element BIN index in [0, num_bins); a bin->value
+    mapper then emits a SampleT in the bin's interval (EVEN: midpoint; RANGE:
+    level-interval midpoint). CUB re-derives the bin, so the in-bench verifier
+    validates the mapping.
+  * i.i.d. distribution shapes: build a host pmf -> inclusive CDF -> per element
+    draw u01_from_hash(element_key(i, seed)) and upper_bound_cdf into a bin.
+  * ordering shapes (stale_resident/temporal_phases/strided_sweep): positional
+    functors, order is intrinsic.
+  * the concentrated uniform endpoint (knob>=1.0) is an exact equal-count tiling
+    bin(i)=i%num_bins (sequential, NOT shuffled).
+  * hot bins are scattered off zero via scatter_bin (a fixed coprime
+    permutation seeded by seed%num_bins), so the mode is never bin 0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Constants — mirror histogram_inputs.cuh exactly.
+# ---------------------------------------------------------------------------
+K_ADVERSARIAL_CACHE_SLOTS = 4096           # kAdversarialCacheSlots
+K_HASH_SYNONYM_COUNT      = 32             # kHashSynonymCount
+K_SCATTER_PRIME           = 2147483647     # kScatterPrime (2^31 - 1)
+
+DEFAULT_CONCENTRATED_ENTROPY = 0.5         # bare "concentrated"
+DEFAULT_POWERLAW_ENTROPY     = 0.5         # bare "powerlaw"
+DEFAULT_ZIPF_EXPONENT        = 1.0         # bare "zipf"
+DEFAULT_HASH_SYNONYM_HOTSHARE = 0.9        # bare "hash_synonym"
+DEFAULT_TEMPORAL_PHASES      = 8           # bare "temporal_phases"
+DEFAULT_STRIDED_STRIDE       = 9973        # bare "strided_sweep"
+DEFAULT_SAWTOOTH_PERIOD      = 0           # bare "sawtooth" => period == num_bins
+
+_U64 = np.uint64
+_MASK64 = (1 << 64) - 1
+
+
+# ---------------------------------------------------------------------------
+# Bit-exact RNG / index helpers (splitmix64 + LCG decorrelation), mirroring the
+# __host__ __device__ inline functions in the header. All arithmetic is done in
+# explicit uint64 with wraparound so results match the C++ byte-for-byte.
+# ---------------------------------------------------------------------------
+
+def u01_from_hash(x: np.ndarray | int) -> np.ndarray:
+    """Port of u01_from_hash: splitmix64 finalizer -> double in [0, 1)."""
+    x = np.asarray(x, dtype=_U64)
+    with np.errstate(over="ignore"):
+        x = x + _U64(0x9E3779B97F4A7C15)
+        x = (x ^ (x >> _U64(30))) * _U64(0xBF58476D1CE4E5B9)
+        x = (x ^ (x >> _U64(27))) * _U64(0x94D049BB133111EB)
+        x = x ^ (x >> _U64(31))
+    return (x >> _U64(11)).astype(np.float64) * (1.0 / 9007199254740992.0)  # 2^53
+
+
+def element_key(i: np.ndarray | int, seed: int) -> np.ndarray:
+    """Port of element_key: i*6364136223846793005 + 1442695040888963407 + seed*phi."""
+    i = np.asarray(i, dtype=_U64)
+    with np.errstate(over="ignore"):
+        return (i * _U64(6364136223846793005)
+                + _U64(1442695040888963407)
+                + _U64(seed & _MASK64) * _U64(0x9E3779B97F4A7C15))
+
+
+def scatter_bin(rank: int, num_bins: int, offset: int) -> int:
+    """Port of scatter_bin: (rank*kScatterPrime + offset) % num_bins, in uint64."""
+    return int((( (rank & _MASK64) * K_SCATTER_PRIME + offset) & _MASK64) % num_bins)
+
+
+def _feistel_mix(x: np.ndarray, k: int) -> np.ndarray:
+    """Port of feistel_mix: splitmix64-style round function (uint64 wraparound)."""
+    with np.errstate(over="ignore"):
+        z = x + _U64(k & _MASK64) + _U64(0x9E3779B97F4A7C15)
+        z = (z ^ (z >> _U64(30))) * _U64(0xBF58476D1CE4E5B9)
+        z = (z ^ (z >> _U64(27))) * _U64(0x94D049BB133111EB)
+        return z ^ (z >> _U64(31))
+
+
+def permute_index(i: np.ndarray, n: int, seed: int) -> np.ndarray:
+    """Port of permute_index: a keyed pseudo-random bijection on [0, n) via a
+    4-round balanced Feistel network with cycle-walking. Vectorized over `i`;
+    bit-for-bit identical to the device functor (same half-width, mask, rounds,
+    round keys, and mixing constants)."""
+    i = np.asarray(i, dtype=_U64)
+    if n <= 1:
+        return np.zeros_like(i)
+    bits = int(n - 1).bit_length()          # ceil(log2(n)) for n >= 2
+    half = (bits + 1) // 2
+    mask = _MASK64 if half >= 64 else ((1 << half) - 1)
+    mask = _U64(mask)
+    hh = _U64(half)
+    x = i.copy()
+    todo = np.ones(x.shape, dtype=bool)
+    with np.errstate(over="ignore"):
+        for _ in range(128):                # cycle-walk; expected < 4 iters
+            xs = x[todo]
+            l = (xs >> hh) & mask
+            r = xs & mask
+            for rnd in range(4):
+                nl = r
+                nr = l ^ (_feistel_mix(r, seed + rnd) & mask)
+                l, r = nl, nr
+            x[todo] = (l << hh) | r
+            todo = x >= _U64(n)
+            if not todo.any():
+                break
+    return x
+
+
+def _scatter_bin_vec(ranks: np.ndarray, num_bins: int, offset: int) -> np.ndarray:
+    r = ranks.astype(object)  # python big-ints to avoid overflow before mod
+    return np.array([(int(x) * K_SCATTER_PRIME + offset) % num_bins for x in r], dtype=np.int64)
+
+
+# ---------------------------------------------------------------------------
+# Spec + parse — mirror ShapeSpec / parse_input_shape / knob_or.
+# ---------------------------------------------------------------------------
+
+VALID_SHAPES = {
+    "concentrated", "powerlaw", "zipf", "hash_synonym",
+    "stale_resident", "temporal_phases", "strided_sweep",
+    "sawtooth",
+}
+
+
+@dataclass
+class ShapeSpec:
+    shape: str
+    knob: float = 0.0
+    has_knob: bool = False
+
+
+def parse_input_shape(spec: str) -> ShapeSpec:
+    """Port of parse_input_shape: "name" or "name:knob"."""
+    name = spec
+    knob = 0.0
+    has_knob = False
+    if ":" in spec:
+        name, knob_s = spec.split(":", 1)
+        knob = float(knob_s)
+        has_knob = True
+    if name not in VALID_SHAPES:
+        raise ValueError(f"Unknown InputShape: {spec}")
+    return ShapeSpec(shape=name, knob=knob, has_knob=has_knob)
+
+
+def knob_or(spec: ShapeSpec, default_value: float) -> float:
+    return spec.knob if spec.has_knob else default_value
+
+
+# ---------------------------------------------------------------------------
+# pmf math — mirror normalized_entropy / ranked_powerlaw / solvers.
+# ---------------------------------------------------------------------------
+
+def normalized_entropy(pmf: np.ndarray) -> float:
+    if len(pmf) <= 1:
+        return 0.0
+    p = pmf[pmf > 0]
+    return float(-(p * np.log2(p)).sum() / np.log2(len(pmf)))
+
+
+def ranked_powerlaw(num_bins: int, s: float) -> np.ndarray:
+    w = np.arange(1, num_bins + 1, dtype=np.float64) ** (-s)
+    return w / w.sum()
+
+
+def solve_powerlaw_exponent(num_bins: int, target: float) -> float:
+    """Bisection mirror: 60 iters, [0, 60], entropy decreasing in s."""
+    lo, hi = 0.0, 60.0
+    for _ in range(60):
+        mid = 0.5 * (lo + hi)
+        if normalized_entropy(ranked_powerlaw(num_bins, mid)) < target:
+            hi = mid
+        else:
+            lo = mid
+    return 0.5 * (lo + hi)
+
+
+def softmax_logits(num_bins: int, seed: int) -> np.ndarray:
+    """Per-bin standard-normal logits (Box-Muller on two hashed uniforms),
+    mirroring softmax_logits() in the header."""
+    b = np.arange(num_bins, dtype=_U64)
+    u1 = u01_from_hash(element_key(b, seed))
+    u2 = u01_from_hash(element_key(b, seed ^ 0xD1B54A32D192ED03))
+    u1 = np.where(u1 > 0.0, u1, 1e-300)
+    return np.sqrt(-2.0 * np.log(u1)) * np.cos(2.0 * np.pi * u2)
+
+
+def softmax_pmf(g: np.ndarray, T: float) -> np.ndarray:
+    z = (g - g.max()) / T
+    e = np.exp(z)
+    return e / e.sum()
+
+
+def solve_softmax_pmf(num_bins: int, target: float, seed: int) -> np.ndarray:
+    """Softmax over random logits, temperature bisected in log-space to hit the
+    target normalized entropy (entropy increases with T). Mirrors the header."""
+    g = softmax_logits(num_bins, seed)
+    lo, hi = 1e-3, 1e3
+    for _ in range(80):
+        mid = (lo * hi) ** 0.5
+        if normalized_entropy(softmax_pmf(g, mid)) < target:
+            lo = mid
+        else:
+            hi = mid
+    return softmax_pmf(g, (lo * hi) ** 0.5)
+
+
+# ---------------------------------------------------------------------------
+# build_pmf — mirror the C++ switch exactly (i.i.d. distribution shapes).
+# ---------------------------------------------------------------------------
+
+def build_pmf(spec: ShapeSpec, num_bins: int, seed: int) -> np.ndarray:
+    pmf = np.zeros(num_bins, dtype=np.float64)
+    offset = seed % num_bins
+
+    if spec.shape == "concentrated":
+        target = knob_or(spec, DEFAULT_CONCENTRATED_ENTROPY)
+        if target >= 1.0:
+            pmf[:] = 1.0 / num_bins
+        elif target <= 0.0:
+            pmf[scatter_bin(0, num_bins, offset)] = 1.0
+        else:
+            # Completely random bin probabilities dialed to the target entropy
+            # (softmax over per-bin random logits). All bins occupied, smoothly
+            # more uniform as the knob -> 1; no single dominant "hot" bin.
+            pmf[:] = solve_softmax_pmf(num_bins, target, seed)
+
+    elif spec.shape == "powerlaw":
+        s = solve_powerlaw_exponent(num_bins, knob_or(spec, DEFAULT_POWERLAW_ENTROPY))
+        w = ranked_powerlaw(num_bins, s)
+        idx = _scatter_bin_vec(np.arange(num_bins), num_bins, offset)
+        pmf[idx] = w
+
+    elif spec.shape == "zipf":
+        s = knob_or(spec, DEFAULT_ZIPF_EXPONENT)
+        w = ranked_powerlaw(num_bins, s)
+        idx = _scatter_bin_vec(np.arange(num_bins), num_bins, offset)
+        pmf[idx] = w
+
+    elif spec.shape == "hash_synonym":
+        hot_share = knob_or(spec, DEFAULT_HASH_SYNONYM_HOTSHARE)
+        slot = offset % K_ADVERSARIAL_CACHE_SLOTS
+        syn = [slot + k * K_ADVERSARIAL_CACHE_SLOTS
+               for k in range(K_HASH_SYNONYM_COUNT)
+               if slot + k * K_ADVERSARIAL_CACHE_SLOTS < num_bins]
+        pmf[:] = (1.0 - hot_share) / num_bins
+        if syn:
+            per = hot_share / len(syn)
+            for b in syn:
+                pmf[b] += per
+        else:
+            pmf[scatter_bin(0, num_bins, offset)] += hot_share
+
+    else:
+        raise ValueError(f"build_pmf called with non-distribution shape {spec.shape!r}")
+
+    return pmf
+
+
+def is_ordering_shape(shape: str) -> bool:
+    return shape in ("stale_resident", "temporal_phases", "strided_sweep", "sawtooth")
+
+
+# ---------------------------------------------------------------------------
+# Core generation — mirror generate_shape_impl. Returns BIN INDICES (the value
+# mapping is applied by the public entry points below).
+# ---------------------------------------------------------------------------
+
+def _bins_for_spec(spec: ShapeSpec, n: int, num_bins: int, seed: int) -> np.ndarray:
+    offset = seed % num_bins
+
+    # Exact-uniform endpoint: exact round-robin counts, but in pseudo-random
+    # sequence order (a Feistel permutation of the tiling). Uniform counts,
+    # randomly distributed in the input -- NOT the sequential ramp (= sawtooth).
+    if spec.shape == "concentrated" and spec.has_knob and spec.knob >= 1.0:
+        perm = permute_index(np.arange(n, dtype=_U64), n, seed)
+        return (perm % np.uint64(num_bins)).astype(np.int64)
+
+    if not is_ordering_shape(spec.shape):
+        pmf = build_pmf(spec, num_bins, seed)
+        cdf = np.cumsum(pmf)
+        cdf[-1] = 1.0  # guard fp drift, matches header
+        u = u01_from_hash(element_key(np.arange(n, dtype=_U64), seed))
+        bins = np.searchsorted(cdf, u, side="right").astype(np.int64)  # == upper_bound_cdf
+        np.clip(bins, 0, num_bins - 1, out=bins)
+        return bins
+
+    if spec.shape == "strided_sweep":
+        stride = int(round(spec.knob)) if spec.has_knob else DEFAULT_STRIDED_STRIDE
+        i = np.arange(n, dtype=object)  # big-int to mirror uint64 multiply then mod
+        return np.array([(int(x) * stride) % num_bins for x in i], dtype=np.int64)
+
+    if spec.shape == "sawtooth":
+        # bin = i % period; period 0 (the default) means a full num_bins sweep.
+        requested = int(round(spec.knob)) if spec.has_knob else DEFAULT_SAWTOOTH_PERIOD
+        period = num_bins if requested == 0 else min(requested, num_bins)
+        return (np.arange(n, dtype=np.int64) % period)
+
+    if spec.shape == "temporal_phases":
+        requested = int(round(spec.knob)) if spec.has_knob else DEFAULT_TEMPORAL_PHASES
+        phases = max(1, min(requested, num_bins))
+        i = np.arange(n, dtype=np.int64)
+        phase = (i * phases) // n
+        np.clip(phase, 0, phases - 1, out=phase)
+        step = num_bins // phases + 1
+        return _scatter_bin_vec(phase.astype(object) * step, num_bins, offset)
+
+    if spec.shape == "stale_resident":
+        # A cold working set of `span` distinct bins, swept cyclically (k = i*odd
+        # % span) and scattered across the array. Recurs in every block but
+        # overflows the per-block cache when span > slots -> thrashes it.
+        cover = knob_or(spec, 2.0)
+        want = int(round(cover * K_ADVERSARIAL_CACHE_SLOTS))
+        span = max(1, min(want, num_bins))
+        k = (np.arange(n, dtype=_U64) * _U64(2654435761)) % _U64(span)
+        return _scatter_bin_vec(k.astype(object), num_bins, offset)
+
+    raise ValueError(f"unreachable shape {spec.shape!r}")
+
+
+# ---------------------------------------------------------------------------
+# Bin -> sample value mappers — mirror even_bin_to_value / range_bin_to_value.
+# ---------------------------------------------------------------------------
+
+def _even_bin_to_value(bins, num_bins, lo, hi, dtype):
+    w = (float(hi) - float(lo)) / num_bins
+    v = float(lo) + (bins.astype(np.float64) + 0.5) * w
+    if np.issubdtype(np.dtype(dtype), np.integer):
+        v = np.floor(v)
+        v = np.clip(v, lo, hi - 1)
+        return v.astype(dtype)
+    v = np.maximum(v, float(lo))
+    return v.astype(dtype)
+
+
+def _range_bin_to_value(bins, levels, dtype):
+    num_bins = len(levels) - 1
+    b = np.clip(bins, 0, num_bins - 1)
+    loi = levels[b].astype(np.float64)
+    hii = levels[b + 1].astype(np.float64)
+    v = 0.5 * (loi + hii)
+    if np.issubdtype(np.dtype(dtype), np.integer):
+        v = np.floor(v)
+    s = v.astype(dtype)
+    # guarantee s in [levels[b], levels[b+1]) like the header
+    below = s < levels[b]
+    s[below] = levels[b][below]
+    atorabove = s >= levels[b + 1]
+    s[atorabove] = levels[b][atorabove]
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Public entry points — mirror generate_histogram_input_{even,range}.
+# Return (values, bins). `bins` is what the histogram counts; graphs use it.
+# ---------------------------------------------------------------------------
+
+def generate_histogram_input_even(spec, n, num_bins, lower, upper, dtype=np.int32, seed=42):
+    if isinstance(spec, str):
+        spec = parse_input_shape(spec)
+    bins = _bins_for_spec(spec, n, num_bins, seed)
+    values = _even_bin_to_value(bins, num_bins, lower, upper, dtype)
+    return values, bins
+
+
+def generate_histogram_input_range(spec, n, num_bins, levels, dtype=np.int32, seed=42):
+    if isinstance(spec, str):
+        spec = parse_input_shape(spec)
+    levels = np.asarray(levels)
+    bins = _bins_for_spec(spec, n, num_bins, seed)
+    values = _range_bin_to_value(bins, levels, dtype)
+    return values, bins
+
+
+# Convenience for the viz scripts: bins only (EVEN-equivalent), no value map.
+def generate_bins(spec, n, num_bins, seed=42):
+    if isinstance(spec, str):
+        spec = parse_input_shape(spec)
+    return _bins_for_spec(spec, n, num_bins, seed)
+
+
+# ---------------------------------------------------------------------------
+# Self-test: confirm the mirror reproduces the documented behavior.
+# ---------------------------------------------------------------------------
+
+def _demo():
+    N, B = 200_000, 64
+
+    print("== exact endpoints ==")
+    b = generate_bins("concentrated:1.0", N, B, seed=42)
+    c = np.bincount(b, minlength=B)
+    print(f"  concentrated:1.0  per-bin min={c.min()} max={c.max()} (exact uniform), H={normalized_entropy(c/N):.4f}")
+    b = generate_bins("concentrated:0.0", N, B, seed=42)
+    c = np.bincount(b, minlength=B)
+    print(f"  concentrated:0.0  nonzero bins={np.count_nonzero(c)} at bin {c.argmax()} (constant, scattered off 0)")
+
+    print("== concentrated entropy knob (measured top-bin share) ==")
+    for e in (1.0, 0.75, 0.5, 0.25, 0.0):
+        b = generate_bins(f"concentrated:{e}", N, B, seed=42)
+        c = np.bincount(b, minlength=B)
+        print(f"  E={e:.2f}: H={normalized_entropy(c/N):.3f}  top-share={c.max()/N:.1%}")
+
+    print("== hot bin varies with seed (concentrated:0.3) ==")
+    args = {int(np.bincount(generate_bins('concentrated:0.3', N, B, seed=s), minlength=B).argmax()) for s in range(1, 6)}
+    print(f"  argmax bins across seeds 1..5: {sorted(args)} (not pinned to 0)")
+
+    print("== adversarial: hash_synonym collides on one slot ==")
+    b = generate_bins("hash_synonym", N, 262144, seed=42)
+    hotbins = np.argsort(np.bincount(b, minlength=262144))[::-1][:K_HASH_SYNONYM_COUNT]
+    print(f"  distinct slots among the {K_HASH_SYNONYM_COUNT} hottest bins: {len(set(int(x) % 4096 for x in hotbins))} (want 1)")
+
+    print("== adversarial: temporal_phases moves the hot bin ==")
+    b = generate_bins("temporal_phases:4", N, 256, seed=42)
+    q = N // 4
+    print(f"  per-quarter hot bin: {[int(np.bincount(b[i*q:(i+1)*q], minlength=256).argmax()) for i in range(4)]}")
+
+
+if __name__ == "__main__":
+    _demo()

--- a/cub/benchmarks/bench/histogram/histogram_input_design.py
+++ b/cub/benchmarks/bench/histogram/histogram_input_design.py
@@ -33,22 +33,23 @@ Mechanism mirrored from the header:
 from __future__ import annotations
 
 from dataclasses import dataclass
+
 import numpy as np
 
 # ---------------------------------------------------------------------------
 # Constants — mirror histogram_inputs.cuh exactly.
 # ---------------------------------------------------------------------------
-K_ADVERSARIAL_CACHE_SLOTS = 4096           # kAdversarialCacheSlots
-K_HASH_SYNONYM_COUNT      = 32             # kHashSynonymCount
-K_SCATTER_PRIME           = 2147483647     # kScatterPrime (2^31 - 1)
+K_ADVERSARIAL_CACHE_SLOTS = 4096  # kAdversarialCacheSlots
+K_HASH_SYNONYM_COUNT = 32  # kHashSynonymCount
+K_SCATTER_PRIME = 2147483647  # kScatterPrime (2^31 - 1)
 
-DEFAULT_CONCENTRATED_ENTROPY = 0.5         # bare "concentrated"
-DEFAULT_POWERLAW_ENTROPY     = 0.5         # bare "powerlaw"
-DEFAULT_ZIPF_EXPONENT        = 1.0         # bare "zipf"
-DEFAULT_HASH_SYNONYM_HOTSHARE = 0.9        # bare "hash_synonym"
-DEFAULT_TEMPORAL_PHASES      = 8           # bare "temporal_phases"
-DEFAULT_STRIDED_STRIDE       = 9973        # bare "strided_sweep"
-DEFAULT_SAWTOOTH_PERIOD      = 0           # bare "sawtooth" => period == num_bins
+DEFAULT_CONCENTRATED_ENTROPY = 0.5  # bare "concentrated"
+DEFAULT_POWERLAW_ENTROPY = 0.5  # bare "powerlaw"
+DEFAULT_ZIPF_EXPONENT = 1.0  # bare "zipf"
+DEFAULT_HASH_SYNONYM_HOTSHARE = 0.9  # bare "hash_synonym"
+DEFAULT_TEMPORAL_PHASES = 8  # bare "temporal_phases"
+DEFAULT_STRIDED_STRIDE = 9973  # bare "strided_sweep"
+DEFAULT_SAWTOOTH_PERIOD = 0  # bare "sawtooth" => period == num_bins
 
 _U64 = np.uint64
 _MASK64 = (1 << 64) - 1
@@ -59,6 +60,7 @@ _MASK64 = (1 << 64) - 1
 # __host__ __device__ inline functions in the header. All arithmetic is done in
 # explicit uint64 with wraparound so results match the C++ byte-for-byte.
 # ---------------------------------------------------------------------------
+
 
 def u01_from_hash(x: np.ndarray | int) -> np.ndarray:
     """Port of u01_from_hash: splitmix64 finalizer -> double in [0, 1)."""
@@ -75,14 +77,16 @@ def element_key(i: np.ndarray | int, seed: int) -> np.ndarray:
     """Port of element_key: i*6364136223846793005 + 1442695040888963407 + seed*phi."""
     i = np.asarray(i, dtype=_U64)
     with np.errstate(over="ignore"):
-        return (i * _U64(6364136223846793005)
-                + _U64(1442695040888963407)
-                + _U64(seed & _MASK64) * _U64(0x9E3779B97F4A7C15))
+        return (
+            i * _U64(6364136223846793005)
+            + _U64(1442695040888963407)
+            + _U64(seed & _MASK64) * _U64(0x9E3779B97F4A7C15)
+        )
 
 
 def scatter_bin(rank: int, num_bins: int, offset: int) -> int:
     """Port of scatter_bin: (rank*kScatterPrime + offset) % num_bins, in uint64."""
-    return int((( (rank & _MASK64) * K_SCATTER_PRIME + offset) & _MASK64) % num_bins)
+    return int((((rank & _MASK64) * K_SCATTER_PRIME + offset) & _MASK64) % num_bins)
 
 
 def _feistel_mix(x: np.ndarray, k: int) -> np.ndarray:
@@ -102,7 +106,7 @@ def permute_index(i: np.ndarray, n: int, seed: int) -> np.ndarray:
     i = np.asarray(i, dtype=_U64)
     if n <= 1:
         return np.zeros_like(i)
-    bits = int(n - 1).bit_length()          # ceil(log2(n)) for n >= 2
+    bits = int(n - 1).bit_length()  # ceil(log2(n)) for n >= 2
     half = (bits + 1) // 2
     mask = _MASK64 if half >= 64 else ((1 << half) - 1)
     mask = _U64(mask)
@@ -110,15 +114,15 @@ def permute_index(i: np.ndarray, n: int, seed: int) -> np.ndarray:
     x = i.copy()
     todo = np.ones(x.shape, dtype=bool)
     with np.errstate(over="ignore"):
-        for _ in range(128):                # cycle-walk; expected < 4 iters
+        for _ in range(128):  # cycle-walk; expected < 4 iters
             xs = x[todo]
-            l = (xs >> hh) & mask
-            r = xs & mask
+            left = (xs >> hh) & mask
+            right = xs & mask
             for rnd in range(4):
-                nl = r
-                nr = l ^ (_feistel_mix(r, seed + rnd) & mask)
-                l, r = nl, nr
-            x[todo] = (l << hh) | r
+                next_left = right
+                next_right = left ^ (_feistel_mix(right, seed + rnd) & mask)
+                left, right = next_left, next_right
+            x[todo] = (left << hh) | right
             todo = x >= _U64(n)
             if not todo.any():
                 break
@@ -127,7 +131,9 @@ def permute_index(i: np.ndarray, n: int, seed: int) -> np.ndarray:
 
 def _scatter_bin_vec(ranks: np.ndarray, num_bins: int, offset: int) -> np.ndarray:
     r = ranks.astype(object)  # python big-ints to avoid overflow before mod
-    return np.array([(int(x) * K_SCATTER_PRIME + offset) % num_bins for x in r], dtype=np.int64)
+    return np.array(
+        [(int(x) * K_SCATTER_PRIME + offset) % num_bins for x in r], dtype=np.int64
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -135,8 +141,13 @@ def _scatter_bin_vec(ranks: np.ndarray, num_bins: int, offset: int) -> np.ndarra
 # ---------------------------------------------------------------------------
 
 VALID_SHAPES = {
-    "concentrated", "powerlaw", "zipf", "hash_synonym",
-    "stale_resident", "temporal_phases", "strided_sweep",
+    "concentrated",
+    "powerlaw",
+    "zipf",
+    "hash_synonym",
+    "stale_resident",
+    "temporal_phases",
+    "strided_sweep",
     "sawtooth",
 }
 
@@ -169,6 +180,7 @@ def knob_or(spec: ShapeSpec, default_value: float) -> float:
 # ---------------------------------------------------------------------------
 # pmf math — mirror normalized_entropy / ranked_powerlaw / solvers.
 # ---------------------------------------------------------------------------
+
 
 def normalized_entropy(pmf: np.ndarray) -> float:
     if len(pmf) <= 1:
@@ -228,6 +240,7 @@ def solve_softmax_pmf(num_bins: int, target: float, seed: int) -> np.ndarray:
 # build_pmf — mirror the C++ switch exactly (i.i.d. distribution shapes).
 # ---------------------------------------------------------------------------
 
+
 def build_pmf(spec: ShapeSpec, num_bins: int, seed: int) -> np.ndarray:
     pmf = np.zeros(num_bins, dtype=np.float64)
     offset = seed % num_bins
@@ -259,9 +272,11 @@ def build_pmf(spec: ShapeSpec, num_bins: int, seed: int) -> np.ndarray:
     elif spec.shape == "hash_synonym":
         hot_share = knob_or(spec, DEFAULT_HASH_SYNONYM_HOTSHARE)
         slot = offset % K_ADVERSARIAL_CACHE_SLOTS
-        syn = [slot + k * K_ADVERSARIAL_CACHE_SLOTS
-               for k in range(K_HASH_SYNONYM_COUNT)
-               if slot + k * K_ADVERSARIAL_CACHE_SLOTS < num_bins]
+        syn = [
+            slot + k * K_ADVERSARIAL_CACHE_SLOTS
+            for k in range(K_HASH_SYNONYM_COUNT)
+            if slot + k * K_ADVERSARIAL_CACHE_SLOTS < num_bins
+        ]
         pmf[:] = (1.0 - hot_share) / num_bins
         if syn:
             per = hot_share / len(syn)
@@ -285,6 +300,7 @@ def is_ordering_shape(shape: str) -> bool:
 # mapping is applied by the public entry points below).
 # ---------------------------------------------------------------------------
 
+
 def _bins_for_spec(spec: ShapeSpec, n: int, num_bins: int, seed: int) -> np.ndarray:
     offset = seed % num_bins
 
@@ -300,7 +316,9 @@ def _bins_for_spec(spec: ShapeSpec, n: int, num_bins: int, seed: int) -> np.ndar
         cdf = np.cumsum(pmf)
         cdf[-1] = 1.0  # guard fp drift, matches header
         u = u01_from_hash(element_key(np.arange(n, dtype=_U64), seed))
-        bins = np.searchsorted(cdf, u, side="right").astype(np.int64)  # == upper_bound_cdf
+        bins = np.searchsorted(cdf, u, side="right").astype(
+            np.int64
+        )  # == upper_bound_cdf
         np.clip(bins, 0, num_bins - 1, out=bins)
         return bins
 
@@ -313,7 +331,7 @@ def _bins_for_spec(spec: ShapeSpec, n: int, num_bins: int, seed: int) -> np.ndar
         # bin = i % period; period 0 (the default) means a full num_bins sweep.
         requested = int(round(spec.knob)) if spec.has_knob else DEFAULT_SAWTOOTH_PERIOD
         period = num_bins if requested == 0 else min(requested, num_bins)
-        return (np.arange(n, dtype=np.int64) % period)
+        return np.arange(n, dtype=np.int64) % period
 
     if spec.shape == "temporal_phases":
         requested = int(round(spec.knob)) if spec.has_knob else DEFAULT_TEMPORAL_PHASES
@@ -340,6 +358,7 @@ def _bins_for_spec(spec: ShapeSpec, n: int, num_bins: int, seed: int) -> np.ndar
 # ---------------------------------------------------------------------------
 # Bin -> sample value mappers — mirror even_bin_to_value / range_bin_to_value.
 # ---------------------------------------------------------------------------
+
 
 def _even_bin_to_value(bins, num_bins, lo, hi, dtype):
     w = (float(hi) - float(lo)) / num_bins
@@ -374,7 +393,10 @@ def _range_bin_to_value(bins, levels, dtype):
 # Return (values, bins). `bins` is what the histogram counts; graphs use it.
 # ---------------------------------------------------------------------------
 
-def generate_histogram_input_even(spec, n, num_bins, lower, upper, dtype=np.int32, seed=42):
+
+def generate_histogram_input_even(
+    spec, n, num_bins, lower, upper, dtype=np.int32, seed=42
+):
     if isinstance(spec, str):
         spec = parse_input_shape(spec)
     bins = _bins_for_spec(spec, n, num_bins, seed)
@@ -402,36 +424,54 @@ def generate_bins(spec, n, num_bins, seed=42):
 # Self-test: confirm the mirror reproduces the documented behavior.
 # ---------------------------------------------------------------------------
 
+
 def _demo():
     N, B = 200_000, 64
 
     print("== exact endpoints ==")
     b = generate_bins("concentrated:1.0", N, B, seed=42)
     c = np.bincount(b, minlength=B)
-    print(f"  concentrated:1.0  per-bin min={c.min()} max={c.max()} (exact uniform), H={normalized_entropy(c/N):.4f}")
+    print(
+        f"  concentrated:1.0  per-bin min={c.min()} max={c.max()} (exact uniform), H={normalized_entropy(c / N):.4f}"
+    )
     b = generate_bins("concentrated:0.0", N, B, seed=42)
     c = np.bincount(b, minlength=B)
-    print(f"  concentrated:0.0  nonzero bins={np.count_nonzero(c)} at bin {c.argmax()} (constant, scattered off 0)")
+    print(
+        f"  concentrated:0.0  nonzero bins={np.count_nonzero(c)} at bin {c.argmax()} (constant, scattered off 0)"
+    )
 
     print("== concentrated entropy knob (measured top-bin share) ==")
     for e in (1.0, 0.75, 0.5, 0.25, 0.0):
         b = generate_bins(f"concentrated:{e}", N, B, seed=42)
         c = np.bincount(b, minlength=B)
-        print(f"  E={e:.2f}: H={normalized_entropy(c/N):.3f}  top-share={c.max()/N:.1%}")
+        print(
+            f"  E={e:.2f}: H={normalized_entropy(c / N):.3f}  top-share={c.max() / N:.1%}"
+        )
 
     print("== hot bin varies with seed (concentrated:0.3) ==")
-    args = {int(np.bincount(generate_bins('concentrated:0.3', N, B, seed=s), minlength=B).argmax()) for s in range(1, 6)}
+    args = {
+        int(
+            np.bincount(
+                generate_bins("concentrated:0.3", N, B, seed=s), minlength=B
+            ).argmax()
+        )
+        for s in range(1, 6)
+    }
     print(f"  argmax bins across seeds 1..5: {sorted(args)} (not pinned to 0)")
 
     print("== adversarial: hash_synonym collides on one slot ==")
     b = generate_bins("hash_synonym", N, 262144, seed=42)
     hotbins = np.argsort(np.bincount(b, minlength=262144))[::-1][:K_HASH_SYNONYM_COUNT]
-    print(f"  distinct slots among the {K_HASH_SYNONYM_COUNT} hottest bins: {len(set(int(x) % 4096 for x in hotbins))} (want 1)")
+    print(
+        f"  distinct slots among the {K_HASH_SYNONYM_COUNT} hottest bins: {len(set(int(x) % 4096 for x in hotbins))} (want 1)"
+    )
 
     print("== adversarial: temporal_phases moves the hot bin ==")
     b = generate_bins("temporal_phases:4", N, 256, seed=42)
     q = N // 4
-    print(f"  per-quarter hot bin: {[int(np.bincount(b[i*q:(i+1)*q], minlength=256).argmax()) for i in range(4)]}")
+    print(
+        f"  per-quarter hot bin: {[int(np.bincount(b[i * q : (i + 1) * q], minlength=256).argmax()) for i in range(4)]}"
+    )
 
 
 if __name__ == "__main__":

--- a/cub/benchmarks/bench/histogram/histogram_inputs.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_inputs.cuh
@@ -1,0 +1,678 @@
+// SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+#pragma once
+
+// Input-shape generators for the CUB histogram benchmarks.
+//
+// The legacy `generate(elements, entropy, lower, upper)` knob (bitwise-AND
+// "entropy") is non-linear, bunched at the extremes, always pins the hot bin to
+// the zero value, and cannot express multi-hot or cache-adversarial inputs.
+// This header replaces it with a set of named INPUT SHAPES that control the
+// *bin* distribution directly.
+//
+// Mechanism: every shape decides a per-element BIN index in [0, num_bins), then
+// emits a SampleT value that lands inside that bin's value interval. CUB then
+// re-derives the bin from the value, so the in-bench verifier
+// (`bench_verify_histogram_*` in histogram_common.cuh) validates the mapping
+// automatically -- we feed the verifier, never bypass it.
+//
+//   * EVEN  path: bin b owns [lower + b*w, lower + (b+1)*w), w=(upper-lower)/B.
+//                 emit the bin midpoint -> CUB's (s-lower)*B/(upper-lower) == b.
+//   * RANGE path: bin b owns [levels[b], levels[b+1]).
+//                 emit that interval's midpoint -> UpperBound(levels, s)-1 == b.
+//
+// Shapes split into i.i.d. DISTRIBUTION shapes (only the pmf differs; positions
+// are independent) and ORDERING shapes (the pathology lives in the sequence
+// order, so they are generated positionally).
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/tabulate.h>
+
+#include <cuda/std/type_traits>
+
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Shape catalog
+// ---------------------------------------------------------------------------
+
+enum class InputShape
+{
+  concentrated,   // spike-slab family. KNOB = target normalized entropy in
+                  // [0,1]: 1.0 = uniform, 0.0 = constant (single bin), in
+                  // between = one hot bin over a uniform floor. Sweeping the
+                  // knob reproduces (and generalizes) the old Entropy sweep --
+                  // continuously, and with the hot bin scattered off zero.
+  powerlaw,       // decaying warm set (many hot bins). KNOB = target normalized
+                  // entropy in [0,1]; the rank exponent is solved to hit it.
+                  // Independent of the concentrated knob.
+  zipf,           // decaying warm set with a classic exponent. KNOB = exponent
+                  // s >= 0 (default 1.0).
+  hash_synonym,   // hot bins all collide on one cache slot. KNOB = hot share
+                  // in [0,1] (default 0.9).
+  capacity_cliff, // equiprobable active set sized around cache capacity. KNOB =
+                  // active set as a multiple of cache slots (default => slots+1,
+                  // the just-over-capacity cliff).
+  stale_resident, // cold prefix claims slots, then a hot bulk (attacks
+                  // no-evict). KNOB = prefix coverage as a multiple of cache
+                  // slots (default 1.0 => claim `slots` bins).
+  temporal_phases,// the hot bin steps to a new location across phases. KNOB =
+                  // number of phases (default 8).
+  strided_sweep,  // bin = stride*i % B (minimal temporal locality). KNOB =
+                  // stride (default a large prime).
+};
+
+// A shape plus an optional knob value. `has_knob == false` means "use the
+// shape's default". The knob's meaning is shape-specific (see the enum).
+struct ShapeSpec
+{
+  InputShape shape;
+  double knob    = 0.0;
+  bool has_knob  = false;
+};
+
+// kAdversarialCacheSlots mirrors the SMEM cuckoo-cache capacity in
+// tuning_histogram.cuh; it is a benchmark *probe* and never affects
+// correctness. TODO: wire to the policy's actual slot count rather than
+// hardcoding, so the adversarial shapes track the cache as it is tuned.
+constexpr int kAdversarialCacheSlots = 4096;
+constexpr int kHashSynonymCount      = 32; // number of colliding bins
+
+// Parse an InputShape axis value of the form "name" or "name:knob".
+//   "concentrated:1.0"    -> uniform (entropy 1.0)
+//   "concentrated:0.5"    -> a single hot bin over a floor (was "spike")
+//   "concentrated:0.0"    -> a single bin gets 100% (was "constant")
+//   "powerlaw:0.3"        -> power law at target entropy 0.3
+//   "capacity_cliff"      -> default (slots+1) cliff
+// There is deliberately ONE concentrated shape spanning uniform<->constant via
+// its entropy knob -- no separate uniform/constant/spike names.
+inline ShapeSpec parse_input_shape(const std::string& spec)
+{
+  std::string name = spec;
+  ShapeSpec out{};
+  const auto colon = spec.find(':');
+  if (colon != std::string::npos)
+  {
+    name        = spec.substr(0, colon);
+    out.knob    = std::stod(spec.substr(colon + 1));
+    out.has_knob = true;
+  }
+
+  if (name == "concentrated") { out.shape = InputShape::concentrated; }
+  else if (name == "powerlaw") { out.shape = InputShape::powerlaw; }
+  else if (name == "zipf")     { out.shape = InputShape::zipf; }
+  else if (name == "hash_synonym")    { out.shape = InputShape::hash_synonym; }
+  else if (name == "capacity_cliff")  { out.shape = InputShape::capacity_cliff; }
+  else if (name == "stale_resident")  { out.shape = InputShape::stale_resident; }
+  else if (name == "temporal_phases") { out.shape = InputShape::temporal_phases; }
+  else if (name == "strided_sweep")   { out.shape = InputShape::strided_sweep; }
+  else { throw std::runtime_error("Unknown InputShape: " + spec); }
+  return out;
+}
+
+// Resolve a knob to a concrete value, applying the shape's default when the
+// axis value did not specify one.
+inline double knob_or(const ShapeSpec& s, double default_value)
+{
+  return s.has_knob ? s.knob : default_value;
+}
+
+// A large prime > every bins-axis value; multiplying bin ranks by it modulo
+// num_bins is a bijection (a cheap fixed permutation), used to SCATTER hot bins
+// across the array so the mode is never forced to bin 0.
+constexpr uint64_t kScatterPrime = 2147483647ull; // 2^31 - 1, prime
+
+// ---------------------------------------------------------------------------
+// Per-element uniform draw: splitmix64 finalizer on a decorrelated key, mapped
+// to [0, 1). Higher quality per index than seeding a thrust engine per element.
+// ---------------------------------------------------------------------------
+__host__ __device__ inline double u01_from_hash(uint64_t x)
+{
+  x += 0x9E3779B97F4A7C15ull;
+  x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ull;
+  x = (x ^ (x >> 27)) * 0x94D049BB133111EBull;
+  x = x ^ (x >> 31);
+  return static_cast<double>(x >> 11) * (1.0 / 9007199254740992.0); // 2^53
+}
+
+__host__ __device__ inline uint64_t element_key(uint64_t i, uint64_t seed)
+{
+  return i * 6364136223846793005ull + 1442695040888963407ull + seed * 0x9E3779B97F4A7C15ull;
+}
+
+__host__ __device__ inline int scatter_bin(uint64_t rank, int num_bins, uint64_t offset)
+{
+  return static_cast<int>((rank * kScatterPrime + offset) % static_cast<uint64_t>(num_bins));
+}
+
+// First index `i` in [0, n) with `val < cdf[i]` (upper-bound binary search).
+// Local host/device implementation so this header has no device-only deps
+// (cub::UpperBound is _CCCL_DEVICE only and we need a host path for tests).
+__host__ __device__ inline int upper_bound_cdf(const double* cdf, int n, double val)
+{
+  int lo = 0;
+  int len = n;
+  while (len > 0)
+  {
+    const int half = len >> 1;
+    if (val < cdf[lo + half])
+    {
+      len = half;
+    }
+    else
+    {
+      lo  = lo + half + 1;
+      len = len - (half + 1);
+    }
+  }
+  return lo;
+}
+
+// ---------------------------------------------------------------------------
+// Bin -> sample value mappers (one per histogram path). Both emit a value in
+// the *interior* of bin `b` so CUB re-derives exactly `b`.
+// ---------------------------------------------------------------------------
+template <class SampleT>
+struct even_bin_to_value
+{
+  double L;
+  double w; // (upper - lower) / num_bins
+  SampleT lower;
+  SampleT upper;
+
+  __host__ __device__ SampleT operator()(int bin) const
+  {
+    double v = L + (static_cast<double>(bin) + 0.5) * w;
+    if constexpr (::cuda::std::is_integral_v<SampleT>)
+    {
+      double f = ::floor(v);
+      if (f < static_cast<double>(lower))
+      {
+        f = static_cast<double>(lower);
+      }
+      if (f > static_cast<double>(upper) - 1.0)
+      {
+        f = static_cast<double>(upper) - 1.0;
+      }
+      return static_cast<SampleT>(f);
+    }
+    else
+    {
+      if (v < static_cast<double>(lower))
+      {
+        v = static_cast<double>(lower);
+      }
+      return static_cast<SampleT>(v);
+    }
+  }
+};
+
+template <class SampleT>
+struct range_bin_to_value
+{
+  const SampleT* levels; // num_bins + 1 strictly increasing levels
+  int num_bins;
+
+  __host__ __device__ SampleT operator()(int bin) const
+  {
+    if (bin < 0)
+    {
+      bin = 0;
+    }
+    if (bin > num_bins - 1)
+    {
+      bin = num_bins - 1;
+    }
+    const double lo = static_cast<double>(levels[bin]);
+    const double hi = static_cast<double>(levels[bin + 1]);
+    double v        = 0.5 * (lo + hi);
+    SampleT s;
+    if constexpr (::cuda::std::is_integral_v<SampleT>)
+    {
+      s = static_cast<SampleT>(::floor(v));
+    }
+    else
+    {
+      s = static_cast<SampleT>(v);
+    }
+    // Guarantee s lands in [levels[bin], levels[bin+1]).
+    if (s < levels[bin])
+    {
+      s = levels[bin];
+    }
+    if (s >= levels[bin + 1])
+    {
+      s = levels[bin];
+    }
+    return s;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Device functors.
+// ---------------------------------------------------------------------------
+
+// Inverse-CDF sampler for the i.i.d. distribution shapes.
+template <class SampleT, class Mapper>
+struct cdf_sample_functor
+{
+  const double* cdf; // inclusive prefix sum over bins, cdf[num_bins-1] == 1
+  int num_bins;
+  uint64_t seed;
+  Mapper mapper;
+
+  template <class I>
+  __host__ __device__ SampleT operator()(I i) const
+  {
+    const double u = u01_from_hash(element_key(static_cast<uint64_t>(i), seed));
+    int bin        = upper_bound_cdf(cdf, num_bins, u);
+    if (bin >= num_bins)
+    {
+      bin = num_bins - 1;
+    }
+    return mapper(bin);
+  }
+};
+
+// strided_sweep: bin = stride*i % num_bins.
+template <class SampleT, class Mapper>
+struct strided_functor
+{
+  int num_bins;
+  uint64_t stride;
+  Mapper mapper;
+
+  template <class I>
+  __host__ __device__ SampleT operator()(I i) const
+  {
+    int bin = static_cast<int>((static_cast<uint64_t>(i) * stride) % static_cast<uint64_t>(num_bins));
+    return mapper(bin);
+  }
+};
+
+// temporal_phases: contiguous phases, each hammering one scattered bin.
+template <class SampleT, class Mapper>
+struct phases_functor
+{
+  int num_bins;
+  int num_phases;
+  uint64_t n;
+  uint64_t offset;
+  Mapper mapper;
+
+  template <class I>
+  __host__ __device__ SampleT operator()(I i) const
+  {
+    uint64_t phase = (static_cast<uint64_t>(i) * static_cast<uint64_t>(num_phases)) / n;
+    if (phase >= static_cast<uint64_t>(num_phases))
+    {
+      phase = static_cast<uint64_t>(num_phases) - 1;
+    }
+    // Spread phases across the bin array, scattered off zero.
+    int bin = scatter_bin(phase * (static_cast<uint64_t>(num_bins) / static_cast<uint64_t>(num_phases) + 1), num_bins, offset);
+    return mapper(bin);
+  }
+};
+
+// Exact uniform: round-robin tiling bin(i) = i % num_bins. Every bin receives
+// exactly floor(n/num_bins) or +1 samples -- ACTUALLY uniform (zero count
+// variance), unlike i.i.d. sampling of a uniform pmf which leaves multinomial
+// noise and ~37% empty bins when bins ~= elements. This is the canonical
+// entropy=1.0 endpoint. Access is sequential (a benign, low-contention
+// baseline); contrast strided_sweep, which uses a large coprime stride to
+// destroy locality on purpose.
+template <class SampleT, class Mapper>
+struct uniform_tiling_functor
+{
+  int num_bins;
+  Mapper mapper;
+
+  template <class I>
+  __host__ __device__ SampleT operator()(I i) const
+  {
+    return mapper(static_cast<int>(static_cast<uint64_t>(i) % static_cast<uint64_t>(num_bins)));
+  }
+};
+
+// stale_resident: a cold prefix sweeps `n_cold` distinct bins once (claiming
+// every cache slot), then the hot bulk hammers a single bin disjoint from the
+// prefix.
+template <class SampleT, class Mapper>
+struct stale_functor
+{
+  int num_bins;
+  uint64_t n_cold;
+  int hot_bin;
+  Mapper mapper;
+
+  template <class I>
+  __host__ __device__ SampleT operator()(I i) const
+  {
+    uint64_t idx = static_cast<uint64_t>(i);
+    int bin      = (idx < n_cold) ? static_cast<int>(idx % static_cast<uint64_t>(num_bins)) : hot_bin;
+    return mapper(bin);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Host pmf construction for the distribution shapes.
+// ---------------------------------------------------------------------------
+
+inline double normalized_entropy(const std::vector<double>& pmf)
+{
+  if (pmf.size() <= 1)
+  {
+    return 0.0;
+  }
+  double h = 0.0;
+  for (double p : pmf)
+  {
+    if (p > 0.0)
+    {
+      h -= p * std::log2(p);
+    }
+  }
+  return h / std::log2(static_cast<double>(pmf.size()));
+}
+
+// Ranked weights w[r] ~ (r+1)^(-s), normalized.
+inline std::vector<double> ranked_powerlaw(int num_bins, double s)
+{
+  std::vector<double> w(num_bins);
+  double sum = 0.0;
+  for (int r = 0; r < num_bins; ++r)
+  {
+    w[r] = std::pow(static_cast<double>(r + 1), -s);
+    sum += w[r];
+  }
+  for (double& x : w)
+  {
+    x /= sum;
+  }
+  return w;
+}
+
+// Solve the power-law exponent so normalized entropy ~= target (monotone
+// decreasing in s -> bisection).
+inline double solve_powerlaw_exponent(int num_bins, double target)
+{
+  double lo = 0.0, hi = 60.0;
+  for (int it = 0; it < 60; ++it)
+  {
+    const double mid = 0.5 * (lo + hi);
+    const double h   = normalized_entropy(ranked_powerlaw(num_bins, mid));
+    // entropy decreases as s grows
+    if (h < target)
+    {
+      hi = mid;
+    }
+    else
+    {
+      lo = mid;
+    }
+  }
+  return 0.5 * (lo + hi);
+}
+
+// Spike-slab pmf: probability `p` on one hot bin, `(1-p)` spread uniformly over
+// all bins. Normalized entropy decreases monotonically from 1.0 (p=0, uniform)
+// to 0.0 (p=1, single bin), so we bisect `p` to hit a target entropy.
+inline double spike_slab_entropy(int num_bins, double p)
+{
+  const double base = (1.0 - p) / num_bins;
+  std::vector<double> pmf(num_bins, base);
+  pmf[0] += p;
+  return normalized_entropy(pmf);
+}
+
+inline double solve_spike_share(int num_bins, double target)
+{
+  double lo = 0.0, hi = 1.0;
+  for (int it = 0; it < 60; ++it)
+  {
+    const double mid = 0.5 * (lo + hi);
+    const double h   = spike_slab_entropy(num_bins, mid);
+    if (h < target)
+    {
+      hi = mid; // too concentrated -> reduce p
+    }
+    else
+    {
+      lo = mid;
+    }
+  }
+  return 0.5 * (lo + hi);
+}
+
+// Defaults applied when the axis value supplies no knob.
+constexpr double kDefaultConcentratedEntropy = 0.5; // bare "concentrated"
+constexpr double kDefaultPowerlawEntropy     = 0.5; // bare "powerlaw"
+constexpr double kDefaultZipfExponent        = 1.0; // bare "zipf"
+constexpr double kDefaultHashSynonymHotShare = 0.9; // bare "hash_synonym"
+constexpr int kDefaultTemporalPhases         = 8;   // bare "temporal_phases"
+constexpr uint64_t kDefaultStridedStride     = 9973ull; // bare "strided_sweep"
+
+// Build the per-bin pmf for an i.i.d. distribution shape, honoring the spec's
+// knob. Hot ranks are scattered across bins via scatter_bin() so the mode is
+// not forced to bin 0.
+inline std::vector<double> build_pmf(const ShapeSpec& spec, int num_bins, uint64_t seed)
+{
+  std::vector<double> pmf(num_bins, 0.0);
+  const uint64_t offset = seed % static_cast<uint64_t>(num_bins);
+
+  switch (spec.shape)
+  {
+    case InputShape::concentrated: {
+      // KNOB = target normalized entropy. Exact endpoints, solver in between.
+      const double target = knob_or(spec, kDefaultConcentratedEntropy);
+      if (target >= 1.0)
+      {
+        const double p = 1.0 / num_bins; // exact uniform
+        for (int b = 0; b < num_bins; ++b)
+        {
+          pmf[b] = p;
+        }
+      }
+      else if (target <= 0.0)
+      {
+        pmf[scatter_bin(0, num_bins, offset)] = 1.0; // exact single bin
+      }
+      else
+      {
+        const double p       = solve_spike_share(num_bins, target);
+        const double floor_p = (1.0 - p) / num_bins;
+        for (int b = 0; b < num_bins; ++b)
+        {
+          pmf[b] = floor_p;
+        }
+        pmf[scatter_bin(0, num_bins, offset)] += p;
+      }
+      break;
+    }
+    case InputShape::powerlaw: {
+      const double target         = knob_or(spec, kDefaultPowerlawEntropy);
+      const double s              = solve_powerlaw_exponent(num_bins, target);
+      const std::vector<double> w = ranked_powerlaw(num_bins, s);
+      for (int r = 0; r < num_bins; ++r)
+      {
+        pmf[scatter_bin(static_cast<uint64_t>(r), num_bins, offset)] = w[r];
+      }
+      break;
+    }
+    case InputShape::zipf: {
+      const double s              = knob_or(spec, kDefaultZipfExponent);
+      const std::vector<double> w = ranked_powerlaw(num_bins, s);
+      for (int r = 0; r < num_bins; ++r)
+      {
+        pmf[scatter_bin(static_cast<uint64_t>(r), num_bins, offset)] = w[r];
+      }
+      break;
+    }
+    case InputShape::hash_synonym: {
+      // KNOB = hot share. kHashSynonymCount bins that all collide on one cache
+      // slot share the hot traffic; the rest is uniform background.
+      const double hot_share = knob_or(spec, kDefaultHashSynonymHotShare);
+      const int slot         = static_cast<int>(offset % static_cast<uint64_t>(kAdversarialCacheSlots));
+      std::vector<int> syn;
+      for (int k = 0; k < kHashSynonymCount; ++k)
+      {
+        const int b = slot + k * kAdversarialCacheSlots;
+        if (b < num_bins)
+        {
+          syn.push_back(b);
+        }
+      }
+      const double bg = (1.0 - hot_share) / num_bins;
+      for (int b = 0; b < num_bins; ++b)
+      {
+        pmf[b] = bg;
+      }
+      if (!syn.empty())
+      {
+        const double per = hot_share / syn.size();
+        for (int b : syn)
+        {
+          pmf[b] += per;
+        }
+      }
+      else
+      {
+        pmf[scatter_bin(0, num_bins, offset)] += hot_share; // degenerate fallback
+      }
+      break;
+    }
+    case InputShape::capacity_cliff: {
+      // KNOB = active set as a multiple of cache slots. Default => slots+1
+      // (the just-over-capacity cliff). Equiprobable bins, spread across the
+      // array so they do not trivially share slots.
+      int k;
+      if (spec.has_knob)
+      {
+        k = static_cast<int>(std::lround(spec.knob * kAdversarialCacheSlots));
+      }
+      else
+      {
+        k = kAdversarialCacheSlots + 1;
+      }
+      k = std::max(1, std::min(k, num_bins));
+      const double p = 1.0 / k;
+      for (int j = 0; j < k; ++j)
+      {
+        const int b = static_cast<int>((static_cast<uint64_t>(j) * num_bins) / static_cast<uint64_t>(k));
+        pmf[b] = p;
+      }
+      break;
+    }
+    default:
+      throw std::runtime_error("build_pmf called with a non-distribution shape");
+  }
+  return pmf;
+}
+
+inline bool is_ordering_shape(InputShape shape)
+{
+  return shape == InputShape::stale_resident || shape == InputShape::temporal_phases
+      || shape == InputShape::strided_sweep;
+}
+
+// ---------------------------------------------------------------------------
+// Core generation: given a bin->value mapper, fill an output device vector of
+// `n` samples according to `spec`.
+// ---------------------------------------------------------------------------
+template <class SampleT, class OffsetT, class Mapper>
+thrust::device_vector<SampleT>
+generate_shape_impl(const ShapeSpec& spec, OffsetT n, int num_bins, Mapper mapper, uint64_t seed)
+{
+  thrust::device_vector<SampleT> out(static_cast<std::size_t>(n));
+  const uint64_t offset = seed % static_cast<uint64_t>(num_bins);
+
+  // Exact-uniform endpoint: emitted as equal-count tiling rather than i.i.d.
+  // sampling, so every bin gets exactly n/num_bins (+-1) -- truly uniform.
+  if (spec.shape == InputShape::concentrated && spec.has_knob && spec.knob >= 1.0)
+  {
+    uniform_tiling_functor<SampleT, Mapper> fn{num_bins, mapper};
+    thrust::tabulate(out.begin(), out.end(), fn);
+    return out;
+  }
+
+  if (!is_ordering_shape(spec.shape))
+  {
+    // Distribution shape: host pmf -> inclusive CDF -> device -> inverse-CDF sample.
+    std::vector<double> pmf = build_pmf(spec, num_bins, seed);
+    thrust::host_vector<double> h_cdf(num_bins);
+    double acc = 0.0;
+    for (int b = 0; b < num_bins; ++b)
+    {
+      acc += pmf[b];
+      h_cdf[b] = acc;
+    }
+    h_cdf[num_bins - 1] = 1.0; // guard against fp drift on the last bin
+    thrust::device_vector<double> d_cdf = h_cdf;
+    cdf_sample_functor<SampleT, Mapper> fn{thrust::raw_pointer_cast(d_cdf.data()), num_bins, seed, mapper};
+    thrust::tabulate(out.begin(), out.end(), fn);
+    return out;
+  }
+
+  switch (spec.shape)
+  {
+    case InputShape::strided_sweep: {
+      // KNOB = stride.
+      const uint64_t stride =
+        spec.has_knob ? static_cast<uint64_t>(std::llround(spec.knob)) : kDefaultStridedStride;
+      strided_functor<SampleT, Mapper> fn{num_bins, stride, mapper};
+      thrust::tabulate(out.begin(), out.end(), fn);
+      break;
+    }
+    case InputShape::temporal_phases: {
+      // KNOB = number of phases.
+      const int requested = spec.has_knob ? static_cast<int>(std::llround(spec.knob)) : kDefaultTemporalPhases;
+      const int phases    = std::max(1, std::min(requested, num_bins));
+      phases_functor<SampleT, Mapper> fn{num_bins, phases, static_cast<uint64_t>(n), offset, mapper};
+      thrust::tabulate(out.begin(), out.end(), fn);
+      break;
+    }
+    case InputShape::stale_resident: {
+      // KNOB = prefix coverage as a multiple of cache slots (default 1.0).
+      const double cover    = knob_or(spec, 1.0);
+      const int64_t want    = static_cast<int64_t>(std::llround(cover * kAdversarialCacheSlots));
+      const uint64_t n_cold = static_cast<uint64_t>(std::max<int64_t>(1, std::min<int64_t>(want, num_bins)));
+      // hot bin disjoint from the cold prefix [0, n_cold) when possible.
+      const int hot_bin =
+        (num_bins > static_cast<int>(n_cold))
+          ? static_cast<int>(n_cold + (offset % (static_cast<uint64_t>(num_bins) - n_cold)))
+          : num_bins / 2;
+      stale_functor<SampleT, Mapper> fn{num_bins, n_cold, hot_bin, mapper};
+      thrust::tabulate(out.begin(), out.end(), fn);
+      break;
+    }
+    default:
+      throw std::runtime_error("unreachable ordering shape");
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points -- drop-in replacements for the legacy generate() call.
+// ---------------------------------------------------------------------------
+template <class SampleT, class OffsetT>
+thrust::device_vector<SampleT> generate_histogram_input_even(
+  const ShapeSpec& spec, OffsetT n, int num_bins, SampleT lower, SampleT upper, uint64_t seed = 42)
+{
+  const double w = (static_cast<double>(upper) - static_cast<double>(lower)) / static_cast<double>(num_bins);
+  even_bin_to_value<SampleT> mapper{static_cast<double>(lower), w, lower, upper};
+  return generate_shape_impl<SampleT, OffsetT>(spec, n, num_bins, mapper, seed);
+}
+
+template <class SampleT, class OffsetT>
+thrust::device_vector<SampleT> generate_histogram_input_range(
+  const ShapeSpec& spec, OffsetT n, int num_bins, const SampleT* d_levels, uint64_t seed = 42)
+{
+  range_bin_to_value<SampleT> mapper{d_levels, num_bins};
+  return generate_shape_impl<SampleT, OffsetT>(spec, n, num_bins, mapper, seed);
+}

--- a/cub/benchmarks/bench/histogram/histogram_inputs.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_inputs.cuh
@@ -44,30 +44,30 @@
 
 enum class InputShape
 {
-  concentrated,   // spike-slab family. KNOB = target normalized entropy in
-                  // [0,1]: 1.0 = uniform, 0.0 = constant (single bin), in
-                  // between = one hot bin over a uniform floor. Sweeping the
-                  // knob reproduces (and generalizes) the old Entropy sweep --
-                  // continuously, and with the hot bin scattered off zero.
-  powerlaw,       // decaying warm set (many hot bins). KNOB = target normalized
-                  // entropy in [0,1]; the rank exponent is solved to hit it.
-                  // Independent of the concentrated knob.
-  zipf,           // decaying warm set with a classic exponent. KNOB = exponent
-                  // s >= 0 (default 1.0).
-  hash_synonym,   // hot bins all collide on one cache slot. KNOB = hot share
-                  // in [0,1] (default 0.9).
+  concentrated, // spike-slab family. KNOB = target normalized entropy in
+                // [0,1]: 1.0 = uniform, 0.0 = constant (single bin), in
+                // between = one hot bin over a uniform floor. Sweeping the
+                // knob reproduces (and generalizes) the old Entropy sweep --
+                // continuously, and with the hot bin scattered off zero.
+  powerlaw, // decaying warm set (many hot bins). KNOB = target normalized
+            // entropy in [0,1]; the rank exponent is solved to hit it.
+            // Independent of the concentrated knob.
+  zipf, // decaying warm set with a classic exponent. KNOB = exponent
+        // s >= 0 (default 1.0).
+  hash_synonym, // hot bins all collide on one cache slot. KNOB = hot share
+                // in [0,1] (default 0.9).
   stale_resident, // a cold working set, swept cyclically, that recurs in every
                   // block but overflows the SMEM cache so it cannot stay resident
                   // (thrashes it). KNOB = working-set size as a multiple of cache
                   // slots (default 2.0 => twice the slots, overflowing the cache).
-  temporal_phases,// the hot bin steps to a new location across phases. KNOB =
-                  // number of phases (default 8).
-  strided_sweep,  // bin = stride*i % B (minimal temporal locality). KNOB =
-                  // stride (default a large prime).
-  sawtooth,       // bin = i % period: a monotonic ramp 0..period-1 that resets
-                  // periodically (sequential locality over a bounded working
-                  // set). KNOB = ramp period in bins (default = num_bins => one
-                  // full 0..B-1 sweep, the classic sawtooth).
+  temporal_phases, // the hot bin steps to a new location across phases. KNOB =
+                   // number of phases (default 8).
+  strided_sweep, // bin = stride*i % B (minimal temporal locality). KNOB =
+                 // stride (default a large prime).
+  sawtooth, // bin = i % period: a monotonic ramp 0..period-1 that resets
+            // periodically (sequential locality over a bounded working
+            // set). KNOB = ramp period in bins (default = num_bins => one
+            // full 0..B-1 sweep, the classic sawtooth).
 };
 
 // A shape plus an optional knob value. `has_knob == false` means "use the
@@ -75,8 +75,8 @@ enum class InputShape
 struct ShapeSpec
 {
   InputShape shape;
-  double knob    = 0.0;
-  bool has_knob  = false;
+  double knob   = 0.0;
+  bool has_knob = false;
 };
 
 // kAdversarialCacheSlots mirrors the SMEM cuckoo-cache capacity in
@@ -100,20 +100,47 @@ inline ShapeSpec parse_input_shape(const std::string& spec)
   const auto colon = spec.find(':');
   if (colon != std::string::npos)
   {
-    name        = spec.substr(0, colon);
-    out.knob    = std::stod(spec.substr(colon + 1));
+    name         = spec.substr(0, colon);
+    out.knob     = std::stod(spec.substr(colon + 1));
     out.has_knob = true;
   }
 
-  if (name == "concentrated") { out.shape = InputShape::concentrated; }
-  else if (name == "powerlaw") { out.shape = InputShape::powerlaw; }
-  else if (name == "zipf")     { out.shape = InputShape::zipf; }
-  else if (name == "hash_synonym")    { out.shape = InputShape::hash_synonym; }
-  else if (name == "stale_resident")  { out.shape = InputShape::stale_resident; }
-  else if (name == "temporal_phases") { out.shape = InputShape::temporal_phases; }
-  else if (name == "strided_sweep")   { out.shape = InputShape::strided_sweep; }
-  else if (name == "sawtooth")         { out.shape = InputShape::sawtooth; }
-  else { throw std::runtime_error("Unknown InputShape: " + spec); }
+  if (name == "concentrated")
+  {
+    out.shape = InputShape::concentrated;
+  }
+  else if (name == "powerlaw")
+  {
+    out.shape = InputShape::powerlaw;
+  }
+  else if (name == "zipf")
+  {
+    out.shape = InputShape::zipf;
+  }
+  else if (name == "hash_synonym")
+  {
+    out.shape = InputShape::hash_synonym;
+  }
+  else if (name == "stale_resident")
+  {
+    out.shape = InputShape::stale_resident;
+  }
+  else if (name == "temporal_phases")
+  {
+    out.shape = InputShape::temporal_phases;
+  }
+  else if (name == "strided_sweep")
+  {
+    out.shape = InputShape::strided_sweep;
+  }
+  else if (name == "sawtooth")
+  {
+    out.shape = InputShape::sawtooth;
+  }
+  else
+  {
+    throw std::runtime_error("Unknown InputShape: " + spec);
+  }
   return out;
 }
 
@@ -157,7 +184,7 @@ __host__ __device__ inline int scatter_bin(uint64_t rank, int num_bins, uint64_t
 // (cub::UpperBound is _CCCL_DEVICE only and we need a host path for tests).
 __host__ __device__ inline int upper_bound_cdf(const double* cdf, int n, double val)
 {
-  int lo = 0;
+  int lo  = 0;
   int len = n;
   while (len > 0)
   {
@@ -335,7 +362,8 @@ struct phases_functor
       phase = static_cast<uint64_t>(num_phases) - 1;
     }
     // Spread phases across the bin array, scattered off zero.
-    int bin = scatter_bin(phase * (static_cast<uint64_t>(num_bins) / static_cast<uint64_t>(num_phases) + 1), num_bins, offset);
+    int bin =
+      scatter_bin(phase * (static_cast<uint64_t>(num_bins) / static_cast<uint64_t>(num_phases) + 1), num_bins, offset);
     return mapper(bin);
   }
 };
@@ -349,8 +377,8 @@ struct phases_functor
 __host__ __device__ inline uint64_t feistel_mix(uint64_t x, uint64_t k)
 {
   uint64_t z = x + k + 0x9E3779B97F4A7C15ull;
-  z         = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ull;
-  z         = (z ^ (z >> 27)) * 0x94D049BB133111EBull;
+  z          = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ull;
+  z          = (z ^ (z >> 27)) * 0x94D049BB133111EBull;
   return z ^ (z >> 31);
 }
 
@@ -365,9 +393,9 @@ __host__ __device__ inline uint64_t permute_index(uint64_t i, uint64_t n, uint64
   {
     ++bits; // bits == ceil(log2(n)) for n >= 2
   }
-  const int half        = (bits + 1) / 2;
-  const uint64_t mask    = (half >= 64) ? ~0ull : ((1ull << half) - 1ull);
-  uint64_t x             = i;
+  const int half      = (bits + 1) / 2;
+  const uint64_t mask = (half >= 64) ? ~0ull : ((1ull << half) - 1ull);
+  uint64_t x          = i;
   do
   {
     uint64_t l = (x >> half) & mask;
@@ -567,10 +595,10 @@ constexpr double kDefaultConcentratedEntropy = 0.5; // bare "concentrated"
 constexpr double kDefaultPowerlawEntropy     = 0.5; // bare "powerlaw"
 constexpr double kDefaultZipfExponent        = 1.0; // bare "zipf"
 constexpr double kDefaultHashSynonymHotShare = 0.9; // bare "hash_synonym"
-constexpr int kDefaultTemporalPhases         = 8;   // bare "temporal_phases"
+constexpr int kDefaultTemporalPhases         = 8; // bare "temporal_phases"
 constexpr uint64_t kDefaultStridedStride     = 9973ull; // bare "strided_sweep"
 // bare "sawtooth" => period 0 sentinel, resolved to num_bins at generation time.
-constexpr uint64_t kDefaultSawtoothPeriod    = 0ull;
+constexpr uint64_t kDefaultSawtoothPeriod = 0ull;
 
 // Build the per-bin pmf for an i.i.d. distribution shape, honoring the spec's
 // knob. Hot ranks are scattered across bins via scatter_bin() so the mode is
@@ -705,7 +733,7 @@ generate_shape_impl(const ShapeSpec& spec, OffsetT n, int num_bins, Mapper mappe
       acc += pmf[b];
       h_cdf[b] = acc;
     }
-    h_cdf[num_bins - 1] = 1.0; // guard against fp drift on the last bin
+    h_cdf[num_bins - 1]                 = 1.0; // guard against fp drift on the last bin
     thrust::device_vector<double> d_cdf = h_cdf;
     cdf_sample_functor<SampleT, Mapper> fn{thrust::raw_pointer_cast(d_cdf.data()), num_bins, seed, mapper};
     thrust::tabulate(out.begin(), out.end(), fn);
@@ -716,8 +744,7 @@ generate_shape_impl(const ShapeSpec& spec, OffsetT n, int num_bins, Mapper mappe
   {
     case InputShape::strided_sweep: {
       // KNOB = stride.
-      const uint64_t stride =
-        spec.has_knob ? static_cast<uint64_t>(std::llround(spec.knob)) : kDefaultStridedStride;
+      const uint64_t stride = spec.has_knob ? static_cast<uint64_t>(std::llround(spec.knob)) : kDefaultStridedStride;
       strided_functor<SampleT, Mapper> fn{num_bins, stride, mapper};
       thrust::tabulate(out.begin(), out.end(), fn);
       break;
@@ -727,8 +754,7 @@ generate_shape_impl(const ShapeSpec& spec, OffsetT n, int num_bins, Mapper mappe
       const uint64_t requested =
         spec.has_knob ? static_cast<uint64_t>(std::llround(spec.knob)) : kDefaultSawtoothPeriod;
       const uint64_t period =
-        (requested == 0) ? static_cast<uint64_t>(num_bins)
-                         : std::min(requested, static_cast<uint64_t>(num_bins));
+        (requested == 0) ? static_cast<uint64_t>(num_bins) : std::min(requested, static_cast<uint64_t>(num_bins));
       sawtooth_functor<SampleT, Mapper> fn{period, mapper};
       thrust::tabulate(out.begin(), out.end(), fn);
       break;

--- a/cub/benchmarks/bench/histogram/histogram_inputs.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_inputs.cuh
@@ -56,16 +56,18 @@ enum class InputShape
                   // s >= 0 (default 1.0).
   hash_synonym,   // hot bins all collide on one cache slot. KNOB = hot share
                   // in [0,1] (default 0.9).
-  capacity_cliff, // equiprobable active set sized around cache capacity. KNOB =
-                  // active set as a multiple of cache slots (default => slots+1,
-                  // the just-over-capacity cliff).
-  stale_resident, // cold prefix claims slots, then a hot bulk (attacks
-                  // no-evict). KNOB = prefix coverage as a multiple of cache
-                  // slots (default 1.0 => claim `slots` bins).
+  stale_resident, // a cold working set, swept cyclically, that recurs in every
+                  // block but overflows the SMEM cache so it cannot stay resident
+                  // (thrashes it). KNOB = working-set size as a multiple of cache
+                  // slots (default 2.0 => twice the slots, overflowing the cache).
   temporal_phases,// the hot bin steps to a new location across phases. KNOB =
                   // number of phases (default 8).
   strided_sweep,  // bin = stride*i % B (minimal temporal locality). KNOB =
                   // stride (default a large prime).
+  sawtooth,       // bin = i % period: a monotonic ramp 0..period-1 that resets
+                  // periodically (sequential locality over a bounded working
+                  // set). KNOB = ramp period in bins (default = num_bins => one
+                  // full 0..B-1 sweep, the classic sawtooth).
 };
 
 // A shape plus an optional knob value. `has_knob == false` means "use the
@@ -89,7 +91,6 @@ constexpr int kHashSynonymCount      = 32; // number of colliding bins
 //   "concentrated:0.5"    -> a single hot bin over a floor (was "spike")
 //   "concentrated:0.0"    -> a single bin gets 100% (was "constant")
 //   "powerlaw:0.3"        -> power law at target entropy 0.3
-//   "capacity_cliff"      -> default (slots+1) cliff
 // There is deliberately ONE concentrated shape spanning uniform<->constant via
 // its entropy knob -- no separate uniform/constant/spike names.
 inline ShapeSpec parse_input_shape(const std::string& spec)
@@ -108,10 +109,10 @@ inline ShapeSpec parse_input_shape(const std::string& spec)
   else if (name == "powerlaw") { out.shape = InputShape::powerlaw; }
   else if (name == "zipf")     { out.shape = InputShape::zipf; }
   else if (name == "hash_synonym")    { out.shape = InputShape::hash_synonym; }
-  else if (name == "capacity_cliff")  { out.shape = InputShape::capacity_cliff; }
   else if (name == "stale_resident")  { out.shape = InputShape::stale_resident; }
   else if (name == "temporal_phases") { out.shape = InputShape::temporal_phases; }
   else if (name == "strided_sweep")   { out.shape = InputShape::strided_sweep; }
+  else if (name == "sawtooth")         { out.shape = InputShape::sawtooth; }
   else { throw std::runtime_error("Unknown InputShape: " + spec); }
   return out;
 }
@@ -296,6 +297,25 @@ struct strided_functor
   }
 };
 
+// sawtooth: bin = i % period. A monotonically increasing ramp that resets to 0
+// every `period` elements -- sequential access over a bounded working set, with
+// a periodic discontinuity. With period == num_bins this is exactly the uniform
+// round-robin tiling (the concentrated:1.0 endpoint); smaller periods confine
+// the sweep to a `period`-bin window (e.g. period <= cache slots stays cache
+// resident, period just over it thrashes).
+template <class SampleT, class Mapper>
+struct sawtooth_functor
+{
+  uint64_t period;
+  Mapper mapper;
+
+  template <class I>
+  __host__ __device__ SampleT operator()(I i) const
+  {
+    return mapper(static_cast<int>(static_cast<uint64_t>(i) % period));
+  }
+};
+
 // temporal_phases: contiguous phases, each hammering one scattered bin.
 template <class SampleT, class Mapper>
 struct phases_functor
@@ -320,42 +340,98 @@ struct phases_functor
   }
 };
 
-// Exact uniform: round-robin tiling bin(i) = i % num_bins. Every bin receives
-// exactly floor(n/num_bins) or +1 samples -- ACTUALLY uniform (zero count
-// variance), unlike i.i.d. sampling of a uniform pmf which leaves multinomial
-// noise and ~37% empty bins when bins ~= elements. This is the canonical
-// entropy=1.0 endpoint. Access is sequential (a benign, low-contention
-// baseline); contrast strided_sweep, which uses a large coprime stride to
-// destroy locality on purpose.
-template <class SampleT, class Mapper>
-struct uniform_tiling_functor
+// A keyed pseudo-random bijection on [0, n), evaluated per index with no
+// buffers and no global sort: a 4-round balanced Feistel network with
+// cycle-walking. The Feistel is a bijection on the padded domain
+// [0, 2^(2*half)); cycle-walking (re-enciphering any result >= n) restricts it
+// to an exact bijection on [0, n). Used to put the exact-count uniform tiling
+// into a RANDOM sequence order (see shuffled_uniform_functor).
+__host__ __device__ inline uint64_t feistel_mix(uint64_t x, uint64_t k)
 {
+  uint64_t z = x + k + 0x9E3779B97F4A7C15ull;
+  z         = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ull;
+  z         = (z ^ (z >> 27)) * 0x94D049BB133111EBull;
+  return z ^ (z >> 31);
+}
+
+__host__ __device__ inline uint64_t permute_index(uint64_t i, uint64_t n, uint64_t seed)
+{
+  if (n <= 1)
+  {
+    return 0;
+  }
+  int bits = 0;
+  while ((n - 1) >> bits)
+  {
+    ++bits; // bits == ceil(log2(n)) for n >= 2
+  }
+  const int half        = (bits + 1) / 2;
+  const uint64_t mask    = (half >= 64) ? ~0ull : ((1ull << half) - 1ull);
+  uint64_t x             = i;
+  do
+  {
+    uint64_t l = (x >> half) & mask;
+    uint64_t r = x & mask;
+    for (int round = 0; round < 4; ++round)
+    {
+      const uint64_t nl = r;
+      const uint64_t nr = l ^ (feistel_mix(r, seed + static_cast<uint64_t>(round)) & mask);
+      l                 = nl;
+      r                 = nr;
+    }
+    x = (l << half) | r;
+  } while (x >= n); // cycle-walk back into range
+  return x;
+}
+
+// Exact uniform with RANDOM sequence order: every bin still receives exactly
+// floor(n/num_bins) or +1 samples (the round-robin tiling multiset), but the
+// positions are a pseudo-random permutation, so access is NOT sequential. This
+// is the entropy=1.0 endpoint: uniform counts, randomly distributed in the
+// input. (Pure sequential tiling bin(i)=i%num_bins is available as the
+// `sawtooth` shape; strided_sweep destroys locality with a coprime stride.)
+template <class SampleT, class Mapper>
+struct shuffled_uniform_functor
+{
+  uint64_t n;
   int num_bins;
+  uint64_t seed;
   Mapper mapper;
 
   template <class I>
   __host__ __device__ SampleT operator()(I i) const
   {
-    return mapper(static_cast<int>(static_cast<uint64_t>(i) % static_cast<uint64_t>(num_bins)));
+    const uint64_t j = permute_index(static_cast<uint64_t>(i), n, seed);
+    return mapper(static_cast<int>(j % static_cast<uint64_t>(num_bins)));
   }
 };
 
-// stale_resident: a cold prefix sweeps `n_cold` distinct bins once (claiming
-// every cache slot), then the hot bulk hammers a single bin disjoint from the
-// prefix.
+// stale_resident: a cold WORKING SET of `span` distinct bins (sized as a multiple
+// of the SMEM cache capacity via the cover knob), scattered across the bin array
+// and swept CYCLICALLY. The same `span` keys recur in every block/tile -- so the
+// per-block cache is hit by them on every block -- but when span > cache slots the
+// set cannot stay resident: each key is evicted before it comes around again, so
+// the cache yields ~no benefit (the keys are "stale residents" that thrash it).
+// span <= slots fits and caches well; the default (cover=2 => 2*slots) overflows
+// it. The cyclic SEQUENTIAL reuse (each key revisited at a fixed stride apart) is
+// what makes the cache's capacity boundary actually show. The cyclic counter advances
+// by a large odd stride so a thread's grid-strided positions still walk distinct
+// keys (it does not alias the launch's grid stride).
 template <class SampleT, class Mapper>
 struct stale_functor
 {
   int num_bins;
-  uint64_t n_cold;
-  int hot_bin;
+  uint64_t span; // size of the cold working set (number of distinct bins)
+  uint64_t offset;
   Mapper mapper;
 
   template <class I>
   __host__ __device__ SampleT operator()(I i) const
   {
-    uint64_t idx = static_cast<uint64_t>(i);
-    int bin      = (idx < n_cold) ? static_cast<int>(idx % static_cast<uint64_t>(num_bins)) : hot_bin;
+    // Position -> which cold key. A large odd multiplier decorrelates the key
+    // index from the grid-stride launch geometry while still cycling [0, span).
+    const uint64_t k = (static_cast<uint64_t>(i) * 2654435761ull) % span;
+    const int bin    = scatter_bin(k, num_bins, offset); // scatter across the array
     return mapper(bin);
   }
 };
@@ -420,34 +496,70 @@ inline double solve_powerlaw_exponent(int num_bins, double target)
   return 0.5 * (lo + hi);
 }
 
-// Spike-slab pmf: probability `p` on one hot bin, `(1-p)` spread uniformly over
-// all bins. Normalized entropy decreases monotonically from 1.0 (p=0, uniform)
-// to 0.0 (p=1, single bin), so we bisect `p` to hit a target entropy.
-inline double spike_slab_entropy(int num_bins, double p)
+// Softmax-over-random-logits pmf: draw a fixed random logit g[b] per bin, then
+// pmf[b] = softmax(g/T)[b]. Temperature T dials the spread CONTINUOUSLY and
+// SMOOTHLY: T->inf gives uniform (entropy 1.0), T->0 concentrates onto the
+// single largest-logit bin (entropy 0.0). Unlike the old spike-slab (one hot bin
+// over a flat floor), EVERY bin stays occupied and varies randomly -- e.g. at
+// entropy 0.75 the distribution is "mostly uniform with mild random variation",
+// not one dominant spike. Normalized entropy is monotincreasing in T, so we
+// bisect log(T) to hit a target entropy. The logits are seeded so the shape is
+// reproducible and the mode is not pinned to bin 0.
+inline std::vector<double> softmax_logits(int num_bins, uint64_t seed)
 {
-  const double base = (1.0 - p) / num_bins;
-  std::vector<double> pmf(num_bins, base);
-  pmf[0] += p;
-  return normalized_entropy(pmf);
+  std::vector<double> g(num_bins);
+  for (int b = 0; b < num_bins; ++b)
+  {
+    // Two hashed uniforms -> a standard-normal logit via Box-Muller. Decorrelated
+    // per bin; host/device parity not required (concentrated interior is not swept).
+    const double u1 = u01_from_hash(element_key(static_cast<uint64_t>(b), seed));
+    const double u2 = u01_from_hash(element_key(static_cast<uint64_t>(b), seed ^ 0xD1B54A32D192ED03ull));
+    const double r  = std::sqrt(-2.0 * std::log(u1 > 0.0 ? u1 : 1e-300));
+    g[b]            = r * std::cos(6.283185307179586 * u2);
+  }
+  return g;
 }
 
-inline double solve_spike_share(int num_bins, double target)
+inline std::vector<double> softmax_pmf(const std::vector<double>& g, double T)
 {
-  double lo = 0.0, hi = 1.0;
-  for (int it = 0; it < 60; ++it)
+  const int num_bins = static_cast<int>(g.size());
+  double gmax        = g[0];
+  for (double v : g)
   {
-    const double mid = 0.5 * (lo + hi);
-    const double h   = spike_slab_entropy(num_bins, mid);
-    if (h < target)
+    gmax = v > gmax ? v : gmax;
+  }
+  std::vector<double> pmf(num_bins);
+  double sum = 0.0;
+  for (int b = 0; b < num_bins; ++b)
+  {
+    pmf[b] = std::exp((g[b] - gmax) / T);
+    sum += pmf[b];
+  }
+  for (double& v : pmf)
+  {
+    v /= sum;
+  }
+  return pmf;
+}
+
+inline std::vector<double> solve_softmax_pmf(int num_bins, double target, uint64_t seed)
+{
+  const std::vector<double> g = softmax_logits(num_bins, seed);
+  // Bisect in log-space: entropy increases with T.
+  double lo = 1e-3, hi = 1e3;
+  for (int it = 0; it < 80; ++it)
+  {
+    const double mid = std::sqrt(lo * hi);
+    if (normalized_entropy(softmax_pmf(g, mid)) < target)
     {
-      hi = mid; // too concentrated -> reduce p
+      lo = mid; // too concentrated -> raise T
     }
     else
     {
-      lo = mid;
+      hi = mid;
     }
   }
-  return 0.5 * (lo + hi);
+  return softmax_pmf(g, std::sqrt(lo * hi));
 }
 
 // Defaults applied when the axis value supplies no knob.
@@ -457,6 +569,8 @@ constexpr double kDefaultZipfExponent        = 1.0; // bare "zipf"
 constexpr double kDefaultHashSynonymHotShare = 0.9; // bare "hash_synonym"
 constexpr int kDefaultTemporalPhases         = 8;   // bare "temporal_phases"
 constexpr uint64_t kDefaultStridedStride     = 9973ull; // bare "strided_sweep"
+// bare "sawtooth" => period 0 sentinel, resolved to num_bins at generation time.
+constexpr uint64_t kDefaultSawtoothPeriod    = 0ull;
 
 // Build the per-bin pmf for an i.i.d. distribution shape, honoring the spec's
 // knob. Hot ranks are scattered across bins via scatter_bin() so the mode is
@@ -485,13 +599,10 @@ inline std::vector<double> build_pmf(const ShapeSpec& spec, int num_bins, uint64
       }
       else
       {
-        const double p       = solve_spike_share(num_bins, target);
-        const double floor_p = (1.0 - p) / num_bins;
-        for (int b = 0; b < num_bins; ++b)
-        {
-          pmf[b] = floor_p;
-        }
-        pmf[scatter_bin(0, num_bins, offset)] += p;
+        // Completely random bin probabilities dialed to the target entropy: a
+        // softmax over per-bin random logits. All bins occupied, smoothly more
+        // uniform as the knob -> 1 (no single dominant "hot" bin).
+        pmf = solve_softmax_pmf(num_bins, target, seed);
       }
       break;
     }
@@ -547,28 +658,6 @@ inline std::vector<double> build_pmf(const ShapeSpec& spec, int num_bins, uint64
       }
       break;
     }
-    case InputShape::capacity_cliff: {
-      // KNOB = active set as a multiple of cache slots. Default => slots+1
-      // (the just-over-capacity cliff). Equiprobable bins, spread across the
-      // array so they do not trivially share slots.
-      int k;
-      if (spec.has_knob)
-      {
-        k = static_cast<int>(std::lround(spec.knob * kAdversarialCacheSlots));
-      }
-      else
-      {
-        k = kAdversarialCacheSlots + 1;
-      }
-      k = std::max(1, std::min(k, num_bins));
-      const double p = 1.0 / k;
-      for (int j = 0; j < k; ++j)
-      {
-        const int b = static_cast<int>((static_cast<uint64_t>(j) * num_bins) / static_cast<uint64_t>(k));
-        pmf[b] = p;
-      }
-      break;
-    }
     default:
       throw std::runtime_error("build_pmf called with a non-distribution shape");
   }
@@ -578,7 +667,7 @@ inline std::vector<double> build_pmf(const ShapeSpec& spec, int num_bins, uint64
 inline bool is_ordering_shape(InputShape shape)
 {
   return shape == InputShape::stale_resident || shape == InputShape::temporal_phases
-      || shape == InputShape::strided_sweep;
+      || shape == InputShape::strided_sweep || shape == InputShape::sawtooth;
 }
 
 // ---------------------------------------------------------------------------
@@ -592,11 +681,15 @@ generate_shape_impl(const ShapeSpec& spec, OffsetT n, int num_bins, Mapper mappe
   thrust::device_vector<SampleT> out(static_cast<std::size_t>(n));
   const uint64_t offset = seed % static_cast<uint64_t>(num_bins);
 
-  // Exact-uniform endpoint: emitted as equal-count tiling rather than i.i.d.
-  // sampling, so every bin gets exactly n/num_bins (+-1) -- truly uniform.
+  // Exact-uniform endpoint: every bin gets exactly n/num_bins (+-1) samples, in
+  // a pseudo-random sequence order (a Feistel permutation of the round-robin
+  // tiling). Uniform counts, randomly distributed in the input -- not the
+  // sequential ramp (that is the `sawtooth` shape). Emitted directly rather than
+  // via i.i.d. uniform sampling so the per-bin counts are exact (no multinomial
+  // noise / empty bins when bins ~= elements).
   if (spec.shape == InputShape::concentrated && spec.has_knob && spec.knob >= 1.0)
   {
-    uniform_tiling_functor<SampleT, Mapper> fn{num_bins, mapper};
+    shuffled_uniform_functor<SampleT, Mapper> fn{static_cast<uint64_t>(n), num_bins, seed, mapper};
     thrust::tabulate(out.begin(), out.end(), fn);
     return out;
   }
@@ -629,6 +722,17 @@ generate_shape_impl(const ShapeSpec& spec, OffsetT n, int num_bins, Mapper mappe
       thrust::tabulate(out.begin(), out.end(), fn);
       break;
     }
+    case InputShape::sawtooth: {
+      // KNOB = ramp period in bins; 0 (the default) means a full num_bins sweep.
+      const uint64_t requested =
+        spec.has_knob ? static_cast<uint64_t>(std::llround(spec.knob)) : kDefaultSawtoothPeriod;
+      const uint64_t period =
+        (requested == 0) ? static_cast<uint64_t>(num_bins)
+                         : std::min(requested, static_cast<uint64_t>(num_bins));
+      sawtooth_functor<SampleT, Mapper> fn{period, mapper};
+      thrust::tabulate(out.begin(), out.end(), fn);
+      break;
+    }
     case InputShape::temporal_phases: {
       // KNOB = number of phases.
       const int requested = spec.has_knob ? static_cast<int>(std::llround(spec.knob)) : kDefaultTemporalPhases;
@@ -638,16 +742,13 @@ generate_shape_impl(const ShapeSpec& spec, OffsetT n, int num_bins, Mapper mappe
       break;
     }
     case InputShape::stale_resident: {
-      // KNOB = prefix coverage as a multiple of cache slots (default 1.0).
-      const double cover    = knob_or(spec, 1.0);
-      const int64_t want    = static_cast<int64_t>(std::llround(cover * kAdversarialCacheSlots));
-      const uint64_t n_cold = static_cast<uint64_t>(std::max<int64_t>(1, std::min<int64_t>(want, num_bins)));
-      // hot bin disjoint from the cold prefix [0, n_cold) when possible.
-      const int hot_bin =
-        (num_bins > static_cast<int>(n_cold))
-          ? static_cast<int>(n_cold + (offset % (static_cast<uint64_t>(num_bins) - n_cold)))
-          : num_bins / 2;
-      stale_functor<SampleT, Mapper> fn{num_bins, n_cold, hot_bin, mapper};
+      // KNOB = cold working-set size as a multiple of cache slots (default 2.0 =>
+      // twice the slots, so it overflows and thrashes a per-block cache). The set
+      // recurs in every block but cannot stay resident when span > slots.
+      const double cover  = knob_or(spec, 2.0);
+      const int64_t want  = static_cast<int64_t>(std::llround(cover * kAdversarialCacheSlots));
+      const uint64_t span = static_cast<uint64_t>(std::max<int64_t>(1, std::min<int64_t>(want, num_bins)));
+      stale_functor<SampleT, Mapper> fn{num_bins, span, offset, mapper};
       thrust::tabulate(out.begin(), out.end(), fn);
       break;
     }

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -58,6 +58,63 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   state.add_global_memory_reads<SampleT>(elements * num_active_channels);
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
+  // Warmup + correctness check: run MultiHistogramEven once outside
+  // `state.exec`, checking the dispatch return code, then verify each
+  // channel's histogram bin-by-bin against an independent reference.
+  // Skipped when CUB_BENCH_HISTOGRAM_VERIFY=0|false|no|off.
+  if (bench_correctness_checks_enabled())
+  {
+    thrust::fill(hist_r.begin(), hist_r.end(), CounterT{0});
+    thrust::fill(hist_g.begin(), hist_g.end(), CounterT{0});
+    thrust::fill(hist_b.begin(), hist_b.end(), CounterT{0});
+    void* d_temp_storage      = nullptr;
+    size_t temp_storage_bytes = 0;
+    bench_check_cuda(
+      (cub::DeviceHistogram::MultiHistogramEven<num_channels, num_active_channels>(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+        cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+        cuda::std::array<SampleT, num_active_channels>{lower_level_r, lower_level_g, lower_level_b},
+        cuda::std::array<SampleT, num_active_channels>{upper_level_r, upper_level_g, upper_level_b},
+        static_cast<OffsetT>(elements))),
+      "warmup MultiHistogramEven temp-size");
+    thrust::device_vector<unsigned char> warmup_tmp(temp_storage_bytes);
+    d_temp_storage = thrust::raw_pointer_cast(warmup_tmp.data());
+    bench_check_cuda(
+      (cub::DeviceHistogram::MultiHistogramEven<num_channels, num_active_channels>(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+        cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+        cuda::std::array<SampleT, num_active_channels>{lower_level_r, lower_level_g, lower_level_b},
+        cuda::std::array<SampleT, num_active_channels>{upper_level_r, upper_level_g, upper_level_b},
+        static_cast<OffsetT>(elements))),
+      "warmup MultiHistogramEven");
+    bench_check_cuda(cudaDeviceSynchronize(), "warmup sync");
+
+    std::vector<thrust::device_vector<CounterT>> opt_hists_d;
+    opt_hists_d.emplace_back(std::move(hist_r));
+    opt_hists_d.emplace_back(std::move(hist_g));
+    opt_hists_d.emplace_back(std::move(hist_b));
+    bench_verify_histogram_even<num_channels, num_active_channels, SampleT, CounterT, OffsetT>(
+      input,
+      opt_hists_d,
+      static_cast<OffsetT>(elements),
+      static_cast<int>(num_bins),
+      lower_level_r,
+      upper_level_r,
+      "multi.even");
+    hist_r        = std::move(opt_hists_d[0]);
+    hist_g        = std::move(opt_hists_d[1]);
+    hist_b        = std::move(opt_hists_d[2]);
+    d_histogram_r = thrust::raw_pointer_cast(hist_r.data());
+    d_histogram_g = thrust::raw_pointer_cast(hist_g.data());
+    d_histogram_b = thrust::raw_pointer_cast(hist_b.data());
+  }
+
   caching_allocator_t alloc;
   // Force the persisting-L2 reservation back to 0 and demote any persisting
   // lines outside the timed window, so neither cudaAccessPolicyWindow nor a

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -4,6 +4,7 @@
 #include <nvbench_helper.cuh>
 
 #include "../histogram_common.cuh"
+#include "../histogram_inputs.cuh"
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
 // %RANGE% TUNE_THREADS tpb 128:1024:32
@@ -20,7 +21,7 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   constexpr int num_channels        = 4;
   constexpr int num_active_channels = 3;
 
-  const auto entropy     = str_to_entropy(state.get_string("Entropy"));
+  const auto shape       = parse_input_shape(state.get_string("InputShape"));
   const auto elements    = state.get_int64("Elements{io}");
   const auto num_bins    = state.get_int64("Bins");
   const int num_levels_r = static_cast<int>(num_bins) + 1;
@@ -58,7 +59,8 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   thrust::device_vector<CounterT> hist_r(num_bins);
   thrust::device_vector<CounterT> hist_g(num_bins);
   thrust::device_vector<CounterT> hist_b(num_bins);
-  thrust::device_vector<SampleT> input = generate(elements * num_channels, entropy, lower_level_r, upper_level_r);
+  thrust::device_vector<SampleT> input = generate_histogram_input_even<SampleT>(
+    shape, elements * num_channels, static_cast<int>(num_bins), lower_level_r, upper_level_r);
 
   SampleT* d_input        = thrust::raw_pointer_cast(input.data());
   CounterT* d_histogram_r = thrust::raw_pointer_cast(hist_r.data());
@@ -173,4 +175,18 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_of
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
   .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
-  .add_string_axis("Entropy", {"0.201", "1.000"});
+  // One `concentrated` shape swept across entropy (1.0=uniform, 0.5=spike,
+  // 0.0=constant) plus the multi-hot and cache-adversarial shapes. Each value
+  // may carry an inline knob as "name:value"; see histogram_inputs.cuh.
+  .add_string_axis(
+    "InputShape",
+    {"concentrated:1.0",
+     "concentrated:0.5",
+     "concentrated:0.0",
+     "powerlaw:0.5",
+     "zipf:1.0",
+     "hash_synonym",
+     "capacity_cliff",
+     "stale_resident",
+     "temporal_phases",
+     "strided_sweep"});

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -35,6 +35,19 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
     return;
   }
 
+  // Skip configurations whose row stride in samples (= elements * num_channels)
+  // overflows OffsetT. The MultiHistogramEven<NUM_CHANNELS> single-row
+  // overload internally computes `row_stride_samples = elements * num_channels`
+  // and stores it as OffsetT; the rectangular overload does the same. For
+  // OffsetT = int32_t and num_channels = 4 this caps at elements <= INT_MAX/4
+  // (~536M); above that the cast wraps to a negative value and the kernel
+  // produces zero output. Reported by autocuda matrix runs at elements=1G.
+  if (static_cast<int64_t>(elements) * num_channels > static_cast<int64_t>(::cuda::std::numeric_limits<OffsetT>::max()))
+  {
+    state.skip("Row stride samples (elements * num_channels) overflows OffsetT");
+    return;
+  }
+
   const SampleT lower_level_r = get_lower_level<SampleT>();
   const SampleT upper_level_r = get_upper_level<SampleT>(num_bins, elements);
   const SampleT lower_level_g = lower_level_r;

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -27,17 +27,15 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   const int num_levels_g = num_levels_r;
   const int num_levels_b = num_levels_g;
 
-  // Skip invalid configurations where LevelT (= SampleT) cannot represent the number of bins
-  if constexpr (cuda::std::is_integral_v<SampleT>)
+  // Skip invalid configurations where the SampleT range can't hold enough
+  // strictly-monotonic levels.
+  if (num_bins > max_representable_bins<SampleT>())
   {
-    if (num_bins > static_cast<int64_t>(cuda::std::numeric_limits<SampleT>::max()))
-    {
-      state.skip("Number of bins exceeds what LevelT (= SampleT) can represent");
-      return;
-    }
+    state.skip("Number of bins exceeds what SampleT can represent");
+    return;
   }
 
-  const SampleT lower_level_r = 0;
+  const SampleT lower_level_r = get_lower_level<SampleT>();
   const SampleT upper_level_r = get_upper_level<SampleT>(num_bins, elements);
   const SampleT lower_level_g = lower_level_r;
   const SampleT upper_level_g = upper_level_r;

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -59,26 +59,32 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
   caching_allocator_t alloc;
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    auto env = cub_bench_env(
-      alloc,
-      launch
+  // Demote persisting L2 lines outside the timed window so that no
+  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
+             [&](nvbench::launch& launch, auto& timer) {
+               cudaCtxResetPersistingL2Cache();
+               timer.start();
+               auto env = cub_bench_env(
+                 alloc,
+                 launch
 #if !TUNE_BASE
-      ,
-      cuda::execution::tune(bench_policy_selector<key_t, num_channels, num_active_channels>{})
+                 ,
+                 cuda::execution::tune(bench_policy_selector<key_t, num_channels, num_active_channels>{})
 #endif // !TUNE_BASE
-    );
-    _CCCL_TRY_CUDA_API(
-      (cub::DeviceHistogram::MultiHistogramEven<num_channels, num_active_channels>),
-      "MultiHistogramEven failed",
-      d_input,
-      cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
-      cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
-      cuda::std::array<SampleT, num_active_channels>{lower_level_r, lower_level_g, lower_level_b},
-      cuda::std::array<SampleT, num_active_channels>{upper_level_r, upper_level_g, upper_level_b},
-      static_cast<OffsetT>(elements),
-      env);
-  });
+               );
+               _CCCL_TRY_CUDA_API(
+                 (cub::DeviceHistogram::MultiHistogramEven<num_channels, num_active_channels>),
+                 "MultiHistogramEven failed",
+                 d_input,
+                 cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+                 cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+                 cuda::std::array<SampleT, num_active_channels>{lower_level_r, lower_level_g, lower_level_b},
+                 cuda::std::array<SampleT, num_active_channels>{upper_level_r, upper_level_g, upper_level_b},
+                 static_cast<OffsetT>(elements),
+                 env);
+               timer.stop();
+             });
 }
 
 using counter_types     = nvbench::type_list<int32_t>;
@@ -93,6 +99,6 @@ using sample_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, float
 NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_offset_types))
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_int64_axis("Bins", {32, 128, 2048, 2097152})
+  .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
+  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -59,10 +59,14 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
   caching_allocator_t alloc;
-  // Demote persisting L2 lines outside the timed window so that no
-  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  // Force the persisting-L2 reservation back to 0 and demote any persisting
+  // lines outside the timed window, so neither cudaAccessPolicyWindow nor a
+  // bumped cudaLimitPersistingL2CacheSize can carry across iterations. The
+  // default reservation is 0; hardcoding 0 also clears any pollution left by
+  // a prior benchmark in the same nvbench process.
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
+               cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, 0);
                cudaCtxResetPersistingL2Cache();
                timer.start();
                auto env = cub_bench_env(

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -104,5 +104,5 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_of
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
-  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
+  .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -186,7 +186,7 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_of
      "powerlaw:0.5",
      "zipf:1.0",
      "hash_synonym",
-     "capacity_cliff",
      "stale_resident",
      "temporal_phases",
-     "strided_sweep"});
+     "strided_sweep",
+     "sawtooth"});

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -31,7 +31,14 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   const int num_levels_g = num_levels_r;
   const int num_levels_b = num_levels_g;
 
-  const SampleT lower_level = 0;
+  // Skip invalid configurations; see range.cu for rationale.
+  if (num_bins > max_representable_bins<SampleT>())
+  {
+    state.skip("Number of bins exceeds what SampleT can represent");
+    return;
+  }
+
+  const SampleT lower_level = get_lower_level<SampleT>();
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
   // Jittered uniform spacing keeps DispatchRange on the SearchTransform path

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -125,5 +125,5 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_o
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
-  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
+  .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3
 
-#include <thrust/sequence.h>
+#include <thrust/host_vector.h>
 
 #include <nvbench_helper.cuh>
 
@@ -32,11 +32,23 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   const SampleT lower_level = 0;
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
-  SampleT step = (upper_level - lower_level) / num_bins;
-  thrust::device_vector<SampleT> levels_r(num_bins + 1);
-
-  // TODO Extract sequence to the helper TU
-  thrust::sequence(levels_r.begin(), levels_r.end(), lower_level, step);
+  // Quadratic spacing keeps DispatchRange on the SearchTransform path.
+  thrust::host_vector<SampleT> h_levels(num_bins + 1);
+  h_levels[0]    = lower_level;
+  const double L = static_cast<double>(lower_level);
+  const double U = static_cast<double>(upper_level);
+  const double n = static_cast<double>(num_bins);
+  for (int i = 1; i <= num_bins; ++i)
+  {
+    const double t = static_cast<double>(i) / n;
+    SampleT lvl    = static_cast<SampleT>(L + (U - L) * t * t);
+    if (lvl <= h_levels[i - 1])
+    {
+      lvl = static_cast<SampleT>(h_levels[i - 1] + SampleT{1});
+    }
+    h_levels[i] = lvl;
+  }
+  thrust::device_vector<SampleT> levels_r = h_levels;
   thrust::device_vector<SampleT> levels_g = levels_r;
   thrust::device_vector<SampleT> levels_b = levels_g;
 
@@ -59,25 +71,31 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
   caching_allocator_t alloc;
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    auto env = cub_bench_env(
-      alloc,
-      launch
+  // Demote persisting L2 lines outside the timed window so that no
+  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
+             [&](nvbench::launch& launch, auto& timer) {
+               cudaCtxResetPersistingL2Cache();
+               timer.start();
+               auto env = cub_bench_env(
+                 alloc,
+                 launch
 #if !TUNE_BASE
-      ,
-      cuda::execution::tune(bench_policy_selector<key_t, num_channels, num_active_channels>{})
+                 ,
+                 cuda::execution::tune(bench_policy_selector<key_t, num_channels, num_active_channels>{})
 #endif // !TUNE_BASE
-    );
-    _CCCL_TRY_CUDA_API(
-      (cub::DeviceHistogram::MultiHistogramRange<num_channels, num_active_channels>),
-      "MultiHistogramRange failed",
-      d_input,
-      cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
-      cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
-      cuda::std::array<const SampleT*, num_active_channels>{d_levels_r, d_levels_g, d_levels_b},
-      static_cast<OffsetT>(elements),
-      env);
-  });
+               );
+               _CCCL_TRY_CUDA_API(
+                 (cub::DeviceHistogram::MultiHistogramRange<num_channels, num_active_channels>),
+                 "MultiHistogramRange failed",
+                 d_input,
+                 cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+                 cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+                 cuda::std::array<const SampleT*, num_active_channels>{d_levels_r, d_levels_g, d_levels_b},
+                 static_cast<OffsetT>(elements),
+                 env);
+               timer.stop();
+             });
 }
 
 using counter_types     = nvbench::type_list<int32_t>;
@@ -92,6 +110,6 @@ using sample_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, float
 NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_offset_types))
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_int64_axis("Bins", {32, 128, 2048, 2097152})
+  .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
+  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -38,6 +38,14 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
     return;
   }
 
+  // Skip when row_stride_samples (= elements * num_channels) would overflow
+  // OffsetT. See multi/even.cu for the rationale.
+  if (static_cast<int64_t>(elements) * num_channels > static_cast<int64_t>(::cuda::std::numeric_limits<OffsetT>::max()))
+  {
+    state.skip("Row stride samples (elements * num_channels) overflows OffsetT");
+    return;
+  }
+
   const SampleT lower_level = get_lower_level<SampleT>();
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -80,6 +80,65 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   state.add_global_memory_reads<SampleT>(elements * num_active_channels);
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
+  // Warmup + correctness check: run MultiHistogramRange once outside
+  // `state.exec`, checking the dispatch return code, then verify each
+  // channel's histogram bin-by-bin against an independent reference.
+  // Skipped when CUB_BENCH_HISTOGRAM_VERIFY=0|false|no|off.
+  if (bench_correctness_checks_enabled())
+  {
+    thrust::fill(hist_r.begin(), hist_r.end(), CounterT{0});
+    thrust::fill(hist_g.begin(), hist_g.end(), CounterT{0});
+    thrust::fill(hist_b.begin(), hist_b.end(), CounterT{0});
+    void* d_temp_storage      = nullptr;
+    size_t temp_storage_bytes = 0;
+    bench_check_cuda(
+      (cub::DeviceHistogram::MultiHistogramRange<num_channels, num_active_channels>(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+        cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+        cuda::std::array<const SampleT*, num_active_channels>{d_levels_r, d_levels_g, d_levels_b},
+        static_cast<OffsetT>(elements))),
+      "warmup MultiHistogramRange temp-size");
+    thrust::device_vector<unsigned char> warmup_tmp(temp_storage_bytes);
+    d_temp_storage = thrust::raw_pointer_cast(warmup_tmp.data());
+    bench_check_cuda(
+      (cub::DeviceHistogram::MultiHistogramRange<num_channels, num_active_channels>(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+        cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+        cuda::std::array<const SampleT*, num_active_channels>{d_levels_r, d_levels_g, d_levels_b},
+        static_cast<OffsetT>(elements))),
+      "warmup MultiHistogramRange");
+    bench_check_cuda(cudaDeviceSynchronize(), "warmup sync");
+
+    std::vector<thrust::device_vector<CounterT>> opt_hists_d;
+    opt_hists_d.emplace_back(std::move(hist_r));
+    opt_hists_d.emplace_back(std::move(hist_g));
+    opt_hists_d.emplace_back(std::move(hist_b));
+    std::vector<thrust::device_vector<SampleT>> d_levels_per_channel;
+    d_levels_per_channel.emplace_back(std::move(levels_r));
+    d_levels_per_channel.emplace_back(std::move(levels_g));
+    d_levels_per_channel.emplace_back(std::move(levels_b));
+    bench_verify_histogram_range<num_channels, num_active_channels, SampleT, CounterT, OffsetT>(
+      input, opt_hists_d, d_levels_per_channel, static_cast<OffsetT>(elements), "multi.range");
+    hist_r        = std::move(opt_hists_d[0]);
+    hist_g        = std::move(opt_hists_d[1]);
+    hist_b        = std::move(opt_hists_d[2]);
+    d_histogram_r = thrust::raw_pointer_cast(hist_r.data());
+    d_histogram_g = thrust::raw_pointer_cast(hist_g.data());
+    d_histogram_b = thrust::raw_pointer_cast(hist_b.data());
+    levels_r      = std::move(d_levels_per_channel[0]);
+    levels_g      = std::move(d_levels_per_channel[1]);
+    levels_b      = std::move(d_levels_per_channel[2]);
+    d_levels_r    = thrust::raw_pointer_cast(levels_r.data());
+    d_levels_g    = thrust::raw_pointer_cast(levels_g.data());
+    d_levels_b    = thrust::raw_pointer_cast(levels_b.data());
+  }
+
   caching_allocator_t alloc;
   // Force the persisting-L2 reservation back to 0 and demote any persisting
   // lines outside the timed window, so neither cudaAccessPolicyWindow nor a

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -8,6 +8,7 @@
 #include <nvbench_helper.cuh>
 
 #include "../histogram_common.cuh"
+#include "../histogram_inputs.cuh"
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
 // %RANGE% TUNE_THREADS tpb 128:1024:32
@@ -24,7 +25,7 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   constexpr int num_channels        = 4;
   constexpr int num_active_channels = 3;
 
-  const auto entropy     = str_to_entropy(state.get_string("Entropy"));
+  const auto shape       = parse_input_shape(state.get_string("InputShape"));
   const auto elements    = state.get_int64("Elements{io}");
   const auto num_bins    = state.get_int64("Bins");
   const int num_levels_r = static_cast<int>(num_bins) + 1;
@@ -84,7 +85,8 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   thrust::device_vector<CounterT> hist_r(num_bins);
   thrust::device_vector<CounterT> hist_g(num_bins);
   thrust::device_vector<CounterT> hist_b(num_bins);
-  thrust::device_vector<SampleT> input = generate(elements * num_channels, entropy, lower_level, upper_level);
+  thrust::device_vector<SampleT> input = generate_histogram_input_range<SampleT>(
+    shape, elements * num_channels, static_cast<int>(num_bins), d_levels_r);
 
   SampleT* d_input        = thrust::raw_pointer_cast(input.data());
   CounterT* d_histogram_r = thrust::raw_pointer_cast(hist_r.data());
@@ -200,4 +202,18 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_o
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
   .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
-  .add_string_axis("Entropy", {"0.201", "1.000"});
+  // One `concentrated` shape swept across entropy (1.0=uniform, 0.5=spike,
+  // 0.0=constant) plus the multi-hot and cache-adversarial shapes. Each value
+  // may carry an inline knob as "name:value"; see histogram_inputs.cuh.
+  .add_string_axis(
+    "InputShape",
+    {"concentrated:1.0",
+     "concentrated:0.5",
+     "concentrated:0.0",
+     "powerlaw:0.5",
+     "zipf:1.0",
+     "hash_synonym",
+     "capacity_cliff",
+     "stale_resident",
+     "temporal_phases",
+     "strided_sweep"});

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -71,10 +71,14 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
   caching_allocator_t alloc;
-  // Demote persisting L2 lines outside the timed window so that no
-  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  // Force the persisting-L2 reservation back to 0 and demote any persisting
+  // lines outside the timed window, so neither cudaAccessPolicyWindow nor a
+  // bumped cudaLimitPersistingL2CacheSize can carry across iterations. The
+  // default reservation is 0; hardcoding 0 also clears any pollution left by
+  // a prior benchmark in the same nvbench process.
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
+               cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, 0);
                cudaCtxResetPersistingL2Cache();
                timer.start();
                auto env = cub_bench_env(

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -3,6 +3,8 @@
 
 #include <thrust/host_vector.h>
 
+#include <random>
+
 #include <nvbench_helper.cuh>
 
 #include "../histogram_common.cuh"
@@ -32,21 +34,29 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   const SampleT lower_level = 0;
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
-  // Quadratic spacing keeps DispatchRange on the SearchTransform path.
+  // Jittered uniform spacing keeps DispatchRange on the SearchTransform path
+  // while keeping bin widths within ~2x of each other. Fixed seed makes the
+  // levels reproducible across runs.
   thrust::host_vector<SampleT> h_levels(num_bins + 1);
-  h_levels[0]    = lower_level;
-  const double L = static_cast<double>(lower_level);
-  const double U = static_cast<double>(upper_level);
-  const double n = static_cast<double>(num_bins);
-  for (int i = 1; i <= num_bins; ++i)
+  const double L    = static_cast<double>(lower_level);
+  const double U    = static_cast<double>(upper_level);
+  const double step = (U - L) / static_cast<double>(num_bins);
+  std::mt19937 rng(0xC0FFEE);
+  std::uniform_real_distribution<double> jitter(-0.25, 0.25);
+  h_levels[0]        = lower_level;
+  h_levels[num_bins] = upper_level;
+  for (int i = 1; i < num_bins; ++i)
   {
-    const double t = static_cast<double>(i) / n;
-    SampleT lvl    = static_cast<SampleT>(L + (U - L) * t * t);
+    SampleT lvl = static_cast<SampleT>(L + i * step + step * jitter(rng));
     if (lvl <= h_levels[i - 1])
     {
       lvl = static_cast<SampleT>(h_levels[i - 1] + SampleT{1});
     }
     h_levels[i] = lvl;
+  }
+  if (h_levels[num_bins] <= h_levels[num_bins - 1])
+  {
+    h_levels[num_bins] = static_cast<SampleT>(h_levels[num_bins - 1] + SampleT{1});
   }
   thrust::device_vector<SampleT> levels_r = h_levels;
   thrust::device_vector<SampleT> levels_g = levels_r;

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -213,7 +213,7 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_o
      "powerlaw:0.5",
      "zipf:1.0",
      "hash_synonym",
-     "capacity_cliff",
      "stale_resident",
      "temporal_phases",
-     "strided_sweep"});
+     "strided_sweep",
+     "sawtooth"});

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -85,8 +85,8 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   thrust::device_vector<CounterT> hist_r(num_bins);
   thrust::device_vector<CounterT> hist_g(num_bins);
   thrust::device_vector<CounterT> hist_b(num_bins);
-  thrust::device_vector<SampleT> input = generate_histogram_input_range<SampleT>(
-    shape, elements * num_channels, static_cast<int>(num_bins), d_levels_r);
+  thrust::device_vector<SampleT> input =
+    generate_histogram_input_range<SampleT>(shape, elements * num_channels, static_cast<int>(num_bins), d_levels_r);
 
   SampleT* d_input        = thrust::raw_pointer_cast(input.data());
   CounterT* d_histogram_r = thrust::raw_pointer_cast(hist_r.data());

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -26,7 +26,18 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   const auto num_bins  = state.get_int64("Bins");
   const int num_levels = static_cast<int>(num_bins) + 1;
 
-  const SampleT lower_level = 0;
+  // Skip invalid configurations where the SampleT range can't hold enough
+  // strictly-monotonic levels. The level-construction loop below uses
+  // `h_levels[i-1] + SampleT{1}` to enforce strict monotonicity; for narrow
+  // integer SampleT this overflows once bins exceed the count of distinct
+  // SampleT values, leaving a non-monotonic level array.
+  if (num_bins > max_representable_bins<SampleT>())
+  {
+    state.skip("Number of bins exceeds what SampleT can represent");
+    return;
+  }
+
+  const SampleT lower_level = get_lower_level<SampleT>();
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
   // Jittered uniform spacing keeps DispatchRange on the SearchTransform path

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -66,7 +66,53 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   state.add_global_memory_reads<SampleT>(elements);
   state.add_global_memory_writes<CounterT>(num_bins);
 
+  // Warmup + correctness check: run HistogramRange once outside
+  // `state.exec`, checking the dispatch return code, then verify the
+  // produced histogram bin-by-bin against an independent reference.
+  // Skipped when CUB_BENCH_HISTOGRAM_VERIFY=0|false|no|off.
+  if (bench_correctness_checks_enabled())
+  {
+    thrust::fill(hist.begin(), hist.end(), CounterT{0});
+    void* d_temp_storage      = nullptr;
+    size_t temp_storage_bytes = 0;
+    bench_check_cuda(
+      cub::DeviceHistogram::HistogramRange(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        d_histogram,
+        num_levels,
+        d_levels,
+        static_cast<OffsetT>(elements)),
+      "warmup HistogramRange temp-size");
+    thrust::device_vector<unsigned char> warmup_tmp(temp_storage_bytes);
+    d_temp_storage = thrust::raw_pointer_cast(warmup_tmp.data());
+    bench_check_cuda(
+      cub::DeviceHistogram::HistogramRange(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        d_histogram,
+        num_levels,
+        d_levels,
+        static_cast<OffsetT>(elements)),
+      "warmup HistogramRange");
+    bench_check_cuda(cudaDeviceSynchronize(), "warmup sync");
+
+    std::vector<thrust::device_vector<CounterT>> opt_hists_d;
+    opt_hists_d.emplace_back(std::move(hist));
+    std::vector<thrust::device_vector<SampleT>> d_levels_per_channel;
+    d_levels_per_channel.emplace_back(std::move(levels));
+    bench_verify_histogram_range<1, 1, SampleT, CounterT, OffsetT>(
+      input, opt_hists_d, d_levels_per_channel, static_cast<OffsetT>(elements), "range");
+    hist        = std::move(opt_hists_d[0]);
+    d_histogram = thrust::raw_pointer_cast(hist.data());
+    levels      = std::move(d_levels_per_channel[0]);
+    d_levels    = thrust::raw_pointer_cast(levels.data());
+  }
+
   caching_allocator_t alloc;
+
   // Force the persisting-L2 reservation back to 0 and demote any persisting
   // lines outside the timed window, so neither cudaAccessPolicyWindow nor a
   // bumped cudaLimitPersistingL2CacheSize can carry across iterations. The

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -8,6 +8,7 @@
 #include <nvbench_helper.cuh>
 
 #include "histogram_common.cuh"
+#include "histogram_inputs.cuh"
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
 // %RANGE% TUNE_THREADS tpb 128:1024:32
@@ -21,7 +22,7 @@
 template <typename SampleT, typename CounterT, typename OffsetT>
 static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, OffsetT>)
 {
-  const auto entropy   = str_to_entropy(state.get_string("Entropy"));
+  const auto shape     = parse_input_shape(state.get_string("InputShape"));
   const auto elements  = state.get_int64("Elements{io}");
   const auto num_bins  = state.get_int64("Bins");
   const int num_levels = static_cast<int>(num_bins) + 1;
@@ -67,7 +68,8 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   thrust::device_vector<SampleT> levels = h_levels;
   SampleT* d_levels                     = thrust::raw_pointer_cast(levels.data());
 
-  thrust::device_vector<SampleT> input = generate(elements, entropy, lower_level, upper_level);
+  thrust::device_vector<SampleT> input =
+    generate_histogram_input_range<SampleT>(shape, elements, static_cast<int>(num_bins), d_levels);
   thrust::device_vector<CounterT> hist(num_bins);
 
   SampleT* d_input      = thrust::raw_pointer_cast(input.data());
@@ -169,4 +171,18 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_o
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
   .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
-  .add_string_axis("Entropy", {"0.201", "1.000"});
+  // One `concentrated` shape swept across entropy (1.0=uniform, 0.5=spike,
+  // 0.0=constant) plus the multi-hot and cache-adversarial shapes. Each value
+  // may carry an inline knob as "name:value"; see histogram_inputs.cuh.
+  .add_string_axis(
+    "InputShape",
+    {"concentrated:1.0",
+     "concentrated:0.5",
+     "concentrated:0.0",
+     "powerlaw:0.5",
+     "zipf:1.0",
+     "hash_synonym",
+     "capacity_cliff",
+     "stale_resident",
+     "temporal_phases",
+     "strided_sweep"});

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3
 
-#include <thrust/sequence.h>
+#include <thrust/host_vector.h>
 
 #include <nvbench_helper.cuh>
 
@@ -27,12 +27,24 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   const SampleT lower_level = 0;
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
-  SampleT step = (upper_level - lower_level) / num_bins;
-  thrust::device_vector<SampleT> levels(num_bins + 1);
-
-  // TODO Extract sequence to the helper TU
-  thrust::sequence(levels.begin(), levels.end(), lower_level, step);
-  SampleT* d_levels = thrust::raw_pointer_cast(levels.data());
+  // Quadratic spacing keeps DispatchRange on the SearchTransform path.
+  thrust::host_vector<SampleT> h_levels(num_bins + 1);
+  h_levels[0]    = lower_level;
+  const double L = static_cast<double>(lower_level);
+  const double U = static_cast<double>(upper_level);
+  const double n = static_cast<double>(num_bins);
+  for (int i = 1; i <= num_bins; ++i)
+  {
+    const double t = static_cast<double>(i) / n;
+    SampleT lvl    = static_cast<SampleT>(L + (U - L) * t * t);
+    if (lvl <= h_levels[i - 1])
+    {
+      lvl = static_cast<SampleT>(h_levels[i - 1] + SampleT{1});
+    }
+    h_levels[i] = lvl;
+  }
+  thrust::device_vector<SampleT> levels = h_levels;
+  SampleT* d_levels                     = thrust::raw_pointer_cast(levels.data());
 
   thrust::device_vector<SampleT> input = generate(elements, entropy, lower_level, upper_level);
   thrust::device_vector<CounterT> hist(num_bins);
@@ -45,25 +57,31 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   state.add_global_memory_writes<CounterT>(num_bins);
 
   caching_allocator_t alloc;
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    auto env = cub_bench_env(
-      alloc,
-      launch
+  // Demote persisting L2 lines outside the timed window so that no
+  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
+             [&](nvbench::launch& launch, auto& timer) {
+               cudaCtxResetPersistingL2Cache();
+               timer.start();
+               auto env = cub_bench_env(
+                 alloc,
+                 launch
 #if !TUNE_BASE
-      ,
-      cuda::execution::tune(bench_policy_selector<key_t, 1, 1>{})
+                 ,
+                 cuda::execution::tune(bench_policy_selector<key_t, 1, 1>{})
 #endif // !TUNE_BASE
-    );
-    _CCCL_TRY_CUDA_API(
-      cub::DeviceHistogram::HistogramRange,
-      "HistogramRange failed",
-      d_input,
-      d_histogram,
-      num_levels,
-      d_levels,
-      static_cast<OffsetT>(elements),
-      env);
-  });
+               );
+               _CCCL_TRY_CUDA_API(
+                 cub::DeviceHistogram::HistogramRange,
+                 "HistogramRange failed",
+                 d_input,
+                 d_histogram,
+                 num_levels,
+                 d_levels,
+                 static_cast<OffsetT>(elements),
+                 env);
+               timer.stop();
+             });
 }
 
 using counter_types     = nvbench::type_list<int32_t>;
@@ -78,6 +96,6 @@ using sample_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, float
 NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_offset_types))
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
+  .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
   .add_int64_axis("Bins", {32, 128, 2048, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -97,5 +97,5 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_o
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
-  .add_int64_axis("Bins", {32, 128, 2048, 2097152})
+  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -57,10 +57,14 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   state.add_global_memory_writes<CounterT>(num_bins);
 
   caching_allocator_t alloc;
-  // Demote persisting L2 lines outside the timed window so that no
-  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  // Force the persisting-L2 reservation back to 0 and demote any persisting
+  // lines outside the timed window, so neither cudaAccessPolicyWindow nor a
+  // bumped cudaLimitPersistingL2CacheSize can carry across iterations. The
+  // default reservation is 0; hardcoding 0 also clears any pollution left by
+  // a prior benchmark in the same nvbench process.
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
+               cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, 0);
                cudaCtxResetPersistingL2Cache();
                timer.start();
                auto env = cub_bench_env(

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -111,5 +111,5 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_o
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
-  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
+  .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -3,6 +3,8 @@
 
 #include <thrust/host_vector.h>
 
+#include <random>
+
 #include <nvbench_helper.cuh>
 
 #include "histogram_common.cuh"
@@ -27,21 +29,29 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   const SampleT lower_level = 0;
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
-  // Quadratic spacing keeps DispatchRange on the SearchTransform path.
+  // Jittered uniform spacing keeps DispatchRange on the SearchTransform path
+  // while keeping bin widths within ~2x of each other. Fixed seed makes the
+  // levels reproducible across runs.
   thrust::host_vector<SampleT> h_levels(num_bins + 1);
-  h_levels[0]    = lower_level;
-  const double L = static_cast<double>(lower_level);
-  const double U = static_cast<double>(upper_level);
-  const double n = static_cast<double>(num_bins);
-  for (int i = 1; i <= num_bins; ++i)
+  const double L    = static_cast<double>(lower_level);
+  const double U    = static_cast<double>(upper_level);
+  const double step = (U - L) / static_cast<double>(num_bins);
+  std::mt19937 rng(0xC0FFEE);
+  std::uniform_real_distribution<double> jitter(-0.25, 0.25);
+  h_levels[0]        = lower_level;
+  h_levels[num_bins] = upper_level;
+  for (int i = 1; i < num_bins; ++i)
   {
-    const double t = static_cast<double>(i) / n;
-    SampleT lvl    = static_cast<SampleT>(L + (U - L) * t * t);
+    SampleT lvl = static_cast<SampleT>(L + i * step + step * jitter(rng));
     if (lvl <= h_levels[i - 1])
     {
       lvl = static_cast<SampleT>(h_levels[i - 1] + SampleT{1});
     }
     h_levels[i] = lvl;
+  }
+  if (h_levels[num_bins] <= h_levels[num_bins - 1])
+  {
+    h_levels[num_bins] = static_cast<SampleT>(h_levels[num_bins - 1] + SampleT{1});
   }
   thrust::device_vector<SampleT> levels = h_levels;
   SampleT* d_levels                     = thrust::raw_pointer_cast(levels.data());

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -157,8 +157,19 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
              });
 }
 
-using counter_types     = nvbench::type_list<int32_t>;
+// CounterT / OffsetT overridable for the 64-bit-counter / 64-bit-offset baseline build
+// (matches the feature branch's bench guards). Inert when undefined -> baseline dispatch
+// semantics unchanged. A 64-bit OffsetT is required for >2^31 elements.
+#ifdef TUNE_CounterT
+using counter_types = nvbench::type_list<TUNE_CounterT>;
+#else
+using counter_types = nvbench::type_list<int32_t>;
+#endif
+#ifdef TUNE_OffsetT
+using some_offset_types = nvbench::type_list<TUNE_OffsetT>;
+#else
 using some_offset_types = nvbench::type_list<int32_t>;
+#endif
 
 #ifdef TUNE_SampleT
 using sample_types = nvbench::type_list<TUNE_SampleT>;

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -90,25 +90,13 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
     size_t temp_storage_bytes = 0;
     bench_check_cuda(
       cub::DeviceHistogram::HistogramRange(
-        d_temp_storage,
-        temp_storage_bytes,
-        d_input,
-        d_histogram,
-        num_levels,
-        d_levels,
-        static_cast<OffsetT>(elements)),
+        d_temp_storage, temp_storage_bytes, d_input, d_histogram, num_levels, d_levels, static_cast<OffsetT>(elements)),
       "warmup HistogramRange temp-size");
     thrust::device_vector<unsigned char> warmup_tmp(temp_storage_bytes);
     d_temp_storage = thrust::raw_pointer_cast(warmup_tmp.data());
     bench_check_cuda(
       cub::DeviceHistogram::HistogramRange(
-        d_temp_storage,
-        temp_storage_bytes,
-        d_input,
-        d_histogram,
-        num_levels,
-        d_levels,
-        static_cast<OffsetT>(elements)),
+        d_temp_storage, temp_storage_bytes, d_input, d_histogram, num_levels, d_levels, static_cast<OffsetT>(elements)),
       "warmup HistogramRange");
     bench_check_cuda(cudaDeviceSynchronize(), "warmup sync");
 

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -182,7 +182,7 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_o
      "powerlaw:0.5",
      "zipf:1.0",
      "hash_synonym",
-     "capacity_cliff",
      "stale_resident",
      "temporal_phases",
-     "strided_sweep"});
+     "strided_sweep",
+     "sawtooth"});

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -147,8 +147,36 @@ struct DeviceHistogramKernelSource
     if constexpr (::cuda::std::is_integral_v<CommonT>)
     {
       using IntArithmeticT = typename TransformsT::ScaleTransform::IntArithmeticT;
-      return static_cast<IntArithmeticT>(upper_level[channel] - lower_level[channel])
-           > (::cuda::std::numeric_limits<IntArithmeticT>::max() / static_cast<IntArithmeticT>(num_bins));
+      // Compute `upper - lower` without overflowing the level type. For
+      // signed integer level types with full range (e.g. int32_t with
+      // [INT_MIN, INT_MAX/4]), the signed difference overflows.
+      // Reinterpret-cast each operand through its unsigned counterpart and
+      // subtract in unsigned arithmetic; modular wrap-around produces the
+      // correct (non-negative) difference.
+      // Compute `upper - lower` without overflow. For signed integer
+      // level types, the signed difference can overflow (e.g. int32_t
+      // with [INT_MIN, INT_MAX]) and even narrow types are subject to
+      // C++ integer promotion to `int`, which then converts back to
+      // unsigned through sign-extension. We:
+      //   1. Cast each operand to its unsigned counterpart of the same
+      //      width (`make_unsigned_t<LevelT>`). This reinterprets the
+      //      bit pattern: int8_t(-128..127) -> uint8_t(128..255, 0..127).
+      //   2. Subtract through an unsigned-wraparound assignment. C++
+      //      integer promotion forces the operands up to `int` for the
+      //      subtraction, but assigning the result back to ULevelT
+      //      truncates via unsigned modular wrap-around, producing the
+      //      correct difference in [0, 2^N - 1]. Pre-promoting to the
+      //      destination integer arithmetic type before subtraction would
+      //      sign-extend the int promotion's negative result into the
+      //      wider type and yield a giant garbage value.
+      //   3. Widen the truncated unsigned difference to `IntArithmeticT`,
+      //      which holds it without overflow.
+      using ArrayLevelT = typename UpperLevelArrayT::value_type;
+      using ULevelT     = ::cuda::std::make_unsigned_t<ArrayLevelT>;
+      const ULevelT diff = static_cast<ULevelT>(static_cast<ULevelT>(upper_level[channel])
+                                                - static_cast<ULevelT>(lower_level[channel]));
+      const IntArithmeticT range = static_cast<IntArithmeticT>(diff);
+      return range > (::cuda::std::numeric_limits<IntArithmeticT>::max() / static_cast<IntArithmeticT>(num_bins));
     }
     else
     {
@@ -1013,7 +1041,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch_even(
       num_privatized_levels[channel] = 257;
 
       int num_levels = num_output_levels[channel];
-      if (kernel_source.MayOverflow(static_cast<CommonT>(num_levels - 1), upper_level, lower_level, channel))
+      if (kernel_source.MayOverflow(num_levels - 1, upper_level, lower_level, channel))
       {
         if (!d_temp_storage)
         {
@@ -1079,7 +1107,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch_even(
     for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
     {
       int num_levels = num_output_levels[channel];
-      if (kernel_source.MayOverflow(static_cast<CommonT>(num_levels - 1), upper_level, lower_level, channel))
+      if (kernel_source.MayOverflow(num_levels - 1, upper_level, lower_level, channel))
       {
         if (!d_temp_storage)
         {

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -173,8 +173,8 @@ struct DeviceHistogramKernelSource
       //      which holds it without overflow.
       using ArrayLevelT = typename UpperLevelArrayT::value_type;
       using ULevelT     = ::cuda::std::make_unsigned_t<ArrayLevelT>;
-      const ULevelT diff = static_cast<ULevelT>(static_cast<ULevelT>(upper_level[channel])
-                                                - static_cast<ULevelT>(lower_level[channel]));
+      const ULevelT diff =
+        static_cast<ULevelT>(static_cast<ULevelT>(upper_level[channel]) - static_cast<ULevelT>(lower_level[channel]));
       const IntArithmeticT range = static_cast<IntArithmeticT>(diff);
       return range > (::cuda::std::numeric_limits<IntArithmeticT>::max() / static_cast<IntArithmeticT>(num_bins));
     }

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -117,14 +117,24 @@ struct Transforms
       ::cuda::std::is_integral<T>;
 #endif // !_CCCL_HAS_INT128()
 
+    // Storage type for the precomputed `range = max_level - min_level` and
+    // `bins = num_levels - 1` used by the integer ComputeBin path. For
+    // narrow integer CommonT (e.g. int8_t with full range), `max - min`
+    // overflows CommonT and would silently produce wrong bins; widening to
+    // `IntArithmeticT` (uint32_t / uint64_t) holds the difference without
+    // overflow. For 128-bit and non-integer types, IntArithmeticT == CommonT
+    // (or wider), so this is also correct.
+    using FractionStorageT =
+      ::cuda::std::_If<is_integral_excl_int128<CommonT>::value, IntArithmeticT, CommonT>;
+
     union ScaleT
     {
       // Used when CommonT is not floating-point to avoid intermediate
       // rounding errors (see NVIDIA/cub#489).
       struct FractionT
       {
-        CommonT bins;
-        CommonT range;
+        FractionStorageT bins;
+        FractionStorageT range;
       } fraction;
 
       // Used when CommonT is floating-point as an optimization.
@@ -149,8 +159,30 @@ struct Transforms
     ComputeScale(int num_levels, T max_level, T min_level, ::cuda::std::false_type /* is_fp */)
     {
       ScaleT result;
-      result.fraction.bins  = static_cast<T>(num_levels - 1);
-      result.fraction.range = static_cast<T>(max_level - min_level);
+      result.fraction.bins = static_cast<FractionStorageT>(num_levels - 1);
+      // Compute `max - min` without overflowing T. For signed integer T
+      // with full range (e.g. int8_t with [-128, 127]), the signed
+      // difference `127 - (-128) = 255` overflows int8_t. Cast each
+      // operand to its unsigned counterpart of the same width and
+      // subtract, then assign back to that unsigned type to truncate via
+      // modular wrap-around: e.g. for int8_t with max=127, min=-128, the
+      // unsigned reinterpretations are uint8_t(127)=127 and
+      // uint8_t(-128)=128 (two's complement bit pattern). C++ integer
+      // promotion lifts the subtraction to int (127 - 128 = -1), and
+      // truncating that back to uint8_t yields 255 — the correct
+      // difference in [0, 2^N - 1]. The intermediate ULevelT is required
+      // because casting the int result directly to FractionStorageT (a
+      // wider unsigned type) would sign-extend -1 into a giant value.
+      if constexpr (::cuda::std::is_integral_v<T>)
+      {
+        using UT          = ::cuda::std::make_unsigned_t<T>;
+        const UT diff     = static_cast<UT>(static_cast<UT>(max_level) - static_cast<UT>(min_level));
+        result.fraction.range = static_cast<FractionStorageT>(diff);
+      }
+      else
+      {
+        result.fraction.range = static_cast<FractionStorageT>(max_level - min_level);
+      }
       return result;
     }
 
@@ -303,7 +335,20 @@ struct Transforms
     {
       if (valid)
       {
-        bin = static_cast<int>(sample);
+        // The byte-sample privatized histogram has 256 bins indexed by the
+        // sample's unsigned byte value. For signed integer samples this
+        // reinterprets the bit pattern: int8_t(-128..127) -> uint8_t(128..255, 0..127).
+        // Without this reinterpretation, negative samples cast directly to
+        // `int` produce negative bin indices and are silently dropped.
+        if constexpr (::cuda::std::is_integral_v<_SampleT>)
+        {
+          using UT = ::cuda::std::make_unsigned_t<_SampleT>;
+          bin      = static_cast<int>(static_cast<UT>(sample));
+        }
+        else
+        {
+          bin = static_cast<int>(sample);
+        }
       }
     }
   };

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -262,13 +262,25 @@ struct Transforms
       return static_cast<int>(((sample - min_level) * scale.fraction.bins) / scale.fraction.range);
     }
 
-    //! @brief Bin computation for integral types of up to 64-bit types
+    //! @brief Bin computation for integral types of up to 64-bit types.
+    //!
+    //! Compute `sample - min_level` via the unsigned representation of T,
+    //! mirroring `ComputeScale`. For signed integer T with negative
+    //! `min_level` (e.g. `min_level = INT_MIN`), the signed difference
+    //! `sample - min_level` overflows T and is undefined behaviour; the
+    //! resulting numerator on two's complement is a wildly wrong magnitude
+    //! and produces an incorrect bin (the sample is dropped from the output
+    //! histogram). The unsigned subtraction wraps modularly and yields the
+    //! correct non-negative difference exactly the way `ComputeScale`
+    //! computes `max_level - min_level`.
     template <typename T, ::cuda::std::enable_if_t<is_integral_excl_int128<T>::value, int> = 0>
     _CCCL_HOST_DEVICE _CCCL_FORCEINLINE int ComputeBin(T sample, T min_level, ScaleT scale) const
     {
+      using UT                  = ::cuda::std::make_unsigned_t<T>;
+      const IntArithmeticT diff = static_cast<IntArithmeticT>(
+        static_cast<UT>(static_cast<UT>(sample) - static_cast<UT>(min_level)));
       return static_cast<int>(
-        (static_cast<IntArithmeticT>(sample - min_level) * static_cast<IntArithmeticT>(scale.fraction.bins))
-        / static_cast<IntArithmeticT>(scale.fraction.range));
+        (diff * static_cast<IntArithmeticT>(scale.fraction.bins)) / static_cast<IntArithmeticT>(scale.fraction.range));
     }
 
     template <typename T, ::cuda::std::enable_if_t<!is_integral_excl_int128<T>::value, int> = 0>

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -124,8 +124,7 @@ struct Transforms
     // `IntArithmeticT` (uint32_t / uint64_t) holds the difference without
     // overflow. For 128-bit and non-integer types, IntArithmeticT == CommonT
     // (or wider), so this is also correct.
-    using FractionStorageT =
-      ::cuda::std::_If<is_integral_excl_int128<CommonT>::value, IntArithmeticT, CommonT>;
+    using FractionStorageT = ::cuda::std::_If<is_integral_excl_int128<CommonT>::value, IntArithmeticT, CommonT>;
 
     union ScaleT
     {
@@ -175,8 +174,8 @@ struct Transforms
       // wider unsigned type) would sign-extend -1 into a giant value.
       if constexpr (::cuda::std::is_integral_v<T>)
       {
-        using UT          = ::cuda::std::make_unsigned_t<T>;
-        const UT diff     = static_cast<UT>(static_cast<UT>(max_level) - static_cast<UT>(min_level));
+        using UT              = ::cuda::std::make_unsigned_t<T>;
+        const UT diff         = static_cast<UT>(static_cast<UT>(max_level) - static_cast<UT>(min_level));
         result.fraction.range = static_cast<FractionStorageT>(diff);
       }
       else
@@ -276,9 +275,9 @@ struct Transforms
     template <typename T, ::cuda::std::enable_if_t<is_integral_excl_int128<T>::value, int> = 0>
     _CCCL_HOST_DEVICE _CCCL_FORCEINLINE int ComputeBin(T sample, T min_level, ScaleT scale) const
     {
-      using UT                  = ::cuda::std::make_unsigned_t<T>;
-      const IntArithmeticT diff = static_cast<IntArithmeticT>(
-        static_cast<UT>(static_cast<UT>(sample) - static_cast<UT>(min_level)));
+      using UT = ::cuda::std::make_unsigned_t<T>;
+      const IntArithmeticT diff =
+        static_cast<IntArithmeticT>(static_cast<UT>(static_cast<UT>(sample) - static_cast<UT>(min_level)));
       return static_cast<int>(
         (diff * static_cast<IntArithmeticT>(scale.fraction.bins)) / static_cast<IntArithmeticT>(scale.fraction.range));
     }

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -208,6 +208,12 @@ auto setup_bin_levels_for_range(const array<int, ActiveChannels>& num_levels, Le
   const auto min_bin_width = max_level / (max_level_count - 1);
   REQUIRE(min_bin_width > 0);
 
+  // Perturb interior levels to defeat uniform-spacing detection so the
+  // SearchTransform path is exercised. Endpoints stay anchored. When
+  // min_bin_width is too small for a strictly monotonic shift (e.g. byte-sample
+  // tests with 256 levels), levels stay uniform.
+  const auto perturbation_step = min_bin_width / 4;
+
   array<c2h::host_vector<LevelT>, ActiveChannels> levels;
   for (size_t c = 0; c < ActiveChannels; ++c)
   {
@@ -217,7 +223,12 @@ auto setup_bin_levels_for_range(const array<int, ActiveChannels>& num_levels, Le
     const auto lower_level    = (max_level / 2 - min_hist_width / 2);
     for (int l = 0; l < num_levels[c]; ++l)
     {
-      levels[c][l] = static_cast<LevelT>(lower_level + l * min_bin_width);
+      auto level = static_cast<LevelT>(lower_level + l * min_bin_width);
+      if (l > 0 && l < num_levels[c] - 1 && perturbation_step > LevelT{0})
+      {
+        level = static_cast<LevelT>(level + (l % 2 == 0 ? perturbation_step : -perturbation_step));
+      }
+      levels[c][l] = level;
       if (l > 0)
       {
         REQUIRE(levels[c][l - 1] < levels[c][l]);

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -759,8 +759,15 @@ C2H_TEST_LIST("DeviceHistogram::HistogramEven bin computation does not overflow"
   CHECK(error2 == (num_bins == 1 || sizeof(sample_t) <= 4UL ? cudaSuccess : cudaErrorInvalidValue));
 }
 
-// When the number of bins exceeds what LevelT can represent, the bin computation will overflow
-// during the cast to CommonT. We expect cudaErrorInvalidValue to be returned.
+// `num_bins` may exceed what `LevelT` can represent without an error: bin
+// width can be fractional (smaller than one LevelT distinct value), and the
+// integer ComputeBin path promotes through `IntArithmeticT` (uint32_t /
+// uint64_t) so the multiplication and division do not overflow even when
+// `num_bins > numeric_limits<LevelT>::max()`. The previous implementation
+// returned `cudaErrorInvalidValue` in this regime because both the
+// `MayOverflow` precondition and `ScaleTransform`'s `range = max - min`
+// storage truncated `num_bins` and the level difference back to `LevelT`
+// before checking; once those casts are removed, the dispatch succeeds.
 C2H_TEST_LIST(
   "DeviceHistogram::HistogramEven num_bins exceeds LevelT range", "[histogram_even][device]", int8_t, int16_t)
 {
@@ -776,13 +783,13 @@ C2H_TEST_LIST(
   auto d_samples   = cuda::counting_iterator<sample_t>{0};
   auto d_histo_out = c2h::device_vector<counter_t>(4096);
 
-  // Test with num_bins that exceeds what LevelT can represent
-  // int8_t max = 127, so 128 bins will overflow
-  // int16_t max = 32767, so 32768 bins will overflow
+  // num_bins that previously overflowed LevelT-typed storage:
+  //   int8_t  max = 127, so 128 bins triggered the bug
+  //   int16_t max = 32767, so 32768 bins triggered the bug
   const int num_bins_overflow = static_cast<int>(cs::numeric_limits<level_t>::max()) + 1;
   const int num_levels        = num_bins_overflow + 1;
 
-  // Verify temp_storage_bytes is always initialized even on error
+  // Verify temp_storage_bytes is always initialized.
   constexpr size_t canary_bytes = 3;
   size_t temp_storage_bytes     = canary_bytes;
 
@@ -796,12 +803,12 @@ C2H_TEST_LIST(
     upper_level,
     num_samples);
 
-  // Should return error because num_bins overflows LevelT
-  CHECK(error1 == cudaErrorInvalidValue);
-  // Should still initialize temp_storage_bytes to a valid value
+  // Now succeeds: bin width is fractional but the integer ComputeBin path
+  // handles it correctly.
+  CHECK(error1 == cudaSuccess);
   CHECK(temp_storage_bytes != canary_bytes);
 
-  // Also verify that valid num_bins works
+  // Also verify that num_bins == numeric_limits<LevelT>::max() still works.
   const int valid_num_bins   = static_cast<int>(cs::numeric_limits<level_t>::max());
   const int valid_num_levels = valid_num_bins + 1;
 

--- a/cub/test/catch2_test_device_histogram_input_shapes.cu
+++ b/cub/test/catch2_test_device_histogram_input_shapes.cu
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+// Validates the histogram-benchmark input-shape generators in
+// cub/benchmarks/bench/histogram/histogram_inputs.cuh: that each named shape
+// produces the bin distribution / ordering structure it claims, and that the
+// entropy and per-shape knobs behave monotonically. This is the shape contract;
+// per-bin *counting* correctness is separately enforced by the in-bench
+// verifier (bench_verify_histogram_*).
+
+#include <thrust/copy.h>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <vector>
+
+// The generator header lives in the benchmarks tree; include it by relative
+// path. It is self-contained (thrust + cuda/std only), so this is safe.
+#include "../benchmarks/bench/histogram/histogram_inputs.cuh"
+
+#include <c2h/catch2_test_helper.h>
+
+namespace
+{
+
+// Generate an EVEN input for `spec` and return the per-bin counts, recomputed
+// from the sample values with the same formula CUB uses.
+template <class SampleT>
+std::vector<long long>
+bin_counts_even(const ShapeSpec& spec, int64_t n, int num_bins, SampleT lower, SampleT upper, uint64_t seed = 42)
+{
+  thrust::device_vector<SampleT> d_input =
+    generate_histogram_input_even<SampleT>(spec, n, num_bins, lower, upper, seed);
+  thrust::host_vector<SampleT> h_input = d_input;
+
+  std::vector<long long> counts(num_bins, 0);
+  const double L     = static_cast<double>(lower);
+  const double U     = static_cast<double>(upper);
+  const double scale = static_cast<double>(num_bins) / (U - L);
+  for (SampleT s : h_input)
+  {
+    if (s < lower || s >= upper)
+    {
+      continue; // out-of-range samples are not counted by CUB either
+    }
+    int bin = static_cast<int>((static_cast<double>(s) - L) * scale);
+    if (bin >= num_bins)
+    {
+      bin = num_bins - 1;
+    }
+    if (bin >= 0)
+    {
+      ++counts[bin];
+    }
+  }
+  return counts;
+}
+
+double normalized_entropy_counts(const std::vector<long long>& counts, int64_t n)
+{
+  if (counts.size() <= 1 || n == 0)
+  {
+    return 0.0;
+  }
+  double h = 0.0;
+  for (long long c : counts)
+  {
+    if (c > 0)
+    {
+      const double p = static_cast<double>(c) / static_cast<double>(n);
+      h -= p * std::log2(p);
+    }
+  }
+  return h / std::log2(static_cast<double>(counts.size()));
+}
+
+int nonzero_bins(const std::vector<long long>& counts)
+{
+  return static_cast<int>(std::count_if(counts.begin(), counts.end(), [](long long c) {
+    return c > 0;
+  }));
+}
+
+long long top_count(const std::vector<long long>& counts)
+{
+  return *std::max_element(counts.begin(), counts.end());
+}
+
+constexpr int64_t N = 200000;
+constexpr int32_t LO = 0;
+constexpr int32_t HI = 4096; // bin width 1 at B=4096; >1 below that
+
+} // namespace
+
+C2H_TEST("histogram input: concentrated endpoints are exact", "[histogram][input_shapes]")
+{
+  const int num_bins = 64;
+
+  // entropy 1.0 -> uniform: every bin within a few % of N/num_bins.
+  {
+    auto counts        = bin_counts_even<int32_t>(parse_input_shape("concentrated:1.0"), N, num_bins, LO, HI);
+    const double mean  = static_cast<double>(N) / num_bins;
+    REQUIRE(nonzero_bins(counts) == num_bins);
+    for (long long c : counts)
+    {
+      REQUIRE(std::abs(c - mean) < 0.15 * mean);
+    }
+    REQUIRE(normalized_entropy_counts(counts, N) > 0.99);
+  }
+
+  // entropy 0.0 -> constant: exactly one nonzero bin holding everything.
+  {
+    auto counts = bin_counts_even<int32_t>(parse_input_shape("concentrated:0.0"), N, num_bins, LO, HI);
+    REQUIRE(nonzero_bins(counts) == 1);
+    REQUIRE(top_count(counts) == N);
+  }
+}
+
+C2H_TEST("histogram input: concentrated entropy knob is monotone", "[histogram][input_shapes]")
+{
+  const int num_bins = 64;
+  // As the entropy knob falls, the top-bin share must rise monotonically.
+  double prev_share = -1.0;
+  for (double e : {1.0, 0.75, 0.5, 0.25, 0.0})
+  {
+    auto counts        = bin_counts_even<int32_t>(parse_input_shape("concentrated:" + std::to_string(e)), N, num_bins, LO, HI);
+    const double share = static_cast<double>(top_count(counts)) / N;
+    if (prev_share >= 0.0)
+    {
+      REQUIRE(share >= prev_share - 0.02); // non-decreasing (small tolerance)
+    }
+    prev_share = share;
+  }
+  REQUIRE(prev_share > 0.99); // entropy 0 ends at ~100% top share
+}
+
+C2H_TEST("histogram input: hot bin is not pinned to zero", "[histogram][input_shapes]")
+{
+  const int num_bins = 64;
+  // Different seeds should move the hot bin (spike-slab at entropy 0.3).
+  std::map<int, int> argmax_seen;
+  for (uint64_t seed : {1ull, 2ull, 3ull, 4ull, 5ull})
+  {
+    auto counts   = bin_counts_even<int32_t>(parse_input_shape("concentrated:0.3"), N, num_bins, LO, HI, seed);
+    const int arg = static_cast<int>(std::max_element(counts.begin(), counts.end()) - counts.begin());
+    ++argmax_seen[arg];
+  }
+  // The mode is not always bin 0, and varies across seeds.
+  REQUIRE(argmax_seen.count(0) < 5);
+  REQUIRE(argmax_seen.size() >= 2);
+}
+
+C2H_TEST("histogram input: powerlaw is a decaying warm set", "[histogram][input_shapes]")
+{
+  const int num_bins = 256;
+  auto counts        = bin_counts_even<int32_t>(parse_input_shape("powerlaw:0.4"), N, num_bins, LO, HI);
+  // Many hot bins (more than a single spike), with a heavy head: the top bin
+  // holds a large share and the warm set (top-K) dominates.
+  REQUIRE(nonzero_bins(counts) > 5);
+  std::vector<long long> sorted(counts);
+  std::sort(sorted.rbegin(), sorted.rend());
+  const double top1 = static_cast<double>(sorted[0]) / N;
+  double top8       = 0.0;
+  for (int i = 0; i < 8 && i < static_cast<int>(sorted.size()); ++i)
+  {
+    top8 += static_cast<double>(sorted[i]) / N;
+  }
+  REQUIRE(top1 > 0.05);
+  REQUIRE(top8 > 0.5); // a small warm set carries most of the mass
+  REQUIRE(top1 < 0.99); // but not a single spike
+}
+
+C2H_TEST("histogram input: powerlaw knob is monotone in entropy", "[histogram][input_shapes]")
+{
+  const int num_bins = 256;
+  // Entropy decreases across the loop, so the top-bin share must RISE
+  // (non-decreasing): lower target entropy -> higher concentration.
+  double prev_top = -1.0;
+  for (double e : {0.8, 0.6, 0.4, 0.2})
+  {
+    auto counts        = bin_counts_even<int32_t>(parse_input_shape("powerlaw:" + std::to_string(e)), N, num_bins, LO, HI);
+    std::vector<long long> sorted(counts);
+    std::sort(sorted.rbegin(), sorted.rend());
+    const double top1 = static_cast<double>(sorted[0]) / N;
+    REQUIRE(top1 >= prev_top - 0.02); // non-decreasing as entropy falls
+    prev_top = top1;
+  }
+}
+
+C2H_TEST("histogram input: capacity_cliff active set tracks the knob", "[histogram][input_shapes]")
+{
+  // num_bins large enough that the active set fits below it.
+  const int num_bins = 16384;
+  // Default => kAdversarialCacheSlots + 1 distinct equiprobable bins.
+  {
+    auto counts = bin_counts_even<int32_t>(parse_input_shape("capacity_cliff"), N * 4, num_bins, LO, 16384);
+    // Sampling N*4 over slots+1 bins: expect ~ all of them populated.
+    const int nz = nonzero_bins(counts);
+    REQUIRE(nz > kAdversarialCacheSlots / 2); // a large active set, near capacity
+    REQUIRE(nz <= kAdversarialCacheSlots + 1);
+  }
+  // Knob 0.25 => ~1024 active bins (a quarter of capacity).
+  {
+    const int num_bins2 = 4096;
+    auto counts = bin_counts_even<int32_t>(parse_input_shape("capacity_cliff:0.25"), N * 4, num_bins2, LO, 4096);
+    const int nz = nonzero_bins(counts);
+    REQUIRE(nz > 256);
+    REQUIRE(nz <= 1100);
+  }
+}
+
+C2H_TEST("histogram input: stale_resident has a cold prefix and a dominant hot bin", "[histogram][input_shapes]")
+{
+  const int num_bins = 16384;
+  // n must exceed the cold prefix (kAdversarialCacheSlots) so a hot bulk exists.
+  auto counts = bin_counts_even<int32_t>(parse_input_shape("stale_resident"), N, num_bins, LO, 16384);
+  // Cold prefix touches ~kAdversarialCacheSlots distinct bins once each.
+  REQUIRE(nonzero_bins(counts) > kAdversarialCacheSlots / 2);
+  // One hot bin dominates (the bulk), far above the single-visit cold bins.
+  const double top = static_cast<double>(top_count(counts)) / N;
+  REQUIRE(top > 0.5);
+}
+
+C2H_TEST("histogram input: temporal_phases changes the hot bin across phases", "[histogram][input_shapes]")
+{
+  const int num_bins = 256;
+  const int phases   = 4;
+  thrust::device_vector<int32_t> d_input =
+    generate_histogram_input_even<int32_t>(parse_input_shape("temporal_phases:" + std::to_string(phases)), N, num_bins, LO, HI);
+  thrust::host_vector<int32_t> h = d_input;
+
+  const double scale = static_cast<double>(num_bins) / (static_cast<double>(HI) - static_cast<double>(LO));
+  std::vector<int> phase_mode;
+  const int64_t per = N / phases;
+  for (int p = 0; p < phases; ++p)
+  {
+    std::map<int, long long> c;
+    for (int64_t i = p * per; i < (p + 1) * per; ++i)
+    {
+      int bin = static_cast<int>(static_cast<double>(h[i]) * scale);
+      if (bin >= num_bins) bin = num_bins - 1;
+      ++c[bin];
+    }
+    int best = -1; long long bestc = -1;
+    for (auto& kv : c) { if (kv.second > bestc) { bestc = kv.second; best = kv.first; } }
+    phase_mode.push_back(best);
+  }
+  // Adjacent phases must have different hot bins.
+  for (int p = 1; p < phases; ++p)
+  {
+    REQUIRE(phase_mode[p] != phase_mode[p - 1]);
+  }
+}
+
+C2H_TEST("histogram input: strided_sweep is flat in distribution but ordered", "[histogram][input_shapes]")
+{
+  const int num_bins = 256;
+  auto counts        = bin_counts_even<int32_t>(parse_input_shape("strided_sweep"), N, num_bins, LO, HI);
+  // A stride coprime to num_bins visits every bin near-equally.
+  REQUIRE(nonzero_bins(counts) == num_bins);
+  REQUIRE(normalized_entropy_counts(counts, N) > 0.98);
+}
+
+C2H_TEST("histogram input: RANGE path maps bins into level intervals", "[histogram][input_shapes]")
+{
+  // Build a simple strictly-increasing level array and check that a constant
+  // (entropy 0) input lands every sample inside one [levels[b], levels[b+1]).
+  const int num_bins = 32;
+  thrust::host_vector<int32_t> h_levels(num_bins + 1);
+  for (int i = 0; i <= num_bins; ++i)
+  {
+    h_levels[i] = i * 10; // levels 0,10,20,...,320
+  }
+  thrust::device_vector<int32_t> d_levels = h_levels;
+
+  thrust::device_vector<int32_t> d_input = generate_histogram_input_range<int32_t>(
+    parse_input_shape("concentrated:0.0"), N, num_bins, thrust::raw_pointer_cast(d_levels.data()));
+  thrust::host_vector<int32_t> h = d_input;
+
+  // All samples equal (constant) and inside the same level interval.
+  const int32_t v0 = h[0];
+  for (int32_t v : h)
+  {
+    REQUIRE(v == v0);
+  }
+  // v0 must sit within some [levels[b], levels[b+1]).
+  REQUIRE(v0 >= h_levels[0]);
+  REQUIRE(v0 < h_levels[num_bins]);
+}

--- a/cub/test/catch2_test_device_histogram_input_shapes.cu
+++ b/cub/test/catch2_test_device_histogram_input_shapes.cu
@@ -20,12 +20,10 @@
 // The generator header lives in the benchmarks tree; include it by relative
 // path. It is self-contained (thrust + cuda/std only), so this is safe.
 #include "../benchmarks/bench/histogram/histogram_inputs.cuh"
-
 #include <c2h/catch2_test_helper.h>
 
 namespace
 {
-
 // Generate an EVEN input for `spec` and return the per-bin counts, recomputed
 // from the sample values with the same formula CUB uses.
 template <class SampleT>
@@ -89,10 +87,9 @@ long long top_count(const std::vector<long long>& counts)
   return *std::max_element(counts.begin(), counts.end());
 }
 
-constexpr int64_t N = 200000;
+constexpr int64_t N  = 200000;
 constexpr int32_t LO = 0;
 constexpr int32_t HI = 4096; // bin width 1 at B=4096; >1 below that
-
 } // namespace
 
 C2H_TEST("histogram input: concentrated endpoints are exact", "[histogram][input_shapes]")
@@ -101,8 +98,8 @@ C2H_TEST("histogram input: concentrated endpoints are exact", "[histogram][input
 
   // entropy 1.0 -> uniform: every bin within a few % of N/num_bins.
   {
-    auto counts        = bin_counts_even<int32_t>(parse_input_shape("concentrated:1.0"), N, num_bins, LO, HI);
-    const double mean  = static_cast<double>(N) / num_bins;
+    auto counts       = bin_counts_even<int32_t>(parse_input_shape("concentrated:1.0"), N, num_bins, LO, HI);
+    const double mean = static_cast<double>(N) / num_bins;
     REQUIRE(nonzero_bins(counts) == num_bins);
     for (long long c : counts)
     {
@@ -126,7 +123,7 @@ C2H_TEST("histogram input: concentrated entropy knob is monotone", "[histogram][
   double prev_share = -1.0;
   for (double e : {1.0, 0.75, 0.5, 0.25, 0.0})
   {
-    auto counts        = bin_counts_even<int32_t>(parse_input_shape("concentrated:" + std::to_string(e)), N, num_bins, LO, HI);
+    auto counts = bin_counts_even<int32_t>(parse_input_shape("concentrated:" + std::to_string(e)), N, num_bins, LO, HI);
     const double share = static_cast<double>(top_count(counts)) / N;
     if (prev_share >= 0.0)
     {
@@ -181,7 +178,7 @@ C2H_TEST("histogram input: powerlaw knob is monotone in entropy", "[histogram][i
   double prev_top = -1.0;
   for (double e : {0.8, 0.6, 0.4, 0.2})
   {
-    auto counts        = bin_counts_even<int32_t>(parse_input_shape("powerlaw:" + std::to_string(e)), N, num_bins, LO, HI);
+    auto counts = bin_counts_even<int32_t>(parse_input_shape("powerlaw:" + std::to_string(e)), N, num_bins, LO, HI);
     std::vector<long long> sorted(counts);
     std::sort(sorted.rbegin(), sorted.rend());
     const double top1 = static_cast<double>(sorted[0]) / N;
@@ -205,7 +202,7 @@ C2H_TEST("histogram input: capacity_cliff active set tracks the knob", "[histogr
   // Knob 0.25 => ~1024 active bins (a quarter of capacity).
   {
     const int num_bins2 = 4096;
-    auto counts = bin_counts_even<int32_t>(parse_input_shape("capacity_cliff:0.25"), N * 4, num_bins2, LO, 4096);
+    auto counts  = bin_counts_even<int32_t>(parse_input_shape("capacity_cliff:0.25"), N * 4, num_bins2, LO, 4096);
     const int nz = nonzero_bins(counts);
     REQUIRE(nz > 256);
     REQUIRE(nz <= 1100);
@@ -226,10 +223,10 @@ C2H_TEST("histogram input: stale_resident has a cold prefix and a dominant hot b
 
 C2H_TEST("histogram input: temporal_phases changes the hot bin across phases", "[histogram][input_shapes]")
 {
-  const int num_bins = 256;
-  const int phases   = 4;
-  thrust::device_vector<int32_t> d_input =
-    generate_histogram_input_even<int32_t>(parse_input_shape("temporal_phases:" + std::to_string(phases)), N, num_bins, LO, HI);
+  const int num_bins                     = 256;
+  const int phases                       = 4;
+  thrust::device_vector<int32_t> d_input = generate_histogram_input_even<int32_t>(
+    parse_input_shape("temporal_phases:" + std::to_string(phases)), N, num_bins, LO, HI);
   thrust::host_vector<int32_t> h = d_input;
 
   const double scale = static_cast<double>(num_bins) / (static_cast<double>(HI) - static_cast<double>(LO));
@@ -241,11 +238,22 @@ C2H_TEST("histogram input: temporal_phases changes the hot bin across phases", "
     for (int64_t i = p * per; i < (p + 1) * per; ++i)
     {
       int bin = static_cast<int>(static_cast<double>(h[i]) * scale);
-      if (bin >= num_bins) bin = num_bins - 1;
+      if (bin >= num_bins)
+      {
+        bin = num_bins - 1;
+      }
       ++c[bin];
     }
-    int best = -1; long long bestc = -1;
-    for (auto& kv : c) { if (kv.second > bestc) { bestc = kv.second; best = kv.first; } }
+    int best        = -1;
+    long long bestc = -1;
+    for (auto& kv : c)
+    {
+      if (kv.second > bestc)
+      {
+        bestc = kv.second;
+        best  = kv.first;
+      }
+    }
     phase_mode.push_back(best);
   }
   // Adjacent phases must have different hot bins.

--- a/cub/test/catch2_test_device_histogram_thread_local_cache.cu
+++ b/cub/test/catch2_test_device_histogram_thread_local_cache.cu
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Exercises the thread_local detection-stream / detection-buffer cache used by
+// dispatch_range's uniform-levels detection path: sequential calls on multiple
+// user streams, concurrent calls from multiple threads, and the cross-device
+// hazard where the cache is bound to the device current at first call.
+
+#include <cub/device/device_histogram.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include <c2h/catch2_test_helper.h>
+
+namespace
+{
+
+using sample_t  = int;
+using counter_t = int;
+
+// Non-uniform spacing keeps DispatchRange on the SearchTransform path, which is
+// where the thread_local detection cache is exercised.
+auto make_levels(int num_bins) -> thrust::host_vector<sample_t>
+{
+  thrust::host_vector<sample_t> levels(num_bins + 1);
+  levels[0] = 0;
+  for (int i = 1; i <= num_bins; ++i)
+  {
+    const double t = static_cast<double>(i) / num_bins;
+    sample_t v     = static_cast<sample_t>(t * t * 1024.0);
+    if (v <= levels[i - 1])
+    {
+      v = static_cast<sample_t>(levels[i - 1] + 1);
+    }
+    levels[i] = v;
+  }
+  return levels;
+}
+
+auto reference_histogram(const thrust::host_vector<sample_t>& samples, const thrust::host_vector<sample_t>& levels)
+  -> thrust::host_vector<counter_t>
+{
+  const int num_bins = static_cast<int>(levels.size()) - 1;
+  thrust::host_vector<counter_t> ref(num_bins, 0);
+  for (sample_t s : samples)
+  {
+    auto ub = std::upper_bound(levels.begin(), levels.end(), s);
+    if (ub == levels.begin() || ub == levels.end())
+    {
+      continue;
+    }
+    ++ref[std::distance(levels.begin(), ub) - 1];
+  }
+  return ref;
+}
+
+void run_histogram_range(
+  cudaStream_t stream,
+  const thrust::device_vector<sample_t>& d_samples,
+  const thrust::device_vector<sample_t>& d_levels,
+  thrust::device_vector<counter_t>& d_histogram)
+{
+  const int num_levels = static_cast<int>(d_levels.size());
+  size_t temp_bytes    = 0;
+  REQUIRE(cudaSuccess
+          == cub::DeviceHistogram::HistogramRange(
+            nullptr,
+            temp_bytes,
+            thrust::raw_pointer_cast(d_samples.data()),
+            thrust::raw_pointer_cast(d_histogram.data()),
+            num_levels,
+            thrust::raw_pointer_cast(d_levels.data()),
+            static_cast<int>(d_samples.size()),
+            stream));
+  thrust::device_vector<unsigned char> temp(temp_bytes);
+  REQUIRE(cudaSuccess
+          == cub::DeviceHistogram::HistogramRange(
+            thrust::raw_pointer_cast(temp.data()),
+            temp_bytes,
+            thrust::raw_pointer_cast(d_samples.data()),
+            thrust::raw_pointer_cast(d_histogram.data()),
+            num_levels,
+            thrust::raw_pointer_cast(d_levels.data()),
+            static_cast<int>(d_samples.size()),
+            stream));
+}
+
+} // namespace
+
+C2H_TEST("DeviceHistogram::HistogramRange thread_local cache: sequential calls on multiple user streams",
+         "[histogram][device]")
+{
+  constexpr int num_bins    = 32;
+  constexpr int num_samples = 4096;
+
+  const auto h_levels = make_levels(num_bins);
+  thrust::host_vector<sample_t> h_samples(num_samples);
+  for (int i = 0; i < num_samples; ++i)
+  {
+    h_samples[i] = static_cast<sample_t>((i * 31) % 1024);
+  }
+  const auto h_ref = reference_histogram(h_samples, h_levels);
+
+  thrust::device_vector<sample_t> d_samples = h_samples;
+  thrust::device_vector<sample_t> d_levels  = h_levels;
+
+  cudaStream_t stream_a;
+  cudaStream_t stream_b;
+  REQUIRE(cudaSuccess == cudaStreamCreate(&stream_a));
+  REQUIRE(cudaSuccess == cudaStreamCreate(&stream_b));
+
+  for (cudaStream_t s : {stream_a, stream_b, stream_a})
+  {
+    thrust::device_vector<counter_t> d_histogram(num_bins, 0);
+    run_histogram_range(s, d_samples, d_levels, d_histogram);
+    REQUIRE(cudaSuccess == cudaStreamSynchronize(s));
+    thrust::host_vector<counter_t> h_got = d_histogram;
+    CHECK(h_got == h_ref);
+  }
+
+  REQUIRE(cudaSuccess == cudaStreamDestroy(stream_a));
+  REQUIRE(cudaSuccess == cudaStreamDestroy(stream_b));
+}
+
+C2H_TEST("DeviceHistogram::HistogramRange thread_local cache: concurrent threads on the same device",
+         "[histogram][device]")
+{
+  constexpr int num_bins    = 64;
+  constexpr int num_samples = 8192;
+  constexpr int num_threads = 4;
+
+  const auto h_levels = make_levels(num_bins);
+  thrust::host_vector<sample_t> h_samples(num_samples);
+  for (int i = 0; i < num_samples; ++i)
+  {
+    h_samples[i] = static_cast<sample_t>((i * 13 + 7) % 1024);
+  }
+  const auto h_ref = reference_histogram(h_samples, h_levels);
+
+  thrust::device_vector<sample_t> d_samples = h_samples;
+  thrust::device_vector<sample_t> d_levels  = h_levels;
+
+  std::atomic<int> failures{0};
+  std::vector<std::thread> threads;
+  threads.reserve(num_threads);
+
+  for (int t = 0; t < num_threads; ++t)
+  {
+    threads.emplace_back([&]() {
+      cudaStream_t stream;
+      if (cudaStreamCreate(&stream) != cudaSuccess)
+      {
+        failures.fetch_add(1);
+        return;
+      }
+      for (int it = 0; it < 2; ++it)
+      {
+        thrust::device_vector<counter_t> d_histogram(num_bins, 0);
+        const int num_levels = static_cast<int>(d_levels.size());
+        size_t temp_bytes    = 0;
+        if (cub::DeviceHistogram::HistogramRange(
+              nullptr,
+              temp_bytes,
+              thrust::raw_pointer_cast(d_samples.data()),
+              thrust::raw_pointer_cast(d_histogram.data()),
+              num_levels,
+              thrust::raw_pointer_cast(d_levels.data()),
+              static_cast<int>(d_samples.size()),
+              stream)
+            != cudaSuccess)
+        {
+          failures.fetch_add(1);
+          continue;
+        }
+        thrust::device_vector<unsigned char> temp(temp_bytes);
+        if (cub::DeviceHistogram::HistogramRange(
+              thrust::raw_pointer_cast(temp.data()),
+              temp_bytes,
+              thrust::raw_pointer_cast(d_samples.data()),
+              thrust::raw_pointer_cast(d_histogram.data()),
+              num_levels,
+              thrust::raw_pointer_cast(d_levels.data()),
+              static_cast<int>(d_samples.size()),
+              stream)
+            != cudaSuccess)
+        {
+          failures.fetch_add(1);
+          continue;
+        }
+        if (cudaStreamSynchronize(stream) != cudaSuccess)
+        {
+          failures.fetch_add(1);
+          continue;
+        }
+        thrust::host_vector<counter_t> h_got = d_histogram;
+        if (h_got != h_ref)
+        {
+          failures.fetch_add(1);
+        }
+      }
+      cudaStreamDestroy(stream);
+    });
+  }
+  for (auto& th : threads)
+  {
+    th.join();
+  }
+  CHECK(failures.load() == 0);
+}
+
+C2H_TEST("DeviceHistogram::HistogramRange thread_local cache: same thread switches devices between calls",
+         "[histogram][device]")
+{
+  int num_devices = 0;
+  REQUIRE(cudaSuccess == cudaGetDeviceCount(&num_devices));
+  if (num_devices < 2)
+  {
+    SKIP("Requires >= 2 CUDA devices");
+  }
+
+  constexpr int num_bins    = 32;
+  constexpr int num_samples = 4096;
+
+  const auto h_levels = make_levels(num_bins);
+  thrust::host_vector<sample_t> h_samples(num_samples);
+  for (int i = 0; i < num_samples; ++i)
+  {
+    h_samples[i] = static_cast<sample_t>((i * 17) % 1024);
+  }
+  const auto h_ref = reference_histogram(h_samples, h_levels);
+
+  for (int dev : {0, 1, 0})
+  {
+    REQUIRE(cudaSuccess == cudaSetDevice(dev));
+    thrust::device_vector<sample_t> d_samples = h_samples;
+    thrust::device_vector<sample_t> d_levels  = h_levels;
+    thrust::device_vector<counter_t> d_histogram(num_bins, 0);
+    run_histogram_range(/*stream=*/0, d_samples, d_levels, d_histogram);
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    thrust::host_vector<counter_t> h_got = d_histogram;
+    INFO("device " << dev);
+    CHECK(h_got == h_ref);
+  }
+  REQUIRE(cudaSuccess == cudaSetDevice(0));
+}

--- a/cub/test/catch2_test_device_histogram_thread_local_cache.cu
+++ b/cub/test/catch2_test_device_histogram_thread_local_cache.cu
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <random>
 #include <thread>
 #include <vector>
 
@@ -24,21 +25,30 @@ namespace
 using sample_t  = int;
 using counter_t = int;
 
-// Non-uniform spacing keeps DispatchRange on the SearchTransform path, which is
-// where the thread_local detection cache is exercised.
+// Jittered uniform spacing keeps DispatchRange on the SearchTransform path,
+// which is where the thread_local detection cache is exercised. Fixed seed
+// makes the levels reproducible across runs.
 auto make_levels(int num_bins) -> thrust::host_vector<sample_t>
 {
+  constexpr double upper = 1024.0;
+  const double step      = upper / static_cast<double>(num_bins);
   thrust::host_vector<sample_t> levels(num_bins + 1);
-  levels[0] = 0;
-  for (int i = 1; i <= num_bins; ++i)
+  std::mt19937 rng(0xC0FFEE);
+  std::uniform_real_distribution<double> jitter(-0.25, 0.25);
+  levels[0]        = 0;
+  levels[num_bins] = static_cast<sample_t>(upper);
+  for (int i = 1; i < num_bins; ++i)
   {
-    const double t = static_cast<double>(i) / num_bins;
-    sample_t v     = static_cast<sample_t>(t * t * 1024.0);
+    sample_t v = static_cast<sample_t>(i * step + step * jitter(rng));
     if (v <= levels[i - 1])
     {
       v = static_cast<sample_t>(levels[i - 1] + 1);
     }
     levels[i] = v;
+  }
+  if (levels[num_bins] <= levels[num_bins - 1])
+  {
+    levels[num_bins] = static_cast<sample_t>(levels[num_bins - 1] + 1);
   }
   return levels;
 }

--- a/cub/test/catch2_test_device_histogram_thread_local_cache.cu
+++ b/cub/test/catch2_test_device_histogram_thread_local_cache.cu
@@ -21,7 +21,6 @@
 
 namespace
 {
-
 using sample_t  = int;
 using counter_t = int;
 
@@ -70,37 +69,37 @@ auto reference_histogram(const thrust::host_vector<sample_t>& samples, const thr
   return ref;
 }
 
-void run_histogram_range(
-  cudaStream_t stream,
-  const thrust::device_vector<sample_t>& d_samples,
-  const thrust::device_vector<sample_t>& d_levels,
-  thrust::device_vector<counter_t>& d_histogram)
+void run_histogram_range(cudaStream_t stream,
+                         const thrust::device_vector<sample_t>& d_samples,
+                         const thrust::device_vector<sample_t>& d_levels,
+                         thrust::device_vector<counter_t>& d_histogram)
 {
   const int num_levels = static_cast<int>(d_levels.size());
   size_t temp_bytes    = 0;
-  REQUIRE(cudaSuccess
-          == cub::DeviceHistogram::HistogramRange(
-            nullptr,
-            temp_bytes,
-            thrust::raw_pointer_cast(d_samples.data()),
-            thrust::raw_pointer_cast(d_histogram.data()),
-            num_levels,
-            thrust::raw_pointer_cast(d_levels.data()),
-            static_cast<int>(d_samples.size()),
-            stream));
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceHistogram::HistogramRange(
+      nullptr,
+      temp_bytes,
+      thrust::raw_pointer_cast(d_samples.data()),
+      thrust::raw_pointer_cast(d_histogram.data()),
+      num_levels,
+      thrust::raw_pointer_cast(d_levels.data()),
+      static_cast<int>(d_samples.size()),
+      stream));
   thrust::device_vector<unsigned char> temp(temp_bytes);
-  REQUIRE(cudaSuccess
-          == cub::DeviceHistogram::HistogramRange(
-            thrust::raw_pointer_cast(temp.data()),
-            temp_bytes,
-            thrust::raw_pointer_cast(d_samples.data()),
-            thrust::raw_pointer_cast(d_histogram.data()),
-            num_levels,
-            thrust::raw_pointer_cast(d_levels.data()),
-            static_cast<int>(d_samples.size()),
-            stream));
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceHistogram::HistogramRange(
+      thrust::raw_pointer_cast(temp.data()),
+      temp_bytes,
+      thrust::raw_pointer_cast(d_samples.data()),
+      thrust::raw_pointer_cast(d_histogram.data()),
+      num_levels,
+      thrust::raw_pointer_cast(d_levels.data()),
+      static_cast<int>(d_samples.size()),
+      stream));
 }
-
 } // namespace
 
 C2H_TEST("DeviceHistogram::HistogramRange thread_local cache: sequential calls on multiple user streams",


### PR DESCRIPTION
## Why

The DeviceHistogram optimization work in #10547 needs a trustworthy, reusable way to generate difficult inputs, detect incorrect output, and compare algorithm behavior before implementation changes can be reviewed independently.

The previous benchmark mostly measured a narrow family of inputs, and some invalid benchmark cells could be skipped rather than fail. That made it too easy for an optimization to look successful because it recognized the benchmark pattern, silently avoided an unsupported case, or produced an incorrect histogram.

This draft is the first focused extraction from the raw autoresearch branch. It contains benchmark and correctness infrastructure only; it does not include the new shared-memory or high-bin caching algorithms. The next focused PR will be stacked on this branch while it is under review, then retargeted to `main` after this lands.

## What changed

### Reproducible input shapes

The histogram benchmarks now generate explicit, deterministic input shapes instead of relying on a single entropy-style knob. The available shapes exercise materially different workloads, including concentrated hot bins, uniform traffic, and distributions intended to stress cache capacity and collisions. Single-channel and multi-channel benchmarks use the same input contracts.

The benchmark documentation and Python tooling describe and visualize those distributions, run comparable sweeps, and retain the configuration needed to interpret a result. The plotting paths use current algorithm keys so results from later implementation PRs can be compared without rewriting the analysis scripts.

### Independent correctness checks

Benchmark results are checked bin by bin against a reference implementation. A mismatch is now fatal instead of silently skipping the cell. RANGE benchmarks use genuinely non-uniform integer levels, and the reference path is deliberately separate from the device bin-computation path so the same defect is less likely to affect both sides.

The tests cover the input-shape generators and the thread-local benchmark cache. Existing DeviceHistogram coverage is extended for the boundary cases exposed while building the harness.

### Wide and overflow-prone cases

The benchmark can be built with alternate counter and offset types, including a 64-bit baseline. It covers larger bin counts, including 16,384 and 60,000 bins, and uses the full representable integer sample range where applicable.

This work also fixes correctness and undefined-behavior issues found by the new coverage:

- signed overflow in `ScaleTransform::ComputeBin` for negative minimum levels;
- bin computation when the level range is wider than `LevelT`;
- row-stride overflow in invalid multi-channel benchmark cells;
- stale persisting-L2 state affecting comparisons between benchmark iterations.

## Scope and follow-up

This is intentionally a benchmark/testing foundation rather than an algorithm PR. It is larger than a normal test-only change because the generators, reference validation, C++ benchmark integration, and analysis tools form one reproducibility contract.

The next focused PR will add the shared-memory privatized enhancements as a stacked change. Its intended scope is one generic dynamic-shared-memory privatized kernel, byte- and counter-width-aware capacity checks, occupancy-aware launch handling, conservative selection, and focused correctness tests. It will exclude the new high-bin cache, direct-atomic selector experiments, and the historical staging/combine designs from #10547.

Later PRs will separately cover the high-bin global-memory baseline, the cache algorithm, selector/tuning policy, and C Parallel integration, as outlined in #10547.

## Validation

Formatting and repository checks:

```text
pre-commit run --files <all changed files>
git diff --check upstream/main...HEAD
```

Both pass.

Configured and built with CUDA 13.3.33 for SM90:

```text
CUDAHOSTCXX=/usr/bin/c++ CXX=/usr/bin/c++ \
  cmake --fresh --preset cub-cpp20 -DCMAKE_CUDA_ARCHITECTURES=90

ninja -C build/cub-cpp20 \
  cub.test.device.histogram_input_shapes \
  cub.test.device.histogram_thread_local_cache \
  cub.test.device.histogram
```

All requested targets compile successfully.

Runtime execution is currently blocked by the available test environment. The machine has an NVIDIA B200, but its installed driver rejects PTX produced by CUDA 13.3.33 with `cudaErrorUnsupportedPtxVersion: the provided PTX was compiled with an unsupported toolchain`. The same startup failure affects the existing histogram test and both new test binaries, before any test assertion runs. Runtime results will need to be collected with a compatible driver/toolkit pair.

## Relationship to the research snapshot

This code was extracted and formatted from the raw autoresearch output in #10547. Scratch-directory changes, implementation experiments, generated artifacts, design notes, and the new histogram algorithms are not included here.
