### PR TITLE
[Tile] Mark some parts of `<memory>` and `<cstdlib>` as host device only

### DIFF
--- a/libcudacxx/include/cuda/__memory/check_address.h
+++ b/libcudacxx/include/cuda/__memory/check_address.h
@@ -62,7 +62,8 @@ _CCCL_END_NAMESPACE_CUDA_DEVICE
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-[[nodiscard]] _CCCL_API inline bool __is_valid_address_range(const void* __ptr, ::cuda::std::size_t __n) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API inline bool
+__is_valid_address_range(const void* __ptr, ::cuda::std::size_t __n) noexcept
 {
   if (__n == 0)
   {
@@ -89,7 +90,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA
   return (__ptr != nullptr);
 }
 
-[[nodiscard]] _CCCL_API inline bool __is_valid_address(const void* __ptr) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API inline bool __is_valid_address(const void* __ptr) noexcept
 {
   return ::cuda::__is_valid_address_range(__ptr, 0);
 }

--- a/libcudacxx/include/cuda/__memory/ranges_overlap.h
+++ b/libcudacxx/include/cuda/__memory/ranges_overlap.h
@@ -35,7 +35,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA
 
 #if _CCCL_CUDA_COMPILATION()
-[[nodiscard]] _CCCL_DEVICE_API inline bool __ptr_ranges_overlap_device(
+[[nodiscard]] _CCCL_DEVICE_TILE_API inline bool __ptr_ranges_overlap_device(
   const void* __lhs_begin, const void* __lhs_end, const void* __rhs_begin, const void* __rhs_end) noexcept
 {
   using uintptr_t            = ::cuda::std::uintptr_t;
@@ -103,6 +103,7 @@ ranges_overlap(_Tp __lhs_begin, _Tp __lhs_end, _Tp __rhs_begin, _Tp __rhs_end) n
         return true;
       }
     }
+
     for (auto __rhs_it = __rhs_begin; __rhs_it != __rhs_end; ++__rhs_it)
     {
       if (__rhs_it == __lhs_begin)

--- a/libcudacxx/include/cuda/std/__cstdlib/aligned_alloc.h
+++ b/libcudacxx/include/cuda/std/__cstdlib/aligned_alloc.h
@@ -52,7 +52,7 @@ __aligned_alloc_host([[maybe_unused]] size_t __align, [[maybe_unused]] size_t __
 }
 #endif // !_CCCL_COMPILER(NVRTC)
 
-[[nodiscard]] _CCCL_API inline void* aligned_alloc(size_t __align, size_t __nbytes) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API inline void* aligned_alloc(size_t __align, size_t __nbytes) noexcept
 {
   NV_IF_ELSE_TARGET(NV_IS_HOST,
                     (return ::cuda::std::__aligned_alloc_host(__align, __nbytes);),

--- a/libcudacxx/include/cuda/std/__cstdlib/malloc.h
+++ b/libcudacxx/include/cuda/std/__cstdlib/malloc.h
@@ -43,9 +43,6 @@ using ::malloc;
 {
   void* __ptr{};
 
-#  if _CCCL_TILE_COMPILATION() // dynamic allocations are not supported in tile mode
-  _CCCL_VERIFY(false, "dynamimc allocation is not supported in tile programs");
-#  else // ^^^ _CCCL_TILE_COMPILATION() ^^^ / vvv !_CCCL_TILE_COMPILATION() vvv
   // check for overflow through a hypothetical larger integer
   // TODO (miscco): use `mul_overflow` once implemented
   if (::cuda::mul_hi(__n, __size) == 0)
@@ -57,13 +54,12 @@ using ::malloc;
       ::cuda::std::memset(__ptr, 0, __nbytes);
     }
   }
-#  endif // !_CCCL_TILE_COMPILATION()
 
   return __ptr;
 }
 #endif // _CCCL_CUDA_COMPILATION()
 
-[[nodiscard]] _CCCL_API inline void* calloc(size_t __n, size_t __size) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API inline void* calloc(size_t __n, size_t __size) noexcept
 {
   NV_IF_ELSE_TARGET(NV_IS_HOST, (return ::calloc(__n, __size);), (return ::cuda::std::__calloc_device(__n, __size);))
 }

--- a/libcudacxx/include/cuda/std/__memory/temporary_buffer.h
+++ b/libcudacxx/include/cuda/std/__memory/temporary_buffer.h
@@ -36,7 +36,8 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp>
-[[nodiscard]] _CCCL_NO_CFI _CCCL_API inline pair<_Tp*, ptrdiff_t> get_temporary_buffer(ptrdiff_t __n) noexcept
+[[nodiscard]] _CCCL_NO_CFI _CCCL_HOST_DEVICE_API inline pair<_Tp*, ptrdiff_t>
+get_temporary_buffer(ptrdiff_t __n) noexcept
 {
   pair<_Tp*, ptrdiff_t> __r(0, 0);
   const ptrdiff_t __m = (~ptrdiff_t(0) ^ ptrdiff_t(ptrdiff_t(1) << (sizeof(ptrdiff_t) * CHAR_BIT - 1))) / sizeof(_Tp);
@@ -78,7 +79,7 @@ template <class _Tp>
 }
 
 template <class _Tp>
-_CCCL_API inline void return_temporary_buffer(_Tp* __p) noexcept
+_CCCL_HOST_DEVICE_API inline void return_temporary_buffer(_Tp* __p) noexcept
 {
   ::cuda::std::__cccl_deallocate_unsized((void*) __p, alignof(_Tp));
 }
@@ -86,7 +87,7 @@ _CCCL_API inline void return_temporary_buffer(_Tp* __p) noexcept
 struct __return_temporary_buffer
 {
   template <class _Tp>
-  _CCCL_API void operator()(_Tp* __p) const noexcept
+  _CCCL_HOST_DEVICE_API void operator()(_Tp* __p) const noexcept
   {
     ::cuda::std::return_temporary_buffer(__p);
   }

--- a/libcudacxx/include/cuda/std/__new/allocate.h
+++ b/libcudacxx/include/cuda/std/__new/allocate.h
@@ -39,7 +39,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_API constexpr bool __is_overaligned_for_new(size_t __align) noexcept
+_CCCL_HOST_DEVICE_API constexpr bool __is_overaligned_for_new(size_t __align) noexcept
 {
 #ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
   return __align > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
@@ -49,7 +49,7 @@ _CCCL_API constexpr bool __is_overaligned_for_new(size_t __align) noexcept
 }
 
 template <class... _Args>
-_CCCL_API inline void* __cccl_operator_new(_Args... __args)
+_CCCL_HOST_DEVICE_API inline void* __cccl_operator_new(_Args... __args)
 {
   // Those builtins are not usable on device and the tests crash when using them
 #if defined(_CCCL_BUILTIN_OPERATOR_NEW)
@@ -60,7 +60,7 @@ _CCCL_API inline void* __cccl_operator_new(_Args... __args)
 }
 
 template <class... _Args>
-_CCCL_API inline void __cccl_operator_delete(_Args... __args)
+_CCCL_HOST_DEVICE_API inline void __cccl_operator_delete(_Args... __args)
 {
   // Those builtins are not usable on device and the tests crash when using them
 #if defined(_CCCL_BUILTIN_OPERATOR_DELETE)
@@ -74,7 +74,7 @@ _CCCL_API inline void __cccl_operator_delete(_Args... __args)
 using ::std::align_val_t;
 #endif // _LIBCUDACXX_HAS_ALIGNED_ALLOCATION()
 
-_CCCL_API inline void* __cccl_allocate(size_t __size, [[maybe_unused]] size_t __align)
+_CCCL_HOST_DEVICE_API inline void* __cccl_allocate(size_t __size, [[maybe_unused]] size_t __align)
 {
 #if _LIBCUDACXX_HAS_ALIGNED_ALLOCATION()
   if (::cuda::std::__is_overaligned_for_new(__align))
@@ -87,7 +87,8 @@ _CCCL_API inline void* __cccl_allocate(size_t __size, [[maybe_unused]] size_t __
 }
 
 template <class... _Args>
-_CCCL_API inline void __do_deallocate_handle_size(void* __ptr, [[maybe_unused]] size_t __size, _Args... __args)
+_CCCL_HOST_DEVICE_API inline void
+__do_deallocate_handle_size(void* __ptr, [[maybe_unused]] size_t __size, _Args... __args)
 {
 #if _LIBCUDACXX_HAS_SIZED_DEALLOCATION()
   return ::cuda::std::__cccl_operator_delete(__ptr, __size, __args...);
@@ -96,7 +97,7 @@ _CCCL_API inline void __do_deallocate_handle_size(void* __ptr, [[maybe_unused]] 
 #endif // !_LIBCUDACXX_HAS_SIZED_DEALLOCATION()
 }
 
-_CCCL_API inline void __cccl_deallocate(void* __ptr, size_t __size, [[maybe_unused]] size_t __align)
+_CCCL_HOST_DEVICE_API inline void __cccl_deallocate(void* __ptr, size_t __size, [[maybe_unused]] size_t __align)
 {
 #if _LIBCUDACXX_HAS_ALIGNED_ALLOCATION()
   if (::cuda::std::__is_overaligned_for_new(__align))
@@ -108,7 +109,7 @@ _CCCL_API inline void __cccl_deallocate(void* __ptr, size_t __size, [[maybe_unus
   return ::cuda::std::__do_deallocate_handle_size(__ptr, __size);
 }
 
-_CCCL_API inline void __cccl_deallocate_unsized(void* __ptr, [[maybe_unused]] size_t __align)
+_CCCL_HOST_DEVICE_API inline void __cccl_deallocate_unsized(void* __ptr, [[maybe_unused]] size_t __align)
 {
 #if _LIBCUDACXX_HAS_ALIGNED_ALLOCATION()
   if (::cuda::std::__is_overaligned_for_new(__align))

--- a/libcudacxx/test/libcudacxx/cuda/memory/address_space.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/address_space.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
-
 #include <cuda/memory>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/memory/align_down.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/align_down.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
 
 #include <cuda/memory>
@@ -18,7 +18,7 @@
 #include "test_macros.h"
 
 template <typename T>
-TEST_FUNC void test_impl()
+TEST_HOST_DEVICE_FUNC void test_impl()
 {
   if constexpr (alignof(T) <= 2)
   {
@@ -37,7 +37,7 @@ TEST_FUNC void test_impl()
 }
 
 template <typename T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   test_impl<T*>();
   test_impl<const T*>();
@@ -45,7 +45,7 @@ TEST_FUNC void test()
   test_impl<const volatile T*>();
 }
 
-TEST_FUNC bool test()
+TEST_HOST_DEVICE_FUNC bool test()
 {
   test<char>();
   test<short>();

--- a/libcudacxx/test/libcudacxx/cuda/memory/align_down.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/align_down.runfail.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
+// UNSUPPORTED: force-tile
+// nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
 
 #include <cuda/memory>
 #include <cuda/std/cassert>
@@ -17,7 +17,7 @@
 
 #include "test_macros.h"
 
-TEST_FUNC bool test()
+TEST_HOST_DEVICE_FUNC bool test()
 {
   uintptr_t ptr_int = 10;
   auto ptr          = reinterpret_cast<int*>(ptr_int);

--- a/libcudacxx/test/libcudacxx/cuda/memory/align_up.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/align_up.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
 
 #include <cuda/memory>
@@ -18,7 +18,7 @@
 #include "test_macros.h"
 
 template <typename T>
-TEST_FUNC void test_impl()
+TEST_HOST_DEVICE_FUNC void test_impl()
 {
   if constexpr (alignof(T) <= 2)
   {
@@ -35,7 +35,7 @@ TEST_FUNC void test_impl()
 }
 
 template <typename T>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   test_impl<T*>();
   test_impl<const T*>();
@@ -43,7 +43,7 @@ TEST_FUNC void test()
   test_impl<const volatile T*>();
 }
 
-TEST_FUNC bool test()
+TEST_HOST_DEVICE_FUNC bool test()
 {
   test<char>();
   test<short>();

--- a/libcudacxx/test/libcudacxx/cuda/memory/align_up.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/align_up.runfail.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
+// UNSUPPORTED: force-tile
+// nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
 
 #include <cuda/memory>
 #include <cuda/std/cassert>
@@ -17,7 +17,7 @@
 
 #include "test_macros.h"
 
-TEST_FUNC bool test()
+TEST_HOST_DEVICE_FUNC bool test()
 {
   uintptr_t ptr_int = 10;
   auto ptr          = reinterpret_cast<int*>(ptr_int);

--- a/libcudacxx/test/libcudacxx/cuda/memory/aligned_size_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/aligned_size_t.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/cuda/memory/check_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/check_address.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
+// UNSUPPORTED: force-tile
+// nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
 
 #include <cuda/memory>
 #include <cuda/std/cassert>
@@ -32,7 +32,7 @@ TEST_DEVICE_FUNC void device_test()
   assert(!cuda::device::__is_smem_valid_address_range(&var, cuda::std::numeric_limits<size_t>::max()));
 }
 
-TEST_FUNC void host_device_test()
+TEST_HOST_DEVICE_FUNC void host_device_test()
 {
   int var = 0;
   assert(cuda::__is_valid_address_range(&var, sizeof(var)));
@@ -43,7 +43,7 @@ TEST_FUNC void host_device_test()
   assert(!cuda::__is_valid_address_range(ptr2, 4));
 }
 
-TEST_FUNC bool test()
+TEST_HOST_DEVICE_FUNC bool test()
 {
   NV_IF_TARGET(NV_IS_DEVICE, (device_test();))
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/memory/discard_memory.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/discard_memory.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 #include <cuda/memory>
@@ -19,7 +19,7 @@
 #include "test_macros.h"
 
 template <class T>
-TEST_FUNC volatile T* make_array(cuda::std::size_t n)
+TEST_HOST_DEVICE_FUNC volatile T* make_array(cuda::std::size_t n)
 {
   auto ptr = static_cast<T*>(cuda::std::malloc(n * sizeof(T)));
   assert(ptr != nullptr);
@@ -32,12 +32,12 @@ TEST_FUNC volatile T* make_array(cuda::std::size_t n)
   return const_cast<volatile T*>(ptr);
 }
 
-TEST_FUNC void destroy_array(volatile void* ptr)
+TEST_HOST_DEVICE_FUNC void destroy_array(volatile void* ptr)
 {
   cuda::std::free(const_cast<void*>(ptr));
 }
 
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   using T = int;
 

--- a/libcudacxx/test/libcudacxx/cuda/memory/get_device_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/get_device_address.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
 
 #include <cuda/__runtime/ensure_current_context.h>
 #include <cuda/devices>
@@ -88,7 +88,7 @@ void test_explicit_device_with_different_current_device()
 #endif // !TEST_COMPILER(NVRTC)
 
 template <class T>
-TEST_FUNC void test(T& object)
+TEST_HOST_DEVICE_FUNC void test(T& object)
 {
   NV_IF_ELSE_TARGET(
     NV_IS_DEVICE, (assert(cuda::std::addressof(object) == cuda::get_device_address(object));), (test_host(object);))

--- a/libcudacxx/test/libcudacxx/cuda/memory/is_aligned.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/is_aligned.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
-
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/memory/is_pointer_accessible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/is_pointer_accessible.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: nvrtc
 
 #include <cuda/__runtime/ensure_current_context.h>

--- a/libcudacxx/test/libcudacxx/cuda/memory/is_valid_alignment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/is_valid_alignment.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
-
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/memory/ptr_alignment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/ptr_alignment.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
-
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/memory/ptr_in_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/ptr_in_range.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
-
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/type_traits>
@@ -43,6 +40,7 @@ TEST_FUNC void test_variants()
   assert(!cuda::ptr_in_range(firstA, firstB, lastB));
   assert(!cuda::ptr_in_range(lastA, firstB, lastB));
 
+#if !_CCCL_TILE_COMPILATION()
   T* arrayC = new T[6]{};
   T* firstC = arrayC + 1;
   T* lastC  = arrayC + 5;
@@ -52,6 +50,7 @@ TEST_FUNC void test_variants()
   assert(!cuda::ptr_in_range(firstA, firstC, lastC));
   assert(!cuda::ptr_in_range(lastA, firstC, lastC));
   delete[] arrayC;
+#endif // !_CCCL_TILE_COMPILATION()
 }
 
 template <typename T>

--- a/libcudacxx/test/libcudacxx/cuda/memory/ptr_rebind.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/ptr_rebind.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
 
 #include <cuda/memory>
@@ -19,14 +19,14 @@
 #include "test_macros.h"
 
 template <typename T, typename U, typename V>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   uintptr_t ptr_int         = 16;
   [[maybe_unused]] auto ptr = reinterpret_cast<T>(ptr_int);
   static_assert(cuda::std::is_same_v<U, decltype(cuda::ptr_rebind<V>(ptr))>);
 }
 
-TEST_FUNC bool test()
+TEST_HOST_DEVICE_FUNC bool test()
 {
   test<char*, char*, char>();
   test<char*, short*, short>();

--- a/libcudacxx/test/libcudacxx/cuda/memory/ranges_overlap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/ranges_overlap.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
-
 #include <cuda/iterator>
 #include <cuda/memory>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/libcxx/memory/uninitialized_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/memory/uninitialized_array.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
-
 #include <cuda/__memory/uninitialized_array.h>
 #include <cuda/std/cassert>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/aligned_alloc.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/aligned_alloc.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 // Disable CCCL assertions in this test to test the erroneous behavior
 #undef CCCL_ENABLE_ASSERTIONS
@@ -26,7 +26,8 @@
 TEST_DIAG_SUPPRESS_MSVC(4324) // padding was added at the end of a structure because of an alignment specifier
 
 template <class T>
-TEST_FUNC void test_aligned_alloc(bool expect_success, cuda::std::size_t n, cuda::std::size_t align = alignof(T))
+TEST_HOST_DEVICE_FUNC void
+test_aligned_alloc(bool expect_success, cuda::std::size_t n, cuda::std::size_t align = alignof(T))
 {
   static_assert(noexcept(cuda::std::aligned_alloc(align, n * sizeof(T))));
   T* ptr = static_cast<T*>(cuda::std::aligned_alloc(align, n * sizeof(T)));
@@ -60,7 +61,7 @@ struct alignas(128) OverAlignedStruct
   char data[32];
 };
 
-TEST_FUNC bool should_expect_success()
+TEST_HOST_DEVICE_FUNC bool should_expect_success()
 {
   bool host_expect_success = true;
 #if TEST_COMPILER(MSVC)
@@ -72,7 +73,7 @@ TEST_FUNC bool should_expect_success()
   NV_IF_ELSE_TARGET(NV_IS_HOST, (return host_expect_success;), (return true;))
 }
 
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   const bool expect_success = should_expect_success();
 

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/calloc.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/calloc.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>
@@ -18,7 +18,7 @@
 #include "test_macros.h"
 
 template <class T>
-TEST_FUNC void test_calloc_success(cuda::std::size_t n)
+TEST_HOST_DEVICE_FUNC void test_calloc_success(cuda::std::size_t n)
 {
   T* ptr = static_cast<T*>(cuda::std::calloc(n, sizeof(T)));
 
@@ -38,7 +38,7 @@ TEST_FUNC void test_calloc_success(cuda::std::size_t n)
 }
 
 template <class T>
-TEST_FUNC void test_calloc_fail(cuda::std::size_t n)
+TEST_HOST_DEVICE_FUNC void test_calloc_fail(cuda::std::size_t n)
 {
   T* ptr = static_cast<T*>(cuda::std::calloc(n, sizeof(T)));
 
@@ -54,7 +54,7 @@ struct BigStruct
 
   int data[n];
 
-  TEST_FUNC bool operator==(const BigStruct& other) const
+  TEST_HOST_DEVICE_FUNC bool operator==(const BigStruct& other) const
   {
     for (cuda::std::size_t i{}; i < n; ++i)
     {
@@ -74,7 +74,7 @@ struct alignas(cuda::std::max_align_t) AlignedStruct
 
   char data[n];
 
-  TEST_FUNC bool operator==(const AlignedStruct& other) const
+  TEST_HOST_DEVICE_FUNC bool operator==(const AlignedStruct& other) const
   {
     for (cuda::std::size_t i{}; i < n; ++i)
     {
@@ -88,7 +88,7 @@ struct alignas(cuda::std::max_align_t) AlignedStruct
   }
 };
 
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   test_calloc_success<int>(10);
   test_calloc_success<char>(128);

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/allocator.traits/allocator.traits.members/destroy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/allocator.traits/allocator.traits.members/destroy.pass.cpp
@@ -8,10 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <memory>
+// UNSUPPORTED: force-tile
+// error: dynamic allocations are not supported in tile mode
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// <memory>
 
 // template <class Alloc>
 // struct allocator_traits
@@ -35,12 +35,12 @@ struct NoDestroy
 {
   using value_type = T;
 
-  TEST_FUNC TEST_CONSTEXPR_CXX20 T* allocate(cuda::std::size_t n)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 T* allocate(cuda::std::size_t n)
   {
     return cuda::std::allocator<T>().allocate(n);
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX20 void deallocate(T* p, cuda::std::size_t n) noexcept
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 void deallocate(T* p, cuda::std::size_t n) noexcept
   {
     return cuda::std::allocator<T>().deallocate(p, n);
   }
@@ -49,30 +49,30 @@ struct NoDestroy
 template <class T>
 struct CountDestroy
 {
-  TEST_FUNC constexpr explicit CountDestroy(int* counter)
+  TEST_HOST_DEVICE_FUNC constexpr explicit CountDestroy(int* counter)
       : counter_(counter)
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX20 ~CountDestroy() {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 ~CountDestroy() {}
 
   using value_type = T;
 
-  TEST_FUNC TEST_CONSTEXPR_CXX20 T* allocate(cuda::std::size_t n)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 T* allocate(cuda::std::size_t n)
   {
     return &storage;
   }
 
-  TEST_FUNC TEST_CONSTEXPR_CXX20 void deallocate(T* p, cuda::std::size_t n) noexcept {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 void deallocate(T* p, cuda::std::size_t n) noexcept {}
 
   template <class U, class... Args>
-  TEST_FUNC TEST_CONSTEXPR_CXX20 void construct(U* p, Args&&... args)
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 void construct(U* p, Args&&... args)
   {
     assert(p == nullptr);
     cuda::std::__construct_at(&storage, cuda::std::forward<Args>(args)...);
   }
 
   template <class U>
-  TEST_FUNC TEST_CONSTEXPR_CXX20 void destroy(U* p) noexcept
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 void destroy(U* p) noexcept
   {
     assert(p == nullptr);
     ++*counter_;
@@ -89,11 +89,11 @@ struct CountDestroy
 
 struct CountDestructor
 {
-  TEST_FUNC constexpr explicit CountDestructor(int* counter)
+  TEST_HOST_DEVICE_FUNC constexpr explicit CountDestructor(int* counter)
       : counter_(counter)
   {}
 
-  TEST_FUNC TEST_CONSTEXPR_CXX20 ~CountDestructor()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 ~CountDestructor()
   {
     ++*counter_;
   }
@@ -101,7 +101,7 @@ struct CountDestructor
   int* counter_;
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
 #if TEST_STD_VER >= 2020
   if (!TEST_IS_CONSTANT_EVALUATED())

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/default.allocator/allocator.members/allocate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/default.allocator/allocator.members/allocate.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a non-__tile__ variable cannot be used in tile code
+// UNSUPPORTED: force-tile
+// error: dynamic allocations are not supported in tile mode
 
 // <memory>
 
@@ -47,22 +47,22 @@ template <cuda::std::size_t Align>
 struct alignas(Align) AlignedType
 {
   char data;
-  TEST_FUNC AlignedType()
+  TEST_HOST_DEVICE_FUNC AlignedType()
   {
     ++AlignedType_constructed;
   }
-  TEST_FUNC AlignedType(AlignedType const&)
+  TEST_HOST_DEVICE_FUNC AlignedType(AlignedType const&)
   {
     ++AlignedType_constructed;
   }
-  TEST_FUNC ~AlignedType()
+  TEST_HOST_DEVICE_FUNC ~AlignedType()
   {
     --AlignedType_constructed;
   }
 };
 
 template <cuda::std::size_t Align>
-TEST_FUNC void test_aligned()
+TEST_HOST_DEVICE_FUNC void test_aligned()
 {
   using T                 = AlignedType<Align>;
   AlignedType_constructed = 0;
@@ -99,7 +99,7 @@ TEST_FUNC void test_aligned()
 
 #if TEST_STD_VER >= 2020
 template <cuda::std::size_t Align>
-TEST_FUNC constexpr bool test_aligned_constexpr()
+TEST_HOST_DEVICE_FUNC constexpr bool test_aligned_constexpr()
 {
   using T = AlignedType<Align>;
   cuda::std::allocator<T> a;

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/align.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/align.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
 
 // #include <memory>

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/assume_aligned.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/assume_aligned.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
 
 // #include <memory>
@@ -24,7 +24,7 @@
 TEST_DIAG_SUPPRESS_MSVC(4324) // structure was padded due to alignment specifier
 
 template <typename T>
-TEST_FUNC constexpr void check(T* p)
+TEST_HOST_DEVICE_FUNC constexpr void check(T* p)
 {
   static_assert(cuda::std::is_same_v<T*, decltype(cuda::std::assume_aligned<1>(p))>);
   constexpr cuda::std::size_t alignment = alignof(T);
@@ -46,7 +46,7 @@ struct alignas(64) S64
 struct alignas(128) S128
 {};
 
-TEST_FUNC constexpr bool tests()
+TEST_HOST_DEVICE_FUNC constexpr bool tests()
 {
   char c{};
   int i{};

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/assume_aligned.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/assume_aligned.runfail.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
 
 #include <cuda/std/memory>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
@@ -17,9 +17,6 @@
 // Self assignment post-conditions are tested.
 // ADDITIONAL_COMPILE_OPTIONS_HOST: -Wno-self-move
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
-
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.pass.cpp
@@ -13,9 +13,6 @@
 
 // UNSUPPORTED: nvrtc
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
-
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/dereference.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/dereference.verify.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
-
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_arrow.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_arrow.verify.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
-
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique.sizezero.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique.sizezero.pass.cpp
@@ -12,10 +12,10 @@
 // UNSUPPORTED: nvrtc
 // UNSUPPORTED: nvhpc
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
-
 // Test the fix for https://llvm.org/PR54100
+
+// UNSUPPORTED: force-tile
+// error: dynamic allocation is not supported in tile mode
 
 #include <cuda/std/__memory_>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/specialized.algorithms/specialized.destroy/destroy_at.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/specialized.algorithms/specialized.destroy/destroy_at.pass.cpp
@@ -9,9 +9,8 @@
 
 // UNSUPPORTED: gcc-6
 
-// XFAIL: enable-tile
+// UNSUPPORTED: force-tile
 // error: a non-__tile__ variable cannot be used in tile code
-// error: virtual function is unsupported in tile code
 
 // <memory>
 
@@ -28,44 +27,44 @@
 struct Counted
 {
   int* counter_;
-  TEST_FUNC constexpr Counted(int* counter)
+  TEST_HOST_DEVICE_FUNC constexpr Counted(int* counter)
       : counter_(counter)
   {
     ++*counter_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX20 ~Counted()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 ~Counted()
   {
     --*counter_;
   }
-  TEST_FUNC friend void operator&(Counted) = delete;
+  TEST_HOST_DEVICE_FUNC friend void operator&(Counted) = delete;
 };
 
 #if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
 struct VirtualCounted
 {
   int* counter_;
-  TEST_FUNC constexpr VirtualCounted(int* counter)
+  TEST_HOST_DEVICE_FUNC constexpr VirtualCounted(int* counter)
       : counter_(counter)
   {
     ++*counter_;
   }
-  TEST_FUNC TEST_CONSTEXPR_CXX20 virtual ~VirtualCounted()
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 virtual ~VirtualCounted()
   {
     --*counter_;
   }
-  TEST_FUNC void operator&() const = delete;
+  TEST_HOST_DEVICE_FUNC void operator&() const = delete;
 };
 
 struct DerivedCounted : VirtualCounted
 {
-  TEST_FUNC constexpr DerivedCounted(int* counter)
+  TEST_HOST_DEVICE_FUNC constexpr DerivedCounted(int* counter)
       : VirtualCounted(counter)
   {}
-  TEST_FUNC TEST_CONSTEXPR_CXX20 ~DerivedCounted() override {}
+  TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 ~DerivedCounted() override {}
 };
 #endif // !_CCCL_TILE_COMPILATION()
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_arrays()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test_arrays()
 {
   {
     int counter    = 0;
@@ -103,7 +102,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_arrays()
   return true;
 }
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
   {
     int counter = 0;
@@ -122,6 +121,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
     cuda::std::__construct_at(cuda::std::addressof(first), &counter);
     cuda::std::__construct_at(cuda::std::addressof(second), &counter);
   }
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
   {
     int counter = 0;
     DerivedCounted first{&counter};
@@ -139,6 +139,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
     cuda::std::__construct_at(cuda::std::addressof(first), &counter);
     cuda::std::__construct_at(cuda::std::addressof(second), &counter);
   }
+#endif // !_CCCL_TILE_COMPILATION()
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
@@ -10,6 +10,9 @@
 
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_IGNORE_DEPRECATED_API
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocations are not supported in tile mode
+
 // <memory>
 
 // template <class T>
@@ -19,9 +22,6 @@
 // template <class T>
 //   void
 //   return_temporary_buffer(T* p);
-
-// XFAIL: enable-tile
-// In tile mode dynamic memory allocation is unsupported
 
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/temporary.buffer/temporary_buffer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/temporary.buffer/temporary_buffer.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: dynamic allocations are not supported in tile mode
+
 // <memory>
 
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_IGNORE_DEPRECATED_API
@@ -21,9 +24,6 @@
 //   return_temporary_buffer(T* p);
 
 // UNSUPPORTED: nvrtc
-
-// XFAIL: enable-tile
-// In tile mode dynamic memory allocation is unsupported
 
 #include <cuda/std/cassert>
 #include <cuda/std/memory>


### PR DESCRIPTION
We cannot use ptx or dynamic allocations, so mark all those APIs as unsupported in tile mode

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>