### PR TITLE
[Tile] Mark most `<cmath>` functions as host device only

### DIFF
--- a/libcudacxx/include/cuda/__cmath/sincos.h
+++ b/libcudacxx/include/cuda/__cmath/sincos.h
@@ -66,7 +66,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT sincos_result
 //! @return The \c cuda::sincos_result with the results of sin and cos operations.
 _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(::cuda::std::__is_extended_arithmetic_v<_Tp>)
-[[nodiscard]] _CCCL_API auto sincos(_Tp __v) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API auto sincos(_Tp __v) noexcept
   -> sincos_result<::cuda::std::conditional_t<::cuda::std::is_integral_v<_Tp>, double, _Tp>>
 {
   if constexpr (::cuda::std::is_integral_v<_Tp>)

--- a/libcudacxx/include/cuda/std/__numeric/saturating_cast.h
+++ b/libcudacxx/include/cuda/std/__numeric/saturating_cast.h
@@ -382,10 +382,12 @@ _CCCL_TEMPLATE(class _To, class _From)
 _CCCL_REQUIRES(__cccl_is_integer_v<_To> _CCCL_AND __cccl_is_integer_v<_From>)
 [[nodiscard]] _CCCL_API constexpr _To saturating_cast(_From __x) noexcept
 {
+#if !_CCCL_TILE_COMPILATION()
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     NV_IF_TARGET(NV_IS_DEVICE, ({ return ::cuda::std::__saturating_cast_impl_device<_To>(__x, 0); }))
   }
+#endif // !_CCCL_TILE_COMPILATION()
   return ::cuda::saturating_overflow_cast<_To>(__x).value;
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/cmath/fast_modulo_division.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath/fast_modulo_division.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
 
 #include <cuda/cmath>
 #include <cuda/std/chrono>
@@ -21,7 +21,7 @@
 
 // test all power of 2 and maximum values
 template <typename value_t, typename divisor_t>
-TEST_FUNC void test_power_of_2(value_t value)
+TEST_HOST_DEVICE_FUNC void test_power_of_2(value_t value)
 {
   constexpr auto max_divisor = cuda::std::numeric_limits<divisor_t>::max();
   constexpr auto max_value   = cuda::std::numeric_limits<value_t>::max();
@@ -41,7 +41,7 @@ TEST_FUNC void test_power_of_2(value_t value)
 }
 
 template <typename value_t, typename divisor_t>
-TEST_FUNC void test_sequence(value_t value)
+TEST_HOST_DEVICE_FUNC void test_sequence(value_t value)
 {
   constexpr auto max_value  = cuda::std::numeric_limits<divisor_t>::max();
   constexpr divisor_t range = max_value < 10000 ? max_value : 10000;
@@ -53,7 +53,7 @@ TEST_FUNC void test_sequence(value_t value)
 }
 
 template <typename value_t, typename divisor_t, typename gen_t>
-TEST_FUNC void test_random(value_t value, gen_t& gen)
+TEST_HOST_DEVICE_FUNC void test_random(value_t value, gen_t& gen)
 {
   cuda::std::uniform_int_distribution<divisor_t> distrib_div;
   constexpr auto max_value  = cuda::std::numeric_limits<divisor_t>::max();
@@ -67,7 +67,7 @@ TEST_FUNC void test_random(value_t value, gen_t& gen)
 }
 
 template <typename value_t, typename divisor_t>
-TEST_FUNC void test_boundary_divisors(value_t value)
+TEST_HOST_DEVICE_FUNC void test_boundary_divisors(value_t value)
 {
   using div_op               = cuda::fast_mod_div<divisor_t>;
   using unsigned_divisor_t   = cuda::std::make_unsigned_t<divisor_t>;
@@ -100,7 +100,7 @@ struct PositiveDistribution
   cuda::std::minstd_rand0 rng;
 
   template <typename T>
-  TEST_FUNC T operator()(cuda::std::uniform_int_distribution<T>& distrib)
+  TEST_HOST_DEVICE_FUNC T operator()(cuda::std::uniform_int_distribution<T>& distrib)
   {
     auto value = distrib(rng);
     return cuda::std::max(T{1}, static_cast<T>(cuda::uabs(value)));
@@ -108,7 +108,7 @@ struct PositiveDistribution
 };
 
 template <typename value_t, typename divisor_t>
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   auto seed = cuda::std::chrono::system_clock::now().time_since_epoch().count();
   printf("%s: seed: %lld\n", (_CCCL_BUILTIN_PRETTY_FUNCTION()), (long long int) seed);
@@ -123,7 +123,7 @@ TEST_FUNC void test()
 }
 
 #if _CCCL_HAS_INT128()
-TEST_FUNC void test_int128()
+TEST_HOST_DEVICE_FUNC void test_int128()
 {
   constexpr __uint128_t unsigned_value = (__uint128_t{1} << 127) + 123456789;
   constexpr __int128_t signed_value    = static_cast<__int128_t>((__uint128_t{1} << 126) + 123456789);
@@ -142,7 +142,7 @@ TEST_FUNC void test_int128()
 }
 #endif // _CCCL_HAS_INT128()
 
-TEST_FUNC void test_cpp_semantic()
+TEST_HOST_DEVICE_FUNC void test_cpp_semantic()
 {
   cuda::fast_mod_div<int> div{3};
   assert(div == 3);
@@ -151,7 +151,7 @@ TEST_FUNC void test_cpp_semantic()
   assert(cuda::div(5, div) == (cuda::std::pair<int, int>{1, 2}));
 }
 
-TEST_FUNC void test_divisor_is_never_one()
+TEST_HOST_DEVICE_FUNC void test_divisor_is_never_one()
 {
   cuda::fast_mod_div<int, true> div{3};
   assert(div == 3);
@@ -160,7 +160,7 @@ TEST_FUNC void test_divisor_is_never_one()
   assert(cuda::div(5, div) == (cuda::std::pair<int, int>{1, 2}));
 }
 
-TEST_FUNC bool test()
+TEST_HOST_DEVICE_FUNC bool test()
 {
   test<int8_t, int8_t>();
   test<uint8_t, uint8_t>();

--- a/libcudacxx/test/libcudacxx/cuda/cmath/sincos.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath/sincos.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077402: error: "call to non-tile function not supported!"
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function from a __host__ __device__ __tile__ function is not allowed
 
 // <cuda/cmath>
 
@@ -20,39 +20,39 @@
 
 #include "test_macros.h"
 
-TEST_FUNC bool is_about(float x, float y)
+TEST_HOST_DEVICE_FUNC bool is_about(float x, float y)
 {
   return (cuda::std::abs((x - y) / (x + y)) < 1.e-6);
 }
 
-TEST_FUNC bool is_about(double x, double y)
+TEST_HOST_DEVICE_FUNC bool is_about(double x, double y)
 {
   return (cuda::std::abs((x - y) / (x + y)) < 1.e-14);
 }
 
 #if _CCCL_HAS_LONG_DOUBLE()
-TEST_FUNC bool is_about(long double x, long double y)
+TEST_HOST_DEVICE_FUNC bool is_about(long double x, long double y)
 {
   return (cuda::std::abs((x - y) / (x + y)) < 1.e-14);
 }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
 #if _LIBCUDACXX_HAS_NVFP16()
-TEST_FUNC bool is_about(__half x, __half y)
+TEST_HOST_DEVICE_FUNC bool is_about(__half x, __half y)
 {
   return (cuda::std::fabs((x - y) / (x + y)) <= __half(1e-3));
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
 
 #if _LIBCUDACXX_HAS_NVBF16()
-TEST_FUNC bool is_about(__nv_bfloat16 x, __nv_bfloat16 y)
+TEST_HOST_DEVICE_FUNC bool is_about(__nv_bfloat16 x, __nv_bfloat16 y)
 {
   return (cuda::std::fabs((x - y) / (x + y)) <= __nv_bfloat16(5e-3));
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
 template <class T>
-TEST_FUNC void test_type(float zero)
+TEST_HOST_DEVICE_FUNC void test_type(float zero)
 {
   using Result = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
 
@@ -102,7 +102,7 @@ TEST_FUNC void test_type(float zero)
   }
 }
 
-TEST_FUNC void test(float zero)
+TEST_HOST_DEVICE_FUNC void test(float zero)
 {
   test_type<float>(zero);
   test_type<double>(zero);

--- a/libcudacxx/test/libcudacxx/cuda/float/bfloat_cos_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/bfloat_cos_comparison.pass.cpp
@@ -9,9 +9,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
-// XFAIL: enable-tile
-// tile does not support access to members of `__half` or `__nv_bfloat16`
-
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"
@@ -19,7 +16,7 @@
 
 struct func
 {
-  TEST_FUNC __nv_bfloat16 operator()(cuda::std::size_t i) const
+  TEST_HOST_DEVICE_FUNC __nv_bfloat16 operator()(cuda::std::size_t i) const
   {
     auto raw = __nv_bfloat16_raw();
     raw.x    = (unsigned short) i;

--- a/libcudacxx/test/libcudacxx/cuda/float/bfloat_exp_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/bfloat_exp_comparison.pass.cpp
@@ -9,9 +9,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
-// XFAIL: enable-tile
-// tile does not support access to members of `__half` or `__nv_bfloat16`
-
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"
@@ -19,7 +16,7 @@
 
 struct func
 {
-  TEST_FUNC __nv_bfloat16 operator()(cuda::std::size_t i) const
+  TEST_HOST_DEVICE_FUNC __nv_bfloat16 operator()(cuda::std::size_t i) const
   {
     auto raw = __nv_bfloat16_raw();
     raw.x    = (unsigned short) i;

--- a/libcudacxx/test/libcudacxx/cuda/float/bfloat_log_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/bfloat_log_comparison.pass.cpp
@@ -9,9 +9,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
-// XFAIL: enable-tile
-// tile does not support access to members of `__half` or `__nv_bfloat16`
-
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"
@@ -19,7 +16,7 @@
 
 struct func
 {
-  TEST_FUNC __nv_bfloat16 operator()(cuda::std::size_t i) const
+  TEST_HOST_DEVICE_FUNC __nv_bfloat16 operator()(cuda::std::size_t i) const
   {
     auto raw = __nv_bfloat16_raw();
     raw.x    = (unsigned short) i;

--- a/libcudacxx/test/libcudacxx/cuda/float/bfloat_sin_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/bfloat_sin_comparison.pass.cpp
@@ -9,9 +9,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
-// XFAIL: enable-tile
-// tile does not support access to members of `__half` or `__nv_bfloat16`
-
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"
@@ -19,7 +16,7 @@
 
 struct func
 {
-  TEST_FUNC __nv_bfloat16 operator()(cuda::std::size_t i) const
+  TEST_HOST_DEVICE_FUNC __nv_bfloat16 operator()(cuda::std::size_t i) const
   {
     auto raw = __nv_bfloat16_raw();
     raw.x    = (unsigned short) i;

--- a/libcudacxx/test/libcudacxx/cuda/float/bfloat_sqrt_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/bfloat_sqrt_comparison.pass.cpp
@@ -9,9 +9,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
-// XFAIL: enable-tile
-// tile does not support access to members of `__half` or `__nv_bfloat16`
-
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"
@@ -19,7 +16,7 @@
 
 struct func
 {
-  TEST_FUNC __nv_bfloat16 operator()(cuda::std::size_t i) const
+  TEST_HOST_DEVICE_FUNC __nv_bfloat16 operator()(cuda::std::size_t i) const
   {
     auto raw = __nv_bfloat16_raw();
     raw.x    = (unsigned short) i;

--- a/libcudacxx/test/libcudacxx/cuda/float/half_cos_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/half_cos_comparison.pass.cpp
@@ -9,9 +9,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
-// XFAIL: enable-tile
-// tile does not support access to members of `__half` or `__nv_bfloat16`
-
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"
@@ -19,7 +16,7 @@
 
 struct func
 {
-  TEST_FUNC __half operator()(cuda::std::size_t i) const
+  TEST_HOST_DEVICE_FUNC __half operator()(cuda::std::size_t i) const
   {
     auto raw = __half_raw();
     raw.x    = (unsigned short) i;

--- a/libcudacxx/test/libcudacxx/cuda/float/half_exp_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/half_exp_comparison.pass.cpp
@@ -9,9 +9,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
-// XFAIL: enable-tile
-// tile does not support access to members of `__half` or `__nv_bfloat16`
-
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"
@@ -19,7 +16,7 @@
 
 struct func
 {
-  TEST_FUNC __half operator()(cuda::std::size_t i) const
+  TEST_HOST_DEVICE_FUNC __half operator()(cuda::std::size_t i) const
   {
     auto raw = __half_raw();
     raw.x    = (unsigned short) i;

--- a/libcudacxx/test/libcudacxx/cuda/float/half_log_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/half_log_comparison.pass.cpp
@@ -9,9 +9,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
-// XFAIL: enable-tile
-// tile does not support access to members of `__half` or `__nv_bfloat16`
-
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"
@@ -19,7 +16,7 @@
 
 struct func
 {
-  TEST_FUNC __half operator()(cuda::std::size_t i) const
+  TEST_HOST_DEVICE_FUNC __half operator()(cuda::std::size_t i) const
   {
     auto raw = __half_raw();
     raw.x    = (unsigned short) i;

--- a/libcudacxx/test/libcudacxx/cuda/float/half_sin_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/half_sin_comparison.pass.cpp
@@ -9,9 +9,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
-// XFAIL: enable-tile
-// tile does not support access to members of `__half` or `__nv_bfloat16`
-
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"
@@ -19,7 +16,7 @@
 
 struct func
 {
-  TEST_FUNC __half operator()(cuda::std::size_t i) const
+  TEST_HOST_DEVICE_FUNC __half operator()(cuda::std::size_t i) const
   {
     auto raw = __half_raw();
     raw.x    = (unsigned short) i;

--- a/libcudacxx/test/libcudacxx/cuda/float/half_sqrt_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/half_sqrt_comparison.pass.cpp
@@ -9,9 +9,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
-// XFAIL: enable-tile
-// tile does not support access to members of `__half` or `__nv_bfloat16`
-
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"
@@ -23,7 +20,7 @@ static_assert(false);
 
 struct func
 {
-  TEST_FUNC __half operator()(cuda::std::size_t i) const
+  TEST_HOST_DEVICE_FUNC __half operator()(cuda::std::size_t i) const
   {
     auto raw = __half_raw();
     raw.x    = (unsigned short) i;

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/accuracy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/accuracy.pass.cpp
@@ -13,6 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/api.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/api.pass.cpp
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/api_unpacked.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/api_unpacked.pass.cpp
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/bit_cast.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/bit_cast.pass.cpp
@@ -18,6 +18,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/bit>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/charbool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/charbool.pass.cpp
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/conv.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/conv.pass.cpp
@@ -19,6 +19,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/copyable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/copyable.pass.cpp
@@ -11,6 +11,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/cassert>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/core.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/core.pass.cpp
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/core_unpacked.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/core_unpacked.pass.cpp
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/cmath>
 

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/cuda_std.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/cuda_std.pass.cpp
@@ -19,6 +19,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/exp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/exp.pass.cpp
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/bit>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/float64.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/float64.pass.cpp
@@ -16,6 +16,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 // nvcc doesn't currently support _Float64 in device code.
 // UNSUPPORTED: nvcc
 

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/mixed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/mixed.pass.cpp
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/template.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/template.pass.cpp
@@ -13,6 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>

--- a/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/volatile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/fp/units/fpemu/volatile.pass.cpp
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
+
 #include <cuda/fpemu>
 #include <cuda/std/cassert>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/cuda/numeric/isclose/isclose.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/numeric/isclose/isclose.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: calling a host device function in tile mode
+
 #include <cuda/__complex_>
 #include <cuda/numeric>
 #include <cuda/std/cassert>
@@ -33,7 +36,7 @@ inline constexpr bool has_isclose_abs_tol_v<
     cuda::std::declval<T>(), cuda::std::declval<T>(), 0.0f, cuda::std::declval<AbsTol>()))>> = true;
 
 template <class T>
-TEST_FUNC bool test_floating_point()
+TEST_HOST_DEVICE_FUNC bool test_floating_point()
 {
   static_assert(cuda::std::is_same_v<bool, decltype(cuda::isclose(T{}, T{}))>);
   static_assert(cuda::std::is_same_v<bool, decltype(cuda::isclose(T{}, T{}, 0.0f))>);
@@ -62,7 +65,7 @@ TEST_FUNC bool test_floating_point()
 }
 
 template <typename T>
-TEST_FUNC bool test_integral()
+TEST_HOST_DEVICE_FUNC bool test_integral()
 {
   static_assert(cuda::std::is_same_v<bool, decltype(cuda::isclose(T{}, T{}))>);
   static_assert(cuda::std::is_same_v<bool, decltype(cuda::isclose(T{}, T{}, 0.0f))>);
@@ -105,7 +108,7 @@ TEST_FUNC bool test_integral()
   return true;
 }
 
-TEST_FUNC bool test_integral_boundaries()
+TEST_HOST_DEVICE_FUNC bool test_integral_boundaries()
 {
   constexpr uint64_t rhs       = 18446744073586094827ull;
   constexpr uint64_t threshold = 1844674434846400176ull;
@@ -137,7 +140,7 @@ TEST_FUNC bool test_integral_boundaries()
 }
 
 template <class Complex>
-TEST_FUNC void test_complex()
+TEST_HOST_DEVICE_FUNC void test_complex()
 {
   using T = typename Complex::value_type;
   static_assert(cuda::std::is_same_v<bool, decltype(cuda::isclose(Complex{}, Complex{}))>);
@@ -171,7 +174,7 @@ TEST_FUNC void test_complex()
   assert(!cuda::isclose(Complex{nan, T{}}, Complex{}));
 }
 
-TEST_FUNC constexpr void test_invalid_complex_cases()
+TEST_HOST_DEVICE_FUNC constexpr void test_invalid_complex_cases()
 {
   static_assert(!has_isclose_abs_tol_v<cuda::std::complex<double>, float>);
   static_assert(!has_isclose_abs_tol_v<cuda::complex<double>, float>);
@@ -183,7 +186,7 @@ TEST_FUNC constexpr void test_invalid_complex_cases()
 #endif // _CCCL_HAS_HOST_STD_LIB()
 }
 
-TEST_FUNC bool test_standard_types()
+TEST_HOST_DEVICE_FUNC bool test_standard_types()
 {
   test_floating_point<float>();
   test_floating_point<double>();
@@ -214,7 +217,7 @@ TEST_FUNC bool test_standard_types()
 }
 
 template <template <typename> class Complex>
-TEST_FUNC void test_complex_types()
+TEST_HOST_DEVICE_FUNC void test_complex_types()
 {
   test_complex<Complex<float>>();
   test_complex<Complex<double>>();
@@ -224,7 +227,7 @@ TEST_FUNC void test_complex_types()
   // complex__float128 support requires std::hypot overload
 }
 
-TEST_FUNC bool test_extended_fp()
+TEST_HOST_DEVICE_FUNC bool test_extended_fp()
 {
 #if _LIBCUDACXX_HAS_NVFP16()
   test_floating_point<__half>();

--- a/libcudacxx/test/libcudacxx/cuda/numeric/overflow.arithmetic/add_overflow.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/numeric/overflow.arithmetic/add_overflow.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile && !c++17
-// nvbug6085768: compiler hangs
+// UNSUPPORTED: force-tile
+// blows up the tile compiler
 
 #include <cuda/numeric>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/numeric/overflow.arithmetic/sub_overflow.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/numeric/overflow.arithmetic/sub_overflow.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile && !c++17
-// nvbug6085768: compiler hangs
+// UNSUPPORTED: force-tile
+// blows up the tile compiler
 
 #include <cuda/numeric>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/device_fp128_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/device_fp128_functions.pass.cpp
@@ -8,10 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: int128 is not supported in tile mode
+
 // ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
-// UNSUPPORTED: enable-tile
-
 #include <cuda/std/__floating_point/cuda_fp_types.h>
 #include <cuda/std/cassert>
 #include <cuda/std/limits>

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bit.endian/endian.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bit.endian/endian.pass.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: calling a host device function in tile mode
 
 // enum class endian;
 // <cuda/std/bit>

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bit.shift/shl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bit.shift/shl.pass.cpp
@@ -31,8 +31,10 @@ TEST_FUNC constexpr T invoke_shl(T v, S shift)
   }
   else
   {
+#if !_CCCL_TILE_COMPILATION()
     DoNotOptimize(v);
     DoNotOptimize(shift);
+#endif // !_CCCL_TILE_COMPILATION()
     return cuda::std::shl(v, shift);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bit.shift/shr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bit.shift/shr.pass.cpp
@@ -31,8 +31,10 @@ TEST_FUNC constexpr T invoke_shr(T v, S shift)
   }
   else
   {
+#if !_CCCL_TILE_COMPILATION()
     DoNotOptimize(v);
     DoNotOptimize(shift);
+#endif // !_CCCL_TILE_COMPILATION()
     return cuda::std::shr(v, shift);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/logarithms.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/logarithms.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077402: error: "call to non-tile function not supported!"
-
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/modulo.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/modulo.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077402: error: "call to non-tile function not supported!"
-
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/remainder.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/remainder.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077402: error: "call to non-tile function not supported!"
-
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/roots.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/roots.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077402: error: "call to non-tile function not supported!"
-
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/rounding.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/rounding.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077402: error: "call to non-tile function not supported!"
-
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/trigonometric_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/trigonometric_functions.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077402: error: "call to non-tile function not supported!"
-
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/accumulate/accumulate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/accumulate/accumulate.pass.cpp
@@ -56,9 +56,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/accumulate/accumulate_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/accumulate/accumulate_op.pass.cpp
@@ -103,9 +103,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   test_use_move();
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/adjacent_difference.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/adjacent_difference.pass.cpp
@@ -126,9 +126,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   X x[3] = {X(1), X(2), X(3)};
   Y y[3] = {Y(1), Y(2), Y(3)};

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/adjacent_difference_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/adjacent_difference_op.pass.cpp
@@ -186,9 +186,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   X x[3] = {X(1), X(2), X(3)};
   Y y[3] = {Y(1), Y(2), Y(3)};

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/exclusive_scan.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/exclusive_scan.pass.cpp
@@ -116,9 +116,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/exclusive_scan_init_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/exclusive_scan_init_op.pass.cpp
@@ -78,9 +78,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   //  Make sure that the calculations are done using the init typedef
   {

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/inclusive_scan.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/inclusive_scan.pass.cpp
@@ -126,9 +126,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/inclusive_scan_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/inclusive_scan_op.pass.cpp
@@ -130,9 +130,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/inclusive_scan_op_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/inclusive_scan_op_init.pass.cpp
@@ -147,9 +147,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inner.product/inner_product.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inner.product/inner_product.pass.cpp
@@ -85,9 +85,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inner.product/inner_product_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inner.product/inner_product_comp.pass.cpp
@@ -149,9 +149,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   test_use_move();
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.iota/iota.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.iota/iota.pass.cpp
@@ -43,9 +43,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, test<host_only_iterator<int*>>();)
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, test<device_only_iterator<int*>>();)
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.float.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.float.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077402: error: "call to non-tile function not supported!"
-
 // <numeric>
 
 // template <class _Float>

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.ops.sat/saturating_cast.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.ops.sat/saturating_cast.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// blows up the tile compiler
+
 // <cuda/std/numeric>
 
 // template<class R, class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/partial.sum/partial_sum.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/partial.sum/partial_sum.pass.cpp
@@ -75,9 +75,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/partial.sum/partial_sum_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/partial.sum/partial_sum_op.pass.cpp
@@ -137,9 +137,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   test_use_move();
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/reduce.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/reduce.pass.cpp
@@ -67,9 +67,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/reduce_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/reduce_init.pass.cpp
@@ -71,9 +71,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/reduce_init_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/reduce_init_op.pass.cpp
@@ -72,9 +72,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   //  Make sure the math is done using the correct type
   {

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.exclusive.scan/transform_exclusive_scan_init_bop_uop.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.exclusive.scan/transform_exclusive_scan_init_bop_uop.pass.cpp
@@ -180,9 +180,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.inclusive.scan/transform_inclusive_scan_bop_uop.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.inclusive.scan/transform_inclusive_scan_bop_uop.pass.cpp
@@ -146,9 +146,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.inclusive.scan/transform_inclusive_scan_bop_uop_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.inclusive.scan/transform_inclusive_scan_bop_uop_init.pass.cpp
@@ -181,9 +181,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/transform_reduce_iter_iter_init_bop_uop.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/transform_reduce_iter_iter_init_bop_uop.pass.cpp
@@ -134,9 +134,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   //  Make sure the math is done using the correct type
   {

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/transform_reduce_iter_iter_iter_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/transform_reduce_iter_iter_iter_init.pass.cpp
@@ -101,9 +101,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<const unsigned int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<const unsigned int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   //  just plain pointers (const vs. non-const, too)
   test<const int*, const unsigned int*>();

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/transform_reduce_iter_iter_iter_init_op_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/transform_reduce_iter_iter_iter_init_op_op.pass.cpp
@@ -117,9 +117,9 @@ TEST_FUNC constexpr bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>, host_only_iterator<const unsigned int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !defined(CCCL_FORCE_TILE_TESTS)
   NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>, device_only_iterator<const unsigned int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !CCCL_FORCE_TILE_TESTS
 
   //  just plain pointers (const vs. non-const, too)
   test<const int*, const unsigned int*>();


### PR DESCRIPTION
They are mostly not yet implemented for tile

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>