### PR TITLE
cudax: add configurable on_throw exception handling

### DIFF
--- a/cudax/include/cuda/experimental/__stf/graph/graph_task.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/graph_task.cuh
@@ -128,7 +128,7 @@ public:
 
     // DOT tracing and set_ready_prereqs must not throw after capture has begun,
     // or the stream would be left capturing. Abort instead.
-    throw_proof->*[&] {
+    on_throw(::std::abort) << [&] {
       if (dot.is_tracing())
       {
         dot.template add_vertex<task, logical_data_untyped>(*this);

--- a/cudax/include/cuda/experimental/__stf/internal/ctx_resource.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/ctx_resource.cuh
@@ -114,16 +114,17 @@ public:
 
       // Add a single host callback using lambda that will release all callback resources
       auto release_lambda = [](cudaStream_t /*stream*/, cudaError_t /*status*/, void* userData) -> void {
-        auto* resources = static_cast<decltype(callback_list.get())>(userData);
+        // The CUDA runtime calls this back, so an exception must not leave it.
+        on_throw(::std::abort) << [userData] {
+          auto* resources = static_cast<decltype(callback_list.get())>(userData);
 
-        // Release all callback resources
-        for (auto& resource : *resources)
-        {
-          // This is noexcept code
-          resource->release_in_callback();
-        }
+          for (auto& resource : *resources)
+          {
+            resource->release_in_callback();
+          }
 
-        delete resources;
+          delete resources;
+        };
       };
 
       cuda_try<cudaStreamAddCallback>(stream, release_lambda, callback_list.get(), 0);

--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -40,6 +40,7 @@
 #include <cuda/experimental/__stf/utility/cuda_safe_call.cuh>
 #include <cuda/experimental/__stf/utility/hash.cuh>
 #include <cuda/experimental/__stf/utility/nvtx.cuh>
+#include <cuda/experimental/__stf/utility/scope_guard.cuh>
 #include <cuda/experimental/__stf/utility/threads.cuh>
 #include <cuda/experimental/__stf/utility/unique_id.cuh>
 #include <cuda/experimental/__utility/meyers_singleton.cuh>
@@ -542,17 +543,21 @@ public:
   }
 
   template <typename task_type>
-  void add_vertex_timing(const task_type& t, float time_ms, [[maybe_unused]] int device = -1)
+  void add_vertex_timing(const task_type& t, float time_ms, [[maybe_unused]] int device = -1) noexcept
   {
-    ::std::scoped_lock guard(mtx);
+    // Timing metadata is diagnostic only; allocation or locking failures must
+    // not interfere with task teardown.
+    ::cuda::experimental::stf::on_throw(stderr) << [&] {
+      ::std::scoped_lock guard(mtx);
 
-    if (!tracing_enabled)
-    {
-      return;
-    }
+      if (!tracing_enabled)
+      {
+        return;
+      }
 
-    // Save timing information for this task
-    metadata[t.get_unique_id()].timing = time_ms;
+      // Save timing information for this task
+      metadata[t.get_unique_id()].timing = time_ms;
+    };
   }
 
   // Take a reference to an (unused) `::std::scoped_lock<::std::mutex>` to make sure someone did take a lock.

--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -36,6 +36,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/source_location>
+
 #include <cuda/experimental/__stf/internal/constants.cuh>
 #include <cuda/experimental/__stf/utility/cuda_safe_call.cuh>
 #include <cuda/experimental/__stf/utility/hash.cuh>
@@ -542,12 +544,21 @@ public:
     }
   }
 
+  //! @brief Records task timing metadata without disrupting task teardown on failure.
+  //!
+  //! @param[in] t The task whose timing is recorded.
+  //! @param[in] time_ms The task duration in milliseconds.
+  //! @param[in] device The device that executed the task, or `-1` if unspecified.
+  //! @param[in] loc The caller location reported if recording fails.
   template <typename task_type>
-  void add_vertex_timing(const task_type& t, float time_ms, [[maybe_unused]] int device = -1) noexcept
+  void add_vertex_timing(const task_type& t,
+                         float time_ms,
+                         [[maybe_unused]] int device            = -1,
+                         const ::cuda::std::source_location loc = ::cuda::std::source_location::current()) noexcept
   {
     // Timing metadata is diagnostic only; allocation or locking failures must
     // not interfere with task teardown.
-    ::cuda::experimental::stf::on_throw(stderr) << [&] {
+    ::cuda::experimental::stf::on_throw(stderr, loc) << [&] {
       ::std::scoped_lock guard(mtx);
 
       if (!tracing_enabled)

--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -558,7 +558,7 @@ public:
   {
     // Timing metadata is diagnostic only; allocation or locking failures must
     // not interfere with task teardown.
-    ::cuda::experimental::stf::on_throw(::cuda::experimental::stf::notify, loc) << [&] {
+    on_throw(notify, loc) << [&] {
       ::std::scoped_lock guard(mtx);
 
       if (!tracing_enabled)

--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -558,7 +558,7 @@ public:
   {
     // Timing metadata is diagnostic only; allocation or locking failures must
     // not interfere with task teardown.
-    ::cuda::experimental::stf::on_throw(stderr, loc) << [&] {
+    ::cuda::experimental::stf::on_throw(::cuda::experimental::stf::notify, loc) << [&] {
       ::std::scoped_lock guard(mtx);
 
       if (!tracing_enabled)

--- a/cudax/include/cuda/experimental/__stf/internal/host_launch_scope.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/host_launch_scope.cuh
@@ -34,6 +34,7 @@
 #include <cuda/experimental/__stf/internal/task_statistics.cuh>
 #include <cuda/experimental/__stf/internal/thread_hierarchy.cuh>
 #include <cuda/experimental/__stf/internal/void_interface.cuh>
+#include <cuda/experimental/__stf/utility/scope_guard.cuh>
 
 #include <memory>
 #include <type_traits>
@@ -327,15 +328,19 @@ public:
       user_data_dtor_    = nullptr;
 
       auto callback = [](void* raw) {
-        auto* w = static_cast<decltype(resolved.get())>(raw);
-        SCOPE(exit)
-        {
-          if constexpr (!::std::is_same_v<Ctx, graph_ctx>)
+        // The CUDA runtime calls this back, so an exception thrown by the user code must not
+        // leave it.
+        on_throw(::std::abort) << [raw] {
+          auto* w = static_cast<decltype(resolved.get())>(raw);
+          SCOPE(exit)
           {
-            delete w;
-          }
+            if constexpr (!::std::is_same_v<Ctx, graph_ctx>)
+            {
+              delete w;
+            }
+          };
+          w->first(w->second);
         };
-        w->first(w->second);
       };
 
       if constexpr (::std::is_same_v<Ctx, graph_ctx>)
@@ -375,30 +380,32 @@ public:
       auto wrapper = ::std::make_unique<::std::pair<Fun, decltype(payload)>>(::std::forward<Fun>(f), mv(payload));
 
       auto callback = [](void* untyped_wrapper) {
-        auto w = static_cast<decltype(wrapper.get())>(untyped_wrapper);
-        SCOPE(exit)
-        {
-          if constexpr (!::std::is_same_v<Ctx, graph_ctx>)
+        on_throw(::std::abort) << [untyped_wrapper] {
+          auto w = static_cast<decltype(wrapper.get())>(untyped_wrapper);
+          SCOPE(exit)
           {
-            delete w;
+            if constexpr (!::std::is_same_v<Ctx, graph_ctx>)
+            {
+              delete w;
+            }
+          };
+
+          constexpr bool fun_invocable_task_deps = reserved::is_applicable_v<Fun, decltype(payload)>;
+          constexpr bool fun_invocable_task_non_void_deps =
+            reserved::is_applicable_v<Fun, remove_void_interface_t<decltype(payload)>>;
+
+          static_assert(fun_invocable_task_deps || fun_invocable_task_non_void_deps,
+                        "Incorrect lambda function signature in host_launch.");
+
+          if constexpr (fun_invocable_task_deps)
+          {
+            ::std::apply(::std::forward<Fun>(w->first), mv(w->second));
+          }
+          else if constexpr (fun_invocable_task_non_void_deps)
+          {
+            ::std::apply(::std::forward<Fun>(w->first), reserved::remove_void_interface(mv(w->second)));
           }
         };
-
-        constexpr bool fun_invocable_task_deps = reserved::is_applicable_v<Fun, decltype(payload)>;
-        constexpr bool fun_invocable_task_non_void_deps =
-          reserved::is_applicable_v<Fun, remove_void_interface_t<decltype(payload)>>;
-
-        static_assert(fun_invocable_task_deps || fun_invocable_task_non_void_deps,
-                      "Incorrect lambda function signature in host_launch.");
-
-        if constexpr (fun_invocable_task_deps)
-        {
-          ::std::apply(::std::forward<Fun>(w->first), mv(w->second));
-        }
-        else if constexpr (fun_invocable_task_non_void_deps)
-        {
-          ::std::apply(::std::forward<Fun>(w->first), reserved::remove_void_interface(mv(w->second)));
-        }
       };
 
       if constexpr (::std::is_same_v<Ctx, graph_ctx>)

--- a/cudax/include/cuda/experimental/__stf/internal/parallel_for_scope.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/parallel_for_scope.cuh
@@ -34,6 +34,7 @@
 #include <cuda/experimental/__stf/internal/task_statistics.cuh>
 #include <cuda/experimental/__stf/stream/internal/event_types.cuh>
 #include <cuda/experimental/__stf/utility/occupancy.cuh>
+#include <cuda/experimental/__stf/utility/scope_guard.cuh>
 
 #include <type_traits>
 #include <utility>
@@ -1103,39 +1104,43 @@ public:
 
     // The function which the host callback will execute
     auto host_func = [](void* untyped_args) {
-      auto p = static_cast<decltype(args)>(untyped_args);
+      // The CUDA runtime calls this back, so an exception thrown by the user code must not leave
+      // it.
+      on_throw(::std::abort) << [untyped_args] {
+        auto p = static_cast<decltype(args)>(untyped_args);
 
-      auto& data               = ::std::get<0>(*p);
-      const size_t n           = ::std::get<1>(*p);
-      Fun& f                   = ::std::get<2>(*p);
-      const sub_shape_t& shape = ::std::get<3>(*p);
+        auto& data               = ::std::get<0>(*p);
+        const size_t n           = ::std::get<1>(*p);
+        Fun& f                   = ::std::get<2>(*p);
+        const sub_shape_t& shape = ::std::get<3>(*p);
 
-      // deps_ops_t are pairs of data instance type, and a reduction operator,
-      // this gets only the data instance types (eg. slice<double>)
-      auto explode_coords = [&](size_t i, auto&&... data) {
-        auto h = [&](auto&&... coords) {
-          f(::std::forward<decltype(coords)>(coords)..., ::std::forward<decltype(data)>(data)...);
+        // deps_ops_t are pairs of data instance type, and a reduction operator,
+        // this gets only the data instance types (eg. slice<double>)
+        auto explode_coords = [&](size_t i, auto&&... data) {
+          auto h = [&](auto&&... coords) {
+            f(::std::forward<decltype(coords)>(coords)..., ::std::forward<decltype(data)>(data)...);
+          };
+          auto coords = shape.index_to_coords(i);
+          if (!::cuda::experimental::stf::reserved::__shape_contains(shape, coords, 0))
+          {
+            return;
+          }
+          ::cuda::experimental::stf::reserved::__apply_coords(h, mv(coords));
         };
-        auto coords = shape.index_to_coords(i);
-        if (!::cuda::experimental::stf::reserved::__shape_contains(shape, coords, 0))
+
+        // Finally we get to do the workload on every 1D item of the shape
+        for (size_t i = 0; i < n; ++i)
         {
-          return;
+          ::std::apply(explode_coords, ::std::tuple_cat(::std::make_tuple(i), data));
         }
-        ::cuda::experimental::stf::reserved::__apply_coords(h, mv(coords));
+
+        // For stream contexts, delete immediately (no replay risk)
+        // For graph contexts, resource system handles cleanup (avoid use-after-free on replay)
+        if constexpr (!::std::is_same_v<context, graph_ctx>)
+        {
+          delete p;
+        }
       };
-
-      // Finally we get to do the workload on every 1D item of the shape
-      for (size_t i = 0; i < n; ++i)
-      {
-        ::std::apply(explode_coords, ::std::tuple_cat(::std::make_tuple(i), data));
-      }
-
-      // For stream contexts, delete immediately (no replay risk)
-      // For graph contexts, resource system handles cleanup (avoid use-after-free on replay)
-      if constexpr (!::std::is_same_v<context, graph_ctx>)
-      {
-        delete p;
-      }
     };
 
     if constexpr (::std::is_same_v<context, stream_ctx>)

--- a/cudax/include/cuda/experimental/__stf/internal/parallel_for_scope.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/parallel_for_scope.cuh
@@ -653,6 +653,18 @@ public:
 
     SCOPE(exit)
     {
+      if (start_event)
+      {
+        cuda_safe_call(cudaEventDestroy(start_event));
+      }
+      if (end_event)
+      {
+        cuda_safe_call(cudaEventDestroy(end_event));
+      }
+    };
+
+    SCOPE(success)
+    {
       t.end_uncleared();
       if constexpr (::std::is_same_v<context, stream_ctx>)
       {
@@ -677,6 +689,11 @@ public:
       }
 
       t.clear();
+    };
+
+    SCOPE(fail)
+    {
+      t.end();
     };
 
     if constexpr (::std::is_same_v<context, stream_ctx>)

--- a/cudax/include/cuda/experimental/__stf/internal/task_statistics.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/task_statistics.cuh
@@ -32,6 +32,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/source_location>
+
 #include <cuda/experimental/__stf/utility/hash.cuh>
 #include <cuda/experimental/__stf/utility/scope_guard.cuh>
 #include <cuda/experimental/__stf/utility/unittest.cuh>
@@ -93,12 +95,19 @@ public:
     calibrating = true;
   }
 
+  //! @brief Records calibration data without disrupting task teardown on failure.
+  //!
+  //! @param[in] t The task whose timing is recorded.
+  //! @param[in] time The task duration in milliseconds.
+  //! @param[in] loc The caller location reported if recording fails.
   template <typename task_type>
-  void log_task_time(const task_type& t, double time) noexcept
+  void log_task_time(const task_type& t,
+                     double time,
+                     const ::cuda::std::source_location loc = ::cuda::std::source_location::current()) noexcept
   {
     // Calibration is diagnostic only; allocation failures must not interfere
     // with task teardown.
-    ::cuda::experimental::stf::on_throw(stderr) << [&] {
+    ::cuda::experimental::stf::on_throw(stderr, loc) << [&] {
       auto key = ::std::pair{t.get_symbol(), get_data_footprint(t)};
 
       auto it = statistics.find(key);

--- a/cudax/include/cuda/experimental/__stf/internal/task_statistics.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/task_statistics.cuh
@@ -33,6 +33,7 @@
 #endif // no system header
 
 #include <cuda/experimental/__stf/utility/hash.cuh>
+#include <cuda/experimental/__stf/utility/scope_guard.cuh>
 #include <cuda/experimental/__stf/utility/unittest.cuh>
 #include <cuda/experimental/__utility/meyers_singleton.cuh>
 
@@ -93,19 +94,23 @@ public:
   }
 
   template <typename task_type>
-  void log_task_time(const task_type& t, double time)
+  void log_task_time(const task_type& t, double time) noexcept
   {
-    auto key = ::std::pair{t.get_symbol(), get_data_footprint(t)};
+    // Calibration is diagnostic only; allocation failures must not interfere
+    // with task teardown.
+    ::cuda::experimental::stf::on_throw(stderr) << [&] {
+      auto key = ::std::pair{t.get_symbol(), get_data_footprint(t)};
 
-    auto it = statistics.find(key);
-    if (it == statistics.end())
-    {
-      statistics.emplace(key, statistic(time));
-    }
-    else
-    {
-      it->second.update(time);
-    }
+      auto it = statistics.find(key);
+      if (it == statistics.end())
+      {
+        statistics.emplace(key, statistic(time));
+      }
+      else
+      {
+        it->second.update(time);
+      }
+    };
   }
 
   class statistic

--- a/cudax/include/cuda/experimental/__stf/internal/task_statistics.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/task_statistics.cuh
@@ -107,7 +107,7 @@ public:
   {
     // Calibration is diagnostic only; allocation failures must not interfere
     // with task teardown.
-    ::cuda::experimental::stf::on_throw(stderr, loc) << [&] {
+    ::cuda::experimental::stf::on_throw(::cuda::experimental::stf::notify, loc) << [&] {
       auto key = ::std::pair{t.get_symbol(), get_data_footprint(t)};
 
       auto it = statistics.find(key);

--- a/cudax/include/cuda/experimental/__stf/internal/task_statistics.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/task_statistics.cuh
@@ -107,7 +107,7 @@ public:
   {
     // Calibration is diagnostic only; allocation failures must not interfere
     // with task teardown.
-    ::cuda::experimental::stf::on_throw(::cuda::experimental::stf::notify, loc) << [&] {
+    on_throw(notify, loc) << [&] {
       auto key = ::std::pair{t.get_symbol(), get_data_footprint(t)};
 
       auto it = statistics.find(key);

--- a/cudax/include/cuda/experimental/__stf/places/exec/host/callback_queues.cuh
+++ b/cudax/include/cuda/experimental/__stf/places/exec/host/callback_queues.cuh
@@ -25,6 +25,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/experimental/__stf/utility/scope_guard.cuh>
 #include <cuda/experimental/__utility/meyers_singleton.cuh>
 
 #include <cstdio>
@@ -274,10 +275,13 @@ public:
 
   static void* callback_queue_worker(void* args)
   {
-    fprintf(stderr, "CALLBACK RUNNING...\n");
-    class callback_queue* cbq = (callback_queue*) args;
-    cudaCallbackQueueProgress(cbq, 1);
-    fprintf(stderr, "CALLBACK HALTING...\n");
+    // pthread calls this, so an exception must not leave it either.
+    on_throw(::std::abort) << [args] {
+      fprintf(stderr, "CALLBACK RUNNING...\n");
+      class callback_queue* cbq = (callback_queue*) args;
+      cudaCallbackQueueProgress(cbq, 1);
+      fprintf(stderr, "CALLBACK HALTING...\n");
+    };
 
     return NULL;
   }
@@ -296,27 +300,33 @@ inline int* cf_pop(callback_queue* q)
 
 inline void callback_dispatcher(cudaStream_t, cudaError_t, void* userData)
 {
-  class cb* cb_               = (cb*) userData;
-  class callback_queue* queue = cb_->queue;
+  // The CUDA runtime calls this back, so an exception must not leave it; it would also strand
+  // the queue mutex.
+  on_throw(::std::abort) << [userData] {
+    class cb* cb_               = (cb*) userData;
+    class callback_queue* queue = cb_->queue;
 
-  // Protect the queue
-  pthread_mutex_lock(&queue->mutex);
-  queue->dq.push_back(cb_);
-  pthread_cond_broadcast(&queue->cond);
-  pthread_mutex_unlock(&queue->mutex);
+    // Protect the queue
+    pthread_mutex_lock(&queue->mutex);
+    queue->dq.push_back(cb_);
+    pthread_cond_broadcast(&queue->cond);
+    pthread_mutex_unlock(&queue->mutex);
+  };
 }
 
 inline void cudagraph_callback_dispatcher(void* userData)
 {
-  cb* cb_ = (cb*) userData;
+  on_throw(::std::abort) << [userData] {
+    cb* cb_ = (cb*) userData;
 
-  class callback_queue* queue = cb_->queue;
+    class callback_queue* queue = cb_->queue;
 
-  // Protect the queue
-  pthread_mutex_lock(&queue->mutex);
-  queue->dq.push_back(cb_);
-  pthread_cond_broadcast(&queue->cond);
-  pthread_mutex_unlock(&queue->mutex);
+    // Protect the queue
+    pthread_mutex_lock(&queue->mutex);
+    queue->dq.push_back(cb_);
+    pthread_cond_broadcast(&queue->cond);
+    pthread_mutex_unlock(&queue->mutex);
+  };
 }
 
 // There is likely a more efficient way in the current implementation of callbacks !

--- a/cudax/include/cuda/experimental/__stf/stream/stream_task.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/stream_task.cuh
@@ -206,7 +206,7 @@ public:
     auto& dot = ctx.get_dot();
     // DOT tracing and set_ready_prereqs must not leave the task half-started;
     // abort instead of letting an exception escape.
-    throw_proof->*[&] {
+    on_throw(::std::abort) << [&] {
       if (dot->is_tracing())
       {
         dot->template add_vertex<task, logical_data_untyped>(*this);

--- a/cudax/include/cuda/experimental/__stf/utility/memory.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/memory.cuh
@@ -235,9 +235,12 @@ inline void deallocateHostMemory(void* p, size_t sz, cudaStream_t stream)
   cuda_try(cudaLaunchHostFunc(
     stream,
     [](void* vp) {
-      auto args = static_cast<::std::pair<size_t, void*>*>(vp);
-      deallocateHostMemory(args->second, args->first);
-      delete args;
+      // The CUDA runtime calls this back, so an exception must not leave it.
+      on_throw(::std::abort) << [vp] {
+        auto args = static_cast<::std::pair<size_t, void*>*>(vp);
+        deallocateHostMemory(args->second, args->first);
+        delete args;
+      };
     },
     args.get()));
   args.release();
@@ -262,9 +265,11 @@ inline void deallocateManagedMemory(void* p, size_t sz, cudaStream_t stream)
   cuda_try(cudaLaunchHostFunc(
     stream,
     [](void* vp) {
-      auto args = static_cast<::std::pair<size_t, void*>*>(vp);
-      deallocateManagedMemory(args->second, args->first);
-      delete args;
+      on_throw(::std::abort) << [vp] {
+        auto args = static_cast<::std::pair<size_t, void*>*>(vp);
+        deallocateManagedMemory(args->second, args->first);
+        delete args;
+      };
     },
     args.get()));
   args.release();
@@ -290,9 +295,11 @@ inline cudaGraphNode_t deallocateHostMemory(
   const cudaHostNodeParams params = {
     .fn =
       [](void* vp) {
-        auto args = static_cast<::std::pair<size_t, void*>*>(vp);
-        deallocateHostMemory(args->second, args->first);
-        delete args;
+        on_throw(::std::abort) << [vp] {
+          auto args = static_cast<::std::pair<size_t, void*>*>(vp);
+          deallocateHostMemory(args->second, args->first);
+          delete args;
+        };
       },
     .userData = args.get()};
   const auto result = cuda_try<cudaGraphAddHostNode>(graph, pDependencies, numDependencies, &params);

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -80,6 +80,120 @@ decltype(auto) operator<<(decltype(on_throw(::std::ignore)), _Fn&& __fn) noexcep
 }
 
 /**
+ * @brief The type of a handler that reports an exception and lets execution resume.
+ *
+ * The `decltype(::std::ignore)` return type marks the handler as suppressing; the returned
+ * value itself is discarded. The handler receives a pointer to the caught `std::exception`,
+ * or `nullptr` if the exception does not derive from `std::exception`, together with the
+ * location captured at the `on_throw` call site.
+ */
+using throw_handler_ignore_t =
+  decltype(::std::ignore) (*)(const ::std::exception*, ::cuda::std::source_location) noexcept;
+
+/**
+ * @brief The type of a handler that reports an exception and is expected not to return.
+ *
+ * The `void` return type marks the handler as terminating. `[[noreturn]]` appertains to a
+ * function declaration rather than to a function type, so it cannot be part of this alias
+ * and the contract is unenforceable; `::std::abort` runs if the handler returns anyway. The
+ * handler receives a pointer to the caught `std::exception`, or `nullptr` if the exception
+ * does not derive from `std::exception`, together with the location captured at the
+ * `on_throw` call site.
+ */
+using throw_handler_terminate_t = void (*)(const ::std::exception*, ::cuda::std::source_location) noexcept;
+
+/**
+ * @brief Creates a policy that hands an exception to a handler and then suppresses it.
+ *
+ * Apply the policy with `on_throw(handler) << callable`. If the callable throws, the handler
+ * is invoked with the caught exception (or `nullptr` for an exception that does not derive
+ * from `std::exception`) and `__loc`. Execution then resumes: a `void` result is suppressed
+ * and a non-void result is replaced with a default-constructed value. Consequently, a
+ * non-void callable must return a default-constructible type.
+ *
+ * @param[in] __handler A non-null suppressing handler.
+ * @param[in] __loc The location passed to the handler; defaults to the call site.
+ * @return A policy object consumed by `operator<<`.
+ */
+inline auto on_throw(throw_handler_ignore_t __handler,
+                     const ::cuda::std::source_location __loc = ::cuda::std::source_location::current()) noexcept
+{
+  struct __result
+  {
+    throw_handler_ignore_t __handler_;
+    ::cuda::std::source_location __loc_;
+  };
+  return __result{__handler, __loc};
+}
+
+template <class _Fn>
+decltype(auto) operator<<(decltype(on_throw(throw_handler_ignore_t{})) __policy, _Fn&& __fn) noexcept
+{
+  using _Result = decltype(::cuda::std::forward<_Fn>(__fn)());
+  static_assert(::cuda::std::is_void_v<_Result> || ::cuda::std::is_default_constructible_v<_Result>,
+                "on_throw(throw_handler_ignore_t) requires a default-constructible result");
+  _CCCL_TRY
+  {
+    return ::cuda::std::forward<_Fn>(__fn)();
+  }
+  _CCCL_CATCH (const ::std::exception& __exception)
+  {
+    __policy.__handler_(&__exception, __policy.__loc_);
+  }
+  _CCCL_CATCH_ALL
+  {
+    __policy.__handler_(nullptr, __policy.__loc_);
+  }
+
+  if constexpr (!::cuda::std::is_void_v<_Result>)
+  {
+    return _Result{};
+  }
+}
+
+/**
+ * @brief Creates a policy that hands an exception to a handler that must not return.
+ *
+ * Apply the policy with `on_throw(handler) << callable`. If the callable throws, the handler
+ * is invoked with the caught exception (or `nullptr` for an exception that does not derive
+ * from `std::exception`) and `__loc`. The handler is assumed to terminate; `::std::abort`
+ * runs immediately afterwards in case it returns.
+ *
+ * @param[in] __handler A non-null terminating handler.
+ * @param[in] __loc The location passed to the handler; defaults to the call site.
+ * @return A policy object consumed by `operator<<`.
+ */
+inline auto on_throw(throw_handler_terminate_t __handler,
+                     const ::cuda::std::source_location __loc = ::cuda::std::source_location::current()) noexcept
+{
+  struct __result
+  {
+    throw_handler_terminate_t __handler_;
+    ::cuda::std::source_location __loc_;
+  };
+  return __result{__handler, __loc};
+}
+
+template <class _Fn>
+decltype(auto) operator<<(decltype(on_throw(throw_handler_terminate_t{})) __policy, _Fn&& __fn) noexcept
+{
+  _CCCL_TRY
+  {
+    return ::cuda::std::forward<_Fn>(__fn)();
+  }
+  _CCCL_CATCH (const ::std::exception& __exception)
+  {
+    __policy.__handler_(&__exception, __policy.__loc_);
+  }
+  _CCCL_CATCH_ALL
+  {
+    __policy.__handler_(nullptr, __policy.__loc_);
+  }
+  ::std::abort();
+  _CCCL_UNREACHABLE();
+}
+
+/**
  * @brief Creates a policy that reports and suppresses exceptions.
  *
  * Apply the policy with `on_throw(stream) << callable`. If the callable throws,
@@ -204,6 +318,15 @@ UNITTEST("on_throw")
   EXPECT(value == 42);
   //! [on_throw]
 
+  // A terminating handler stays out of the way as long as nothing throws.
+  const throw_handler_terminate_t die = [](const ::std::exception*, ::cuda::std::source_location) noexcept {
+    ::std::abort();
+  };
+  const int untouched = on_throw(die) << [] {
+    return 7;
+  };
+  EXPECT(untouched == 7);
+
 #  if _CCCL_HAS_EXCEPTIONS()
   const int ignored = on_throw(::std::ignore) << []() -> int {
     throw ::std::runtime_error("ignored");
@@ -232,6 +355,30 @@ UNITTEST("on_throw")
              loc.function_name());
   EXPECT(::std::string_view{message} == expected);
   ::fclose(log);
+
+  // A suppressing handler sees the exception and the call site, then execution resumes.
+  static bool saw_std_exception = false;
+  static unsigned reported_line = 0;
+  const throw_handler_ignore_t note =
+    [](const ::std::exception* __exception, ::cuda::std::source_location __where) noexcept -> decltype(::std::ignore) {
+    saw_std_exception = __exception != nullptr;
+    reported_line     = __where.line();
+    return ::std::ignore;
+  };
+
+  const auto site = ::cuda::std::source_location::current();
+  const int noted = on_throw(note, site) << []() -> int {
+    throw ::std::runtime_error("noted");
+  };
+  EXPECT(noted == 0);
+  EXPECT(saw_std_exception);
+  EXPECT(reported_line == site.line());
+
+  // An exception that does not derive from std::exception reaches the handler as nullptr.
+  on_throw(note, site) << [] {
+    throw 42;
+  };
+  EXPECT(!saw_std_exception);
 #  endif // _CCCL_HAS_EXCEPTIONS()
 };
 #endif // UNITTESTED_FILE

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -57,7 +57,7 @@ namespace cuda::experimental::stf
  * @param[in] __exception The caught exception, or `nullptr` if it does not derive from
  *            `std::exception`, in which case the report carries no message.
  * @param[in] __loc The location to report.
- * @return `::std::ignore`, which marks this handler as suppressing.
+ * @return `std::ignore`, which marks this handler as suppressing.
  */
 inline decltype(::std::ignore)
 notify(const ::std::exception* __exception, const ::cuda::std::source_location __loc) noexcept
@@ -97,9 +97,10 @@ struct __on_throw_policy
   _Reaction __reaction_;
   ::cuda::std::source_location __loc_;
 
-  // Runs with the exception in flight and produces what `operator<<` returns in its stead.
+  // Runs with the exception in flight and produces what `operator<<` returns in its stead. The
+  // reactions that say nothing never read the exception, which gcc 9 flags without the attribute.
   template <class _Result>
-  _Result __report(const ::std::exception* __exception) noexcept
+  _Result __report([[maybe_unused]] const ::std::exception* __exception) noexcept
   {
     // A handler is anything callable with the caught exception and a location; the other three
     // reactions are recognized in the branches below.
@@ -189,11 +190,11 @@ decltype(auto) operator<<(__on_throw_policy<_Reaction> __policy, _Fn&& __fn) noe
  *   exception that does not derive from `std::exception`, along with `__loc`. Its return type
  *   says what happens next: returning `decltype(::std::ignore)` resumes execution with a
  *   default-constructed result, and returning `void` claims the handler ends the program, with
- *   `::std::abort` running right after it in case it does not. `notify` is such a handler.
- * - A terminating action: any nullary `noexcept` callable returning `void`, `::std::abort` and
- *   `::std::terminate` being the obvious ones. The exception is reported through `notify`, the
- *   action runs, and `::std::abort` follows in case it returns.
- * - `::std::ignore`, which suppresses the exception silently and resumes execution with a
+ *   `std::abort` running right after it in case it does not. `notify` is such a handler.
+ * - A terminating action: any nullary `noexcept` callable returning `void`, `std::abort` and
+ *   `std::terminate` being the obvious ones. The exception is reported through `notify`, the
+ *   action runs, and `std::abort` follows in case it returns.
+ * - `std::ignore`, which suppresses the exception silently and resumes execution with a
  *   default-constructed result.
  * - Anything else, taken as a replacement value for the result. It must be convertible to the
  *   callable's result type, and is moved into the result.

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -26,10 +26,10 @@
 #endif // no system header
 
 #include <cuda/std/__exception/exception_macros.h>
-#include <cuda/std/__type_traits/decay.h>
-#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__functional/invoke.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/is_default_constructible.h>
+#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_void.h>
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/move.h>
@@ -48,70 +48,11 @@
 namespace cuda::experimental::stf
 {
 /**
- * @brief Creates a policy that suppresses exceptions.
- *
- * Apply the policy to a callable with `on_throw(::std::ignore) << callable`.
- * If the callable throws, a `void` result is simply suppressed and a non-void
- * result is replaced with a default-constructed value. Consequently, a
- * non-void callable must return a default-constructible type.
- *
- * @return A policy object consumed by `operator<<`.
- */
-inline auto on_throw(decltype(::std::ignore)) noexcept
-{
-  struct __result
-  {};
-  return __result{};
-}
-
-template <class _Fn>
-decltype(auto) operator<<(decltype(on_throw(::std::ignore)), _Fn&& __fn) noexcept
-{
-  using _Result = decltype(::cuda::std::forward<_Fn>(__fn)());
-  static_assert(::cuda::std::is_void_v<_Result> || ::cuda::std::is_default_constructible_v<_Result>,
-                "on_throw(std::ignore) requires a default-constructible result");
-  _CCCL_TRY
-  {
-    return ::cuda::std::forward<_Fn>(__fn)();
-  }
-  _CCCL_CATCH_ALL
-  {
-    if constexpr (!::cuda::std::is_void_v<_Result>)
-    {
-      return _Result{};
-    }
-  }
-}
-
-/**
- * @brief The type of a handler that reports an exception and lets execution resume.
- *
- * The `decltype(::std::ignore)` return type marks the handler as suppressing; the returned
- * value itself is discarded. The handler receives a pointer to the caught `std::exception`,
- * or `nullptr` if the exception does not derive from `std::exception`, together with the
- * location captured at the `on_throw` call site.
- */
-using throw_handler_ignore_t =
-  decltype(::std::ignore) (*)(const ::std::exception*, ::cuda::std::source_location) noexcept;
-
-/**
- * @brief The type of a handler that reports an exception and is expected not to return.
- *
- * The `void` return type marks the handler as terminating. `[[noreturn]]` appertains to a
- * function declaration rather than to a function type, so it cannot be part of this alias
- * and the contract is unenforceable; `::std::abort` runs if the handler returns anyway. The
- * handler receives a pointer to the caught `std::exception`, or `nullptr` if the exception
- * does not derive from `std::exception`, together with the location captured at the
- * `on_throw` call site.
- */
-using throw_handler_terminate_t = void (*)(const ::std::exception*, ::cuda::std::source_location) noexcept;
-
-/**
  * @brief A suppressing handler that reports an exception on `stderr` and flushes it.
  *
  * Use it as in `on_throw(notify) << callable` to report an exception and carry on.
- * Reporting to a destination other than `stderr` is a matter of defining another
- * `throw_handler_ignore_t`.
+ * Reporting to a destination other than `stderr` is a matter of writing another
+ * handler, which this function doubles as the model for.
  *
  * @param[in] __exception The caught exception, or `nullptr` if it does not derive from
  *            `std::exception`, in which case the report carries no message.
@@ -142,205 +83,132 @@ notify(const ::std::exception* __exception, const ::cuda::std::source_location _
   return ::std::ignore;
 }
 
-/**
- * @brief Creates a policy that hands an exception to a handler and then suppresses it.
- *
- * Apply the policy with `on_throw(handler) << callable`. If the callable throws, the handler
- * is invoked with the caught exception (or `nullptr` for an exception that does not derive
- * from `std::exception`) and `__loc`. Execution then resumes: a `void` result is suppressed
- * and a non-void result is replaced with a default-constructed value. Consequently, a
- * non-void callable must return a default-constructible type.
- *
- * @param[in] __handler A non-null suppressing handler.
- * @param[in] __loc The location passed to the handler; defaults to the call site.
- * @return A policy object consumed by `operator<<`.
- */
-inline auto on_throw(throw_handler_ignore_t __handler,
-                     const ::cuda::std::source_location __loc = ::cuda::std::source_location::current()) noexcept
-{
-  struct __result
-  {
-    throw_handler_ignore_t __handler_;
-    ::cuda::std::source_location __loc_;
-  };
-  return __result{__handler, __loc};
-}
-
-template <class _Fn>
-decltype(auto) operator<<(decltype(on_throw(throw_handler_ignore_t{})) __policy, _Fn&& __fn) noexcept
-{
-  using _Result = decltype(::cuda::std::forward<_Fn>(__fn)());
-  static_assert(::cuda::std::is_void_v<_Result> || ::cuda::std::is_default_constructible_v<_Result>,
-                "on_throw(throw_handler_ignore_t) requires a default-constructible result");
-  _CCCL_TRY
-  {
-    return ::cuda::std::forward<_Fn>(__fn)();
-  }
-  _CCCL_CATCH (const ::std::exception& __exception)
-  {
-    __policy.__handler_(&__exception, __policy.__loc_);
-  }
-  _CCCL_CATCH_ALL
-  {
-    __policy.__handler_(nullptr, __policy.__loc_);
-  }
-
-  if constexpr (!::cuda::std::is_void_v<_Result>)
-  {
-    return _Result{};
-  }
-}
-
-/**
- * @brief Creates a policy that hands an exception to a handler that must not return.
- *
- * Apply the policy with `on_throw(handler) << callable`. If the callable throws, the handler
- * is invoked with the caught exception (or `nullptr` for an exception that does not derive
- * from `std::exception`) and `__loc`. The handler is assumed to terminate; `::std::abort`
- * runs immediately afterwards in case it returns.
- *
- * @param[in] __handler A non-null terminating handler.
- * @param[in] __loc The location passed to the handler; defaults to the call site.
- * @return A policy object consumed by `operator<<`.
- */
-inline auto on_throw(throw_handler_terminate_t __handler,
-                     const ::cuda::std::source_location __loc = ::cuda::std::source_location::current()) noexcept
-{
-  struct __result
-  {
-    throw_handler_terminate_t __handler_;
-    ::cuda::std::source_location __loc_;
-  };
-  return __result{__handler, __loc};
-}
-
-template <class _Fn>
-decltype(auto) operator<<(decltype(on_throw(throw_handler_terminate_t{})) __policy, _Fn&& __fn) noexcept
-{
-  _CCCL_TRY
-  {
-    return ::cuda::std::forward<_Fn>(__fn)();
-  }
-  _CCCL_CATCH (const ::std::exception& __exception)
-  {
-    __policy.__handler_(&__exception, __policy.__loc_);
-  }
-  _CCCL_CATCH_ALL
-  {
-    __policy.__handler_(nullptr, __policy.__loc_);
-  }
-  ::std::abort();
-  _CCCL_UNREACHABLE();
-}
-
-/**
- * @brief Creates a policy that reports an exception and terminates.
- *
- * Apply the policy with `on_throw(::std::abort) << callable` or
- * `on_throw(::std::terminate) << callable`. If the callable throws, the policy
- * reports the exception through `notify` and invokes the chosen handler. Passing
- * any other function pointer reports the invalid handler and terminates
- * immediately.
- *
- * @param[in] __handler The address of `std::abort` or `std::terminate`.
- * @param[in] __loc The location reported on failure; defaults to the call site.
- * @return A policy object consumed by `operator<<`.
- */
-inline auto on_throw(void (*__handler)() noexcept,
-                     const ::cuda::std::source_location __loc = ::cuda::std::source_location::current()) noexcept
-{
-  struct local
-  {
-    static void abort(const ::std::exception* __exception, ::cuda::std::source_location __where) noexcept
-    {
-      notify(__exception, __where);
-      ::std::abort();
-    }
-    static void terminate(const ::std::exception* __exception, ::cuda::std::source_location __where) noexcept
-    {
-      notify(__exception, __where);
-      ::std::terminate();
-    }
-  };
-  if (__handler == &::std::abort)
-  {
-    return on_throw(local::abort, __loc);
-  }
-  if (__handler == &::std::terminate)
-  {
-    return on_throw(local::terminate, __loc);
-  }
-  // The function-pointer type also accepts any other `void() noexcept` function,
-  // so overload resolution alone cannot restrict this argument to these two values.
-  ::fprintf(stderr,
-            "%s(%u) invalid on_throw termination handler in %s; expected std::abort or std::terminate\n",
-            __loc.file_name(),
-            __loc.line(),
-            __loc.function_name());
-  ::fflush(stderr);
-  ::std::terminate();
-  _CCCL_UNREACHABLE();
-}
-
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 namespace detail
 {
-// Unlike the other policies this one cannot keep its state in a local struct, because
-// `operator<<` has to deduce the value type and could not do so from a parameter spelled
-// `decltype(on_throw(...))`. Its `operator<<` lives here as well, so that argument-dependent
-// lookup, which only searches the innermost namespace enclosing the policy, still finds it.
-template <class _Value>
-struct __on_throw_value
+// One policy for all four reactions: the alternative is constraining the `on_throw` overloads
+// against one another, which is fragile, because clang keeps `[[noreturn]]` in the type of
+// `std::abort` and thereby makes a `void (*)() noexcept` parameter an inexact match that a
+// catch-all template would win. `operator<<` lives here too, since argument-dependent lookup
+// only searches the innermost namespace enclosing the policy type.
+template <class _Reaction>
+struct __on_throw_policy
 {
-  _Value __value_;
+  _Reaction __reaction_;
+  ::cuda::std::source_location __loc_;
+
+  // Runs with the exception in flight and produces what `operator<<` returns in its stead.
+  template <class _Result>
+  _Result __report(const ::std::exception* __exception) noexcept
+  {
+    // A handler is anything callable with the caught exception and a location; the other three
+    // reactions are recognized in the branches below.
+    constexpr bool __handles =
+      ::cuda::std::is_invocable_v<_Reaction&, const ::std::exception*, ::cuda::std::source_location>;
+    constexpr bool __drops = ::cuda::std::is_same_v<const _Reaction, const decltype(::std::ignore)>;
+    // Whether the exception is answered rather than fatal, which `::std::ignore` decides by being
+    // what it is and a handler decides by returning it. Asking the same of `void` would be
+    // useless, every result type being convertible to `void`, but nothing except `::std::ignore`
+    // itself converts to its type.
+    constexpr bool __resumes =
+      __handles
+        ? ::cuda::std::
+            is_invocable_r_v<decltype(::std::ignore), _Reaction&, const ::std::exception*, ::cuda::std::source_location>
+        : __drops;
+
+    if constexpr (__handles)
+    {
+      static_assert(
+        ::cuda::std::is_nothrow_invocable_v<_Reaction&, const ::std::exception*, ::cuda::std::source_location>,
+        "an on_throw handler runs while an exception is in flight and must be noexcept");
+      __reaction_(__exception, __loc_);
+      if constexpr (!__resumes)
+      {
+        static_assert(
+          ::cuda::std::is_void_v<
+            ::cuda::std::invoke_result_t<_Reaction&, const ::std::exception*, ::cuda::std::source_location>>,
+          "an on_throw handler must return void, to end the program, or ::std::ignore, to go on");
+        ::std::abort(); // the handler was supposed to see to that itself
+        _CCCL_UNREACHABLE();
+      }
+    }
+    else if constexpr (::cuda::std::is_convertible_v<_Reaction, void (*)() noexcept>)
+    {
+      // A terminating action, `::std::abort` and `::std::terminate` being the ones worth naming.
+      notify(__exception, __loc_);
+      __reaction_();
+      ::std::abort(); // in case it returns after all
+      _CCCL_UNREACHABLE();
+    }
+    else if constexpr (!__drops)
+    {
+      static_assert(::cuda::std::is_convertible_v<_Reaction, _Result>,
+                    "on_throw(value) requires a value convertible to the result of the callable");
+      return static_cast<_Result>(::cuda::std::move(__reaction_));
+    }
+
+    // Left over are the two reactions that resume, both of which owe the caller a result.
+    if constexpr (__resumes && !::cuda::std::is_void_v<_Result>)
+    {
+      static_assert(::cuda::std::is_default_constructible_v<_Result>,
+                    "an on_throw reaction that resumes requires a default-constructible result");
+      return _Result{};
+    }
+  }
 };
 
-// Anything the other overloads accept must be kept away from the value overload. Preferring a
-// non-template overload on a tie is not enough: clang keeps `[[noreturn]]` in the type of
-// `std::abort`, which makes the termination overload an inexact match that the value overload
-// would win.
-template <class _Tp>
-inline constexpr bool __selects_on_throw_policy_v =
-  ::cuda::std::is_convertible_v<_Tp, decltype(::std::ignore)> //
-  || ::cuda::std::is_convertible_v<_Tp, throw_handler_ignore_t> //
-  || ::cuda::std::is_convertible_v<_Tp, throw_handler_terminate_t> //
-  || ::cuda::std::is_convertible_v<_Tp, void (*)() noexcept>;
-
-template <class _Value, class _Fn>
-decltype(auto) operator<<(__on_throw_value<_Value> __policy, _Fn&& __fn) noexcept
+template <class _Reaction, class _Fn>
+decltype(auto) operator<<(__on_throw_policy<_Reaction> __policy, _Fn&& __fn) noexcept
 {
   using _Result = decltype(::cuda::std::forward<_Fn>(__fn)());
-  static_assert(::cuda::std::is_convertible_v<_Value, _Result>,
-                "on_throw(value) requires a value convertible to the result of the callable");
   _CCCL_TRY
   {
     return ::cuda::std::forward<_Fn>(__fn)();
   }
+  _CCCL_CATCH (const ::std::exception& __exception)
+  {
+    return __policy.template __report<_Result>(&__exception);
+  }
   _CCCL_CATCH_ALL
   {
-    return static_cast<_Result>(::cuda::std::move(__policy.__value_));
+    return __policy.template __report<_Result>(nullptr);
   }
 }
 } // namespace detail
 #endif // !_CCCL_DOXYGEN_INVOKED
 
 /**
- * @brief Creates a policy that replaces a thrown exception with a value.
+ * @brief Creates a policy saying how to react if a callable throws.
  *
- * `on_throw(value) << callable` evaluates to the result of the callable, or to `value`
- * converted to that result type if the callable throws. The value is stored in the policy,
- * so a temporary is safe, and it is moved into the result. Handlers are not values: an
- * argument convertible to `throw_handler_ignore_t` or `throw_handler_terminate_t` selects
- * the corresponding handler overload instead.
+ * Apply the policy with `on_throw(reaction) << callable`, which evaluates to the result of the
+ * callable when nothing goes wrong. The reaction is one of four things, recognized by type:
  *
- * @param[in] __value The replacement, which must be convertible to the callable's result
- *            and must not throw while being converted.
+ * - A handler: any `noexcept` callable accepting a `const std::exception*` and a
+ *   `cuda::std::source_location`, be it a function, a function pointer, or a function object,
+ *   capturing or not. It is invoked with the caught exception, or with `nullptr` for an
+ *   exception that does not derive from `std::exception`, along with `__loc`. Its return type
+ *   says what happens next: returning `decltype(::std::ignore)` resumes execution with a
+ *   default-constructed result, and returning `void` claims the handler ends the program, with
+ *   `::std::abort` running right after it in case it does not. `notify` is such a handler.
+ * - A terminating action: any nullary `noexcept` callable returning `void`, `::std::abort` and
+ *   `::std::terminate` being the obvious ones. The exception is reported through `notify`, the
+ *   action runs, and `::std::abort` follows in case it returns.
+ * - `::std::ignore`, which suppresses the exception silently and resumes execution with a
+ *   default-constructed result.
+ * - Anything else, taken as a replacement value for the result. It must be convertible to the
+ *   callable's result type, and is moved into the result.
+ *
+ * The two resuming reactions leave a `void` result alone and require a default-constructible
+ * type of a non-void one.
+ *
+ * @param[in] __reaction The reaction, which the policy stores.
+ * @param[in] __loc The location passed to the handler; defaults to the call site.
  * @return A policy object consumed by `operator<<`.
  */
-template <class _Value, ::cuda::std::enable_if_t<!detail::__selects_on_throw_policy_v<_Value>, int> = 0>
-auto on_throw(_Value&& __value)
+template <class _Reaction>
+auto on_throw(_Reaction __reaction, const ::cuda::std::source_location __loc = ::cuda::std::source_location::current())
 {
-  return detail::__on_throw_value<::cuda::std::decay_t<_Value>>{::cuda::std::forward<_Value>(__value)};
+  return detail::__on_throw_policy<_Reaction>{::cuda::std::move(__reaction), __loc};
 }
 
 #ifdef UNITTESTED_FILE
@@ -361,8 +229,9 @@ UNITTEST("on_throw")
   EXPECT(answer == 42);
   //! [on_throw]
 
-  // A terminating handler stays out of the way as long as nothing throws.
-  const throw_handler_terminate_t die = [](const ::std::exception*, ::cuda::std::source_location) noexcept {
+  // A terminating handler, recognized by its void return, stays out of the way as long as
+  // nothing throws.
+  const auto die = [](const ::std::exception*, ::cuda::std::source_location) noexcept {
     ::std::abort();
   };
   const int untouched = on_throw(die) << [] {
@@ -380,10 +249,11 @@ UNITTEST("on_throw")
   };
 
   // Reporting somewhere other than stderr is what defining a handler is for; `notify` is the
-  // same code writing to stderr, which a test cannot capture portably.
-  static ::FILE* log = nullptr;
-  const throw_handler_ignore_t to_log =
-    [](const ::std::exception* __exception, ::cuda::std::source_location __where) noexcept -> decltype(::std::ignore) {
+  // same code writing to stderr, which a test cannot capture portably. A handler may capture,
+  // so the destination needs no static storage.
+  ::FILE* const log = ::tmpfile();
+  EXPECT(log != nullptr);
+  const auto to_log = [log](const ::std::exception* __exception, ::cuda::std::source_location __where) noexcept {
     ::fprintf(log,
               "%s(%u) in %s: %s\n",
               __where.file_name(),
@@ -393,8 +263,6 @@ UNITTEST("on_throw")
     return ::std::ignore;
   };
 
-  log = ::tmpfile();
-  EXPECT(log != nullptr);
   const auto site  = ::cuda::std::source_location::current();
   const int logged = on_throw(to_log, site) << []() -> int {
     throw ::std::runtime_error("boom");

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -100,7 +100,7 @@ struct __on_throw_policy
   // Runs with the exception in flight and produces what `operator<<` returns in its stead. The
   // reactions that say nothing never read the exception, which gcc 9 flags without the attribute.
   template <class _Result>
-  _Result __report([[maybe_unused]] const ::std::exception* __exception) noexcept
+  _Result __handle([[maybe_unused]] const ::std::exception* __exception) noexcept
   {
     // A handler is anything callable with the caught exception and a location; the other three
     // reactions are recognized in the branches below.
@@ -184,11 +184,11 @@ decltype(auto) operator<<(__on_throw_policy<_Reaction> __policy, _Fn&& __fn) noe
   }
   _CCCL_CATCH (const ::std::exception& __exception)
   {
-    return __policy.template __report<_Result>(&__exception);
+    return __policy.template __handle<_Result>(&__exception);
   }
   _CCCL_CATCH_ALL
   {
-    return __policy.template __report<_Result>(nullptr);
+    return __policy.template __handle<_Result>(nullptr);
   }
 }
 } // namespace detail

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -145,14 +145,20 @@ struct __on_throw_policy
     }
     else if constexpr (!__drops)
     {
+      // The value outlives neither the policy nor this call, so a reference to it would dangle.
+      static_assert(!::cuda::std::is_reference_v<_Result>,
+                    "on_throw(value) cannot stand in for a callable that returns a reference");
       static_assert(::cuda::std::is_convertible_v<_Reaction, _Result>,
-                    "on_throw(value) requires a value convertible to the result of the callable");
+                    "an on_throw reaction is a handler, something convertible to void (*)(), "
+                    "::std::ignore, or a value convertible to the result of the callable");
       return static_cast<_Result>(::cuda::std::move(__reaction_));
     }
 
     // Left over are the two reactions that resume, both of which owe the caller a result.
     if constexpr (__resumes && !::cuda::std::is_void_v<_Result>)
     {
+      static_assert(!::cuda::std::is_reference_v<_Result>,
+                    "an on_throw reaction that resumes has nothing to refer to for a reference result");
       static_assert(::cuda::std::is_default_constructible_v<_Result>,
                     "an on_throw reaction that resumes requires a default-constructible result");
       return _Result{};
@@ -202,7 +208,8 @@ decltype(auto) operator<<(__on_throw_policy<_Reaction> __policy, _Fn&& __fn) noe
  *   callable's result type, and is moved into the result.
  *
  * The two resuming reactions leave a `void` result alone and require a default-constructible
- * type of a non-void one.
+ * type of a non-void one. Only a terminating action goes with a callable that returns a
+ * reference, the other reactions having nothing to refer to.
  *
  * @param[in] __reaction The reaction, which the policy stores.
  * @param[in] __loc The location passed to the handler; defaults to the call site.
@@ -250,6 +257,15 @@ UNITTEST("on_throw")
     return 9;
   };
   EXPECT(spared == 9);
+
+  // A terminating action is also the one reaction that goes with a reference result, since it
+  // never has to produce one. The referent is static because nvcc reads a return of a
+  // by-reference capture as a return of a local.
+  static int target = 5;
+  int& alias        = on_throw(::std::abort) << []() -> int& {
+    return target;
+  };
+  EXPECT(&alias == &target);
 
 #  if _CCCL_HAS_EXCEPTIONS()
   const int ignored = on_throw(::std::ignore) << []() -> int {

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -95,7 +95,7 @@ template <class _Reaction>
 struct __on_throw_policy
 {
   _Reaction __reaction_;
-  ::cuda::std::source_location __loc_;
+  const ::cuda::std::source_location __loc_;
 
   // Runs with the exception in flight and produces what `operator<<` returns in its stead. The
   // reactions that say nothing never read the exception, which gcc 9 flags without the attribute.
@@ -106,7 +106,8 @@ struct __on_throw_policy
     // reactions are recognized in the branches below.
     constexpr bool __handles =
       ::cuda::std::is_invocable_v<_Reaction&, const ::std::exception*, ::cuda::std::source_location>;
-    constexpr bool __drops = ::cuda::std::is_same_v<const _Reaction, const decltype(::std::ignore)>;
+    constexpr bool __drops =
+      ::cuda::std::is_same_v<const ::cuda::std::remove_reference_t<_Reaction>, const decltype(::std::ignore)>;
     // Whether the exception is answered rather than fatal, which `::std::ignore` decides by being
     // what it is and a handler decides by returning it. Asking the same of `void` would be
     // useless, every result type being convertible to `void`, but nothing except `::std::ignore`
@@ -145,13 +146,20 @@ struct __on_throw_policy
     }
     else if constexpr (!__drops)
     {
-      // The value outlives neither the policy nor this call, so a reference to it would dangle.
-      static_assert(!::cuda::std::is_reference_v<_Result>,
-                    "on_throw(value) cannot stand in for a callable that returns a reference");
+      // A reference result may only name the reaction itself: a value the policy owns dies with
+      // this call, and so does any temporary a conversion would materialize. Pointers convert
+      // exactly when the reference binds directly, which is the question being asked.
+      static_assert(
+        !::cuda::std::is_reference_v<_Result>
+          || (::cuda::std::is_lvalue_reference_v<_Reaction> && ::cuda::std::is_lvalue_reference_v<_Result>
+              && ::cuda::std::is_convertible_v<::cuda::std::remove_reference_t<_Reaction>*,
+                                               ::cuda::std::remove_reference_t<_Result>*>),
+        "a reference result needs an on_throw reaction passed as an lvalue of the same "
+        "type, anything else dying with the call");
       static_assert(::cuda::std::is_convertible_v<_Reaction, _Result>,
                     "an on_throw reaction is a handler, something convertible to void (*)(), "
                     "::std::ignore, or a value convertible to the result of the callable");
-      return static_cast<_Result>(::cuda::std::move(__reaction_));
+      return ::cuda::std::forward<_Reaction>(__reaction_);
     }
 
     // Left over are the two reactions that resume, both of which owe the caller a result.
@@ -205,20 +213,30 @@ decltype(auto) operator<<(__on_throw_policy<_Reaction> __policy, _Fn&& __fn) noe
  * - `std::ignore`, which suppresses the exception silently and resumes execution with a
  *   default-constructed result.
  * - Anything else, taken as a replacement value for the result. It must be convertible to the
- *   callable's result type, and is moved into the result.
+ *   callable's result type, and is moved into the result if the policy owns it.
  *
  * The two resuming reactions leave a `void` result alone and require a default-constructible
- * type of a non-void one. Only a terminating action goes with a callable that returns a
- * reference, the other reactions having nothing to refer to.
+ * type of a non-void one, having nothing to refer to for a reference.
  *
- * @param[in] __reaction The reaction, which the policy stores.
+ * A callable returning a reference therefore goes with a terminating action, which never has to
+ * produce a result, or with a replacement passed as an lvalue of the same type, which the policy
+ * refers to rather than copies and which the caller keeps alive:
+ *
+ * @code
+ * int fallback = 42;
+ * int& x = on_throw(fallback) << [] { return returns_a_reference(); }; // x is fallback on a throw
+ * @endcode
+ *
+ * @param[in] __reaction The reaction, which the policy owns if passed an rvalue and refers to if
+ *            passed an lvalue.
  * @param[in] __loc The location passed to the handler; defaults to the call site.
  * @return A policy object consumed by `operator<<`.
  */
 template <class _Reaction>
-auto on_throw(_Reaction __reaction, const ::cuda::std::source_location __loc = ::cuda::std::source_location::current())
+auto on_throw(_Reaction&& __reaction,
+              const ::cuda::std::source_location __loc = ::cuda::std::source_location::current())
 {
-  return detail::__on_throw_policy<_Reaction>{::cuda::std::move(__reaction), __loc};
+  return detail::__on_throw_policy<_Reaction>{::cuda::std::forward<_Reaction>(__reaction), __loc};
 }
 
 #ifdef UNITTESTED_FILE
@@ -267,7 +285,20 @@ UNITTEST("on_throw")
   };
   EXPECT(&alias == &target);
 
+  // A replacement passed as an lvalue outlives the call, so it can stand in for a reference
+  // result as well.
+  int fallback = 42;
+  int& picked  = on_throw(fallback) << []() -> int& {
+    return target;
+  };
+  EXPECT(&picked == &target);
+
 #  if _CCCL_HAS_EXCEPTIONS()
+  int& supplanted = on_throw(fallback) << []() -> int& {
+    throw ::std::runtime_error("no reference to give");
+  };
+  EXPECT(&supplanted == &fallback);
+
   const int ignored = on_throw(::std::ignore) << []() -> int {
     throw ::std::runtime_error("ignored");
   };

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -10,7 +10,7 @@
 
 /**
  * @file
- * @brief SCOPE guards and throw sinks (`throw_proof`, `throw_defer`)
+ * @brief SCOPE guards and exception handling (`on_throw`)
  */
 
 #pragma once
@@ -26,7 +26,9 @@
 #endif // no system header
 
 #include <cuda/std/__exception/exception_macros.h>
+#include <cuda/std/__type_traits/is_default_constructible.h>
 #include <cuda/std/__type_traits/is_void.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__utility/forward.h>
 
 #include <cuda/experimental/__stf/utility/source_location.cuh>
@@ -37,86 +39,205 @@
 #include <exception>
 #include <stdexcept>
 #include <string_view>
+#include <tuple>
 #include <utility>
 
 namespace cuda::experimental::stf
 {
 /**
- * @brief Invokes a callable and aborts if it throws.
+ * @brief Suppresses exceptions thrown by the callable on the right-hand side.
  *
- * Use around code that must not let an exception escape into backend state
- * that cannot recover (e.g. after a CUDA stream capture has begun).
- *
- * Usage: `throw_proof->*[&] { ... };`
- *
- * `throw_proof` converts to `with_location`, which captures the call-site
- * `source_location` (overloaded operators cannot take default arguments). An
- * explicit `with_location{throw_proof, loc}` can forward a previously captured
- * location (CTAD, C++17).
+ * A non-void callable must return a default-constructible type; that default
+ * value is returned after an exception.
  */
-struct throw_proof_t
+inline auto on_throw(decltype(::std::ignore)) noexcept
 {
-} inline constexpr throw_proof{};
+  struct __result
+  {};
+  return __result{};
+}
 
-template <class F>
-decltype(auto) operator->*(with_location<throw_proof_t> s, F&& f) noexcept
+template <class _Fn>
+decltype(auto) operator<<(decltype(on_throw(::std::ignore)), _Fn&& __fn) noexcept
 {
+  using _Result = decltype(::cuda::std::forward<_Fn>(__fn)());
   _CCCL_TRY
   {
-    return ::cuda::std::forward<F>(f)();
-  }
-  _CCCL_CATCH (const ::std::exception& e)
-  {
-    ::fprintf(
-      stderr, "%s(%u) throw_proof in %s: %s\n", s.loc.file_name(), s.loc.line(), s.loc.function_name(), e.what());
+    return ::cuda::std::forward<_Fn>(__fn)();
   }
   _CCCL_CATCH_ALL
   {
-    ::fprintf(
-      stderr, "%s(%u) throw_proof in %s: unknown exception\n", s.loc.file_name(), s.loc.line(), s.loc.function_name());
+    static_assert(::cuda::std::is_void_v<_Result> || ::cuda::std::is_default_constructible_v<_Result>,
+                  "on_throw(std::ignore) requires a default-constructible result");
+    if constexpr (!::cuda::std::is_void_v<_Result>)
+    {
+      return _Result{};
+    }
   }
-  ::std::abort();
 }
 
 /**
- * @brief Invokes a callable and returns any thrown exception as an `exception_ptr`.
+ * @brief Logs exceptions thrown by the callable on the right-hand side.
  *
- * Use around best-effort code where a failure should not escape (e.g. optional DOT
- * timing annotations) but the caller may still want to inspect or rethrow later.
- * The callable's return value must be `void` (enforced at compile time); the
- * result is empty if nothing was thrown.
- *
- * Usage: `auto e = throw_defer->*[&] { ... };`
- *
- * The result is `[[nodiscard]]` so the caller must acknowledge it (store it, test it,
- * or deliberately discard it, e.g. by assigning to std::ignore).
+ * Diagnostics are written to the supplied C stream. A non-void callable must
+ * return a default-constructible type; that default value is returned after an
+ * exception.
  */
-struct throw_defer_t
+inline auto on_throw(::FILE* __stream,
+                     const ::cuda::std::source_location __loc = ::cuda::std::source_location::current()) noexcept
 {
-} inline constexpr throw_defer{};
+  struct __result
+  {
+    ::FILE* __stream_;
+    ::cuda::std::source_location __loc_;
+  };
+  return __result{__stream, __loc};
+}
 
-template <class F>
-[[nodiscard]] ::std::exception_ptr operator->*(throw_defer_t, F&& f) noexcept
+template <class _Fn>
+decltype(auto) operator<<(decltype(on_throw(stderr)) __policy,
+                          _Fn&& __fn) noexcept(noexcept(::cuda::std::forward<_Fn>(__fn)()))
 {
-  static_assert(::cuda::std::is_void_v<decltype(::cuda::std::forward<F>(f)())>,
-                "throw_defer requires a void-returning callable");
+  using _Result = decltype(::cuda::std::forward<_Fn>(__fn)());
   _CCCL_TRY
   {
-    ::cuda::std::forward<F>(f)();
-    return {};
+    return ::cuda::std::forward<_Fn>(__fn)();
+  }
+  _CCCL_CATCH (const ::std::exception& __exception)
+  {
+    const auto& __type = type_name<::cuda::std::remove_cvref_t<decltype(__exception)>>;
+    ::fprintf(
+      __policy.__stream_,
+      "%s(%u) on_throw violation in %s with exception of type %.*s: %s\n",
+      __policy.__loc_.file_name(),
+      __policy.__loc_.line(),
+      __policy.__loc_.function_name(),
+      static_cast<int>(__type.size()),
+      __type.data(),
+      __exception.what());
   }
   _CCCL_CATCH_ALL
   {
-    return ::std::current_exception();
+    ::fprintf(__policy.__stream_,
+              "%s(%u) on_throw violation in %s: nonstandard exception\n",
+              __policy.__loc_.file_name(),
+              __policy.__loc_.line(),
+              __policy.__loc_.function_name());
+  }
+  ::fflush(__policy.__stream_);
+
+  static_assert(::cuda::std::is_void_v<_Result> || ::cuda::std::is_default_constructible_v<_Result>,
+                "on_throw(FILE*) requires a default-constructible result");
+  if constexpr (!::cuda::std::is_void_v<_Result>)
+  {
+    return _Result{};
   }
 }
+
+/**
+ * @brief Reports an exception and invokes `std::abort` or `std::terminate`.
+ *
+ * The source location defaults to the call site. No other function pointer is
+ * accepted by this overload.
+ */
+inline auto on_throw(void (*__handler)() noexcept,
+                     const ::cuda::std::source_location __loc = ::cuda::std::source_location::current()) noexcept
+{
+  // The function-pointer type also accepts any other `void() noexcept` function,
+  // so overload resolution alone cannot restrict this argument to these two values.
+  if (__handler != &::std::abort && __handler != &::std::terminate)
+  {
+    ::fprintf(stderr,
+              "%s(%u) invalid on_throw termination handler in %s; expected std::abort or std::terminate\n",
+              __loc.file_name(),
+              __loc.line(),
+              __loc.function_name());
+    ::fflush(stderr);
+    ::std::terminate();
+  }
+  struct __result
+  {
+    void (*__handler_)() noexcept;
+    ::cuda::std::source_location __loc_;
+  };
+  return __result{__handler, __loc};
+}
+
+template <class _Fn>
+decltype(auto) operator<<(decltype(on_throw(::std::abort)) __policy,
+                          _Fn&& __fn) noexcept(noexcept(::cuda::std::forward<_Fn>(__fn)()))
+{
+  _CCCL_TRY
+  {
+    return ::cuda::std::forward<_Fn>(__fn)();
+  }
+  _CCCL_CATCH_ALL
+  {
+    on_throw(stderr, __policy.__loc_) << [] {
+      throw;
+    };
+  }
+  ::fflush(stderr);
+  __policy.__handler_();
+  _CCCL_UNREACHABLE();
+}
+
+#ifdef UNITTESTED_FILE
+UNITTEST("on_throw")
+{
+  using namespace cuda::experimental::stf;
+  //! [on_throw]
+  int value = 0;
+  on_throw(::std::abort) << [&] {
+    value = 42; // would abort the application if this code threw
+  };
+  on_throw(::std::terminate) << [] {};
+  on_throw(stderr) << [] {};
+  EXPECT(value == 42);
+  //! [on_throw]
+
+#  if _CCCL_HAS_EXCEPTIONS()
+  const int ignored = on_throw(::std::ignore) << []() -> int {
+    throw ::std::runtime_error("ignored");
+  };
+  EXPECT(ignored == 0);
+  on_throw(::std::ignore) << [] {
+    throw 42;
+  };
+
+  ::FILE* const log = ::tmpfile();
+  EXPECT(log != nullptr);
+  const auto loc   = ::cuda::std::source_location::current();
+  const int logged = on_throw(log, loc) << []() -> int {
+    throw ::std::runtime_error("boom");
+  };
+  EXPECT(logged == 0);
+  ::rewind(log);
+  char message[1024]{};
+  EXPECT(::fgets(message, sizeof(message), log) != nullptr);
+  char expected[1024]{};
+  const auto& exception_type = type_name<::std::exception>;
+  ::snprintf(
+    expected,
+    sizeof(expected),
+    "%s(%u) on_throw violation in %s with exception of type %.*s: boom\n",
+    loc.file_name(),
+    loc.line(),
+    loc.function_name(),
+    static_cast<int>(exception_type.size()),
+    exception_type.data());
+  EXPECT(::std::string_view{message} == expected);
+  ::fclose(log);
+#  endif // _CCCL_HAS_EXCEPTIONS()
+};
+#endif // UNITTESTED_FILE
 
 /**
  * @brief Automatically runs code when a scope is exited (`SCOPE(exit)`), exited by means of an exception
  * (`SCOPE(fail)`), or exited normally (`SCOPE(success)`).
  *
  * The code controlled by `SCOPE(exit)` and `SCOPE(fail)` must not throw. In debug builds (`NDEBUG` not
- * defined) those lambdas are invoked via `throw_proof` using the `SCOPE` call-site location; in release
+ * defined) those lambdas are invoked via `on_throw(::std::abort)`; in release
  * builds they are called directly. The code controlled by `SCOPE(success)` may throw. In all cases the
  * controlled code must return `void` (enforced at compile time).
  *
@@ -158,8 +279,7 @@ void invoke_nothrow(F& f, ::cuda::std::source_location loc)
 {
   static_assert(::std::is_void_v<decltype(f())>, "SCOPE requires a void-returning callable");
 #  ifndef NDEBUG
-  // Forward the SCOPE call-site location into throw_proof.
-  with_location{throw_proof, loc}->*f;
+  on_throw(::std::abort, loc) << f;
 #  else // ^^^ !NDEBUG ^^^ / vvv NDEBUG vvv
   (void) loc;
   f();
@@ -273,64 +393,6 @@ auto operator->*(success, F&& f)
 } // namespace cuda::experimental::stf
 
 #ifdef UNITTESTED_FILE
-UNITTEST("throw_proof")
-{
-  using namespace cuda::experimental::stf;
-  //! [throw_proof]
-  int value = 0;
-  throw_proof->*[&] {
-    value = 42; // would abort the application if this code threw
-  };
-  EXPECT(value == 42);
-  //! [throw_proof]
-  EXPECT((throw_proof->*
-          [] {
-            return 7;
-          })
-         == 7);
-
-  // Empty tag lvalues must remain convertible — that is how `throw_proof->*f`
-  // captures source_location via with_location.
-  static_assert(::std::is_constructible_v<with_location<throw_proof_t>, throw_proof_t&>);
-  static_assert(::std::is_constructible_v<with_location<throw_proof_t>, const throw_proof_t&>);
-  static_assert(::std::is_constructible_v<with_location<throw_proof_t>, throw_proof_t>);
-
-  const auto loc = ::cuda::std::source_location::current();
-  auto wl        = with_location{throw_proof, loc};
-  static_assert(::std::is_same_v<decltype(wl), with_location<throw_proof_t>>);
-  EXPECT(wl.loc.line() == loc.line());
-};
-
-UNITTEST("throw_defer")
-{
-  using namespace cuda::experimental::stf;
-  //! [throw_defer]
-  int value = 0;
-  auto e    = throw_defer->*[&] {
-    value = 42; // if this threw, e would hold the exception_ptr
-  };
-  EXPECT(!e);
-  EXPECT(value == 42);
-  //! [throw_defer]
-
-#  if _CCCL_HAS_EXCEPTIONS()
-  e = throw_defer->*[] {
-    throw ::std::runtime_error("boom");
-  };
-  EXPECT(static_cast<bool>(e));
-  try
-  {
-    ::std::rethrow_exception(e);
-  }
-  catch (const ::std::runtime_error& ex)
-  {
-    EXPECT(::std::string_view(ex.what()) == "boom");
-    return;
-  }
-  EXPECT(false, "rethrow should have transferred control");
-#  endif // _CCCL_HAS_EXCEPTIONS()
-};
-
 UNITTEST("SCOPE(exit)")
 {
   //! [SCOPE(exit)]

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -178,6 +178,12 @@ template <class _Reaction, class _Fn>
 decltype(auto) operator<<(__on_throw_policy<_Reaction> __policy, _Fn&& __fn) noexcept
 {
   using _Result = decltype(::cuda::std::forward<_Fn>(__fn)());
+  // A `noexcept` callable puts the reaction out of reach: an exception raised inside it ends the
+  // program where it stands, so the catch below could never run and the policy would be a promise
+  // nobody keeps.
+  static_assert(!noexcept(::cuda::std::forward<_Fn>(__fn)()),
+                "on_throw has nothing to do for a noexcept callable, which terminates rather than "
+                "throws; call such a callable directly");
   _CCCL_TRY
   {
     return ::cuda::std::forward<_Fn>(__fn)();
@@ -217,6 +223,10 @@ decltype(auto) operator<<(__on_throw_policy<_Reaction> __policy, _Fn&& __fn) noe
  *
  * The two resuming reactions leave a `void` result alone and require a default-constructible
  * type of a non-void one, having nothing to refer to for a reference.
+ *
+ * The callable itself must not be `noexcept`: an exception raised inside one ends the program
+ * where it stands, leaving the reaction unreachable, so such a pairing is rejected instead of
+ * standing there looking like protection. Call such a callable directly.
  *
  * A callable returning a reference therefore goes with a terminating action, which never has to
  * produce a result, or with a replacement passed as an lvalue of the same type, which the policy

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -28,7 +28,6 @@
 #include <cuda/std/__exception/exception_macros.h>
 #include <cuda/std/__type_traits/is_default_constructible.h>
 #include <cuda/std/__type_traits/is_void.h>
-#include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__utility/forward.h>
 
 #include <cuda/experimental/__stf/utility/source_location.cuh>
@@ -45,10 +44,14 @@
 namespace cuda::experimental::stf
 {
 /**
- * @brief Suppresses exceptions thrown by the callable on the right-hand side.
+ * @brief Creates a policy that suppresses exceptions.
  *
- * A non-void callable must return a default-constructible type; that default
- * value is returned after an exception.
+ * Apply the policy to a callable with `on_throw(::std::ignore) << callable`.
+ * If the callable throws, a `void` result is simply suppressed and a non-void
+ * result is replaced with a default-constructed value. Consequently, a
+ * non-void callable must return a default-constructible type.
+ *
+ * @return A policy object consumed by `operator<<`.
  */
 inline auto on_throw(decltype(::std::ignore)) noexcept
 {
@@ -61,14 +64,14 @@ template <class _Fn>
 decltype(auto) operator<<(decltype(on_throw(::std::ignore)), _Fn&& __fn) noexcept
 {
   using _Result = decltype(::cuda::std::forward<_Fn>(__fn)());
+  static_assert(::cuda::std::is_void_v<_Result> || ::cuda::std::is_default_constructible_v<_Result>,
+                "on_throw(std::ignore) requires a default-constructible result");
   _CCCL_TRY
   {
     return ::cuda::std::forward<_Fn>(__fn)();
   }
   _CCCL_CATCH_ALL
   {
-    static_assert(::cuda::std::is_void_v<_Result> || ::cuda::std::is_default_constructible_v<_Result>,
-                  "on_throw(std::ignore) requires a default-constructible result");
     if constexpr (!::cuda::std::is_void_v<_Result>)
     {
       return _Result{};
@@ -77,11 +80,16 @@ decltype(auto) operator<<(decltype(on_throw(::std::ignore)), _Fn&& __fn) noexcep
 }
 
 /**
- * @brief Logs exceptions thrown by the callable on the right-hand side.
+ * @brief Creates a policy that reports and suppresses exceptions.
  *
- * Diagnostics are written to the supplied C stream. A non-void callable must
- * return a default-constructible type; that default value is returned after an
- * exception.
+ * Apply the policy with `on_throw(stream) << callable`. If the callable throws,
+ * the policy writes the captured call-site location and exception message to
+ * `stream`, flushes it, and returns a default-constructed result for a non-void
+ * callable. Non-standard exceptions are reported without a message.
+ *
+ * @param[in] __stream A non-null writable C stream.
+ * @param[in] __loc The location reported on failure; defaults to the call site.
+ * @return A policy object consumed by `operator<<`.
  */
 inline auto on_throw(::FILE* __stream,
                      const ::cuda::std::source_location __loc = ::cuda::std::source_location::current()) noexcept
@@ -95,26 +103,23 @@ inline auto on_throw(::FILE* __stream,
 }
 
 template <class _Fn>
-decltype(auto) operator<<(decltype(on_throw(stderr)) __policy,
-                          _Fn&& __fn) noexcept(noexcept(::cuda::std::forward<_Fn>(__fn)()))
+decltype(auto) operator<<(decltype(on_throw(stderr)) __policy, _Fn&& __fn) noexcept
 {
   using _Result = decltype(::cuda::std::forward<_Fn>(__fn)());
+  static_assert(::cuda::std::is_void_v<_Result> || ::cuda::std::is_default_constructible_v<_Result>,
+                "on_throw(FILE*) requires a default-constructible result");
   _CCCL_TRY
   {
     return ::cuda::std::forward<_Fn>(__fn)();
   }
   _CCCL_CATCH (const ::std::exception& __exception)
   {
-    const auto& __type = type_name<::cuda::std::remove_cvref_t<decltype(__exception)>>;
-    ::fprintf(
-      __policy.__stream_,
-      "%s(%u) on_throw violation in %s with exception of type %.*s: %s\n",
-      __policy.__loc_.file_name(),
-      __policy.__loc_.line(),
-      __policy.__loc_.function_name(),
-      static_cast<int>(__type.size()),
-      __type.data(),
-      __exception.what());
+    ::fprintf(__policy.__stream_,
+              "%s(%u) on_throw violation in %s: %s\n",
+              __policy.__loc_.file_name(),
+              __policy.__loc_.line(),
+              __policy.__loc_.function_name(),
+              __exception.what());
   }
   _CCCL_CATCH_ALL
   {
@@ -126,8 +131,6 @@ decltype(auto) operator<<(decltype(on_throw(stderr)) __policy,
   }
   ::fflush(__policy.__stream_);
 
-  static_assert(::cuda::std::is_void_v<_Result> || ::cuda::std::is_default_constructible_v<_Result>,
-                "on_throw(FILE*) requires a default-constructible result");
   if constexpr (!::cuda::std::is_void_v<_Result>)
   {
     return _Result{};
@@ -135,10 +138,17 @@ decltype(auto) operator<<(decltype(on_throw(stderr)) __policy,
 }
 
 /**
- * @brief Reports an exception and invokes `std::abort` or `std::terminate`.
+ * @brief Creates a policy that reports an exception and terminates.
  *
- * The source location defaults to the call site. No other function pointer is
- * accepted by this overload.
+ * Apply the policy with `on_throw(::std::abort) << callable` or
+ * `on_throw(::std::terminate) << callable`. If the callable throws, the policy
+ * reports the exception to `stderr`, flushes the stream, and invokes the chosen
+ * handler. Passing any other function pointer reports the invalid handler and
+ * terminates immediately.
+ *
+ * @param[in] __handler The address of `std::abort` or `std::terminate`.
+ * @param[in] __loc The location reported on failure; defaults to the call site.
+ * @return A policy object consumed by `operator<<`.
  */
 inline auto on_throw(void (*__handler)() noexcept,
                      const ::cuda::std::source_location __loc = ::cuda::std::source_location::current()) noexcept
@@ -164,8 +174,7 @@ inline auto on_throw(void (*__handler)() noexcept,
 }
 
 template <class _Fn>
-decltype(auto) operator<<(decltype(on_throw(::std::abort)) __policy,
-                          _Fn&& __fn) noexcept(noexcept(::cuda::std::forward<_Fn>(__fn)()))
+decltype(auto) operator<<(decltype(on_throw(::std::abort)) __policy, _Fn&& __fn) noexcept
 {
   _CCCL_TRY
   {
@@ -177,7 +186,6 @@ decltype(auto) operator<<(decltype(on_throw(::std::abort)) __policy,
       throw;
     };
   }
-  ::fflush(stderr);
   __policy.__handler_();
   _CCCL_UNREACHABLE();
 }
@@ -216,16 +224,12 @@ UNITTEST("on_throw")
   char message[1024]{};
   EXPECT(::fgets(message, sizeof(message), log) != nullptr);
   char expected[1024]{};
-  const auto& exception_type = type_name<::std::exception>;
-  ::snprintf(
-    expected,
-    sizeof(expected),
-    "%s(%u) on_throw violation in %s with exception of type %.*s: boom\n",
-    loc.file_name(),
-    loc.line(),
-    loc.function_name(),
-    static_cast<int>(exception_type.size()),
-    exception_type.data());
+  ::snprintf(expected,
+             sizeof(expected),
+             "%s(%u) on_throw violation in %s: boom\n",
+             loc.file_name(),
+             loc.line(),
+             loc.function_name());
   EXPECT(::std::string_view{message} == expected);
   ::fclose(log);
 #  endif // _CCCL_HAS_EXCEPTIONS()

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -26,9 +26,13 @@
 #endif // no system header
 
 #include <cuda/std/__exception/exception_macros.h>
+#include <cuda/std/__type_traits/decay.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/is_default_constructible.h>
 #include <cuda/std/__type_traits/is_void.h>
 #include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/move.h>
 
 #include <cuda/experimental/__stf/utility/source_location.cuh>
 #include <cuda/experimental/__stf/utility/unittest.cuh>
@@ -101,6 +105,42 @@ using throw_handler_ignore_t =
  * `on_throw` call site.
  */
 using throw_handler_terminate_t = void (*)(const ::std::exception*, ::cuda::std::source_location) noexcept;
+
+/**
+ * @brief A suppressing handler that reports an exception on `stderr` and flushes it.
+ *
+ * Use it as in `on_throw(notify) << callable` to report an exception and carry on.
+ * Reporting to a destination other than `stderr` is a matter of defining another
+ * `throw_handler_ignore_t`.
+ *
+ * @param[in] __exception The caught exception, or `nullptr` if it does not derive from
+ *            `std::exception`, in which case the report carries no message.
+ * @param[in] __loc The location to report.
+ * @return `::std::ignore`, which marks this handler as suppressing.
+ */
+inline decltype(::std::ignore)
+notify(const ::std::exception* __exception, const ::cuda::std::source_location __loc) noexcept
+{
+  if (__exception != nullptr)
+  {
+    ::fprintf(stderr,
+              "%s(%u) on_throw violation in %s: %s\n",
+              __loc.file_name(),
+              __loc.line(),
+              __loc.function_name(),
+              __exception->what());
+  }
+  else
+  {
+    ::fprintf(stderr,
+              "%s(%u) on_throw violation in %s: nonstandard exception\n",
+              __loc.file_name(),
+              __loc.line(),
+              __loc.function_name());
+  }
+  ::fflush(stderr);
+  return ::std::ignore;
+}
 
 /**
  * @brief Creates a policy that hands an exception to a handler and then suppresses it.
@@ -194,71 +234,13 @@ decltype(auto) operator<<(decltype(on_throw(throw_handler_terminate_t{})) __poli
 }
 
 /**
- * @brief Creates a policy that reports and suppresses exceptions.
- *
- * Apply the policy with `on_throw(stream) << callable`. If the callable throws,
- * the policy writes the captured call-site location and exception message to
- * `stream`, flushes it, and returns a default-constructed result for a non-void
- * callable. Non-standard exceptions are reported without a message.
- *
- * @param[in] __stream A non-null writable C stream.
- * @param[in] __loc The location reported on failure; defaults to the call site.
- * @return A policy object consumed by `operator<<`.
- */
-inline auto on_throw(::FILE* __stream,
-                     const ::cuda::std::source_location __loc = ::cuda::std::source_location::current()) noexcept
-{
-  struct __result
-  {
-    ::FILE* __stream_;
-    ::cuda::std::source_location __loc_;
-  };
-  return __result{__stream, __loc};
-}
-
-template <class _Fn>
-decltype(auto) operator<<(decltype(on_throw(stderr)) __policy, _Fn&& __fn) noexcept
-{
-  using _Result = decltype(::cuda::std::forward<_Fn>(__fn)());
-  static_assert(::cuda::std::is_void_v<_Result> || ::cuda::std::is_default_constructible_v<_Result>,
-                "on_throw(FILE*) requires a default-constructible result");
-  _CCCL_TRY
-  {
-    return ::cuda::std::forward<_Fn>(__fn)();
-  }
-  _CCCL_CATCH (const ::std::exception& __exception)
-  {
-    ::fprintf(__policy.__stream_,
-              "%s(%u) on_throw violation in %s: %s\n",
-              __policy.__loc_.file_name(),
-              __policy.__loc_.line(),
-              __policy.__loc_.function_name(),
-              __exception.what());
-  }
-  _CCCL_CATCH_ALL
-  {
-    ::fprintf(__policy.__stream_,
-              "%s(%u) on_throw violation in %s: nonstandard exception\n",
-              __policy.__loc_.file_name(),
-              __policy.__loc_.line(),
-              __policy.__loc_.function_name());
-  }
-  ::fflush(__policy.__stream_);
-
-  if constexpr (!::cuda::std::is_void_v<_Result>)
-  {
-    return _Result{};
-  }
-}
-
-/**
  * @brief Creates a policy that reports an exception and terminates.
  *
  * Apply the policy with `on_throw(::std::abort) << callable` or
  * `on_throw(::std::terminate) << callable`. If the callable throws, the policy
- * reports the exception to `stderr`, flushes the stream, and invokes the chosen
- * handler. Passing any other function pointer reports the invalid handler and
- * terminates immediately.
+ * reports the exception through `notify` and invokes the chosen handler. Passing
+ * any other function pointer reports the invalid handler and terminates
+ * immediately.
  *
  * @param[in] __handler The address of `std::abort` or `std::terminate`.
  * @param[in] __loc The location reported on failure; defaults to the call site.
@@ -267,41 +249,98 @@ decltype(auto) operator<<(decltype(on_throw(stderr)) __policy, _Fn&& __fn) noexc
 inline auto on_throw(void (*__handler)() noexcept,
                      const ::cuda::std::source_location __loc = ::cuda::std::source_location::current()) noexcept
 {
+  struct local
+  {
+    static void abort(const ::std::exception* __exception, ::cuda::std::source_location __where) noexcept
+    {
+      notify(__exception, __where);
+      ::std::abort();
+    }
+    static void terminate(const ::std::exception* __exception, ::cuda::std::source_location __where) noexcept
+    {
+      notify(__exception, __where);
+      ::std::terminate();
+    }
+  };
+  if (__handler == &::std::abort)
+  {
+    return on_throw(local::abort, __loc);
+  }
+  if (__handler == &::std::terminate)
+  {
+    return on_throw(local::terminate, __loc);
+  }
   // The function-pointer type also accepts any other `void() noexcept` function,
   // so overload resolution alone cannot restrict this argument to these two values.
-  if (__handler != &::std::abort && __handler != &::std::terminate)
-  {
-    ::fprintf(stderr,
-              "%s(%u) invalid on_throw termination handler in %s; expected std::abort or std::terminate\n",
-              __loc.file_name(),
-              __loc.line(),
-              __loc.function_name());
-    ::fflush(stderr);
-    ::std::terminate();
-  }
-  struct __result
-  {
-    void (*__handler_)() noexcept;
-    ::cuda::std::source_location __loc_;
-  };
-  return __result{__handler, __loc};
+  ::fprintf(stderr,
+            "%s(%u) invalid on_throw termination handler in %s; expected std::abort or std::terminate\n",
+            __loc.file_name(),
+            __loc.line(),
+            __loc.function_name());
+  ::fflush(stderr);
+  ::std::terminate();
+  _CCCL_UNREACHABLE();
 }
 
-template <class _Fn>
-decltype(auto) operator<<(decltype(on_throw(::std::abort)) __policy, _Fn&& __fn) noexcept
+#ifndef _CCCL_DOXYGEN_INVOKED // Do not document
+namespace detail
 {
+// Unlike the other policies this one cannot keep its state in a local struct, because
+// `operator<<` has to deduce the value type and could not do so from a parameter spelled
+// `decltype(on_throw(...))`. Its `operator<<` lives here as well, so that argument-dependent
+// lookup, which only searches the innermost namespace enclosing the policy, still finds it.
+template <class _Value>
+struct __on_throw_value
+{
+  _Value __value_;
+};
+
+// Anything the other overloads accept must be kept away from the value overload. Preferring a
+// non-template overload on a tie is not enough: clang keeps `[[noreturn]]` in the type of
+// `std::abort`, which makes the termination overload an inexact match that the value overload
+// would win.
+template <class _Tp>
+inline constexpr bool __selects_on_throw_policy_v =
+  ::cuda::std::is_convertible_v<_Tp, decltype(::std::ignore)> //
+  || ::cuda::std::is_convertible_v<_Tp, throw_handler_ignore_t> //
+  || ::cuda::std::is_convertible_v<_Tp, throw_handler_terminate_t> //
+  || ::cuda::std::is_convertible_v<_Tp, void (*)() noexcept>;
+
+template <class _Value, class _Fn>
+decltype(auto) operator<<(__on_throw_value<_Value> __policy, _Fn&& __fn) noexcept
+{
+  using _Result = decltype(::cuda::std::forward<_Fn>(__fn)());
+  static_assert(::cuda::std::is_convertible_v<_Value, _Result>,
+                "on_throw(value) requires a value convertible to the result of the callable");
   _CCCL_TRY
   {
     return ::cuda::std::forward<_Fn>(__fn)();
   }
   _CCCL_CATCH_ALL
   {
-    on_throw(stderr, __policy.__loc_) << [] {
-      throw;
-    };
+    return static_cast<_Result>(::cuda::std::move(__policy.__value_));
   }
-  __policy.__handler_();
-  _CCCL_UNREACHABLE();
+}
+} // namespace detail
+#endif // !_CCCL_DOXYGEN_INVOKED
+
+/**
+ * @brief Creates a policy that replaces a thrown exception with a value.
+ *
+ * `on_throw(value) << callable` evaluates to the result of the callable, or to `value`
+ * converted to that result type if the callable throws. The value is stored in the policy,
+ * so a temporary is safe, and it is moved into the result. Handlers are not values: an
+ * argument convertible to `throw_handler_ignore_t` or `throw_handler_terminate_t` selects
+ * the corresponding handler overload instead.
+ *
+ * @param[in] __value The replacement, which must be convertible to the callable's result
+ *            and must not throw while being converted.
+ * @return A policy object consumed by `operator<<`.
+ */
+template <class _Value, ::cuda::std::enable_if_t<!detail::__selects_on_throw_policy_v<_Value>, int> = 0>
+auto on_throw(_Value&& __value)
+{
+  return detail::__on_throw_value<::cuda::std::decay_t<_Value>>{::cuda::std::forward<_Value>(__value)};
 }
 
 #ifdef UNITTESTED_FILE
@@ -314,8 +353,12 @@ UNITTEST("on_throw")
     value = 42; // would abort the application if this code threw
   };
   on_throw(::std::terminate) << [] {};
-  on_throw(stderr) << [] {};
+  on_throw(notify) << [] {}; // would report the exception on stderr and carry on
+  const int answer = on_throw(-1) << [] {
+    return 42; // would yield -1 instead if this code threw
+  };
   EXPECT(value == 42);
+  EXPECT(answer == 42);
   //! [on_throw]
 
   // A terminating handler stays out of the way as long as nothing throws.
@@ -336,49 +379,73 @@ UNITTEST("on_throw")
     throw 42;
   };
 
-  ::FILE* const log = ::tmpfile();
-  EXPECT(log != nullptr);
-  const auto loc   = ::cuda::std::source_location::current();
-  const int logged = on_throw(log, loc) << []() -> int {
-    throw ::std::runtime_error("boom");
-  };
-  EXPECT(logged == 0);
-  ::rewind(log);
-  char message[1024]{};
-  EXPECT(::fgets(message, sizeof(message), log) != nullptr);
-  char expected[1024]{};
-  ::snprintf(expected,
-             sizeof(expected),
-             "%s(%u) on_throw violation in %s: boom\n",
-             loc.file_name(),
-             loc.line(),
-             loc.function_name());
-  EXPECT(::std::string_view{message} == expected);
-  ::fclose(log);
-
-  // A suppressing handler sees the exception and the call site, then execution resumes.
-  static bool saw_std_exception = false;
-  static unsigned reported_line = 0;
-  const throw_handler_ignore_t note =
+  // Reporting somewhere other than stderr is what defining a handler is for; `notify` is the
+  // same code writing to stderr, which a test cannot capture portably.
+  static ::FILE* log = nullptr;
+  const throw_handler_ignore_t to_log =
     [](const ::std::exception* __exception, ::cuda::std::source_location __where) noexcept -> decltype(::std::ignore) {
-    saw_std_exception = __exception != nullptr;
-    reported_line     = __where.line();
+    ::fprintf(log,
+              "%s(%u) in %s: %s\n",
+              __where.file_name(),
+              __where.line(),
+              __where.function_name(),
+              __exception != nullptr ? __exception->what() : "nonstandard exception");
     return ::std::ignore;
   };
 
-  const auto site = ::cuda::std::source_location::current();
-  const int noted = on_throw(note, site) << []() -> int {
-    throw ::std::runtime_error("noted");
+  log = ::tmpfile();
+  EXPECT(log != nullptr);
+  const auto site  = ::cuda::std::source_location::current();
+  const int logged = on_throw(to_log, site) << []() -> int {
+    throw ::std::runtime_error("boom");
   };
-  EXPECT(noted == 0);
-  EXPECT(saw_std_exception);
-  EXPECT(reported_line == site.line());
+  EXPECT(logged == 0);
 
   // An exception that does not derive from std::exception reaches the handler as nullptr.
-  on_throw(note, site) << [] {
+  on_throw(to_log, site) << [] {
     throw 42;
   };
-  EXPECT(!saw_std_exception);
+
+  ::rewind(log);
+  char message[1024]{};
+  char expected[1024]{};
+  EXPECT(::fgets(message, sizeof(message), log) != nullptr);
+  ::snprintf(expected, sizeof(expected), "%s(%u) in %s: boom\n", site.file_name(), site.line(), site.function_name());
+  EXPECT(::std::string_view{message} == expected);
+  EXPECT(::fgets(message, sizeof(message), log) != nullptr);
+  ::snprintf(expected,
+             sizeof(expected),
+             "%s(%u) in %s: nonstandard exception\n",
+             site.file_name(),
+             site.line(),
+             site.function_name());
+  EXPECT(::std::string_view{message} == expected);
+  ::fclose(log);
+
+  // A replacement value stands in for the result, converted to the callable's result type.
+  const int replaced = on_throw(42) << []() -> int {
+    throw ::std::runtime_error("replaced");
+  };
+  EXPECT(replaced == 42);
+  const double widened = on_throw(42) << []() -> double {
+    throw 42;
+  };
+  EXPECT(widened == 42.0);
+
+  // The value is moved into the result, so a move-only replacement works.
+  struct movable
+  {
+    int v;
+    explicit movable(int value_)
+        : v(value_)
+    {}
+    movable(const movable&) = delete;
+    movable(movable&&)      = default;
+  };
+  const movable moved = on_throw(movable{7}) << []() -> movable {
+    throw 42;
+  };
+  EXPECT(moved.v == 7);
 #  endif // _CCCL_HAS_EXCEPTIONS()
 };
 #endif // UNITTESTED_FILE

--- a/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/scope_guard.cuh
@@ -133,9 +133,11 @@ struct __on_throw_policy
         _CCCL_UNREACHABLE();
       }
     }
-    else if constexpr (::cuda::std::is_convertible_v<_Reaction, void (*)() noexcept>)
+    else if constexpr (::cuda::std::is_convertible_v<_Reaction, void (*)()>)
     {
       // A terminating action, `::std::abort` and `::std::terminate` being the ones worth naming.
+      // A `noexcept` pointer is not asked for, even though the action runs during unwinding,
+      // because Microsoft's `abort` is not declared `noexcept` and would miss this branch.
       notify(__exception, __loc_);
       __reaction_();
       ::std::abort(); // in case it returns after all
@@ -191,7 +193,7 @@ decltype(auto) operator<<(__on_throw_policy<_Reaction> __policy, _Fn&& __fn) noe
  *   says what happens next: returning `decltype(::std::ignore)` resumes execution with a
  *   default-constructed result, and returning `void` claims the handler ends the program, with
  *   `std::abort` running right after it in case it does not. `notify` is such a handler.
- * - A terminating action: any nullary `noexcept` callable returning `void`, `std::abort` and
+ * - A terminating action: anything convertible to `void (*)()`, `std::abort` and
  *   `std::terminate` being the obvious ones. The exception is reported through `notify`, the
  *   action runs, and `std::abort` follows in case it returns.
  * - `std::ignore`, which suppresses the exception silently and resumes execution with a
@@ -239,6 +241,15 @@ UNITTEST("on_throw")
     return 7;
   };
   EXPECT(untouched == 7);
+
+  // A terminating action need not be `noexcept`, which is how Microsoft declares `abort`.
+  void (*const bail)() = [] {
+    ::std::abort();
+  };
+  const int spared = on_throw(bail) << [] {
+    return 9;
+  };
+  EXPECT(spared == 9);
 
 #  if _CCCL_HAS_EXCEPTIONS()
   const int ignored = on_throw(::std::ignore) << []() -> int {


### PR DESCRIPTION
## Summary
- replace `throw_proof` with `on_throw` policies for suppression, `FILE*` diagnostics, and abort/terminate handling
- preserve the existing `SCOPE` `->*` API while routing debug-time violations through `on_throw(std::abort)`
- make optional task timing diagnostics non-throwing and separate parallel-for success/failure cleanup

## Test plan
- [x] `pre-commit` on all changed files
- [x] build `cudax.test.stf.unittest_headers.__stf.utility.scope_guard`
- [x] build `cudax.test.stf.parallel_for.parallel_for_box`
- [ ] run scope guard header test (blocked locally by NVCC mangling the Unicode `Păcală` source path used by the unit-test file check)
- [ ] run GPU test (local CUDA driver is older than CUDA 13.2 runtime)