### PR TITLE
[Tile] Mark clocks as host device only

### DIFF
--- a/libcudacxx/include/cuda/std/__chrono/steady_clock.h
+++ b/libcudacxx/include/cuda/std/__chrono/steady_clock.h
@@ -45,7 +45,7 @@ public:
   using time_point                = ::cuda::std::chrono::time_point<steady_clock, duration>;
   static constexpr bool is_steady = true;
 
-  [[nodiscard]] _CCCL_API static time_point now() noexcept;
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static time_point now() noexcept;
 };
 } // namespace chrono
 

--- a/libcudacxx/include/cuda/std/__chrono/system_clock.h
+++ b/libcudacxx/include/cuda/std/__chrono/system_clock.h
@@ -44,7 +44,7 @@ public:
   using time_point                = ::cuda::std::chrono::time_point<system_clock>;
   static constexpr bool is_steady = false;
 
-  [[nodiscard]] _CCCL_API inline static time_point now() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API inline static time_point now() noexcept
   {
     NV_IF_ELSE_TARGET(
       NV_IS_HOST,
@@ -54,12 +54,12 @@ public:
       (return time_point(duration_cast<duration>(nanoseconds(::cuda::ptx::get_sreg_globaltimer())));))
   }
 
-  [[nodiscard]] _CCCL_API inline static time_t to_time_t(const time_point& __t) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API inline static time_t to_time_t(const time_point& __t) noexcept
   {
     return time_t(::cuda::std::chrono::duration_cast<seconds>(__t.time_since_epoch()).count());
   }
 
-  [[nodiscard]] _CCCL_API inline static time_point from_time_t(time_t __t) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API inline static time_point from_time_t(time_t __t) noexcept
   {
     return time_point(::cuda::std::chrono::seconds(__t));
   }

--- a/libcudacxx/include/cuda/std/ctime
+++ b/libcudacxx/include/cuda/std/ctime
@@ -53,7 +53,7 @@ using ::timespec;
 
 // clock
 
-[[nodiscard]] _CCCL_API inline clock_t clock() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API inline clock_t clock() noexcept
 {
 #if _CCCL_HOSTJIT() // host-side `clock` is not supported in freestanding
   NV_IF_ELSE_TARGET(
@@ -65,7 +65,7 @@ using ::timespec;
 
 // difftime
 
-[[nodiscard]] _CCCL_API constexpr double difftime(time_t __end, time_t __start) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr double difftime(time_t __end, time_t __start) noexcept
 {
   return static_cast<double>(__end - __start);
 }
@@ -84,7 +84,7 @@ using ::timespec;
 }
 #endif // _CCCL_CUDA_COMPILATION()
 
-_CCCL_API inline time_t time(time_t* __v) noexcept
+_CCCL_HOST_DEVICE_API inline time_t time(time_t* __v) noexcept
 {
 #if _CCCL_HOSTJIT() // host-side `time` is not supported in freestanding
   NV_IF_ELSE_TARGET(NV_IS_HOST, (::cuda::std::terminate();), (return ::cuda::std::__cccl_time_impl_device(__v);))
@@ -111,7 +111,7 @@ _CCCL_API inline time_t time(time_t* __v) noexcept
 }
 #  endif // _CCCL_CUDA_COMPILATION()
 
-[[nodiscard]] _CCCL_API inline int timespec_get(timespec* __ts, int __base) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API inline int timespec_get(timespec* __ts, int __base) noexcept
 {
 #  if _CCCL_HOSTJIT() // host-side `timespec_get` is not supported in freestanding
   NV_IF_ELSE_TARGET(

--- a/libcudacxx/test/libcudacxx/std/time/ctime/ctime.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/time/ctime/ctime.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: asm statement not supported in tile
 
 #include <cuda/std/cassert>
 #include <cuda/std/ctime>
@@ -23,7 +23,7 @@
 
 static_assert(TIME_UTC != 0);
 
-TEST_FUNC bool test()
+TEST_HOST_DEVICE_FUNC bool test()
 {
   // struct timespec
 

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.file/consistency.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.file/consistency.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: c++17
 // XFAIL: dylib-has-no-filesystem
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // Due to C++17 inline variables ASAN flags this test as containing an ODR
 // violation because Clock::is_steady is defined in both the dylib and this TU.
 // UNSUPPORTED: asan
@@ -24,8 +27,10 @@
 
 #include <cuda/std/chrono>
 
+#include "test_macros.h"
+
 template <class T>
-TEST_FUNC void test(const T&)
+TEST_HOST_DEVICE_FUNC void test(const T&)
 {}
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.file/file_time.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.file/file_time.pass.cpp
@@ -8,6 +8,9 @@
 
 // UNSUPPORTED: c++17
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // <cuda/std/chrono>
 
 // file_time

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.file/now.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.file/now.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: c++17
 // XFAIL: dylib-has-no-filesystem
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // File clock is unsupported in NVRTC
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.file/rep_signed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.file/rep_signed.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: c++17
 // XFAIL: dylib-has-no-filesystem
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // File clock is unsupported in NVRTC
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.hires/consistency.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.hires/consistency.pass.cpp
@@ -10,6 +10,9 @@
 // violation because Clock::is_steady is defined in both the dylib and this TU.
 // UNSUPPORTED: asan
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // <cuda/std/chrono>
 
 // high_resolution_clock
@@ -21,7 +24,7 @@
 #include "test_macros.h"
 
 template <class T>
-TEST_FUNC void test(const T&)
+TEST_HOST_DEVICE_FUNC void test(const T&)
 {}
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.hires/now.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.hires/now.pass.cpp
@@ -6,14 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // <cuda/std/chrono>
 
 // high_resolution_clock
 
 // static time_point now();
-
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
 
 #include <cuda/std/cassert>
 #include <cuda/std/chrono>

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/consistency.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/consistency.pass.cpp
@@ -10,6 +10,9 @@
 // violation because Clock::is_steady is defined in both the dylib and this TU.
 // UNSUPPORTED: asan
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // <cuda/std/chrono>
 
 // system_clock
@@ -21,7 +24,7 @@
 #include "test_macros.h"
 
 template <class T>
-TEST_FUNC void test(const T&)
+TEST_HOST_DEVICE_FUNC void test(const T&)
 {}
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/from_time_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/from_time_t.pass.cpp
@@ -6,14 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // <cuda/std/chrono>
 
 // system_clock
 
 // static time_point from_time_t(time_t t);
-
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
 
 #include <cuda/std/chrono>
 #include <cuda/std/ctime>

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/local_time.types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/local_time.types.pass.cpp
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++17
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // <cuda/std/chrono>
 
 // struct local_t {};

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/now.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/now.pass.cpp
@@ -6,14 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // <cuda/std/chrono>
 
 // system_clock
 
 // static time_point now();
-
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
 
 #include <cuda/std/cassert>
 #include <cuda/std/chrono>

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/rep_signed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/rep_signed.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // <cuda/std/chrono>
 
 // system_clock

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/sys.time.types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/sys.time.types.pass.cpp
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++17
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // <cuda/std/chrono>
 
 // template<class Duration>

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/to_time_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/to_time_t.pass.cpp
@@ -6,14 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: clocks are not supported in tile mode
+
 // <cuda/std/chrono>
 
 // system_clock
 
 // time_t to_time_t(const time_point& t);
-
-// UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
 
 #include <cuda/std/chrono>
 #include <cuda/std/ctime>

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.duration/time.duration.cons/convert_overflow.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.duration/time.duration.cons/convert_overflow.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // <chrono>
 
 // duration
@@ -16,9 +19,6 @@
 
 // overflow should SFINAE instead of error out, LWG 2094
 
-// XFAIL: enable-tile
-// error: a non-__tile__ variable cannot be used in tile code
-
 #include <cuda/std/cassert>
 #include <cuda/std/chrono>
 #include <cuda/std/ratio>
@@ -27,8 +27,8 @@
 
 TEST_GLOBAL_VARIABLE bool called = false;
 
-TEST_FUNC void f(cuda::std::chrono::milliseconds);
-TEST_FUNC void f(cuda::std::chrono::seconds)
+TEST_HOST_DEVICE_FUNC void f(cuda::std::chrono::milliseconds);
+TEST_HOST_DEVICE_FUNC void f(cuda::std::chrono::seconds)
 {
   called = true;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.point/time.point.nonmember/op_-duration.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.point/time.point.nonmember/op_-duration.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: no clock in tile mode
+
 // <cuda/std/chrono>
 
 // time_point
@@ -22,7 +25,7 @@
 #include "test_macros.h"
 
 template <class D>
-TEST_FUNC void test2739() // LWG2739
+TEST_HOST_DEVICE_FUNC void test2739() // LWG2739
 {
   using TimePoint = cuda::std::chrono::time_point<cuda::std::chrono::system_clock>;
   using Dur       = cuda::std::chrono::duration<D>;
@@ -32,7 +35,7 @@ TEST_FUNC void test2739() // LWG2739
   assert(t1 < t0);
 }
 
-TEST_FUNC constexpr bool test()
+TEST_HOST_DEVICE_FUNC constexpr bool test()
 {
   using Clock     = cuda::std::chrono::system_clock;
   using Duration1 = cuda::std::chrono::milliseconds;


### PR DESCRIPTION
They rely on ptx for device counters

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>