### PR TITLE
[CUB] Add runtime-sized shared-memory histogram privatization

### DIFF
--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -187,6 +187,9 @@ _CCCL_DEVICE _CCCL_FORCEINLINE auto NativePointer(IteratorT itr)
 //!
 //! @tparam OffsetT
 //!   Signed integer type for global offsets
+//!
+//! @tparam UseDynamicSmemHistogram
+//!   Whether the privatized histogram is supplied separately in dynamic shared memory.
 template <typename AgentHistogramPolicyT,
           int PrivatizedSmemBins,
           int NumChannels,
@@ -195,7 +198,8 @@ template <typename AgentHistogramPolicyT,
           typename CounterT,
           typename PrivatizedDecodeOpT,
           typename OutputDecodeOpT,
-          typename OffsetT>
+          typename OffsetT,
+          bool UseDynamicSmemHistogram = false>
 struct AgentHistogram
 {
   static constexpr int vec_size                    = AgentHistogramPolicyT::VEC_SIZE;
@@ -230,10 +234,13 @@ struct AgentHistogram
     BlockLoad<PixelT, threads_per_block, pixels_per_thread, AgentHistogramPolicyT::LOAD_ALGORITHM>;
   using BlockLoadVecT = BlockLoad<VecT, threads_per_block, vecs_per_thread, AgentHistogramPolicyT::LOAD_ALGORITHM>;
 
+  using HistogramsStorageT = ::cuda::std::
+    _If<UseDynamicSmemHistogram, CounterT* [NumActiveChannels], CounterT[NumActiveChannels][PrivatizedSmemBins + 1]>;
+
   struct _TempStorage
   {
-    // Smem needed for block-privatized smem histogram (with 1 word of padding)
-    CounterT histograms[NumActiveChannels][PrivatizedSmemBins + 1];
+    // Static histogram storage or pointers into the separately allocated dynamic storage.
+    HistogramsStorageT histograms;
     int tile_idx;
 
     union
@@ -631,6 +638,10 @@ struct AgentHistogram
                                                : // prefer gmem privatized histograms
                       blockIdx.x & 1) // prefer blended privatized histograms
   {
+    static_assert(!UseDynamicSmemHistogram,
+                  "AgentHistogram with UseDynamicSmemHistogram=true requires the dynamic-SMEM "
+                  "constructor that takes an extern __shared__ base pointer.");
+
     const int blockId = static_cast<int>((blockIdx.y * gridDim.x) + blockIdx.x);
 
     // TODO(bgruber): d_privatized_histograms seems only used when !prefer_smem, can we skip it if prefer_smem?
@@ -639,6 +650,44 @@ struct AgentHistogram
     {
       const auto offset                 = static_cast<::cuda::std::int64_t>(blockId) * num_privatized_bins[ch];
       this->d_privatized_histograms[ch] = d_privatized_histograms[ch] + offset;
+    }
+  }
+
+  //! @brief Constructor for a histogram stored in dynamic shared memory
+  _CCCL_DEVICE _CCCL_FORCEINLINE AgentHistogram(
+    TempStorage& temp_storage,
+    SampleIteratorT d_samples,
+    const int* num_output_bins,
+    const int* num_privatized_bins,
+    CounterT** d_output_histograms,
+    CounterT** d_privatized_histograms,
+    const OutputDecodeOpT* output_decode_op,
+    const PrivatizedDecodeOpT* privatized_decode_op,
+    CounterT* dyn_smem_histogram_base)
+      : temp_storage(temp_storage.Alias())
+      , d_wrapped_samples(d_samples)
+      , d_native_samples(NativePointer(d_wrapped_samples))
+      , num_output_bins(num_output_bins)
+      , num_privatized_bins(num_privatized_bins)
+      , d_output_histograms(d_output_histograms)
+      , output_decode_op(output_decode_op)
+      , privatized_decode_op(privatized_decode_op)
+      , prefer_smem(true)
+  {
+    static_assert(UseDynamicSmemHistogram,
+                  "Dynamic-SMEM AgentHistogram constructor requires UseDynamicSmemHistogram=true.");
+
+    for (int ch = 0; ch < NumActiveChannels; ++ch)
+    {
+      this->d_privatized_histograms[ch] = d_privatized_histograms[ch];
+    }
+
+    CounterT* p = dyn_smem_histogram_base;
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int ch = 0; ch < NumActiveChannels; ++ch)
+    {
+      this->temp_storage.histograms[ch] = p;
+      p += num_privatized_bins[ch];
     }
   }
 

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -56,6 +56,11 @@ namespace detail::histogram
 // Maximum number of bins per channel for which we will use a privatized smem strategy
 static constexpr int max_privatized_smem_bins = 256;
 
+// Use one runtime-sized shared-memory histogram above the static tier. Keep the
+// initial budget conservative so the path is portable across supported devices.
+static constexpr int dynamic_smem_histogram_bytes = 32 * 1024;
+static constexpr int dynamic_smem_histogram_tag   = dynamic_smem_histogram_bytes / sizeof(unsigned int);
+
 template <int NUM_CHANNELS,
           int NUM_ACTIVE_CHANNELS,
           typename SampleIteratorT,
@@ -78,6 +83,21 @@ struct DeviceHistogramKernelSource
   _CCCL_HIDE_FROM_ABI CUB_RUNTIME_FUNCTION static constexpr auto HistogramSweepKernel()
   {
     return &DeviceHistogramSweepKernel<
+      PolicyT,
+      PRIVATIZED_SMEM_BINS,
+      NUM_CHANNELS,
+      NUM_ACTIVE_CHANNELS,
+      SampleIteratorT,
+      CounterT,
+      PrivatizedDecodeOpT,
+      OutputDecodeOpT,
+      OffsetT>;
+  }
+
+  template <typename PolicyT, int PRIVATIZED_SMEM_BINS, typename PrivatizedDecodeOpT, typename OutputDecodeOpT>
+  _CCCL_HIDE_FROM_ABI CUB_RUNTIME_FUNCTION static constexpr auto HistogramSweepDynamicSmemKernel()
+  {
+    return &DeviceHistogramSweepDynamicSmemKernel<
       PolicyT,
       PRIVATIZED_SMEM_BINS,
       NUM_CHANNELS,
@@ -211,17 +231,28 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
                }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
-  const auto init_kernel = kernel_source.template HistogramInitKernel<PolicySelector>();
-  auto sweep_kernel      = [&] {
-    if constexpr (IsDeviceInit)
+  const auto init_kernel          = kernel_source.template HistogramInitKernel<PolicySelector>();
+  constexpr bool use_dynamic_smem = PRIVATIZED_SMEM_BINS == dynamic_smem_histogram_tag;
+  auto sweep_kernel               = [&] {
+    if constexpr (use_dynamic_smem)
+    {
+      static_assert(!IsDeviceInit, "Dynamic shared-memory histograms require host-initialized transforms");
+      using output_decode_op_t     = typename FirstLevelArrayT::value_type;
+      using privatized_decode_op_t = typename SecondLevelArrayT::value_type;
+      return kernel_source.template HistogramSweepDynamicSmemKernel<PolicySelector,
+                                                                                  PRIVATIZED_SMEM_BINS,
+                                                                                  privatized_decode_op_t,
+                                                                                  output_decode_op_t>();
+    }
+    else if constexpr (IsDeviceInit)
     {
       return kernel_source.template HistogramSweepKernelDeviceInit<
-             PolicySelector,
-             PRIVATIZED_SMEM_BINS,
-             FirstLevelArrayT,
-             SecondLevelArrayT,
-             IsEven,
-             IsByteSample>();
+                      PolicySelector,
+                      PRIVATIZED_SMEM_BINS,
+                      FirstLevelArrayT,
+                      SecondLevelArrayT,
+                      IsEven,
+                      IsByteSample>();
     }
     else
     {
@@ -235,6 +266,15 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
   const int threads_per_block = active_policy.threads_per_block;
   const int pixels_per_thread = active_policy.pixels_per_thread;
 
+  int dynamic_smem_bytes = 0;
+  if constexpr (use_dynamic_smem)
+  {
+    for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
+    {
+      dynamic_smem_bytes += (num_privatized_levels[channel] - 1) * static_cast<int>(kernel_source.CounterSize());
+    }
+  }
+
   // Get SM count
   int sm_count;
   if (const auto error = CubDebug(launcher_factory.MultiProcessorCount(sm_count)))
@@ -244,8 +284,8 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
 
   // Get SM occupancy for sweep_kernel
   int histogram_sweep_sm_occupancy;
-  if (const auto error =
-        CubDebug(launcher_factory.MaxSmOccupancy(histogram_sweep_sm_occupancy, sweep_kernel, threads_per_block)))
+  if (const auto error = CubDebug(launcher_factory.MaxSmOccupancy(
+        histogram_sweep_sm_occupancy, sweep_kernel, threads_per_block, dynamic_smem_bytes)))
   {
     return error;
   }
@@ -284,7 +324,8 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
   for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
   {
     allocation_sizes[CHANNEL] =
-      size_t(num_thread_blocks) * (num_privatized_levels[CHANNEL] - 1) * kernel_source.CounterSize();
+      use_dynamic_smem ? 0
+                       : size_t(num_thread_blocks) * (num_privatized_levels[CHANNEL] - 1) * kernel_source.CounterSize();
   }
 
   allocation_sizes[NUM_ALLOCATIONS - 1] = GridQueue<int>::AllocationSize();
@@ -353,20 +394,24 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
 
 // Log histogram_sweep_kernel configuration
 #ifdef CUB_DEBUG_LOG
-  _CubLog("Invoking histogram_sweep_kernel<<<{%d, %d, %d}, %d, 0, %lld>>>(), %d pixels "
+  _CubLog("Invoking histogram_sweep_kernel<<<{%d, %d, %d}, %d, %d, %lld>>>(), %d pixels "
           "per thread, %d SM occupancy\n",
           sweep_grid_dims.x,
           sweep_grid_dims.y,
           sweep_grid_dims.z,
           threads_per_block,
+          dynamic_smem_bytes,
           (long long) stream,
           pixels_per_thread,
           histogram_sweep_sm_occupancy);
 #endif // CUB_DEBUG_LOG
 
   if (const auto error = CubDebug(
-        launcher_factory(
-          sweep_grid_dims, threads_per_block, 0, stream, /* dependent_launch */ cc >= ::cuda::compute_capability{9, 0})
+        launcher_factory(sweep_grid_dims,
+                         threads_per_block,
+                         dynamic_smem_bytes,
+                         stream,
+                         /* dependent_launch */ cc >= ::cuda::compute_capability{9, 0})
           .doit(sweep_kernel,
                 d_samples,
                 num_output_bins_wrapper,
@@ -891,6 +936,32 @@ CUB_RUNTIME_FUNCTION static cudaError_t dispatch_range(
     }
     int max_num_output_bins = max_levels - 1;
 
+    if constexpr (NUM_ACTIVE_CHANNELS == 1)
+    {
+      if (max_num_output_bins > max_privatized_smem_bins
+          && size_t(max_num_output_bins) * kernel_source.CounterSize() <= dynamic_smem_histogram_bytes)
+      {
+        constexpr int PRIVATIZED_SMEM_BINS = dynamic_smem_histogram_tag;
+        return detail::histogram::dispatch<NUM_CHANNELS, NUM_ACTIVE_CHANNELS, PRIVATIZED_SMEM_BINS, false, false, false>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_samples,
+          d_output_histograms,
+          num_output_levels,
+          num_output_levels,
+          output_decode_op,
+          privatized_decode_op,
+          max_num_output_bins,
+          num_row_pixels,
+          num_rows,
+          row_stride_samples,
+          stream,
+          policy_selector,
+          kernel_source,
+          launcher_factory);
+      }
+    }
+
     // Dispatch
     if (max_num_output_bins > max_privatized_smem_bins)
     {
@@ -1096,6 +1167,32 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch_even(
       }
     }
     int max_num_output_bins = max_levels - 1;
+
+    if constexpr (NUM_ACTIVE_CHANNELS == 1)
+    {
+      if (max_num_output_bins > max_privatized_smem_bins
+          && size_t(max_num_output_bins) * kernel_source.CounterSize() <= dynamic_smem_histogram_bytes)
+      {
+        constexpr int PRIVATIZED_SMEM_BINS = dynamic_smem_histogram_tag;
+        return detail::histogram::dispatch<NUM_CHANNELS, NUM_ACTIVE_CHANNELS, PRIVATIZED_SMEM_BINS, false, false, false>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_samples,
+          d_output_histograms,
+          num_output_levels,
+          num_output_levels,
+          output_decode_op,
+          privatized_decode_op,
+          max_num_output_bins,
+          num_row_pixels,
+          num_rows,
+          row_stride_samples,
+          stream,
+          policy_selector,
+          kernel_source,
+          launcher_factory);
+      }
+    }
 
     if (max_num_output_bins > max_privatized_smem_bins)
     {

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -518,6 +518,81 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
   agent.StoreOutput();
 }
 
+//! Histogram sweep kernel with the privatized histogram in dynamic shared memory.
+//!
+//! The host supplies `num_privatized_bins * sizeof(CounterT)` bytes of dynamic
+//! shared memory. Keeping the runtime-sized histogram outside `TempStorage`
+//! allows one kernel instantiation to cover larger histograms without a ladder
+//! of statically sized kernels.
+template <typename PolicySelector,
+          int PrivatizedSmemBins,
+          int NumChannels,
+          int NumActiveChannels,
+          typename SampleIteratorT,
+          typename CounterT,
+          typename PrivatizedDecodeOpT,
+          typename OutputDecodeOpT,
+          typename OffsetT>
+#if _CCCL_HAS_CONCEPTS()
+  requires histogram_policy_selector<PolicySelector>
+#endif // _CCCL_HAS_CONCEPTS()
+__launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
+  _CCCL_KERNEL_ATTRIBUTES void DeviceHistogramSweepDynamicSmemKernel(
+    const SampleIteratorT d_samples,
+    const ::cuda::std::array<int, NumActiveChannels> num_output_bins_wrapper,
+    const ::cuda::std::array<int, NumActiveChannels> num_privatized_bins_wrapper,
+    ::cuda::std::array<CounterT*, NumActiveChannels> d_output_histograms_wrapper,
+    ::cuda::std::array<CounterT*, NumActiveChannels> d_privatized_histograms_wrapper,
+    const ::cuda::std::array<OutputDecodeOpT, NumActiveChannels> output_decode_op_wrapper,
+    const ::cuda::std::array<PrivatizedDecodeOpT, NumActiveChannels> privatized_decode_op_wrapper,
+    const OffsetT num_row_pixels,
+    const OffsetT num_rows,
+    const OffsetT row_stride_samples,
+    const int tiles_per_row,
+    GridQueue<int> tile_queue)
+{
+  static constexpr HistogramPolicy hp = current_policy<PolicySelector>();
+
+  using AgentHistogramPolicyT = agent_histogram_policy<
+    hp.threads_per_block,
+    hp.pixels_per_thread,
+    hp.load_algorithm,
+    hp.load_modifier,
+    hp.rle_compress,
+    hp.mem_preference,
+    hp.use_work_stealing,
+    hp.vec_size>;
+  using AgentHistogramT =
+    AgentHistogram<AgentHistogramPolicyT,
+                   PrivatizedSmemBins,
+                   NumChannels,
+                   NumActiveChannels,
+                   SampleIteratorT,
+                   CounterT,
+                   PrivatizedDecodeOpT,
+                   OutputDecodeOpT,
+                   OffsetT,
+                   true>;
+
+  __shared__ typename AgentHistogramT::TempStorage temp_storage;
+  extern __shared__ unsigned char dynamic_smem[];
+
+  AgentHistogramT agent(
+    temp_storage,
+    d_samples,
+    num_output_bins_wrapper.data(),
+    num_privatized_bins_wrapper.data(),
+    d_output_histograms_wrapper.data(),
+    d_privatized_histograms_wrapper.data(),
+    output_decode_op_wrapper.data(),
+    privatized_decode_op_wrapper.data(),
+    reinterpret_cast<CounterT*>(dynamic_smem));
+
+  agent.InitBinCounters();
+  agent.ConsumeTiles(num_row_pixels, num_rows, row_stride_samples, tiles_per_row, tile_queue);
+  agent.StoreOutput();
+}
+
 //! Histogram privatized sweep kernel entry point (multi-block) with device-side initialization.
 //! Computes privatized histograms, one per thread block.
 //! This kernel initializes decode operators from level arrays inside the kernel.

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -573,6 +573,14 @@ C2H_TEST_LIST("DeviceHistogram::Histogram* channel configs",
   test_even_and_range<int, TestType::channels, TestType::active_channels, int, int, int>(256, 256 + 1, 128, 32);
 }
 
+C2H_TEST("DeviceHistogram::Histogram* dynamic shared-memory privatization", "[histogram][device]")
+{
+  using counter_t      = unsigned long long;
+  const int num_levels = GENERATE(1025, 4097);
+
+  test_even_and_range<int, 1, 1, counter_t>(num_levels - 1, num_levels, 4096, 4);
+}
+
 // Testing only HistogramEven is fine, because HistogramRange shares the loading logic and the different binning
 // implementations are not affected by the iterator.
 C2H_TEST("DeviceHistogram::HistogramEven sample iterator", "[histogram_even][device]")


### PR DESCRIPTION
## Why

CUB currently keeps at most 256 privatized histogram bins per channel in shared memory. Larger histograms use per-block global-memory privatization, even when the complete histogram would fit comfortably in the device's runtime-sized shared-memory budget.

The raw experiments in #10547 explored several ways to extend this range, including multiple compile-time bin tiers, global staging slabs, cooperative combine kernels, and hybrid paths. This PR extracts the smallest useful design from that work: one runtime-sized shared-memory kernel with a direct per-block merge into the output.

This PR is independent of the benchmark/testing PR #10548 and is based directly on `main`.

## What changed

### Runtime-sized privatized storage

`AgentHistogram` can now receive its privatized counter storage from an `extern __shared__` allocation. The existing accumulation, zeroing, and output-store code continues to access the histogram through the same per-channel indexing interface.

The normal static-storage constructor is unchanged. The dynamic-storage constructor always selects the shared-memory path and initializes channel pointers into the contiguous runtime allocation.

### One dynamic shared-memory kernel

The new sweep kernel keeps only the small agent metadata and block-load scratch storage in static shared memory. Histogram counters are allocated dynamically at launch according to the actual number of bins and `sizeof(CounterT)`.

After processing its tiles, each block merges its private histogram directly into the output using the existing `StoreOutput` path. There is no global staging slab, follow-on combine kernel, cooperative launch, or cache algorithm in this PR.

### Conservative dispatch

The new path is initially limited to single-channel, host-initialized, non-byte EVEN and RANGE histograms. The existing 256-bin static path remains unchanged. Histograms use the dynamic path only when:

- they have more than 256 bins; and
- their counters require no more than 32 KiB of dynamic shared memory per block.

The capacity check is byte-based, so a 64-bit counter supports half as many bins as a 32-bit counter. Larger or otherwise unsupported cases retain the existing global-memory privatized fallback.

The occupancy query receives the dynamic allocation size, and the temporary-storage calculation does not allocate an unused per-block global histogram slab for dynamic-shared-memory cells.

## Deliberately excluded

This PR does not include:

- high-bin direct-atomic or caching algorithms;
- staging/combine or cooperative-grid implementations;
- multi-channel dynamic shared-memory selection;
- device-initialized C Parallel launcher support;
- architecture-specific tuning or low-bin RANGE policy changes;
- selector framework changes from the raw research branch.

Those concerns can be measured and reviewed independently after this basic shared-memory extension is accepted.

## Tests

The histogram test adds single-channel EVEN and RANGE cases above the static 256-bin boundary. It covers:

- 1,024 and 4,096 bins;
- 32-bit counters, where both cases fit the dynamic budget; and
- 64-bit counters, including a case at the 32 KiB capacity boundary.

Formatting and source checks pass:

```text
pre-commit run --files \
  cub/cub/agent/agent_histogram.cuh \
  cub/cub/device/dispatch/dispatch_histogram.cuh \
  cub/cub/device/dispatch/kernels/kernel_histogram.cuh \
  cub/test/catch2_test_device_histogram.cu

git diff --check upstream/main...HEAD
```

The focused test target builds successfully with CUDA 13.3.33 for SM90:

```text
CUDAHOSTCXX=/usr/bin/c++ CXX=/usr/bin/c++ \
  cmake --fresh --preset cub-cpp20 -DCMAKE_CUDA_ARCHITECTURES=90

ninja -C build/cub-cpp20 cub.test.device.histogram
```

Runtime execution is blocked by the current machine's driver/toolkit combination. All three histogram launch modes, including unchanged tests, fail before assertions with:

```text
cudaErrorUnsupportedPtxVersion: the provided PTX was compiled with an unsupported toolchain
```

Runtime validation therefore still needs a compatible CUDA driver for the CUDA 13.3.33-generated PTX.

## Relationship to the research snapshot

This is a clean reimplementation of the final simplified shared-memory idea from #10547, rather than a chronological cherry-pick of the research commits. The earlier staging, cooperative, and fixed-tier implementations were intentionally discarded.
