### PR TITLE
[libcu++] Fix intseq tests for older nvrtc

### DIFF
--- a/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/get.pass.cpp
@@ -55,12 +55,20 @@ TEST_FUNC constexpr void test(typename Seq::value_type ref_val)
 }
 
 template <class T, T... Vs>
+struct TestFunctor
+{
+  template <cuda::std::size_t I>
+  TEST_FUNC constexpr void operator()(cuda::std::integral_constant<cuda::std::size_t, I>) const
+  {
+    constexpr T values[(sizeof...(Vs) > 0) ? sizeof...(Vs) : 1]{Vs...};
+    test<cuda::std::integer_sequence<T, Vs...>, I>(values[I]);
+  }
+};
+
+template <class T, T... Vs>
 TEST_FUNC constexpr void test()
 {
-  cuda::static_for<sizeof...(Vs)>([](auto i) {
-    constexpr T values[(sizeof...(Vs) > 0) ? sizeof...(Vs) : 1]{Vs...};
-    test<cuda::std::integer_sequence<T, Vs...>, i()>(values[i()]);
-  });
+  cuda::static_for<sizeof...(Vs)>(TestFunctor<T, Vs...>{});
 }
 
 TEST_FUNC constexpr bool test()

--- a/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/tuple_element.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/tuple_element.compile.pass.cpp
@@ -20,23 +20,31 @@
 #include "test_macros.h"
 
 template <class T, T... Vs>
-TEST_FUNC constexpr bool test_tuple_element()
+struct TestTupleElement
 {
-  using Seq = cuda::std::integer_sequence<T, Vs...>;
+  template <cuda::std::size_t I>
+  TEST_FUNC constexpr void operator()(cuda::std::integral_constant<cuda::std::size_t, I>) const
+  {
+    using Seq = cuda::std::integer_sequence<T, Vs...>;
 
-  cuda::static_for<sizeof...(Vs)>([](auto i) {
     // Test std::tuple_element.
-    static_assert(cuda::std::is_same_v<T, typename std::tuple_element<i(), Seq>::type>);
-    static_assert(cuda::std::is_same_v<T, typename std::tuple_element<i(), const Seq>::type>);
+    static_assert(cuda::std::is_same_v<T, typename std::tuple_element<I, Seq>::type>);
+    static_assert(cuda::std::is_same_v<T, typename std::tuple_element<I, const Seq>::type>);
 
     // Test cuda::std::tuple_element.
-    static_assert(cuda::std::is_same_v<T, typename cuda::std::tuple_element<i(), Seq>::type>);
-    static_assert(cuda::std::is_same_v<T, typename cuda::std::tuple_element<i(), const Seq>::type>);
+    static_assert(cuda::std::is_same_v<T, typename cuda::std::tuple_element<I, Seq>::type>);
+    static_assert(cuda::std::is_same_v<T, typename cuda::std::tuple_element<I, const Seq>::type>);
 
     // Test cuda::std::tuple_element_t.
-    static_assert(cuda::std::is_same_v<T, cuda::std::tuple_element_t<i(), Seq>>);
-    static_assert(cuda::std::is_same_v<T, cuda::std::tuple_element_t<i(), const Seq>>);
-  });
+    static_assert(cuda::std::is_same_v<T, cuda::std::tuple_element_t<I, Seq>>);
+    static_assert(cuda::std::is_same_v<T, cuda::std::tuple_element_t<I, const Seq>>);
+  }
+};
+
+template <class T, T... Vs>
+TEST_FUNC constexpr bool test_tuple_element()
+{
+  cuda::static_for<sizeof...(Vs)>(TestTupleElement<T, Vs...>{});
 
   return true;
 }


### PR DESCRIPTION
Older nvrtc emit errors like:
```
/home/coder/cccl/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/tuple_element.compile.pass.cpp(35): error: A function without execution space annotations (__host__/__device__/__global__) is considered a host function, and host functions are not allowed in JIT mode. Consider using -default-device flag to process unannotated functions as __device__ functions in JIT mode
    1:     cuda::static_for<sizeof...(Vs)>([](auto i) {
```
when using a lambda in `cuda::static_for`. This PR changes the tests to use `struct` functors