### PR TITLE
[libcu++] Add cuda::empty_like for buffers

### DIFF
--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -973,6 +973,36 @@ _CCCL_HOST_API auto make_buffer(
 }
 #  endif // _CCCL_DOXYGEN_INVOKED
 
+//! @brief Creates a buffer like \p __source with \p __size uninitialized elements on \p __stream.
+//! @param[in] __stream The stream used for allocation and stored in the new buffer.
+//! @param[in] __source The source buffer whose memory resource, type, properties, and alignment are reused.
+//! @param[in] __size The number of uninitialized elements in the new buffer.
+//! @return A new buffer with the same type and allocation metadata as \p __source.
+template <class _Tp, class... _Properties>
+[[nodiscard]] _CCCL_HOST_API buffer<_Tp, _Properties...>
+empty_like(const stream_ref __stream,
+           const buffer<_Tp, _Properties...>& __source,
+           const typename buffer<_Tp, _Properties...>::size_type __size)
+{
+  return buffer<_Tp, _Properties...>{
+    __stream,
+    __source.memory_resource(),
+    __size,
+    ::cuda::no_init,
+    ::cuda::std::execution::prop{::cuda::allocation_alignment, __source.alignment()}};
+}
+
+//! @brief Creates a buffer like \p __source with the same size and uninitialized elements on \p __stream.
+//! @param[in] __stream The stream used for allocation and stored in the new buffer.
+//! @param[in] __source The source buffer whose memory resource, type, properties, size, and alignment are reused.
+//! @return A new buffer with the same type and allocation metadata as \p __source.
+template <class _Tp, class... _Properties>
+[[nodiscard]] _CCCL_HOST_API buffer<_Tp, _Properties...>
+empty_like(const stream_ref __stream, const buffer<_Tp, _Properties...>& __source)
+{
+  return ::cuda::empty_like(__stream, __source, __source.size());
+}
+
 // Empty buffer make function
 _CCCL_TEMPLATE(
   class _Tp, class _FirstProperty, class... _RestProperties, class _Resource, class _Env = ::cuda::std::execution::env<>)

--- a/libcudacxx/include/cuda/__container/empty_like.h
+++ b/libcudacxx/include/cuda/__container/empty_like.h
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___CONTAINER_EMPTY_LIKE_H
+#define _CUDA___CONTAINER_EMPTY_LIKE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_CTK()
+
+#  include <cuda/__container/buffer.h>
+#  include <cuda/__memory_resource/allocation_alignment.h>
+#  include <cuda/__stream/stream_ref.h>
+#  include <cuda/__utility/no_init.h>
+#  include <cuda/std/__execution/env.h>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+_CCCL_BEGIN_NAMESPACE_ABI_VER4_BUMP
+
+//! @brief Creates a buffer like \p __source with \p __size uninitialized elements on \p __stream.
+//! @param[in] __stream The stream used for allocation and stored in the new buffer.
+//! @param[in] __source The source buffer whose memory resource, type, properties, and alignment are reused.
+//! @param[in] __size The number of uninitialized elements in the new buffer.
+//! @return A new buffer with the same type and allocation metadata as \p __source.
+template <class _Tp, class... _Properties>
+[[nodiscard]] _CCCL_HOST_API buffer<_Tp, _Properties...>
+__empty_like(const stream_ref __stream,
+             const buffer<_Tp, _Properties...>& __source,
+             const typename buffer<_Tp, _Properties...>::size_type __size)
+{
+  return buffer<_Tp, _Properties...>{
+    __stream,
+    __source.memory_resource(),
+    __size,
+    ::cuda::no_init,
+    ::cuda::std::execution::prop{::cuda::allocation_alignment, __source.alignment()}};
+}
+
+//! @brief Creates a buffer like \p __source with the same size and uninitialized elements on \p __stream.
+//! @param[in] __stream The stream used for allocation and stored in the new buffer.
+//! @param[in] __source The source buffer whose memory resource, type, properties, size, and alignment are reused.
+//! @return A new buffer with the same type and allocation metadata as \p __source.
+template <class _Tp, class... _Properties>
+[[nodiscard]] _CCCL_HOST_API buffer<_Tp, _Properties...>
+__empty_like(const stream_ref __stream, const buffer<_Tp, _Properties...>& __source)
+{
+  return ::cuda::__empty_like(__stream, __source, __source.size());
+}
+
+_CCCL_END_NAMESPACE_ABI_VER4_BUMP
+_CCCL_END_NAMESPACE_CUDA
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_HAS_CTK()
+
+#endif // _CUDA___CONTAINER_EMPTY_LIKE_H

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/copy.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/copy.cu
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/__container/empty_like.h>
 #include <cuda/__memory_resource/shared_resource.h>
 #include <cuda/buffer>
 #include <cuda/devices>
@@ -20,6 +21,8 @@
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
+
+#include <test_resources.h>
 
 #include "helper.h"
 #include "types.h"
@@ -148,6 +151,80 @@ C2H_CCCLRT_TEST("cuda::buffer make_buffer", "[container][buffer]", test_types)
       CCCLRT_CHECK(!buf.empty());
       CCCLRT_CHECK(equal_range(buf));
     }
+  }
+}
+
+C2H_CCCLRT_TEST("cuda::buffer __empty_like", "[container][buffer]", test_types)
+{
+  using Buffer   = c2h::get<0, TestType>;
+  using Resource = typename extract_properties<Buffer>::resource;
+  using T        = typename Buffer::value_type;
+
+  if (!extract_properties<Buffer>::is_resource_supported())
+  {
+    return;
+  }
+
+  const cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream other_stream{cuda::device_ref{0}};
+  const cuda::stream_ref stream_ref{stream};
+  const cuda::stream_ref other_stream_ref{other_stream};
+  const Resource resource = extract_properties<Buffer>::get_resource();
+
+  { // matching size
+    const Buffer input{stream_ref, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
+    const auto buf = cuda::__empty_like(other_stream_ref, input);
+
+    static_assert(cuda::std::is_same_v<cuda::std::remove_cv_t<decltype(buf)>, Buffer>);
+    CCCLRT_CHECK(buf.size() == input.size());
+    CCCLRT_CHECK(buf.stream() == other_stream_ref);
+    CCCLRT_CHECK(buf.memory_resource() == input.memory_resource());
+    CCCLRT_CHECK(buf.alignment() == input.alignment());
+    CCCLRT_CHECK(cuda::allocation_alignment(buf) == cuda::allocation_alignment(input));
+    CCCLRT_CHECK(buf.data() != nullptr);
+    CCCLRT_CHECK(buf.data() != input.data());
+    CCCLRT_CHECK(is_pointer_aligned(buf.data(), input.alignment()));
+  }
+
+  { // explicit size
+    const Buffer input{stream_ref, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
+    const auto buf = cuda::__empty_like(other_stream_ref, input, 3);
+
+    static_assert(cuda::std::is_same_v<cuda::std::remove_cv_t<decltype(buf)>, Buffer>);
+    CCCLRT_CHECK(buf.size() == 3);
+    CCCLRT_CHECK(buf.stream() == other_stream_ref);
+    CCCLRT_CHECK(buf.memory_resource() == input.memory_resource());
+    CCCLRT_CHECK(buf.alignment() == input.alignment());
+    CCCLRT_CHECK(buf.data() != nullptr);
+    CCCLRT_CHECK(buf.data() != input.data());
+    CCCLRT_CHECK(is_pointer_aligned(buf.data(), input.alignment()));
+  }
+
+  { // explicit zero size
+    const Buffer input{stream_ref, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
+    const auto buf = cuda::__empty_like(other_stream_ref, input, 0);
+
+    static_assert(cuda::std::is_same_v<cuda::std::remove_cv_t<decltype(buf)>, Buffer>);
+    CCCLRT_CHECK(buf.empty());
+    CCCLRT_CHECK(buf.data() == nullptr);
+    CCCLRT_CHECK(buf.stream() == other_stream_ref);
+    CCCLRT_CHECK(buf.memory_resource() == input.memory_resource());
+    CCCLRT_CHECK(buf.alignment() == input.alignment());
+  }
+
+  { // custom allocation alignment
+    const ::cuda::std::size_t alignment = ::cuda::mr::default_cuda_malloc_alignment / 2;
+    const auto env                      = ::cuda::std::execution::prop{::cuda::allocation_alignment, alignment};
+    const Buffer input{stream_ref, resource, 5, cuda::no_init, env};
+    const auto buf = cuda::__empty_like(other_stream_ref, input, 7);
+
+    static_assert(cuda::std::is_same_v<cuda::std::remove_cv_t<decltype(buf)>, Buffer>);
+    CCCLRT_CHECK(buf.size() == 7);
+    CCCLRT_CHECK(buf.stream() == other_stream_ref);
+    CCCLRT_CHECK(buf.memory_resource() == input.memory_resource());
+    CCCLRT_CHECK(buf.alignment() == alignment);
+    CCCLRT_CHECK(cuda::allocation_alignment(buf) == alignment);
+    CCCLRT_CHECK(is_pointer_aligned(buf.data(), alignment));
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/copy.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/copy.cu
@@ -21,6 +21,8 @@
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 
+#include <test_resources.h>
+
 #include "helper.h"
 #include "types.h"
 
@@ -148,6 +150,80 @@ C2H_CCCLRT_TEST("cuda::buffer make_buffer", "[container][buffer]", test_types)
       CCCLRT_CHECK(!buf.empty());
       CCCLRT_CHECK(equal_range(buf));
     }
+  }
+}
+
+C2H_CCCLRT_TEST("cuda::buffer empty_like", "[container][buffer]", test_types)
+{
+  using Buffer   = c2h::get<0, TestType>;
+  using Resource = typename extract_properties<Buffer>::resource;
+  using T        = typename Buffer::value_type;
+
+  if (!extract_properties<Buffer>::is_resource_supported())
+  {
+    return;
+  }
+
+  const cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream other_stream{cuda::device_ref{0}};
+  const cuda::stream_ref stream_ref{stream};
+  const cuda::stream_ref other_stream_ref{other_stream};
+  const Resource resource = extract_properties<Buffer>::get_resource();
+
+  { // matching size
+    const Buffer input{stream_ref, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
+    const auto buf = cuda::empty_like(other_stream_ref, input);
+
+    static_assert(cuda::std::is_same_v<cuda::std::remove_cv_t<decltype(buf)>, Buffer>);
+    CCCLRT_CHECK(buf.size() == input.size());
+    CCCLRT_CHECK(buf.stream() == other_stream_ref);
+    CCCLRT_CHECK(buf.memory_resource() == input.memory_resource());
+    CCCLRT_CHECK(buf.alignment() == input.alignment());
+    CCCLRT_CHECK(cuda::allocation_alignment(buf) == cuda::allocation_alignment(input));
+    CCCLRT_CHECK(buf.data() != nullptr);
+    CCCLRT_CHECK(buf.data() != input.data());
+    CCCLRT_CHECK(is_pointer_aligned(buf.data(), input.alignment()));
+  }
+
+  { // explicit size
+    const Buffer input{stream_ref, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
+    const auto buf = cuda::empty_like(other_stream_ref, input, 3);
+
+    static_assert(cuda::std::is_same_v<cuda::std::remove_cv_t<decltype(buf)>, Buffer>);
+    CCCLRT_CHECK(buf.size() == 3);
+    CCCLRT_CHECK(buf.stream() == other_stream_ref);
+    CCCLRT_CHECK(buf.memory_resource() == input.memory_resource());
+    CCCLRT_CHECK(buf.alignment() == input.alignment());
+    CCCLRT_CHECK(buf.data() != nullptr);
+    CCCLRT_CHECK(buf.data() != input.data());
+    CCCLRT_CHECK(is_pointer_aligned(buf.data(), input.alignment()));
+  }
+
+  { // explicit zero size
+    const Buffer input{stream_ref, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
+    const auto buf = cuda::empty_like(other_stream_ref, input, 0);
+
+    static_assert(cuda::std::is_same_v<cuda::std::remove_cv_t<decltype(buf)>, Buffer>);
+    CCCLRT_CHECK(buf.empty());
+    CCCLRT_CHECK(buf.data() == nullptr);
+    CCCLRT_CHECK(buf.stream() == other_stream_ref);
+    CCCLRT_CHECK(buf.memory_resource() == input.memory_resource());
+    CCCLRT_CHECK(buf.alignment() == input.alignment());
+  }
+
+  { // custom allocation alignment
+    const ::cuda::std::size_t alignment = ::cuda::mr::default_cuda_malloc_alignment / 2;
+    const auto env                      = ::cuda::std::execution::prop{::cuda::allocation_alignment, alignment};
+    const Buffer input{stream_ref, resource, 5, cuda::no_init, env};
+    const auto buf = cuda::empty_like(other_stream_ref, input, 7);
+
+    static_assert(cuda::std::is_same_v<cuda::std::remove_cv_t<decltype(buf)>, Buffer>);
+    CCCLRT_CHECK(buf.size() == 7);
+    CCCLRT_CHECK(buf.stream() == other_stream_ref);
+    CCCLRT_CHECK(buf.memory_resource() == input.memory_resource());
+    CCCLRT_CHECK(buf.alignment() == alignment);
+    CCCLRT_CHECK(cuda::allocation_alignment(buf) == alignment);
+    CCCLRT_CHECK(is_pointer_aligned(buf.data(), alignment));
   }
 }
 


### PR DESCRIPTION
closes #10214 

I made a small change and added an explicit stream argument. I want all stream ordered APIs to have an explicit stream argument, so its clearly visible what is stream ordered and what is CPU ordered