### PR TITLE
Add root `index.html` to redirect `Documentation` link to unstable docs

### DIFF
--- a/docs/gen_docs.bash
+++ b/docs/gen_docs.bash
@@ -286,6 +286,7 @@ fi
 ./scrape_docs.bash "${HTML_DIR}/${VERSION}"
 
 cp "./404.html" "${HTML_DIR}/404.html"
+cp "./index.html" "${HTML_DIR}/index.html"
 
 # Provide version metadata for the theme switcher
 cat > "${HTML_DIR}/nv-versions.json" <<EOF

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=unstable/">
+  <link rel="canonical" href="unstable/">
+  <title>CUDA Core Compute Libraries</title>
+</head>
+<body>
+  <a href="unstable/">CUDA Core Compute Libraries documentation</a>
+</body>
+</html>


### PR DESCRIPTION
Clicking the **Documentation** link in the README (`https://nvidia.github.io/cccl`) hits a 404 page, which then internally redirects to `unstable/`. Users see a brief 404 flash and a confusing URL in the address bar before landing on the actual docs.

<img width="1020" height="333" alt="image" src="https://github.com/user-attachments/assets/9b897840-8a1d-440e-b80f-5f80aa99c15f" />

leads to:

<img width="528" height="105" alt="image" src="https://github.com/user-attachments/assets/9cfe2b31-e819-48d3-9ded-f730298b0e14" />

This PR adds a root `docs/index.html` with a `<meta http-equiv="refresh">` redirect to `unstable/`, mirroring the same pattern used by `docs/404.html`.  Users will now land directly on the docs index with no intermediate 404.