### PR TITLE
[Tile] Mark all ptx tests host device only

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.clusterlaunchcontrol.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.clusterlaunchcontrol.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.tensor.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.tensor.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.mbarrier.arrive.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.mbarrier.arrive.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.reduce.async.bulk.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.reduce.async.bulk.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.reduce.async.bulk.tensor.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.reduce.async.bulk.tensor.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.getctarank.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.getctarank.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.ld.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.ld.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.arrive.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.arrive.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.expect_tx.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.expect_tx.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.init.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.init.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.wait.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.wait.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier_inval.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier_inval.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.multimem.ld_reduce.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.multimem.ld_reduce.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.multimem.red.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.multimem.red.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.multimem.st.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.multimem.st.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.red.async.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.red.async.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.shfl.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.shfl.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads
@@ -21,7 +21,7 @@
 
 #include "test_macros.h"
 
-TEST_FUNC void test_shfl_full_mask()
+TEST_HOST_DEVICE_FUNC void test_shfl_full_mask()
 {
 #if __cccl_ptx_isa >= 600 && _CCCL_DEVICE_COMPILATION()
   constexpr unsigned FullMask = 0xFFFFFFFF;
@@ -55,7 +55,7 @@ TEST_FUNC void test_shfl_full_mask()
 #endif // __cccl_ptx_isa >= 600 && _CCCL_DEVICE_COMPILATION()
 }
 
-TEST_FUNC void test_shfl_full_mask_no_pred()
+TEST_HOST_DEVICE_FUNC void test_shfl_full_mask_no_pred()
 {
 #if __cccl_ptx_isa >= 600 && _CCCL_DEVICE_COMPILATION()
   constexpr unsigned FullMask = 0xFFFFFFFF;
@@ -88,7 +88,7 @@ TEST_FUNC void test_shfl_full_mask_no_pred()
 #endif // __cccl_ptx_isa >= 600 && _CCCL_DEVICE_COMPILATION()
 }
 
-TEST_FUNC void test_shfl_partial_mask()
+TEST_HOST_DEVICE_FUNC void test_shfl_partial_mask()
 {
 #if __cccl_ptx_isa >= 600 && _CCCL_DEVICE_COMPILATION()
   constexpr unsigned PartialMask = 0b1111;
@@ -102,7 +102,7 @@ TEST_FUNC void test_shfl_partial_mask()
 #endif // __cccl_ptx_isa >= 600 && _CCCL_DEVICE_COMPILATION()
 }
 
-TEST_FUNC void test_shfl_partial_warp()
+TEST_HOST_DEVICE_FUNC void test_shfl_partial_warp()
 {
 #if __cccl_ptx_isa >= 600 && _CCCL_DEVICE_COMPILATION()
   constexpr unsigned FullMask = 0xFFFFFFFF;
@@ -146,7 +146,7 @@ TEST_FUNC void test_shfl_partial_warp()
 #endif // __cccl_ptx_isa >= 600 && _CCCL_DEVICE_COMPILATION()
 }
 
-TEST_FUNC void test_shfl_divergence()
+TEST_HOST_DEVICE_FUNC void test_shfl_divergence()
 {
 #if __cccl_ptx_isa >= 600 && _CCCL_DEVICE_COMPILATION()
   if (threadIdx.x == 0)

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.st.async.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.st.async.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.st.bulk.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.st.bulk.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.st.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.st.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tensormap.cp_fenceproxy.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tensormap.cp_fenceproxy.compile.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // UNSUPPORTED: libcpp-has-no-threads


### PR DESCRIPTION
PTX is generally not suppported in tile mode


## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>