### PR TITLE
[libcu++] Add atomic debugger pretty-printers

### DIFF
--- a/libcudacxx/share/libcudacxx/gdb/__init__.py
+++ b/libcudacxx/share/libcudacxx/gdb/__init__.py
@@ -18,6 +18,7 @@ _SCRIPT_DIRECTORY = str(Path(__file__).resolve().parent)
 if _SCRIPT_DIRECTORY not in sys.path:
     sys.path.insert(0, _SCRIPT_DIRECTORY)
 
+import atomic  # noqa: E402
 import buffer  # noqa: E402
 import complex  # noqa: E402
 import event  # noqa: E402
@@ -26,7 +27,16 @@ import memory_resource  # noqa: E402
 import std_array  # noqa: E402
 import tuple  # noqa: E402
 
-_PRINTERS = (memory_resource, buffer, std_array, complex, tuple, inplace_vector, event)
+_PRINTERS = (
+    memory_resource,
+    atomic,
+    buffer,
+    std_array,
+    complex,
+    tuple,
+    inplace_vector,
+    event,
+)
 
 
 def register() -> None:

--- a/libcudacxx/share/libcudacxx/gdb/atomic.py
+++ b/libcudacxx/share/libcudacxx/gdb/atomic.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""GDB pretty printer for cuda::std::atomic and cuda::std::atomic_ref."""
+"""GDB pretty printers for CUDA atomic and atomic_ref types."""
 
 from __future__ import annotations
 
@@ -14,11 +14,18 @@ import memory_resource
 import gdb
 import gdb.printing
 
-_ATOMIC_NAMES = frozenset({"cuda::std::atomic", "cuda::std::atomic_ref"})
+_ATOMIC_NAMES = frozenset(
+    {"cuda::atomic", "cuda::atomic_ref", "cuda::std::atomic", "cuda::std::atomic_ref"}
+)
+_ATOMIC_REF_NAMES = frozenset({"cuda::atomic_ref", "cuda::std::atomic_ref"})
 
 
 def _template_name(type_name: str) -> str:
     return type_name.split("<", 1)[0]
+
+
+def _is_atomic_ref(type_name: str) -> bool:
+    return _template_name(type_name) in _ATOMIC_REF_NAMES
 
 
 def _is_cuda_atomic(value_type: gdb.Type) -> bool:
@@ -27,13 +34,16 @@ def _is_cuda_atomic(value_type: gdb.Type) -> bool:
     return template_name in _ATOMIC_NAMES
 
 
-def _stored_value(value: gdb.Value) -> gdb.Value:
+def _reference_pointer(value: gdb.Value) -> gdb.Value:
+    return value["__a"]["__a_value"]
+
+
+def _stored_value(value: gdb.Value, type_name: str) -> gdb.Value:
     value_type = value.type.strip_typedefs().unqualified()
-    type_name = memory_resource.public_type_name(value_type)
     storage = value["__a"]
     stored = storage["__a_value"]
 
-    if _template_name(type_name) == "cuda::std::atomic_ref":
+    if _is_atomic_ref(type_name):
         return stored.dereference()
 
     storage_type = str(storage.type.strip_typedefs())
@@ -53,9 +63,12 @@ class AtomicPrinter:
         self.type_name = memory_resource.public_type_name(self.type)
 
     def children(self) -> Iterator[tuple[str, gdb.Value]]:
-        yield "value", _stored_value(self.value)
+        yield "value", _stored_value(self.value, self.type_name)
 
     def to_string(self) -> str:
+        if _is_atomic_ref(self.type_name):
+            pointer = int(_reference_pointer(self.value))
+            return f"{self.type_name} ptr={pointer:#x}"
         return self.type_name
 
 
@@ -63,7 +76,7 @@ class AtomicPrinterLookup(gdb.printing.PrettyPrinter):
     """Select the atomic printer by its public class name."""
 
     def __init__(self) -> None:
-        super().__init__("cuda::std::atomic")
+        super().__init__("cuda::atomic")
 
     def __call__(self, value: gdb.Value) -> AtomicPrinter | None:
         if _is_cuda_atomic(value.type):

--- a/libcudacxx/share/libcudacxx/gdb/atomic.py
+++ b/libcudacxx/share/libcudacxx/gdb/atomic.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""GDB pretty printer for cuda::std::atomic and cuda::std::atomic_ref."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import ModuleType
+
+import memory_resource
+
+import gdb
+import gdb.printing
+
+_ATOMIC_NAMES = frozenset({"cuda::std::atomic", "cuda::std::atomic_ref"})
+
+
+def _template_name(type_name: str) -> str:
+    return type_name.split("<", 1)[0]
+
+
+def _is_cuda_atomic(value_type: gdb.Type) -> bool:
+    value_type = value_type.strip_typedefs().unqualified()
+    template_name = _template_name(memory_resource.public_type_name(value_type))
+    return template_name in _ATOMIC_NAMES
+
+
+def _stored_value(value: gdb.Value) -> gdb.Value:
+    value_type = value.type.strip_typedefs().unqualified()
+    type_name = memory_resource.public_type_name(value_type)
+    storage = value["__a"]
+    stored = storage["__a_value"]
+
+    if _template_name(type_name) == "cuda::std::atomic_ref":
+        return stored.dereference()
+
+    storage_type = str(storage.type.strip_typedefs())
+    if "__atomic_small_storage<" in storage_type:
+        stored = stored["__a_value"]
+        value_pointer_type = value_type.template_argument(0).pointer()
+        return stored.address.reinterpret_cast(value_pointer_type).dereference()
+    return stored
+
+
+class AtomicPrinter:
+    """Expose the value represented by a CUDA atomic without executing inferior code."""
+
+    def __init__(self, value: gdb.Value) -> None:
+        self.value = value
+        self.type = value.type.strip_typedefs().unqualified()
+        self.type_name = memory_resource.public_type_name(self.type)
+
+    def children(self) -> Iterator[tuple[str, gdb.Value]]:
+        yield "value", _stored_value(self.value)
+
+    def to_string(self) -> str:
+        return self.type_name
+
+
+class AtomicPrinterLookup(gdb.printing.PrettyPrinter):
+    """Select the atomic printer by its public class name."""
+
+    def __init__(self) -> None:
+        super().__init__("cuda::std::atomic")
+
+    def __call__(self, value: gdb.Value) -> AtomicPrinter | None:
+        if _is_cuda_atomic(value.type):
+            return AtomicPrinter(value)
+        return None
+
+
+def register(objfile: ModuleType) -> None:
+    """Register the CUDA atomic printer with GDB."""
+    gdb.printing.register_pretty_printer(objfile, AtomicPrinterLookup(), replace=True)

--- a/libcudacxx/share/libcudacxx/gdb/atomic.py
+++ b/libcudacxx/share/libcudacxx/gdb/atomic.py
@@ -18,6 +18,12 @@ _ATOMIC_NAMES = frozenset(
     {"cuda::atomic", "cuda::atomic_ref", "cuda::std::atomic", "cuda::std::atomic_ref"}
 )
 _ATOMIC_REF_NAMES = frozenset({"cuda::atomic_ref", "cuda::std::atomic_ref"})
+_THREAD_SCOPE_NAMES = {
+    0: "system",
+    1: "device",
+    2: "block",
+    10: "thread",
+}
 
 
 def _template_name(type_name: str) -> str:
@@ -26,6 +32,19 @@ def _template_name(type_name: str) -> str:
 
 def _is_atomic_ref(type_name: str) -> bool:
     return _template_name(type_name) in _ATOMIC_REF_NAMES
+
+
+def _complete_type_name(value_type: gdb.Type) -> str:
+    """Return the complete public type name, including CUDA thread scope."""
+    value_type = value_type.strip_typedefs().unqualified()
+    type_name = memory_resource.public_type_name(value_type)
+    template_name = _template_name(type_name)
+    if template_name not in {"cuda::atomic", "cuda::atomic_ref"}:
+        return type_name
+
+    value_type_name = memory_resource.public_type_name(value_type.template_argument(0))
+    scope = int(value_type.template_argument(1))
+    return f"{template_name}<{value_type_name}, cuda::thread_scope_{_THREAD_SCOPE_NAMES[scope]}>"
 
 
 def _is_cuda_atomic(value_type: gdb.Type) -> bool:
@@ -60,7 +79,7 @@ class AtomicPrinter:
     def __init__(self, value: gdb.Value) -> None:
         self.value = value
         self.type = value.type.strip_typedefs().unqualified()
-        self.type_name = memory_resource.public_type_name(self.type)
+        self.type_name = _complete_type_name(self.type)
 
     def children(self) -> Iterator[tuple[str, gdb.Value]]:
         yield "value", _stored_value(self.value, self.type_name)

--- a/libcudacxx/share/libcudacxx/lldb/__init__.py
+++ b/libcudacxx/share/libcudacxx/lldb/__init__.py
@@ -9,6 +9,7 @@ Requires Python 3.12 or newer.
 
 from __future__ import annotations
 
+import atomic
 import buffer
 import complex
 import event
@@ -22,6 +23,7 @@ import lldb
 _CATEGORY = "cccl"
 _FORMATTERS = (
     memory_resource,
+    atomic,
     buffer,
     std_array,
     complex,

--- a/libcudacxx/share/libcudacxx/lldb/atomic.py
+++ b/libcudacxx/share/libcudacxx/lldb/atomic.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""LLDB pretty printer for cuda::std::atomic and cuda::std::atomic_ref."""
+
+from __future__ import annotations
+
+import re
+
+import lldb
+
+_ATOMIC_PATTERN = re.compile(r"^cuda::std::atomic(?:_ref)?<.+>$")
+InternalDict = dict[str, object]
+
+
+def _type_name(value_type: lldb.SBType) -> str:
+    return value_type.GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName() or ""
+
+
+def is_cuda_atomic(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
+    return _ATOMIC_PATTERN.fullmatch(_type_name(value_type)) is not None
+
+
+def _stored_value(value: lldb.SBValue) -> lldb.SBValue:
+    value_type = value.GetType().GetCanonicalType().GetUnqualifiedType()
+    type_name = _type_name(value_type)
+    storage = value.GetChildMemberWithName("__a")
+    if not storage.IsValid():
+        return lldb.SBValue()
+
+    stored = storage.GetChildMemberWithName("__a_value")
+    if not stored.IsValid():
+        return lldb.SBValue()
+
+    if type_name.startswith("cuda::std::atomic_ref<"):
+        return stored.Dereference().Clone("value")
+
+    storage_type = _type_name(storage.GetType())
+    if "__atomic_small_storage<" in storage_type:
+        stored = stored.GetChildMemberWithName("__a_value")
+        if not stored.IsValid():
+            return lldb.SBValue()
+        address = stored.GetLoadAddress()
+        if address == lldb.LLDB_INVALID_ADDRESS:
+            return lldb.SBValue()
+        stored = stored.CreateValueFromAddress(
+            "value", address, value_type.GetTemplateArgumentType(0)
+        )
+    return stored.Clone("value")
+
+
+class AtomicSyntheticProvider:
+    """Expose the value represented by a CUDA atomic as one synthetic child."""
+
+    def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
+        self.value = value.GetNonSyntheticValue()
+        self.child = lldb.SBValue()
+        self.update()
+
+    def update(self) -> bool:
+        self.type_name = _type_name(self.value.GetType())
+        self.child = _stored_value(self.value)
+        return self.child.IsValid()
+
+    def num_children(self) -> int:
+        return int(self.child.IsValid())
+
+    def has_children(self) -> bool:
+        return self.child.IsValid()
+
+    def get_type_name(self) -> str:
+        return self.type_name
+
+    def get_child_index(self, name: str) -> int:
+        return 0 if name == "value" else -1
+
+    def get_child_at_index(self, index: int) -> lldb.SBValue | None:
+        if index == 0 and self.child.IsValid():
+            return self.child
+        return None
+
+
+def register(debugger: lldb.SBDebugger, category: str, module: str) -> None:
+    """Register CUDA atomic formatters in an LLDB category."""
+    debugger.HandleCommand(
+        f"type synthetic add --category {category} --python-class {module}.AtomicSyntheticProvider "
+        f"--recognizer-function {module}.is_cuda_atomic"
+    )

--- a/libcudacxx/share/libcudacxx/lldb/atomic.py
+++ b/libcudacxx/share/libcudacxx/lldb/atomic.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""LLDB pretty printer for cuda::std::atomic and cuda::std::atomic_ref."""
+"""LLDB pretty printers for CUDA atomic and atomic_ref types."""
 
 from __future__ import annotations
 
@@ -10,7 +10,8 @@ import re
 
 import lldb
 
-_ATOMIC_PATTERN = re.compile(r"^cuda::std::atomic(?:_ref)?<.+>$")
+_ATOMIC_PATTERN = re.compile(r"^cuda::(?:std::)?atomic(?:_ref)?<.+>$")
+_ATOMIC_REF_PATTERN = re.compile(r"^cuda::(?:std::)?atomic_ref<.+>$")
 InternalDict = dict[str, object]
 
 
@@ -22,20 +23,34 @@ def is_cuda_atomic(value_type: lldb.SBType, _internal_dict: InternalDict) -> boo
     return _ATOMIC_PATTERN.fullmatch(_type_name(value_type)) is not None
 
 
-def _stored_value(value: lldb.SBValue) -> lldb.SBValue:
-    value_type = value.GetType().GetCanonicalType().GetUnqualifiedType()
-    type_name = _type_name(value_type)
+def is_cuda_atomic_ref(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
+    return _ATOMIC_REF_PATTERN.fullmatch(_type_name(value_type)) is not None
+
+
+def _reference_pointer(value: lldb.SBValue) -> lldb.SBValue:
     storage = value.GetChildMemberWithName("__a")
     if not storage.IsValid():
         return lldb.SBValue()
+    return storage.GetChildMemberWithName("__a_value")
 
-    stored = storage.GetChildMemberWithName("__a_value")
+
+def atomic_ref_summary(value: lldb.SBValue, _internal_dict: InternalDict) -> str | None:
+    pointer = _reference_pointer(value.GetNonSyntheticValue())
+    if not pointer.IsValid():
+        return None
+    return f"ptr={pointer.GetValueAsUnsigned(0):#x}"
+
+
+def _stored_value(value: lldb.SBValue, type_name: str) -> lldb.SBValue:
+    value_type = value.GetType().GetCanonicalType().GetUnqualifiedType()
+    stored = _reference_pointer(value)
     if not stored.IsValid():
         return lldb.SBValue()
 
-    if type_name.startswith("cuda::std::atomic_ref<"):
+    if _ATOMIC_REF_PATTERN.fullmatch(type_name) is not None:
         return stored.Dereference().Clone("value")
 
+    storage = value.GetChildMemberWithName("__a")
     storage_type = _type_name(storage.GetType())
     if "__atomic_small_storage<" in storage_type:
         stored = stored.GetChildMemberWithName("__a_value")
@@ -60,7 +75,7 @@ class AtomicSyntheticProvider:
 
     def update(self) -> bool:
         self.type_name = _type_name(self.value.GetType())
-        self.child = _stored_value(self.value)
+        self.child = _stored_value(self.value, self.type_name)
         return self.child.IsValid()
 
     def num_children(self) -> int:
@@ -83,6 +98,10 @@ class AtomicSyntheticProvider:
 
 def register(debugger: lldb.SBDebugger, category: str, module: str) -> None:
     """Register CUDA atomic formatters in an LLDB category."""
+    debugger.HandleCommand(
+        f"type summary add --category {category} --expand --python-function "
+        f"{module}.atomic_ref_summary --recognizer-function {module}.is_cuda_atomic_ref"
+    )
     debugger.HandleCommand(
         f"type synthetic add --category {category} --python-class {module}.AtomicSyntheticProvider "
         f"--recognizer-function {module}.is_cuda_atomic"

--- a/libcudacxx/share/libcudacxx/lldb/atomic.py
+++ b/libcudacxx/share/libcudacxx/lldb/atomic.py
@@ -12,11 +12,33 @@ import lldb
 
 _ATOMIC_PATTERN = re.compile(r"^cuda::(?:std::)?atomic(?:_ref)?<.+>$")
 _ATOMIC_REF_PATTERN = re.compile(r"^cuda::(?:std::)?atomic_ref<.+>$")
+_ABI_NAMESPACE_PATTERN = re.compile(r"::__(?:\d+|version_bump_ver\d+_)(?=::)")
+_THREAD_SCOPE_VALUE_PATTERN = re.compile(
+    r"\((?:enum )?cuda(?:::std)?::thread_scope\)\s*(10|[012])(?=\s*>)"
+)
+_THREAD_SCOPE_NAMES = {
+    0: "system",
+    1: "device",
+    2: "block",
+    10: "thread",
+}
 InternalDict = dict[str, object]
 
 
 def _type_name(value_type: lldb.SBType) -> str:
     return value_type.GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName() or ""
+
+
+def _complete_type_name(value_type: lldb.SBType) -> str:
+    """Return the complete public type name, including default template arguments."""
+    value_type = value_type.GetCanonicalType().GetUnqualifiedType()
+    type_name = value_type.GetName() or value_type.GetDisplayTypeName() or ""
+    type_name = _ABI_NAMESPACE_PATTERN.sub("", type_name)
+    type_name = type_name.replace("cuda::std::thread_scope_", "cuda::thread_scope_")
+    return _THREAD_SCOPE_VALUE_PATTERN.sub(
+        lambda match: f"cuda::thread_scope_{_THREAD_SCOPE_NAMES[int(match.group(1))]}",
+        type_name,
+    )
 
 
 def is_cuda_atomic(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
@@ -74,7 +96,7 @@ class AtomicSyntheticProvider:
         self.update()
 
     def update(self) -> bool:
-        self.type_name = _type_name(self.value.GetType())
+        self.type_name = _complete_type_name(self.value.GetType())
         self.child = _stored_value(self.value, self.type_name)
         return self.child.IsValid()
 

--- a/libcudacxx/test/debugging/CMakeLists.txt
+++ b/libcudacxx/test/debugging/CMakeLists.txt
@@ -198,6 +198,7 @@ function(libcudacxx_add_pretty_printer_test)
 endfunction()
 
 add_subdirectory(array)
+add_subdirectory(atomic)
 add_subdirectory(buffer)
 add_subdirectory(complex)
 add_subdirectory(event)

--- a/libcudacxx/test/debugging/atomic/CMakeLists.txt
+++ b/libcudacxx/test/debugging/atomic/CMakeLists.txt
@@ -15,6 +15,9 @@ libcudacxx_add_pretty_printer_test(
     --case inspect_locked_reference 1 atomic.locked_reference locked_reference
     --case inspect_cuda_integer 1 atomic.cuda_integer cuda_integer
     --case inspect_cuda_reference 1 atomic.cuda_reference cuda_reference
+    --case inspect_cuda_device_integer 1 atomic.cuda_device_integer cuda_device_integer
+    --case inspect_cuda_block_reference 1 atomic.cuda_block_reference cuda_block_reference
+    --case inspect_cuda_thread_integer 1 atomic.cuda_thread_integer cuda_thread_integer
     --case inspect_before_update 1 atomic.update.before updated
     --case inspect_after_update 1 atomic.update.after updated
     --case inspect_reference_before_update 1 atomic.reference_update.before updated_reference

--- a/libcudacxx/test/debugging/atomic/CMakeLists.txt
+++ b/libcudacxx/test/debugging/atomic/CMakeLists.txt
@@ -13,6 +13,8 @@ libcudacxx_add_pretty_printer_test(
     --case inspect_nested 1 atomic.nested nested
     --case inspect_reference 1 atomic.reference reference
     --case inspect_locked_reference 1 atomic.locked_reference locked_reference
+    --case inspect_cuda_integer 1 atomic.cuda_integer cuda_integer
+    --case inspect_cuda_reference 1 atomic.cuda_reference cuda_reference
     --case inspect_before_update 1 atomic.update.before updated
     --case inspect_after_update 1 atomic.update.after updated
     --case inspect_reference_before_update 1 atomic.reference_update.before updated_reference

--- a/libcudacxx/test/debugging/atomic/CMakeLists.txt
+++ b/libcudacxx/test/debugging/atomic/CMakeLists.txt
@@ -1,0 +1,21 @@
+libcudacxx_add_pretty_printer_test(
+  NAME atomic
+  SOURCES source.cu
+  CASES
+    # gersemi: off
+    --case inspect_integer 1 atomic.integer integer
+    --case inspect_boolean 1 atomic.boolean boolean
+    --case inspect_small_object 1 atomic.small_object small_object
+    --case inspect_floating_point 1 atomic.floating_point floating_point
+    --case inspect_pointer 1 atomic.pointer pointer
+    --case inspect_locked 1 atomic.locked locked
+    --case inspect_alias 1 atomic.alias alias
+    --case inspect_nested 1 atomic.nested nested
+    --case inspect_reference 1 atomic.reference reference
+    --case inspect_locked_reference 1 atomic.locked_reference locked_reference
+    --case inspect_before_update 1 atomic.update.before updated
+    --case inspect_after_update 1 atomic.update.after updated
+    --case inspect_reference_before_update 1 atomic.reference_update.before updated_reference
+    --case inspect_reference_after_update 1 atomic.reference_update.after updated_reference
+    # gersemi: on
+)

--- a/libcudacxx/test/debugging/atomic/gdb.expected
+++ b/libcudacxx/test/debugging/atomic/gdb.expected
@@ -65,15 +65,30 @@ cuda::std::atomic_ref<payload> ptr=<address> = {
 }
 =============== atomic.locked_reference end ===============
 =============== atomic.cuda_integer begin ===============
-cuda::atomic<int> = {
+cuda::atomic<int, cuda::thread_scope_system> = {
   value = 41
 }
 =============== atomic.cuda_integer end ===============
 =============== atomic.cuda_reference begin ===============
-cuda::atomic_ref<int> ptr=<address> = {
+cuda::atomic_ref<int, cuda::thread_scope_system> ptr=<address> = {
   value = -26
 }
 =============== atomic.cuda_reference end ===============
+=============== atomic.cuda_device_integer begin ===============
+cuda::atomic<int, cuda::thread_scope_device> = {
+  value = 29
+}
+=============== atomic.cuda_device_integer end ===============
+=============== atomic.cuda_block_reference begin ===============
+cuda::atomic_ref<int, cuda::thread_scope_block> ptr=<address> = {
+  value = -38
+}
+=============== atomic.cuda_block_reference end ===============
+=============== atomic.cuda_thread_integer begin ===============
+cuda::atomic<int, cuda::thread_scope_thread> = {
+  value = 17
+}
+=============== atomic.cuda_thread_integer end ===============
 =============== atomic.update.before begin ===============
 cuda::std::atomic<int> = {
   value = 85

--- a/libcudacxx/test/debugging/atomic/gdb.expected
+++ b/libcudacxx/test/debugging/atomic/gdb.expected
@@ -1,0 +1,86 @@
+=============== atomic.integer begin ===============
+cuda::std::atomic<int> = {
+  value = -7
+}
+=============== atomic.integer end ===============
+=============== atomic.boolean begin ===============
+cuda::std::atomic<bool> = {
+  value = true
+}
+=============== atomic.boolean end ===============
+=============== atomic.small_object begin ===============
+cuda::std::atomic<small_payload> = {
+  value = {
+    first = true,
+    second = false
+  }
+}
+=============== atomic.small_object end ===============
+=============== atomic.floating_point begin ===============
+cuda::std::atomic<double> = {
+  value = -3.5
+}
+=============== atomic.floating_point end ===============
+=============== atomic.pointer begin ===============
+cuda::std::atomic<int*> = {
+  value = <address>
+}
+=============== atomic.pointer end ===============
+=============== atomic.locked begin ===============
+cuda::std::atomic<payload> = {
+  value = {
+    first = 13,
+    second = -5,
+    third = 88
+  }
+}
+=============== atomic.locked end ===============
+=============== atomic.alias begin ===============
+cuda::std::atomic<long long> = {
+  value = -31
+}
+=============== atomic.alias end ===============
+=============== atomic.nested begin ===============
+cuda::std::array<cuda::std::atomic<int>, 2> = {
+  [0] = cuda::std::atomic<int> = {
+    value = 17
+  },
+  [1] = cuda::std::atomic<int> = {
+    value = -64
+  }
+}
+=============== atomic.nested end ===============
+=============== atomic.reference begin ===============
+cuda::std::atomic_ref<int> = {
+  value = 52
+}
+=============== atomic.reference end ===============
+=============== atomic.locked_reference begin ===============
+cuda::std::atomic_ref<payload> = {
+  value = {
+    first = 6,
+    second = -91,
+    third = 3
+  }
+}
+=============== atomic.locked_reference end ===============
+=============== atomic.update.before begin ===============
+cuda::std::atomic<int> = {
+  value = 85
+}
+=============== atomic.update.before end ===============
+=============== atomic.update.after begin ===============
+cuda::std::atomic<int> = {
+  value = 99
+}
+=============== atomic.update.after end ===============
+=============== atomic.reference_update.before begin ===============
+cuda::std::atomic_ref<int> = {
+  value = -12
+}
+=============== atomic.reference_update.before end ===============
+=============== atomic.reference_update.after begin ===============
+cuda::std::atomic_ref<int> = {
+  value = 73
+}
+=============== atomic.reference_update.after end ===============

--- a/libcudacxx/test/debugging/atomic/gdb.expected
+++ b/libcudacxx/test/debugging/atomic/gdb.expected
@@ -51,12 +51,12 @@ cuda::std::array<cuda::std::atomic<int>, 2> = {
 }
 =============== atomic.nested end ===============
 =============== atomic.reference begin ===============
-cuda::std::atomic_ref<int> = {
+cuda::std::atomic_ref<int> ptr=<address> = {
   value = 52
 }
 =============== atomic.reference end ===============
 =============== atomic.locked_reference begin ===============
-cuda::std::atomic_ref<payload> = {
+cuda::std::atomic_ref<payload> ptr=<address> = {
   value = {
     first = 6,
     second = -91,
@@ -64,6 +64,16 @@ cuda::std::atomic_ref<payload> = {
   }
 }
 =============== atomic.locked_reference end ===============
+=============== atomic.cuda_integer begin ===============
+cuda::atomic<int> = {
+  value = 41
+}
+=============== atomic.cuda_integer end ===============
+=============== atomic.cuda_reference begin ===============
+cuda::atomic_ref<int> ptr=<address> = {
+  value = -26
+}
+=============== atomic.cuda_reference end ===============
 =============== atomic.update.before begin ===============
 cuda::std::atomic<int> = {
   value = 85
@@ -75,12 +85,12 @@ cuda::std::atomic<int> = {
 }
 =============== atomic.update.after end ===============
 =============== atomic.reference_update.before begin ===============
-cuda::std::atomic_ref<int> = {
+cuda::std::atomic_ref<int> ptr=<address> = {
   value = -12
 }
 =============== atomic.reference_update.before end ===============
 =============== atomic.reference_update.after begin ===============
-cuda::std::atomic_ref<int> = {
+cuda::std::atomic_ref<int> ptr=<address> = {
   value = 73
 }
 =============== atomic.reference_update.after end ===============

--- a/libcudacxx/test/debugging/atomic/lldb.expected
+++ b/libcudacxx/test/debugging/atomic/lldb.expected
@@ -42,13 +42,24 @@
 }
 =============== atomic.locked_reference end ===============
 =============== atomic.cuda_integer begin ===============
-(cuda::atomic<int>)  (value = 41)
+(cuda::atomic<int, cuda::thread_scope_system>)  (value = 41)
 =============== atomic.cuda_integer end ===============
 =============== atomic.cuda_reference begin ===============
-(cuda::atomic_ref<int>) ptr=<address> {
+(cuda::atomic_ref<int, cuda::thread_scope_system>) ptr=<address> {
   value = -26
 }
 =============== atomic.cuda_reference end ===============
+=============== atomic.cuda_device_integer begin ===============
+(cuda::atomic<int, cuda::thread_scope_device>)  (value = 29)
+=============== atomic.cuda_device_integer end ===============
+=============== atomic.cuda_block_reference begin ===============
+(cuda::atomic_ref<int, cuda::thread_scope_block>) ptr=<address> {
+  value = -38
+}
+=============== atomic.cuda_block_reference end ===============
+=============== atomic.cuda_thread_integer begin ===============
+(cuda::atomic<int, cuda::thread_scope_thread>)  (value = 17)
+=============== atomic.cuda_thread_integer end ===============
 =============== atomic.update.before begin ===============
 (cuda::std::atomic<int>)  (value = 85)
 =============== atomic.update.before end ===============

--- a/libcudacxx/test/debugging/atomic/lldb.expected
+++ b/libcudacxx/test/debugging/atomic/lldb.expected
@@ -1,0 +1,53 @@
+=============== atomic.integer begin ===============
+(cuda::std::atomic<int>)  (value = -7)
+=============== atomic.integer end ===============
+=============== atomic.boolean begin ===============
+(cuda::std::atomic<bool>)  (value = true)
+=============== atomic.boolean end ===============
+=============== atomic.small_object begin ===============
+(cuda::std::atomic<small_payload>) {
+  value = (first = true, second = false)
+}
+=============== atomic.small_object end ===============
+=============== atomic.floating_point begin ===============
+(cuda::std::atomic<double>)  (value = -3.5)
+=============== atomic.floating_point end ===============
+=============== atomic.pointer begin ===============
+(cuda::std::atomic<int *>) {
+  value = <address>
+}
+=============== atomic.pointer end ===============
+=============== atomic.locked begin ===============
+(cuda::std::atomic<payload>) {
+  value = (first = 13, second = -5, third = 88)
+}
+=============== atomic.locked end ===============
+=============== atomic.alias begin ===============
+(cuda::std::atomic<long long>)  (value = -31)
+=============== atomic.alias end ===============
+=============== atomic.nested begin ===============
+(cuda::std::array<cuda::std::atomic<int>, 2>) {
+  [0] = (value = 17)
+  [1] = (value = -64)
+}
+=============== atomic.nested end ===============
+=============== atomic.reference begin ===============
+(cuda::std::atomic_ref<int>)  (value = 52)
+=============== atomic.reference end ===============
+=============== atomic.locked_reference begin ===============
+(cuda::std::atomic_ref<payload>) {
+  value = (first = 6, second = -91, third = 3)
+}
+=============== atomic.locked_reference end ===============
+=============== atomic.update.before begin ===============
+(cuda::std::atomic<int>)  (value = 85)
+=============== atomic.update.before end ===============
+=============== atomic.update.after begin ===============
+(cuda::std::atomic<int>)  (value = 99)
+=============== atomic.update.after end ===============
+=============== atomic.reference_update.before begin ===============
+(cuda::std::atomic_ref<int>)  (value = -12)
+=============== atomic.reference_update.before end ===============
+=============== atomic.reference_update.after begin ===============
+(cuda::std::atomic_ref<int>)  (value = 73)
+=============== atomic.reference_update.after end ===============

--- a/libcudacxx/test/debugging/atomic/lldb.expected
+++ b/libcudacxx/test/debugging/atomic/lldb.expected
@@ -32,13 +32,23 @@
 }
 =============== atomic.nested end ===============
 =============== atomic.reference begin ===============
-(cuda::std::atomic_ref<int>)  (value = 52)
+(cuda::std::atomic_ref<int>) ptr=<address> {
+  value = 52
+}
 =============== atomic.reference end ===============
 =============== atomic.locked_reference begin ===============
-(cuda::std::atomic_ref<payload>) {
+(cuda::std::atomic_ref<payload>) ptr=<address> {
   value = (first = 6, second = -91, third = 3)
 }
 =============== atomic.locked_reference end ===============
+=============== atomic.cuda_integer begin ===============
+(cuda::atomic<int>)  (value = 41)
+=============== atomic.cuda_integer end ===============
+=============== atomic.cuda_reference begin ===============
+(cuda::atomic_ref<int>) ptr=<address> {
+  value = -26
+}
+=============== atomic.cuda_reference end ===============
 =============== atomic.update.before begin ===============
 (cuda::std::atomic<int>)  (value = 85)
 =============== atomic.update.before end ===============
@@ -46,8 +56,12 @@
 (cuda::std::atomic<int>)  (value = 99)
 =============== atomic.update.after end ===============
 =============== atomic.reference_update.before begin ===============
-(cuda::std::atomic_ref<int>)  (value = -12)
+(cuda::std::atomic_ref<int>) ptr=<address> {
+  value = -12
+}
 =============== atomic.reference_update.before end ===============
 =============== atomic.reference_update.after begin ===============
-(cuda::std::atomic_ref<int>)  (value = 73)
+(cuda::std::atomic_ref<int>) ptr=<address> {
+  value = 73
+}
 =============== atomic.reference_update.after end ===============

--- a/libcudacxx/test/debugging/atomic/source.cu
+++ b/libcudacxx/test/debugging/atomic/source.cu
@@ -137,6 +137,6 @@ int main()
   updated.store(99);
   inspect_after_update(updated);
   inspect_reference_before_update(updated_reference);
-  updated_target = 73;
+  updated_reference.store(73);
   inspect_reference_after_update(updated_reference);
 }

--- a/libcudacxx/test/debugging/atomic/source.cu
+++ b/libcudacxx/test/debugging/atomic/source.cu
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cuda/atomic>
 #include <cuda/std/array>
 #include <cuda/std/atomic>
 
@@ -80,6 +81,16 @@ using atomic_alias = cuda::std::atomic<long long>;
   keep_for_debugger(value);
 }
 
+[[gnu::noinline]] void inspect_cuda_integer(const cuda::atomic<int>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_cuda_reference(const cuda::atomic_ref<int>& value)
+{
+  keep_for_debugger(value);
+}
+
 [[gnu::noinline]] void inspect_before_update(const cuda::std::atomic<int>& value)
 {
   keep_for_debugger(value);
@@ -119,6 +130,10 @@ int main()
   payload referenced_payload{6, -91, 3};
   const cuda::std::atomic_ref<payload> locked_reference{referenced_payload};
 
+  const cuda::atomic<int> cuda_integer{41};
+  int cuda_referenced = -26;
+  const cuda::atomic_ref<int> cuda_reference{cuda_referenced};
+
   cuda::std::atomic<int> updated{85};
   int updated_target = -12;
   cuda::std::atomic_ref<int> updated_reference{updated_target};
@@ -133,6 +148,8 @@ int main()
   inspect_nested(nested);
   inspect_reference(reference);
   inspect_locked_reference(locked_reference);
+  inspect_cuda_integer(cuda_integer);
+  inspect_cuda_reference(cuda_reference);
   inspect_before_update(updated);
   updated.store(99);
   inspect_after_update(updated);

--- a/libcudacxx/test/debugging/atomic/source.cu
+++ b/libcudacxx/test/debugging/atomic/source.cu
@@ -91,6 +91,21 @@ using atomic_alias = cuda::std::atomic<long long>;
   keep_for_debugger(value);
 }
 
+[[gnu::noinline]] void inspect_cuda_device_integer(const cuda::atomic<int, cuda::thread_scope_device>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_cuda_block_reference(const cuda::atomic_ref<int, cuda::thread_scope_block>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_cuda_thread_integer(const cuda::atomic<int, cuda::thread_scope_thread>& value)
+{
+  keep_for_debugger(value);
+}
+
 [[gnu::noinline]] void inspect_before_update(const cuda::std::atomic<int>& value)
 {
   keep_for_debugger(value);
@@ -133,6 +148,10 @@ int main()
   const cuda::atomic<int> cuda_integer{41};
   int cuda_referenced = -26;
   const cuda::atomic_ref<int> cuda_reference{cuda_referenced};
+  const cuda::atomic<int, cuda::thread_scope_device> cuda_device_integer{29};
+  int cuda_block_referenced = -38;
+  const cuda::atomic_ref<int, cuda::thread_scope_block> cuda_block_reference{cuda_block_referenced};
+  const cuda::atomic<int, cuda::thread_scope_thread> cuda_thread_integer{17};
 
   cuda::std::atomic<int> updated{85};
   int updated_target = -12;
@@ -150,6 +169,9 @@ int main()
   inspect_locked_reference(locked_reference);
   inspect_cuda_integer(cuda_integer);
   inspect_cuda_reference(cuda_reference);
+  inspect_cuda_device_integer(cuda_device_integer);
+  inspect_cuda_block_reference(cuda_block_reference);
+  inspect_cuda_thread_integer(cuda_thread_integer);
   inspect_before_update(updated);
   updated.store(99);
   inspect_after_update(updated);

--- a/libcudacxx/test/debugging/atomic/source.cu
+++ b/libcudacxx/test/debugging/atomic/source.cu
@@ -1,0 +1,142 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cuda/std/array>
+#include <cuda/std/atomic>
+
+template <class T>
+[[gnu::noinline]] void keep_for_debugger(const T& value)
+{
+  asm volatile("" : : "g"(&value) : "memory");
+}
+
+struct alignas(16) payload
+{
+  int first;
+  int second;
+  int third;
+};
+
+struct small_payload
+{
+  bool first;
+  bool second;
+};
+
+static_assert(sizeof(payload) > 8);
+static_assert(alignof(payload) >= cuda::std::atomic_ref<payload>::required_alignment);
+static_assert(sizeof(small_payload) < 4);
+
+using atomic_alias = cuda::std::atomic<long long>;
+
+[[gnu::noinline]] void inspect_integer(const cuda::std::atomic<int>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_boolean(const cuda::std::atomic<bool>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_small_object(const cuda::std::atomic<small_payload>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_floating_point(const cuda::std::atomic<double>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_pointer(const cuda::std::atomic<int*>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_locked(const cuda::std::atomic<payload>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_alias(const atomic_alias& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_nested(const cuda::std::array<cuda::std::atomic<int>, 2>& values)
+{
+  keep_for_debugger(values);
+}
+
+[[gnu::noinline]] void inspect_reference(const cuda::std::atomic_ref<int>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_locked_reference(const cuda::std::atomic_ref<payload>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_before_update(const cuda::std::atomic<int>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_after_update(const cuda::std::atomic<int>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_reference_before_update(const cuda::std::atomic_ref<int>& value)
+{
+  keep_for_debugger(value);
+}
+
+[[gnu::noinline]] void inspect_reference_after_update(const cuda::std::atomic_ref<int>& value)
+{
+  keep_for_debugger(value);
+}
+
+int main()
+{
+  const cuda::std::atomic<int> integer{-7};
+  const cuda::std::atomic<bool> boolean{true};
+  const cuda::std::atomic<small_payload> small_object{small_payload{true, false}};
+  const cuda::std::atomic<double> floating_point{-3.5};
+  int pointee = 42;
+  const cuda::std::atomic<int*> pointer{&pointee};
+  const cuda::std::atomic<payload> locked{payload{13, -5, 88}};
+  const atomic_alias alias{-31};
+  cuda::std::array<cuda::std::atomic<int>, 2> nested{};
+  nested[0].store(17);
+  nested[1].store(-64);
+
+  int referenced = 52;
+  const cuda::std::atomic_ref<int> reference{referenced};
+  payload referenced_payload{6, -91, 3};
+  const cuda::std::atomic_ref<payload> locked_reference{referenced_payload};
+
+  cuda::std::atomic<int> updated{85};
+  int updated_target = -12;
+  cuda::std::atomic_ref<int> updated_reference{updated_target};
+
+  inspect_integer(integer);
+  inspect_boolean(boolean);
+  inspect_small_object(small_object);
+  inspect_floating_point(floating_point);
+  inspect_pointer(pointer);
+  inspect_locked(locked);
+  inspect_alias(alias);
+  inspect_nested(nested);
+  inspect_reference(reference);
+  inspect_locked_reference(locked_reference);
+  inspect_before_update(updated);
+  updated.store(99);
+  inspect_after_update(updated);
+  inspect_reference_before_update(updated_reference);
+  updated_target = 73;
+  inspect_reference_after_update(updated_reference);
+}


### PR DESCRIPTION
## Description

closes #10088

Add GDB and LLDB pretty-printers for `cuda::std::atomic` and `cuda::std::atomic_ref`. The formatters expose the logical value as a single `value` child without executing inferior functions and handle base, small, locked, and reference storage layouts.

The debugger tests cover scalar, small-object, floating-point, pointer, locked, alias, nested, reference, and live-update cases.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
