### PR TITLE
[Tile] For now mark `<inplace_vector>` tests as host device only

### DIFF
--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/access.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/access.pass.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
 
 #include <cuda/std/algorithm>
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/assign.pass.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6080486 : error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
 
 #include <cuda/std/algorithm>
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/assignment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/assignment.pass.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6080486 : error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
 
 #include <cuda/std/algorithm>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/capacity.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/capacity.pass.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
 
 #include <cuda/std/algorithm>
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/comparison.pass.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
 
 #include <cuda/std/cassert>
 #include <cuda/std/initializer_list>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/constructor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/constructor.pass.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6080486 : error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
 
 #include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
 #include <cuda/std/algorithm>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/emplace.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/emplace.pass.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
 
 #include <cuda/std/algorithm>
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/insert.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/insert.pass.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
 
 #include <cuda/std/algorithm>
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/iterators.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/iterators.pass.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
 
 #include <cuda/std/algorithm>
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/properties.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
+
 #include <cuda/std/algorithm>
 #include <cuda/std/cassert>
 #include <cuda/std/initializer_list>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/resize.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/resize.pass.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
 
 #include <cuda/std/algorithm>
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/swap.pass.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
 
 #include <cuda/std/algorithm>
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/format_to_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/format_to_n.pass.cpp
@@ -10,6 +10,9 @@
 // UNSUPPORTED: force-tile
 // error: calling a __host__ __device__ function in tile is not allowed
 
+// UNSUPPORTED: enable-tile
+// nvbug6537343: error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
+
 // <cuda/std/format>
 
 // template<class Out, class... Args>


### PR DESCRIPTION
There is a compiler bug that we need to wait to land in the release candidate

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>