### PR TITLE
CUB: Add a custom memory classification for Non Catch2

### DIFF
--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -62,6 +62,29 @@ function(_cub_is_fail_test result_var test_src)
   endif()
 endfunction()
 
+## _cub_validate_non_catch2_memory_class
+#
+# Require a non-Catch2 runtime test to declare exactly one GPU memory class.
+function(_cub_validate_non_catch2_memory_class test_src)
+  file(READ "${CMAKE_CURRENT_SOURCE_DIR}/${test_src}" test_source)
+  string(
+    REGEX MATCHALL
+    "CUB_TEST_MEMORY_CLASS\\([ \t\r\n]*(CUB_SMALL|CUB_LARGE)[ \t\r\n]*\\)"
+    memory_class_declarations
+    "${test_source}"
+  )
+  list(LENGTH memory_class_declarations memory_class_count)
+
+  if (NOT memory_class_count EQUAL 1)
+    message(
+      FATAL_ERROR
+      "${test_src} must declare exactly one of "
+      "CUB_TEST_MEMORY_CLASS(CUB_SMALL) or "
+      "CUB_TEST_MEMORY_CLASS(CUB_LARGE); found ${memory_class_count}."
+    )
+  endif()
+endfunction()
+
 ## _cub_launcher_requires_rdc
 #
 # If given launcher id corresponds to a CDP launcher, set `out_var` to 1.
@@ -217,6 +240,10 @@ function(
     endif()
   else() # Not catch2:
     _cub_is_fail_test(is_fail_test "${test_src}")
+
+    if (NOT is_fail_test)
+      _cub_validate_non_catch2_memory_class("${test_src}")
+    endif()
 
     if (is_fail_test)
       cccl_add_executable(

--- a/cub/test/cub_non_catch2_test_memory.h
+++ b/cub/test/cub_non_catch2_test_memory.h
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: BSD-3
 
+// TODO: Remove this header once test_device_batch_copy.cu is migrated to Catch2.
+// Make all remaining non-Catch2 runtime tests run as CUB_SMALL.
+
 #pragma once
 
 // Non-Catch2 runtime tests must declare exactly one memory class. CMake checks
@@ -9,6 +12,4 @@
 #define CUB_TEST_MEMORY_CLASS(MEMORY_CLASS) CUB_TEST_MEMORY_CLASS_##MEMORY_CLASS
 
 #define CUB_TEST_MEMORY_CLASS_CUB_SMALL static_assert(true)
-// TODO: Remove CUB_LARGE once test_device_batch_copy.cu is migrated to Catch2.
-// All remaining non-Catch2 runtime tests are small.
 #define CUB_TEST_MEMORY_CLASS_CUB_LARGE static_assert(true)

--- a/cub/test/cub_non_catch2_test_memory.h
+++ b/cub/test/cub_non_catch2_test_memory.h
@@ -9,4 +9,6 @@
 #define CUB_TEST_MEMORY_CLASS(MEMORY_CLASS) CUB_TEST_MEMORY_CLASS_##MEMORY_CLASS
 
 #define CUB_TEST_MEMORY_CLASS_CUB_SMALL static_assert(true)
+// TODO: Remove CUB_LARGE once test_device_batch_copy.cu is migrated to Catch2.
+// All remaining non-Catch2 runtime tests are small.
 #define CUB_TEST_MEMORY_CLASS_CUB_LARGE static_assert(true)

--- a/cub/test/cub_non_catch2_test_memory.h
+++ b/cub/test/cub_non_catch2_test_memory.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+#pragma once
+
+// Non-Catch2 runtime tests must declare exactly one memory class. CMake checks
+// this declaration while registering the test.
+
+#define CUB_TEST_MEMORY_CLASS(MEMORY_CLASS) CUB_TEST_MEMORY_CLASS_##MEMORY_CLASS
+
+#define CUB_TEST_MEMORY_CLASS_CUB_SMALL static_assert(true)
+#define CUB_TEST_MEMORY_CLASS_CUB_LARGE static_assert(true)

--- a/cub/test/test_allocator.cu
+++ b/cub/test/test_allocator.cu
@@ -16,7 +16,10 @@
 
 #include <cstdio>
 
+#include "cub_non_catch2_test_memory.h"
 #include "test_util.h"
+
+CUB_TEST_MEMORY_CLASS(CUB_SMALL);
 
 using namespace cub;
 

--- a/cub/test/test_block_radix_rank.cu
+++ b/cub/test/test_block_radix_rank.cu
@@ -17,7 +17,10 @@
 #include <iostream>
 #include <memory>
 
+#include "cub_non_catch2_test_memory.h"
 #include "test_util.h"
+
+CUB_TEST_MEMORY_CLASS(CUB_SMALL);
 
 bool g_verbose = false;
 cub::CachingDeviceAllocator g_allocator(true);

--- a/cub/test/test_cdp_variant_state.cu
+++ b/cub/test/test_cdp_variant_state.cu
@@ -18,6 +18,10 @@
 
 #include <cstdlib>
 
+#include "cub_non_catch2_test_memory.h"
+
+CUB_TEST_MEMORY_CLASS(CUB_SMALL);
+
 int main()
 {
   // This test just checks that RDC is enabled and detected properly when using

--- a/cub/test/test_device_batch_copy.cu
+++ b/cub/test/test_device_batch_copy.cu
@@ -21,9 +21,12 @@
 #include <utility>
 #include <vector>
 
+#include "cub_non_catch2_test_memory.h"
 #include "test_util.h"
 #include <c2h/catch2_test_helper.h>
 #include <c2h/vector.h>
+
+CUB_TEST_MEMORY_CLASS(CUB_LARGE);
 
 /**
  * @brief Host-side random data generation

--- a/cub/test/test_device_scan_warpspeed_shifted_output.cu
+++ b/cub/test/test_device_scan_warpspeed_shifted_output.cu
@@ -11,6 +11,10 @@
 
 #include <cstdio>
 
+#include "cub_non_catch2_test_memory.h"
+
+CUB_TEST_MEMORY_CLASS(CUB_SMALL);
+
 int main()
 {
   int in_h[2] = {1, 1};

--- a/cub/test/test_future_arch.cu
+++ b/cub/test/test_future_arch.cu
@@ -26,6 +26,10 @@
 
 #include <cuda/std/cstddef>
 
+#include "cub_non_catch2_test_memory.h"
+
+CUB_TEST_MEMORY_CLASS(CUB_SMALL);
+
 cudaError_t compile_only_fn(void* tmp_storage, cuda::std::size_t tmp_storage_size, int* in, int* out, int nitems)
 {
   return cub::DeviceReduce::Sum(tmp_storage, tmp_storage_size, in, out, nitems);

--- a/cub/test/test_namespace_wrapped.cu
+++ b/cub/test/test_namespace_wrapped.cu
@@ -19,7 +19,10 @@
 #include <cstdint>
 #include <cstdlib>
 
+#include "cub_non_catch2_test_memory.h"
 #include "test_util.h"
+
+CUB_TEST_MEMORY_CLASS(CUB_SMALL);
 
 // Test that we can use a few common utilities and algorithms from wrapped
 // Thrust/CUB namespaces at runtime. More extensive testing is performed by the

--- a/cub/test/test_nvtx_disabled.cu
+++ b/cub/test/test_nvtx_disabled.cu
@@ -6,6 +6,10 @@
 #include <cuda/iterator>
 #include <cuda/std/functional>
 
+#include "cub_non_catch2_test_memory.h"
+
+CUB_TEST_MEMORY_CLASS(CUB_SMALL);
+
 #if defined(CCCL_DISABLE_NVTX) && defined(NVTX_VERSION)
 #  error "NVTX was included somewhere even though it is turned off via CCCL_DISABLE_NVTX"
 #endif // defined(CCCL_DISABLE_NVTX) && defined(NVTX_VERSION)

--- a/cub/test/test_nvtx_in_usercode.cu
+++ b/cub/test/test_nvtx_in_usercode.cu
@@ -5,7 +5,10 @@
 #include <cuda/iterator>
 #include <cuda/std/functional>
 
+#include "cub_non_catch2_test_memory.h"
 #include <nvtx3/nvtx3.hpp> // user-side include of NVTX, retrieved elsewhere
+
+CUB_TEST_MEMORY_CLASS(CUB_SMALL);
 
 int main()
 {

--- a/cub/test/test_nvtx_in_usercode_explicit.cu
+++ b/cub/test/test_nvtx_in_usercode_explicit.cu
@@ -4,7 +4,10 @@
 #include <cuda/iterator>
 #include <cuda/std/functional>
 
+#include "cub_non_catch2_test_memory.h"
 #include <nvtx3/nvtx3.hpp> // user-side include of NVTX, retrieved elsewhere
+
+CUB_TEST_MEMORY_CLASS(CUB_SMALL);
 
 int main()
 {

--- a/cub/test/test_nvtx_standalone.cu
+++ b/cub/test/test_nvtx_standalone.cu
@@ -11,6 +11,10 @@
 #include <cuda/iterator>
 #include <cuda/std/functional>
 
+#include "cub_non_catch2_test_memory.h"
+
+CUB_TEST_MEMORY_CLASS(CUB_SMALL);
+
 int main()
 {
   _CCCL_NVTX_RANGE_SCOPE("main");


### PR DESCRIPTION
## Prerequisite for #9550.

**This PR should merge before [#10053](https://github.com/NVIDIA/cccl/pull/10053).** It establishes memory classification for standalone CUB runtime tests before #10053 uses those classifications for GPU scheduling.


## Summary

This change handles CUB runtime tests that do not use Catch2 and therefore cannot use `CUB_TEST(..., CUB_SMALL/CUB_LARGE)`.

Each standalone runtime test now declares exactly one file-level memory class:
CUB_TEST_MEMORY_CLASS(CUB_SMALL)
or:
CUB_TEST_MEMORY_CLASS(CUB_LARGE)

CMake validates the declaration and fails configuration when it is missing or duplicated. Small tests request 15% of a GPU, while large tests request 100%.