### PR TITLE
[Tile] Mark unique_ptr as host device only

### DIFF
--- a/libcudacxx/include/cuda/std/__memory/compressed_pair.h
+++ b/libcudacxx/include/cuda/std/__memory/compressed_pair.h
@@ -57,20 +57,25 @@ struct __compressed_pair_elem
   using reference       = _Tp&;
   using const_reference = const _Tp&;
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr explicit __compressed_pair_elem(__default_init_tag) noexcept(
     is_nothrow_default_constructible_v<_Tp>)
   {}
+
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr explicit __compressed_pair_elem(__value_init_tag) noexcept(is_nothrow_default_constructible_v<_Tp>)
       : __value_()
   {}
 
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Up, enable_if_t<!is_same_v<__compressed_pair_elem, decay_t<_Up>>, int> = 0>
   _CCCL_API constexpr explicit __compressed_pair_elem(_Up&& __u) noexcept(is_nothrow_constructible_v<_Tp, _Up>)
       : __value_(::cuda::std::forward<_Up>(__u))
   {}
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class... _Args, size_t... _Indices>
   _CCCL_API constexpr explicit __compressed_pair_elem(
     piecewise_construct_t,
@@ -100,22 +105,28 @@ struct __compressed_pair_elem<_Tp, _Idx, true> : private _Tp
   using const_reference = const _Tp&;
   using __value_type    = _Tp;
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HIDE_FROM_ABI explicit constexpr __compressed_pair_elem() = default;
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr explicit __compressed_pair_elem(__default_init_tag) noexcept(
     is_nothrow_default_constructible_v<_Tp>)
   {}
+
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr explicit __compressed_pair_elem(__value_init_tag) noexcept(is_nothrow_default_constructible_v<_Tp>)
       : __value_type()
   {}
 
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Up, enable_if_t<!is_same_v<__compressed_pair_elem, decay_t<_Up>>, int> = 0>
   _CCCL_API constexpr explicit __compressed_pair_elem(_Up&& __u) noexcept(is_nothrow_constructible_v<_Tp, _Up>)
       : __value_type(::cuda::std::forward<_Up>(__u))
   {}
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class... _Args, size_t... _Indices>
   _CCCL_API constexpr __compressed_pair_elem(
     piecewise_construct_t,
@@ -152,6 +163,7 @@ public:
   using _Base1 _CCCL_NODEBUG_ALIAS = __compressed_pair_elem<_T1, 0>;
   using _Base2 _CCCL_NODEBUG_ALIAS = __compressed_pair_elem<_T2, 1>;
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <bool _Dummy = true,
             class       = enable_if_t<__dependent_type<is_default_constructible<_T1>, _Dummy>::value
                                       && __dependent_type<is_default_constructible<_T2>, _Dummy>::value>>
@@ -161,6 +173,7 @@ public:
       , _Base2(__value_init_tag())
   {}
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _U1, class _U2>
   _CCCL_API constexpr explicit __compressed_pair(_U1&& __t1, _U2&& __t2) noexcept(
     is_constructible_v<_T1, _U1> && is_constructible_v<_T2, _U2>)
@@ -168,6 +181,7 @@ public:
       , _Base2(::cuda::std::forward<_U2>(__t2))
   {}
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class... _Args1, class... _Args2>
   _CCCL_API constexpr explicit __compressed_pair(
     piecewise_construct_t __pc,
@@ -206,6 +220,7 @@ public:
     return static_cast<_Base2*>(__pair);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr void
   swap(__compressed_pair& __x) noexcept(is_nothrow_swappable_v<_T1> && is_nothrow_swappable_v<_T2>)
   {
@@ -215,6 +230,7 @@ public:
   }
 };
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _T1, class _T2>
 _CCCL_API constexpr void swap(__compressed_pair<_T1, _T2>& __x, __compressed_pair<_T1, _T2>& __y) noexcept(
   is_nothrow_swappable_v<_T1> && is_nothrow_swappable_v<_T2>)

--- a/libcudacxx/include/cuda/std/__memory/unique_ptr.h
+++ b/libcudacxx/include/cuda/std/__memory/unique_ptr.h
@@ -64,12 +64,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete
   _CCCL_HIDE_FROM_ABI constexpr default_delete() noexcept = default;
 
   template <class _Up>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20
   default_delete(const default_delete<_Up>&, enable_if_t<is_convertible_v<_Up*, _Tp*>, int> = 0) noexcept
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void operator()(_Tp* __ptr) const noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 void operator()(_Tp* __ptr) const noexcept
   {
     // NOLINTNEXTLINE(bugprone-sizeof-expression)
     static_assert(sizeof(_Tp) >= 0, "cannot delete an incomplete type");
@@ -84,22 +84,18 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete<_Tp[]>
   _CCCL_HIDE_FROM_ABI constexpr default_delete() noexcept = default;
 
   template <class _Up>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20
   default_delete(const default_delete<_Up[]>&, enable_if_t<is_convertible_v<_Up (*)[], _Tp (*)[]>, int> = 0) noexcept
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Up>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 enable_if_t<is_convertible_v<_Up (*)[], _Tp (*)[]>, void>
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 enable_if_t<is_convertible_v<_Up (*)[], _Tp (*)[]>, void>
   operator()([[maybe_unused]] _Up* __ptr) const noexcept
   {
     // NOLINTNEXTLINE(bugprone-sizeof-expression)
     static_assert(sizeof(_Up) >= 0, "cannot delete an incomplete type");
-#if _CCCL_TILE_COMPILATION()
-    _CCCL_VERIFY(false, "Cannot call delete[] in a tile program");
-#else // ^^^ _CCCL_TILE_COMPILATION() ^^^ / vvv !_CCCL_TILE_COMPILATION() vvv
     delete[] __ptr;
-#endif // !_CCCL_TILE_COMPILATION()
   }
 };
 
@@ -184,36 +180,36 @@ private:
 
 public:
   template <bool _Dummy = true, class = _EnableIfDeleterDefaultConstructible<_Dummy>>
-  _CCCL_API constexpr unique_ptr() noexcept
+  _CCCL_HOST_DEVICE_API constexpr unique_ptr() noexcept
       : __ptr_(__value_init_tag(), __value_init_tag())
   {}
 
   template <bool _Dummy = true, class = _EnableIfDeleterDefaultConstructible<_Dummy>>
-  _CCCL_API constexpr unique_ptr(nullptr_t) noexcept
+  _CCCL_HOST_DEVICE_API constexpr unique_ptr(nullptr_t) noexcept
       : __ptr_(__value_init_tag(), __value_init_tag())
   {}
 
   template <bool _Dummy = true, class = _EnableIfDeleterDefaultConstructible<_Dummy>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit unique_ptr(pointer __p) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 explicit unique_ptr(pointer __p) noexcept
       : __ptr_(__p, __value_init_tag())
   {}
 
   template <bool _Dummy = true, class = _EnableIfDeleterConstructible<_LValRefType<_Dummy>>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(pointer __p, _LValRefType<_Dummy> __d) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(pointer __p, _LValRefType<_Dummy> __d) noexcept
       : __ptr_(__p, __d)
   {}
 
   template <bool _Dummy = true, class = _EnableIfDeleterConstructible<_GoodRValRefType<_Dummy>>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(pointer __p, _GoodRValRefType<_Dummy> __d) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(pointer __p, _GoodRValRefType<_Dummy> __d) noexcept
       : __ptr_(__p, ::cuda::std::move(__d))
   {
     static_assert(!is_reference_v<deleter_type>, "rvalue deleter bound to reference");
   }
 
   template <bool _Dummy = true, class = _EnableIfDeleterConstructible<_BadRValRefType<_Dummy>>>
-  _CCCL_API inline unique_ptr(pointer __p, _BadRValRefType<_Dummy> __d) = delete;
+  _CCCL_HOST_DEVICE_API inline unique_ptr(pointer __p, _BadRValRefType<_Dummy> __d) = delete;
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(unique_ptr&& __u) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(unique_ptr&& __u) noexcept
       : __ptr_(__u.release(), ::cuda::std::forward<deleter_type>(__u.get_deleter()))
   {}
 
@@ -221,11 +217,11 @@ public:
             class _Ep,
             class = _EnableIfMoveConvertible<unique_ptr<_Up, _Ep>, _Up>,
             class = _EnableIfDeleterConvertible<_Ep>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(unique_ptr<_Up, _Ep>&& __u) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(unique_ptr<_Up, _Ep>&& __u) noexcept
       : __ptr_(__u.release(), ::cuda::std::forward<_Ep>(__u.get_deleter()))
   {}
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr& operator=(unique_ptr&& __u) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr& operator=(unique_ptr&& __u) noexcept
   {
     reset(__u.release());
     __ptr_.second() = ::cuda::std::forward<deleter_type>(__u.get_deleter());
@@ -236,7 +232,7 @@ public:
             class _Ep,
             class = _EnableIfMoveConvertible<unique_ptr<_Up, _Ep>, _Up>,
             class = _EnableIfDeleterAssignable<_Ep>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr& operator=(unique_ptr<_Up, _Ep>&& __u) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr& operator=(unique_ptr<_Up, _Ep>&& __u) noexcept
   {
     reset(__u.release());
     __ptr_.second() = ::cuda::std::forward<_Ep>(__u.get_deleter());
@@ -246,43 +242,43 @@ public:
   unique_ptr(unique_ptr const&)            = delete;
   unique_ptr& operator=(unique_ptr const&) = delete;
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 ~unique_ptr()
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 ~unique_ptr()
   {
     reset();
   }
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr& operator=(nullptr_t) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr& operator=(nullptr_t) noexcept
   {
     reset();
     return *this;
   }
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 add_lvalue_reference_t<_Tp> operator*() const
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 add_lvalue_reference_t<_Tp> operator*() const
   {
     return *__ptr_.first();
   }
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 pointer operator->() const noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 pointer operator->() const noexcept
   {
     return __ptr_.first();
   }
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 pointer get() const noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 pointer get() const noexcept
   {
     return __ptr_.first();
   }
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 deleter_type& get_deleter() noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 deleter_type& get_deleter() noexcept
   {
     return __ptr_.second();
   }
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 const deleter_type& get_deleter() const noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 const deleter_type& get_deleter() const noexcept
   {
     return __ptr_.second();
   }
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit operator bool() const noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 explicit operator bool() const noexcept
   {
     return __ptr_.first() != nullptr;
   }
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 pointer release() noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 pointer release() noexcept
   {
     pointer __t    = __ptr_.first();
     __ptr_.first() = pointer();
@@ -290,7 +286,7 @@ public:
   }
 
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void reset(pointer __p = pointer()) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 void reset(pointer __p = pointer()) noexcept
   {
     pointer __tmp  = __ptr_.first();
     __ptr_.first() = __p;
@@ -300,7 +296,7 @@ public:
     }
   }
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void swap(unique_ptr& __u) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 void swap(unique_ptr& __u) noexcept
   {
     __ptr_.swap(__u.__ptr_);
   }
@@ -366,12 +362,12 @@ private:
 
 public:
   template <bool _Dummy = true, class = _EnableIfDeleterDefaultConstructible<_Dummy>>
-  _CCCL_API constexpr unique_ptr() noexcept
+  _CCCL_HOST_DEVICE_API constexpr unique_ptr() noexcept
       : __ptr_(__value_init_tag(), __value_init_tag())
   {}
 
   template <bool _Dummy = true, class = _EnableIfDeleterDefaultConstructible<_Dummy>>
-  _CCCL_API constexpr unique_ptr(nullptr_t) noexcept
+  _CCCL_HOST_DEVICE_API constexpr unique_ptr(nullptr_t) noexcept
       : __ptr_(__value_init_tag(), __value_init_tag())
   {}
 
@@ -379,7 +375,7 @@ public:
             bool _Dummy = true,
             class       = _EnableIfDeleterDefaultConstructible<_Dummy>,
             class       = _EnableIfPointerConvertible<_Pp>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit unique_ptr(_Pp __p) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 explicit unique_ptr(_Pp __p) noexcept
       : __ptr_(__p, __value_init_tag())
   {}
 
@@ -387,12 +383,12 @@ public:
             bool _Dummy = true,
             class       = _EnableIfDeleterConstructible<_LValRefType<_Dummy>>,
             class       = _EnableIfPointerConvertible<_Pp>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(_Pp __p, _LValRefType<_Dummy> __d) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(_Pp __p, _LValRefType<_Dummy> __d) noexcept
       : __ptr_(__p, __d)
   {}
 
   template <bool _Dummy = true, class = _EnableIfDeleterConstructible<_LValRefType<_Dummy>>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(nullptr_t, _LValRefType<_Dummy> __d) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(nullptr_t, _LValRefType<_Dummy> __d) noexcept
       : __ptr_(nullptr, __d)
   {}
 
@@ -400,14 +396,14 @@ public:
             bool _Dummy = true,
             class       = _EnableIfDeleterConstructible<_GoodRValRefType<_Dummy>>,
             class       = _EnableIfPointerConvertible<_Pp>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(_Pp __p, _GoodRValRefType<_Dummy> __d) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(_Pp __p, _GoodRValRefType<_Dummy> __d) noexcept
       : __ptr_(__p, ::cuda::std::move(__d))
   {
     static_assert(!is_reference_v<deleter_type>, "rvalue deleter bound to reference");
   }
 
   template <bool _Dummy = true, class = _EnableIfDeleterConstructible<_GoodRValRefType<_Dummy>>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(nullptr_t, _GoodRValRefType<_Dummy> __d) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(nullptr_t, _GoodRValRefType<_Dummy> __d) noexcept
       : __ptr_(nullptr, ::cuda::std::move(__d))
   {
     static_assert(!is_reference_v<deleter_type>, "rvalue deleter bound to reference");
@@ -417,13 +413,13 @@ public:
             bool _Dummy = true,
             class       = _EnableIfDeleterConstructible<_BadRValRefType<_Dummy>>,
             class       = _EnableIfPointerConvertible<_Pp>>
-  _CCCL_API inline unique_ptr(_Pp __p, _BadRValRefType<_Dummy> __d) = delete;
+  _CCCL_HOST_DEVICE_API inline unique_ptr(_Pp __p, _BadRValRefType<_Dummy> __d) = delete;
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(unique_ptr&& __u) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(unique_ptr&& __u) noexcept
       : __ptr_(__u.release(), ::cuda::std::forward<deleter_type>(__u.get_deleter()))
   {}
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr& operator=(unique_ptr&& __u) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr& operator=(unique_ptr&& __u) noexcept
   {
     reset(__u.release());
     __ptr_.second() = ::cuda::std::forward<deleter_type>(__u.get_deleter());
@@ -434,7 +430,7 @@ public:
             class _Ep,
             class = _EnableIfMoveConvertible<unique_ptr<_Up, _Ep>, _Up>,
             class = _EnableIfDeleterConvertible<_Ep>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(unique_ptr<_Up, _Ep>&& __u) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(unique_ptr<_Up, _Ep>&& __u) noexcept
       : __ptr_(__u.release(), ::cuda::std::forward<_Ep>(__u.get_deleter()))
   {}
 
@@ -442,7 +438,7 @@ public:
             class _Ep,
             class = _EnableIfMoveConvertible<unique_ptr<_Up, _Ep>, _Up>,
             class = _EnableIfDeleterAssignable<_Ep>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr& operator=(unique_ptr<_Up, _Ep>&& __u) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr& operator=(unique_ptr<_Up, _Ep>&& __u) noexcept
   {
     reset(__u.release());
     __ptr_.second() = ::cuda::std::forward<_Ep>(__u.get_deleter());
@@ -450,41 +446,41 @@ public:
   }
 
 public:
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 ~unique_ptr()
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 ~unique_ptr()
   {
     reset();
   }
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr& operator=(nullptr_t) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr& operator=(nullptr_t) noexcept
   {
     reset();
     return *this;
   }
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 add_lvalue_reference_t<_Tp> operator[](size_t __i) const
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 add_lvalue_reference_t<_Tp> operator[](size_t __i) const
   {
     return __ptr_.first()[__i];
   }
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 pointer get() const noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 pointer get() const noexcept
   {
     return __ptr_.first();
   }
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 deleter_type& get_deleter() noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 deleter_type& get_deleter() noexcept
   {
     return __ptr_.second();
   }
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 const deleter_type& get_deleter() const noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 const deleter_type& get_deleter() const noexcept
   {
     return __ptr_.second();
   }
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit operator bool() const noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 explicit operator bool() const noexcept
   {
     return __ptr_.first() != nullptr;
   }
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 pointer release() noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 pointer release() noexcept
   {
     pointer __t    = __ptr_.first();
     __ptr_.first() = pointer();
@@ -492,7 +488,7 @@ public:
   }
 
   template <class _Pp, enable_if_t<_CheckArrayPointerConversion<_Pp>::value, int> = 0>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void reset(_Pp __p) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 void reset(_Pp __p) noexcept
   {
     pointer __tmp  = __ptr_.first();
     __ptr_.first() = __p;
@@ -502,7 +498,7 @@ public:
     }
   }
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void reset(nullptr_t = nullptr) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 void reset(nullptr_t = nullptr) noexcept
   {
     pointer __tmp  = __ptr_.first();
     __ptr_.first() = nullptr;
@@ -512,41 +508,36 @@ public:
     }
   }
 
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void swap(unique_ptr& __u) noexcept
+  _CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 void swap(unique_ptr& __u) noexcept
   {
     __ptr_.swap(__u.__ptr_);
   }
 };
 
 template <class _Tp, class _Dp>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 enable_if_t<is_nothrow_swappable_v<_Dp>, void>
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 enable_if_t<is_nothrow_swappable_v<_Dp>, void>
 swap(unique_ptr<_Tp, _Dp>& __x, unique_ptr<_Tp, _Dp>& __y) noexcept
 {
   __x.swap(__y);
 }
 
 template <class _T1, class _D1, class _T2, class _D2>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 bool operator==(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 bool
+operator==(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
 {
   return __x.get() == __y.get();
 }
 
 #if _CCCL_STD_VER <= 2017
 template <class _T1, class _D1, class _T2, class _D2>
-_CCCL_API inline
-
-  bool
-  operator!=(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
+_CCCL_HOST_DEVICE_API inline bool operator!=(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
 {
   return !(__x == __y);
 }
 #endif
 
 template <class _T1, class _D1, class _T2, class _D2>
-_CCCL_API inline
-
-  bool
-  operator<(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
+_CCCL_HOST_DEVICE_API inline bool operator<(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
 {
   using _P1 = typename unique_ptr<_T1, _D1>::pointer;
   using _P2 = typename unique_ptr<_T2, _D2>::pointer;
@@ -555,28 +546,19 @@ _CCCL_API inline
 }
 
 template <class _T1, class _D1, class _T2, class _D2>
-_CCCL_API inline
-
-  bool
-  operator>(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
+_CCCL_HOST_DEVICE_API inline bool operator>(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
 {
   return __y < __x;
 }
 
 template <class _T1, class _D1, class _T2, class _D2>
-_CCCL_API inline
-
-  bool
-  operator<=(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
+_CCCL_HOST_DEVICE_API inline bool operator<=(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
 {
   return !(__y < __x);
 }
 
 template <class _T1, class _D1, class _T2, class _D2>
-_CCCL_API inline
-
-  bool
-  operator>=(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
+_CCCL_HOST_DEVICE_API inline bool operator>=(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
 {
   return !(__x < __y);
 }
@@ -585,8 +567,8 @@ _CCCL_API inline
 #  if _CCCL_STD_VER >= 2020
 template <class _T1, class _D1, class _T2, class _D2>
   requires three_way_comparable_with<typename unique_ptr<_T1, _D1>::pointer, typename unique_ptr<_T2, _D2>::pointer>
-_CCCL_API inline compare_three_way_result_t<typename unique_ptr<_T1, _D1>::pointer,
-                                            typename unique_ptr<_T2, _D2>::pointer>
+_CCCL_HOST_DEVICE_API inline compare_three_way_result_t<typename unique_ptr<_T1, _D1>::pointer,
+                                                        typename unique_ptr<_T2, _D2>::pointer>
 operator<=>(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
 {
   return compare_three_way()(__x.get(), __y.get());
@@ -595,86 +577,77 @@ operator<=>(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y)
 #endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 
 template <class _T1, class _D1>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 bool operator==(const unique_ptr<_T1, _D1>& __x, nullptr_t) noexcept
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 bool operator==(const unique_ptr<_T1, _D1>& __x, nullptr_t) noexcept
 {
   return !__x;
 }
 
 #if _CCCL_STD_VER <= 2017
 template <class _T1, class _D1>
-_CCCL_API inline
-
-  bool
-  operator==(nullptr_t, const unique_ptr<_T1, _D1>& __x) noexcept
+_CCCL_HOST_DEVICE_API inline bool operator==(nullptr_t, const unique_ptr<_T1, _D1>& __x) noexcept
 {
   return !__x;
 }
 
 template <class _T1, class _D1>
-_CCCL_API inline
-
-  bool
-  operator!=(const unique_ptr<_T1, _D1>& __x, nullptr_t) noexcept
+_CCCL_HOST_DEVICE_API inline bool operator!=(const unique_ptr<_T1, _D1>& __x, nullptr_t) noexcept
 {
   return static_cast<bool>(__x);
 }
 
 template <class _T1, class _D1>
-_CCCL_API inline
-
-  bool
-  operator!=(nullptr_t, const unique_ptr<_T1, _D1>& __x) noexcept
+_CCCL_HOST_DEVICE_API inline bool operator!=(nullptr_t, const unique_ptr<_T1, _D1>& __x) noexcept
 {
   return static_cast<bool>(__x);
 }
 #endif // _CCCL_STD_VER <= 2017
 
 template <class _T1, class _D1>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 bool operator<(const unique_ptr<_T1, _D1>& __x, nullptr_t)
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 bool operator<(const unique_ptr<_T1, _D1>& __x, nullptr_t)
 {
   using _P1 = typename unique_ptr<_T1, _D1>::pointer;
   return less<_P1>()(__x.get(), nullptr);
 }
 
 template <class _T1, class _D1>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 bool operator<(nullptr_t, const unique_ptr<_T1, _D1>& __x)
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 bool operator<(nullptr_t, const unique_ptr<_T1, _D1>& __x)
 {
   using _P1 = typename unique_ptr<_T1, _D1>::pointer;
   return less<_P1>()(nullptr, __x.get());
 }
 
 template <class _T1, class _D1>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 bool operator>(const unique_ptr<_T1, _D1>& __x, nullptr_t)
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 bool operator>(const unique_ptr<_T1, _D1>& __x, nullptr_t)
 {
   return nullptr < __x;
 }
 
 template <class _T1, class _D1>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 bool operator>(nullptr_t, const unique_ptr<_T1, _D1>& __x)
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 bool operator>(nullptr_t, const unique_ptr<_T1, _D1>& __x)
 {
   return __x < nullptr;
 }
 
 template <class _T1, class _D1>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 bool operator<=(const unique_ptr<_T1, _D1>& __x, nullptr_t)
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 bool operator<=(const unique_ptr<_T1, _D1>& __x, nullptr_t)
 {
   return !(nullptr < __x);
 }
 
 template <class _T1, class _D1>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 bool operator<=(nullptr_t, const unique_ptr<_T1, _D1>& __x)
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 bool operator<=(nullptr_t, const unique_ptr<_T1, _D1>& __x)
 {
   return !(__x < nullptr);
 }
 
 template <class _T1, class _D1>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 bool operator>=(const unique_ptr<_T1, _D1>& __x, nullptr_t)
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 bool operator>=(const unique_ptr<_T1, _D1>& __x, nullptr_t)
 {
   return !(__x < nullptr);
 }
 
 template <class _T1, class _D1>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 bool operator>=(nullptr_t, const unique_ptr<_T1, _D1>& __x)
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 bool operator>=(nullptr_t, const unique_ptr<_T1, _D1>& __x)
 {
   return !(nullptr < __x);
 }
@@ -683,7 +656,7 @@ _CCCL_API inline _CCCL_CONSTEXPR_CXX20 bool operator>=(nullptr_t, const unique_p
 #  if _CCCL_STD_VER >= 2020
 template <class _T1, class _D1>
   requires three_way_comparable<typename unique_ptr<_T1, _D1>::pointer>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 compare_three_way_result_t<typename unique_ptr<_T1, _D1>::pointer>
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 compare_three_way_result_t<typename unique_ptr<_T1, _D1>::pointer>
 operator<=>(const unique_ptr<_T1, _D1>& __x, nullptr_t)
 {
   return compare_three_way()(__x.get(), static_cast<typename unique_ptr<_T1, _D1>::pointer>(nullptr));
@@ -711,39 +684,42 @@ struct __unique_if<_Tp[_Np]>
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class... _Args>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 typename __unique_if<_Tp>::__unique_single make_unique(_Args&&... __args)
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 typename __unique_if<_Tp>::__unique_single
+make_unique(_Args&&... __args)
 {
   return unique_ptr<_Tp>(new _Tp(::cuda::std::forward<_Args>(__args)...));
 }
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 typename __unique_if<_Tp>::__unique_array_unknown_bound make_unique(size_t __n)
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 typename __unique_if<_Tp>::__unique_array_unknown_bound
+make_unique(size_t __n)
 {
   using _Up = remove_extent_t<_Tp>;
   return unique_ptr<_Tp>(new _Up[__n]());
 }
 
 template <class _Tp, class... _Args>
-_CCCL_API inline typename __unique_if<_Tp>::__unique_array_known_bound make_unique(_Args&&...) = delete;
+_CCCL_HOST_DEVICE_API inline typename __unique_if<_Tp>::__unique_array_known_bound make_unique(_Args&&...) = delete;
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 typename __unique_if<_Tp>::__unique_single make_unique_for_overwrite()
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 typename __unique_if<_Tp>::__unique_single make_unique_for_overwrite()
 {
   return unique_ptr<_Tp>(new _Tp);
 }
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 typename __unique_if<_Tp>::__unique_array_unknown_bound
+_CCCL_HOST_DEVICE_API inline _CCCL_CONSTEXPR_CXX20 typename __unique_if<_Tp>::__unique_array_unknown_bound
 make_unique_for_overwrite(size_t __n)
 {
   return unique_ptr<_Tp>(new remove_extent_t<_Tp>[__n]);
 }
 
 template <class _Tp, class... _Args>
-_CCCL_API inline typename __unique_if<_Tp>::__unique_array_known_bound make_unique_for_overwrite(_Args&&...) = delete;
+_CCCL_HOST_DEVICE_API inline typename __unique_if<_Tp>::__unique_array_known_bound
+make_unique_for_overwrite(_Args&&...) = delete;
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT hash;
@@ -757,7 +733,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<unique_ptr<_Tp, _Dp>>
   using result_type   = CCCL_DEPRECATED size_t;
 #  endif
 
-  _CCCL_API inline size_t operator()(const unique_ptr<_Tp, _Dp>& __ptr) const
+  _CCCL_HOST_DEVICE_API inline size_t operator()(const unique_ptr<_Tp, _Dp>& __ptr) const
   {
     using pointer = typename unique_ptr<_Tp, _Dp>::pointer;
     return hash<pointer>()(__ptr.get());

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/pointer_type.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/pointer_type.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
 // <memory>
 
 // unique_ptr
@@ -41,7 +44,7 @@ struct D3
 #endif // !TEST_COMPILER(NVRTC)
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   using VT = typename cuda::std::conditional<IsArray, int[], int>::type;
   {
@@ -66,7 +69,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 #endif // !TEST_COMPILER(NVRTC)
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   test_basic</*IsArray*/ false>();
   test_basic<true>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
@@ -8,6 +8,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: assertion failed
+
 // Self assignment post-conditions are tested.
 // ADDITIONAL_COMPILE_OPTIONS_HOST: -Wno-self-move
 
@@ -33,11 +39,11 @@
 
 struct GenericDeleter
 {
-  TEST_FUNC void operator()(void*) const;
+  TEST_HOST_DEVICE_FUNC void operator()(void*) const;
 };
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   using VT               = typename cuda::std::conditional<IsArray, A[], A>::type;
   const int expect_alive = IsArray ? 5 : 1;
@@ -120,7 +126,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 {
   using VT = typename cuda::std::conditional<IsArray, int[], int>::type;
   {
@@ -153,7 +159,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     test_basic</*IsArray*/ false>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp
@@ -10,8 +10,8 @@
 
 // UNSUPPORTED: nvrtc
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -29,23 +29,23 @@
 template <int ID = 0>
 struct GenericDeleter
 {
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
 };
 
 template <int ID = 0>
 struct GenericConvertingDeleter
 {
   template <int OID>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 GenericConvertingDeleter(GenericConvertingDeleter<OID>)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 GenericConvertingDeleter(GenericConvertingDeleter<OID>)
   {}
 
   template <int OID>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 GenericConvertingDeleter& operator=(GenericConvertingDeleter<OID> const&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 GenericConvertingDeleter& operator=(GenericConvertingDeleter<OID> const&)
   {
     return *this;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
 };
 
 template <class T, class U>
@@ -75,46 +75,46 @@ struct ConstTrackingDeleter;
 template <int ID>
 struct TrackingDeleter
 {
-  TEST_FUNC TrackingDeleter()
+  TEST_HOST_DEVICE_FUNC TrackingDeleter()
       : arg_type(&makeArgumentID<>())
   {}
 
-  TEST_FUNC TrackingDeleter(TrackingDeleter const&)
+  TEST_HOST_DEVICE_FUNC TrackingDeleter(TrackingDeleter const&)
       : arg_type(&makeArgumentID<TrackingDeleter const&>())
   {}
 
-  TEST_FUNC TrackingDeleter(TrackingDeleter&&)
+  TEST_HOST_DEVICE_FUNC TrackingDeleter(TrackingDeleter&&)
       : arg_type(&makeArgumentID<TrackingDeleter&&>())
   {}
 
   template <class T, class = EnableIfSpecialization<TrackingDeleter, T>>
-  TEST_FUNC TrackingDeleter(T&&)
+  TEST_HOST_DEVICE_FUNC TrackingDeleter(T&&)
       : arg_type(&makeArgumentID<T&&>())
   {}
 
-  TEST_FUNC TrackingDeleter& operator=(TrackingDeleter const&)
+  TEST_HOST_DEVICE_FUNC TrackingDeleter& operator=(TrackingDeleter const&)
   {
     arg_type = &makeArgumentID<TrackingDeleter const&>();
     return *this;
   }
 
-  TEST_FUNC TrackingDeleter& operator=(TrackingDeleter&&)
+  TEST_HOST_DEVICE_FUNC TrackingDeleter& operator=(TrackingDeleter&&)
   {
     arg_type = &makeArgumentID<TrackingDeleter&&>();
     return *this;
   }
 
   template <class T, class = EnableIfSpecialization<TrackingDeleter, T>>
-  TEST_FUNC TrackingDeleter& operator=(T&&)
+  TEST_HOST_DEVICE_FUNC TrackingDeleter& operator=(T&&)
   {
     arg_type = &makeArgumentID<T&&>();
     return *this;
   }
 
-  TEST_FUNC void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC void operator()(void*) const {}
 
 public:
-  TEST_FUNC TypeID const* reset() const
+  TEST_HOST_DEVICE_FUNC TypeID const* reset() const
   {
     TypeID const* tmp = arg_type;
     arg_type          = nullptr;
@@ -127,46 +127,46 @@ public:
 template <int ID>
 struct ConstTrackingDeleter
 {
-  TEST_FUNC ConstTrackingDeleter()
+  TEST_HOST_DEVICE_FUNC ConstTrackingDeleter()
       : arg_type(&makeArgumentID<>())
   {}
 
-  TEST_FUNC ConstTrackingDeleter(ConstTrackingDeleter const&)
+  TEST_HOST_DEVICE_FUNC ConstTrackingDeleter(ConstTrackingDeleter const&)
       : arg_type(&makeArgumentID<ConstTrackingDeleter const&>())
   {}
 
-  TEST_FUNC ConstTrackingDeleter(ConstTrackingDeleter&&)
+  TEST_HOST_DEVICE_FUNC ConstTrackingDeleter(ConstTrackingDeleter&&)
       : arg_type(&makeArgumentID<ConstTrackingDeleter&&>())
   {}
 
   template <class T, class = EnableIfSpecialization<ConstTrackingDeleter, T>>
-  TEST_FUNC ConstTrackingDeleter(T&&)
+  TEST_HOST_DEVICE_FUNC ConstTrackingDeleter(T&&)
       : arg_type(&makeArgumentID<T&&>())
   {}
 
-  TEST_FUNC const ConstTrackingDeleter& operator=(ConstTrackingDeleter const&) const
+  TEST_HOST_DEVICE_FUNC const ConstTrackingDeleter& operator=(ConstTrackingDeleter const&) const
   {
     arg_type = &makeArgumentID<ConstTrackingDeleter const&>();
     return *this;
   }
 
-  TEST_FUNC const ConstTrackingDeleter& operator=(ConstTrackingDeleter&&) const
+  TEST_HOST_DEVICE_FUNC const ConstTrackingDeleter& operator=(ConstTrackingDeleter&&) const
   {
     arg_type = &makeArgumentID<ConstTrackingDeleter&&>();
     return *this;
   }
 
   template <class T, class = EnableIfSpecialization<ConstTrackingDeleter, T>>
-  TEST_FUNC const ConstTrackingDeleter& operator=(T&&) const
+  TEST_HOST_DEVICE_FUNC const ConstTrackingDeleter& operator=(T&&) const
   {
     arg_type = &makeArgumentID<T&&>();
     return *this;
   }
 
-  TEST_FUNC void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC void operator()(void*) const {}
 
 public:
-  TEST_FUNC TypeID const* reset() const
+  TEST_HOST_DEVICE_FUNC TypeID const* reset() const
   {
     TypeID const* tmp = arg_type;
     arg_type          = nullptr;
@@ -177,13 +177,13 @@ public:
 };
 
 template <class ExpectT, int ID>
-TEST_FUNC bool checkArg(TrackingDeleter<ID> const& d)
+TEST_HOST_DEVICE_FUNC bool checkArg(TrackingDeleter<ID> const& d)
 {
   return d.arg_type && *d.arg_type == makeArgumentID<ExpectT>();
 }
 
 template <class ExpectT, int ID>
-TEST_FUNC bool checkArg(ConstTrackingDeleter<ID> const& d)
+TEST_HOST_DEVICE_FUNC bool checkArg(ConstTrackingDeleter<ID> const& d)
 {
   return d.arg_type && *d.arg_type == makeArgumentID<ExpectT>();
 }
@@ -204,24 +204,24 @@ struct AssignDeleter
   AssignDeleter& operator=(T&&) const&& = delete;
 
   template <class T, class = typename cuda::std::enable_if<cuda::std::is_same<T&&, From>::value && !AssignIsConst>::type>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 AssignDeleter& operator=(T&&) &
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 AssignDeleter& operator=(T&&) &
   {
     return *this;
   }
 
   template <class T, class = typename cuda::std::enable_if<cuda::std::is_same<T&&, From>::value && AssignIsConst>::type>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 const AssignDeleter& operator=(T&&) const&
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 const AssignDeleter& operator=(T&&) const&
   {
     return *this;
   }
 
   template <class T>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T) const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T) const
   {}
 };
 
 template <class VT, class DDest, class DSource>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void doDeleterTest()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void doDeleterTest()
 {
   using U1 = cuda::std::unique_ptr<VT, DDest>;
   using U2 = cuda::std::unique_ptr<VT, DSource>;
@@ -234,7 +234,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void doDeleterTest()
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 {
   using VT = typename cuda::std::conditional<IsArray, A[], A>::type;
 
@@ -324,7 +324,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
 {
   using VT = typename cuda::std::conditional<IsArray, A[], A>::type;
   {
@@ -350,7 +350,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
 }
 
 template <bool IsArray>
-TEST_FUNC void test_deleter_value_category()
+TEST_HOST_DEVICE_FUNC void test_deleter_value_category()
 {
   using VT  = typename cuda::std::conditional<IsArray, A[], A>::type;
   using TD1 = TrackingDeleter<1>;
@@ -448,7 +448,7 @@ TEST_FUNC void test_deleter_value_category()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     test_sfinae</*IsArray*/ false>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.runtime.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.runtime.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -25,7 +25,7 @@
 #include "unique_ptr_test_helper.h"
 
 template <class APtr, class BPtr>
-TEST_FUNC void testAssign(APtr& aptr, BPtr& bptr)
+TEST_HOST_DEVICE_FUNC void testAssign(APtr& aptr, BPtr& bptr)
 {
   A* p = bptr.get();
   assert(A_count == 2);
@@ -37,7 +37,7 @@ TEST_FUNC void testAssign(APtr& aptr, BPtr& bptr)
 }
 
 template <class LHS, class RHS>
-TEST_FUNC void checkDeleter(LHS& lhs, RHS& rhs, int LHSState, int RHSState)
+TEST_HOST_DEVICE_FUNC void checkDeleter(LHS& lhs, RHS& rhs, int LHSState, int RHSState)
 {
   assert(lhs.get_deleter().state() == LHSState);
   assert(rhs.get_deleter().state() == RHSState);
@@ -51,10 +51,10 @@ struct NCConvertingDeleter
   NCConvertingDeleter(NCConvertingDeleter&&)      = default;
 
   template <class U>
-  TEST_FUNC NCConvertingDeleter(NCConvertingDeleter<U>&&)
+  TEST_HOST_DEVICE_FUNC NCConvertingDeleter(NCConvertingDeleter<U>&&)
   {}
 
-  TEST_FUNC void operator()(T*) const {}
+  TEST_HOST_DEVICE_FUNC void operator()(T*) const {}
 };
 
 template <class T>
@@ -65,15 +65,15 @@ struct NCConvertingDeleter<T[]>
   NCConvertingDeleter(NCConvertingDeleter&&)      = default;
 
   template <class U>
-  TEST_FUNC NCConvertingDeleter(NCConvertingDeleter<U>&&)
+  TEST_HOST_DEVICE_FUNC NCConvertingDeleter(NCConvertingDeleter<U>&&)
   {}
 
-  TEST_FUNC void operator()(T*) const {}
+  TEST_HOST_DEVICE_FUNC void operator()(T*) const {}
 };
 
 struct GenericDeleter
 {
-  TEST_FUNC void operator()(void*) const;
+  TEST_HOST_DEVICE_FUNC void operator()(void*) const;
 };
 
 struct NCGenericDeleter
@@ -82,10 +82,10 @@ struct NCGenericDeleter
   NCGenericDeleter(NCGenericDeleter const&) = delete;
   NCGenericDeleter(NCGenericDeleter&&)      = default;
 
-  TEST_FUNC void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC void operator()(void*) const {}
 };
 
-TEST_FUNC void test_sfinae()
+TEST_HOST_DEVICE_FUNC void test_sfinae()
 {
   using DA  = NCConvertingDeleter<A[]>; // non-copyable deleters
   using DAC = NCConvertingDeleter<const A[]>; // non-copyable deleters

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.single.pass.cpp
@@ -8,8 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: assertion failed
 
 // <memory>
 
@@ -26,7 +29,7 @@
 #include "unique_ptr_test_helper.h"
 
 template <class APtr, class BPtr>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void testAssign(APtr& aptr, BPtr& bptr)
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void testAssign(APtr& aptr, BPtr& bptr)
 {
   A* p = bptr.get();
   if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
@@ -44,7 +47,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void testAssign(APtr& aptr, BPtr& bptr)
 }
 
 template <class LHS, class RHS>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void checkDeleter(LHS& lhs, RHS& rhs, int LHSState, int RHSState)
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void checkDeleter(LHS& lhs, RHS& rhs, int LHSState, int RHSState)
 {
   assert(lhs.get_deleter().state() == LHSState);
   assert(rhs.get_deleter().state() == RHSState);
@@ -58,10 +61,10 @@ struct NCConvertingDeleter
   TEST_CONSTEXPR_CXX23 NCConvertingDeleter(NCConvertingDeleter&&) = default;
 
   template <class U>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 NCConvertingDeleter(NCConvertingDeleter<U>&&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 NCConvertingDeleter(NCConvertingDeleter<U>&&)
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T*) const {}
 };
 
 template <class T>
@@ -72,10 +75,10 @@ struct NCConvertingDeleter<T[]>
   TEST_CONSTEXPR_CXX23 NCConvertingDeleter(NCConvertingDeleter&&) = default;
 
   template <class U>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 NCConvertingDeleter(NCConvertingDeleter<U>&&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 NCConvertingDeleter(NCConvertingDeleter<U>&&)
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T*) const {}
 };
 
 struct NCGenericDeleter
@@ -84,10 +87,10 @@ struct NCGenericDeleter
   NCGenericDeleter(NCGenericDeleter const&)                 = delete;
   TEST_CONSTEXPR_CXX23 NCGenericDeleter(NCGenericDeleter&&) = default;
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 {
   using DA  = NCConvertingDeleter<A>; // non-copyable deleters
   using DB  = NCConvertingDeleter<B>;
@@ -131,7 +134,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   test_sfinae();
   {

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/null.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/null.pass.cpp
@@ -8,8 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: assertion failed
 
 // <memory>
 
@@ -25,7 +28,7 @@
 
 // test assignment from null
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   using VT               = typename cuda::std::conditional<IsArray, A[], A>::type;
   const int expect_alive = IsArray ? 5 : 1;
@@ -48,7 +51,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   test_basic</*IsArray*/ false>();
   test_basic<true>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/nullptr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/nullptr.pass.cpp
@@ -8,8 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: assertion failed
 
 // <memory>
 
@@ -26,7 +29,7 @@
 // test assignment from null
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   using VT               = typename cuda::std::conditional<IsArray, A[], A>::type;
   const int expect_alive = IsArray ? 5 : 1;
@@ -49,7 +52,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   test_basic</*IsArray*/ false>();
   test_basic<true>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/deduct.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/deduct.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -28,7 +28,7 @@
 
 struct Deleter
 {
-  TEST_FUNC void operator()(int* p) const
+  TEST_HOST_DEVICE_FUNC void operator()(int* p) const
   {
     delete p;
   }

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/default.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -42,11 +42,11 @@ _CCCL_CONSTINIT cuda::std::unique_ptr<int[]> global_static_unique_ptr_runtime;
 struct NonDefaultDeleter
 {
   NonDefaultDeleter() = delete;
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
 };
 
 template <class ElemType>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 {
   { // the constructor does not participate in overload resolution when
     // the deleter is a pointer type
@@ -66,7 +66,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 }
 
 template <class ElemType>
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test_basic()
 {
   {
     using U1 = cuda::std::unique_ptr<ElemType>;
@@ -105,7 +105,7 @@ DEFINE_AND_RUN_IS_INCOMPLETE_TEST(
   })
 #endif // !_CCCL_CUDA_COMPILATION()
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     test_sfinae<int>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move.pass.cpp
@@ -8,8 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: assertion failed
 
 // <memory>
 
@@ -43,39 +46,39 @@
 //    'sink' should accept the unique_ptr by value. (C-1,2,4)
 
 template <class VT>
-TEST_FUNC TEST_CONSTEXPR_CXX23 cuda::std::unique_ptr<VT> source1()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 cuda::std::unique_ptr<VT> source1()
 {
   return cuda::std::unique_ptr<VT>(newValue<VT>(1));
 }
 
 template <class VT>
-TEST_FUNC TEST_CONSTEXPR_CXX23 cuda::std::unique_ptr<VT, Deleter<VT>> source2()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 cuda::std::unique_ptr<VT, Deleter<VT>> source2()
 {
   return cuda::std::unique_ptr<VT, Deleter<VT>>(newValue<VT>(1), Deleter<VT>(5));
 }
 
 template <class VT>
-TEST_FUNC cuda::std::unique_ptr<VT, NCDeleter<VT>&> source3()
+TEST_HOST_DEVICE_FUNC cuda::std::unique_ptr<VT, NCDeleter<VT>&> source3()
 {
   static NCDeleter<VT> d(5);
   return cuda::std::unique_ptr<VT, NCDeleter<VT>&>(newValue<VT>(1), d);
 }
 
 template <class VT>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void sink1(cuda::std::unique_ptr<VT> p)
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void sink1(cuda::std::unique_ptr<VT> p)
 {
   assert(p.get() != nullptr);
 }
 
 template <class VT>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void sink2(cuda::std::unique_ptr<VT, Deleter<VT>> p)
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void sink2(cuda::std::unique_ptr<VT, Deleter<VT>> p)
 {
   assert(p.get() != nullptr);
   assert(p.get_deleter().state() == 5);
 }
 
 template <class VT>
-TEST_FUNC void sink3(cuda::std::unique_ptr<VT, NCDeleter<VT>&> p)
+TEST_HOST_DEVICE_FUNC void sink3(cuda::std::unique_ptr<VT, NCDeleter<VT>&> p)
 {
   assert(p.get() != nullptr);
   assert(p.get_deleter().state() == 5);
@@ -83,7 +86,7 @@ TEST_FUNC void sink3(cuda::std::unique_ptr<VT, NCDeleter<VT>&> p)
 }
 
 template <class ValueT>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 {
   using U = cuda::std::unique_ptr<ValueT>;
   { // Ensure unique_ptr is non-copyable
@@ -93,7 +96,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   using VT               = typename cuda::std::conditional<!IsArray, A, A[]>::type;
   const int expect_alive = IsArray ? 5 : 1;
@@ -176,7 +179,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 }
 
 template <class VT>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
 {
   {
     using U = cuda::std::unique_ptr<VT>;
@@ -196,7 +199,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     test_basic</*IsArray*/ false>();
@@ -213,7 +216,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
 }
 
 template <bool IsArray>
-TEST_FUNC void test_sink3()
+TEST_HOST_DEVICE_FUNC void test_sink3()
 {
   NV_IF_TARGET(NV_IS_HOST, ({
                  using VT = typename cuda::std::conditional<!IsArray, A, A[]>::type;

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
 // UNSUPPORTED: nvrtc
 
 // XFAIL: enable-tile
@@ -29,16 +32,16 @@
 template <int ID = 0>
 struct GenericDeleter
 {
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
 };
 
 template <int ID = 0>
 struct GenericConvertingDeleter
 {
   template <int OID>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 GenericConvertingDeleter(GenericConvertingDeleter<OID>)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 GenericConvertingDeleter(GenericConvertingDeleter<OID>)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
 };
 
 template <class Templ, class Other>
@@ -59,46 +62,46 @@ using EnableIfSpecialization =
 template <int ID>
 struct TrackingDeleter
 {
-  TEST_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter()
       : arg_type(&makeArgumentID<>())
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter(TrackingDeleter const&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter(TrackingDeleter const&)
       : arg_type(&makeArgumentID<TrackingDeleter const&>())
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter(TrackingDeleter&&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter(TrackingDeleter&&)
       : arg_type(&makeArgumentID<TrackingDeleter&&>())
   {}
 
   template <class T, class = EnableIfSpecialization<TrackingDeleter, T>>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter(T&&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter(T&&)
       : arg_type(&makeArgumentID<T&&>())
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter& operator=(TrackingDeleter const&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter& operator=(TrackingDeleter const&)
   {
     arg_type = &makeArgumentID<TrackingDeleter const&>();
     return *this;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter& operator=(TrackingDeleter&&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter& operator=(TrackingDeleter&&)
   {
     arg_type = &makeArgumentID<TrackingDeleter&&>();
     return *this;
   }
 
   template <class T, class = EnableIfSpecialization<TrackingDeleter, T>>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter& operator=(T&&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 TrackingDeleter& operator=(T&&)
   {
     arg_type = &makeArgumentID<T&&>();
     return *this;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 TypeID const* reset() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 TypeID const* reset() const
   {
     TypeID const* tmp = arg_type;
     arg_type          = nullptr;
@@ -109,13 +112,13 @@ public:
 };
 
 template <class ExpectT, int ID>
-TEST_FUNC bool checkArg(TrackingDeleter<ID> const& d)
+TEST_HOST_DEVICE_FUNC bool checkArg(TrackingDeleter<ID> const& d)
 {
   return d.arg_type && *d.arg_type == makeArgumentID<ExpectT>();
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 {
   using VT = typename cuda::std::conditional<IsArray, A[], A>::type;
 
@@ -164,7 +167,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
 {
   using VT = typename cuda::std::conditional<IsArray, A[], A>::type;
   {
@@ -190,7 +193,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_deleter_value_category()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_deleter_value_category()
 {
   using VT  = typename cuda::std::conditional<IsArray, A[], A>::type;
   using TD1 = TrackingDeleter<1>;
@@ -222,7 +225,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_deleter_value_category()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     test_sfinae</*IsArray*/ false>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.runtime.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.runtime.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -27,19 +27,19 @@
 template <int ID = 0>
 struct GenericDeleter
 {
-  TEST_FUNC void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC void operator()(void*) const {}
 };
 
 template <int ID = 0>
 struct GenericConvertingDeleter
 {
   template <int OID>
-  TEST_FUNC GenericConvertingDeleter(GenericConvertingDeleter<OID>)
+  TEST_HOST_DEVICE_FUNC GenericConvertingDeleter(GenericConvertingDeleter<OID>)
   {}
-  TEST_FUNC void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC void operator()(void*) const {}
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 {
   { // Disallow copying
     using U1 = cuda::std::unique_ptr<A[], GenericConvertingDeleter<0>>;
@@ -84,7 +84,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   test_sfinae();
 

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.single.pass.cpp
@@ -7,8 +7,11 @@
 
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: invalid deduction of host device tile execution space attributes
 
 // <memory>
 
@@ -31,7 +34,7 @@
 // Explicit version
 
 template <class LHS, class RHS>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void checkReferenceDeleter(LHS& lhs, RHS& rhs)
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void checkReferenceDeleter(LHS& lhs, RHS& rhs)
 {
   using NewDel = typename LHS::deleter_type;
   static_assert(cuda::std::is_reference<NewDel>::value);
@@ -44,14 +47,14 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void checkReferenceDeleter(LHS& lhs, RHS& rhs)
 }
 
 template <class LHS, class RHS>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void checkDeleter(LHS& lhs, RHS& rhs, int LHSVal, int RHSVal)
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void checkDeleter(LHS& lhs, RHS& rhs, int LHSVal, int RHSVal)
 {
   assert(lhs.get_deleter().state() == LHSVal);
   assert(rhs.get_deleter().state() == RHSVal);
 }
 
 template <class LHS, class RHS>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void checkCtor(LHS& lhs, RHS& rhs, A* RHSVal)
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void checkCtor(LHS& lhs, RHS& rhs, A* RHSVal)
 {
   assert(lhs.get() == RHSVal);
   assert(rhs.get() == nullptr);
@@ -62,7 +65,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void checkCtor(LHS& lhs, RHS& rhs, A* RHSVal)
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 void checkNoneAlive()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void checkNoneAlive()
 {
   if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
   {
@@ -79,10 +82,10 @@ struct NCConvertingDeleter
   TEST_CONSTEXPR_CXX23 NCConvertingDeleter(NCConvertingDeleter&&) = default;
 
   template <class U>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 NCConvertingDeleter(NCConvertingDeleter<U>&&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 NCConvertingDeleter(NCConvertingDeleter<U>&&)
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T*) const {}
 };
 
 template <class T>
@@ -93,10 +96,10 @@ struct NCConvertingDeleter<T[]>
   TEST_CONSTEXPR_CXX23 NCConvertingDeleter(NCConvertingDeleter&&) = default;
 
   template <class U>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 NCConvertingDeleter(NCConvertingDeleter<U>&&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 NCConvertingDeleter(NCConvertingDeleter<U>&&)
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T*) const {}
 };
 
 struct NCGenericDeleter
@@ -105,10 +108,10 @@ struct NCGenericDeleter
   NCGenericDeleter(NCGenericDeleter const&)                 = delete;
   TEST_CONSTEXPR_CXX23 NCGenericDeleter(NCGenericDeleter&&) = default;
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 {
   using DA  = NCConvertingDeleter<A>; // non-copyable deleters
   using DB  = NCConvertingDeleter<B>;
@@ -152,7 +155,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
 {
   {
     using APtr = cuda::std::unique_ptr<A>;
@@ -176,7 +179,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     test_sfinae();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/null.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/null.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -26,7 +26,7 @@
 #include "unique_ptr_test_helper.h"
 
 template <class VT>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_pointer_ctor()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_pointer_ctor()
 {
   {
     cuda::std::unique_ptr<VT> p(0);
@@ -40,7 +40,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_pointer_ctor()
 }
 
 template <class VT>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_pointer_deleter_ctor()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_pointer_deleter_ctor()
 {
   {
     cuda::std::default_delete<VT> d;
@@ -66,7 +66,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_pointer_deleter_ctor()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     // test_pointer_ctor<int>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/nullptr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/nullptr.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -31,11 +31,11 @@ _CCCL_CONSTINIT cuda::std::unique_ptr<int[]> global_static_unique_ptr_runtime(nu
 struct NonDefaultDeleter
 {
   NonDefaultDeleter() = delete;
-  TEST_FUNC void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC void operator()(void*) const {}
 };
 
 template <class VT>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   {
     using U1 = cuda::std::unique_ptr<VT>;
@@ -60,7 +60,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 }
 
 template <class VT>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 {
   { // the constructor does not participate in overload resolution when
     // the deleter is a pointer type
@@ -100,7 +100,7 @@ DEFINE_AND_RUN_IS_INCOMPLETE_TEST({
 })
 #endif // !_CCCL_CUDA_COMPILATION()
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     test_basic<int>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer.pass.cpp
@@ -8,8 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: assertion failed
 
 // <memory>
 
@@ -42,7 +45,7 @@
 // unique_ptr(pointer) ctor should only require default Deleter ctor
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_pointer()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_pointer()
 {
   using ValueT           = typename cuda::std::conditional<!IsArray, A, A[]>::type;
   const int expect_alive = IsArray ? 5 : 1;
@@ -104,7 +107,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_pointer()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_derived()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_derived()
 {
   {
     B* p = new B;
@@ -141,17 +144,17 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_derived()
 
 struct NonDefaultDeleter
 {
-  TEST_FUNC NonDefaultDeleter() = delete;
-  TEST_FUNC void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC NonDefaultDeleter() = delete;
+  TEST_HOST_DEVICE_FUNC void operator()(void*) const {}
 };
 
 struct GenericDeleter
 {
-  TEST_FUNC void operator()(void*) const;
+  TEST_HOST_DEVICE_FUNC void operator()(void*) const;
 };
 
 template <class T>
-TEST_FUNC void TEST_CONSTEXPR_CXX23 test_sfinae()
+TEST_HOST_DEVICE_FUNC void TEST_CONSTEXPR_CXX23 test_sfinae()
 {
   { // the constructor does not participate in overload resolution when
     // the deleter is a pointer type
@@ -170,7 +173,7 @@ TEST_FUNC void TEST_CONSTEXPR_CXX23 test_sfinae()
   }
 }
 
-TEST_FUNC static TEST_CONSTEXPR_CXX23 void test_sfinae_runtime()
+TEST_HOST_DEVICE_FUNC static TEST_CONSTEXPR_CXX23 void test_sfinae_runtime()
 {
   { // the constructor does not participate in overload resolution when
     // a base <-> derived conversion would occur.
@@ -203,7 +206,7 @@ DEFINE_AND_RUN_IS_INCOMPLETE_TEST({
 })
 #endif // !_CCCL_CUDA_COMPILATION()
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     test_pointer</*IsArray*/ false>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer_deleter.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer_deleter.pass.cpp
@@ -8,8 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: assertion failed
 
 // <memory>
 
@@ -35,14 +38,14 @@
 
 TEST_GLOBAL_VARIABLE bool my_free_called = false;
 
-TEST_FUNC void my_free(void*)
+TEST_HOST_DEVICE_FUNC void my_free(void*)
 {
   my_free_called = true;
 }
 
 struct DeleterBase
 {
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
 };
 struct CopyOnlyDeleter : DeleterBase
 {
@@ -62,7 +65,7 @@ struct NoCopyMoveDeleter : DeleterBase
 };
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 {
   using VT = typename cuda::std::conditional<!IsArray, int, int[]>::type;
   {
@@ -111,7 +114,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae()
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
 {
   using VT = typename cuda::std::conditional<!IsArray, int, int[]>::type;
   {
@@ -141,7 +144,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_noexcept()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae_runtime()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae_runtime()
 {
   {
     using D = CopyOnlyDeleter;
@@ -211,7 +214,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_sfinae_runtime()
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   using VT               = typename cuda::std::conditional<!IsArray, A, A[]>::type;
   const int expect_alive = IsArray ? 5 : 1;
@@ -294,7 +297,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic_single()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic_single()
 {
   if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
   {
@@ -332,7 +335,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic_single()
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_nullptr()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_nullptr()
 {
   using VT = typename cuda::std::conditional<!IsArray, A, A[]>::type;
   {
@@ -351,7 +354,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_nullptr()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     test_basic</*IsArray*/ false>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.dtor/null.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.dtor/null.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
 // <memory>
 
 // unique_ptr
@@ -23,27 +26,27 @@ class Deleter
 {
   int state_;
 
-  TEST_FUNC Deleter(Deleter&);
-  TEST_FUNC Deleter& operator=(Deleter&);
+  TEST_HOST_DEVICE_FUNC Deleter(Deleter&);
+  TEST_HOST_DEVICE_FUNC Deleter& operator=(Deleter&);
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 Deleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 Deleter()
       : state_(0)
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*)
   {
     ++state_;
   }
 };
 
 template <class T>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   Deleter d;
   assert(d.state() == 0);
@@ -55,7 +58,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
   assert(d.state() == 0);
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   test_basic<int>();
   test_basic<int[]>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/release.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/release.pass.cpp
@@ -8,8 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: assertion failed
 
 // <memory>
 
@@ -24,7 +27,7 @@
 #include "unique_ptr_test_helper.h"
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   using VT               = typename cuda::std::conditional<IsArray, A[], A>::type;
   const int expect_alive = IsArray ? 3 : 1;
@@ -70,7 +73,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   test_basic</*IsArray*/ false>();
   test_basic<true>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset.pass.cpp
@@ -8,8 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: invalid deduction of host device tile execution space attributes
 
 // <memory>
 
@@ -24,7 +27,7 @@
 #include "unique_ptr_test_helper.h"
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_reset_pointer()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_reset_pointer()
 {
   using VT               = typename cuda::std::conditional<IsArray, A[], A>::type;
   const int expect_alive = IsArray ? 3 : 1;
@@ -85,7 +88,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_reset_pointer()
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_reset_nullptr()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_reset_nullptr()
 {
   using VT               = typename cuda::std::conditional<IsArray, A[], A>::type;
   const int expect_alive = IsArray ? 3 : 1;
@@ -117,7 +120,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_reset_nullptr()
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_reset_no_arg()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_reset_no_arg()
 {
   using VT               = typename cuda::std::conditional<IsArray, A[], A>::type;
   const int expect_alive = IsArray ? 3 : 1;
@@ -148,7 +151,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_reset_no_arg()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     test_reset_pointer</*IsArray*/ false>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset.single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset.single.pass.cpp
@@ -8,8 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: assertion failed
 
 // <memory>
 
@@ -23,7 +26,7 @@
 #include "test_macros.h"
 #include "unique_ptr_test_helper.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     cuda::std::unique_ptr<A> p(new A);

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset_self.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset_self.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -25,16 +25,16 @@ struct A
 {
   cuda::std::unique_ptr<A> ptr_;
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 A()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 A()
       : ptr_(this)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void reset()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void reset()
   {
     ptr_.reset();
   }
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   (new A)->reset();
 

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/swap.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -28,7 +28,7 @@ TEST_GLOBAL_VARIABLE int TT_count = 0;
 struct TT
 {
   int state_;
-  TEST_FUNC TEST_CONSTEXPR_CXX23 TT()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 TT()
       : state_(-1)
   {
     if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
@@ -36,7 +36,7 @@ struct TT
       ++TT_count;
     }
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit TT(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit TT(int i)
       : state_(i)
   {
     if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
@@ -44,7 +44,7 @@ struct TT
       ++TT_count;
     }
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 TT(const TT& a)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 TT(const TT& a)
       : state_(a.state_)
   {
     if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
@@ -52,12 +52,12 @@ struct TT
       ++TT_count;
     }
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 TT& operator=(const TT& a)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 TT& operator=(const TT& a)
   {
     state_ = a.state_;
     return *this;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 ~TT()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 ~TT()
   {
     if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
     {
@@ -65,14 +65,15 @@ struct TT
     }
   }
 
-  TEST_FUNC friend TEST_CONSTEXPR_CXX23 bool operator==(const TT& x, const TT& y)
+  TEST_HOST_DEVICE_FUNC friend TEST_CONSTEXPR_CXX23 bool operator==(const TT& x, const TT& y)
   {
     return x.state_ == y.state_;
   }
 };
 
 template <class T>
-TEST_FUNC TEST_CONSTEXPR_CXX23 typename cuda::std::remove_all_extents<T>::type* newValueInit(int size, int new_value)
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 typename cuda::std::remove_all_extents<T>::type*
+newValueInit(int size, int new_value)
 {
   using VT = typename cuda::std::remove_all_extents<T>::type;
   VT* p    = newValue<T>(size);
@@ -84,7 +85,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 typename cuda::std::remove_all_extents<T>::type* 
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   using VT               = typename cuda::std::conditional<IsArray, TT[], TT>::type;
   const int expect_alive = IsArray ? 5 : 1;
@@ -123,7 +124,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   test_basic</*IsArray*/ false>();
   test_basic<true>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/dereference.single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/dereference.single.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -22,7 +22,7 @@
 
 #include "test_macros.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   cuda::std::unique_ptr<int> p(new int(3));
   assert(*p == 3);

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/explicit_bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/explicit_bool.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -24,7 +24,7 @@
 #include "unique_ptr_test_helper.h"
 
 template <class UPtr>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void doTest(UPtr& p, bool ExpectTrue)
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void doTest(UPtr& p, bool ExpectTrue)
 {
   if (p)
   {
@@ -46,7 +46,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void doTest(UPtr& p, bool ExpectTrue)
 }
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   using VT = typename cuda::std::conditional<IsArray, int[], int>::type;
   using U  = cuda::std::unique_ptr<VT>;
@@ -72,7 +72,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   test_basic</*IsArray*/ false>();
   test_basic<true>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/get.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -24,7 +24,7 @@
 #include "unique_ptr_test_helper.h"
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   using VT  = typename cuda::std::conditional<IsArray, int[], int>::type;
   using CVT = const VT;
@@ -50,7 +50,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   test_basic</*IsArray*/ false>();
   test_basic<true>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/get_deleter.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/get_deleter.pass.cpp
@@ -8,6 +8,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: invalid host device tile execution space deduction
+
 // <memory>
 
 // unique_ptr
@@ -22,22 +28,22 @@
 
 struct Deleter
 {
-  TEST_FUNC TEST_CONSTEXPR_CXX23 Deleter() {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 Deleter() {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(void*) const {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int test()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int test()
   {
     return 5;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int test() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int test() const
   {
     return 6;
   }
 };
 
 template <bool IsArray>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
 {
   using VT = typename cuda::std::conditional<IsArray, int[], int>::type;
   {
@@ -70,7 +76,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX23 void test_basic()
   }
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   test_basic</*IsArray*/ false>();
   test_basic<true>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_arrow.single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_arrow.single.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -26,12 +26,12 @@ struct A
 {
   int i_;
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 A()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 A()
       : i_(7)
   {}
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   cuda::std::unique_ptr<A> p(new A);
   assert(p->i_ == 7);

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_subscript.runtime.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_subscript.runtime.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -36,7 +36,7 @@ class A
   int state_;
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 A()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 A()
       : state_(0)
   {
     if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
@@ -45,24 +45,24 @@ public:
     }
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int get() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int get() const
   {
     return state_;
   }
 
-  TEST_FUNC friend TEST_CONSTEXPR_CXX23 bool operator==(const A& x, int y)
+  TEST_HOST_DEVICE_FUNC friend TEST_CONSTEXPR_CXX23 bool operator==(const A& x, int y)
   {
     return x.state_ == y;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 A& operator=(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 A& operator=(int i)
   {
     state_ = i;
     return *this;
   }
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   cuda::std::unique_ptr<A[]> p(new A[3]);
   if (!TEST_IS_CONSTANT_EVALUATED_CXX23())

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique.array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique.array.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 #include <cuda/std/__memory_>
 #if defined(_LIBCUDACXX_HAS_STRING)
@@ -24,10 +24,10 @@
 class foo
 {
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 foo()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 foo()
       : val_(3)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int get() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int get() const
   {
     return val_;
   }
@@ -36,7 +36,7 @@ private:
   int val_;
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     auto p1 = cuda::std::make_unique<int[]>(5);

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique.single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique.single.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 #include <cuda/std/__memory_>
 #if defined(_LIBCUDACXX_HAS_STRING)
@@ -19,7 +19,7 @@
 
 #include "test_macros.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     cuda::std::unique_ptr<int> p1 = cuda::std::make_unique<int>(1);

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique_for_overwrite.default_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique_for_overwrite.default_init.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
 // UNSUPPORTED: sanitizer-new-delete
 
 // It is not possible to overwrite device operator new
@@ -69,7 +72,7 @@ void operator delete[](void* ptr, cuda::std::size_t) noexcept
 }
 #endif // TEST_COMPILER(GCC)
 
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   {
     decltype(auto) ptr = cuda::std::make_unique_for_overwrite<int>();

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique_for_overwrite.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique_for_overwrite.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // template<class T>
 //   constexpr unique_ptr<T> make_unique_for_overwrite(); // T is not array
@@ -75,12 +75,12 @@ static_assert(!HasMakeUniqueForOverwrite<Foo[2], int, int>);
 struct WithDefaultConstructor
 {
   int i;
-  TEST_FUNC constexpr WithDefaultConstructor()
+  TEST_HOST_DEVICE_FUNC constexpr WithDefaultConstructor()
       : i(5)
   {}
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   // single int
   {
@@ -128,21 +128,21 @@ TEST_GLOBAL_VARIABLE bool WithCustomNew_customNewArrCalled = false;
 
 struct WithCustomNew
 {
-  TEST_FUNC static void* operator new(cuda::std::size_t n)
+  TEST_HOST_DEVICE_FUNC static void* operator new(cuda::std::size_t n)
   {
     WithCustomNew_customNewCalled = true;
     return ::operator new(n);
     ;
   }
 
-  TEST_FUNC static void* operator new[](cuda::std::size_t n)
+  TEST_HOST_DEVICE_FUNC static void* operator new[](cuda::std::size_t n)
   {
     WithCustomNew_customNewArrCalled = true;
     return ::operator new[](n);
   }
 };
 
-TEST_FUNC void testCustomNew()
+TEST_HOST_DEVICE_FUNC void testCustomNew()
 {
   // single with custom operator new
   {

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt/convert_ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt/convert_ctor.pass.cpp
@@ -8,8 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: assertion failed
 
 // <memory>
 
@@ -23,7 +26,7 @@
 #include "test_macros.h"
 #include "unique_ptr_test_helper.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   cuda::std::default_delete<B> d2;
   cuda::std::default_delete<A> d1 = d2;

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt/default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt/default.pass.cpp
@@ -8,8 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
+// UNSUPPORTED: enable-tile
+// error: assertion failed
 
 // <memory>
 
@@ -21,7 +24,7 @@
 #include "test_macros.h"
 #include "unique_ptr_test_helper.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   cuda::std::default_delete<A> d;
   A* p = new A;

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/convert_ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/convert_ctor.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
 // <memory>
 
 // default_delete[]
@@ -23,7 +26,7 @@
 
 #include "test_macros.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   cuda::std::default_delete<int[]> d1;
   cuda::std::default_delete<const int[]> d2 = d1;

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/default.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -26,7 +26,7 @@
 #include "test_macros.h"
 #include "unique_ptr_test_helper.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   cuda::std::default_delete<A[]> d;
   A* p = new A[3];

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.special/cmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.special/cmp.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -54,7 +54,7 @@
 #include "test_macros.h"
 #include "unique_ptr_test_helper.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   AssertComparisonsReturnBool<cuda::std::unique_ptr<int>>();
 #if TEST_STD_VER >= 2020 && _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.special/cmp_nullptr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.special/cmp_nullptr.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -57,7 +57,7 @@ TEST_NV_DIAG_SUPPRESS(3060) // call to __builtin_is_constant_evaluated appearing
 TEST_DIAG_SUPPRESS_GCC("-Wtautological-compare")
 TEST_DIAG_SUPPRESS_CLANG("-Wtautological-compare")
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
   {

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.special/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.special/swap.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <memory>
 
@@ -34,7 +34,7 @@ TEST_GLOBAL_VARIABLE int A_count = 0;
 struct A
 {
   int state_;
-  TEST_FUNC TEST_CONSTEXPR_CXX23 A()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 A()
       : state_(0)
   {
     if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
@@ -42,7 +42,7 @@ struct A
       ++A_count;
     }
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit A(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit A(int i)
       : state_(i)
   {
     if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
@@ -50,7 +50,7 @@ struct A
       ++A_count;
     }
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 A(const A& a)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 A(const A& a)
       : state_(a.state_)
   {
     if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
@@ -58,12 +58,12 @@ struct A
       ++A_count;
     }
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 A& operator=(const A& a)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 A& operator=(const A& a)
   {
     state_ = a.state_;
     return *this;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 ~A()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 ~A()
   {
     if (!TEST_IS_CONSTANT_EVALUATED_CXX23())
     {
@@ -71,7 +71,7 @@ struct A
     }
   }
 
-  TEST_FUNC friend TEST_CONSTEXPR_CXX23 bool operator==(const A& x, const A& y)
+  TEST_HOST_DEVICE_FUNC friend TEST_CONSTEXPR_CXX23 bool operator==(const A& x, const A& y)
   {
     return x.state_ == y.state_;
   }
@@ -80,18 +80,18 @@ struct A
 template <class T>
 struct NonSwappableDeleter
 {
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit NonSwappableDeleter(int) {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 NonSwappableDeleter& operator=(NonSwappableDeleter const&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit NonSwappableDeleter(int) {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 NonSwappableDeleter& operator=(NonSwappableDeleter const&)
   {
     return *this;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T*) const {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T*) const {}
 
 private:
-  TEST_FUNC NonSwappableDeleter(NonSwappableDeleter const&);
+  TEST_HOST_DEVICE_FUNC NonSwappableDeleter(NonSwappableDeleter const&);
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX23 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 bool test()
 {
   {
     A* p1 = new A(1);

--- a/libcudacxx/test/support/deleter_types.h
+++ b/libcudacxx/test/support/deleter_types.h
@@ -28,36 +28,36 @@ class Deleter
 {
   int state_;
 
-  TEST_FUNC Deleter(const Deleter&);
-  TEST_FUNC Deleter& operator=(const Deleter&);
+  TEST_HOST_DEVICE_FUNC Deleter(const Deleter&);
+  TEST_HOST_DEVICE_FUNC Deleter& operator=(const Deleter&);
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 Deleter(Deleter&& r)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 Deleter(Deleter&& r)
       : state_(r.state_)
   {
     r.state_ = 0;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 Deleter& operator=(Deleter&& r)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 Deleter& operator=(Deleter&& r)
   {
     state_   = r.state_;
     r.state_ = 0;
     return *this;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 Deleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 Deleter()
       : state_(0)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit Deleter(int s)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit Deleter(int s)
       : state_(s)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 ~Deleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 ~Deleter()
   {
     assert(state_ >= 0);
     state_ = -1;
   }
 
   template <class U>
-  TEST_FUNC TEST_CONSTEXPR_CXX23
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23
   Deleter(Deleter<U>&& d, typename cuda::std::enable_if<!cuda::std::is_same<U, T>::value>::type* = 0)
       : state_(d.state())
   {
@@ -66,19 +66,20 @@ public:
 
 private:
   template <class U>
-  TEST_FUNC Deleter(const Deleter<U>& d, typename cuda::std::enable_if<!cuda::std::is_same<U, T>::value>::type* = 0);
+  TEST_HOST_DEVICE_FUNC
+  Deleter(const Deleter<U>& d, typename cuda::std::enable_if<!cuda::std::is_same<U, T>::value>::type* = 0);
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
   {
     state_ = i;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
   {
     delete p;
   }
@@ -89,51 +90,51 @@ class Deleter<T[]>
 {
   int state_;
 
-  TEST_FUNC Deleter(const Deleter&);
-  TEST_FUNC Deleter& operator=(const Deleter&);
+  TEST_HOST_DEVICE_FUNC Deleter(const Deleter&);
+  TEST_HOST_DEVICE_FUNC Deleter& operator=(const Deleter&);
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 Deleter(Deleter&& r)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 Deleter(Deleter&& r)
       : state_(r.state_)
   {
     r.state_ = 0;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 Deleter& operator=(Deleter&& r)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 Deleter& operator=(Deleter&& r)
   {
     state_   = r.state_;
     r.state_ = 0;
     return *this;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 Deleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 Deleter()
       : state_(0)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit Deleter(int s)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit Deleter(int s)
       : state_(s)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 ~Deleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 ~Deleter()
   {
     assert(state_ >= 0);
     state_ = -1;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
   {
     state_ = i;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
   {
     delete[] p;
   }
 };
 
 template <class T>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void swap(Deleter<T>& x, Deleter<T>& y)
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void swap(Deleter<T>& x, Deleter<T>& y)
 {
   Deleter<T> t(cuda::std::move(x));
   x = cuda::std::move(y);
@@ -146,33 +147,33 @@ class CDeleter
   int state_;
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 CDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 CDeleter()
       : state_(0)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit CDeleter(int s)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit CDeleter(int s)
       : state_(s)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 ~CDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 ~CDeleter()
   {
     assert(state_ >= 0);
     state_ = -1;
   }
 
   template <class U>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 CDeleter(const CDeleter<U>& d)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 CDeleter(const CDeleter<U>& d)
       : state_(d.state())
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
   {
     state_ = i;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
   {
     delete p;
   }
@@ -184,40 +185,40 @@ class CDeleter<T[]>
   int state_;
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 CDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 CDeleter()
       : state_(0)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit CDeleter(int s)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit CDeleter(int s)
       : state_(s)
   {}
   template <class U>
-  TEST_FUNC TEST_CONSTEXPR_CXX23 CDeleter(const CDeleter<U>& d)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 CDeleter(const CDeleter<U>& d)
       : state_(d.state())
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 ~CDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 ~CDeleter()
   {
     assert(state_ >= 0);
     state_ = -1;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
   {
     state_ = i;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
   {
     delete[] p;
   }
 };
 
 template <class T>
-TEST_FUNC TEST_CONSTEXPR_CXX23 void swap(CDeleter<T>& x, CDeleter<T>& y)
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void swap(CDeleter<T>& x, CDeleter<T>& y)
 {
   CDeleter<T> t(cuda::std::move(x));
   x = cuda::std::move(y);
@@ -229,32 +230,32 @@ template <class T>
 class NCDeleter
 {
   int state_;
-  TEST_FUNC NCDeleter(NCDeleter const&);
-  TEST_FUNC NCDeleter& operator=(NCDeleter const&);
+  TEST_HOST_DEVICE_FUNC NCDeleter(NCDeleter const&);
+  TEST_HOST_DEVICE_FUNC NCDeleter& operator=(NCDeleter const&);
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 NCDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 NCDeleter()
       : state_(0)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit NCDeleter(int s)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit NCDeleter(int s)
       : state_(s)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 ~NCDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 ~NCDeleter()
   {
     assert(state_ >= 0);
     state_ = -1;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
   {
     state_ = i;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
   {
     delete p;
   }
@@ -264,32 +265,32 @@ template <class T>
 class NCDeleter<T[]>
 {
   int state_;
-  TEST_FUNC NCDeleter(NCDeleter const&);
-  TEST_FUNC NCDeleter& operator=(NCDeleter const&);
+  TEST_HOST_DEVICE_FUNC NCDeleter(NCDeleter const&);
+  TEST_HOST_DEVICE_FUNC NCDeleter& operator=(NCDeleter const&);
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 NCDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 NCDeleter()
       : state_(0)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit NCDeleter(int s)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit NCDeleter(int s)
       : state_(s)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 ~NCDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 ~NCDeleter()
   {
     assert(state_ >= 0);
     state_ = -1;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
   {
     state_ = i;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
   {
     delete[] p;
   }
@@ -300,32 +301,32 @@ template <class T>
 class NCConstDeleter
 {
   int state_;
-  TEST_FUNC NCConstDeleter(NCConstDeleter const&);
-  TEST_FUNC NCConstDeleter& operator=(NCConstDeleter const&);
+  TEST_HOST_DEVICE_FUNC NCConstDeleter(NCConstDeleter const&);
+  TEST_HOST_DEVICE_FUNC NCConstDeleter& operator=(NCConstDeleter const&);
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 NCConstDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 NCConstDeleter()
       : state_(0)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit NCConstDeleter(int s)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit NCConstDeleter(int s)
       : state_(s)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 ~NCConstDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 ~NCConstDeleter()
   {
     assert(state_ >= 0);
     state_ = -1;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
   {
     state_ = i;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p) const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p) const
   {
     delete p;
   }
@@ -335,32 +336,32 @@ template <class T>
 class NCConstDeleter<T[]>
 {
   int state_;
-  TEST_FUNC NCConstDeleter(NCConstDeleter const&);
-  TEST_FUNC NCConstDeleter& operator=(NCConstDeleter const&);
+  TEST_HOST_DEVICE_FUNC NCConstDeleter(NCConstDeleter const&);
+  TEST_HOST_DEVICE_FUNC NCConstDeleter& operator=(NCConstDeleter const&);
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 NCConstDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 NCConstDeleter()
       : state_(0)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit NCConstDeleter(int s)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit NCConstDeleter(int s)
       : state_(s)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 ~NCConstDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 ~NCConstDeleter()
   {
     assert(state_ >= 0);
     state_ = -1;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
   {
     state_ = i;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p) const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p) const
   {
     delete[] p;
   }
@@ -373,37 +374,37 @@ class CopyDeleter
   int state_;
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 CopyDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 CopyDeleter()
       : state_(0)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit CopyDeleter(int s)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit CopyDeleter(int s)
       : state_(s)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 ~CopyDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 ~CopyDeleter()
   {
     assert(state_ >= 0);
     state_ = -1;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 CopyDeleter(CopyDeleter const& other)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 CopyDeleter(CopyDeleter const& other)
       : state_(other.state_)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 CopyDeleter& operator=(CopyDeleter const& other)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 CopyDeleter& operator=(CopyDeleter const& other)
   {
     state_ = other.state_;
     return *this;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
   {
     state_ = i;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
   {
     delete p;
   }
@@ -415,37 +416,37 @@ class CopyDeleter<T[]>
   int state_;
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 CopyDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 CopyDeleter()
       : state_(0)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit CopyDeleter(int s)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit CopyDeleter(int s)
       : state_(s)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 ~CopyDeleter()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 ~CopyDeleter()
   {
     assert(state_ >= 0);
     state_ = -1;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 CopyDeleter(CopyDeleter const& other)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 CopyDeleter(CopyDeleter const& other)
       : state_(other.state_)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX23 CopyDeleter& operator=(CopyDeleter const& other)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 CopyDeleter& operator=(CopyDeleter const& other)
   {
     state_ = other.state_;
     return *this;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void set_state(int i)
   {
     state_ = i;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
   {
     delete[] p;
   }
@@ -462,48 +463,48 @@ class test_deleter : public test_deleter_base
   int state_;
 
 public:
-  TEST_FUNC test_deleter()
+  TEST_HOST_DEVICE_FUNC test_deleter()
       : state_(0)
   {
     ++test_deleter_base_count;
   }
-  TEST_FUNC explicit test_deleter(int s)
+  TEST_HOST_DEVICE_FUNC explicit test_deleter(int s)
       : state_(s)
   {
     ++test_deleter_base_count;
   }
-  TEST_FUNC test_deleter(const test_deleter& d)
+  TEST_HOST_DEVICE_FUNC test_deleter(const test_deleter& d)
       : state_(d.state_)
   {
     ++test_deleter_base_count;
   }
-  TEST_FUNC ~test_deleter()
+  TEST_HOST_DEVICE_FUNC ~test_deleter()
   {
     assert(state_ >= 0);
     --test_deleter_base_count;
     state_ = -1;
   }
 
-  TEST_FUNC int state() const
+  TEST_HOST_DEVICE_FUNC int state() const
   {
     return state_;
   }
-  TEST_FUNC void set_state(int i)
+  TEST_HOST_DEVICE_FUNC void set_state(int i)
   {
     state_ = i;
   }
 
-  TEST_FUNC void operator()(T* p)
+  TEST_HOST_DEVICE_FUNC void operator()(T* p)
   {
     assert(state_ >= 0);
     ++test_deleter_base_count;
     delete p;
   }
-  TEST_FUNC test_deleter* operator&() const = delete;
+  TEST_HOST_DEVICE_FUNC test_deleter* operator&() const = delete;
 };
 
 template <class T>
-TEST_FUNC void swap(test_deleter<T>& x, test_deleter<T>& y)
+TEST_HOST_DEVICE_FUNC void swap(test_deleter<T>& x, test_deleter<T>& y)
 {
   test_deleter<T> t(cuda::std::move(x));
   x = cuda::std::move(y);
@@ -513,8 +514,8 @@ TEST_FUNC void swap(test_deleter<T>& x, test_deleter<T>& y)
 template <class T, cuda::std::size_t ID = 0>
 class PointerDeleter
 {
-  TEST_FUNC PointerDeleter(const PointerDeleter&);
-  TEST_FUNC PointerDeleter& operator=(const PointerDeleter&);
+  TEST_HOST_DEVICE_FUNC PointerDeleter(const PointerDeleter&);
+  TEST_HOST_DEVICE_FUNC PointerDeleter& operator=(const PointerDeleter&);
 
 public:
   using pointer = min_pointer<T, cuda::std::integral_constant<cuda::std::size_t, ID>>;
@@ -522,14 +523,14 @@ public:
   TEST_CONSTEXPR_CXX23 PointerDeleter()                            = default;
   TEST_CONSTEXPR_CXX23 PointerDeleter(PointerDeleter&&)            = default;
   TEST_CONSTEXPR_CXX23 PointerDeleter& operator=(PointerDeleter&&) = default;
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit PointerDeleter(int) {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit PointerDeleter(int) {}
 
   template <class U>
-  TEST_FUNC TEST_CONSTEXPR_CXX23
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23
   PointerDeleter(PointerDeleter<U, ID>&&, typename cuda::std::enable_if<!cuda::std::is_same<U, T>::value>::type* = 0)
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(pointer p)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(pointer p)
   {
     if (p)
     {
@@ -539,15 +540,15 @@ public:
 
 private:
   template <class U>
-  TEST_FUNC PointerDeleter(const PointerDeleter<U, ID>&,
-                           typename cuda::std::enable_if<!cuda::std::is_same<U, T>::value>::type* = 0);
+  TEST_HOST_DEVICE_FUNC PointerDeleter(const PointerDeleter<U, ID>&,
+                                       typename cuda::std::enable_if<!cuda::std::is_same<U, T>::value>::type* = 0);
 };
 
 template <class T, cuda::std::size_t ID>
 class PointerDeleter<T[], ID>
 {
-  TEST_FUNC PointerDeleter(const PointerDeleter&);
-  TEST_FUNC PointerDeleter& operator=(const PointerDeleter&);
+  TEST_HOST_DEVICE_FUNC PointerDeleter(const PointerDeleter&);
+  TEST_HOST_DEVICE_FUNC PointerDeleter& operator=(const PointerDeleter&);
 
 public:
   using pointer = min_pointer<T, cuda::std::integral_constant<cuda::std::size_t, ID>>;
@@ -555,14 +556,14 @@ public:
   TEST_CONSTEXPR_CXX23 PointerDeleter()                            = default;
   TEST_CONSTEXPR_CXX23 PointerDeleter(PointerDeleter&&)            = default;
   TEST_CONSTEXPR_CXX23 PointerDeleter& operator=(PointerDeleter&&) = default;
-  TEST_FUNC TEST_CONSTEXPR_CXX23 explicit PointerDeleter(int) {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 explicit PointerDeleter(int) {}
 
   template <class U>
-  TEST_FUNC TEST_CONSTEXPR_CXX23
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23
   PointerDeleter(PointerDeleter<U, ID>&&, typename cuda::std::enable_if<!cuda::std::is_same<U, T>::value>::type* = 0)
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(pointer p)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(pointer p)
   {
     if (p)
     {
@@ -572,8 +573,8 @@ public:
 
 private:
   template <class U>
-  TEST_FUNC PointerDeleter(const PointerDeleter<U, ID>&,
-                           typename cuda::std::enable_if<!cuda::std::is_same<U, T>::value>::type* = 0);
+  TEST_HOST_DEVICE_FUNC PointerDeleter(const PointerDeleter<U, ID>&,
+                                       typename cuda::std::enable_if<!cuda::std::is_same<U, T>::value>::type* = 0);
 };
 
 template <class T>
@@ -582,11 +583,11 @@ class DefaultCtorDeleter
   int state_;
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
   {
     delete p;
   }
@@ -598,11 +599,11 @@ class DefaultCtorDeleter<T[]>
   int state_;
 
 public:
-  TEST_FUNC TEST_CONSTEXPR_CXX23 int state() const
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 int state() const
   {
     return state_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 void operator()(T* p)
   {
     delete[] p;
   }

--- a/libcudacxx/test/support/type_id.h
+++ b/libcudacxx/test/support/type_id.h
@@ -24,11 +24,11 @@
 // comparisons between different types.
 struct TypeID
 {
-  TEST_FUNC friend bool operator==(TypeID const& LHS, TypeID const& RHS)
+  TEST_HOST_DEVICE_FUNC friend bool operator==(TypeID const& LHS, TypeID const& RHS)
   {
     return LHS.m_id == RHS.m_id;
   }
-  TEST_FUNC friend bool operator!=(TypeID const& LHS, TypeID const& RHS)
+  TEST_HOST_DEVICE_FUNC friend bool operator!=(TypeID const& LHS, TypeID const& RHS)
   {
     return LHS.m_id != RHS.m_id;
   }
@@ -38,13 +38,13 @@ struct TypeID
     return demangle(m_id);
   }
 #else
-  TEST_FUNC const char* name() const
+  TEST_HOST_DEVICE_FUNC const char* name() const
   {
     return m_id;
   }
 #endif
 
-  TEST_FUNC void dump() const
+  TEST_HOST_DEVICE_FUNC void dump() const
   {
 #if 0
     std::string s = name();
@@ -55,7 +55,7 @@ struct TypeID
   }
 
 private:
-  TEST_FUNC explicit constexpr TypeID(const char* xid)
+  TEST_HOST_DEVICE_FUNC explicit constexpr TypeID(const char* xid)
       : m_id(xid)
   {}
 
@@ -64,12 +64,12 @@ private:
 
   const char* const m_id;
   template <class T>
-  TEST_FUNC friend TypeID const& makeTypeIDImp();
+  TEST_HOST_DEVICE_FUNC friend TypeID const& makeTypeIDImp();
 };
 
 // makeTypeID - Return the TypeID for the specified type 'T'.
 template <class T>
-TEST_FUNC inline TypeID const& makeTypeIDImp()
+TEST_HOST_DEVICE_FUNC inline TypeID const& makeTypeIDImp()
 {
 #ifdef __CUDA_ARCH__
   __constant__ static const TypeID id{__PRETTY_FUNCTION__};
@@ -87,7 +87,7 @@ struct TypeWrapper
 {};
 
 template <class T>
-TEST_FUNC inline TypeID const& makeTypeID()
+TEST_HOST_DEVICE_FUNC inline TypeID const& makeTypeID()
 {
   return makeTypeIDImp<TypeWrapper<T>>();
 }
@@ -99,7 +99,7 @@ struct ArgumentListID
 // makeArgumentID - Create and return a unique identifier for a given set
 // of arguments.
 template <class... Args>
-TEST_FUNC inline TypeID const& makeArgumentID()
+TEST_HOST_DEVICE_FUNC inline TypeID const& makeArgumentID()
 {
   return makeTypeIDImp<ArgumentListID<Args...>>();
 }
@@ -108,7 +108,7 @@ TEST_FUNC inline TypeID const& makeArgumentID()
 // two typeid's are expected to be equal
 #define COMPARE_TYPEID(LHS, RHS) CompareTypeIDVerbose(#LHS, LHS, #RHS, RHS)
 
-TEST_FUNC inline bool
+TEST_HOST_DEVICE_FUNC inline bool
 CompareTypeIDVerbose(const char* LHSString, TypeID const* LHS, const char* RHSString, TypeID const* RHS)
 {
   if (*LHS == *RHS)

--- a/libcudacxx/test/support/unique_ptr_test_helper.h
+++ b/libcudacxx/test/support/unique_ptr_test_helper.h
@@ -25,21 +25,21 @@ TEST_GLOBAL_VARIABLE int A_count = 0;
 
 struct A
 {
-  TEST_FUNC TEST_CONSTEXPR_CXX23 A()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 A()
   {
     if (!::cuda::std::__cccl_default_is_constant_evaluated())
     {
       ++A_count;
     }
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 A(const A&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 A(const A&)
   {
     if (!::cuda::std::__cccl_default_is_constant_evaluated())
     {
       ++A_count;
     }
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 virtual ~A()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 virtual ~A()
   {
     if (!::cuda::std::__cccl_default_is_constant_evaluated())
     {
@@ -52,14 +52,14 @@ TEST_GLOBAL_VARIABLE int B_count = 0;
 
 struct B : public A
 {
-  TEST_FUNC TEST_CONSTEXPR_CXX23 B()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 B()
   {
     if (!::cuda::std::__cccl_default_is_constant_evaluated())
     {
       ++B_count;
     }
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX23 B(const B&)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23 B(const B&)
       : A()
   {
     if (!::cuda::std::__cccl_default_is_constant_evaluated())
@@ -67,7 +67,7 @@ struct B : public A
       ++B_count;
     }
   }
-  TEST_FUNC virtual TEST_CONSTEXPR_CXX23 ~B()
+  TEST_HOST_DEVICE_FUNC virtual TEST_CONSTEXPR_CXX23 ~B()
   {
     if (!::cuda::std::__cccl_default_is_constant_evaluated())
     {
@@ -77,7 +77,7 @@ struct B : public A
 };
 
 template <class T>
-typename cuda::std::enable_if<!cuda::std::is_array<T>::value, T*>::type TEST_FUNC TEST_CONSTEXPR_CXX23
+typename cuda::std::enable_if<!cuda::std::is_array<T>::value, T*>::type TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23
 newValue(int num_elements)
 {
   assert(num_elements == 1);
@@ -86,7 +86,7 @@ newValue(int num_elements)
 
 template <class T>
 typename cuda::std::enable_if<cuda::std::is_array<T>::value, typename cuda::std::remove_all_extents<T>::type*>::type
-  TEST_FUNC TEST_CONSTEXPR_CXX23
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX23
   newValue(int num_elements)
 {
   using VT = typename cuda::std::remove_all_extents<T>::type;
@@ -96,10 +96,10 @@ typename cuda::std::enable_if<cuda::std::is_array<T>::value, typename cuda::std:
 
 struct IncompleteType;
 
-TEST_FUNC void checkNumIncompleteTypeAlive(int i);
-TEST_FUNC int getNumIncompleteTypeAlive();
-TEST_FUNC IncompleteType* getNewIncomplete();
-TEST_FUNC IncompleteType* getNewIncompleteArray(int size);
+TEST_HOST_DEVICE_FUNC void checkNumIncompleteTypeAlive(int i);
+TEST_HOST_DEVICE_FUNC int getNumIncompleteTypeAlive();
+TEST_HOST_DEVICE_FUNC IncompleteType* getNewIncomplete();
+TEST_HOST_DEVICE_FUNC IncompleteType* getNewIncompleteArray(int size);
 
 template <class ThisT, class... Args>
 struct args_is_this_type : cuda::std::false_type
@@ -121,26 +121,26 @@ struct StoresIncomplete
   StoresIncomplete(StoresIncomplete&&)      = default;
 
   template <class... Args>
-  TEST_FUNC StoresIncomplete(Args&&... args)
+  TEST_HOST_DEVICE_FUNC StoresIncomplete(Args&&... args)
       : m_ptr(cuda::std::forward<Args>(args)...)
   {
     static_assert(!args_is_this_type<StoresIncomplete, Args...>::value);
   }
 
-  TEST_FUNC ~StoresIncomplete();
+  TEST_HOST_DEVICE_FUNC ~StoresIncomplete();
 
-  TEST_FUNC IncompleteType* get() const
+  TEST_HOST_DEVICE_FUNC IncompleteType* get() const
   {
     return m_ptr.get();
   }
-  TEST_FUNC Del& get_deleter()
+  TEST_HOST_DEVICE_FUNC Del& get_deleter()
   {
     return m_ptr.get_deleter();
   }
 };
 
 template <class IncompleteT = IncompleteType, class Del = cuda::std::default_delete<IncompleteT>, class... Args>
-TEST_FUNC void doIncompleteTypeTest(int expect_alive, Args&&... ctor_args)
+TEST_HOST_DEVICE_FUNC void doIncompleteTypeTest(int expect_alive, Args&&... ctor_args)
 {
   checkNumIncompleteTypeAlive(expect_alive);
   {
@@ -158,48 +158,48 @@ TEST_FUNC void doIncompleteTypeTest(int expect_alive, Args&&... ctor_args)
   checkNumIncompleteTypeAlive(0);
 }
 
-#define INCOMPLETE_TEST_EPILOGUE()                                         \
-  _LIBCUDACXX_DEVICE int is_incomplete_test_anchor = is_incomplete_test(); \
-                                                                           \
-  TEST_GLOBAL_VARIABLE int IncompleteType_count = 0;                       \
-  struct IncompleteType                                                    \
-  {                                                                        \
-    TEST_FUNC IncompleteType()                                             \
-    {                                                                      \
-      ++IncompleteType_count;                                              \
-    }                                                                      \
-    TEST_FUNC ~IncompleteType()                                            \
-    {                                                                      \
-      --IncompleteType_count;                                              \
-    }                                                                      \
-  };                                                                       \
-                                                                           \
-  TEST_FUNC void checkNumIncompleteTypeAlive(int i)                        \
-  {                                                                        \
-    assert(IncompleteType_count == i);                                     \
-  }                                                                        \
-  TEST_FUNC int getNumIncompleteTypeAlive()                                \
-  {                                                                        \
-    return IncompleteType_count;                                           \
-  }                                                                        \
-  TEST_FUNC IncompleteType* getNewIncomplete()                             \
-  {                                                                        \
-    return new IncompleteType;                                             \
-  }                                                                        \
-  TEST_FUNC IncompleteType* getNewIncompleteArray(int size)                \
-  {                                                                        \
-    return new IncompleteType[size];                                       \
-  }                                                                        \
-                                                                           \
-  template <class IncompleteT, class Del>                                  \
-  TEST_FUNC StoresIncomplete<IncompleteT, Del>::~StoresIncomplete()        \
+#define INCOMPLETE_TEST_EPILOGUE()                                              \
+  _LIBCUDACXX_DEVICE int is_incomplete_test_anchor = is_incomplete_test();      \
+                                                                                \
+  TEST_GLOBAL_VARIABLE int IncompleteType_count = 0;                            \
+  struct IncompleteType                                                         \
+  {                                                                             \
+    TEST_HOST_DEVICE_FUNC IncompleteType()                                      \
+    {                                                                           \
+      ++IncompleteType_count;                                                   \
+    }                                                                           \
+    TEST_HOST_DEVICE_FUNC ~IncompleteType()                                     \
+    {                                                                           \
+      --IncompleteType_count;                                                   \
+    }                                                                           \
+  };                                                                            \
+                                                                                \
+  TEST_HOST_DEVICE_FUNC void checkNumIncompleteTypeAlive(int i)                 \
+  {                                                                             \
+    assert(IncompleteType_count == i);                                          \
+  }                                                                             \
+  TEST_HOST_DEVICE_FUNC int getNumIncompleteTypeAlive()                         \
+  {                                                                             \
+    return IncompleteType_count;                                                \
+  }                                                                             \
+  TEST_HOST_DEVICE_FUNC IncompleteType* getNewIncomplete()                      \
+  {                                                                             \
+    return new IncompleteType;                                                  \
+  }                                                                             \
+  TEST_HOST_DEVICE_FUNC IncompleteType* getNewIncompleteArray(int size)         \
+  {                                                                             \
+    return new IncompleteType[size];                                            \
+  }                                                                             \
+                                                                                \
+  template <class IncompleteT, class Del>                                       \
+  TEST_HOST_DEVICE_FUNC StoresIncomplete<IncompleteT, Del>::~StoresIncomplete() \
   {}
 
-#define DEFINE_AND_RUN_IS_INCOMPLETE_TEST(...)        \
-  TEST_FUNC static constexpr int is_incomplete_test() \
-  {                                                   \
-    __VA_ARGS__ return 0;                             \
-  }                                                   \
+#define DEFINE_AND_RUN_IS_INCOMPLETE_TEST(...)                    \
+  TEST_HOST_DEVICE_FUNC static constexpr int is_incomplete_test() \
+  {                                                               \
+    __VA_ARGS__ return 0;                                         \
+  }                                                               \
   INCOMPLETE_TEST_EPILOGUE()
 
 #endif // TEST_SUPPORT_UNIQUE_PTR_TEST_HELPER_H


### PR DESCRIPTION

Dynamic allocations are currently not supported within a tile context, so the whole feature does nto make sense there