### PR TITLE
Allow fixed-size spans in copy_bytes()

### DIFF
--- a/libcudacxx/include/cuda/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/__algorithm/copy.h
@@ -65,21 +65,35 @@ struct copy_configuration
 
 namespace __detail
 {
-template <typename _SrcTy, typename _DstTy>
+template <typename _SrcTy, ::cuda::std::size_t _SrcSize, typename _DstTy, ::cuda::std::size_t _DstSize>
 _CCCL_HOST_API void __copy_bytes_impl(
   stream_ref __stream,
-  ::cuda::std::span<_SrcTy> __src,
-  ::cuda::std::span<_DstTy> __dst,
+  ::cuda::std::span<_SrcTy, _SrcSize> __src,
+  ::cuda::std::span<_DstTy, _DstSize> __dst,
   [[maybe_unused]] copy_configuration __config)
 {
   static_assert(!::cuda::std::is_const_v<_DstTy>, "Copy destination can't be const");
   static_assert(::cuda::is_trivially_copyable_v<_SrcTy> && ::cuda::is_trivially_copyable_v<_DstTy>);
 
-  if (__src.size_bytes() > __dst.size_bytes())
+  // If neither are dynamic_extent then they are a number, and in that case we can check at compile-time
+  if constexpr ((_SrcSize != ::cuda::std::dynamic_extent) && (_DstSize != ::cuda::std::dynamic_extent))
   {
-    _CCCL_THROW(::std::invalid_argument, "Copy destination is too small to fit the source data");
+    // Can't use size_bytes() here because while the sizes are statically determinable, __src
+    // and __dest are not core constexpr expressions due to be function arguments.
+    constexpr auto __src_size  = _SrcSize * sizeof(_SrcTy);
+    constexpr auto __dest_size = _DstSize * sizeof(_DstTy);
+
+    static_assert(__dest_size >= __src_size, "Copy destination is too small to fit the source data");
   }
-  if (__src.size_bytes() == 0)
+  else
+  {
+    if (__src.size_bytes() > __dst.size_bytes())
+    {
+      _CCCL_THROW(::std::invalid_argument, "Copy destination is too small to fit the source data");
+    }
+  }
+
+  if (__src.empty())
   {
     return;
   }

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/copy.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/copy.cu
@@ -102,6 +102,37 @@ C2H_CCCLRT_TEST("1d Copy", "[algorithm]")
     CCCLRT_REQUIRE(vec[0] == get_expected_value(fill_byte));
     CCCLRT_REQUIRE(vec[1] == 0xbeef);
   }
+
+  SECTION("Fixed size")
+  {
+    auto host_buffer = make_pinned_memory_buffer<int>(_stream, buffer_size);
+    ::std::vector<int> vec(buffer_size, 0xbeef);
+    cuda::fill_bytes(_stream, host_buffer, fill_byte);
+
+    SECTION("Both fixed")
+    {
+      cuda::copy_bytes(_stream, cuda::std::span<int, buffer_size>{host_buffer}, cuda::std::span<int, buffer_size>{vec});
+      check_result_and_erase(_stream, vec);
+    }
+
+    SECTION("Src fixed")
+    {
+      cuda::copy_bytes(_stream,
+                       cuda::std::span<int, buffer_size>{host_buffer},
+                       // Don't technically need to spell out dynamic_extent here but just to be safe
+                       cuda::std::span<int, cuda::std::dynamic_extent>{vec});
+      check_result_and_erase(_stream, vec);
+    }
+
+    SECTION("Dest fixed")
+    {
+      cuda::copy_bytes(_stream,
+                       // Don't technically need to spell out dynamic_extent here but just to be safe
+                       cuda::std::span<int, cuda::std::dynamic_extent>{host_buffer},
+                       cuda::std::span<int, buffer_size>{vec});
+      check_result_and_erase(_stream, vec);
+    }
+  }
 }
 
 C2H_CCCLRT_TEST("copy_bytes uses the stream device when current device differs", "[algorithm][multi_gpu]")


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Allow fixed-size spans to be passed to `copy_bytes()`. As an added bonus, if both sizes are fixed we can check that all is well at compile-time.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
