### PR TITLE
[Tile] Mark a lot of `<ranges>` tests as host device only

### DIFF
--- a/libcudacxx/include/cuda/std/__ranges/movable_box.h
+++ b/libcudacxx/include/cuda/std/__ranges/movable_box.h
@@ -244,6 +244,7 @@ struct __mb_holder
 {
   _Tp __val_;
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class... _Args>
   _CCCL_API constexpr explicit __mb_holder(in_place_t,
                                            _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
@@ -256,6 +257,7 @@ struct __mb_holder<_Tp, true>
 {
   _CCCL_NO_UNIQUE_ADDRESS _Tp __val_;
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class... _Args>
   _CCCL_API constexpr explicit __mb_holder(in_place_t,
                                            _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
@@ -268,6 +270,7 @@ struct __mb_holder_base
 {
   _CCCL_NO_UNIQUE_ADDRESS __mb_holder<_Tp> __holder_;
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class... _Args)
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __mb_holder_base(in_place_t,
@@ -281,10 +284,12 @@ struct __mb_holder_base<_Tp, true>
 {
   _CCCL_NO_UNIQUE_ADDRESS __mb_holder<_Tp> __holder_;
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr __mb_holder_base() noexcept(is_nothrow_default_constructible_v<_Tp>)
       : __holder_(in_place_t{})
   {}
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class... _Args)
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __mb_holder_base(in_place_t,

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.common.view/adaptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.common.view/adaptor.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
 
 // cuda::std::views::common
 
@@ -26,7 +26,7 @@ template <class View, class T>
 _CCCL_CONCEPT CanBePiped =
   _CCCL_REQUIRES_EXPR((View, T), View&& view, T&& t)((cuda::std::forward<View>(view) | cuda::std::forward<T>(t)));
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
   int buf[] = {1, 2, 3};
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop.while/adaptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop.while/adaptor.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
 
 // cuda::std::views::drop_while
 
@@ -22,7 +22,7 @@
 
 struct Pred
 {
-  TEST_FUNC constexpr bool operator()(int i) const
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
   {
     return i < 3;
   }
@@ -38,7 +38,7 @@ struct BufferView : cuda::std::ranges::view_base
   cuda::std::size_t size_;
 
   template <cuda::std::size_t N>
-  TEST_FUNC constexpr BufferView(T (&b)[N])
+  TEST_HOST_DEVICE_FUNC constexpr BufferView(T (&b)[N])
       : buffer_(b)
       , size_(N)
   {}
@@ -52,7 +52,7 @@ struct MoveOnlyView : IntBufferView
   MoveOnlyView() noexcept = default;
 
   template <class T>
-  TEST_FUNC constexpr MoveOnlyView(T&& arr) noexcept(noexcept(IntBufferView(cuda::std::declval<T>())))
+  TEST_HOST_DEVICE_FUNC constexpr MoveOnlyView(T&& arr) noexcept(noexcept(IntBufferView(cuda::std::declval<T>())))
       : IntBufferView(cuda::std::forward<T>(arr))
   {}
 #else
@@ -63,11 +63,11 @@ struct MoveOnlyView : IntBufferView
   MoveOnlyView& operator=(const MoveOnlyView&) = delete;
   MoveOnlyView(MoveOnlyView&&)                 = default;
   MoveOnlyView& operator=(MoveOnlyView&&)      = default;
-  TEST_FUNC constexpr const int* begin() const
+  TEST_HOST_DEVICE_FUNC constexpr const int* begin() const
   {
     return buffer_;
   }
-  TEST_FUNC constexpr const int* end() const
+  TEST_HOST_DEVICE_FUNC constexpr const int* end() const
   {
     return buffer_ + size_;
   }
@@ -92,7 +92,7 @@ static_assert(!CanBePiped<int, decltype(cuda::std::views::drop_while(Pred{}))>);
 static_assert(!CanBePiped<Foo (&)[2], decltype(cuda::std::views::drop_while(Pred{}))>);
 
 template <class Range, class Expected>
-TEST_FUNC constexpr bool equal(Range&& range, Expected&& expected)
+TEST_HOST_DEVICE_FUNC constexpr bool equal(Range&& range, Expected&& expected)
 {
   auto irange    = range.begin();
   auto iexpected = cuda::std::begin(expected);
@@ -106,7 +106,7 @@ TEST_FUNC constexpr bool equal(Range&& range, Expected&& expected)
   return true;
 }
 
-TEST_FUNC constexpr bool test()
+TEST_HOST_DEVICE_FUNC constexpr bool test()
 {
   int buff[] = {1, 2, 3, 4, 3, 2, 1};
 
@@ -157,7 +157,7 @@ TEST_FUNC constexpr bool test()
   {
     struct Pred2
     {
-      TEST_FUNC constexpr bool operator()(int i) const
+      TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
       {
         return i < 4;
       }

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop.while/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop.while/begin.pass.cpp
@@ -7,7 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
 // error: function-to-pointer decay is unsupported in tile code
 
 // constexpr auto begin();
@@ -23,11 +24,11 @@
 
 struct View : cuda::std::ranges::view_base
 {
-  TEST_FUNC int* begin() const
+  TEST_HOST_DEVICE_FUNC int* begin() const
   {
     return nullptr;
   }
-  TEST_FUNC int* end() const
+  TEST_HOST_DEVICE_FUNC int* end() const
   {
     return nullptr;
   }
@@ -40,7 +41,7 @@ _CCCL_CONCEPT HasBegin = _CCCL_REQUIRES_EXPR((View), View v)((v.begin()));
 
 struct Pred
 {
-  TEST_FUNC constexpr bool operator()(int i) const
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
   {
     return i < 3;
   }
@@ -53,7 +54,7 @@ template <bool Ret>
 struct always
 {
   template <class... Args>
-  TEST_FUNC constexpr bool operator()(Args&&...) const
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(Args&&...) const
   {
     return Ret;
   }
@@ -61,17 +62,17 @@ struct always
 
 struct TrackingPred
 {
-  TEST_FUNC constexpr explicit TrackingPred(bool* moved, bool* copied)
+  TEST_HOST_DEVICE_FUNC constexpr explicit TrackingPred(bool* moved, bool* copied)
       : moved_(moved)
       , copied_(copied)
   {}
-  TEST_FUNC constexpr TrackingPred(TrackingPred const& other)
+  TEST_HOST_DEVICE_FUNC constexpr TrackingPred(TrackingPred const& other)
       : moved_(other.moved_)
       , copied_(other.copied_)
   {
     *copied_ = true;
   }
-  TEST_FUNC constexpr TrackingPred(TrackingPred&& other)
+  TEST_HOST_DEVICE_FUNC constexpr TrackingPred(TrackingPred&& other)
       : moved_(other.moved_)
       , copied_(other.copied_)
   {
@@ -80,7 +81,7 @@ struct TrackingPred
   TrackingPred& operator=(TrackingPred const&) = default;
   TrackingPred& operator=(TrackingPred&&)      = default;
 
-  TEST_FUNC constexpr bool operator()(int i) const
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
   {
     return i < 3;
   }
@@ -89,13 +90,13 @@ struct TrackingPred
 };
 
 template <class Range, class Iter, class Sent, cuda::std::size_t N>
-TEST_FUNC constexpr auto make_subrange(int (&buffer)[N])
+TEST_HOST_DEVICE_FUNC constexpr auto make_subrange(int (&buffer)[N])
 {
   return Range{Iter{buffer}, Sent{Iter{buffer + N}}};
 }
 
 template <class Iter>
-TEST_FUNC constexpr void testOne()
+TEST_HOST_DEVICE_FUNC constexpr void testOne()
 {
   using Sent  = sentinel_wrapper<Iter>;
   using Range = cuda::std::ranges::subrange<Iter, Sent>;
@@ -155,7 +156,7 @@ TEST_FUNC constexpr void testOne()
   {
     struct LessThan3
     {
-      TEST_FUNC constexpr bool operator()(int i) const
+      TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
       {
         return i < 3;
       }
@@ -183,7 +184,7 @@ TEST_FUNC constexpr void testOne()
     unused(it);
   }
 
-#if !TEST_COMPILER(MSVC)
+#if !TEST_COMPILER(MSVC) && !_CCCL_TILE_COMPILATION() // lambda-to-pointer is invalid
   // Test with a non-const predicate
   {
     auto mutable_pred = [](int& i) mutable {
@@ -197,13 +198,13 @@ TEST_FUNC constexpr void testOne()
     static_assert(cuda::std::same_as<decltype(it), Iter>);
     assert(base(it) == buffer + 2);
   }
-#endif // !TEST_COMPILER(MSVC)
+#endif // !TEST_COMPILER(MSVC) && !_CCCL_TILE_COMPILATION()
 
   // Test with a predicate that takes by non-const reference
   {
     struct LessThan3
     {
-      TEST_FUNC constexpr bool operator()(int& i) const
+      TEST_HOST_DEVICE_FUNC constexpr bool operator()(int& i) const
       {
         return i < 3;
       }
@@ -240,7 +241,7 @@ TEST_FUNC constexpr void testOne()
   }
 }
 
-TEST_FUNC constexpr bool test()
+TEST_HOST_DEVICE_FUNC constexpr bool test()
 {
   testOne<cpp17_input_iterator<int*>>();
   testOne<cpp20_input_iterator<int*>>();

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop.while/end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop.while/end.pass.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // constexpr auto end();

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop/adaptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop/adaptor.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: force-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // cuda::std::views::drop
@@ -32,16 +32,16 @@ struct SizedView : cuda::std::ranges::view_base
 {
   int* begin_ = nullptr;
   int* end_   = nullptr;
-  TEST_FUNC constexpr SizedView(int* begin, int* end)
+  TEST_HOST_DEVICE_FUNC constexpr SizedView(int* begin, int* end)
       : begin_(begin)
       , end_(end)
   {}
 
-  TEST_FUNC constexpr auto begin() const
+  TEST_HOST_DEVICE_FUNC constexpr auto begin() const
   {
     return forward_iterator<int*>(begin_);
   }
-  TEST_FUNC constexpr auto end() const
+  TEST_HOST_DEVICE_FUNC constexpr auto end() const
   {
     return sized_sentinel<forward_iterator<int*>>(forward_iterator<int*>(end_));
   }
@@ -57,20 +57,20 @@ struct SizedViewWithUnsizedSentinel : cuda::std::ranges::view_base
 
   int* begin_ = nullptr;
   int* end_   = nullptr;
-  TEST_FUNC constexpr SizedViewWithUnsizedSentinel(int* begin, int* end)
+  TEST_HOST_DEVICE_FUNC constexpr SizedViewWithUnsizedSentinel(int* begin, int* end)
       : begin_(begin)
       , end_(end)
   {}
 
-  TEST_FUNC constexpr auto begin() const
+  TEST_HOST_DEVICE_FUNC constexpr auto begin() const
   {
     return iterator(begin_);
   }
-  TEST_FUNC constexpr auto end() const
+  TEST_HOST_DEVICE_FUNC constexpr auto end() const
   {
     return sentinel(iterator(end_));
   }
-  TEST_FUNC constexpr size_t size() const
+  TEST_HOST_DEVICE_FUNC constexpr size_t size() const
   {
     return end_ - begin_;
   }
@@ -82,7 +82,7 @@ static_assert(
 static_assert(cuda::std::ranges::view<SizedViewWithUnsizedSentinel>);
 
 template <class T>
-TEST_FUNC constexpr void test_small_range(const T& input)
+TEST_HOST_DEVICE_FUNC constexpr void test_small_range(const T& input)
 {
   constexpr int N = 100;
   auto size       = cuda::std::ranges::size(input);
@@ -94,13 +94,13 @@ TEST_FUNC constexpr void test_small_range(const T& input)
 
 struct Pred
 {
-  TEST_FUNC constexpr int operator()(int i) noexcept
+  TEST_HOST_DEVICE_FUNC constexpr int operator()(int i) noexcept
   {
     return i;
   }
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
   constexpr int N = 8;
   int buf[N]      = {1, 2, 3, 4, 5, 6, 7, 8};

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop/begin.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: force-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // constexpr auto begin()
@@ -32,21 +32,21 @@ struct MaybeSimpleView : cuda::std::ranges::view_base
   int* num_of_non_const_begin_calls;
   int* num_of_const_begin_calls;
 
-  TEST_FUNC constexpr int* begin()
+  TEST_HOST_DEVICE_FUNC constexpr int* begin()
   {
     ++(*num_of_non_const_begin_calls);
     return nullptr;
   }
-  TEST_FUNC constexpr cuda::std::conditional_t<IsSimple, int*, const int*> begin() const
+  TEST_HOST_DEVICE_FUNC constexpr cuda::std::conditional_t<IsSimple, int*, const int*> begin() const
   {
     ++(*num_of_const_begin_calls);
     return nullptr;
   }
-  TEST_FUNC constexpr int* end() const
+  TEST_HOST_DEVICE_FUNC constexpr int* end() const
   {
     return nullptr;
   }
-  TEST_FUNC constexpr size_t size() const
+  TEST_HOST_DEVICE_FUNC constexpr size_t size() const
   {
     return 0;
   }
@@ -55,7 +55,7 @@ struct MaybeSimpleView : cuda::std::ranges::view_base
 using SimpleView    = MaybeSimpleView<true>;
 using NonSimpleView = MaybeSimpleView<false>;
 
-TEST_FUNC constexpr bool test()
+TEST_HOST_DEVICE_FUNC constexpr bool test()
 {
   // random_access_range<const V> && sized_range<const V>
   cuda::std::ranges::drop_view dropView1(MoveOnlyView(), 4);

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop/ctor.view.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop/ctor.view.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: force-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // constexpr drop_view(V base, range_difference_t<V> count);
@@ -18,7 +18,7 @@
 #include "test_macros.h"
 #include "types.h"
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
   cuda::std::ranges::drop_view dropView1(MoveOnlyView(), 4);
   assert(dropView1.size() == 4);

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop/dangling.cache.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop/dangling.cache.pass.cpp
@@ -7,8 +7,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // If we have a copy-propagating cache, when we copy ZeroOnDestroy, we will get a

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop/types.h
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop/types.h
@@ -11,6 +11,9 @@
 #ifndef TEST_STD_RANGES_RANGE_ADAPTORS_RANGE_DROP_TYPES_H
 #define TEST_STD_RANGES_RANGE_ADAPTORS_RANGE_DROP_TYPES_H
 
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 #include "test_iterators.h"
 #include "test_macros.h"
 
@@ -23,21 +26,21 @@ struct drop_sentinel
   int* num_of_sentinel_cmp_calls;
 
 public:
-  TEST_FUNC friend constexpr bool operator==(drop_sentinel const s, T* const ptr) noexcept
+  TEST_HOST_DEVICE_FUNC friend constexpr bool operator==(drop_sentinel const s, T* const ptr) noexcept
   {
     ++(*s.num_of_sentinel_cmp_calls);
     return {s.ptr_ == ptr};
   }
-  TEST_FUNC friend constexpr bool operator==(T* const ptr, drop_sentinel const s) noexcept
+  TEST_HOST_DEVICE_FUNC friend constexpr bool operator==(T* const ptr, drop_sentinel const s) noexcept
   {
     ++(*s.num_of_sentinel_cmp_calls);
     return {s.ptr_ == ptr};
   }
-  TEST_FUNC friend constexpr bool operator!=(drop_sentinel const s, T* const ptr) noexcept
+  TEST_HOST_DEVICE_FUNC friend constexpr bool operator!=(drop_sentinel const s, T* const ptr) noexcept
   {
     return !(s == ptr);
   }
-  TEST_FUNC friend constexpr bool operator!=(T* const ptr, drop_sentinel const s) noexcept
+  TEST_HOST_DEVICE_FUNC friend constexpr bool operator!=(T* const ptr, drop_sentinel const s) noexcept
   {
     return !(s == ptr);
   }
@@ -48,23 +51,23 @@ struct MaybeSimpleNonCommonView : cuda::std::ranges::view_base
 {
   int start_;
   int* num_of_sentinel_cmp_calls;
-  TEST_FUNC constexpr cuda::std::size_t size() const
+  TEST_HOST_DEVICE_FUNC constexpr cuda::std::size_t size() const
   {
     return 8;
   }
-  TEST_FUNC constexpr int* begin()
+  TEST_HOST_DEVICE_FUNC constexpr int* begin()
   {
     return globalBuff + start_;
   }
-  TEST_FUNC constexpr cuda::std::conditional_t<IsSimple, int*, const int*> begin() const
+  TEST_HOST_DEVICE_FUNC constexpr cuda::std::conditional_t<IsSimple, int*, const int*> begin() const
   {
     return globalBuff + start_;
   }
-  TEST_FUNC constexpr drop_sentinel<int> end()
+  TEST_HOST_DEVICE_FUNC constexpr drop_sentinel<int> end()
   {
     return drop_sentinel<int>{globalBuff + size(), num_of_sentinel_cmp_calls};
   }
-  TEST_FUNC constexpr auto end() const
+  TEST_HOST_DEVICE_FUNC constexpr auto end() const
   {
     return cuda::std::conditional_t<IsSimple, drop_sentinel<int>, drop_sentinel<const int>>{
       globalBuff + size(), num_of_sentinel_cmp_calls};
@@ -74,16 +77,16 @@ struct MaybeSimpleNonCommonView : cuda::std::ranges::view_base
 struct MoveOnlyView : cuda::std::ranges::view_base
 {
   int start_;
-  TEST_FUNC constexpr explicit MoveOnlyView(int start = 0)
+  TEST_HOST_DEVICE_FUNC constexpr explicit MoveOnlyView(int start = 0)
       : start_(start)
   {}
   constexpr MoveOnlyView(MoveOnlyView&&)            = default;
   constexpr MoveOnlyView& operator=(MoveOnlyView&&) = default;
-  TEST_FUNC constexpr int* begin() const
+  TEST_HOST_DEVICE_FUNC constexpr int* begin() const
   {
     return globalBuff + start_;
   }
-  TEST_FUNC constexpr int* end() const
+  TEST_HOST_DEVICE_FUNC constexpr int* end() const
   {
     return globalBuff + 8;
   }
@@ -95,16 +98,16 @@ static_assert(!cuda::std::copyable<MoveOnlyView>);
 struct CopyableView : cuda::std::ranges::view_base
 {
   int start_;
-  TEST_FUNC constexpr explicit CopyableView(int start = 0)
+  TEST_HOST_DEVICE_FUNC constexpr explicit CopyableView(int start = 0)
       : start_(start)
   {}
   constexpr CopyableView(CopyableView const&)            = default;
   constexpr CopyableView& operator=(CopyableView const&) = default;
-  TEST_FUNC constexpr int* begin() const
+  TEST_HOST_DEVICE_FUNC constexpr int* begin() const
   {
     return globalBuff + start_;
   }
-  TEST_FUNC constexpr int* end() const
+  TEST_HOST_DEVICE_FUNC constexpr int* end() const
   {
     return globalBuff + 8;
   }
@@ -113,14 +116,14 @@ struct CopyableView : cuda::std::ranges::view_base
 using ForwardIter = forward_iterator<int*>;
 struct ForwardView : cuda::std::ranges::view_base
 {
-  TEST_FUNC constexpr explicit ForwardView() noexcept {};
+  TEST_HOST_DEVICE_FUNC constexpr explicit ForwardView() noexcept {};
   constexpr ForwardView(ForwardView&&)            = default;
   constexpr ForwardView& operator=(ForwardView&&) = default;
-  TEST_FUNC constexpr forward_iterator<int*> begin() const
+  TEST_HOST_DEVICE_FUNC constexpr forward_iterator<int*> begin() const
   {
     return forward_iterator<int*>(globalBuff);
   }
-  TEST_FUNC constexpr forward_iterator<int*> end() const
+  TEST_HOST_DEVICE_FUNC constexpr forward_iterator<int*> end() const
   {
     return forward_iterator<int*>(globalBuff + 8);
   }
@@ -128,66 +131,66 @@ struct ForwardView : cuda::std::ranges::view_base
 
 struct ForwardRange
 {
-  TEST_FUNC ForwardIter begin() const;
-  TEST_FUNC ForwardIter end() const;
+  TEST_HOST_DEVICE_FUNC ForwardIter begin() const;
+  TEST_HOST_DEVICE_FUNC ForwardIter end() const;
 };
 
 struct ThrowingDefaultCtorForwardView : cuda::std::ranges::view_base
 {
-  TEST_FUNC ThrowingDefaultCtorForwardView() noexcept(false);
-  TEST_FUNC ForwardIter begin() const;
-  TEST_FUNC ForwardIter end() const;
+  TEST_HOST_DEVICE_FUNC ThrowingDefaultCtorForwardView() noexcept(false);
+  TEST_HOST_DEVICE_FUNC ForwardIter begin() const;
+  TEST_HOST_DEVICE_FUNC ForwardIter end() const;
 };
 
 struct NoDefaultCtorForwardView : cuda::std::ranges::view_base
 {
   NoDefaultCtorForwardView() = delete;
-  TEST_FUNC ForwardIter begin() const;
-  TEST_FUNC ForwardIter end() const;
+  TEST_HOST_DEVICE_FUNC ForwardIter begin() const;
+  TEST_HOST_DEVICE_FUNC ForwardIter end() const;
 };
 
 struct BorrowableRange
 {
-  TEST_FUNC int* begin() const;
-  TEST_FUNC int* end() const;
+  TEST_HOST_DEVICE_FUNC int* begin() const;
+  TEST_HOST_DEVICE_FUNC int* end() const;
 };
 template <>
 inline constexpr bool cuda::std::ranges::enable_borrowed_range<BorrowableRange> = true;
 
 struct BorrowableView : cuda::std::ranges::view_base
 {
-  TEST_FUNC int* begin() const;
-  TEST_FUNC int* end() const;
+  TEST_HOST_DEVICE_FUNC int* begin() const;
+  TEST_HOST_DEVICE_FUNC int* end() const;
 };
 template <>
 inline constexpr bool cuda::std::ranges::enable_borrowed_range<BorrowableView> = true;
 
 struct InputView : cuda::std::ranges::view_base
 {
-  TEST_FUNC constexpr cpp20_input_iterator<int*> begin() const
+  TEST_HOST_DEVICE_FUNC constexpr cpp20_input_iterator<int*> begin() const
   {
     return cpp20_input_iterator<int*>(globalBuff);
   }
-  TEST_FUNC constexpr int* end() const
+  TEST_HOST_DEVICE_FUNC constexpr int* end() const
   {
     return globalBuff + 8;
   }
 };
 // TODO: remove these bogus operators
-TEST_FUNC constexpr bool operator==(const cpp20_input_iterator<int*>& lhs, int* rhs)
+TEST_HOST_DEVICE_FUNC constexpr bool operator==(const cpp20_input_iterator<int*>& lhs, int* rhs)
 {
   return base(lhs) == rhs;
 }
-TEST_FUNC constexpr bool operator==(int* lhs, const cpp20_input_iterator<int*>& rhs)
+TEST_HOST_DEVICE_FUNC constexpr bool operator==(int* lhs, const cpp20_input_iterator<int*>& rhs)
 {
   return base(rhs) == lhs;
 }
 #if TEST_STD_VER < 2020
-TEST_FUNC constexpr bool operator!=(const cpp20_input_iterator<int*>& lhs, int* rhs)
+TEST_HOST_DEVICE_FUNC constexpr bool operator!=(const cpp20_input_iterator<int*>& lhs, int* rhs)
 {
   return base(lhs) != rhs;
 }
-TEST_FUNC constexpr bool operator!=(int* lhs, const cpp20_input_iterator<int*>& rhs)
+TEST_HOST_DEVICE_FUNC constexpr bool operator!=(int* lhs, const cpp20_input_iterator<int*>& rhs)
 {
   return base(rhs) != lhs;
 }
@@ -195,18 +198,18 @@ TEST_FUNC constexpr bool operator!=(int* lhs, const cpp20_input_iterator<int*>& 
 
 struct Range
 {
-  TEST_FUNC int* begin() const;
-  TEST_FUNC int* end() const;
+  TEST_HOST_DEVICE_FUNC int* begin() const;
+  TEST_HOST_DEVICE_FUNC int* end() const;
 };
 
 using CountedIter = stride_counting_iterator<forward_iterator<int*>>;
 struct CountedView : cuda::std::ranges::view_base
 {
-  TEST_FUNC constexpr CountedIter begin() const
+  TEST_HOST_DEVICE_FUNC constexpr CountedIter begin() const
   {
     return CountedIter(ForwardIter(globalBuff));
   }
-  TEST_FUNC constexpr CountedIter end() const
+  TEST_HOST_DEVICE_FUNC constexpr CountedIter end() const
   {
     return CountedIter(ForwardIter(globalBuff + 8));
   }

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/adaptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/adaptor.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // cuda::std::views::filter
@@ -32,7 +32,7 @@ struct NonCopyablePredicate
   NonCopyablePredicate& operator=(NonCopyablePredicate const&) = delete;
 
   template <class T>
-  [[nodiscard]] TEST_FUNC constexpr bool operator()(const T& x) const
+  [[nodiscard]] TEST_HOST_DEVICE_FUNC constexpr bool operator()(const T& x) const
   {
     return x % 2 == 0;
   }
@@ -43,15 +43,15 @@ struct Range : cuda::std::ranges::view_base
   using Iterator = forward_iterator<int*>;
   using Sentinel = sentinel_wrapper<Iterator>;
 
-  TEST_FUNC constexpr explicit Range(int* b, int* e)
+  TEST_HOST_DEVICE_FUNC constexpr explicit Range(int* b, int* e)
       : begin_(b)
       , end_(e)
   {}
-  [[nodiscard]] TEST_FUNC constexpr Iterator begin() const
+  [[nodiscard]] TEST_HOST_DEVICE_FUNC constexpr Iterator begin() const
   {
     return Iterator(begin_);
   }
-  [[nodiscard]] TEST_FUNC constexpr Sentinel end() const
+  [[nodiscard]] TEST_HOST_DEVICE_FUNC constexpr Sentinel end() const
   {
     return Sentinel(Iterator(end_));
   }
@@ -63,14 +63,14 @@ private:
 
 struct Pred
 {
-  [[nodiscard]] TEST_FUNC constexpr bool operator()(int i) const
+  [[nodiscard]] TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
   {
     return i % 2 == 0;
   }
 };
 
 template <typename View>
-TEST_FUNC constexpr void compareViews(View v, cuda::std::initializer_list<int> list)
+TEST_HOST_DEVICE_FUNC constexpr void compareViews(View v, cuda::std::initializer_list<int> list)
 {
   auto b1 = v.begin();
   auto e1 = v.end();
@@ -84,7 +84,7 @@ TEST_FUNC constexpr void compareViews(View v, cuda::std::initializer_list<int> l
   assert(b2 == e2);
 }
 
-TEST_FUNC constexpr bool test()
+TEST_HOST_DEVICE_FUNC constexpr bool test()
 {
   int buff[] = {0, 1, 2, 3, 4, 5, 6, 7};
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/begin.pass.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // constexpr iterator begin();

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.default.pass.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // filter_view() requires cuda::std::default_initializable<View> &&

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.view_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.view_pred.pass.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // constexpr filter_view(View, Pred); // explicit since C++23

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // friend constexpr bool operator==(iterator const&, iterator const&)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/decrement.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/decrement.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // constexpr iterator& operator--() requires bidirectional_range<V>;
@@ -27,7 +27,7 @@
 struct EqualTo
 {
   int x;
-  TEST_FUNC constexpr bool operator()(int y) const
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int y) const
   {
     return x == y;
   }
@@ -45,14 +45,14 @@ using FilterIteratorFor = cuda::std::ranges::iterator_t<
 
 // needs to be a standalone function for NVRTC
 template <class FilterView, class View, class Iter, class Sent, class T, class U, class V>
-TEST_FUNC constexpr FilterView make_filter_view(T begin, U end, V pred)
+TEST_HOST_DEVICE_FUNC constexpr FilterView make_filter_view(T begin, U end, V pred)
 {
   View view{Iter(begin), Sent(Iter(end))};
   return FilterView(cuda::std::move(view), pred);
 }
 
 template <class Iter, class Sent = sentinel_wrapper<Iter>>
-TEST_FUNC constexpr void test()
+TEST_HOST_DEVICE_FUNC constexpr void test()
 {
   using View           = minimal_view<Iter, Sent>;
   using FilterView     = cuda::std::ranges::filter_view<View, EqualTo>;
@@ -130,7 +130,7 @@ TEST_FUNC constexpr void test()
   }
 }
 
-TEST_FUNC constexpr bool tests()
+TEST_HOST_DEVICE_FUNC constexpr bool tests()
 {
   test<bidirectional_iterator<int*>>();
   test<random_access_iterator<int*>>();

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/increment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/increment.pass.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // constexpr iterator& operator++();

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/iter_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/iter_move.pass.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // friend constexpr range_rvalue_reference_t<V> iter_move(iterator const& i)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/iter_swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/iter_swap.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // friend constexpr void iter_swap(iterator const& x, iterator const& y)
@@ -29,7 +29,7 @@ _CCCL_CONCEPT has_iter_swap = _CCCL_REQUIRES_EXPR((It), It it)(cuda::std::ranges
 
 struct IsEven
 {
-  TEST_FUNC constexpr bool operator()(int x) const
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int x) const
   {
     return x % 2 == 0;
   }
@@ -37,14 +37,14 @@ struct IsEven
 
 // needs to be a standalone function for NVRTC
 template <class FilterView, class View, class Iter, class Sent, class T, class U, class V>
-TEST_FUNC constexpr FilterView make_filter_view(T begin, U end, V pred)
+TEST_HOST_DEVICE_FUNC constexpr FilterView make_filter_view(T begin, U end, V pred)
 {
   View view{Iter(begin), Sent(Iter(end))};
   return FilterView(cuda::std::move(view), pred);
 }
 
 template <class Iterator, bool IsNoexcept>
-TEST_FUNC constexpr void test()
+TEST_HOST_DEVICE_FUNC constexpr void test()
 {
   using Sentinel       = sentinel_wrapper<Iterator>;
   using View           = minimal_view<Iterator, Sentinel>;
@@ -68,7 +68,7 @@ TEST_FUNC constexpr void test()
   }
 }
 
-TEST_FUNC constexpr bool tests()
+TEST_HOST_DEVICE_FUNC constexpr bool tests()
 {
   test<cpp17_input_iterator<int*>, /* noexcept */ false>();
   test<cpp20_input_iterator<int*>, /* noexcept */ false>();

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/base.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/base.pass.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // constexpr sentinel_t<V> base() const;

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/compare.pass.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // friend constexpr bool operator==(iterator const&, sentinel const&);

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/ctor.parent.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/ctor.parent.pass.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // constexpr explicit sentinel(filter_view&);

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.reverse/adaptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.reverse/adaptor.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
+// UNSUPPORTED: force-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // cuda::std::views::reverse
@@ -37,13 +37,13 @@ inline constexpr bool
 
 struct Pred
 {
-  TEST_FUNC int operator()(int i) const noexcept
+  TEST_HOST_DEVICE_FUNC int operator()(int i) const noexcept
   {
     return i;
   }
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
   int buf[] = {1, 2, 3};
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.reverse/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.reverse/begin.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: force-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // constexpr reverse_iterator<iterator_t<V>> begin();
@@ -33,58 +33,58 @@ struct CountedIter
   using self              = CountedIter;
 
   pointer ptr_;
-  TEST_FUNC CountedIter(pointer ptr)
+  TEST_HOST_DEVICE_FUNC CountedIter(pointer ptr)
       : ptr_(ptr)
   {}
   CountedIter() = default;
 
-  TEST_FUNC reference operator*() const;
-  TEST_FUNC pointer operator->() const;
+  TEST_HOST_DEVICE_FUNC reference operator*() const;
+  TEST_HOST_DEVICE_FUNC pointer operator->() const;
 #if TEST_HAS_SPACESHIP()
   auto operator<=>(const self&) const = default;
 #else
-  TEST_FUNC bool operator==(const self& rhs) const
+  TEST_HOST_DEVICE_FUNC bool operator==(const self& rhs) const
   {
     return ptr_ == rhs.ptr_;
   }
-  TEST_FUNC bool operator!=(const self& rhs) const
+  TEST_HOST_DEVICE_FUNC bool operator!=(const self& rhs) const
   {
     return ptr_ != rhs.ptr_;
   }
 
-  TEST_FUNC bool operator<(const self& rhs) const
+  TEST_HOST_DEVICE_FUNC bool operator<(const self& rhs) const
   {
     return ptr_ < rhs.ptr_;
   }
-  TEST_FUNC bool operator<=(const self& rhs) const
+  TEST_HOST_DEVICE_FUNC bool operator<=(const self& rhs) const
   {
     return ptr_ <= rhs.ptr_;
   }
-  TEST_FUNC bool operator>(const self& rhs) const
+  TEST_HOST_DEVICE_FUNC bool operator>(const self& rhs) const
   {
     return ptr_ > rhs.ptr_;
   }
-  TEST_FUNC bool operator>=(const self& rhs) const
+  TEST_HOST_DEVICE_FUNC bool operator>=(const self& rhs) const
   {
     return ptr_ >= rhs.ptr_;
   }
 #endif
 
-  TEST_FUNC self& operator++()
+  TEST_HOST_DEVICE_FUNC self& operator++()
   {
     globalCount++;
     ++ptr_;
     return *this;
   }
-  TEST_FUNC self operator++(int)
+  TEST_HOST_DEVICE_FUNC self operator++(int)
   {
     auto tmp = *this;
     ++*this;
     return tmp;
   }
 
-  TEST_FUNC self& operator--();
-  TEST_FUNC self operator--(int);
+  TEST_HOST_DEVICE_FUNC self& operator--();
+  TEST_HOST_DEVICE_FUNC self operator--(int);
 };
 
 struct CountedView : cuda::std::ranges::view_base
@@ -92,24 +92,24 @@ struct CountedView : cuda::std::ranges::view_base
   int* begin_;
   int* end_;
 
-  TEST_FUNC CountedView(int* b, int* e)
+  TEST_HOST_DEVICE_FUNC CountedView(int* b, int* e)
       : begin_(b)
       , end_(e)
   {}
 
-  TEST_FUNC auto begin()
+  TEST_HOST_DEVICE_FUNC auto begin()
   {
     return CountedIter(begin_);
   }
-  TEST_FUNC auto begin() const
+  TEST_HOST_DEVICE_FUNC auto begin() const
   {
     return CountedIter(begin_);
   }
-  TEST_FUNC auto end()
+  TEST_HOST_DEVICE_FUNC auto end()
   {
     return sentinel_wrapper<CountedIter>(CountedIter(end_));
   }
-  TEST_FUNC auto end() const
+  TEST_HOST_DEVICE_FUNC auto end() const
   {
     return sentinel_wrapper<CountedIter>(CountedIter(end_));
   }
@@ -123,24 +123,24 @@ struct RASentRange : cuda::std::ranges::view_base
   int* begin_;
   int* end_;
 
-  TEST_FUNC constexpr RASentRange(int* b, int* e)
+  TEST_HOST_DEVICE_FUNC constexpr RASentRange(int* b, int* e)
       : begin_(b)
       , end_(e)
   {}
 
-  TEST_FUNC constexpr random_access_iterator<int*> begin()
+  TEST_HOST_DEVICE_FUNC constexpr random_access_iterator<int*> begin()
   {
     return random_access_iterator<int*>{begin_};
   }
-  TEST_FUNC constexpr random_access_iterator<const int*> begin() const
+  TEST_HOST_DEVICE_FUNC constexpr random_access_iterator<const int*> begin() const
   {
     return random_access_iterator<const int*>{begin_};
   }
-  TEST_FUNC constexpr sent_t end()
+  TEST_HOST_DEVICE_FUNC constexpr sent_t end()
   {
     return sent_t{random_access_iterator<int*>{end_}};
   }
-  TEST_FUNC constexpr sent_const_t end() const
+  TEST_HOST_DEVICE_FUNC constexpr sent_const_t end() const
   {
     return sent_const_t{random_access_iterator<const int*>{end_}};
   }
@@ -157,7 +157,7 @@ template <class T>
 inline constexpr bool BeginInvocable<T, cuda::std::void_t<decltype(cuda::std::declval<T>().begin())>> = true;
 #endif
 
-TEST_FUNC constexpr bool test()
+TEST_HOST_DEVICE_FUNC constexpr bool test()
 {
   int buffer[8] = {1, 2, 3, 4, 5, 6, 7, 8};
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.reverse/end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.reverse/end.pass.cpp
@@ -7,8 +7,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // constexpr reverse_iterator<iterator_t<V>> end();

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.take.while/adaptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.take.while/adaptor.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
 
 // cuda::std::views::take_while
 
@@ -23,7 +23,7 @@
 
 struct Pred
 {
-  TEST_FUNC constexpr bool operator()(int i) const
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
   {
     return i < 3;
   }
@@ -38,7 +38,7 @@ struct MoveOnlyView : IntBufferViewBase
   MoveOnlyView() = default;
 
   template <class T>
-  TEST_FUNC constexpr MoveOnlyView(T&& input)
+  TEST_HOST_DEVICE_FUNC constexpr MoveOnlyView(T&& input)
       : IntBufferViewBase(cuda::std::forward<T>(input))
   {}
 #else // ^^^ C++20 ^^^ / vvv C++17 vvv
@@ -49,11 +49,11 @@ struct MoveOnlyView : IntBufferViewBase
   MoveOnlyView& operator=(const MoveOnlyView&) = delete;
   MoveOnlyView(MoveOnlyView&&)                 = default;
   MoveOnlyView& operator=(MoveOnlyView&&)      = default;
-  TEST_FUNC constexpr const int* begin() const
+  TEST_HOST_DEVICE_FUNC constexpr const int* begin() const
   {
     return buffer_;
   }
-  TEST_FUNC constexpr const int* end() const
+  TEST_HOST_DEVICE_FUNC constexpr const int* end() const
   {
     return buffer_ + size_;
   }
@@ -78,7 +78,7 @@ static_assert(!CanBePiped<int, decltype(cuda::std::views::take_while(Pred{}))>);
 static_assert(!CanBePiped<Foo (&)[2], decltype(cuda::std::views::take_while(Pred{}))>);
 
 template <class Range, class Expected>
-TEST_FUNC constexpr bool equal(Range&& range, Expected&& expected)
+TEST_HOST_DEVICE_FUNC constexpr bool equal(Range&& range, Expected&& expected)
 {
   auto irange    = range.begin();
   auto iexpected = cuda::std::begin(expected);
@@ -92,7 +92,7 @@ TEST_FUNC constexpr bool equal(Range&& range, Expected&& expected)
   return true;
 }
 
-TEST_FUNC constexpr bool test()
+TEST_HOST_DEVICE_FUNC constexpr bool test()
 {
   int buff[] = {1, 2, 3, 4, 3, 2, 1};
 
@@ -143,7 +143,7 @@ TEST_FUNC constexpr bool test()
   {
     struct Pred2
     {
-      TEST_FUNC constexpr bool operator()(int i) const
+      TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
       {
         return i < 2;
       }

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.take.while/general.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.take.while/general.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
 
 // Some basic examples of how take_while_view might be used in the wild. This is a general
 // collection of sample algorithms and functions that try to mock general usage of
@@ -21,7 +21,7 @@
 #include "test_macros.h"
 
 template <class Range, class Expected>
-TEST_FUNC constexpr bool equal(Range&& range, Expected&& expected)
+TEST_HOST_DEVICE_FUNC constexpr bool equal(Range&& range, Expected&& expected)
 {
   auto irange    = range.begin();
   auto iexpected = cuda::std::begin(expected);

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.take/adaptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.take/adaptor.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
+// UNSUPPORTED: force-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // cuda::std::views::take
@@ -29,16 +29,16 @@ struct SizedView : cuda::std::ranges::view_base
 {
   int* begin_ = nullptr;
   int* end_   = nullptr;
-  TEST_FUNC constexpr SizedView(int* begin, int* end)
+  TEST_HOST_DEVICE_FUNC constexpr SizedView(int* begin, int* end)
       : begin_(begin)
       , end_(end)
   {}
 
-  TEST_FUNC constexpr auto begin() const
+  TEST_HOST_DEVICE_FUNC constexpr auto begin() const
   {
     return forward_iterator<int*>(begin_);
   }
-  TEST_FUNC constexpr auto end() const
+  TEST_HOST_DEVICE_FUNC constexpr auto end() const
   {
     return sized_sentinel<forward_iterator<int*>>(forward_iterator<int*>(end_));
   }
@@ -48,7 +48,7 @@ static_assert(cuda::std::ranges::sized_range<SizedView>);
 static_assert(cuda::std::ranges::view<SizedView>);
 
 template <class T>
-TEST_FUNC constexpr void test_small_range(const T& input)
+TEST_HOST_DEVICE_FUNC constexpr void test_small_range(const T& input)
 {
   constexpr int N = 100;
   auto size       = cuda::std::ranges::size(input);
@@ -60,7 +60,7 @@ TEST_FUNC constexpr void test_small_range(const T& input)
 
 struct Pred
 {
-  TEST_FUNC int operator()(int i) const noexcept
+  TEST_HOST_DEVICE_FUNC int operator()(int i) const noexcept
   {
     return i;
   }
@@ -70,7 +70,7 @@ struct Pred
 using result_subrange       = cuda::std::ranges::subrange<int*>;
 using result_subrange_sized = cuda::std::ranges::subrange<int*, int*, cuda::std::ranges::subrange_kind::sized>;
 
-TEST_FUNC constexpr bool test()
+TEST_HOST_DEVICE_FUNC constexpr bool test()
 {
   constexpr int N = 8;
   int buf[N]      = {1, 2, 3, 4, 5, 6, 7, 8};

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.transform/general.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.transform/general.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
 
 // Some basic examples of how transform_view might be used in the wild. This is a general
 // collection of sample algorithms and functions that try to mock general usage of
@@ -37,7 +37,7 @@ static_assert(!ValidTransformView<MoveOnlyView, BadFunction>);
 
 struct toUpperFn
 {
-  TEST_FUNC constexpr char operator()(const char c) const noexcept
+  TEST_HOST_DEVICE_FUNC constexpr char operator()(const char c) const noexcept
   {
     if (c >= 'a' && c <= 'z')
     {
@@ -48,13 +48,13 @@ struct toUpperFn
 };
 
 template <class R, cuda::std::enable_if_t<cuda::std::ranges::range<R>, int> = 0>
-TEST_FUNC auto toUpper(R range)
+TEST_HOST_DEVICE_FUNC auto toUpper(R range)
 {
   return cuda::std::ranges::transform_view(range, toUpperFn{});
 }
 
 template <class E1, class E2, size_t N, class Join = cuda::std::plus<E1>>
-TEST_FUNC auto joinArrays(E1 (&a)[N], E2 (&b)[N], Join join = Join())
+TEST_HOST_DEVICE_FUNC auto joinArrays(E1 (&a)[N], E2 (&b)[N], Join join = Join())
 {
   return cuda::std::ranges::transform_view(a, [&a, &b, join](E1& x) {
     auto idx = (&x) - a;
@@ -64,15 +64,15 @@ TEST_FUNC auto joinArrays(E1 (&a)[N], E2 (&b)[N], Join join = Join())
 
 struct NonConstView : cuda::std::ranges::view_base
 {
-  TEST_FUNC explicit NonConstView(int* b, int* e)
+  TEST_HOST_DEVICE_FUNC explicit NonConstView(int* b, int* e)
       : b_(b)
       , e_(e)
   {}
-  TEST_FUNC const int* begin()
+  TEST_HOST_DEVICE_FUNC const int* begin()
   {
     return b_;
   } // deliberately non-const
-  TEST_FUNC const int* end()
+  TEST_HOST_DEVICE_FUNC const int* end()
   {
     return e_;
   } // deliberately non-const
@@ -81,7 +81,7 @@ struct NonConstView : cuda::std::ranges::view_base
 };
 
 template <class Range, class Expected>
-TEST_FUNC constexpr bool equal(Range&& range, Expected&& expected)
+TEST_HOST_DEVICE_FUNC constexpr bool equal(Range&& range, Expected&& expected)
 {
   for (size_t i = 0; i < cuda::std::size(expected); ++i)
   {

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.transform/iterator/deref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.transform/iterator/deref.pass.cpp
@@ -7,8 +7,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // transform_view::<iterator>::operator*

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.zip/iterator/iter_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.zip/iterator/iter_move.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // friend constexpr auto iter_move(const iterator& i) noexcept(see below);
 
 #include <cuda/std/array>
@@ -21,10 +24,10 @@
 struct ThrowingMove
 {
   ThrowingMove() = default;
-  TEST_FUNC constexpr ThrowingMove(ThrowingMove&&){}; // NOLINT(performance-noexcept-move-constructor)
+  TEST_HOST_DEVICE_FUNC constexpr ThrowingMove(ThrowingMove&&){}; // NOLINT(performance-noexcept-move-constructor)
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
   {
     // underlying iter_move noexcept

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.zip/iterator/iter_swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.zip/iterator/iter_swap.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // friend constexpr void iter_swap(const iterator& l, const iterator& r) noexcept(see below)
 //   requires (indirectly_swappable<iterator_t<maybe-const<Const, Views>>> && ...);
 
@@ -20,14 +23,14 @@
 struct ThrowingMove
 {
   ThrowingMove() = default;
-  TEST_FUNC ThrowingMove(ThrowingMove&&) {};
-  TEST_FUNC ThrowingMove& operator=(ThrowingMove&&)
+  TEST_HOST_DEVICE_FUNC ThrowingMove(ThrowingMove&&) {};
+  TEST_HOST_DEVICE_FUNC ThrowingMove& operator=(ThrowingMove&&)
   {
     return *this;
   }
 };
 
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test()
+TEST_HOST_DEVICE_FUNC TEST_CONSTEXPR_CXX20 bool test()
 {
   {
     cuda::std::array<int, 4> a1{1, 2, 3, 4};

--- a/libcudacxx/test/libcudacxx/std/ranges/range.factories/range.iota.view/type.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.factories/range.iota.view/type.compile.pass.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: variadic function is unsupported in tile code
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
 
 #include <cuda/std/ranges>
 
@@ -18,12 +18,12 @@
 // Test that we SFINAE away iota_view<bool>.
 
 template <class T>
-TEST_FUNC cuda::std::ranges::iota_view<T> f(int);
+TEST_HOST_DEVICE_FUNC cuda::std::ranges::iota_view<T> f(int);
 template <class T>
-TEST_FUNC void f(...)
+TEST_HOST_DEVICE_FUNC void f(...)
 {}
 
-TEST_FUNC void test()
+TEST_HOST_DEVICE_FUNC void test()
 {
   f<bool>(42);
 }


### PR DESCRIPTION
We cannot test the CPOs in tile mode, also a lot of tests rely on other globals

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>