### PR TITLE
[Tile] Mark some parts of `<functional>` as host device only

### DIFF
--- a/libcudacxx/include/cuda/__functional/equal_to_value.h
+++ b/libcudacxx/include/cuda/__functional/equal_to_value.h
@@ -36,11 +36,13 @@ struct equal_to_value
 {
   _Tp __value_;
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API explicit constexpr equal_to_value(const _Tp& __value) noexcept(
     ::cuda::std::is_nothrow_copy_constructible_v<_Tp>)
       : __value_(__value)
   {}
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Up)
   _CCCL_REQUIRES(::cuda::std::__is_cpp17_equality_comparable_v<_Tp, _Up>)
   [[nodiscard]] _CCCL_API constexpr bool operator()(const _Up& __lhs) const

--- a/libcudacxx/test/libcudacxx/cuda/functional/absorbing_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/absorbing_element.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6077402: error: "call to non-tile function not supported!"
-
 #include <cuda/functional>
 #include <cuda/std/cassert>
 #include <cuda/std/limits>

--- a/libcudacxx/test/libcudacxx/cuda/functional/identity_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/identity_element.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6077402: error: "call to non-tile function not supported!"
-
 #include <cuda/functional>
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>

--- a/libcudacxx/test/libcudacxx/cuda/functional/maximum.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/maximum.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6077402: error: "call to non-tile function not supported!"
-
 #include <cuda/functional>
 #include <cuda/std/cassert>
 #include <cuda/type_traits>

--- a/libcudacxx/test/libcudacxx/cuda/functional/minimum.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/minimum.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6077402: error: "call to non-tile function not supported!"
-
 #include <cuda/functional>
 #include <cuda/std/cassert>
 #include <cuda/type_traits>

--- a/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concept.swappable/swappable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concept.swappable/swappable.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a return statement inside a loop is not currently supported in a tile function
-
 // template<class T>
 // concept swappable = // see below
 

--- a/libcudacxx/test/libcudacxx/std/utilities/expol/environments.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expol/environments.pass.cpp
@@ -8,8 +8,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: nvrtc
-
-// UNSUPPORTED: enable-tile
 // error: function-to-pointer decay is unsupported in tile code
 // error: taking address of a function is unsupported in tile code
 

--- a/libcudacxx/test/libcudacxx/std/utilities/expol/is_execution_policy.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expol/is_execution_policy.compile.pass.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
 //
 //===----------------------------------------------------------------------===//
-
-// UNSUPPORTED: enable-tile
 // error: function-to-pointer decay is unsupported in tile code
 // error: taking address of a function is unsupported in tile code
 

--- a/libcudacxx/test/libcudacxx/std/utilities/expol/policies.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expol/policies.compile.pass.cpp
@@ -18,8 +18,6 @@
 // inline constexpr unsequenced_policy unseq = implementation-defined; // since C++20
 
 // UNSUPPORTED: libcpp-has-no-incomplete-pstl
-
-// UNSUPPORTED: enable-tile
 // error: function-to-pointer decay is unsupported in tile code
 // error: taking address of a function is unsupported in tile code
 

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.bind_front/bind_front.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.bind_front/bind_front.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: function-to-pointer decay is unsupported in tile code
 // error: taking address of a function is unsupported in tile code
 
@@ -34,13 +34,13 @@ struct CopyMoveInfo
     move
   } copy_kind;
 
-  TEST_FUNC constexpr CopyMoveInfo()
+  TEST_HOST_DEVICE_FUNC constexpr CopyMoveInfo()
       : copy_kind(none)
   {}
-  TEST_FUNC constexpr CopyMoveInfo(CopyMoveInfo const&)
+  TEST_HOST_DEVICE_FUNC constexpr CopyMoveInfo(CopyMoveInfo const&)
       : copy_kind(copy)
   {}
-  TEST_FUNC constexpr CopyMoveInfo(CopyMoveInfo&&)
+  TEST_HOST_DEVICE_FUNC constexpr CopyMoveInfo(CopyMoveInfo&&)
       : copy_kind(move)
   {}
 };
@@ -49,11 +49,11 @@ template <class... Args>
 struct is_bind_frontable
 {
   template <class... LocalArgs>
-  TEST_FUNC static auto test(int)
+  TEST_HOST_DEVICE_FUNC static auto test(int)
     -> decltype((void) cuda::std::bind_front(cuda::std::declval<LocalArgs>()...), cuda::std::true_type());
 
   template <class...>
-  TEST_FUNC static cuda::std::false_type test(...);
+  TEST_HOST_DEVICE_FUNC static cuda::std::false_type test(...);
 
   static constexpr bool value = decltype(test<Args...>(0))::value;
 };
@@ -64,26 +64,26 @@ struct NotCopyMove
   NotCopyMove(const NotCopyMove&) = delete;
   NotCopyMove(NotCopyMove&&)      = delete;
   template <class... Args>
-  TEST_FUNC void operator()(Args&&...) const
+  TEST_HOST_DEVICE_FUNC void operator()(Args&&...) const
   {}
 };
 
 struct NonConstCopyConstructible
 {
-  TEST_FUNC explicit NonConstCopyConstructible() {}
-  TEST_FUNC NonConstCopyConstructible(NonConstCopyConstructible&) {}
+  TEST_HOST_DEVICE_FUNC explicit NonConstCopyConstructible() {}
+  TEST_HOST_DEVICE_FUNC NonConstCopyConstructible(NonConstCopyConstructible&) {}
 };
 
 struct MoveConstructible
 {
-  TEST_FUNC explicit MoveConstructible() {}
-  TEST_FUNC MoveConstructible(MoveConstructible&&) {}
+  TEST_HOST_DEVICE_FUNC explicit MoveConstructible() {}
+  TEST_HOST_DEVICE_FUNC MoveConstructible(MoveConstructible&&) {}
 };
 
 struct MakeTuple
 {
   template <class... Args>
-  TEST_FUNC constexpr auto operator()(Args&&... args) const
+  TEST_HOST_DEVICE_FUNC constexpr auto operator()(Args&&... args) const
   {
     return cuda::std::make_tuple(cuda::std::forward<Args>(args)...);
   }
@@ -93,7 +93,7 @@ template <int X>
 struct Elem
 {
   template <int Y>
-  TEST_FUNC constexpr bool operator==(Elem<Y> const&) const
+  TEST_HOST_DEVICE_FUNC constexpr bool operator==(Elem<Y> const&) const
   {
     return X == Y;
   }
@@ -102,11 +102,11 @@ struct Elem
 struct TakeAnything
 {
   template <class... Ts>
-  TEST_FUNC constexpr void operator()(Ts&&...) const
+  TEST_HOST_DEVICE_FUNC constexpr void operator()(Ts&&...) const
   {}
 };
 
-TEST_FUNC constexpr bool test()
+TEST_HOST_DEVICE_FUNC constexpr bool test()
 {
   // Bind arguments, call without arguments
   {
@@ -220,7 +220,7 @@ TEST_FUNC constexpr bool test()
   {
     struct MemberFunction
     {
-      TEST_FUNC constexpr bool foo(int, int)
+      TEST_HOST_DEVICE_FUNC constexpr bool foo(int, int)
       {
         return true;
       }
@@ -268,19 +268,19 @@ TEST_FUNC constexpr bool test()
   {
     struct F
     {
-      TEST_FUNC constexpr int operator()() &
+      TEST_HOST_DEVICE_FUNC constexpr int operator()() &
       {
         return 1;
       }
-      TEST_FUNC constexpr int operator()() const&
+      TEST_HOST_DEVICE_FUNC constexpr int operator()() const&
       {
         return 2;
       }
-      TEST_FUNC constexpr int operator()() &&
+      TEST_HOST_DEVICE_FUNC constexpr int operator()() &&
       {
         return 3;
       }
-      TEST_FUNC constexpr int operator()() const&&
+      TEST_HOST_DEVICE_FUNC constexpr int operator()() const&&
       {
         return 4;
       }
@@ -310,10 +310,10 @@ TEST_FUNC constexpr bool test()
     {
       struct F
       {
-        TEST_FUNC void operator()() & {}
-        TEST_FUNC void operator()() const& {}
+        TEST_HOST_DEVICE_FUNC void operator()() & {}
+        TEST_HOST_DEVICE_FUNC void operator()() const& {}
         void operator()() && = delete;
-        TEST_FUNC void operator()() const&& {}
+        TEST_HOST_DEVICE_FUNC void operator()() const&& {}
       };
       using X = decltype(cuda::std::bind_front(F{}));
       static_assert(cuda::std::is_invocable_v<X&>);
@@ -326,9 +326,9 @@ TEST_FUNC constexpr bool test()
     {
       struct F
       {
-        TEST_FUNC void operator()() & {}
-        TEST_FUNC void operator()() const& {}
-        TEST_FUNC void operator()() && {}
+        TEST_HOST_DEVICE_FUNC void operator()() & {}
+        TEST_HOST_DEVICE_FUNC void operator()() const& {}
+        TEST_HOST_DEVICE_FUNC void operator()() && {}
         void operator()() const&& = delete;
       };
       using X = decltype(cuda::std::bind_front(F{}));
@@ -347,7 +347,7 @@ TEST_FUNC constexpr bool test()
       {};
       struct F
       {
-        TEST_FUNC void operator()(T&&) const& {}
+        TEST_HOST_DEVICE_FUNC void operator()(T&&) const& {}
         void operator()(T&&) && = delete;
       };
       using X = decltype(cuda::std::bind_front(F{}));
@@ -359,7 +359,7 @@ TEST_FUNC constexpr bool test()
       {};
       struct F
       {
-        TEST_FUNC void operator()(T const&) const {}
+        TEST_HOST_DEVICE_FUNC void operator()(T const&) const {}
         void operator()(T&&) const = delete;
       };
       using X = decltype(cuda::std::bind_front(F{}, T{}));

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: function-to-pointer decay is unsupported in tile code
 // error: taking address of a function is unsupported in tile code
 
@@ -22,22 +22,22 @@
 
 struct A
 {
-  TEST_FUNC char test0()
+  TEST_HOST_DEVICE_FUNC char test0()
   {
     return 'a';
   }
-  TEST_FUNC char test1(int)
+  TEST_HOST_DEVICE_FUNC char test1(int)
   {
     return 'b';
   }
-  TEST_FUNC char test2(int, double)
+  TEST_HOST_DEVICE_FUNC char test2(int, double)
   {
     return 'c';
   }
 };
 
 template <class F>
-TEST_FUNC void test0(F f)
+TEST_HOST_DEVICE_FUNC void test0(F f)
 {
   {
     A a;
@@ -50,7 +50,7 @@ TEST_FUNC void test0(F f)
 }
 
 template <class F>
-TEST_FUNC void test1(F f)
+TEST_HOST_DEVICE_FUNC void test1(F f)
 {
   {
     A a;
@@ -63,7 +63,7 @@ TEST_FUNC void test1(F f)
 }
 
 template <class F>
-TEST_FUNC void test2(F f)
+TEST_HOST_DEVICE_FUNC void test2(F f)
 {
   {
     A a;

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function_const.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function_const.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: function-to-pointer decay is unsupported in tile code
 // error: taking address of a function is unsupported in tile code
 
@@ -22,22 +22,22 @@
 
 struct A
 {
-  TEST_FUNC char test0() const
+  TEST_HOST_DEVICE_FUNC char test0() const
   {
     return 'a';
   }
-  TEST_FUNC char test1(int) const
+  TEST_HOST_DEVICE_FUNC char test1(int) const
   {
     return 'b';
   }
-  TEST_FUNC char test2(int, double) const
+  TEST_HOST_DEVICE_FUNC char test2(int, double) const
   {
     return 'c';
   }
 };
 
 template <class F>
-TEST_FUNC void test0(F f)
+TEST_HOST_DEVICE_FUNC void test0(F f)
 {
   {
     A a;
@@ -52,7 +52,7 @@ TEST_FUNC void test0(F f)
 }
 
 template <class F>
-TEST_FUNC void test1(F f)
+TEST_HOST_DEVICE_FUNC void test1(F f)
 {
   {
     A a;
@@ -67,7 +67,7 @@ TEST_FUNC void test1(F f)
 }
 
 template <class F>
-TEST_FUNC void test2(F f)
+TEST_HOST_DEVICE_FUNC void test2(F f)
 {
   {
     A a;

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function_const_volatile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function_const_volatile.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: function-to-pointer decay is unsupported in tile code
 // error: taking address of a function is unsupported in tile code
 
@@ -22,22 +22,22 @@
 
 struct A
 {
-  TEST_FUNC char test0() const volatile
+  TEST_HOST_DEVICE_FUNC char test0() const volatile
   {
     return 'a';
   }
-  TEST_FUNC char test1(int) const volatile
+  TEST_HOST_DEVICE_FUNC char test1(int) const volatile
   {
     return 'b';
   }
-  TEST_FUNC char test2(int, double) const volatile
+  TEST_HOST_DEVICE_FUNC char test2(int, double) const volatile
   {
     return 'c';
   }
 };
 
 template <class F>
-TEST_FUNC void test0(F f)
+TEST_HOST_DEVICE_FUNC void test0(F f)
 {
   {
     A a;
@@ -52,7 +52,7 @@ TEST_FUNC void test0(F f)
 }
 
 template <class F>
-TEST_FUNC void test1(F f)
+TEST_HOST_DEVICE_FUNC void test1(F f)
 {
   {
     A a;
@@ -67,7 +67,7 @@ TEST_FUNC void test1(F f)
 }
 
 template <class F>
-TEST_FUNC void test2(F f)
+TEST_HOST_DEVICE_FUNC void test2(F f)
 {
   {
     A a;

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function_volatile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function_volatile.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: function-to-pointer decay is unsupported in tile code
 // error: taking address of a function is unsupported in tile code
 
@@ -22,22 +22,22 @@
 
 struct A
 {
-  TEST_FUNC char test0() volatile
+  TEST_HOST_DEVICE_FUNC char test0() volatile
   {
     return 'a';
   }
-  TEST_FUNC char test1(int) volatile
+  TEST_HOST_DEVICE_FUNC char test1(int) volatile
   {
     return 'b';
   }
-  TEST_FUNC char test2(int, double) volatile
+  TEST_HOST_DEVICE_FUNC char test2(int, double) volatile
   {
     return 'c';
   }
 };
 
 template <class F>
-TEST_FUNC void test0(F f)
+TEST_HOST_DEVICE_FUNC void test0(F f)
 {
   {
     A a;
@@ -52,7 +52,7 @@ TEST_FUNC void test0(F f)
 }
 
 template <class F>
-TEST_FUNC void test1(F f)
+TEST_HOST_DEVICE_FUNC void test1(F f)
 {
   {
     A a;
@@ -67,7 +67,7 @@ TEST_FUNC void test1(F f)
 }
 
 template <class F>
-TEST_FUNC void test2(F f)
+TEST_HOST_DEVICE_FUNC void test2(F f)
 {
   {
     A a;

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.access/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.access/conversion.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: function-to-pointer decay is unsupported in tile code
 // error: taking address of a function is unsupported in tile code
 
@@ -27,14 +27,14 @@ class functor1
 {};
 
 template <class T>
-TEST_FUNC void test(T& t)
+TEST_HOST_DEVICE_FUNC void test(T& t)
 {
   cuda::std::reference_wrapper<T> r(t);
   T& r2 = r;
   assert(&r2 == &t);
 }
 
-TEST_FUNC void f() {}
+TEST_HOST_DEVICE_FUNC void f() {}
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.assign/copy_assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.assign/copy_assign.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: function-to-pointer decay is unsupported in tile code
 // error: taking address of a function is unsupported in tile code
 
@@ -29,18 +29,18 @@ class functor1
 struct convertible_to_int_ref
 {
   int val = 0;
-  TEST_FUNC operator int&()
+  TEST_HOST_DEVICE_FUNC operator int&()
   {
     return val;
   }
-  TEST_FUNC operator int const&() const
+  TEST_HOST_DEVICE_FUNC operator int const&() const
   {
     return val;
   }
 };
 
 template <class T>
-TEST_FUNC void test(T& t)
+TEST_HOST_DEVICE_FUNC void test(T& t)
 {
   cuda::std::reference_wrapper<T> r(t);
   T t2 = t;
@@ -49,10 +49,10 @@ TEST_FUNC void test(T& t)
   assert(&r2.get() == &t);
 }
 
-TEST_FUNC void f() {}
-TEST_FUNC void g() {}
+TEST_HOST_DEVICE_FUNC void f() {}
+TEST_HOST_DEVICE_FUNC void g() {}
 
-TEST_FUNC void test_function()
+TEST_HOST_DEVICE_FUNC void TEST_HOST_DEVICE_FUNCtion()
 {
   cuda::std::reference_wrapper<void()> r(f);
   cuda::std::reference_wrapper<void()> r2(g);
@@ -64,7 +64,7 @@ int main(int, char**)
 {
   void (*fp)() = f;
   test(fp);
-  test_function();
+  TEST_HOST_DEVICE_FUNCtion();
   functor1 f1;
   test(f1);
   int i = 0;

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/copy_ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/copy_ctor.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: function-to-pointer decay is unsupported in tile code
 // error: taking address of a function is unsupported in tile code
 
@@ -27,14 +27,14 @@ class functor1
 {};
 
 template <class T>
-TEST_FUNC void test(T& t)
+TEST_HOST_DEVICE_FUNC void test(T& t)
 {
   cuda::std::reference_wrapper<T> r(t);
   cuda::std::reference_wrapper<T> r2 = r;
   assert(&r2.get() == &t);
 }
 
-TEST_FUNC void f() {}
+TEST_HOST_DEVICE_FUNC void f() {}
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/type_ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/type_ctor.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile
+// UNSUPPORTED: force-tile
 // error: function-to-pointer decay is unsupported in tile code
 // error: taking address of a function is unsupported in tile code
 
@@ -28,13 +28,13 @@ class functor1
 {};
 
 template <class T>
-TEST_FUNC void test(T& t)
+TEST_HOST_DEVICE_FUNC void test(T& t)
 {
   cuda::std::reference_wrapper<T> r(t);
   assert(&r.get() == &t);
 }
 
-TEST_FUNC void f() {}
+TEST_HOST_DEVICE_FUNC void f() {}
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.invoke/invoke.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.invoke/invoke.pass.cpp
@@ -7,8 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a non-__tile__ variable ("count") cannot be used in tile code
+// UNSUPPORTED: force-tile
+// error: indirect call is unsupported in tile code
+
+// UNSUPPORTED: enable-tile
+// BUGBUG: codegen error
 
 // <functional>
 
@@ -29,29 +32,29 @@ TEST_GLOBAL_VARIABLE int count = 0;
 
 // 1 arg, return void
 
-TEST_FUNC void f_void_1(int i)
+TEST_HOST_DEVICE_FUNC void f_void_1(int i)
 {
   count += i;
 }
 
 struct A_void_1
 {
-  TEST_FUNC void operator()(int i)
+  TEST_HOST_DEVICE_FUNC void operator()(int i)
   {
     count += i;
   }
 
-  TEST_FUNC void mem1()
+  TEST_HOST_DEVICE_FUNC void mem1()
   {
     ++count;
   }
-  TEST_FUNC void mem2() const
+  TEST_HOST_DEVICE_FUNC void mem2() const
   {
     ++count;
   }
 };
 
-TEST_FUNC void test_void_1()
+TEST_HOST_DEVICE_FUNC void test_void_1()
 {
   int save_count = count;
   // function
@@ -113,33 +116,33 @@ TEST_FUNC void test_void_1()
 
 // 1 arg, return int
 
-TEST_FUNC int f_int_1(int i)
+TEST_HOST_DEVICE_FUNC int f_int_1(int i)
 {
   return i + 1;
 }
 
 struct A_int_1
 {
-  TEST_FUNC A_int_1()
+  TEST_HOST_DEVICE_FUNC A_int_1()
       : data_(5)
   {}
-  TEST_FUNC int operator()(int i)
+  TEST_HOST_DEVICE_FUNC int operator()(int i)
   {
     return i - 1;
   }
 
-  TEST_FUNC int mem1()
+  TEST_HOST_DEVICE_FUNC int mem1()
   {
     return 3;
   }
-  TEST_FUNC int mem2() const
+  TEST_HOST_DEVICE_FUNC int mem2() const
   {
     return 4;
   }
   int data_;
 };
 
-TEST_FUNC void test_int_1()
+TEST_HOST_DEVICE_FUNC void test_int_1()
 {
   // function
   {
@@ -200,29 +203,29 @@ TEST_FUNC void test_int_1()
 
 // 2 arg, return void
 
-TEST_FUNC void f_void_2(int i, int j)
+TEST_HOST_DEVICE_FUNC void f_void_2(int i, int j)
 {
   count += i + j;
 }
 
 struct A_void_2
 {
-  TEST_FUNC void operator()(int i, int j)
+  TEST_HOST_DEVICE_FUNC void operator()(int i, int j)
   {
     count += i + j;
   }
 
-  TEST_FUNC void mem1(int i)
+  TEST_HOST_DEVICE_FUNC void mem1(int i)
   {
     count += i;
   }
-  TEST_FUNC void mem2(int i) const
+  TEST_HOST_DEVICE_FUNC void mem2(int i) const
   {
     count += i;
   }
 };
 
-TEST_FUNC void test_void_2()
+TEST_HOST_DEVICE_FUNC void test_void_2()
 {
   int save_count = count;
   // function
@@ -288,29 +291,29 @@ TEST_FUNC void test_void_2()
 
 // 2 arg, return int
 
-TEST_FUNC int f_int_2(int i, int j)
+TEST_HOST_DEVICE_FUNC int f_int_2(int i, int j)
 {
   return i + j;
 }
 
 struct A_int_2
 {
-  TEST_FUNC int operator()(int i, int j)
+  TEST_HOST_DEVICE_FUNC int operator()(int i, int j)
   {
     return i + j;
   }
 
-  TEST_FUNC int mem1(int i)
+  TEST_HOST_DEVICE_FUNC int mem1(int i)
   {
     return i + 1;
   }
-  TEST_FUNC int mem2(int i) const
+  TEST_HOST_DEVICE_FUNC int mem2(int i) const
   {
     return i + 2;
   }
 };
 
-TEST_FUNC void testint_2()
+TEST_HOST_DEVICE_FUNC void testint_2()
 {
   // function
   {

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.invoke/invoke_void_0.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.invoke/invoke_void_0.pass.cpp
@@ -7,8 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a non-__tile__ variable ("count") cannot be used in tile code
+// UNSUPPORTED: force-tile
+// error: indirect call is unsupported in tile code
+
+// UNSUPPORTED: enable-tile
+// BUGBUG: codegen error
 
 // <functional>
 
@@ -29,20 +32,20 @@
 
 TEST_GLOBAL_VARIABLE int count = 0;
 
-TEST_FUNC void f_void_0()
+TEST_HOST_DEVICE_FUNC void f_void_0()
 {
   ++count;
 }
 
 struct A_void_0
 {
-  TEST_FUNC void operator()()
+  TEST_HOST_DEVICE_FUNC void operator()()
   {
     ++count;
   }
 };
 
-TEST_FUNC void test_void_0()
+TEST_HOST_DEVICE_FUNC void test_void_0()
 {
   int save_count = count;
   // function

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.invoke/robust_against_adl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.invoke/robust_against_adl.pass.cpp
@@ -7,9 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: force-tile
+// error: indirect call is unsupported in tile code
+
 // UNSUPPORTED: enable-tile
-// error: function-to-pointer decay is unsupported in tile code
-// error: taking address of a function is unsupported in tile code
+// BUGBUG: codegen error
 
 // <functional>
 


### PR DESCRIPTION
We cannot use features that rely on indirect function calls


## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>