### PR TITLE
[libcu++] Allow no GPUDirect RDMA flush options

### DIFF
--- a/libcudacxx/include/cuda/__device/attributes.h
+++ b/libcudacxx/include/cuda/__device/attributes.h
@@ -244,6 +244,7 @@ template <>
 struct __dev_attr<::cudaDevAttrGPUDirectRDMAFlushWritesOptions> //
     : __dev_attr_impl<::cudaDevAttrGPUDirectRDMAFlushWritesOptions, ::cudaFlushGPUDirectRDMAWritesOptions>
 {
+  static constexpr type none    = static_cast<type>(0);
   static constexpr type host    = ::cudaFlushGPUDirectRDMAWritesOptionHost;
   static constexpr type mem_ops = ::cudaFlushGPUDirectRDMAWritesOptionMemOps;
 };

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
@@ -223,15 +223,17 @@ C2H_CCCLRT_TEST("Smoke", "[device]")
 
     SECTION("gpu_direct_rdma_flush_writes_options")
     {
+      STATIC_REQUIRE(
+        static_cast<::cudaFlushGPUDirectRDMAWritesOptions>(0) == attributes::gpu_direct_rdma_flush_writes_options.none);
       STATIC_REQUIRE(::cudaFlushGPUDirectRDMAWritesOptionHost == attributes::gpu_direct_rdma_flush_writes_options.host);
       STATIC_REQUIRE(
         ::cudaFlushGPUDirectRDMAWritesOptionMemOps == attributes::gpu_direct_rdma_flush_writes_options.mem_ops);
 
-      [[maybe_unused]] auto options = device_ref(0).attribute(attributes::gpu_direct_rdma_flush_writes_options);
-#if !_CCCL_COMPILER(MSVC)
-      CCCLRT_REQUIRE((options == attributes::gpu_direct_rdma_flush_writes_options.host || //
-                      options == attributes::gpu_direct_rdma_flush_writes_options.mem_ops));
-#endif
+      constexpr int all_flush_writes_options =
+        attributes::gpu_direct_rdma_flush_writes_options.none | attributes::gpu_direct_rdma_flush_writes_options.host
+        | attributes::gpu_direct_rdma_flush_writes_options.mem_ops;
+      auto options = device_ref(0).attribute(attributes::gpu_direct_rdma_flush_writes_options);
+      CCCLRT_REQUIRE(static_cast<int>(options) <= static_cast<int>(all_flush_writes_options));
     }
 
     SECTION("gpu_direct_rdma_writes_ordering")

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
@@ -233,7 +233,7 @@ C2H_CCCLRT_TEST("Smoke", "[device]")
         attributes::gpu_direct_rdma_flush_writes_options.none | attributes::gpu_direct_rdma_flush_writes_options.host
         | attributes::gpu_direct_rdma_flush_writes_options.mem_ops;
       auto options = device_ref(0).attribute(attributes::gpu_direct_rdma_flush_writes_options);
-      CCCLRT_REQUIRE(static_cast<int>(options) <= static_cast<int>(all_flush_writes_options));
+      CCCLRT_REQUIRE(static_cast<unsigned>(options) <= static_cast<unsigned>(all_flush_writes_options));
     }
 
     SECTION("gpu_direct_rdma_writes_ordering")


### PR DESCRIPTION
I realized this device is a bit mask and we need an option for 0. Also the MSVC ifdef in the test was added mainly to work around this, it's not needed anymore.

NVBUG 6373406