### PR TITLE
Fixes a race condition in `DeviceTopK`

### DIFF
--- a/cub/cub/agent/agent_topk.cuh
+++ b/cub/cub/agent/agent_topk.cuh
@@ -647,10 +647,11 @@ struct AgentTopK
     bool is_last_pass,
     CounterUpdateFn counter_update_fn)
   {
-    // Ensure all writes to the global memory-histogram are visible to all threads before
-    // proceeding to compute the prefix sum over the histogram.
-    __threadfence();
+    // Wait for all threads in this block to finish merge_histograms() before thread 0 signals completion
+    __syncthreads();
 
+    // Make this block's histogram contributions visible device-wide before publishing retirement
+    __threadfence();
     // Identify the last block in the grid to perform the prefix sum over the histogram
     bool is_last_block = false;
     if (threadIdx.x == 0)

--- a/cub/cub/agent/agent_topk.cuh
+++ b/cub/cub/agent/agent_topk.cuh
@@ -647,11 +647,12 @@ struct AgentTopK
     bool is_last_pass,
     CounterUpdateFn counter_update_fn)
   {
+    // Make this block's histogram contributions visible device-wide before publishing retirement
+    __threadfence();
+
     // Wait for all threads in this block to finish merge_histograms() before thread 0 signals completion
     __syncthreads();
 
-    // Make this block's histogram contributions visible device-wide before publishing retirement
-    __threadfence();
     // Identify the last block in the grid to perform the prefix sum over the histogram
     bool is_last_block = false;
     if (threadIdx.x == 0)


### PR DESCRIPTION
## Description

Fixes a potential race condition, where thread `0` signals a CTA's completion of `merge_histograms` while some other threads have not concluded contributing their counts to the global yet.
