### PR TITLE
[Tile] Mark some `<mdspan>` as unsupported

### DIFF
--- a/libcudacxx/include/cuda/__mdspan/layout_stride_relaxed.h
+++ b/libcudacxx/include/cuda/__mdspan/layout_stride_relaxed.h
@@ -65,18 +65,12 @@ template <class _StridedMapping>
   using _RankType       = typename _StridedMapping::rank_type;
   constexpr auto __rank = _Extents::rank();
   // Check if any extent is zero - can't call mapping(0,...) in that case
-  bool __extent_is_zero = false;
   for (_RankType __r = 0; __r != __rank; ++__r)
   {
     if (__mapping.extents().extent(__r) == 0)
     {
-      __extent_is_zero = true;
-      break;
+      return typename _StridedMapping::index_type{0};
     }
-  }
-  if (__extent_is_zero)
-  {
-    return typename _StridedMapping::index_type{0};
   }
   return ::cuda::__layout_stride_relaxed_compute_offset(__mapping, ::cuda::std::make_index_sequence<__rank>{});
 }
@@ -147,16 +141,14 @@ private:
 
   [[nodiscard]] _CCCL_API constexpr bool __has_positive_strides() const noexcept
   {
-    bool __result = true;
     for (rank_type __r = 0; __r != __rank_; ++__r)
     {
       if (strides().stride(__r) <= 0)
       {
-        __result = false;
-        break;
+        return false;
       }
     }
-    return __result;
+    return true;
   }
 
 public:
@@ -273,14 +265,12 @@ public:
       // __min_dot tracks the total positive magnitude of the negative contributions
       index_type __dot{1};
       offset_type __min_dot{0};
-      bool __stride_is_negative = false;
       for (rank_type __r = 0; __r < __rank_; ++__r)
       {
         const auto __ext = extents().extent(__r);
         if (__ext == index_type{0})
         {
-          __stride_is_negative = true;
-          break;
+          return index_type{0};
         }
         const auto __stride_val = strides().stride(__r);
         _CCCL_ASSERT(::cuda::std::in_range<index_type>(::cuda::uabs(__stride_val)),
@@ -310,7 +300,7 @@ public:
                    "layout_stride_relaxed::mapping: offset is insufficient for negative strides");
       _CCCL_ASSERT(!::cuda::add_overflow<index_type>(__offset_val, __dot),
                    "layout_stride_relaxed::mapping: required_span_size is not representable as index_type");
-      return __stride_is_negative ? index_type{0} : static_cast<index_type>(__offset_val + __dot);
+      return static_cast<index_type>(__offset_val + __dot);
     }
   }
 

--- a/libcudacxx/include/cuda/__mdspan/strides.h
+++ b/libcudacxx/include/cuda/__mdspan/strides.h
@@ -229,16 +229,14 @@ public:
     }
     else
     {
-      bool __result = true;
       for (rank_type __r = 0; __r != __rank_; __r++)
       {
         if (::cuda::std::cmp_not_equal(__lhs.stride(__r), __rhs.stride(__r)))
         {
-          __result = false;
-          break;
+          return false;
         }
       }
-      return __result;
+      return true;
     }
   }
 

--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -362,16 +362,14 @@ _CCCL_TEMPLATE(class _To, class _From, size_t _Size)
 _CCCL_REQUIRES(__cccl_is_integer_v<_To>)
 [[nodiscard]] _CCCL_API constexpr bool __are_representable_as(span<_From, _Size> __values)
 {
-  bool __result = true;
   for (size_t __i = 0; __i != _Size; __i++)
   {
     if (!__mdspan_detail::__is_representable_as<_To>(__values[__i]))
     {
-      __result = false;
-      break;
+      return false;
     }
   }
-  return __result;
+  return true;
 }
 
 // ------------------------------------------------------------------
@@ -605,16 +603,14 @@ public:
     }
     else if constexpr (rank() != 0)
     {
-      bool __result = true;
       for (rank_type __r = 0; __r != __rank_; __r++)
       {
         if (::cuda::std::cmp_not_equal(__lhs.extent(__r), __rhs.extent(__r)))
         {
-          __result = false;
-          break;
+          return false;
         }
       }
-      return __result;
+      return true;
     }
     else // MSVC needs this or it complains about unreachable code in the first condition
     {
@@ -655,7 +651,6 @@ template <class _Extents>
 [[nodiscard]] _CCCL_API constexpr bool __required_span_size_is_representable(const _Extents& __ext) noexcept
 {
   using ::cuda::std::__mdspan_detail::__mul_overflow;
-  bool __result = true;
   if constexpr (_Extents::rank() != 0)
   {
     using __index_type  = typename _Extents::index_type;
@@ -665,12 +660,11 @@ template <class _Extents>
     {
       if (__mul_overflow(__prod, __ext.extent(__r), &__prod))
       {
-        __result = false;
-        break;
+        return false;
       }
     }
   }
-  return __result;
+  return true;
 }
 
 // Function to check whether a set of indices are a multidimensional

--- a/libcudacxx/include/cuda/std/__mdspan/layout_left.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_left.h
@@ -146,16 +146,14 @@ public:
   {
     // avoid warning when comparing signed and unsigner integers and pick the wider of two types
     using _CommonType = common_type_t<index_type, typename _OtherMappping::index_type>;
-    bool __result     = true;
     for (rank_type __r = 0; __r != extents_type::rank(); __r++)
     {
       if (static_cast<_CommonType>(stride(__r)) != static_cast<_CommonType>(__other.stride(__r)))
       {
-        __result = false;
-        break;
+        return false;
       }
     }
-    return __result;
+    return true;
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)

--- a/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
@@ -144,7 +144,6 @@ private:
     const extents_type& __ext, [[maybe_unused]] span<_OtherIndexType, extents_type::rank()> __strides)
   {
     // nvcc believes strides is unused here
-    bool __result = true;
     if constexpr (extents_type::rank() != 0)
     {
       index_type __size = 1;
@@ -153,30 +152,26 @@ private:
         // We can only check correct conversion of _OtherIndexType if it is an integral
         if (__conversion_may_overflow(__strides[__r]))
         {
-          __result = false;
-          break;
+          return false;
         }
         if (__ext.extent(__r) == index_type{0})
         {
-          __result = true;
-          break;
+          return true;
         }
 
         index_type __prod = (__ext.extent(__r) - 1);
         if (::cuda::std::__mdspan_detail::__mul_overflow(__prod, static_cast<index_type>(__strides[__r]), &__prod))
         {
-          __result = false;
-          break;
+          return false;
         }
         if (__add_overflow(__size, __prod, &__size))
         {
-          __result = false;
-          break;
+          return false;
         }
       }
     }
 
-    return __result;
+    return true;
   }
 
   // compute offset of a strided layout mapping
@@ -285,17 +280,15 @@ public:
     __bubble_sort_by_strides(__permute);
 
     // check that this permutations represents a growing set
-    bool __result = true;
     for (rank_type __i = 1; __i < __rank_; __i++)
     {
       if (static_cast<index_type>(__strides()[__permute[__i]])
           < static_cast<index_type>(__strides()[__permute[__i - 1]]) * extents().extent(__permute[__i - 1]))
       {
-        __result = false;
-        break;
+        return false;
       }
     }
-    return __result;
+    return true;
   }
   [[nodiscard]] _CCCL_API constexpr bool __check_unique_mapping(index_sequence<>) const noexcept
   {
@@ -513,16 +506,14 @@ public:
             }
           }
 
-          bool __result = true;
           for (rank_type __r = 0; __r != __rank_; __r++)
           {
             if (extents().extent(__r) == 0 && __r != __r_largest)
             {
-              __result = false;
-              break;
+              return false;
             }
           }
-          return __result;
+          return true;
         }
       }
       else

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -409,6 +409,7 @@ public:
     return mapping()(__indices[_Idxs]...);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _OtherIndexType)
   _CCCL_REQUIRES(is_convertible_v<const _OtherIndexType&, index_type> _CCCL_AND
                    is_nothrow_constructible_v<index_type, const _OtherIndexType&>)
@@ -418,6 +419,7 @@ public:
     return accessor().access(data_handle(), __op_bracket(__indices, make_index_sequence<rank()>()));
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _OtherIndexType)
   _CCCL_REQUIRES(is_convertible_v<const _OtherIndexType&, index_type> _CCCL_AND
                    is_nothrow_constructible_v<index_type, const _OtherIndexType&>)
@@ -427,6 +429,7 @@ public:
   }
 
   //! Nonstandard extension to no break our users too hard
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class... _Indices)
   _CCCL_REQUIRES(__mdspan_detail::__all_convertible_to_index_type<index_type, _Indices...>)
   [[nodiscard]] _CCCL_API constexpr reference operator()(_Indices... __indices) const
@@ -441,7 +444,6 @@ public:
   template <size_t... _Idxs>
   [[nodiscard]] _CCCL_API constexpr bool __check_size() const noexcept
   {
-    bool __result = true;
     if constexpr (extents_type::rank() > 0) // MSVC raises a warning even with __r != extents_type::rank()
     {
       size_t __prod = 1;
@@ -450,12 +452,11 @@ public:
         const auto __extent = static_cast<size_t>(mapping().extents().extent(__r));
         if (__mdspan_detail::__mul_overflow(__prod, __extent, &__prod))
         {
-          __result = false;
-          break;
+          return false;
         }
       }
     }
-    return __result;
+    return true;
   }
 
   template <size_t... _Idxs>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.submdspan.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.submdspan.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a non-__tile__ variable cannot be used in tile code
-
 #define _CCCL_DISABLE_MDSPAN_ACCESSOR_DETECT_INVALIDITY
 #include <cuda/mdspan>
 #include <cuda/std/type_traits>
@@ -32,14 +29,18 @@ TEST_FUNC void test_submdspan(int* ptr)
   unused(submd);
 }
 
+#if !_CCCL_TILE_COMPILATION() // error: a non-__tile__ variable ("managed_array") cannot be used in tile code
 _CCCL_DEVICE __managed__ int managed_array[] = {1, 2, 3, 4};
+#endif // !_CCCL_TILE_COMPILATION()
 
 TEST_FUNC void test_submdspan()
 {
   int array[] = {1, 2, 3, 4};
   test_submdspan<cuda::host_mdspan<int, cuda::std::dims<1>>>(array);
   test_submdspan<cuda::device_mdspan<int, cuda::std::dims<1>>>(array);
+#if !_CCCL_TILE_COMPILATION() // error: a non-__tile__ variable ("managed_array") cannot be used in tile code
   test_submdspan<cuda::managed_mdspan<int, cuda::std::dims<1>>>(managed_array);
+#endif // !_CCCL_TILE_COMPILATION()
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_accessor/device_accessor.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_accessor/device_accessor.runfail.cpp
@@ -9,6 +9,10 @@
 
 // UNSUPPORTED: nvrtc
 
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// the assert does not trigger
+
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/properties.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
-
 // <mdspan>
 
 // template<class ElementType, class Extents, class LayoutPolicy = layout_right,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_accessor/host_accessor.1.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_accessor/host_accessor.1.runfail.cpp
@@ -7,9 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-
 // UNSUPPORTED: nvrtc
+
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// the assert does not trigger
 
 #include <cuda/mdspan>
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_accessor/host_accessor.2.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_accessor/host_accessor.2.runfail.cpp
@@ -8,6 +8,8 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// the assert does not trigger
 
 #include <cuda/mdspan>
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_accessor/host_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_accessor/host_accessor.pass.cpp
@@ -7,8 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/properties.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
-
 // <mdspan>
 
 // template<class ElementType, class Extents, class LayoutPolicy = layout_right,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/comparison.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// hangs
+
 // <cuda/mdspan>
 
 // template<class OtherMapping>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.strided_mapping.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.strided_mapping.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// hangs
+
 // <cuda/mdspan>
 
 // Converting constructor from strided layout mappings:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.1.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.1.runfail.cpp
@@ -9,6 +9,10 @@
 
 // UNSUPPORTED: nvrtc
 
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// the assert does not trigger
+
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.2.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.2.runfail.cpp
@@ -9,6 +9,10 @@
 
 // UNSUPPORTED: nvrtc
 
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// the assert does not trigger
+
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/properties.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
-
 // <mdspan>
 
 // template<class ElementType, class Extents, class LayoutPolicy = layout_right,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/properties.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
-
 // <mdspan>
 
 // template<class ElementType, class Extents, class LayoutPolicy = layout_right,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.pass.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: calling a __device__ function("__isShared(const void *)") is not allowed
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.runfail.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: Calling a __device__ function in tile code
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// the assert does not trigger
 
 #include <cuda/mdspan>
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/properties.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
 
 // <mdspan>
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.aligned_accessor/aligned_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.aligned_accessor/aligned_accessor.pass.cpp
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
-// nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+// UNSUPPORTED: force-tile
+// error: calling a __host__ __device__ function in tile is not allowed
 
 #include <cuda/std/cassert>
 #include <cuda/std/mdspan>
@@ -17,19 +17,19 @@
 #include <test_macros.h>
 
 template <class ElementType>
-TEST_FUNC constexpr void take_default_accessor_generic(cuda::std::default_accessor<ElementType>)
+TEST_HOST_DEVICE_FUNC constexpr void take_default_accessor_generic(cuda::std::default_accessor<ElementType>)
 {}
 
 template <class ElementType>
 cuda::std::enable_if_t<cuda::std::is_const_v<ElementType>>
-  TEST_FUNC constexpr take_default_accessor_generic_const(cuda::std::default_accessor<ElementType>)
+  TEST_HOST_DEVICE_FUNC constexpr take_default_accessor_generic_const(cuda::std::default_accessor<ElementType>)
 {}
 
-TEST_FUNC constexpr void take_default_accessor(cuda::std::default_accessor<int>) {}
+TEST_HOST_DEVICE_FUNC constexpr void take_default_accessor(cuda::std::default_accessor<int>) {}
 
-TEST_FUNC constexpr void take_default_accessor_const(cuda::std::default_accessor<const int>) {}
+TEST_HOST_DEVICE_FUNC constexpr void take_default_accessor_const(cuda::std::default_accessor<const int>) {}
 
-TEST_FUNC constexpr bool test()
+TEST_HOST_DEVICE_FUNC constexpr bool test()
 {
   using T = int;
   using E = cuda::std::extents<size_t, 2>;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/properties.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
-
 // <mdspan>
 
 // template<class ElementType, class Extents, class LayoutPolicy = layout_right,

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_left.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_left.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
-
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_right.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_right.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
-
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/pair_like.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/pair_like.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
-
 // <mdspan>
 
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/assign.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a non-__tile__ variable cannot be used in tile code
-
 // <span>
 
 //  constexpr span& operator=(const span& other) noexcept = default;
@@ -34,13 +31,13 @@ TEST_FUNC constexpr bool doAssign(T lhs, T rhs)
 struct A
 {};
 
-TEST_GLOBAL_VARIABLE constexpr int carr1[] = {1, 2, 3, 4};
-TEST_GLOBAL_VARIABLE constexpr int carr2[] = {3, 4, 5};
-TEST_GLOBAL_VARIABLE constexpr int carr3[] = {7, 8};
-_CCCL_DEVICE int arr[]                     = {5, 6, 7, 9};
-
 int main(int, char**)
 {
+  static constexpr int carr1[] = {1, 2, 3, 4};
+  static constexpr int carr2[] = {3, 4, 5};
+  static constexpr int carr3[] = {7, 8};
+  int arr[]                    = {5, 6, 7, 9};
+
   //  constexpr dynamically sized assignment
   {
     //  On systems where 'ptrdiff_t' is a synonym for 'int',

--- a/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/deduct.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/deduct.pass.cpp
@@ -7,11 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a non-__tile__ variable cannot be used in tile code
-
 // gcc does not support deduction guides until gcc-7 and that is buggy
 // UNSUPPORTED: gcc-6, gcc-7
+
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
 
 // <span>
 
@@ -42,7 +42,7 @@
 
 #include "test_macros.h"
 
-TEST_FUNC void test_iterator_sentinel()
+TEST_HOST_DEVICE_FUNC void test_iterator_sentinel()
 {
   int arr[] = {1, 2, 3};
   {
@@ -67,7 +67,7 @@ TEST_FUNC void test_iterator_sentinel()
   }
 }
 
-TEST_FUNC void test_c_array()
+TEST_HOST_DEVICE_FUNC void test_c_array()
 {
   {
     int arr[] = {1, 2, 3};
@@ -86,7 +86,7 @@ TEST_FUNC void test_c_array()
   }
 }
 
-TEST_FUNC void test_cuda_std_array()
+TEST_HOST_DEVICE_FUNC void test_cuda_std_array()
 {
   {
     cuda::std::array<double, 4> arr = {1.0, 2.0, 3.0, 4.0};

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugate_transposed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugate_transposed.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a non-__tile__ variable cannot be used in tile code
-
 #include <cuda/std/cassert>
 #include <cuda/std/complex>
 #include <cuda/std/linalg>

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugated.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugated.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a non-__tile__ variable cannot be used in tile code
-
 #include <cuda/std/cassert>
 #include <cuda/std/complex>
 #include <cuda/std/linalg>


### PR DESCRIPTION
The extended cuda related accessors rely on PTX and builtin functions like __isShared which are not available in tile mode

While we are at it also remove some of the return in loop hacks

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>