### PR TITLE
[Tile] Mark `<random>` as unsupported

### DIFF
--- a/libcudacxx/include/cuda/__random/feistel_bijection.h
+++ b/libcudacxx/include/cuda/__random/feistel_bijection.h
@@ -50,7 +50,7 @@ public:
   _CCCL_HIDE_FROM_ABI constexpr __feistel_bijection() noexcept = default;
 
   template <class _RNG>
-  _CCCL_API __feistel_bijection(uint64_t __num_elements, _RNG&& __gen)
+  _CCCL_HOST_DEVICE_API __feistel_bijection(uint64_t __num_elements, _RNG&& __gen)
   {
     // Calculate number of bits needed to represent num_elements - 1
     // Prevent zero
@@ -72,12 +72,12 @@ public:
     }
   }
 
-  [[nodiscard]] _CCCL_API constexpr uint64_t size() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr uint64_t size() const noexcept
   {
     return 1ull << (__L_bits_ + __R_bits_);
   }
 
-  [[nodiscard]] _CCCL_API constexpr uint64_t operator()(const uint64_t __val) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr uint64_t operator()(const uint64_t __val) const noexcept
   {
     // Mitchell, Rory, et al. "Bandwidth-optimal random shuffling for GPUs." ACM Transactions on Parallel Computing 9.1
     // (2022): 1-20.

--- a/libcudacxx/include/cuda/__random/pcg_engine.h
+++ b/libcudacxx/include/cuda/__random/pcg_engine.h
@@ -43,47 +43,49 @@ private:
   ::cuda::std::uint64_t __lo_;
 
 public:
-  _CCCL_API constexpr __pcg_uint128_fallback() noexcept
+  _CCCL_HOST_DEVICE_API constexpr __pcg_uint128_fallback() noexcept
       : __hi_{0}
       , __lo_{0}
   {}
 
-  _CCCL_API constexpr __pcg_uint128_fallback(::cuda::std::uint64_t __val) noexcept
+  _CCCL_HOST_DEVICE_API constexpr __pcg_uint128_fallback(::cuda::std::uint64_t __val) noexcept
       : __hi_{0}
       , __lo_{__val}
   {}
 
-  _CCCL_API constexpr __pcg_uint128_fallback(::cuda::std::uint64_t __hi, ::cuda::std::uint64_t __lo) noexcept
+  _CCCL_HOST_DEVICE_API constexpr __pcg_uint128_fallback(::cuda::std::uint64_t __hi, ::cuda::std::uint64_t __lo) noexcept
       : __hi_{__hi}
       , __lo_{__lo}
   {}
 
-  [[nodiscard]] _CCCL_API constexpr explicit operator ::cuda::std::uint64_t() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr explicit operator ::cuda::std::uint64_t() const noexcept
   {
     return __lo_;
   }
 
-  [[nodiscard]] _CCCL_API constexpr explicit operator ::cuda::std::uint8_t() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr explicit operator ::cuda::std::uint8_t() const noexcept
   {
     return static_cast<::cuda::std::uint8_t>(__lo_);
   }
 
-  [[nodiscard]] _CCCL_API constexpr __pcg_uint128_fallback operator|(::cuda::std::uint64_t __rhs) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __pcg_uint128_fallback
+  operator|(::cuda::std::uint64_t __rhs) const noexcept
   {
     return __pcg_uint128_fallback(__hi_, __lo_ | __rhs);
   }
 
-  [[nodiscard]] _CCCL_API constexpr __pcg_uint128_fallback operator^(__pcg_uint128_fallback __rhs) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __pcg_uint128_fallback
+  operator^(__pcg_uint128_fallback __rhs) const noexcept
   {
     return __pcg_uint128_fallback(__hi_ ^ __rhs.__hi_, __lo_ ^ __rhs.__lo_);
   }
 
-  [[nodiscard]] _CCCL_API constexpr int operator&(int __rhs) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int operator&(int __rhs) const noexcept
   {
     return __lo_ & static_cast<::cuda::std::uint64_t>(__rhs);
   }
 
-  [[nodiscard]] _CCCL_API constexpr __pcg_uint128_fallback operator<<(int __shift) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __pcg_uint128_fallback operator<<(int __shift) const noexcept
   {
     _CCCL_ASSERT(__shift >= 0 && __shift < 128, "shift value out of range");
     if (__shift == 0)
@@ -101,7 +103,7 @@ public:
     return __pcg_uint128_fallback((__hi_ << __shift) | (__lo_ >> (64 - __shift)), __lo_ << __shift);
   }
 
-  [[nodiscard]] _CCCL_API constexpr __pcg_uint128_fallback operator>>(int __shift) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __pcg_uint128_fallback operator>>(int __shift) const noexcept
   {
     _CCCL_ASSERT(__shift >= 0 && __shift < 128, "shift value out of range");
     if (__shift == 0)
@@ -119,7 +121,8 @@ public:
     return __pcg_uint128_fallback(__hi_ >> __shift, (__lo_ >> __shift) | (__hi_ << (64 - __shift)));
   }
 
-  [[nodiscard]] _CCCL_API constexpr __pcg_uint128_fallback operator+(__pcg_uint128_fallback __rhs) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __pcg_uint128_fallback
+  operator+(__pcg_uint128_fallback __rhs) const noexcept
   {
     // TODO: optimize with PTX add.cc
     ::cuda::std::uint64_t __new_lo = __lo_ + __rhs.__lo_;
@@ -127,24 +130,25 @@ public:
     return __pcg_uint128_fallback(__hi_ + __rhs.__hi_ + __carry, __new_lo);
   }
 
-  [[nodiscard]] _CCCL_API constexpr __pcg_uint128_fallback operator*(__pcg_uint128_fallback __rhs) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __pcg_uint128_fallback
+  operator*(__pcg_uint128_fallback __rhs) const noexcept
   {
     __pcg_uint128_fallback __c(::cuda::mul_hi(__lo_, __rhs.__lo_), __lo_ * __rhs.__lo_);
     __c.__hi_ += __hi_ * __rhs.__lo_ + __lo_ * __rhs.__hi_;
     return __c;
   }
 
-  _CCCL_API constexpr __pcg_uint128_fallback& operator*=(__pcg_uint128_fallback __rhs) noexcept
+  _CCCL_HOST_DEVICE_API constexpr __pcg_uint128_fallback& operator*=(__pcg_uint128_fallback __rhs) noexcept
   {
     return *this = *this * __rhs;
   }
 
-  [[nodiscard]] _CCCL_API constexpr bool operator>(int __x) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool operator>(int __x) const noexcept
   {
     return __hi_ != 0 || __lo_ > static_cast<::cuda::std::uint64_t>(__x);
   }
 
-  [[nodiscard]] _CCCL_API constexpr friend bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(__pcg_uint128_fallback __lhs, __pcg_uint128_fallback __rhs) noexcept
   {
     return __lhs.__hi_ == __rhs.__hi_ && __lhs.__lo_ == __rhs.__lo_;
@@ -152,7 +156,8 @@ public:
 
 #if _CCCL_STD_VER <= 2017
   [[nodiscard]]
-  _CCCL_API constexpr friend bool operator!=(__pcg_uint128_fallback __lhs, __pcg_uint128_fallback __rhs) noexcept
+  _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(__pcg_uint128_fallback __lhs, __pcg_uint128_fallback __rhs) noexcept
   {
     return !(__lhs == __rhs);
   }
@@ -190,14 +195,15 @@ private:
   static constexpr __pcg64_uint128_t __multiplier = (static_cast<__pcg64_uint128_t>(_AHi) << 64) | _ALo;
   static constexpr __pcg64_uint128_t __increment  = (static_cast<__pcg64_uint128_t>(_CHi) << 64) | _CLo;
 
-  [[nodiscard]] _CCCL_API static constexpr result_type __output_transform(__pcg64_uint128_t __internal) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type
+  __output_transform(__pcg64_uint128_t __internal) noexcept
   {
     const int __rot = static_cast<__bitcount_t>(__internal >> 122);
     __internal      = __internal ^ (__internal >> 64);
     return ::cuda::std::rotr(result_type(__internal), __rot);
   }
 
-  [[nodiscard]] _CCCL_API constexpr ::cuda::std::pair<__pcg64_uint128_t, __pcg64_uint128_t>
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr ::cuda::std::pair<__pcg64_uint128_t, __pcg64_uint128_t>
   __power_mod(__pcg64_uint128_t __delta) noexcept
   {
     __pcg64_uint128_t __acc_mult = 1;
@@ -224,25 +230,25 @@ public:
 
   //! @brief Returns the smallest value the engine can produce.
   //! @return Always 0 for pcg64_engine.
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return 0;
   }
   //! @brief Returns the largest value the engine can produce.
   //! @return The maximum representable `result_type`.
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return ::cuda::std::numeric_limits<result_type>::max();
   }
 
   // constructors and seeding functions
   //! @brief Default-constructs the engine using `default_seed`.
-  _CCCL_API constexpr pcg64_engine() noexcept
+  _CCCL_HOST_DEVICE_API constexpr pcg64_engine() noexcept
       : pcg64_engine(default_seed)
   {}
   //! @brief Constructs the engine and seeds it with `__seed`.
   //! @param __seed The seed value used to initialize the engine state.
-  _CCCL_API constexpr explicit pcg64_engine(result_type __seed) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit pcg64_engine(result_type __seed) noexcept
   {
     seed(__seed);
   }
@@ -258,7 +264,7 @@ public:
   }
   //! @brief Seed the engine with an integer seed.
   //! @param __seed The seed value; defaults to `default_seed`.
-  _CCCL_API constexpr void seed(result_type __seed = default_seed) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void seed(result_type __seed = default_seed) noexcept
   {
     __x_ = (__pcg64_uint128_t(__seed) + __increment) * __multiplier + __increment;
   }
@@ -284,7 +290,7 @@ public:
   //! Advances the internal LCG state and applies the PCG output
   //! permutation to produce a 64-bit result.
   //! @return A 64-bit pseudo-random value.
-  _CCCL_API constexpr result_type operator()() noexcept
+  _CCCL_HOST_DEVICE_API constexpr result_type operator()() noexcept
   {
     __x_ = __x_ * __multiplier + __increment;
     return __output_transform(__x_);
@@ -292,7 +298,7 @@ public:
 
   //! @brief Advance the engine state by `__z` steps, discarding outputs.
   //! @param __z Number of values to discard.
-  _CCCL_API constexpr void discard(unsigned long long __z) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void discard(unsigned long long __z) noexcept
   {
     const auto [__mult, __plus] = __power_mod(__z);
     __x_                        = __x_ * __mult + __plus;
@@ -300,14 +306,16 @@ public:
 
   //! @brief Equality comparison for two engines.
   //! @return True if both engines have identical internal state.
-  [[nodiscard]] _CCCL_API constexpr friend bool operator==(const pcg64_engine& __x, const pcg64_engine& __y) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const pcg64_engine& __x, const pcg64_engine& __y) noexcept
   {
     return __x.__x_ == __y.__x_;
   }
 
 #if _CCCL_STD_VER <= 2017
   //! @brief Inequality comparison for two engines.
-  [[nodiscard]] _CCCL_API constexpr friend bool operator!=(const pcg64_engine& __x, const pcg64_engine& __y) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const pcg64_engine& __x, const pcg64_engine& __y) noexcept
   {
     return !(__x == __y);
   }
@@ -316,7 +324,7 @@ public:
 #if _CCCL_HOSTED()
 
   template <typename _CharT, typename _Traits>
-  _CCCL_API friend ::std::basic_ostream<_CharT, _Traits>&
+  _CCCL_HOST_DEVICE_API friend ::std::basic_ostream<_CharT, _Traits>&
   operator<<(::std::basic_ostream<_CharT, _Traits>& __os, const pcg64_engine& __e)
   {
     using ostream_type = ::std::basic_ostream<_CharT, _Traits>;
@@ -343,7 +351,7 @@ public:
   }
 
   template <typename _CharT, typename _Traits>
-  _CCCL_API friend ::std::basic_istream<_CharT, _Traits>&
+  _CCCL_HOST_DEVICE_API friend ::std::basic_istream<_CharT, _Traits>&
   operator>>(::std::basic_istream<_CharT, _Traits>& __is, pcg64_engine& __e)
   {
     using istream_type = ::std::basic_istream<_CharT, _Traits>;

--- a/libcudacxx/include/cuda/__random/random_bijection.h
+++ b/libcudacxx/include/cuda/__random/random_bijection.h
@@ -59,18 +59,19 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Bijection2 = _Bijection)
   _CCCL_REQUIRES(::cuda::std::default_initializable<_Bijection2>)
-  _CCCL_API constexpr random_bijection() noexcept(::cuda::std::is_nothrow_default_constructible_v<_Bijection2>)
+  _CCCL_HOST_DEVICE_API constexpr random_bijection() noexcept(
+    ::cuda::std::is_nothrow_default_constructible_v<_Bijection2>)
       : __bijection_()
       , __num_elements_(0)
   {}
 
   template <class _RNG>
-  _CCCL_API constexpr random_bijection(_IndexType __num_elements, _RNG&& __gen) noexcept
+  _CCCL_HOST_DEVICE_API constexpr random_bijection(_IndexType __num_elements, _RNG&& __gen) noexcept
       : __bijection_(__num_elements, ::cuda::std::forward<_RNG>(__gen))
       , __num_elements_(__num_elements)
   {}
 
-  [[nodiscard]] _CCCL_API constexpr _IndexType operator()(_IndexType __n) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _IndexType operator()(_IndexType __n) const noexcept
   {
     // The initial index must be be in the range [0, __num_elemments]
     // If __n < __num_elements_ Iterating a __bijection_ like this will always terminate.
@@ -84,7 +85,7 @@ public:
     return __n;
   }
 
-  [[nodiscard]] _CCCL_API constexpr _IndexType size() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _IndexType size() const noexcept
   {
     return __num_elements_;
   }

--- a/libcudacxx/include/cuda/std/__random/bernoulli_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/bernoulli_distribution.h
@@ -43,21 +43,23 @@ public:
   public:
     using distribution_type = bernoulli_distribution;
 
-    _CCCL_API constexpr explicit param_type(double __p = 0.5) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(double __p = 0.5) noexcept
         : __p_{__p}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr double p() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr double p() const noexcept
     {
       return __p_;
     }
 
-    [[nodiscard]] _CCCL_API friend constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__p_ == __y.__p_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -69,60 +71,60 @@ private:
 
 public:
   // constructors and reset functions
-  _CCCL_API constexpr bernoulli_distribution() noexcept
+  _CCCL_HOST_DEVICE_API constexpr bernoulli_distribution() noexcept
       : bernoulli_distribution{0.5}
   {}
-  _CCCL_API constexpr explicit bernoulli_distribution(double __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit bernoulli_distribution(double __p) noexcept
       : __p_{param_type(__p)}
   {}
-  _CCCL_API constexpr explicit bernoulli_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit bernoulli_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API constexpr result_type operator()(_URng& __g) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type operator()(_URng& __g) noexcept
   {
     return (*this)(__g, __p_);
   }
   template <class _URng>
-  [[nodiscard]] _CCCL_API constexpr result_type operator()(_URng& __g, const param_type& __p) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type operator()(_URng& __g, const param_type& __p) noexcept
   {
     static_assert(__cccl_random_is_valid_urng<_URng>, "URng must meet the UniformRandomBitGenerator requirements");
     return ::cuda::std::generate_canonical<double, numeric_limits<double>::digits>(__g) < __p.p();
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr double p() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr double p() const noexcept
   {
     return __p_.p();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
-  [[nodiscard]] _CCCL_API constexpr result_type min() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type min() const noexcept
   {
     return false;
   }
-  [[nodiscard]] _CCCL_API constexpr result_type max() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type max() const noexcept
   {
     return true;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const bernoulli_distribution& __x, const bernoulli_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator!=(const bernoulli_distribution& __x, const bernoulli_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/binomial_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/binomial_distribution.h
@@ -52,7 +52,7 @@ public:
 
     // Kemp, C. D. "A modal method for generating binomial variables." Communications in Statistics-Theory and
     // Methods 15.3 (1986): 805-813.
-    _CCCL_API explicit param_type(result_type __t = 1, double __p = 0.5)
+    _CCCL_HOST_DEVICE_API explicit param_type(result_type __t = 1, double __p = 0.5)
         : __t_{__t}
         , __p_{__p}
     {
@@ -66,21 +66,23 @@ public:
       }
     }
 
-    [[nodiscard]] _CCCL_API constexpr result_type t() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type t() const noexcept
     {
       return __t_;
     }
-    [[nodiscard]] _CCCL_API constexpr double p() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr double p() const noexcept
     {
       return __p_;
     }
 
-    [[nodiscard]] friend _CCCL_API constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__t_ == __y.__t_ && __x.__p_ == __y.__p_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] friend _CCCL_API constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -94,20 +96,20 @@ private:
 
 public:
   // constructors and reset functions
-  _CCCL_API binomial_distribution() noexcept
+  _CCCL_HOST_DEVICE_API binomial_distribution() noexcept
       : binomial_distribution{1}
   {}
-  _CCCL_API explicit binomial_distribution(result_type __t, double __p = 0.5) noexcept
+  _CCCL_HOST_DEVICE_API explicit binomial_distribution(result_type __t, double __p = 0.5) noexcept
       : __p_{param_type{__t, __p}}
   {}
-  _CCCL_API explicit binomial_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API explicit binomial_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  _CCCL_API result_type operator()(_URng& __g)
+  _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
@@ -115,7 +117,7 @@ public:
   // Reference: Kemp, C. D. "A modal method for generating binomial variables." Communications in Statistics-Theory and
   // Methods 15.3 (1986): 805-813.
   template <class _URng>
-  _CCCL_API result_type operator()(_URng& __g, const param_type& __pr)
+  _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g, const param_type& __pr)
   {
     static_assert(__cccl_random_is_valid_urng<_URng>, "URng must meet the UniformRandomBitGenerator requirements");
     if (__pr.__t_ == 0 || __pr.__p_ == 0)
@@ -172,40 +174,40 @@ public:
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type t() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type t() const noexcept
   {
     return __p_.t();
   }
-  [[nodiscard]] _CCCL_API constexpr double p() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr double p() const noexcept
   {
     return __p_.p();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API constexpr result_type min() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type min() const noexcept
   {
     return 0;
   }
-  [[nodiscard]] _CCCL_API constexpr result_type max() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type max() const noexcept
   {
     return t();
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const binomial_distribution& __x, const binomial_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator!=(const binomial_distribution& __x, const binomial_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/cauchy_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/cauchy_distribution.h
@@ -47,26 +47,28 @@ public:
   public:
     using distribution_type = cauchy_distribution;
 
-    _CCCL_API constexpr explicit param_type(result_type __a = 0, result_type __b = 1) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(result_type __a = 0, result_type __b = 1) noexcept
         : __a_{__a}
         , __b_{__b}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type a() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type a() const noexcept
     {
       return __a_;
     }
-    [[nodiscard]] _CCCL_API constexpr result_type b() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type b() const noexcept
     {
       return __b_;
     }
 
-    [[nodiscard]] friend _CCCL_API constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__a_ == __y.__a_ && __x.__b_ == __y.__b_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] friend _CCCL_API constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -79,22 +81,22 @@ private:
 public:
   // constructor and reset functions
   constexpr cauchy_distribution() noexcept = default;
-  _CCCL_API constexpr explicit cauchy_distribution(result_type __a, result_type __b = 1) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit cauchy_distribution(result_type __a, result_type __b = 1) noexcept
       : __p_{param_type{__a, __b}}
   {}
-  _CCCL_API constexpr explicit cauchy_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit cauchy_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g, const param_type& __p)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g, const param_type& __p)
   {
     static_assert(__cccl_random_is_valid_urng<_URng>, "URng must meet the UniformRandomBitGenerator requirements");
     uniform_real_distribution<result_type> __gen;
@@ -103,40 +105,40 @@ public:
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type a() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type a() const noexcept
   {
     return __p_.a();
   }
-  [[nodiscard]] _CCCL_API constexpr result_type b() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type b() const noexcept
   {
     return __p_.b();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return -numeric_limits<result_type>::infinity();
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return numeric_limits<result_type>::infinity();
   }
 
-  [[nodiscard]] friend _CCCL_API constexpr bool
+  [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
   operator==(const cauchy_distribution& __x, const cauchy_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] friend _CCCL_API constexpr bool
+  [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
   operator!=(const cauchy_distribution& __x, const cauchy_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/chi_squared_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/chi_squared_distribution.h
@@ -47,21 +47,23 @@ public:
 
     constexpr param_type() noexcept = default;
 
-    _CCCL_API constexpr explicit param_type(result_type __n) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(result_type __n) noexcept
         : __n_{__n}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type n() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type n() const noexcept
     {
       return __n_;
     }
 
-    [[nodiscard]] friend _CCCL_API constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__n_ == __y.__n_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] friend _CCCL_API constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -75,58 +77,58 @@ public:
   // constructor and reset functions
   constexpr chi_squared_distribution() noexcept = default;
 
-  _CCCL_API constexpr explicit chi_squared_distribution(result_type __n) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit chi_squared_distribution(result_type __n) noexcept
       : __p_{param_type{__n}}
   {}
-  _CCCL_API constexpr explicit chi_squared_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit chi_squared_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g, const param_type& __p)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g, const param_type& __p)
   {
     static_assert(__cccl_random_is_valid_urng<_URng>, "URng must meet the UniformRandomBitGenerator requirements");
     return gamma_distribution<result_type>(__p.n() / 2, 2)(__g);
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type n() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type n() const noexcept
   {
     return __p_.n();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return result_type{0};
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return numeric_limits<result_type>::infinity();
   }
 
-  [[nodiscard]] friend _CCCL_API constexpr bool
+  [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
   operator==(const chi_squared_distribution& __x, const chi_squared_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] friend _CCCL_API constexpr bool
+  [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
   operator!=(const chi_squared_distribution& __x, const chi_squared_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/exponential_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/exponential_distribution.h
@@ -49,21 +49,23 @@ public:
   public:
     using distribution_type = exponential_distribution;
 
-    _CCCL_API explicit param_type(result_type __lambda = 1)
+    _CCCL_HOST_DEVICE_API explicit param_type(result_type __lambda = 1)
         : __lambda_{__lambda}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type lambda() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type lambda() const noexcept
     {
       return __lambda_;
     }
 
-    [[nodiscard]] friend _CCCL_API constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__lambda_ == __y.__lambda_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] friend _CCCL_API constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -75,25 +77,25 @@ private:
 
 public:
   // constructors and reset functions
-  _CCCL_API exponential_distribution() noexcept
+  _CCCL_HOST_DEVICE_API exponential_distribution() noexcept
       : exponential_distribution{1}
   {}
-  _CCCL_API explicit exponential_distribution(result_type __lambda) noexcept
+  _CCCL_HOST_DEVICE_API explicit exponential_distribution(result_type __lambda) noexcept
       : __p_{param_type{__lambda}}
   {}
-  _CCCL_API explicit exponential_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API explicit exponential_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g, const param_type& __p)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g, const param_type& __p)
   {
     static_assert(__cccl_random_is_valid_urng<_URng>, "URng must meet the UniformRandomBitGenerator requirements");
     return -::cuda::std::log(
@@ -102,36 +104,36 @@ public:
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type lambda() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type lambda() const noexcept
   {
     return __p_.lambda();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return result_type{0};
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return numeric_limits<result_type>::infinity();
   }
 
-  [[nodiscard]] friend _CCCL_API constexpr bool
+  [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
   operator==(const exponential_distribution& __x, const exponential_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] friend _CCCL_API constexpr bool
+  [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
   operator!=(const exponential_distribution& __x, const exponential_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/extreme_value_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/extreme_value_distribution.h
@@ -49,26 +49,29 @@ public:
   public:
     using distribution_type = extreme_value_distribution;
 
-    _CCCL_API constexpr explicit param_type(result_type __a = result_type{0}, result_type __b = result_type{1}) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(
+      result_type __a = result_type{0}, result_type __b = result_type{1}) noexcept
         : __a_{__a}
         , __b_{__b}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type a() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type a() const noexcept
     {
       return __a_;
     }
-    [[nodiscard]] _CCCL_API constexpr result_type b() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type b() const noexcept
     {
       return __b_;
     }
 
-    [[nodiscard]] friend _CCCL_API constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__a_ == __y.__a_ && __x.__b_ == __y.__b_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] friend _CCCL_API constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -81,22 +84,23 @@ private:
 public:
   // constructor and reset functions
   _CCCL_HIDE_FROM_ABI constexpr extreme_value_distribution() noexcept = default;
-  _CCCL_API constexpr explicit extreme_value_distribution(result_type __a, result_type __b = result_type{1}) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit extreme_value_distribution(
+    result_type __a, result_type __b = result_type{1}) noexcept
       : __p_{param_type{__a, __b}}
   {}
-  _CCCL_API constexpr explicit extreme_value_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit extreme_value_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g, const param_type& __p)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g, const param_type& __p)
   {
     static_assert(__cccl_random_is_valid_urng<_URng>, "URng must meet the UniformRandomBitGenerator requirements");
     return __p.a()
@@ -105,40 +109,40 @@ public:
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type a() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type a() const noexcept
   {
     return __p_.a();
   }
-  [[nodiscard]] _CCCL_API constexpr result_type b() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type b() const noexcept
   {
     return __p_.b();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API _CCCL_CONSTEXPR_CXX20 void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API _CCCL_CONSTEXPR_CXX20 void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return -numeric_limits<result_type>::infinity();
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return numeric_limits<result_type>::infinity();
   }
 
-  [[nodiscard]] friend _CCCL_API constexpr bool
+  [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
   operator==(const extreme_value_distribution& __x, const extreme_value_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] friend _CCCL_API constexpr bool
+  [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
   operator!=(const extreme_value_distribution& __x, const extreme_value_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/fisher_f_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/fisher_f_distribution.h
@@ -48,26 +48,29 @@ public:
   public:
     using distribution_type = fisher_f_distribution;
 
-    _CCCL_API constexpr explicit param_type(result_type __m = result_type{1}, result_type __n = result_type{1}) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(
+      result_type __m = result_type{1}, result_type __n = result_type{1}) noexcept
         : __m_{__m}
         , __n_{__n}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type m() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type m() const noexcept
     {
       return __m_;
     }
-    [[nodiscard]] _CCCL_API constexpr result_type n() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type n() const noexcept
     {
       return __n_;
     }
 
-    [[nodiscard]] friend _CCCL_API constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__m_ == __y.__m_ && __x.__n_ == __y.__n_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] friend _CCCL_API constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -81,22 +84,22 @@ public:
   // constructor and reset functions
   constexpr fisher_f_distribution() = default;
 
-  _CCCL_API constexpr explicit fisher_f_distribution(result_type __m, result_type __n = result_type{1})
+  _CCCL_HOST_DEVICE_API constexpr explicit fisher_f_distribution(result_type __m, result_type __n = result_type{1})
       : __p_{param_type{__m, __n}}
   {}
-  _CCCL_API constexpr explicit fisher_f_distribution(const param_type& __p)
+  _CCCL_HOST_DEVICE_API constexpr explicit fisher_f_distribution(const param_type& __p)
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g, const param_type& __p)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g, const param_type& __p)
   {
     static_assert(__cccl_random_is_valid_urng<_URng>);
     gamma_distribution<result_type> __gdm{__p.m() * result_type{.5}};
@@ -105,40 +108,40 @@ public:
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type m() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type m() const noexcept
   {
     return __p_.m();
   }
-  [[nodiscard]] _CCCL_API constexpr result_type n() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type n() const noexcept
   {
     return __p_.n();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API _CCCL_CONSTEXPR_CXX20 void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API _CCCL_CONSTEXPR_CXX20 void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return result_type{0};
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return numeric_limits<result_type>::infinity();
   }
 
-  [[nodiscard]] friend _CCCL_API constexpr bool
+  [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
   operator==(const fisher_f_distribution& __x, const fisher_f_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] friend _CCCL_API constexpr bool
+  [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
   operator!=(const fisher_f_distribution& __x, const fisher_f_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/gamma_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/gamma_distribution.h
@@ -52,26 +52,29 @@ public:
   public:
     using distribution_type = gamma_distribution;
 
-    _CCCL_API constexpr explicit param_type(result_type __alpha = result_type{1}, result_type __beta = result_type{1})
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(
+      result_type __alpha = result_type{1}, result_type __beta = result_type{1})
         : __alpha_{__alpha}
         , __beta_{__beta}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type alpha() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type alpha() const noexcept
     {
       return __alpha_;
     }
-    [[nodiscard]] _CCCL_API constexpr result_type beta() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type beta() const noexcept
     {
       return __beta_;
     }
 
-    [[nodiscard]] friend _CCCL_API constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__alpha_ == __y.__alpha_ && __x.__beta_ == __y.__beta_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] friend _CCCL_API constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -84,22 +87,23 @@ private:
 public:
   // constructors and reset functions
   constexpr gamma_distribution() = default;
-  _CCCL_API constexpr explicit gamma_distribution(result_type __alpha, result_type __beta = result_type{1}) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit gamma_distribution(
+    result_type __alpha, result_type __beta = result_type{1}) noexcept
       : __p_{param_type{__alpha, __beta}}
   {}
-  _CCCL_API constexpr explicit gamma_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit gamma_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g, const param_type& __p)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g, const param_type& __p)
   {
     static_assert(__cccl_random_is_valid_urng<_URng>, "URng must meet the UniformRandomBitGenerator requirements");
     const result_type __a = __p.alpha();
@@ -167,40 +171,40 @@ public:
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type alpha() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type alpha() const noexcept
   {
     return __p_.alpha();
   }
-  [[nodiscard]] _CCCL_API constexpr result_type beta() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type beta() const noexcept
   {
     return __p_.beta();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return result_type{0};
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return numeric_limits<result_type>::infinity();
   }
 
-  [[nodiscard]] friend _CCCL_API constexpr bool
+  [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
   operator==(const gamma_distribution& __x, const gamma_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] friend _CCCL_API constexpr bool
+  [[nodiscard]] friend _CCCL_HOST_DEVICE_API constexpr bool
   operator!=(const gamma_distribution& __x, const gamma_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/generate_canonical.h
+++ b/libcudacxx/include/cuda/std/__random/generate_canonical.h
@@ -31,7 +31,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 // generate_canonical
 _CCCL_EXEC_CHECK_DISABLE
 template <class _RealType, size_t __bits, class _URng>
-[[nodiscard]] _CCCL_API constexpr _RealType generate_canonical(_URng& __g) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _RealType generate_canonical(_URng& __g) noexcept
 {
   constexpr size_t __dt = numeric_limits<_RealType>::digits;
   const size_t __b      = __dt < __bits ? __dt : __bits;

--- a/libcudacxx/include/cuda/std/__random/geometric_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/geometric_distribution.h
@@ -49,21 +49,23 @@ public:
 
     param_type() noexcept = default;
 
-    _CCCL_API constexpr explicit param_type(double __p) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(double __p) noexcept
         : __p_{__p}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr double p() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr double p() const noexcept
     {
       return __p_;
     }
 
-    [[nodiscard]] _CCCL_API friend constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__p_ == __y.__p_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -76,57 +78,57 @@ private:
 public:
   // constructors and reset functions
   constexpr geometric_distribution() noexcept = default;
-  _CCCL_API constexpr explicit geometric_distribution(double __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit geometric_distribution(double __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr explicit geometric_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit geometric_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g, const param_type& __p)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g, const param_type& __p)
   {
     return negative_binomial_distribution<result_type>(1, __p.p())(__g);
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr double p() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr double p() const noexcept
   {
     return __p_.p();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return result_type{0};
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return numeric_limits<result_type>::max();
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const geometric_distribution& __x, const geometric_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator!=(const geometric_distribution& __x, const geometric_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/linear_congruential_engine.h
+++ b/libcudacxx/include/cuda/std/__random/linear_congruential_engine.h
@@ -63,7 +63,7 @@ template <uint64_t _Ap, uint64_t _Cp, uint64_t _Mp>
 struct __lce_ta<_Ap, _Cp, _Mp, ~uint64_t{0}, true>
 {
   using result_type = uint64_t;
-  [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type next(result_type __x) noexcept
   {
     // Schrage's algorithm
     constexpr result_type __q = _Mp / _Ap;
@@ -80,7 +80,7 @@ template <uint64_t _Ap, uint64_t _Mp>
 struct __lce_ta<_Ap, 0, _Mp, ~uint64_t{0}, true>
 {
   using result_type = uint64_t;
-  [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type next(result_type __x) noexcept
   {
     // Schrage's algorithm
     constexpr result_type __q = _Mp / _Ap;
@@ -96,7 +96,7 @@ template <uint64_t _Ap, uint64_t _Cp, uint64_t _Mp>
 struct __lce_ta<_Ap, _Cp, _Mp, ~uint64_t{0}, false>
 {
   using result_type = uint64_t;
-  [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type next(result_type __x) noexcept
   {
     return (_Ap * __x + _Cp) % _Mp;
   }
@@ -106,7 +106,7 @@ template <uint64_t _Ap, uint64_t _Cp>
 struct __lce_ta<_Ap, _Cp, 0, ~uint64_t{0}, false>
 {
   using result_type = uint64_t;
-  [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type next(result_type __x) noexcept
   {
     return _Ap * __x + _Cp;
   }
@@ -118,7 +118,7 @@ template <uint64_t _Ap, uint64_t _Cp, uint64_t _Mp>
 struct __lce_ta<_Ap, _Cp, _Mp, ~uint32_t{0}, true>
 {
   using result_type = uint32_t;
-  [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type next(result_type __x) noexcept
   {
     constexpr auto __a = static_cast<result_type>(_Ap);
     constexpr auto __c = static_cast<result_type>(_Cp);
@@ -138,7 +138,7 @@ template <uint64_t _Ap, uint64_t _Mp>
 struct __lce_ta<_Ap, 0, _Mp, ~uint32_t{0}, true>
 {
   using result_type = uint32_t;
-  [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type next(result_type __x) noexcept
   {
     constexpr result_type __a = static_cast<result_type>(_Ap);
     constexpr result_type __m = static_cast<result_type>(_Mp);
@@ -156,7 +156,7 @@ template <uint64_t _Ap, uint64_t _Cp, uint64_t _Mp>
 struct __lce_ta<_Ap, _Cp, _Mp, ~uint32_t{0}, false>
 {
   using result_type = uint32_t;
-  [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type next(result_type __x) noexcept
   {
     constexpr result_type __a = static_cast<result_type>(_Ap);
     constexpr result_type __c = static_cast<result_type>(_Cp);
@@ -169,7 +169,7 @@ template <uint64_t _Ap, uint64_t _Cp>
 struct __lce_ta<_Ap, _Cp, 0, ~uint32_t{0}, false>
 {
   using result_type = uint32_t;
-  [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type next(result_type __x) noexcept
   {
     constexpr result_type __a = static_cast<result_type>(_Ap);
     constexpr result_type __c = static_cast<result_type>(_Cp);
@@ -183,7 +183,7 @@ template <uint64_t _Ap, uint64_t _Cp, uint64_t _Mp, bool _UseSchrage>
 struct __lce_ta<_Ap, _Cp, _Mp, static_cast<uint16_t>(~0), _UseSchrage>
 {
   using result_type = uint16_t;
-  [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type next(result_type __x) noexcept
   {
     return static_cast<result_type>(__lce_ta<_Ap, _Cp, _Mp, ~uint32_t{0}>::next(__x));
   }
@@ -195,7 +195,7 @@ template <uint64_t _Ap, uint64_t _Cp, uint64_t _Mp, bool _UseSchrage>
 struct __lce_ta<_Ap, _Cp, _Mp, static_cast<uint8_t>(~0), _UseSchrage>
 {
   using result_type = uint8_t;
-  [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type next(result_type __x) noexcept
   {
     return static_cast<result_type>(__lce_ta<_Ap, _Cp, _Mp, ~uint32_t{0}>::next(__x));
   }
@@ -230,21 +230,21 @@ public:
   static constexpr const result_type multiplier = __A;
   static constexpr const result_type increment  = __C;
   static constexpr const result_type modulus    = __M;
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return _Min;
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return _Max;
   }
   static constexpr const result_type default_seed = 1u;
 
   // constructors and seeding functions
-  _CCCL_API constexpr linear_congruential_engine() noexcept
+  _CCCL_HOST_DEVICE_API constexpr linear_congruential_engine() noexcept
       : linear_congruential_engine(default_seed)
   {}
-  _CCCL_API explicit constexpr linear_congruential_engine(result_type __s) noexcept
+  _CCCL_HOST_DEVICE_API explicit constexpr linear_congruential_engine(result_type __s) noexcept
   {
     seed(__s);
   }
@@ -254,7 +254,7 @@ public:
   {
     seed(__q);
   }
-  _CCCL_API constexpr void seed(result_type __s = default_seed) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void seed(result_type __s = default_seed) noexcept
   {
     seed(integral_constant<bool, __M == 0>(), integral_constant<bool, __C == 0>(), __s);
   }
@@ -267,12 +267,12 @@ public:
   }
 
   // generating functions
-  _CCCL_API constexpr result_type operator()() noexcept
+  _CCCL_HOST_DEVICE_API constexpr result_type operator()() noexcept
   {
     return __x_ = static_cast<result_type>(__lce_ta<__A, __C, __M, _Mp>::next(__x_));
   }
 
-  _CCCL_API constexpr void discard(uint64_t __z) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void discard(uint64_t __z) noexcept
   {
     constexpr bool __can_overflow = (__A != 0 && __M != 0 && __M - 1 > (_Mp - __C) / __A);
     // Fallback implementation
@@ -310,12 +310,12 @@ public:
     }
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const linear_congruential_engine& __x, const linear_congruential_engine& __y) noexcept
   {
     return __x.__x_ == __y.__x_;
   }
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator!=(const linear_congruential_engine& __x, const linear_congruential_engine& __y) noexcept
   {
     return !(__x == __y);
@@ -323,7 +323,7 @@ public:
 
 #if _CCCL_HOSTED()
   template <typename _CharT, typename _Traits>
-  _CCCL_API friend ::std::basic_ostream<_CharT, _Traits>&
+  _CCCL_HOST_DEVICE_API friend ::std::basic_ostream<_CharT, _Traits>&
   operator<<(::std::basic_ostream<_CharT, _Traits>& __os, const linear_congruential_engine& __e)
   {
     using _Ostream                            = ::std::basic_ostream<_CharT, _Traits>;
@@ -334,7 +334,7 @@ public:
     return __os << __e.__x_;
   }
   template <typename _CharT, typename _Traits>
-  _CCCL_API friend ::std::basic_istream<_CharT, _Traits>&
+  _CCCL_HOST_DEVICE_API friend ::std::basic_istream<_CharT, _Traits>&
   operator>>(::std::basic_istream<_CharT, _Traits>& __is, linear_congruential_engine& __e)
   {
     using _Istream                            = ::std::basic_istream<_CharT, _Traits>;
@@ -352,32 +352,32 @@ public:
 #endif // _CCCL_HOSTED()
 
 private:
-  _CCCL_API constexpr void seed(true_type, true_type, result_type __s) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void seed(true_type, true_type, result_type __s) noexcept
   {
     __x_ = __s == 0 ? 1 : __s;
   }
-  _CCCL_API constexpr void seed(true_type, false_type, result_type __s) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void seed(true_type, false_type, result_type __s) noexcept
   {
     __x_ = __s;
   }
-  _CCCL_API constexpr void seed(false_type, true_type, result_type __s) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void seed(false_type, true_type, result_type __s) noexcept
   {
     __x_ = __s % __M == 0 ? 1 : __s % __M;
   }
-  _CCCL_API constexpr void seed(false_type, false_type, result_type __s) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void seed(false_type, false_type, result_type __s) noexcept
   {
     __x_ = __s % __M;
   }
 
   template <class _Sseq>
-  _CCCL_API constexpr void __seed(_Sseq& __q, integral_constant<uint32_t, 1>) noexcept;
+  _CCCL_HOST_DEVICE_API constexpr void __seed(_Sseq& __q, integral_constant<uint32_t, 1>) noexcept;
   template <class _Sseq>
-  _CCCL_API constexpr void __seed(_Sseq& __q, integral_constant<uint32_t, 2>) noexcept;
+  _CCCL_HOST_DEVICE_API constexpr void __seed(_Sseq& __q, integral_constant<uint32_t, 2>) noexcept;
 };
 
 template <class _UIntType, _UIntType __A, _UIntType __C, _UIntType __M>
 template <class _Sseq>
-_CCCL_API constexpr void
+_CCCL_HOST_DEVICE_API constexpr void
 linear_congruential_engine<_UIntType, __A, __C, __M>::__seed(_Sseq& __q, integral_constant<uint32_t, 1>) noexcept
 {
   constexpr uint32_t __k = 1;
@@ -389,7 +389,7 @@ linear_congruential_engine<_UIntType, __A, __C, __M>::__seed(_Sseq& __q, integra
 
 template <class _UIntType, _UIntType __A, _UIntType __C, _UIntType __M>
 template <class _Sseq>
-_CCCL_API constexpr void
+_CCCL_HOST_DEVICE_API constexpr void
 linear_congruential_engine<_UIntType, __A, __C, __M>::__seed(_Sseq& __q, integral_constant<uint32_t, 2>) noexcept
 {
   constexpr uint32_t __k = 2;

--- a/libcudacxx/include/cuda/std/__random/lognormal_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/lognormal_distribution.h
@@ -49,26 +49,29 @@ public:
   public:
     using distribution_type = lognormal_distribution;
 
-    _CCCL_API constexpr explicit param_type(result_type __m = result_type{0}, result_type __s = result_type{1}) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(
+      result_type __m = result_type{0}, result_type __s = result_type{1}) noexcept
         : __m_{__m}
         , __s_{__s}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type m() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type m() const noexcept
     {
       return __m_;
     }
-    [[nodiscard]] _CCCL_API constexpr result_type s() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type s() const noexcept
     {
       return __s_;
     }
 
-    [[nodiscard]] _CCCL_API friend constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__m_ == __y.__m_ && __x.__s_ == __y.__s_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -81,67 +84,68 @@ private:
 public:
   // constructor and reset functions
   constexpr lognormal_distribution() noexcept = default;
-  _CCCL_API constexpr explicit lognormal_distribution(result_type __m, result_type __s = result_type{1}) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit lognormal_distribution(
+    result_type __m, result_type __s = result_type{1}) noexcept
       : __nd_{__m, __s}
   {}
-  _CCCL_API constexpr explicit lognormal_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit lognormal_distribution(const param_type& __p) noexcept
       : __nd_{__p.m(), __p.s()}
   {}
-  _CCCL_API constexpr void reset() noexcept
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept
   {
     __nd_.reset();
   }
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return ::cuda::std::exp(__nd_(__g));
   }
 
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g, const param_type& __p)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g, const param_type& __p)
   {
     typename normal_distribution<result_type>::param_type __pn{__p.m(), __p.s()};
     return ::cuda::std::exp(__nd_(__g, __pn));
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type m() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type m() const noexcept
   {
     return __nd_.mean();
   }
-  [[nodiscard]] _CCCL_API constexpr result_type s() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type s() const noexcept
   {
     return __nd_.stddev();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return param_type{__nd_.mean(), __nd_.stddev()};
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     typename normal_distribution<result_type>::param_type __pn{__p.m(), __p.s()};
     __nd_.param(__pn);
   }
 
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return result_type{0};
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return numeric_limits<result_type>::infinity();
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const lognormal_distribution& __x, const lognormal_distribution& __y) noexcept
   {
     return __x.__nd_ == __y.__nd_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator!=(const lognormal_distribution& __x, const lognormal_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/negative_binomial_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/negative_binomial_distribution.h
@@ -49,26 +49,28 @@ public:
   public:
     using distribution_type = negative_binomial_distribution;
 
-    _CCCL_API constexpr explicit param_type(result_type __k = 1, double __p = 0.5) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(result_type __k = 1, double __p = 0.5) noexcept
         : __k_{__k}
         , __p_{__p}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type k() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type k() const noexcept
     {
       return __k_;
     }
-    [[nodiscard]] _CCCL_API constexpr double p() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr double p() const noexcept
     {
       return __p_;
     }
 
-    [[nodiscard]] _CCCL_API friend constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__k_ == __y.__k_ && __x.__p_ == __y.__p_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -82,22 +84,22 @@ public:
   // constructor and reset functions
   constexpr negative_binomial_distribution() noexcept = default;
 
-  _CCCL_API constexpr explicit negative_binomial_distribution(result_type __k, double __p = 0.5) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit negative_binomial_distribution(result_type __k, double __p = 0.5) noexcept
       : __p_{__k, __p}
   {}
-  _CCCL_API constexpr explicit negative_binomial_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit negative_binomial_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __urng, const param_type& __pr)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __urng, const param_type& __pr)
   {
     static_assert(__cccl_random_is_valid_urng<_URng>, "URng must meet the UniformRandomBitGenerator requirements");
     const result_type __k = __pr.k();
@@ -126,40 +128,40 @@ public:
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type k() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type k() const noexcept
   {
     return __p_.k();
   }
-  [[nodiscard]] _CCCL_API constexpr double p() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr double p() const noexcept
   {
     return __p_.p();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return 0;
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return numeric_limits<result_type>::max();
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const negative_binomial_distribution& __x, const negative_binomial_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator!=(const negative_binomial_distribution& __x, const negative_binomial_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/normal_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/normal_distribution.h
@@ -49,27 +49,29 @@ public:
   public:
     using distribution_type = normal_distribution;
 
-    _CCCL_API constexpr explicit param_type(result_type __mean = 0, result_type __stddev = 1) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(result_type __mean = 0, result_type __stddev = 1) noexcept
         : __mean_{__mean}
         , __stddev_{__stddev}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type mean() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type mean() const noexcept
     {
       return __mean_;
     }
-    [[nodiscard]] _CCCL_API constexpr result_type stddev() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type stddev() const noexcept
     {
       return __stddev_;
     }
 
-    [[nodiscard]] _CCCL_API friend constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__mean_ == __y.__mean_ && __x.__stddev_ == __y.__stddev_;
     }
 
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -82,28 +84,29 @@ private:
   bool __v_hot_{false};
 
 public:
-  _CCCL_API constexpr normal_distribution() noexcept
+  _CCCL_HOST_DEVICE_API constexpr normal_distribution() noexcept
       : normal_distribution{0}
   {}
-  _CCCL_API constexpr explicit normal_distribution(result_type __mean, result_type __stddev = result_type{1}) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit normal_distribution(
+    result_type __mean, result_type __stddev = result_type{1}) noexcept
       : __p_{param_type(__mean, __stddev)}
   {}
-  _CCCL_API constexpr explicit normal_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit normal_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept
   {
     __v_hot_ = false;
   }
 
   // generating functions
   template <class _URng>
-  _CCCL_API constexpr result_type operator()(_URng& __g)
+  _CCCL_HOST_DEVICE_API constexpr result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
   template <class _URng>
-  _CCCL_API constexpr result_type operator()(_URng& __g, const param_type& __p)
+  _CCCL_HOST_DEVICE_API constexpr result_type operator()(_URng& __g, const param_type& __p)
   {
     static_assert(__cccl_random_is_valid_urng<_URng>, "URng must meet the UniformRandomBitGenerator requirements");
     result_type __up = 0;
@@ -133,41 +136,42 @@ public:
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type mean() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type mean() const noexcept
   {
     return __p_.mean();
   }
-  [[nodiscard]] _CCCL_API constexpr result_type stddev() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type stddev() const noexcept
   {
     return __p_.stddev();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API constexpr result_type min() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type min() const noexcept
   {
     return -numeric_limits<result_type>::infinity();
   }
-  [[nodiscard]] _CCCL_API constexpr result_type max() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type max() const noexcept
   {
     return numeric_limits<result_type>::infinity();
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const normal_distribution& __x, const normal_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_ && __x.__v_hot_ == __y.__v_hot_ && (!__x.__v_hot_ || __x.__v_ == __y.__v_);
   }
 #if _CCCL_STD_VER <= 2017
   [[nodiscard]]
-  _CCCL_API friend constexpr bool operator!=(const normal_distribution& __x, const normal_distribution& __y) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator!=(const normal_distribution& __x, const normal_distribution& __y) noexcept
   {
     return !(__x == __y);
   }

--- a/libcudacxx/include/cuda/std/__random/philox_engine.h
+++ b/libcudacxx/include/cuda/std/__random/philox_engine.h
@@ -95,7 +95,7 @@ class philox_engine
   static_assert((0 < _WordSize && _WordSize <= numeric_limits<_UIntType>::digits),
                 "Word size w must satisfy 0 < w <= numeric_limits<_UIntType>::digits");
 
-  [[nodiscard]] _CCCL_API static constexpr auto __multipliers() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr auto __multipliers() noexcept
   {
     constexpr _UIntType __constants[] = {_Constants...};
     if constexpr (_WordCount == 2)
@@ -108,7 +108,7 @@ class philox_engine
     }
   }
 
-  [[nodiscard]] _CCCL_API static constexpr auto __round_consts() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr auto __round_consts() noexcept
   {
     constexpr _UIntType __constants[] = {_Constants...};
     if constexpr (_WordCount == 2)
@@ -131,12 +131,12 @@ public:
   static constexpr result_type default_seed = 20111115u;
 
   //! The smallest value this engine may potentially produce.
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return 0;
   }
   //! The largest value this engine may potentially produce.
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return ((result_type{1} << (word_size - 1)) | ((result_type{1} << (word_size - 1)) - 1));
   }
@@ -145,11 +145,11 @@ public:
   //! philox_engine.
   //!
   //! @param s The seed used to initialize this philox_engine's state.
-  _CCCL_API constexpr philox_engine() noexcept
+  _CCCL_HOST_DEVICE_API constexpr philox_engine() noexcept
   {
     seed(default_seed);
   }
-  _CCCL_API constexpr explicit philox_engine(const result_type __seed) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit philox_engine(const result_type __seed) noexcept
   {
     seed(__seed);
   }
@@ -165,7 +165,7 @@ public:
   //! a seed value.  If none is provided uses ``default_seed``.
   //!
   //! @param __s The seed used to initializes this philox_engine's state.
-  _CCCL_API constexpr void seed(result_type __s = default_seed) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void seed(result_type __s = default_seed) noexcept
   {
     __x_    = {};
     __y_    = {};
@@ -217,7 +217,7 @@ public:
   //!    e2.set_counter({0, 0, 1, 100}); // e2 is now 4*2^w values ahead of e1
   //!
   //! @param __counter The counter.
-  _CCCL_API constexpr void set_counter(const array<result_type, word_count>& __counter) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void set_counter(const array<result_type, word_count>& __counter) noexcept
   {
     _CCCL_PRAGMA_UNROLL_FULL()
     for (size_t __j = 0; __j < word_count; ++__j)
@@ -231,7 +231,7 @@ public:
 
   //! This member function produces a new random value and updates this philox_engine's state.
   //! @return A new random number.
-  _CCCL_API constexpr result_type operator()() noexcept
+  _CCCL_HOST_DEVICE_API constexpr result_type operator()() noexcept
   {
     ++__j_;
     if (__j_ == word_count)
@@ -247,7 +247,7 @@ public:
   //! and discards the results. philox_engine is a counter-based engine, therefore can discard with O(1) complexity.
   //!
   //! @param __z The number of random values to discard.
-  _CCCL_API constexpr void discard(unsigned long long __z) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void discard(unsigned long long __z) noexcept
   {
     // Advance __j_ until we are at n - 1
     auto __advance = ::cuda::std::min(__z, static_cast<unsigned long long>(word_count - 1 - __j_));
@@ -291,7 +291,7 @@ public:
   //! @param lhs The first philox_engine to test.
   //! @param rhs The second philox_engine to test.
   //! @return true if lhs is equal to rhs; false, otherwise.
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const philox_engine& __lhs, const philox_engine& __rhs) noexcept
   {
     if (__lhs.__x_ != __rhs.__x_)
@@ -316,7 +316,7 @@ public:
   //! @param lhs The first philox_engine to test.
   //! @param rhs The second philox_engine to test.
   //! @return true if lhs is not equal to rhs; false, otherwise.
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator!=(const philox_engine& __lhs, const philox_engine& __rhs) noexcept
   {
     return !(__lhs == __rhs);
@@ -329,7 +329,7 @@ public:
   //! @param e The philox_engine to stream out.
   //! @return os
   template <typename _CharT, typename _Traits>
-  _CCCL_API friend ::std::basic_ostream<_CharT, _Traits>&
+  _CCCL_HOST_DEVICE_API friend ::std::basic_ostream<_CharT, _Traits>&
   operator<<(::std::basic_ostream<_CharT, _Traits>& __os, const philox_engine& __e)
   {
     using ostream_type = ::std::basic_ostream<_CharT, _Traits>;
@@ -390,7 +390,7 @@ public:
   //! @param e The philox_engine to stream in.
   //! @return is
   template <typename _CharT, typename _Traits>
-  _CCCL_API friend ::std::basic_istream<_CharT, _Traits>&
+  _CCCL_HOST_DEVICE_API friend ::std::basic_istream<_CharT, _Traits>&
   operator>>(::std::basic_istream<_CharT, _Traits>& __is, philox_engine& __e)
   {
     using istream_type = ::std::basic_istream<_CharT, _Traits>;
@@ -430,7 +430,7 @@ public:
 #endif // _CCCL_HOSTED()
 
 private:
-  _CCCL_API constexpr void __increment_counter() noexcept
+  _CCCL_HOST_DEVICE_API constexpr void __increment_counter() noexcept
   {
     // Increment the big integer __x_ by 1, handling overflow.
     _CCCL_PRAGMA_UNROLL_FULL()
@@ -444,7 +444,7 @@ private:
     }
   }
 
-  [[nodiscard]] static _CCCL_API constexpr auto __mulhilo_fallback(result_type __a, result_type __b) noexcept
+  [[nodiscard]] static _CCCL_HOST_DEVICE_API constexpr auto __mulhilo_fallback(result_type __a, result_type __b) noexcept
   {
     // Generic slow implementation
     constexpr result_type __w_half  = word_size / 2;
@@ -467,7 +467,7 @@ private:
     return pair{__hi & max(), __lo & max()};
   }
 
-  static _CCCL_API constexpr auto __mulhilo(result_type __a, result_type __b) noexcept
+  static _CCCL_HOST_DEVICE_API constexpr auto __mulhilo(result_type __a, result_type __b) noexcept
   {
     if constexpr (word_size == 32 || word_size == 64)
     {
@@ -482,7 +482,7 @@ private:
     }
   }
 
-  _CCCL_API constexpr void __philox() noexcept
+  _CCCL_HOST_DEVICE_API constexpr void __philox() noexcept
   {
     // Only two variants are allowed, n=2 or n=4
     array<result_type, word_count> __S     = __x_;

--- a/libcudacxx/include/cuda/std/__random/poisson_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/poisson_distribution.h
@@ -63,7 +63,7 @@ public:
   public:
     using distribution_type = poisson_distribution;
 
-    _CCCL_API explicit param_type(double __mean = 1.0) noexcept
+    _CCCL_HOST_DEVICE_API explicit param_type(double __mean = 1.0) noexcept
         // According to the standard `inf` is a valid input, but it causes the
         // distribution to hang, so we replace it with the maximum representable
         // mean.
@@ -89,17 +89,19 @@ public:
       }
     }
 
-    [[nodiscard]] _CCCL_API constexpr double mean() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr double mean() const noexcept
     {
       return __mean_;
     }
 
-    [[nodiscard]] _CCCL_API friend constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__mean_ == __y.__mean_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -114,7 +116,7 @@ private:
   template <class _IntT,
             class _FloatT,
             bool _FloatBigger = (numeric_limits<_FloatT>::digits > numeric_limits<_IntT>::digits)>
-  [[nodiscard]] _CCCL_API static constexpr _IntT __max_representable_int_for_float() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _IntT __max_representable_int_for_float() noexcept
   {
     static_assert(::cuda::std::is_floating_point<_FloatT>::value, "must be a floating point type");
     static_assert(::cuda::std::is_integral<_IntT>::value, "must be an integral type");
@@ -124,7 +126,7 @@ private:
   }
 
   template <class _IntT, class _RealT>
-  [[nodiscard]] _CCCL_API static _IntT __clamp_to_integral(_RealT __r) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static _IntT __clamp_to_integral(_RealT __r) noexcept
   {
     using _Limits         = numeric_limits<_IntT>;
     const _IntT __max_val = __max_representable_int_for_float<_IntT, _RealT>();
@@ -141,25 +143,25 @@ private:
 
 public:
   // constructors and reset functions
-  _CCCL_API constexpr poisson_distribution() noexcept
+  _CCCL_HOST_DEVICE_API constexpr poisson_distribution() noexcept
       : poisson_distribution{1.0}
   {}
-  _CCCL_API constexpr explicit poisson_distribution(double __mean) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit poisson_distribution(double __mean) noexcept
       : __p_{__mean}
   {}
-  _CCCL_API constexpr explicit poisson_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit poisson_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
   template <class _URNG>
-  [[nodiscard]] _CCCL_API result_type operator()(_URNG& __urng, const param_type& __pr)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URNG& __urng, const param_type& __pr)
   {
     static_assert(__cccl_random_is_valid_urng<_URNG>);
     double __tx = 0;
@@ -264,37 +266,38 @@ public:
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr double mean() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr double mean() const noexcept
   {
     return __p_.mean();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return 0;
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return numeric_limits<result_type>::max();
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const poisson_distribution& __x, const poisson_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
   [[nodiscard]]
-  _CCCL_API friend constexpr bool operator!=(const poisson_distribution& __x, const poisson_distribution& __y) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator!=(const poisson_distribution& __x, const poisson_distribution& __y) noexcept
   {
     return !(__x == __y);
   }

--- a/libcudacxx/include/cuda/std/__random/student_t_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/student_t_distribution.h
@@ -49,21 +49,23 @@ public:
   public:
     using distribution_type = student_t_distribution;
 
-    _CCCL_API constexpr explicit param_type(result_type __n = result_type{1}) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(result_type __n = result_type{1}) noexcept
         : __n_{__n}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type n() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type n() const noexcept
     {
       return __n_;
     }
 
-    [[nodiscard]] _CCCL_API friend constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__n_ == __y.__n_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -78,25 +80,25 @@ public:
   // constructor and reset functions
   constexpr student_t_distribution() noexcept = default;
 
-  _CCCL_API constexpr explicit student_t_distribution(result_type __n) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit student_t_distribution(result_type __n) noexcept
       : __p_{param_type{__n}}
   {}
-  _CCCL_API constexpr explicit student_t_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit student_t_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept
   {
     __nd_.reset();
   }
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g, const param_type& __p)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g, const param_type& __p)
   {
     static_assert(__cccl_random_is_valid_urng<_URng>, "URng must meet the UniformRandomBitGenerator requirements");
     gamma_distribution<result_type> __gd{__p.n() * result_type{.5}, result_type{2}};
@@ -104,36 +106,36 @@ public:
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type n() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type n() const noexcept
   {
     return __p_.n();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return -numeric_limits<result_type>::infinity();
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return numeric_limits<result_type>::infinity();
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const student_t_distribution& __x, const student_t_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator!=(const student_t_distribution& __x, const student_t_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/uniform_int_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/uniform_int_distribution.h
@@ -62,7 +62,7 @@ private:
 
 public:
   // constructors and seeding functions
-  _CCCL_API constexpr __independent_bits_engine(_Engine& __e, size_t __w) noexcept
+  _CCCL_HOST_DEVICE_API constexpr __independent_bits_engine(_Engine& __e, size_t __w) noexcept
       : __e_(__e)
       , __w_(__w)
   {
@@ -107,7 +107,7 @@ public:
   }
 
   // generating functions
-  [[nodiscard]] _CCCL_API constexpr result_type operator()() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type operator()() noexcept
   {
     if constexpr (_Rp == 0)
     {
@@ -175,27 +175,29 @@ public:
   public:
     using distribution_type = uniform_int_distribution;
 
-    _CCCL_API constexpr explicit param_type(result_type __a = 0,
-                                            result_type __b = numeric_limits<result_type>::max()) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(
+      result_type __a = 0, result_type __b = numeric_limits<result_type>::max()) noexcept
         : __a_(__a)
         , __b_(__b)
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type a() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type a() const noexcept
     {
       return __a_;
     }
-    [[nodiscard]] _CCCL_API constexpr result_type b() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type b() const noexcept
     {
       return __b_;
     }
 
-    [[nodiscard]] _CCCL_API friend constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__a_ == __y.__a_ && __x.__b_ == __y.__b_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -208,24 +210,24 @@ private:
 public:
   // constructors and reset functions
   constexpr uniform_int_distribution() noexcept = default;
-  _CCCL_API explicit constexpr uniform_int_distribution(
+  _CCCL_HOST_DEVICE_API explicit constexpr uniform_int_distribution(
     result_type __a, result_type __b = numeric_limits<result_type>::max()) noexcept
       : __p_(param_type(__a, __b))
   {}
-  _CCCL_API explicit constexpr uniform_int_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API explicit constexpr uniform_int_distribution(const param_type& __p) noexcept
       : __p_(__p)
   {}
-  _CCCL_API constexpr void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API constexpr result_type operator()(_URng& __g) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type operator()(_URng& __g) noexcept
   {
     return (*this)(__g, __p_);
   }
   _CCCL_EXEC_CHECK_DISABLE
   template <class _URng>
-  [[nodiscard]] _CCCL_API constexpr result_type operator()(_URng& __g, const param_type& __p) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type operator()(_URng& __g, const param_type& __p) noexcept
   {
     static_assert(__cccl_random_is_valid_urng<_URng>, "URng must meet the UniformRandomBitGenerator requirements");
     using _UIntType = conditional_t<sizeof(result_type) <= sizeof(uint32_t), uint32_t, make_unsigned_t<result_type>>;
@@ -258,40 +260,40 @@ public:
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type a() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type a() const noexcept
   {
     return __p_.a();
   }
-  [[nodiscard]] _CCCL_API constexpr result_type b() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type b() const noexcept
   {
     return __p_.b();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API constexpr result_type min() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type min() const noexcept
   {
     return a();
   }
-  [[nodiscard]] _CCCL_API constexpr result_type max() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type max() const noexcept
   {
     return b();
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const uniform_int_distribution& __x, const uniform_int_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator!=(const uniform_int_distribution& __x, const uniform_int_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/uniform_real_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/uniform_real_distribution.h
@@ -47,26 +47,28 @@ public:
   public:
     using distribution_type = uniform_real_distribution;
 
-    _CCCL_API constexpr explicit param_type(result_type __a = 0, result_type __b = 1) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(result_type __a = 0, result_type __b = 1) noexcept
         : __a_{__a}
         , __b_{__b}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type a() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type a() const noexcept
     {
       return __a_;
     }
-    [[nodiscard]] _CCCL_API constexpr result_type b() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type b() const noexcept
     {
       return __b_;
     }
 
-    [[nodiscard]] _CCCL_API friend constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__a_ == __y.__a_ && __x.__b_ == __y.__b_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -80,24 +82,24 @@ public:
   // constructors and reset functions
 
   constexpr uniform_real_distribution() noexcept = default;
-  _CCCL_API constexpr explicit uniform_real_distribution(result_type __a, result_type __b = 1) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit uniform_real_distribution(result_type __a, result_type __b = 1) noexcept
       : __p_{param_type(__a, __b)}
   {}
-  _CCCL_API constexpr explicit uniform_real_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit uniform_real_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API constexpr result_type operator()(_URng& __g) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type operator()(_URng& __g) noexcept
   {
     return (*this)(__g, __p_);
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _URng>
-  [[nodiscard]] _CCCL_API constexpr result_type operator()(_URng& __g, const param_type& __p) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type operator()(_URng& __g, const param_type& __p) noexcept
   {
     static_assert(__cccl_random_is_valid_urng<_URng>, "URng must meet the UniformRandomBitGenerator requirements");
     return (__p.b() - __p.a()) * ::cuda::std::generate_canonical<_RealType, numeric_limits<_RealType>::digits>(__g)
@@ -105,40 +107,40 @@ public:
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type a() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type a() const noexcept
   {
     return __p_.a();
   }
-  [[nodiscard]] _CCCL_API constexpr result_type b() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type b() const noexcept
   {
     return __p_.b();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API constexpr result_type min() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type min() const noexcept
   {
     return a();
   }
-  [[nodiscard]] _CCCL_API constexpr result_type max() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type max() const noexcept
   {
     return b();
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const uniform_real_distribution& __x, const uniform_real_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator!=(const uniform_real_distribution& __x, const uniform_real_distribution& __y) noexcept
   {
     return !(__x == __y);

--- a/libcudacxx/include/cuda/std/__random/weibull_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/weibull_distribution.h
@@ -49,26 +49,29 @@ public:
   public:
     using distribution_type = weibull_distribution;
 
-    _CCCL_API constexpr explicit param_type(result_type __a = result_type{1}, result_type __b = result_type{1}) noexcept
+    _CCCL_HOST_DEVICE_API constexpr explicit param_type(
+      result_type __a = result_type{1}, result_type __b = result_type{1}) noexcept
         : __a_{__a}
         , __b_{__b}
     {}
 
-    [[nodiscard]] _CCCL_API constexpr result_type a() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type a() const noexcept
     {
       return __a_;
     }
-    [[nodiscard]] _CCCL_API constexpr result_type b() const noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type b() const noexcept
     {
       return __b_;
     }
 
-    [[nodiscard]] _CCCL_API friend constexpr bool operator==(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator==(const param_type& __x, const param_type& __y) noexcept
     {
       return __x.__a_ == __y.__a_ && __x.__b_ == __y.__b_;
     }
 #if _CCCL_STD_VER <= 2017
-    [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const param_type& __x, const param_type& __y) noexcept
+    [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+    operator!=(const param_type& __x, const param_type& __y) noexcept
     {
       return !(__x == __y);
     }
@@ -81,62 +84,64 @@ private:
 public:
   // constructor and reset functions
   constexpr weibull_distribution() noexcept = default;
-  _CCCL_API constexpr explicit weibull_distribution(result_type __a, result_type __b = result_type{1}) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit weibull_distribution(
+    result_type __a, result_type __b = result_type{1}) noexcept
       : __p_{param_type{__a, __b}}
   {}
-  _CCCL_API constexpr explicit weibull_distribution(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit weibull_distribution(const param_type& __p) noexcept
       : __p_{__p}
   {}
-  _CCCL_API constexpr void reset() noexcept {}
+  _CCCL_HOST_DEVICE_API constexpr void reset() noexcept {}
 
   // generating functions
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g)
   {
     return (*this)(__g, __p_);
   }
   template <class _URng>
-  [[nodiscard]] _CCCL_API result_type operator()(_URng& __g, const param_type& __p)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API result_type operator()(_URng& __g, const param_type& __p)
   {
     return __p.b() * ::cuda::std::pow(exponential_distribution<result_type>{}(__g), result_type{1} / __p.a());
   }
 
   // property functions
-  [[nodiscard]] _CCCL_API constexpr result_type a() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type a() const noexcept
   {
     return __p_.a();
   }
-  [[nodiscard]] _CCCL_API constexpr result_type b() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr result_type b() const noexcept
   {
     return __p_.b();
   }
 
-  [[nodiscard]] _CCCL_API constexpr param_type param() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr param_type param() const noexcept
   {
     return __p_;
   }
-  _CCCL_API constexpr void param(const param_type& __p) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void param(const param_type& __p) noexcept
   {
     __p_ = __p;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr result_type min() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type min() noexcept
   {
     return result_type{0};
   }
-  [[nodiscard]] _CCCL_API static constexpr result_type max() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr result_type max() noexcept
   {
     return numeric_limits<result_type>::infinity();
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const weibull_distribution& __x, const weibull_distribution& __y) noexcept
   {
     return __x.__p_ == __y.__p_;
   }
 #if _CCCL_STD_VER <= 2017
   [[nodiscard]]
-  _CCCL_API friend constexpr bool operator!=(const weibull_distribution& __x, const weibull_distribution& __y) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator!=(const weibull_distribution& __x, const weibull_distribution& __y) noexcept
   {
     return !(__x == __y);
   }

--- a/libcudacxx/test/libcudacxx/cuda/random/feistel_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/random/feistel_size.pass.cpp
@@ -8,13 +8,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a host device math function
+
 #include <cuda/__random/feistel_bijection.h>
 #include <cuda/std/cassert>
 #include <cuda/std/random>
 
 #include "test_macros.h"
 
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   // Size is nearest power of two >= 256
   auto rng = cuda::std::philox4x64{};

--- a/libcudacxx/test/libcudacxx/cuda/random/pcg64.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/random/pcg64.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: calling a host device function in tile mode
 
 // <random>
 
@@ -17,13 +17,13 @@
 #include "random_utilities/test_engine.h"
 
 #if _CCCL_HAS_INT128()
-TEST_FUNC constexpr void compare(__uint128_t x, cuda::__pcg_uint128_fallback b)
+TEST_HOST_DEVICE_FUNC constexpr void compare(__uint128_t x, cuda::__pcg_uint128_fallback b)
 {
   assert(static_cast<::cuda::std::uint64_t>(b) == static_cast<::cuda::std::uint64_t>(x));
   assert(static_cast<::cuda::std::uint64_t>(b >> 64) == static_cast<::cuda::std::uint64_t>(x >> 64));
 }
 
-TEST_FUNC constexpr bool test_fallback_uint128(__uint128_t a, __uint128_t b)
+TEST_HOST_DEVICE_FUNC constexpr bool test_fallback_uint128(__uint128_t a, __uint128_t b)
 {
   using Fallback = cuda::__pcg_uint128_fallback;
 
@@ -75,7 +75,7 @@ TEST_FUNC constexpr bool test_fallback_uint128(__uint128_t a, __uint128_t b)
 
   return true;
 }
-TEST_FUNC constexpr bool test_fallback()
+TEST_HOST_DEVICE_FUNC constexpr bool test_fallback()
 {
   // Generate 100 different test values using PCG engine
   cuda::pcg64 rng(42);
@@ -94,7 +94,7 @@ TEST_FUNC constexpr bool test_fallback()
 
 #endif // _CCCL_HAS_INT128()
 
-TEST_FUNC constexpr bool test_against_reference()
+TEST_HOST_DEVICE_FUNC constexpr bool test_against_reference()
 {
   // reference values obtained from other library implementations
   constexpr int seeds[]                            = {10823018, 0, 23};

--- a/libcudacxx/test/libcudacxx/std/random/distribution/bernoulli.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/bernoulli.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -26,7 +27,7 @@ struct bernoulli_cdf
 {
   using P = cuda::std::bernoulli_distribution::param_type;
 
-  TEST_FUNC double operator()(cuda::std::int64_t x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(cuda::std::int64_t x, const P& p) const
   {
     if (x < 0)
     {
@@ -40,7 +41,7 @@ struct bernoulli_cdf
   }
 };
 
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   [[maybe_unused]] const bool test_constexpr = true; // Erroneous compiler warning about unused variable
   using D                                    = cuda::std::bernoulli_distribution;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/binomial.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/binomial.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -26,7 +27,7 @@ struct binomial_cdf
 {
   using P = cuda::std::binomial_distribution<>::param_type;
 
-  TEST_FUNC double operator()(cuda::std::int64_t x, P p) const
+  TEST_HOST_DEVICE_FUNC double operator()(cuda::std::int64_t x, P p) const
   {
     if (x < 0)
     {
@@ -50,7 +51,7 @@ struct binomial_cdf
   }
 };
 
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   [[maybe_unused]] const bool test_constexpr = false; // Math functions cuda::std::log, cuda::std::exp are not yet
                                                       // constexpr

--- a/libcudacxx/test/libcudacxx/std/random/distribution/cauchy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/cauchy.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -30,7 +31,7 @@ struct cauchy_cdf
 {
   using P = typename cuda::std::cauchy_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     // CDF of Cauchy distribution: F(x; a, b) = (1/π) * arctan((x - a) / b) + 0.5
     return (1.0 / cuda::std::__numbers<double>::__pi()) * cuda::std::atan((x - p.a()) / p.b()) + 0.5;
@@ -38,7 +39,7 @@ struct cauchy_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   [[maybe_unused]] const bool test_constexpr = false;
   using D                                    = cuda::std::cauchy_distribution<T>;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/chi_squared.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/chi_squared.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -30,7 +31,7 @@ struct chi_squared_cdf
 {
   using P = typename cuda::std::chi_squared_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     if (x <= 0.0)
     {
@@ -46,7 +47,7 @@ struct chi_squared_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   // Can be true if/when cuda::std::lgamma is constexpr
   [[maybe_unused]] const bool test_constexpr = false;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/exponential.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/exponential.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -29,7 +30,7 @@ struct exponential_cdf
 {
   using P = typename cuda::std::exponential_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     if (x <= 0.0)
     {
@@ -42,7 +43,7 @@ struct exponential_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   [[maybe_unused]] const bool test_constexpr = false;
   using D                                    = cuda::std::exponential_distribution<T>;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/extreme_value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/extreme_value.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -31,7 +32,7 @@ struct extreme_value_cdf
 {
   using P = typename cuda::std::extreme_value_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     // CDF: F(x; a, b) = exp(-exp(-(x - a) / b))
     return cuda::std::exp(-cuda::std::exp(-(x - p.a()) / p.b()));
@@ -39,7 +40,7 @@ struct extreme_value_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   [[maybe_unused]] const bool test_constexpr = false;
   using D                                    = cuda::std::extreme_value_distribution<T>;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/fisher_f.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/fisher_f.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -30,7 +31,7 @@ struct fisher_f_cdf
 {
   using P = typename cuda::std::fisher_f_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     // CDF: F(x; m, n) = I_{mx/(mx+n)}(m/2, n/2)
     // where I is the regularized incomplete beta function
@@ -46,7 +47,7 @@ struct fisher_f_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   [[maybe_unused]] const bool test_constexpr = false;
   using D                                    = cuda::std::fisher_f_distribution<T>;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/gamma.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/gamma.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -30,7 +31,7 @@ struct gamma_cdf
 {
   using P = typename cuda::std::gamma_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     if (x <= 0.0)
     {
@@ -48,7 +49,7 @@ struct gamma_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   [[maybe_unused]] const bool test_constexpr = false;
   using D                                    = cuda::std::gamma_distribution<T>;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/geometric.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/geometric.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -28,7 +29,7 @@ struct geometric_cdf
 {
   using P = typename cuda::std::geometric_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     // CDF: F(x; p) = 1 - (1-p)^(floor(x)+1) for x >= 0
     // This represents P(X <= x) where X is the number of failures before the first success
@@ -42,7 +43,7 @@ struct geometric_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   // Cannot be constexpr due to negative_binomial_distribution dependencies
   [[maybe_unused]] const bool test_constexpr = false;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/lognormal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/lognormal.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -29,7 +30,7 @@ struct lognormal_cdf
 {
   using P = typename cuda::std::lognormal_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     // CDF: F(x; m, s) = 0.5 * (1 + erf((ln(x) - m) / (s * sqrt(2))))
     if (x <= 0.0)
@@ -43,7 +44,7 @@ struct lognormal_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   // Cannot be constexpr due to log/exp functions
   [[maybe_unused]] const bool test_constexpr = false;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/negative_binomial.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/negative_binomial.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -29,7 +30,7 @@ struct negative_binomial_cdf
 {
   using P = typename cuda::std::negative_binomial_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     // CDF: F(x; k, p) = I_p(k, x+1) where I_p is the regularized incomplete beta function
     // This represents P(X <= x) where X is the number of failures before k successes
@@ -44,7 +45,7 @@ struct negative_binomial_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   // Cannot be constexpr due to gamma_distribution and log/exp
   [[maybe_unused]] const bool test_constexpr = false;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/normal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/normal.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -29,14 +30,14 @@ struct normal_cdf
 {
   using P = typename cuda::std::normal_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     return 0.5 * (1 + cuda::std::erf((x - (p.mean())) / (p.stddev() * cuda::std::sqrt(2))));
   }
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   // Can be true if/when cuda::std::log is constexpr
   const bool test_constexpr     = false;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/poisson.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/poisson.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -29,7 +30,7 @@ struct poisson_cdf
 {
   using P = typename cuda::std::poisson_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(cuda::std::uint64_t x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(cuda::std::uint64_t x, const P& p) const
   {
     double sum  = 0;
     double mean = p.mean();
@@ -47,7 +48,7 @@ struct poisson_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   [[maybe_unused]] const bool test_constexpr = false;
   using D                                    = cuda::std::poisson_distribution<T>;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/student_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/student_t.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -30,7 +31,7 @@ struct student_t_cdf
 {
   using P = typename cuda::std::student_t_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     // CDF of Student's t-distribution: F(x) = 0.5 + 0.5 * sgn(x) * I_{t²/(n+t²)}(0.5, n/2)
     // where I is the regularized incomplete beta function and t = x
@@ -51,7 +52,7 @@ struct student_t_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   [[maybe_unused]] const bool test_constexpr = false;
   using D                                    = cuda::std::student_t_distribution<T>;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/uniform_int.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/uniform_int.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -28,7 +29,7 @@ struct uniform_int_cdf
 {
   using P = typename cuda::std::uniform_int_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     // CDF: F(x; a, b) = (floor(x) - a + 1) / (b - a + 1) for a <= x <= b
     //                 = 0 for x < a
@@ -48,7 +49,7 @@ struct uniform_int_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   [[maybe_unused]] const bool test_constexpr = true;
   using D                                    = cuda::std::uniform_int_distribution<T>;
@@ -65,7 +66,7 @@ TEST_FUNC void test()
 
 // P4037R1: made signed char / unsigned char valid IntType template arguments.
 
-TEST_FUNC void test_p4037r1_small_types()
+TEST_HOST_DEVICE_FUNC void test_p4037r1_small_types()
 {
   using D_s = cuda::std::uniform_int_distribution<signed char>;
   using D_u = cuda::std::uniform_int_distribution<unsigned char>;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/uniform_real.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/uniform_real.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -29,7 +30,7 @@ struct uniform_real_cdf
 {
   using P = typename cuda::std::uniform_real_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     // CDF of uniform distribution: F(x) = (x - a) / (b - a) for a <= x <= b
     double a = p.a();
@@ -47,7 +48,7 @@ struct uniform_real_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   [[maybe_unused]] const bool test_constexpr = true;
   using D                                    = cuda::std::uniform_real_distribution<T>;

--- a/libcudacxx/test/libcudacxx/std/random/distribution/weibull.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/weibull.pass.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // <random>
 
@@ -29,7 +30,7 @@ struct weibull_cdf
 {
   using P = typename cuda::std::weibull_distribution<T>::param_type;
 
-  TEST_FUNC double operator()(double x, const P& p) const
+  TEST_HOST_DEVICE_FUNC double operator()(double x, const P& p) const
   {
     // CDF of Weibull distribution: F(x) = 1 - exp(-(x/b)^a)
     if (x < 0)
@@ -43,7 +44,7 @@ struct weibull_cdf
 };
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   // Can be true if/when cuda::std::exp and cuda::std::pow are constexpr
   [[maybe_unused]] const bool test_constexpr = false;

--- a/libcudacxx/test/libcudacxx/std/random/engine/lcg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/engine/lcg.pass.cpp
@@ -8,21 +8,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 #include <cuda/std/random>
 
 #include "random_utilities/test_engine.h"
 
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   test_engine<cuda::std::minstd_rand0, 1043618065u>();
   test_engine<cuda::std::minstd_rand, 399268537ull>();
 }
 
 // P4037R1: linear_congruential_engine must accept the unsigned char UIntType
-TEST_FUNC void test_p4037r1_small_uinttype()
+TEST_HOST_DEVICE_FUNC void test_p4037r1_small_uinttype()
 {
   using E = cuda::std::linear_congruential_engine<unsigned char, 5u, 1u, 13u>;
   static_assert(cuda::std::is_same_v<E::result_type, unsigned char>);

--- a/libcudacxx/test/libcudacxx/std/random/engine/philox.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/engine/philox.pass.cpp
@@ -8,15 +8,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 #include <cuda/std/random>
 
 #include "random_utilities/test_engine.h"
 
 template <typename Engine>
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_set_counter()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_set_counter()
 {
   Engine e1(7);
   Engine e2(7);
@@ -46,7 +46,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_set_counter()
   return true;
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_against_reference()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_against_reference()
 {
   // reference values obtained from other standard library implementations
   const int seeds[]                               = {10823018, 0, 23};
@@ -81,7 +81,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_against_reference()
   return true;
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
   test_engine<cuda::std::philox4x32, 1955073260u>();
   test_engine<cuda::std::philox4x64, 3409172418970261260ull>();

--- a/libcudacxx/test/libcudacxx/std/random/generate_canonical/generate_canonical.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/generate_canonical/generate_canonical.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
 #include <cuda/std/array>
 #include <cuda/std/cassert>
 #include <cuda/std/numeric>
@@ -15,7 +18,7 @@
 #include "test_macros.h"
 
 template <class T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   cuda::std::array<T, 100> data;
   cuda::std::philox4x64 g{};

--- a/libcudacxx/test/libcudacxx/std/random/seed_seq/assign.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/seed_seq/assign.compile.pass.cpp
@@ -8,12 +8,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
 #include <cuda/std/cassert>
 #include <cuda/std/random>
 
 #include "test_macros.h"
 
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   static_assert(!cuda::std::is_copy_assignable_v<cuda::std::seed_seq>);
   static_assert(!cuda::std::is_move_assignable_v<cuda::std::seed_seq>);

--- a/libcudacxx/test/libcudacxx/std/random/seed_seq/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/seed_seq/ctor.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 #include <cuda/std/cassert>
 #include <cuda/std/random>
@@ -17,7 +17,7 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
   cuda::std::array<cuda::std::uint32_t, 3> seeds{1, 2, 3};
 

--- a/libcudacxx/test/libcudacxx/std/random/seed_seq/equal.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/seed_seq/equal.fail.cpp
@@ -8,10 +8,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
 #include <cuda/std/cassert>
 #include <cuda/std/random>
 
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   ::cuda::std::seed_seq seq1{1, 2, 3};
   ::cuda::std::seed_seq seq2;

--- a/libcudacxx/test/libcudacxx/std/random/seed_seq/generate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/seed_seq/generate.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 #include <cuda/std/random>
 #if _CCCL_HOSTED()
@@ -19,7 +19,7 @@
 
 #include "test_macros.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
   static_assert(noexcept(cuda::std::seed_seq{}));
   cuda::std::seed_seq seq{1, 2, 3, 4, 5};

--- a/libcudacxx/test/libcudacxx/std/random/seed_seq/param.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/seed_seq/param.pass.cpp
@@ -8,15 +8,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 #include <cuda/std/cassert>
 #include <cuda/std/random>
 
 #include "test_macros.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
   cuda::std::array<cuda::std::uint32_t, 3> seeds = {1, 2, 3};
   cuda::std::seed_seq seq1(seeds.begin(), seeds.end());

--- a/libcudacxx/test/libcudacxx/std/random/seed_seq/size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/seed_seq/size.pass.cpp
@@ -8,15 +8,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 #include <cuda/std/cassert>
 #include <cuda/std/random>
 
 #include "test_macros.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
   ::cuda::std::seed_seq seq1{1, 2, 3};
   assert(seq1.size() == 3);

--- a/libcudacxx/test/libcudacxx/std/random/small_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/small_types.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
 // <random>
 //
 // Verify that distributions and engines accept signed char / unsigned char as
@@ -48,7 +51,7 @@ template struct smoke_int_distribution<cuda::std::poisson_distribution, unsigned
 // signed char / unsigned char.
 
 template <class IntType>
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_uniform_int_small_type()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_uniform_int_small_type()
 {
   using D = cuda::std::uniform_int_distribution<IntType>;
   using P = typename D::param_type;
@@ -82,7 +85,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_uniform_int_small_type()
   return true;
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_small_lce()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_small_lce()
 {
   // A trivially small linear_congruential_engine with an 8-bit result_type.
   // Parameters chosen so 0 <= c < m and 0 <= a < m, and _Min (=0) < _Max (=12).

--- a/libcudacxx/test/libcudacxx/std/random/valid_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/valid_types.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
+
 // <random>
 //
 // Verify [rand.req.genl]/1.6 and /1.7 (C++26, P4037R1) for the set of integer

--- a/libcudacxx/test/support/random_utilities/stats_functions.h
+++ b/libcudacxx/test/support/random_utilities/stats_functions.h
@@ -17,7 +17,7 @@
 
 // Regularized incomplete gamma function P(a,x)
 // Adapted from numerical recipes
-TEST_FUNC inline double incomplete_gamma(double a, double x)
+TEST_HOST_DEVICE_FUNC inline double incomplete_gamma(double a, double x)
 {
   if (x <= 0.0)
   {
@@ -43,7 +43,7 @@ TEST_FUNC inline double incomplete_gamma(double a, double x)
 
 // Regularized incomplete beta function I_x(a,b)
 // Adapted from numerical recipes
-TEST_FUNC inline double incomplete_beta(double a, double b, double x)
+TEST_HOST_DEVICE_FUNC inline double incomplete_beta(double a, double b, double x)
 {
   if (x <= 0.0)
   {

--- a/libcudacxx/test/support/random_utilities/test_distribution.h
+++ b/libcudacxx/test/support/random_utilities/test_distribution.h
@@ -24,7 +24,7 @@
 namespace detail
 {
 template <class D, class URNG, class Param>
-TEST_FUNC constexpr bool test_ctor_assign(Param param)
+TEST_HOST_DEVICE_FUNC constexpr bool test_ctor_assign(Param param)
 {
   D d1(param);
   D d2;
@@ -35,7 +35,7 @@ TEST_FUNC constexpr bool test_ctor_assign(Param param)
 }
 
 template <class D, class URNG, class Param>
-TEST_FUNC constexpr bool test_copy(Param param)
+TEST_HOST_DEVICE_FUNC constexpr bool test_copy(Param param)
 {
   D d1(param);
   D d2(d1);
@@ -45,7 +45,7 @@ TEST_FUNC constexpr bool test_copy(Param param)
 }
 
 template <class D, class URNG, class Param>
-TEST_FUNC constexpr bool test_eq(Param param)
+TEST_HOST_DEVICE_FUNC constexpr bool test_eq(Param param)
 {
   D d1(param);
   D d2(param);
@@ -57,7 +57,7 @@ TEST_FUNC constexpr bool test_eq(Param param)
 }
 
 template <class D, class URNG, class Param>
-TEST_FUNC constexpr bool test_get_param(Param param)
+TEST_HOST_DEVICE_FUNC constexpr bool test_get_param(Param param)
 {
   D d1(param);
   assert(d1.param() == param);
@@ -80,7 +80,7 @@ bool test_io(Param param)
 #endif
 
 template <class D, class URNG, class Param>
-TEST_FUNC constexpr bool test_min_max(Param param)
+TEST_HOST_DEVICE_FUNC constexpr bool test_min_max(Param param)
 {
   D d1(param);
   static_assert(noexcept(d1.min()));
@@ -90,7 +90,7 @@ TEST_FUNC constexpr bool test_min_max(Param param)
 }
 
 template <class D, class URNG, class Param>
-TEST_FUNC constexpr bool test_set_param(Param param)
+TEST_HOST_DEVICE_FUNC constexpr bool test_set_param(Param param)
 {
   D d1;
   d1.param(param);
@@ -99,7 +99,7 @@ TEST_FUNC constexpr bool test_set_param(Param param)
 }
 
 template <class D, class URNG, class Param>
-TEST_FUNC constexpr bool test_types(Param param)
+TEST_HOST_DEVICE_FUNC constexpr bool test_types(Param param)
 {
   D d1(param);
   [[maybe_unused]] URNG g{};
@@ -112,7 +112,7 @@ TEST_FUNC constexpr bool test_types(Param param)
 }
 
 template <class D, class URNG, class Param>
-TEST_FUNC constexpr bool test_param(Param param)
+TEST_HOST_DEVICE_FUNC constexpr bool test_param(Param param)
 {
   static_assert(cuda::std::is_same_v<typename D::param_type, Param>);
   static_assert(cuda::std::is_same_v<typename Param::distribution_type, D>);
@@ -130,7 +130,7 @@ TEST_FUNC constexpr bool test_param(Param param)
 
 // Compute KS test statistic for continuous distributions
 template <class D, class CDF>
-TEST_FUNC double ks_test_statistic_continuous(
+TEST_HOST_DEVICE_FUNC double ks_test_statistic_continuous(
   const typename D::result_type* samples, cuda::std::size_t num_samples, const typename D::param_type& param, CDF cdf)
 {
   double d_max = 0.0;
@@ -148,7 +148,7 @@ TEST_FUNC double ks_test_statistic_continuous(
 
 // Compute KS test statistic for discrete distributions
 template <class D, class CDF>
-TEST_FUNC double ks_test_statistic_discrete(
+TEST_HOST_DEVICE_FUNC double ks_test_statistic_discrete(
   const typename D::result_type* samples, cuda::std::size_t num_samples, const typename D::param_type& param, CDF cdf)
 {
   // Compute empirical CDF
@@ -185,7 +185,7 @@ TEST_FUNC double ks_test_statistic_discrete(
 // distribution function from a continuous distribution.
 // Generates a fixed size of 10000 samples
 template <class D, bool continuous, class URNG, bool test_constexpr, class CDF>
-TEST_FUNC bool test_eval(const typename D::param_type param, CDF cdf)
+TEST_HOST_DEVICE_FUNC bool test_eval(const typename D::param_type param, CDF cdf)
 {
   // First check the operator with param is equivalent to the constructor param
   {
@@ -233,7 +233,7 @@ TEST_FUNC bool test_eval(const typename D::param_type param, CDF cdf)
   return true;
 }
 template <class D, class URNG>
-TEST_FUNC constexpr bool test_eval_constexpr()
+TEST_HOST_DEVICE_FUNC constexpr bool test_eval_constexpr()
 {
   typename D::param_type param;
   D dist(param);
@@ -245,7 +245,7 @@ TEST_FUNC constexpr bool test_eval_constexpr()
 } // namespace detail
 
 template <class D, bool continuous, class URNG, bool test_constexpr, class CDF, cuda::std::size_t N>
-TEST_FUNC void constexpr test_distribution(cuda::std::array<typename D::param_type, N> params, CDF cdf)
+TEST_HOST_DEVICE_FUNC void constexpr test_distribution(cuda::std::array<typename D::param_type, N> params, CDF cdf)
 {
   for (cuda::std::size_t i = 0; i < N; ++i)
   {

--- a/libcudacxx/test/support/random_utilities/test_engine.h
+++ b/libcudacxx/test/support/random_utilities/test_engine.h
@@ -16,7 +16,7 @@
 #include "test_macros.h"
 
 template <typename Engine>
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_ctor()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_ctor()
 {
   Engine e1;
   Engine e2(Engine::default_seed);
@@ -33,7 +33,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_ctor()
 }
 
 template <typename Engine>
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_copy()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_copy()
 {
   Engine e1;
   Engine e2 = e1;
@@ -50,7 +50,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_copy()
 }
 
 template <typename Engine>
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_seed()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_seed()
 {
   Engine e1(23);
   Engine e2;
@@ -69,7 +69,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_seed()
 }
 
 template <typename Engine>
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_operator()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_operator()
 {
   Engine e1;
   static_assert(cuda::std::is_same_v<decltype(e1()), typename Engine::result_type>);
@@ -82,7 +82,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_operator()
 }
 
 template <typename Engine, typename Engine::result_type value_10000>
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_discard()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_discard()
 {
   Engine e;
   for (int i = 0; i < 100; ++i)
@@ -104,7 +104,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_discard()
 }
 
 template <typename Engine>
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_equality()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_equality()
 {
   Engine e;
   assert(e == e);
@@ -124,7 +124,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_equality()
 }
 
 template <typename Engine>
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_min_max()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_min_max()
 {
   const auto seeds = {0, 29332, 9000};
   for (auto seed : seeds)
@@ -167,7 +167,7 @@ void test_save_restore()
 #endif // _CCCL_HOSTED()
 
 template <typename Engine, typename Engine::result_type value_10000>
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_engine()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_engine()
 {
   test_ctor<Engine>();
   test_seed<Engine>();


### PR DESCRIPTION
It relies widely on seed_seq which requires dynamic allocations

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>