### PR TITLE
cudax/stf: add defer_exception and void checks for SCOPE

### DIFF
--- a/cudax/include/cuda/experimental/__stf/graph/graph_task.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/graph_task.cuh
@@ -127,7 +127,7 @@ public:
 
     // DOT tracing and set_ready_prereqs must not throw after capture has begun,
     // or the stream would be left capturing. Abort instead.
-    throwproof->*[&] {
+    throw_proof->*[&] {
       if (dot.is_tracing())
       {
         dot.template add_vertex<task, logical_data_untyped>(*this);

--- a/cudax/include/cuda/experimental/__stf/stream/stream_task.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/stream_task.cuh
@@ -205,7 +205,7 @@ public:
     auto& dot = ctx.get_dot();
     // DOT tracing and set_ready_prereqs must not leave the task half-started;
     // abort instead of letting an exception escape.
-    throwproof->*[&] {
+    throw_proof->*[&] {
       if (dot->is_tracing())
       {
         dot->template add_vertex<task, logical_data_untyped>(*this);

--- a/cudax/include/cuda/experimental/__stf/utility/cuda_safe_call.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/cuda_safe_call.cuh
@@ -34,6 +34,7 @@
 #include <cuda/std/source_location>
 
 #include <cuda/experimental/__stf/utility/unittest.cuh>
+#include <cuda/experimental/__utility/scope_exit.cuh>
 
 #include <cstdlib>
 #include <exception>
@@ -324,112 +325,11 @@ void cuda_safe_call(const T status, const ::cuda::std::source_location loc = ::c
   abort();
 }
 
-/**
- * @brief Value (or reference) plus the call-site `source_location` of its construction.
- *
- * Intended as a function parameter type: write `with_location<widget>` instead of `widget`
- * so the callee can report file/line. Construction from an argument captures
- * `source_location::current()` at that call site (overloaded operators cannot take
- * defaulted `source_location` parameters themselves).
- *
- * Move-only: may be constructed as a temporary and moved into a by-value parameter,
- * but not copied. `T` may be a value, lvalue reference, or rvalue reference.
- */
-template <class T>
-struct with_location
-{
-  with_location(const with_location&)            = delete;
-  with_location& operator=(const with_location&) = delete;
-  with_location& operator=(with_location&&)      = delete;
-
-  // Required so a converting temporary can initialize a by-value parameter.
-  with_location(with_location&&) = default;
-
-  // Constrained so that ill-formed reference bindings are detected by
-  // `is_constructible_v` instead of erroring inside the mem-initializer, and so
-  // that this template does not hijack the move constructor.
-  template <typename U,
-            ::std::enable_if_t<!::std::is_same_v<::std::decay_t<U>, with_location> && ::std::is_constructible_v<T, U&&>,
-                               int> = 0>
-  constexpr with_location(U&& payload, ::cuda::std::source_location loc = ::cuda::std::source_location::current())
-      : payload(::std::forward<U>(payload))
-      , loc(loc)
-  {}
-
-  T payload;
-  ::cuda::std::source_location loc;
-};
-
-/**
- * @brief Invokes a callable and aborts if it throws.
- *
- * Use around code that must not let an exception escape into backend state
- * that cannot recover (e.g. after a CUDA stream capture has begun).
- *
- * Usage: `throwproof->*[&] { ... };`
- *
- * `throwproof` converts to `with_location`, which captures the call-site
- * `source_location` (overloaded operators cannot take default arguments).
- *
- * @snippet this throwproof
- */
-struct throwproof_t
-{
-} inline constexpr throwproof{};
-
-template <class F>
-decltype(auto) operator->*(with_location<throwproof_t> s, F&& f) noexcept
-{
-  _CCCL_TRY
-  {
-    return ::std::forward<F>(f)();
-  }
-  _CCCL_CATCH (const ::std::exception& e)
-  {
-    fprintf(stderr, "%s(%u) throwproof in %s: %s\n", s.loc.file_name(), s.loc.line(), s.loc.function_name(), e.what());
-  }
-  _CCCL_CATCH_ALL
-  {
-    fprintf(
-      stderr, "%s(%u) throwproof in %s: unknown exception\n", s.loc.file_name(), s.loc.line(), s.loc.function_name());
-  }
-  ::std::abort();
-}
-
-/**
- * @brief Invokes a callable and returns any thrown exception as an `exception_ptr`.
- *
- * Use around best-effort code where a failure should not escape (e.g. optional DOT
- * timing annotations) but the caller may still want to inspect or rethrow later.
- * The callable's return value must be `void` (enforced at compile time); the
- * result is empty if nothing was thrown.
- *
- * Usage: `auto e = defer_exception->*[&] { ... };`
- *
- * The result is `[[nodiscard]]` so the caller must acknowledge it (store it, test it,
- * or deliberately discard it, e.g. by assigning to std::ignore).
- *
- * @snippet this defer_exception
- */
-struct defer_exception_t
-{
-} inline constexpr defer_exception{};
-
-template <class F>
-[[nodiscard]] ::std::exception_ptr operator->*(defer_exception_t, F&& f) noexcept
-{
-  static_assert(::std::is_void_v<decltype(::std::forward<F>(f)())>,
-                "defer_exception requires a void-returning callable");
-  _CCCL_TRY
-  {
-    ::std::forward<F>(f)();
-    return {};
-  }
-  _CCCL_CATCH_ALL
-  {
-    return ::std::current_exception();
-  }
-}
+using ::cuda::experimental::throw_defer;
+using ::cuda::experimental::throw_defer_t;
+using ::cuda::experimental::throw_proof;
+using ::cuda::experimental::throw_proof_t;
+using ::cuda::experimental::with_location;
 
 #ifdef UNITTESTED_FILE
 UNITTEST("with_location")
@@ -465,11 +365,11 @@ UNITTEST("with_location")
   static_assert(!::std::is_constructible_v<with_location<widget&&>, const widget&>);
   static_assert(::std::is_move_constructible_v<with_location<widget&&>>);
 
-  // Empty tag lvalues (e.g. throwproof) must remain convertible — that is how
-  // `throwproof->*f` captures source_location.
-  static_assert(::std::is_constructible_v<with_location<throwproof_t>, throwproof_t&>);
-  static_assert(::std::is_constructible_v<with_location<throwproof_t>, const throwproof_t&>);
-  static_assert(::std::is_constructible_v<with_location<throwproof_t>, throwproof_t>);
+  // Empty tag lvalues (e.g. throw_proof) must remain convertible — that is how
+  // `throw_proof->*f` captures source_location.
+  static_assert(::std::is_constructible_v<with_location<throw_proof_t>, throw_proof_t&>);
+  static_assert(::std::is_constructible_v<with_location<throw_proof_t>, const throw_proof_t&>);
+  static_assert(::std::is_constructible_v<with_location<throw_proof_t>, throw_proof_t>);
 
   auto consume_value = [](with_location<widget> w) {
     EXPECT(w.payload.x == 42);
@@ -491,35 +391,35 @@ UNITTEST("with_location")
   consume_rref(widget{3});
 };
 
-UNITTEST("throwproof")
+UNITTEST("throw_proof")
 {
-  //! [throwproof]
+  //! [throw_proof]
   int value = 0;
-  throwproof->*[&] {
+  throw_proof->*[&] {
     value = 42; // would abort the application if this code threw
   };
   EXPECT(value == 42);
-  //! [throwproof]
-  EXPECT((throwproof->*
+  //! [throw_proof]
+  EXPECT((throw_proof->*
           [] {
             return 7;
           })
          == 7);
 };
 
-UNITTEST("defer_exception")
+UNITTEST("throw_defer")
 {
-  //! [defer_exception]
+  //! [throw_defer]
   int value = 0;
-  auto e    = defer_exception->*[&] {
+  auto e    = throw_defer->*[&] {
     value = 42; // if this threw, e would hold the exception_ptr
   };
   EXPECT(!e);
   EXPECT(value == 42);
-  //! [defer_exception]
+  //! [throw_defer]
 
 #  if _CCCL_HAS_EXCEPTIONS()
-  e = defer_exception->*[] {
+  e = throw_defer->*[] {
     throw ::std::runtime_error("boom");
   };
   EXPECT(static_cast<bool>(e));

--- a/cudax/include/cuda/experimental/__stf/utility/cuda_safe_call.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/cuda_safe_call.cuh
@@ -407,7 +407,7 @@ decltype(auto) operator->*(with_location<throwproof_t> s, F&& f) noexcept
  * Usage: `auto e = defer_exception->*[&] { ... };`
  *
  * The result is `[[nodiscard]]` so the caller must acknowledge it (store it, test it,
- * or deliberately discard with `::std::ignore = ...`).
+ * or deliberately discard it, e.g. by assigning to std::ignore).
  *
  * @snippet this defer_exception
  */

--- a/cudax/include/cuda/experimental/__stf/utility/cuda_safe_call.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/cuda_safe_call.cuh
@@ -396,6 +396,41 @@ decltype(auto) operator->*(with_location<throwproof_t> s, F&& f) noexcept
   ::std::abort();
 }
 
+/**
+ * @brief Invokes a callable and returns any thrown exception as an `exception_ptr`.
+ *
+ * Use around best-effort code where a failure should not escape (e.g. optional DOT
+ * timing annotations) but the caller may still want to inspect or rethrow later.
+ * The callable's return value must be `void` (enforced at compile time); the
+ * result is empty if nothing was thrown.
+ *
+ * Usage: `auto e = defer_exception->*[&] { ... };`
+ *
+ * The result is `[[nodiscard]]` so the caller must acknowledge it (store it, test it,
+ * or deliberately discard with `::std::ignore = ...`).
+ *
+ * @snippet this defer_exception
+ */
+struct defer_exception_t
+{
+} inline constexpr defer_exception{};
+
+template <class F>
+[[nodiscard]] ::std::exception_ptr operator->*(defer_exception_t, F&& f) noexcept
+{
+  static_assert(::std::is_void_v<decltype(::std::forward<F>(f)())>,
+                "defer_exception requires a void-returning callable");
+  _CCCL_TRY
+  {
+    ::std::forward<F>(f)();
+    return {};
+  }
+  _CCCL_CATCH_ALL
+  {
+    return ::std::current_exception();
+  }
+}
+
 #ifdef UNITTESTED_FILE
 UNITTEST("with_location")
 {
@@ -470,6 +505,35 @@ UNITTEST("throwproof")
             return 7;
           })
          == 7);
+};
+
+UNITTEST("defer_exception")
+{
+  //! [defer_exception]
+  int value = 0;
+  auto e    = defer_exception->*[&] {
+    value = 42; // if this threw, e would hold the exception_ptr
+  };
+  EXPECT(!e);
+  EXPECT(value == 42);
+  //! [defer_exception]
+
+#  if _CCCL_HAS_EXCEPTIONS()
+  e = defer_exception->*[] {
+    throw ::std::runtime_error("boom");
+  };
+  EXPECT(static_cast<bool>(e));
+  try
+  {
+    ::std::rethrow_exception(e);
+  }
+  catch (const ::std::runtime_error& ex)
+  {
+    EXPECT(::std::string_view(ex.what()) == "boom");
+    return;
+  }
+  EXPECT(false, "rethrow should have transferred control");
+#  endif // _CCCL_HAS_EXCEPTIONS()
 };
 
 UNITTEST("cuda_safe_call")

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -27,15 +27,20 @@
 
 #include <cuda/experimental/__stf/utility/unittest.cuh>
 
+#ifndef NDEBUG
+#  include <cuda/experimental/__stf/utility/cuda_safe_call.cuh>
+#endif
+
 namespace cuda::experimental::stf
 {
 /**
  * @brief Automatically runs code when a scope is exited (`SCOPE(exit)`), exited by means of an exception
  * (`SCOPE(fail)`), or exited normally (`SCOPE(success)`).
  *
- * The code controlled by `SCOPE(exit)` and `SCOPE(fail)` must not throw, otherwise the application will be terminated.
- * The code controlled by `SCOPE(success)` may throw. In all cases the controlled code must return `void`
- * (enforced at compile time).
+ * The code controlled by `SCOPE(exit)` and `SCOPE(fail)` must not throw. In debug builds (`NDEBUG` not
+ * defined) those lambdas are invoked via `throwproof`, so a throw aborts with a clear message; in release
+ * builds they are called directly. The code controlled by `SCOPE(success)` may throw. In all cases the
+ * controlled code must return `void` (enforced at compile time).
  *
  * `SCOPE(exit)` runs its code at the natural termination of the current scope. Example: @snippet this SCOPE(exit)
  *
@@ -94,7 +99,21 @@ auto operator->*(::std::integral_constant<scope_guard_condition, cond>, F&& f)
       // By convention, call always if threshold is -1, never if threshold < -1
       if (threshold == -1 || ::std::uncaught_exceptions() == threshold)
       {
-        f();
+        if constexpr (cond == scope_guard_condition::success)
+        {
+          f();
+        }
+        else
+        {
+#  ifndef NDEBUG
+          // exit/fail must not throw; abort with location in debug builds.
+          throwproof->*[&] {
+            f();
+          };
+#  else // ^^^ !NDEBUG ^^^ / vvv NDEBUG vvv
+          f();
+#  endif // NDEBUG
+        }
       }
     }
 

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -56,7 +56,7 @@ namespace cuda::experimental::stf
  */
 ///@{
 #define SCOPE(kind) \
-  auto CUDASTF_UNIQUE_NAME(scope_guard) = ::cuda::experimental::stf::detail::scope_guard_handler::kind{}->*[&]()
+  auto CUDASTF_UNIQUE_NAME(scope_guard) = (::cuda::experimental::stf::detail::scope_guard_handler::kind) {}->*[&]()
 ///@}
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
@@ -72,33 +72,29 @@ enum class success
 {
 };
 
-#  ifndef NDEBUG
 template <class F>
 void invoke_nothrow(F& f, ::cuda::std::source_location loc)
 {
+  static_assert(::std::is_void_v<decltype(f())>, "SCOPE requires a void-returning callable");
+#  ifndef NDEBUG
   // Forward the SCOPE call-site location into throw_proof.
   ::cuda::experimental::with_location<::cuda::experimental::throw_proof_t>{::cuda::experimental::throw_proof, loc}->*
     [&] {
       f();
     };
-}
 #  else // ^^^ !NDEBUG ^^^ / vvv NDEBUG vvv
-template <class F>
-void invoke_nothrow(F& f, ::cuda::std::source_location)
-{
+  (void) loc;
   f();
-}
 #  endif // NDEBUG
+}
 
 template <typename F>
 auto operator->*(::cuda::experimental::with_location<exit> where, F&& f)
 {
-  static_assert(::std::is_void_v<decltype(::std::forward<F>(f)())>, "SCOPE requires a void-returning callable");
-
   struct result
   {
     F f;
-    ::cuda::std::source_location loc;
+    const ::cuda::std::source_location loc;
     bool active = true;
 
     result(F&& f, ::cuda::std::source_location loc)
@@ -129,13 +125,11 @@ auto operator->*(::cuda::experimental::with_location<exit> where, F&& f)
 template <typename F>
 auto operator->*(::cuda::experimental::with_location<fail> where, F&& f)
 {
-  static_assert(::std::is_void_v<decltype(::std::forward<F>(f)())>, "SCOPE requires a void-returning callable");
-
   struct result
   {
     F f;
-    ::cuda::std::source_location loc;
-    int exceptions;
+    const ::cuda::std::source_location loc;
+    const int exceptions;
     bool active = true;
 
     result(F&& f, ::cuda::std::source_location loc, int exceptions)
@@ -167,14 +161,15 @@ auto operator->*(::cuda::experimental::with_location<fail> where, F&& f)
 }
 
 template <typename F>
-auto operator->*(::cuda::experimental::with_location<success> where, F&& f)
+auto operator->*(success, F&& f)
 {
+  // success may throw, so it does not go through invoke_nothrow; keep the same void check.
   static_assert(::std::is_void_v<decltype(::std::forward<F>(f)())>, "SCOPE requires a void-returning callable");
 
   struct result
   {
     F f;
-    int exceptions;
+    const int exceptions;
     bool active = true;
 
     result(F&& f, int exceptions)
@@ -200,7 +195,6 @@ auto operator->*(::cuda::experimental::with_location<success> where, F&& f)
     }
   };
 
-  (void) where; // location unused; success may throw so throw_proof does not apply
   return result{::std::forward<F>(f), ::std::uncaught_exceptions()};
 }
 } // namespace detail::scope_guard_handler

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -28,8 +28,6 @@
 #include <cuda/experimental/__stf/utility/unittest.cuh>
 #include <cuda/experimental/__utility/scope_exit.cuh>
 
-#include <optional>
-
 namespace cuda::experimental::stf
 {
 /**
@@ -97,18 +95,30 @@ auto operator->*(::cuda::experimental::with_location<exit> where, F&& f)
 {
   static_assert(::std::is_void_v<decltype(::std::forward<F>(f)())>, "SCOPE requires a void-returning callable");
 
-  // Aggregate: brace-init at the call site. `optional` makes moved-from guards inert
-  // (no custom move / active flag). Copy is unavailable for the usual `[&]` lambdas.
   struct result
   {
-    ::std::optional<F> f;
+    F f;
     ::cuda::std::source_location loc;
+    bool active = true;
+
+    result(F&& f, ::cuda::std::source_location loc)
+        : f(::std::forward<F>(f))
+        , loc(loc)
+    {}
+    result(result&) = delete;
+    result(result&& rhs)
+        : f(mv(rhs.f))
+        , loc(rhs.loc)
+        , active(rhs.active)
+    {
+      rhs.active = false;
+    }
 
     ~result() noexcept
     {
-      if (f)
+      if (active)
       {
-        invoke_nothrow(*f, loc);
+        invoke_nothrow(f, loc);
       }
     }
   };
@@ -123,15 +133,31 @@ auto operator->*(::cuda::experimental::with_location<fail> where, F&& f)
 
   struct result
   {
-    ::std::optional<F> f;
+    F f;
     ::cuda::std::source_location loc;
     int exceptions;
+    bool active = true;
+
+    result(F&& f, ::cuda::std::source_location loc, int exceptions)
+        : f(::std::forward<F>(f))
+        , loc(loc)
+        , exceptions(exceptions)
+    {}
+    result(result&) = delete;
+    result(result&& rhs)
+        : f(mv(rhs.f))
+        , loc(rhs.loc)
+        , exceptions(rhs.exceptions)
+        , active(rhs.active)
+    {
+      rhs.active = false;
+    }
 
     ~result() noexcept
     {
-      if (f && ::std::uncaught_exceptions() == exceptions)
+      if (active && ::std::uncaught_exceptions() == exceptions)
       {
-        invoke_nothrow(*f, loc);
+        invoke_nothrow(f, loc);
       }
     }
   };
@@ -147,15 +173,29 @@ auto operator->*(::cuda::experimental::with_location<success> where, F&& f)
 
   struct result
   {
-    ::std::optional<F> f;
+    F f;
     int exceptions;
+    bool active = true;
+
+    result(F&& f, int exceptions)
+        : f(::std::forward<F>(f))
+        , exceptions(exceptions)
+    {}
+    result(result&) = delete;
+    result(result&& rhs)
+        : f(mv(rhs.f))
+        , exceptions(rhs.exceptions)
+        , active(rhs.active)
+    {
+      rhs.active = false;
+    }
 
     // May throw — unlike exit/fail.
     ~result() noexcept(false)
     {
-      if (f && ::std::uncaught_exceptions() == exceptions)
+      if (active && ::std::uncaught_exceptions() == exceptions)
       {
-        (*f)();
+        f();
       }
     }
   };

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -26,10 +26,7 @@
 #endif // no system header
 
 #include <cuda/experimental/__stf/utility/unittest.cuh>
-
-#ifndef NDEBUG
-#  include <cuda/experimental/__stf/utility/cuda_safe_call.cuh>
-#endif
+#include <cuda/experimental/__utility/scope_exit.cuh>
 
 namespace cuda::experimental::stf
 {
@@ -38,7 +35,7 @@ namespace cuda::experimental::stf
  * (`SCOPE(fail)`), or exited normally (`SCOPE(success)`).
  *
  * The code controlled by `SCOPE(exit)` and `SCOPE(fail)` must not throw. In debug builds (`NDEBUG` not
- * defined) those lambdas are invoked via `throwproof`, so a throw aborts with a clear message; in release
+ * defined) those lambdas are invoked via `throw_proof` using the `SCOPE` call-site location; in release
  * builds they are called directly. The code controlled by `SCOPE(success)` may throw. In all cases the
  * controlled code must return `void` (enforced at compile time).
  *
@@ -58,76 +55,158 @@ namespace cuda::experimental::stf
  * https://en.cppreference.com/w/cpp/experimental/scope_success
  */
 ///@{
-#define SCOPE(kind)                                                                      \
-  auto CUDASTF_UNIQUE_NAME(scope_guard) =                                                \
-    ::std::integral_constant<::cuda::experimental::stf::scope_guard_condition,           \
-                             (::cuda::experimental::stf::scope_guard_condition::kind)>() \
-      ->*[&]()
+#define SCOPE(kind) \
+  auto CUDASTF_UNIQUE_NAME(scope_guard) = (::cuda::experimental::stf::detail::scope_guard_handler::kind) {}->*[&]()
 ///@}
 
-enum class scope_guard_condition
+#ifndef _CCCL_DOXYGEN_INVOKED // Do not document
+namespace detail::scope_guard_handler
 {
-  exit,
-  fail,
-  success
+enum class exit
+{
+};
+enum class fail
+{
+};
+enum class success
+{
 };
 
-#ifndef _CCCL_DOXYGEN_INVOKED // Do not document
-template <scope_guard_condition cond, typename F>
-auto operator->*(::std::integral_constant<scope_guard_condition, cond>, F&& f)
+#  ifndef NDEBUG
+template <class F>
+void invoke_nothrow(F& f, ::cuda::std::source_location loc)
+{
+  // Forward the SCOPE call-site location into throw_proof.
+  ::cuda::experimental::with_location<::cuda::experimental::throw_proof_t>{::cuda::experimental::throw_proof, loc}->*
+    [&] {
+      f();
+    };
+}
+#  else // ^^^ !NDEBUG ^^^ / vvv NDEBUG vvv
+template <class F>
+void invoke_nothrow(F& f, ::cuda::std::source_location)
+{
+  f();
+}
+#  endif // NDEBUG
+
+template <typename F>
+auto operator->*(::cuda::experimental::with_location<exit> where, F&& f)
 {
   static_assert(::std::is_void_v<decltype(::std::forward<F>(f)())>, "SCOPE requires a void-returning callable");
 
   struct result
   {
-    result(F&& f, int threshold)
+    result(F&& f, ::cuda::std::source_location loc)
         : f(::std::forward<F>(f))
-        , threshold(threshold)
+        , loc(loc)
     {}
     result(result&) = delete;
     result(result&& rhs)
         : f(mv(rhs.f))
-        , threshold(rhs.threshold)
+        , loc(rhs.loc)
+        , active(rhs.active)
     {
-      // Disable call to lambda in rhs's destructor in all cases, we don't want double calls
-      rhs.threshold = -2;
+      rhs.active = false;
     }
 
-    // Destructor (i.e. user's lambda) may throw exceptions if and only if we're in `SCOPE(success)`.
-    ~result() noexcept(cond != scope_guard_condition::success)
+    ~result() noexcept
     {
-      // By convention, call always if threshold is -1, never if threshold < -1
-      if (threshold == -1 || ::std::uncaught_exceptions() == threshold)
+      if (active)
       {
-        if constexpr (cond == scope_guard_condition::success)
-        {
-          f();
-        }
-        else
-        {
-#  ifndef NDEBUG
-          // exit/fail must not throw; abort with location in debug builds.
-          throwproof->*[&] {
-            f();
-          };
-#  else // ^^^ !NDEBUG ^^^ / vvv NDEBUG vvv
-          f();
-#  endif // NDEBUG
-        }
+        invoke_nothrow(f, loc);
       }
     }
 
   private:
     F f;
-    int threshold;
+    ::cuda::std::source_location loc;
+    bool active = true;
   };
 
-  // Threshold is -1 for SCOPE(exit), the same as current exceptions count for SCOPE(success), and 1 above the current
-  // exception count for SCOPE(fail).
-  return result(
-    ::std::forward<F>(f),
-    cond == scope_guard_condition::exit ? -1 : ::std::uncaught_exceptions() + (cond == scope_guard_condition::fail));
+  return result(::std::forward<F>(f), where.loc);
 }
+
+template <typename F>
+auto operator->*(::cuda::experimental::with_location<fail> where, F&& f)
+{
+  static_assert(::std::is_void_v<decltype(::std::forward<F>(f)())>, "SCOPE requires a void-returning callable");
+
+  struct result
+  {
+    result(F&& f, ::cuda::std::source_location loc, int exceptions)
+        : f(::std::forward<F>(f))
+        , loc(loc)
+        , exceptions(exceptions)
+    {}
+    result(result&) = delete;
+    result(result&& rhs)
+        : f(mv(rhs.f))
+        , loc(rhs.loc)
+        , exceptions(rhs.exceptions)
+        , active(rhs.active)
+    {
+      rhs.active = false;
+    }
+
+    ~result() noexcept
+    {
+      if (active && ::std::uncaught_exceptions() == exceptions)
+      {
+        invoke_nothrow(f, loc);
+      }
+    }
+
+  private:
+    F f;
+    ::cuda::std::source_location loc;
+    int exceptions;
+    bool active = true;
+  };
+
+  // Run only if an exception is in flight: uncaught count is one above creation-time count.
+  return result(::std::forward<F>(f), where.loc, ::std::uncaught_exceptions() + 1);
+}
+
+template <typename F>
+auto operator->*(::cuda::experimental::with_location<success> where, F&& f)
+{
+  static_assert(::std::is_void_v<decltype(::std::forward<F>(f)())>, "SCOPE requires a void-returning callable");
+
+  struct result
+  {
+    result(F&& f, int exceptions)
+        : f(::std::forward<F>(f))
+        , exceptions(exceptions)
+    {}
+    result(result&) = delete;
+    result(result&& rhs)
+        : f(mv(rhs.f))
+        , exceptions(rhs.exceptions)
+        , active(rhs.active)
+    {
+      rhs.active = false;
+    }
+
+    // May throw — unlike exit/fail.
+    ~result() noexcept(false)
+    {
+      if (active && ::std::uncaught_exceptions() == exceptions)
+      {
+        f();
+      }
+    }
+
+  private:
+    F f;
+    int exceptions;
+    bool active = true;
+  };
+
+  (void) where; // location unused; success may throw so throw_proof does not apply
+  return result(::std::forward<F>(f), ::std::uncaught_exceptions());
+}
+} // namespace detail::scope_guard_handler
 #endif // !_CCCL_DOXYGEN_INVOKED
 } // namespace cuda::experimental::stf
 
@@ -159,7 +238,7 @@ UNITTEST("SCOPE(fail)")
     };
     EXPECT(!done, "SCOPE_FAIL should not run early.");
   }
-  assert(!done);
+  EXPECT(!done);
 
   try
   {

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -28,6 +28,8 @@
 #include <cuda/experimental/__stf/utility/unittest.cuh>
 #include <cuda/experimental/__utility/scope_exit.cuh>
 
+#include <optional>
+
 namespace cuda::experimental::stf
 {
 /**
@@ -56,7 +58,7 @@ namespace cuda::experimental::stf
  */
 ///@{
 #define SCOPE(kind) \
-  auto CUDASTF_UNIQUE_NAME(scope_guard) = (::cuda::experimental::stf::detail::scope_guard_handler::kind) {}->*[&]()
+  auto CUDASTF_UNIQUE_NAME(scope_guard) = ::cuda::experimental::stf::detail::scope_guard_handler::kind{}->*[&]()
 ///@}
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
@@ -95,36 +97,23 @@ auto operator->*(::cuda::experimental::with_location<exit> where, F&& f)
 {
   static_assert(::std::is_void_v<decltype(::std::forward<F>(f)())>, "SCOPE requires a void-returning callable");
 
+  // Aggregate: brace-init at the call site. `optional` makes moved-from guards inert
+  // (no custom move / active flag). Copy is unavailable for the usual `[&]` lambdas.
   struct result
   {
-    result(F&& f, ::cuda::std::source_location loc)
-        : f(::std::forward<F>(f))
-        , loc(loc)
-    {}
-    result(result&) = delete;
-    result(result&& rhs)
-        : f(mv(rhs.f))
-        , loc(rhs.loc)
-        , active(rhs.active)
-    {
-      rhs.active = false;
-    }
+    ::std::optional<F> f;
+    ::cuda::std::source_location loc;
 
     ~result() noexcept
     {
-      if (active)
+      if (f)
       {
-        invoke_nothrow(f, loc);
+        invoke_nothrow(*f, loc);
       }
     }
-
-  private:
-    F f;
-    ::cuda::std::source_location loc;
-    bool active = true;
   };
 
-  return result(::std::forward<F>(f), where.loc);
+  return result{::std::forward<F>(f), where.loc};
 }
 
 template <typename F>
@@ -134,38 +123,21 @@ auto operator->*(::cuda::experimental::with_location<fail> where, F&& f)
 
   struct result
   {
-    result(F&& f, ::cuda::std::source_location loc, int exceptions)
-        : f(::std::forward<F>(f))
-        , loc(loc)
-        , exceptions(exceptions)
-    {}
-    result(result&) = delete;
-    result(result&& rhs)
-        : f(mv(rhs.f))
-        , loc(rhs.loc)
-        , exceptions(rhs.exceptions)
-        , active(rhs.active)
-    {
-      rhs.active = false;
-    }
+    ::std::optional<F> f;
+    ::cuda::std::source_location loc;
+    int exceptions;
 
     ~result() noexcept
     {
-      if (active && ::std::uncaught_exceptions() == exceptions)
+      if (f && ::std::uncaught_exceptions() == exceptions)
       {
-        invoke_nothrow(f, loc);
+        invoke_nothrow(*f, loc);
       }
     }
-
-  private:
-    F f;
-    ::cuda::std::source_location loc;
-    int exceptions;
-    bool active = true;
   };
 
   // Run only if an exception is in flight: uncaught count is one above creation-time count.
-  return result(::std::forward<F>(f), where.loc, ::std::uncaught_exceptions() + 1);
+  return result{::std::forward<F>(f), where.loc, ::std::uncaught_exceptions() + 1};
 }
 
 template <typename F>
@@ -175,36 +147,21 @@ auto operator->*(::cuda::experimental::with_location<success> where, F&& f)
 
   struct result
   {
-    result(F&& f, int exceptions)
-        : f(::std::forward<F>(f))
-        , exceptions(exceptions)
-    {}
-    result(result&) = delete;
-    result(result&& rhs)
-        : f(mv(rhs.f))
-        , exceptions(rhs.exceptions)
-        , active(rhs.active)
-    {
-      rhs.active = false;
-    }
+    ::std::optional<F> f;
+    int exceptions;
 
     // May throw — unlike exit/fail.
     ~result() noexcept(false)
     {
-      if (active && ::std::uncaught_exceptions() == exceptions)
+      if (f && ::std::uncaught_exceptions() == exceptions)
       {
-        f();
+        (*f)();
       }
     }
-
-  private:
-    F f;
-    int exceptions;
-    bool active = true;
   };
 
   (void) where; // location unused; success may throw so throw_proof does not apply
-  return result(::std::forward<F>(f), ::std::uncaught_exceptions());
+  return result{::std::forward<F>(f), ::std::uncaught_exceptions()};
 }
 } // namespace detail::scope_guard_handler
 #endif // !_CCCL_DOXYGEN_INVOKED

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -34,7 +34,8 @@ namespace cuda::experimental::stf
  * (`SCOPE(fail)`), or exited normally (`SCOPE(success)`).
  *
  * The code controlled by `SCOPE(exit)` and `SCOPE(fail)` must not throw, otherwise the application will be terminated.
- * The code controlled by `SCOPE(exit)` may throw.
+ * The code controlled by `SCOPE(success)` may throw. In all cases the controlled code must return `void`
+ * (enforced at compile time).
  *
  * `SCOPE(exit)` runs its code at the natural termination of the current scope. Example: @snippet this SCOPE(exit)
  *
@@ -70,6 +71,8 @@ enum class scope_guard_condition
 template <scope_guard_condition cond, typename F>
 auto operator->*(::std::integral_constant<scope_guard_condition, cond>, F&& f)
 {
+  static_assert(::std::is_void_v<decltype(::std::forward<F>(f)())>, "SCOPE requires a void-returning callable");
+
   struct result
   {
     result(F&& f, int threshold)

--- a/cudax/include/cuda/experimental/__utility/scope_exit.cuh
+++ b/cudax/include/cuda/experimental/__utility/scope_exit.cuh
@@ -21,10 +21,21 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__exception/exception_macros.h>
+#include <cuda/std/__type_traits/decay.h>
+#include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_callable.h>
+#include <cuda/std/__type_traits/is_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_constructible.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_void.h>
 #include <cuda/std/__utility/forward.h>
+#include <cuda/std/source_location>
+
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
 
 namespace cuda::experimental
 {
@@ -95,6 +106,120 @@ private:
 
 template <class _Fn>
 _CCCL_DEDUCTION_GUIDE_ATTRIBUTES scope_exit(_Fn) -> scope_exit<_Fn>;
+
+/**
+ * @brief Value (or reference) plus the call-site `source_location` of its construction.
+ *
+ * Intended as a function parameter type: write `with_location<widget>` instead of `widget`
+ * so the callee can report file/line. Construction from an argument captures
+ * `source_location::current()` at that call site (overloaded operators cannot take
+ * defaulted `source_location` parameters themselves).
+ *
+ * Move-only: may be constructed as a temporary and moved into a by-value parameter,
+ * but not copied. `T` may be a value, lvalue reference, or rvalue reference.
+ */
+template <class _Tp>
+struct with_location
+{
+  with_location(const with_location&)            = delete;
+  with_location& operator=(const with_location&) = delete;
+  with_location& operator=(with_location&&)      = delete;
+
+  // Required so a converting temporary can initialize a by-value parameter.
+  with_location(with_location&&) = default;
+
+  // Constrained so that ill-formed reference bindings are detected by
+  // `is_constructible_v` instead of erroring inside the mem-initializer, and so
+  // that this template does not hijack the move constructor.
+  template <typename _Up,
+            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<::cuda::std::decay_t<_Up>, with_location>
+                                       && ::cuda::std::is_constructible_v<_Tp, _Up&&>,
+                                     int> = 0>
+  constexpr with_location(_Up&& __payload, ::cuda::std::source_location __loc = ::cuda::std::source_location::current())
+      : payload(::cuda::std::forward<_Up>(__payload))
+      , loc(__loc)
+  {}
+
+  _Tp payload;
+  ::cuda::std::source_location loc;
+};
+
+/**
+ * @brief Invokes a callable and aborts if it throws.
+ *
+ * Use around code that must not let an exception escape into backend state
+ * that cannot recover (e.g. after a CUDA stream capture has begun).
+ *
+ * Usage: `throw_proof->*[&] { ... };`
+ *
+ * `throw_proof` converts to `with_location`, which captures the call-site
+ * `source_location` (overloaded operators cannot take default arguments). An
+ * explicit `with_location<throw_proof_t>{throw_proof, loc}` can forward a
+ * previously captured location.
+ */
+struct throw_proof_t
+{
+} inline constexpr throw_proof{};
+
+template <class _Fn>
+decltype(auto) operator->*(with_location<throw_proof_t> __s, _Fn&& __f) noexcept
+{
+  _CCCL_TRY
+  {
+    return ::cuda::std::forward<_Fn>(__f)();
+  }
+  _CCCL_CATCH (const ::std::exception& __e)
+  {
+    ::fprintf(stderr,
+              "%s(%u) throw_proof in %s: %s\n",
+              __s.loc.file_name(),
+              __s.loc.line(),
+              __s.loc.function_name(),
+              __e.what());
+  }
+  _CCCL_CATCH_ALL
+  {
+    ::fprintf(stderr,
+              "%s(%u) throw_proof in %s: unknown exception\n",
+              __s.loc.file_name(),
+              __s.loc.line(),
+              __s.loc.function_name());
+  }
+  ::std::abort();
+}
+
+/**
+ * @brief Invokes a callable and returns any thrown exception as an `exception_ptr`.
+ *
+ * Use around best-effort code where a failure should not escape (e.g. optional DOT
+ * timing annotations) but the caller may still want to inspect or rethrow later.
+ * The callable's return value must be `void` (enforced at compile time); the
+ * result is empty if nothing was thrown.
+ *
+ * Usage: `auto e = throw_defer->*[&] { ... };`
+ *
+ * The result is `[[nodiscard]]` so the caller must acknowledge it (store it, test it,
+ * or deliberately discard it, e.g. by assigning to std::ignore).
+ */
+struct throw_defer_t
+{
+} inline constexpr throw_defer{};
+
+template <class _Fn>
+[[nodiscard]] ::std::exception_ptr operator->*(throw_defer_t, _Fn&& __f) noexcept
+{
+  static_assert(::cuda::std::is_void_v<decltype(::cuda::std::forward<_Fn>(__f)())>,
+                "throw_defer requires a void-returning callable");
+  _CCCL_TRY
+  {
+    ::cuda::std::forward<_Fn>(__f)();
+    return {};
+  }
+  _CCCL_CATCH_ALL
+  {
+    return ::std::current_exception();
+  }
+}
 } // namespace cuda::experimental
 
 #endif // _CUDAX__EXPERIMENTAL_UTILITY_SCOPE_EXIT


### PR DESCRIPTION
## Summary
- Follow-up to #10523: three commits landed on the branch after that PR was squash-merged and never made it to `main`.
- Adds `defer_exception->*[&]{...}` — same call shape as `throwproof`, but returns a `[[nodiscard]]` `std::exception_ptr` (no `source_location`; failures are deferred, not reported).
- `static_assert` that callables passed to `defer_exception` and `SCOPE` return `void`.
- Fixes SCOPE docs: `SCOPE(success)` may throw, not `SCOPE(exit)`.

## Test plan
- [x] Built/ran `cudax.test.stf.unittest_headers.__stf.utility.cuda_safe_call` and `...scope_guard` locally before the original commits
- [ ] CI on this PR