### PR TITLE
Use nvbench_compare_robust in benchmark workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -48,7 +48,7 @@ on:
         default: ""
         type: string
       nvbench_compare_args:
-        description: "nvbench_compare.py extra args"
+        description: "nvbench-compare-robust extra args"
         required: false
         default: ""
         type: string
@@ -100,7 +100,7 @@ on:
         default: ""
         type: string
       nvbench_compare_args:
-        description: "nvbench_compare.py extra args"
+        description: "nvbench-compare-robust extra args"
         required: false
         default: ""
         type: string
@@ -319,6 +319,7 @@ jobs:
           ./ci/util/retry.sh 5 30 python3 -m pip install \
             colorama \
             jsondiff \
+            numpy \
             tabulate
 
           ./ci/bench/bench.sh "${bench_args[@]}"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -315,12 +315,8 @@ jobs:
           # This adds them to a bench_args array while preserving any quotes, whitespace, etc
           mapfile -d '' -t bench_args < "/bench_args.txt"
 
-          # NVBench deps:
-          ./ci/util/retry.sh 5 30 python3 -m pip install \
-            colorama \
-            jsondiff \
-            numpy \
-            tabulate
+          # NVBench compare deps:
+          ./ci/util/retry.sh 5 30 python3 -m pip install 'cuda-bench[compare]>=0.3.0'
 
           ./ci/bench/bench.sh "${bench_args[@]}"
           EOF

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -383,6 +383,7 @@ jobs:
             --env "CCCL_BENCH_COMPARE_PYTHON=/bench-compare-venv/bin/python3" \
             --env "CCCL_BENCH_DROP_AWS_CREDENTIALS=1" \
             --env "CCCL_BENCH_GPU_NAME=${GPU_NAME}" \
+            --env "CCCL_BENCH_LEGACY_COMPARE_BIN=/bench-compare-venv/bin/nvbench-compare-legacy" \
             --env "CCCL_BENCH_NVBENCH_SHA=${CCCL_BENCH_NVBENCH_SHA}" \
             --env "LAUNCH_ARGS=${LAUNCH_ARGS} ${GPU_ARGS}" \
             --env "SCCACHE_REGION=${AWS_REGION:-}" \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -147,43 +147,6 @@ jobs:
           echo "Resolved NVBench ${nvbench_ref} to ${nvbench_sha}"
           echo "CCCL_BENCH_NVBENCH_SHA=${nvbench_sha}" >> "${GITHUB_ENV}"
 
-      - name: Prepare benchmark compare dependencies
-        env:
-          LAUNCH_ARGS: ${{ inputs.launch_args }}
-        run: |
-          # The devcontainer mounts this path to /home/coder/.aws. Move aside
-          # any preexisting AWS config before installing Python packages, then
-          # use a workflow-owned .aws directory until the cleanup step restores
-          # the original.
-          aws_dir="${{ github.workspace }}/.aws"
-          aws_backup="${RUNNER_TEMP}/bench-original-aws"
-          echo "BENCH_AWS_BACKUP=${aws_backup}" >> "${GITHUB_ENV}"
-          rm -rf "${aws_backup}"
-          if [[ -e "${aws_dir}" ]]; then
-            mv "${aws_dir}" "${aws_backup}"
-          fi
-          mkdir -p "${aws_dir}"
-
-          compare_venv="${RUNNER_TEMP}/bench-compare-venv"
-          deps_script="${RUNNER_TEMP}/bench-compare-deps.sh"
-          mkdir -p "${compare_venv}"
-
-          cat <<"EOF" > "${deps_script}"
-          #! /usr/bin/env bash
-          set -euo pipefail
-
-          python3 -m venv --clear /bench-compare-venv
-          /bench-compare-venv/bin/pip install --upgrade pip
-          ./ci/util/retry.sh 5 30 /bench-compare-venv/bin/pip install 'cuda-bench[compare]>=0.3.0'
-          EOF
-          chmod +x "${deps_script}"
-
-          .devcontainer/launch.sh \
-            -d ${LAUNCH_ARGS} \
-            --volume "${deps_script}:/bench-compare-deps.sh" \
-            --volume "${compare_venv}:/bench-compare-venv" \
-            -- /bench-compare-deps.sh
-
       - name: Get AWS credentials for sccache bucket
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6
         with:
@@ -338,6 +301,7 @@ jobs:
       - name: Run benchmark compare
         id: run-benchmark-compare
         env:
+          GH_TOKEN: ${{ github.token }}
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_REGION: ${{ env.AWS_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
@@ -347,7 +311,6 @@ jobs:
         run: |
           args_file="${{ steps.resolve-args.outputs.args_file }}"
           ci_script="${RUNNER_TEMP}/ci.sh"
-          compare_venv="${RUNNER_TEMP}/bench-compare-venv"
           timestamp_utc="$(date -u +'%Y%m%dT%H%M%SZ')"
 
           mapfile -d '' -t bench_args < "${args_file}"
@@ -379,6 +342,9 @@ jobs:
           # This adds them to a bench_args array while preserving any quotes, whitespace, etc
           mapfile -d '' -t bench_args < "/bench_args.txt"
 
+          # NVBench compare deps:
+          ./ci/util/retry.sh 5 30 python3 -m pip install 'cuda-bench[compare]>=0.3.0'
+
           ./ci/bench/bench.sh "${bench_args[@]}"
           EOF
           chmod +x "${ci_script}"
@@ -392,18 +358,13 @@ jobs:
             --env "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}" \
             --env "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}" \
             --env "CCCL_BENCH_ARTIFACT_ROOT=bench-artifacts" \
-            --env "CCCL_BENCH_AWS_CONFIG_DIR=/home/coder/.aws" \
-            --env "CCCL_BENCH_COMPARE_BIN=/bench-compare-venv/bin/nvbench-compare-robust" \
-            --env "CCCL_BENCH_COMPARE_PYTHON=/bench-compare-venv/bin/python3" \
-            --env "CCCL_BENCH_DROP_AWS_CREDENTIALS=1" \
             --env "CCCL_BENCH_GPU_NAME=${GPU_NAME}" \
-            --env "CCCL_BENCH_LEGACY_COMPARE_BIN=/bench-compare-venv/bin/nvbench-compare-legacy" \
             --env "CCCL_BENCH_NVBENCH_SHA=${CCCL_BENCH_NVBENCH_SHA}" \
+            --env "GH_TOKEN=${GH_TOKEN:-}" \
             --env "LAUNCH_ARGS=${LAUNCH_ARGS} ${GPU_ARGS}" \
             --env "SCCACHE_REGION=${AWS_REGION:-}" \
             --volume "${ci_script}:/ci.sh" \
             --volume "${args_file}:/bench_args.txt" \
-            --volume "${compare_venv}:/bench-compare-venv" \
             -- /ci.sh \
             || rc=$?
 
@@ -433,15 +394,3 @@ jobs:
           path: bench-artifacts/*
           if-no-files-found: warn
           retention-days: 14
-
-      - name: Cleanup AWS config
-        if: ${{ always() }}
-        run: |
-          aws_dir="${{ github.workspace }}/.aws"
-          aws_backup="${BENCH_AWS_BACKUP:-}"
-          rm -rf "${aws_dir}"
-          if [[ -n "${aws_backup}" && -e "${aws_backup}" ]]; then
-            mv "${aws_backup}" "${aws_dir}"
-          else
-            mkdir -p "${aws_dir}"
-          fi

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -124,6 +124,56 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Resolve NVBench SHA
+        run: |
+          nvbench_repo="https://github.com/NVIDIA/nvbench.git"
+          nvbench_ref="refs/heads/main"
+          nvbench_remote_ref="$(git ls-remote "${nvbench_repo}" "${nvbench_ref}")"
+          read -r nvbench_sha resolved_ref <<< "${nvbench_remote_ref}"
+          if [[ "${resolved_ref:-}" != "${nvbench_ref}" || ! "${nvbench_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::Failed to resolve ${nvbench_repo} ${nvbench_ref}; got '${nvbench_remote_ref}'"
+            exit 1
+          fi
+          echo "Resolved NVBench ${nvbench_ref} to ${nvbench_sha}"
+          echo "CCCL_BENCH_NVBENCH_SHA=${nvbench_sha}" >> "${GITHUB_ENV}"
+
+      - name: Prepare benchmark compare dependencies
+        env:
+          LAUNCH_ARGS: ${{ inputs.launch_args }}
+        run: |
+          # The devcontainer mounts this path to /home/coder/.aws. Move aside
+          # any preexisting AWS config before installing Python packages, then
+          # use a workflow-owned .aws directory until the cleanup step restores
+          # the original.
+          aws_dir="${{ github.workspace }}/.aws"
+          aws_backup="${RUNNER_TEMP}/bench-original-aws"
+          echo "BENCH_AWS_BACKUP=${aws_backup}" >> "${GITHUB_ENV}"
+          rm -rf "${aws_backup}"
+          if [[ -e "${aws_dir}" ]]; then
+            mv "${aws_dir}" "${aws_backup}"
+          fi
+          mkdir -p "${aws_dir}"
+
+          compare_venv="${RUNNER_TEMP}/bench-compare-venv"
+          deps_script="${RUNNER_TEMP}/bench-compare-deps.sh"
+          mkdir -p "${compare_venv}"
+
+          cat <<"EOF" > "${deps_script}"
+          #! /usr/bin/env bash
+          set -euo pipefail
+
+          python3 -m venv --clear /bench-compare-venv
+          /bench-compare-venv/bin/pip install --upgrade pip
+          ./ci/util/retry.sh 5 30 /bench-compare-venv/bin/pip install 'cuda-bench[compare]>=0.3.0'
+          EOF
+          chmod +x "${deps_script}"
+
+          .devcontainer/launch.sh \
+            -d ${LAUNCH_ARGS} \
+            --volume "${deps_script}:/bench-compare-deps.sh" \
+            --volume "${compare_venv}:/bench-compare-venv" \
+            -- /bench-compare-deps.sh
+
       - name: Get AWS credentials for sccache bucket
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6
         with:
@@ -274,7 +324,6 @@ jobs:
       - name: Run benchmark compare
         id: run-benchmark-compare
         env:
-          GH_TOKEN: ${{ github.token }}
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_REGION: ${{ env.AWS_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
@@ -284,6 +333,7 @@ jobs:
         run: |
           args_file="${{ steps.resolve-args.outputs.args_file }}"
           ci_script="${RUNNER_TEMP}/ci.sh"
+          compare_venv="${RUNNER_TEMP}/bench-compare-venv"
           timestamp_utc="$(date -u +'%Y%m%dT%H%M%SZ')"
 
           mapfile -d '' -t bench_args < "${args_file}"
@@ -315,9 +365,6 @@ jobs:
           # This adds them to a bench_args array while preserving any quotes, whitespace, etc
           mapfile -d '' -t bench_args < "/bench_args.txt"
 
-          # NVBench compare deps:
-          ./ci/util/retry.sh 5 30 python3 -m pip install 'cuda-bench[compare]>=0.3.0'
-
           ./ci/bench/bench.sh "${bench_args[@]}"
           EOF
           chmod +x "${ci_script}"
@@ -331,12 +378,17 @@ jobs:
             --env "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}" \
             --env "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}" \
             --env "CCCL_BENCH_ARTIFACT_ROOT=bench-artifacts" \
+            --env "CCCL_BENCH_AWS_CONFIG_DIR=/home/coder/.aws" \
+            --env "CCCL_BENCH_COMPARE_BIN=/bench-compare-venv/bin/nvbench-compare-robust" \
+            --env "CCCL_BENCH_COMPARE_PYTHON=/bench-compare-venv/bin/python3" \
+            --env "CCCL_BENCH_DROP_AWS_CREDENTIALS=1" \
             --env "CCCL_BENCH_GPU_NAME=${GPU_NAME}" \
-            --env "GH_TOKEN=${GH_TOKEN:-}" \
+            --env "CCCL_BENCH_NVBENCH_SHA=${CCCL_BENCH_NVBENCH_SHA}" \
             --env "LAUNCH_ARGS=${LAUNCH_ARGS} ${GPU_ARGS}" \
             --env "SCCACHE_REGION=${AWS_REGION:-}" \
             --volume "${ci_script}:/ci.sh" \
             --volume "${args_file}:/bench_args.txt" \
+            --volume "${compare_venv}:/bench-compare-venv" \
             -- /ci.sh \
             || rc=$?
 
@@ -366,3 +418,15 @@ jobs:
           path: bench-artifacts/*
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Cleanup AWS config
+        if: ${{ always() }}
+        run: |
+          aws_dir="${{ github.workspace }}/.aws"
+          aws_backup="${BENCH_AWS_BACKUP:-}"
+          rm -rf "${aws_dir}"
+          if [[ -n "${aws_backup}" && -e "${aws_backup}" ]]; then
+            mv "${aws_backup}" "${aws_dir}"
+          else
+            mkdir -p "${aws_dir}"
+          fi

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -52,6 +52,11 @@ on:
         required: false
         default: ""
         type: string
+      nvbench_compare_legacy_args:
+        description: "nvbench-compare-legacy extra args"
+        required: false
+        default: ""
+        type: string
       raw_args:
         description: "Raw Args (advanced, bypasses all other inputs)"
         required: false
@@ -101,6 +106,11 @@ on:
         type: string
       nvbench_compare_args:
         description: "nvbench-compare-robust extra args"
+        required: false
+        default: ""
+        type: string
+      nvbench_compare_legacy_args:
+        description: "nvbench-compare-legacy extra args"
         required: false
         default: ""
         type: string
@@ -211,6 +221,7 @@ jobs:
           INPUT_RAW_ARGS: ${{ inputs.raw_args }}
           INPUT_NVBENCH_ARGS: ${{ inputs.nvbench_args }}
           INPUT_NVBENCH_COMPARE_ARGS: ${{ inputs.nvbench_compare_args }}
+          INPUT_NVBENCH_COMPARE_LEGACY_ARGS: ${{ inputs.nvbench_compare_legacy_args }}
         run: |
           parse_quoted_args() {
             local quoted_args="$1"
@@ -294,6 +305,9 @@ jobs:
             fi
             if [[ -n "${INPUT_NVBENCH_COMPARE_ARGS}" ]]; then
               bench_args+=(--nvbench-compare-args "${INPUT_NVBENCH_COMPARE_ARGS}")
+            fi
+            if [[ -n "${INPUT_NVBENCH_COMPARE_LEGACY_ARGS}" ]]; then
+              bench_args+=(--nvbench-compare-legacy-args "${INPUT_NVBENCH_COMPARE_LEGACY_ARGS}")
             fi
           fi
 

--- a/.github/workflows/ci-workflow-pull-request.yml
+++ b/.github/workflows/ci-workflow-pull-request.yml
@@ -444,6 +444,7 @@ jobs:
       python_filters: ${{ matrix.python_filters }}
       nvbench_args: ${{ matrix.nvbench_args }}
       nvbench_compare_args: ${{ matrix.nvbench_compare_args }}
+      nvbench_compare_legacy_args: ${{ matrix.nvbench_compare_legacy_args }}
 
   dispatch-compile-time-bench:
     name: Compile-time Bench (${{ matrix.id }})

--- a/ci/bench.template.yaml
+++ b/ci/bench.template.yaml
@@ -63,7 +63,7 @@ benchmarks:
   arch: "native"
   nvbench_args: >-
     --timeout 30
-    --skip-time 15e-6
+    --skip-time 5e-6
     --stopping-criterion entropy
     --throttle-threshold 90
     --throttle-recovery-delay 0.15

--- a/ci/bench.template.yaml
+++ b/ci/bench.template.yaml
@@ -67,4 +67,6 @@ benchmarks:
     --stopping-criterion entropy
     --throttle-threshold 90
     --throttle-recovery-delay 0.15
+    --cold-warmup-runs 10
+    --cold-max-warmup-walltime 0.05
   nvbench_compare_args: ""

--- a/ci/bench.template.yaml
+++ b/ci/bench.template.yaml
@@ -70,3 +70,4 @@ benchmarks:
     --cold-warmup-runs 10
     --cold-max-warmup-walltime 0.05
   nvbench_compare_args: ""
+  nvbench_compare_legacy_args: ""

--- a/ci/bench.yaml
+++ b/ci/bench.yaml
@@ -63,7 +63,7 @@ benchmarks:
   arch: "native"
   nvbench_args: >-
     --timeout 30
-    --skip-time 15e-6
+    --skip-time 5e-6
     --stopping-criterion entropy
     --throttle-threshold 90
     --throttle-recovery-delay 0.15

--- a/ci/bench.yaml
+++ b/ci/bench.yaml
@@ -67,4 +67,6 @@ benchmarks:
     --stopping-criterion entropy
     --throttle-threshold 90
     --throttle-recovery-delay 0.15
+    --cold-warmup-runs 10
+    --cold-max-warmup-walltime 0.05
   nvbench_compare_args: ""

--- a/ci/bench.yaml
+++ b/ci/bench.yaml
@@ -70,3 +70,4 @@ benchmarks:
     --cold-warmup-runs 10
     --cold-max-warmup-walltime 0.05
   nvbench_compare_args: ""
+  nvbench_compare_legacy_args: ""

--- a/ci/bench/README.md
+++ b/ci/bench/README.md
@@ -64,7 +64,7 @@ Python benchmarks live under `python/cuda_cccl/benchmarks/` and use `cuda.bench`
 For CUB-only comparisons, the caller's Python environment must provide the NVBench compare dependencies:
 
 ```bash
-python3 -m pip install 'cuda-bench[compare]'
+python3 -m pip install 'cuda-bench[compare]>=0.3.0'
 ```
 
 For Python benchmarks, `compare_paths.sh`:

--- a/ci/bench/README.md
+++ b/ci/bench/README.md
@@ -74,7 +74,7 @@ For Python benchmarks, `compare_paths.sh`:
 1. Creates isolated virtual environments for base and test trees.
 2. Installs `cuda-cccl[bench-cuXX]` (editable, from each worktree), which pulls in `cuda-bench`, `cupy`, and all other benchmark dependencies.
 3. Runs matching benchmark scripts in each venv.
-4. Compares results using `${CCCL_BENCH_COMPARE_BIN}` when set, or `nvbench-compare-robust` from the benchmark venv otherwise.
+4. Compares results using `${CCCL_BENCH_COMPARE_BIN}` when set, or `nvbench-compare-robust` from the benchmark venv otherwise. It emits robust `intervals`, `simple`, and `explain` reports, plus a diagnostic legacy report when `nvbench-compare-legacy` is available.
 
 Python filters are regex patterns matched against relative paths under `python/cuda_cccl/benchmarks/`, for example:
 - `compute/reduce/sum\.py` — single benchmark
@@ -85,6 +85,7 @@ Python filters are regex patterns matched against relative paths under `python/c
 `compare_paths.sh` writes a run directory under `${CCCL_BENCH_ARTIFACT_ROOT:-$(pwd)/bench-artifacts}` containing:
 
 - per-target JSON, binary sidecars, and markdown outputs for base/test runs,
-- grouped build logs (`build.base.log`, `build.test.log`), per-target run logs, and per-target compare logs (`compare.<target>.log`),
+- per-target robust compare reports (`compare/<target>.md`, `compare/<target>.simple.md`, and `compare/<target>.explain.md`) plus diagnostic legacy reports (`compare/<target>.legacy.md`) when available,
+- grouped build logs (`build.base.log`, `build.test.log`), per-target run logs, and per-target compare logs,
 - Python venv setup logs (`py.venv.base.log`, `py.venv.test.log`),
 - `summary.md` with run metadata and per-target collapsible full compare reports.

--- a/ci/bench/README.md
+++ b/ci/bench/README.md
@@ -59,14 +59,20 @@ In `.github/workflows/bench.yml`:
 
 ## Python Benchmarks
 
-Python benchmarks live under `python/cuda_cccl/benchmarks/` and use `cuda.bench` (the Python nvbench bindings). Each benchmark script outputs nvbench-compatible JSON.
+Python benchmarks live under `python/cuda_cccl/benchmarks/` and use `cuda.bench` (the Python nvbench bindings). Each benchmark script outputs nvbench-compatible JSON with binary sidecars for bulk sample data.
+
+For CUB-only comparisons, the caller's Python environment must provide the NVBench compare dependencies:
+
+```bash
+python3 -m pip install 'cuda-bench[compare]'
+```
 
 For Python benchmarks, `compare_paths.sh`:
 
 1. Creates isolated virtual environments for base and test trees.
 2. Installs `cuda-cccl[bench-cuXX]` (editable, from each worktree), which pulls in `cuda-bench`, `cupy`, and all other benchmark dependencies.
 3. Runs matching benchmark scripts in each venv.
-4. Compares results using `nvbench-compare` (installed with `cuda-bench`).
+4. Compares results using `nvbench-compare-robust` (installed with `cuda-bench`).
 
 Python filters are regex patterns matched against relative paths under `python/cuda_cccl/benchmarks/`, for example:
 - `compute/reduce/sum\.py` — single benchmark
@@ -76,7 +82,7 @@ Python filters are regex patterns matched against relative paths under `python/c
 
 `compare_paths.sh` writes a run directory under `${CCCL_BENCH_ARTIFACT_ROOT:-$(pwd)/bench-artifacts}` containing:
 
-- per-target JSON and markdown outputs for base/test runs,
+- per-target JSON, binary sidecars, and markdown outputs for base/test runs,
 - grouped build logs (`build.base.log`, `build.test.log`), per-target run logs, and per-target compare logs (`compare.<target>.log`),
 - Python venv setup logs (`py.venv.base.log`, `py.venv.test.log`),
 - `summary.md` with run metadata and per-target collapsible full compare reports.

--- a/ci/bench/README.md
+++ b/ci/bench/README.md
@@ -55,6 +55,8 @@ In `.github/workflows/bench.yml`:
 - If `raw_args` is non-empty, it is parsed and passed directly to `ci/bench/bench.sh`.
 - Otherwise, args are assembled from `base_ref`, `test_ref`, `arch`, `cub_filters`, `python_filters`, `nvbench_args`, and `nvbench_compare_args`.
 - CUB filters are passed as `--cub-filter` flags. Python filters are passed as `--python-filter` flags.
+- The workflow resolves NVBench `main` once before requesting AWS credentials and passes the resulting SHA to generated CUB build trees.
+- The workflow passes AWS credentials into the benchmark container for possible CUB builds, then asks `compare_paths.sh` to clear AWS/sccache credential state before benchmark execution, comparison, and Python environment setup.
 - Malformed quoted input (for example unmatched quotes) fails the workflow step.
 
 ## Python Benchmarks
@@ -72,7 +74,7 @@ For Python benchmarks, `compare_paths.sh`:
 1. Creates isolated virtual environments for base and test trees.
 2. Installs `cuda-cccl[bench-cuXX]` (editable, from each worktree), which pulls in `cuda-bench`, `cupy`, and all other benchmark dependencies.
 3. Runs matching benchmark scripts in each venv.
-4. Compares results using `nvbench-compare-robust` (installed with `cuda-bench`).
+4. Compares results using `${CCCL_BENCH_COMPARE_BIN}` when set, or `nvbench-compare-robust` from the benchmark venv otherwise.
 
 Python filters are regex patterns matched against relative paths under `python/cuda_cccl/benchmarks/`, for example:
 - `compute/reduce/sum\.py` — single benchmark

--- a/ci/bench/README.md
+++ b/ci/bench/README.md
@@ -56,8 +56,7 @@ In `.github/workflows/bench.yml`:
 - Otherwise, args are assembled from `base_ref`, `test_ref`, `arch`, `cub_filters`, `python_filters`, `nvbench_args`, `nvbench_compare_args`, and `nvbench_compare_legacy_args`.
 - `nvbench_compare_args` are passed to `nvbench-compare-robust`; `nvbench_compare_legacy_args` are passed to diagnostic `nvbench-compare-legacy` runs.
 - CUB filters are passed as `--cub-filter` flags. Python filters are passed as `--python-filter` flags.
-- The workflow resolves NVBench `main` once before requesting AWS credentials and passes the resulting SHA to generated CUB build trees.
-- The workflow passes AWS credentials into the benchmark container for possible CUB builds, then asks `compare_paths.sh` to clear AWS/sccache credential state before benchmark execution, comparison, and Python environment setup.
+- The workflow resolves NVBench `main` once and passes the resulting SHA to generated CUB build trees.
 - Malformed quoted input (for example unmatched quotes) fails the workflow step.
 
 ## Python Benchmarks

--- a/ci/bench/README.md
+++ b/ci/bench/README.md
@@ -53,7 +53,8 @@ Compare already checked-out trees:
 In `.github/workflows/bench.yml`:
 
 - If `raw_args` is non-empty, it is parsed and passed directly to `ci/bench/bench.sh`.
-- Otherwise, args are assembled from `base_ref`, `test_ref`, `arch`, `cub_filters`, `python_filters`, `nvbench_args`, and `nvbench_compare_args`.
+- Otherwise, args are assembled from `base_ref`, `test_ref`, `arch`, `cub_filters`, `python_filters`, `nvbench_args`, `nvbench_compare_args`, and `nvbench_compare_legacy_args`.
+- `nvbench_compare_args` are passed to `nvbench-compare-robust`; `nvbench_compare_legacy_args` are passed to diagnostic `nvbench-compare-legacy` runs.
 - CUB filters are passed as `--cub-filter` flags. Python filters are passed as `--python-filter` flags.
 - The workflow resolves NVBench `main` once before requesting AWS credentials and passes the resulting SHA to generated CUB build trees.
 - The workflow passes AWS credentials into the benchmark container for possible CUB builds, then asks `compare_paths.sh` to clear AWS/sccache credential state before benchmark execution, comparison, and Python environment setup.

--- a/ci/bench/README.md
+++ b/ci/bench/README.md
@@ -88,4 +88,4 @@ Python filters are regex patterns matched against relative paths under `python/c
 - per-target robust compare reports (`compare/<target>.md`, `compare/<target>.simple.md`, and `compare/<target>.explain.md`) plus diagnostic legacy reports (`compare/<target>.legacy.md`) when available,
 - grouped build logs (`build.base.log`, `build.test.log`), per-target run logs, and per-target compare logs,
 - Python venv setup logs (`py.venv.base.log`, `py.venv.test.log`),
-- `summary.md` with run metadata and per-target collapsible full compare reports.
+- `summary.md` with run metadata, per-target robust comparison summaries, and collapsible full compare reports.

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -16,7 +16,8 @@ Usage: $0 <base-path> <test-path> \
   [--python-filter "<regex>"] \
   [--arch "<arch>"] \
   [--nvbench-args "<args>"] \
-  [--nvbench-compare-args "<args>"]
+  [--nvbench-compare-args "<args>"] \
+  [--nvbench-compare-legacy-args "<args>"]
 
 Compare benchmark performance between two checked-out CCCL trees.
 
@@ -35,6 +36,8 @@ Options:
   --arch <arch>             CMAKE_CUDA_ARCHITECTURES for CUB builds.
   --nvbench-args <args>     Extra args passed to benchmark binaries/scripts.
   --nvbench-compare-args <args>  Extra args passed to nvbench-compare-robust.
+  --nvbench-compare-legacy-args <args>
+                             Extra args passed to nvbench-compare-legacy.
 
 Environment:
   CCCL_BENCH_ARTIFACT_ROOT   Root directory for outputs.
@@ -510,7 +513,7 @@ run_python_compare_target() {
     compare_cmd=(
       "${legacy_compare_bin}"
       --no-color
-      "${NVBENCH_COMPARE_ARGS[@]}"
+      "${NVBENCH_COMPARE_LEGACY_ARGS[@]}"
       "${base_json}"
       "${test_json}"
     )
@@ -905,7 +908,7 @@ run_compare_target() {
       "${compare_python}"
       "${legacy_compare_script}"
       --no-color
-      "${NVBENCH_COMPARE_ARGS[@]}"
+      "${NVBENCH_COMPARE_LEGACY_ARGS[@]}"
       "${base_json}"
       "${test_json}"
     )
@@ -1032,9 +1035,14 @@ write_summary() {
       echo "- NVBench args: not specified"
     fi
     if [[ -n "${NVBENCH_COMPARE_ARGS_STRING}" ]]; then
-      echo "- NVBench compare args: \`${NVBENCH_COMPARE_ARGS_STRING}\`"
+      echo "- NVBench robust compare args: \`${NVBENCH_COMPARE_ARGS_STRING}\`"
     else
-      echo "- NVBench compare args: not specified"
+      echo "- NVBench robust compare args: not specified"
+    fi
+    if [[ -n "${NVBENCH_COMPARE_LEGACY_ARGS_STRING}" ]]; then
+      echo "- NVBench legacy compare args: \`${NVBENCH_COMPARE_LEGACY_ARGS_STRING}\`"
+    else
+      echo "- NVBench legacy compare args: not specified"
     fi
     echo
 
@@ -1113,6 +1121,7 @@ parse_cli_args() {
 
   NVBENCH_ARGS_STRING=""
   NVBENCH_COMPARE_ARGS_STRING=""
+  NVBENCH_COMPARE_LEGACY_ARGS_STRING=""
   TARGET_ARCH=""
   FILTERS=()
   PYTHON_FILTERS=()
@@ -1137,6 +1146,13 @@ parse_cli_args() {
           die "Missing value for --nvbench-compare-args"
         fi
         NVBENCH_COMPARE_ARGS_STRING="$2"
+        shift 2
+        ;;
+      --nvbench-compare-legacy-args)
+        if [[ "$#" -lt 2 ]]; then
+          die "Missing value for --nvbench-compare-legacy-args"
+        fi
+        NVBENCH_COMPARE_LEGACY_ARGS_STRING="$2"
         shift 2
         ;;
       --cub-filter)
@@ -1168,11 +1184,17 @@ parse_cli_args "$@"
 
 declare -a NVBENCH_RUN_ARGS
 declare -a NVBENCH_COMPARE_ARGS
+declare -a NVBENCH_COMPARE_LEGACY_ARGS
 readonly -a COMPARE_DISPLAYS=(intervals simple explain)
 parse_quoted_args_to_array NVBENCH_RUN_ARGS "${NVBENCH_ARGS_STRING}" "--nvbench-args" \
   || die "Failed to parse --nvbench-args."
 parse_quoted_args_to_array NVBENCH_COMPARE_ARGS "${NVBENCH_COMPARE_ARGS_STRING}" "--nvbench-compare-args" \
   || die "Failed to parse --nvbench-compare-args."
+parse_quoted_args_to_array \
+  NVBENCH_COMPARE_LEGACY_ARGS \
+  "${NVBENCH_COMPARE_LEGACY_ARGS_STRING}" \
+  "--nvbench-compare-legacy-args" \
+  || die "Failed to parse --nvbench-compare-legacy-args."
 
 validate_repo_path "${BASE_PATH}"
 validate_repo_path "${TEST_PATH}"
@@ -1239,8 +1261,14 @@ if [[ "${#NVBENCH_RUN_ARGS[@]}" -gt 0 ]]; then
   done
 fi
 if [[ "${#NVBENCH_COMPARE_ARGS[@]}" -gt 0 ]]; then
-  echo "Extra compare args:"
+  echo "Extra robust compare args:"
   for arg in "${NVBENCH_COMPARE_ARGS[@]}"; do
+    echo "  - ${arg}"
+  done
+fi
+if [[ "${#NVBENCH_COMPARE_LEGACY_ARGS[@]}" -gt 0 ]]; then
+  echo "Extra legacy compare args:"
+  for arg in "${NVBENCH_COMPARE_LEGACY_ARGS[@]}"; do
     echo "  - ${arg}"
   done
 fi

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -397,9 +397,7 @@ setup_python_venv() {
       python3 -m venv '${venv_path}'
       '${venv_path}/bin/pip' install --upgrade pip
       '${venv_path}/bin/pip' install -e '${cuda_cccl_dir}[bench-cu${cuda_major}]'
-      if [[ -z \"\${CCCL_BENCH_COMPARE_BIN:-}\" ]]; then
-        '${venv_path}/bin/pip' install 'cuda-bench[compare]>=0.3.0'
-      fi
+      '${venv_path}/bin/pip' install 'cuda-bench[compare]>=0.3.0'
     "
   )
 

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -1025,6 +1025,19 @@ write_summary() {
       echo
     fi
 
+    echo "## Benchmark Arguments"
+    if [[ -n "${NVBENCH_ARGS_STRING}" ]]; then
+      echo "- NVBench args: \`${NVBENCH_ARGS_STRING}\`"
+    else
+      echo "- NVBench args: not specified"
+    fi
+    if [[ -n "${NVBENCH_COMPARE_ARGS_STRING}" ]]; then
+      echo "- NVBench compare args: \`${NVBENCH_COMPARE_ARGS_STRING}\`"
+    else
+      echo "- NVBench compare args: not specified"
+    fi
+    echo
+
     if [[ "${#PYTHON_FILTERS[@]}" -gt 0 ]]; then
       echo "## Python Filters"
       for filter in "${PYTHON_FILTERS[@]}"; do

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -52,6 +52,9 @@ Environment:
                              comparisons.
   CCCL_BENCH_COMPARE_BIN     Optional nvbench-compare-robust executable used for
                              Python benchmark comparisons.
+  CCCL_BENCH_LEGACY_COMPARE_BIN
+                             Optional nvbench-compare-legacy executable used for
+                             Python benchmark comparisons.
   CCCL_BENCH_DROP_AWS_CREDENTIALS
                              If set to 1/ON/TRUE/YES, drop AWS and sccache
                              credentials after CUB builds and before benchmark
@@ -194,6 +197,22 @@ resolve_compare_script() {
   for candidate in \
     "${nvbench_src}/python/scripts/nvbench_compare_robust.py" \
     "${nvbench_src}/scripts/nvbench_compare_robust.py"; do
+    if [[ -f "${candidate}" ]]; then
+      printf "%s" "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+resolve_legacy_compare_script() {
+  local build_path="$1"
+  local nvbench_src="${build_path}/_deps/nvbench-src"
+  local candidate=""
+  # Different versions have the script at different locations:
+  for candidate in \
+    "${nvbench_src}/python/scripts/nvbench_compare.py" \
+    "${nvbench_src}/scripts/nvbench_compare.py"; do
     if [[ -f "${candidate}" ]]; then
       printf "%s" "${candidate}"
       return 0
@@ -416,41 +435,88 @@ run_python_target_for_side() {
     "${bench_cmd[@]}"
 }
 
+resolve_legacy_compare_bin() {
+  local venv_path="$1"
+  local compare_bin="$2"
+  local candidate=""
+
+  if [[ -n "${CCCL_BENCH_LEGACY_COMPARE_BIN:-}" ]]; then
+    printf "%s" "${CCCL_BENCH_LEGACY_COMPARE_BIN}"
+    return 0
+  fi
+
+  if [[ "${compare_bin}" == */* ]]; then
+    candidate="$(dirname "${compare_bin}")/nvbench-compare-legacy"
+    if [[ -x "${candidate}" ]]; then
+      printf "%s" "${candidate}"
+      return 0
+    fi
+  fi
+
+  candidate="${venv_path}/bin/nvbench-compare-legacy"
+  if [[ -x "${candidate}" ]]; then
+    printf "%s" "${candidate}"
+    return 0
+  fi
+
+  command -v nvbench-compare-legacy 2>/dev/null || return 1
+}
+
 run_python_compare_target() {
   local target_name="$1"
   local venv_path="$2"
   local base_json="$3"
   local test_json="$4"
-  local compare_out="$5"
-  local compare_log="$6"
 
-  local label="[py-compare] ${target_name}"
-  local started_at=0
-  local elapsed_s=0
-  local rc=0
   local compare_bin="${CCCL_BENCH_COMPARE_BIN:-${venv_path}/bin/nvbench-compare-robust}"
+  local legacy_compare_bin=""
+  local display=""
+  local compare_out=""
+  local compare_log=""
+  local robust_rc=0
   local -a compare_cmd
-  compare_cmd=("${compare_bin}" --no-color "${NVBENCH_COMPARE_ARGS[@]}" "${base_json}" "${test_json}")
 
-  : > "${compare_log}"
-  echo "::group::${label}"
-  print_shell_command "${compare_cmd[@]}"
-  started_at="${SECONDS}"
-  if "${compare_cmd[@]}" \
-    > >(tee "${compare_out}" | tee -a "${compare_log}") \
-    2> >(tee -a "${compare_log}" >&2); then
-    rc=0
-  else
-    rc=$?
+  for display in intervals simple explain; do
+    compare_out="$(compare_report_path_for_display "${target_name}" "${display}")"
+    compare_log="$(compare_log_path_for_display "${target_name}" "${display}")"
+    compare_cmd=(
+      "${compare_bin}"
+      --no-color
+      "${NVBENCH_COMPARE_ARGS[@]}"
+      --display
+      "${display}"
+      "${base_json}"
+      "${test_json}"
+    )
+
+    if ! run_compare_command \
+      "[py-compare:${display}] ${target_name}" \
+      "${compare_out}" \
+      "${compare_log}" \
+      "${compare_cmd[@]}"; then
+      robust_rc=1
+    fi
+  done
+
+  legacy_compare_bin="$(resolve_legacy_compare_bin "${venv_path}" "${compare_bin}" || true)"
+  if [[ -n "${legacy_compare_bin}" ]]; then
+    compare_cmd=(
+      "${legacy_compare_bin}"
+      --no-color
+      "${NVBENCH_COMPARE_ARGS[@]}"
+      "${base_json}"
+      "${test_json}"
+    )
+    if ! run_compare_command \
+      "[py-compare:legacy] ${target_name}" \
+      "${artifact_dir}/compare/${target_name}.legacy.md" \
+      "${artifact_dir}/logs/compare.${target_name}.legacy.log" \
+      "${compare_cmd[@]}"; then
+      echo "Legacy compare output is diagnostic; continuing after legacy compare failure." >&2
+    fi
   fi
-  elapsed_s=$((SECONDS - started_at))
-  echo "::endgroup::"
-  if [[ "${rc}" -eq 0 ]]; then
-    echo "${label} completed in ${elapsed_s}s"
-  else
-    echo "${label} failed in ${elapsed_s}s (rc=${rc})"
-  fi
-  return "${rc}"
+
+  return "${robust_rc}"
 }
 
 # ============================================================================
@@ -479,6 +545,106 @@ run_grouped_logged_command() {
     rc="${pipe_statuses[1]}"
   fi
   elapsed_s=$((SECONDS - started_at))
+  echo "::endgroup::"
+  if [[ "${rc}" -eq 0 ]]; then
+    echo "${label} completed in ${elapsed_s}s"
+  else
+    echo "${label} failed in ${elapsed_s}s (rc=${rc})"
+  fi
+  return "${rc}"
+}
+
+compare_report_path_for_display() {
+  local target_name="$1"
+  local display="$2"
+
+  if [[ "${display}" == "intervals" ]]; then
+    printf "%s" "${artifact_dir}/compare/${target_name}.md"
+  else
+    printf "%s" "${artifact_dir}/compare/${target_name}.${display}.md"
+  fi
+}
+
+compare_log_path_for_display() {
+  local target_name="$1"
+  local display="$2"
+
+  if [[ "${display}" == "intervals" ]]; then
+    printf "%s" "${artifact_dir}/logs/compare.${target_name}.log"
+  else
+    printf "%s" "${artifact_dir}/logs/compare.${target_name}.${display}.log"
+  fi
+}
+
+run_compare_command() {
+  local label="$1"
+  local compare_out="$2"
+  local compare_log="$3"
+  shift 3
+
+  local started_at=0
+  local elapsed_s=0
+  local rc=0
+
+  : > "${compare_out}"
+  : > "${compare_log}"
+  echo "::group::${label}"
+  print_shell_command "$@"
+  started_at="${SECONDS}"
+  if "$@" \
+    > >(tee "${compare_out}" | tee -a "${compare_log}") \
+    2> >(tee -a "${compare_log}" >&2); then
+    rc=0
+  else
+    rc=$?
+  fi
+  elapsed_s=$((SECONDS - started_at))
+  if [[ "${rc}" -ne 0 && ! -s "${compare_out}" ]]; then
+    printf "_Compare command failed with rc=%s; see \`%s\` for stderr/log output._\n" \
+      "${rc}" \
+      "${compare_log#"${artifact_dir}"/}" \
+      > "${compare_out}"
+  fi
+  echo "::endgroup::"
+  if [[ "${rc}" -eq 0 ]]; then
+    echo "${label} completed in ${elapsed_s}s"
+  else
+    echo "${label} failed in ${elapsed_s}s (rc=${rc})"
+  fi
+  return "${rc}"
+}
+
+run_compare_command_with_pythonpath() {
+  local label="$1"
+  local compare_pythonpath="$2"
+  local compare_out="$3"
+  local compare_log="$4"
+  shift 4
+
+  local started_at=0
+  local elapsed_s=0
+  local rc=0
+
+  : > "${compare_out}"
+  : > "${compare_log}"
+  echo "::group::${label}"
+  print_shell_command --env "PYTHONPATH=${compare_pythonpath}" "$@"
+  started_at="${SECONDS}"
+  if PYTHONPATH="${compare_pythonpath}" \
+    "$@" \
+    > >(tee "${compare_out}" | tee -a "${compare_log}") \
+    2> >(tee -a "${compare_log}" >&2); then
+    rc=0
+  else
+    rc=$?
+  fi
+  elapsed_s=$((SECONDS - started_at))
+  if [[ "${rc}" -ne 0 && ! -s "${compare_out}" ]]; then
+    printf "_Compare command failed with rc=%s; see \`%s\` for stderr/log output._\n" \
+      "${rc}" \
+      "${compare_log#"${artifact_dir}"/}" \
+      > "${compare_out}"
+  fi
   echo "::endgroup::"
   if [[ "${rc}" -eq 0 ]]; then
     echo "${label} completed in ${elapsed_s}s"
@@ -538,38 +704,62 @@ run_compare_target() {
   local compare_script_dir="$3"
   local base_json="$4"
   local test_json="$5"
-  local compare_out="$6"
-  local compare_log="$7"
+  local legacy_compare_script="$6"
+  local legacy_compare_script_dir="$7"
 
-  local label="[compare] ${target}"
-  local started_at=0
-  local elapsed_s=0
-  local rc=0
   local compare_pythonpath="${compare_script_dir}${PYTHONPATH:+:${PYTHONPATH}}"
   local compare_python="${CCCL_BENCH_COMPARE_PYTHON:-python3}"
+  local display=""
+  local compare_out=""
+  local compare_log=""
+  local robust_rc=0
   local -a compare_cmd
-  compare_cmd=("${compare_python}" "${compare_script}" --no-color "${NVBENCH_COMPARE_ARGS[@]}" "${base_json}" "${test_json}")
 
-  : > "${compare_log}"
-  echo "::group::${label}"
-  print_shell_command --env "PYTHONPATH=${compare_pythonpath}" "${compare_cmd[@]}"
-  started_at="${SECONDS}"
-  if PYTHONPATH="${compare_pythonpath}" \
-    "${compare_cmd[@]}" \
-    > >(tee "${compare_out}" | tee -a "${compare_log}") \
-    2> >(tee -a "${compare_log}" >&2); then
-    rc=0
-  else
-    rc=$?
+  for display in intervals simple explain; do
+    compare_out="$(compare_report_path_for_display "${target}" "${display}")"
+    compare_log="$(compare_log_path_for_display "${target}" "${display}")"
+    compare_cmd=(
+      "${compare_python}"
+      "${compare_script}"
+      --no-color
+      "${NVBENCH_COMPARE_ARGS[@]}"
+      --display
+      "${display}"
+      "${base_json}"
+      "${test_json}"
+    )
+
+    if ! run_compare_command_with_pythonpath \
+      "[compare:${display}] ${target}" \
+      "${compare_pythonpath}" \
+      "${compare_out}" \
+      "${compare_log}" \
+      "${compare_cmd[@]}"; then
+      robust_rc=1
+    fi
+  done
+
+  if [[ -n "${legacy_compare_script}" ]]; then
+    compare_pythonpath="${legacy_compare_script_dir}${PYTHONPATH:+:${PYTHONPATH}}"
+    compare_cmd=(
+      "${compare_python}"
+      "${legacy_compare_script}"
+      --no-color
+      "${NVBENCH_COMPARE_ARGS[@]}"
+      "${base_json}"
+      "${test_json}"
+    )
+    if ! run_compare_command_with_pythonpath \
+      "[compare:legacy] ${target}" \
+      "${compare_pythonpath}" \
+      "${artifact_dir}/compare/${target}.legacy.md" \
+      "${artifact_dir}/logs/compare.${target}.legacy.log" \
+      "${compare_cmd[@]}"; then
+      echo "Legacy compare output is diagnostic; continuing after legacy compare failure." >&2
+    fi
   fi
-  elapsed_s=$((SECONDS - started_at))
-  echo "::endgroup::"
-  if [[ "${rc}" -eq 0 ]]; then
-    echo "${label} completed in ${elapsed_s}s"
-  else
-    echo "${label} failed in ${elapsed_s}s (rc=${rc})"
-  fi
-  return "${rc}"
+
+  return "${robust_rc}"
 }
 
 parse_quoted_args_to_nul_file() {
@@ -619,10 +809,28 @@ parse_quoted_args_to_array() {
 # Summary
 # ============================================================================
 
+write_compare_report_details() {
+  local summary="$1"
+  local compare_report_file="$2"
+
+  if [[ ! -f "${compare_report_file}" ]]; then
+    return 1
+  fi
+
+  echo
+  echo "<details><summary>${summary}</summary>"
+  echo
+  cat "${compare_report_file}"
+  echo
+  echo "</details>"
+  return 0
+}
+
 write_summary() {
   local summary_file="$1"
   local target=""
   local compare_report_file=""
+  local display=""
   local reports_emitted=0
 
   {
@@ -668,19 +876,18 @@ write_summary() {
     if [[ "${#selected_targets[@]}" -gt 0 ]]; then
       echo "## CUB Compare Reports"
       for target in "${selected_targets[@]}"; do
-        compare_report_file="${artifact_dir}/compare/${target}.md"
-        if [[ ! -f "${compare_report_file}" ]]; then
-          continue
-        fi
-        reports_emitted=$((reports_emitted + 1))
         echo
         echo "### \`${target}\`"
-        echo
-        echo "<details><summary>Expand full compare output for \`${target}\`</summary>"
-        echo
-        cat "${compare_report_file}"
-        echo
-        echo "</details>"
+        for display in intervals simple explain; do
+          compare_report_file="$(compare_report_path_for_display "${target}" "${display}")"
+          if write_compare_report_details "Robust ${display} output" "${compare_report_file}"; then
+            reports_emitted=$((reports_emitted + 1))
+          fi
+        done
+        compare_report_file="${artifact_dir}/compare/${target}.legacy.md"
+        if write_compare_report_details "Legacy output" "${compare_report_file}"; then
+          reports_emitted=$((reports_emitted + 1))
+        fi
       done
     fi
 
@@ -691,19 +898,18 @@ write_summary() {
       local py_target_name=""
       for py_target_path in "${selected_py_targets[@]}"; do
         py_target_name="$(python_path_to_target_name "${py_target_path}")"
-        compare_report_file="${artifact_dir}/compare/${py_target_name}.md"
-        if [[ ! -f "${compare_report_file}" ]]; then
-          continue
-        fi
-        reports_emitted=$((reports_emitted + 1))
         echo
         echo "### \`${py_target_name}\` (\`${py_target_path}\`)"
-        echo
-        echo "<details><summary>Expand full compare output for \`${py_target_name}\`</summary>"
-        echo
-        cat "${compare_report_file}"
-        echo
-        echo "</details>"
+        for display in intervals simple explain; do
+          compare_report_file="$(compare_report_path_for_display "${py_target_name}" "${display}")"
+          if write_compare_report_details "Robust ${display} output" "${compare_report_file}"; then
+            reports_emitted=$((reports_emitted + 1))
+          fi
+        done
+        compare_report_file="${artifact_dir}/compare/${py_target_name}.legacy.md"
+        if write_compare_report_details "Legacy output" "${compare_report_file}"; then
+          reports_emitted=$((reports_emitted + 1))
+        fi
       done
     fi
 
@@ -919,6 +1125,15 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
   fi
   compare_script_dir="$(dirname "${compare_script}")"
 
+  legacy_compare_script="$(resolve_legacy_compare_script "${test_build_dir}" || true)"
+  if [[ -z "${legacy_compare_script}" ]]; then
+    legacy_compare_script="$(resolve_legacy_compare_script "${base_build_dir}" || true)"
+  fi
+  legacy_compare_script_dir=""
+  if [[ -n "${legacy_compare_script}" ]]; then
+    legacy_compare_script_dir="$(dirname "${legacy_compare_script}")"
+  fi
+
   base_build_all_rc=0
   test_build_all_rc=0
 
@@ -949,8 +1164,6 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
     test_target_run_rc=125
     base_run_log="${artifact_dir}/logs/run.base.${target}.log"
     test_run_log="${artifact_dir}/logs/run.test.${target}.log"
-    compare_report_md="${artifact_dir}/compare/${target}.md"
-    compare_report_log="${artifact_dir}/logs/compare.${target}.log"
 
     base_json="${artifact_dir}/base/${target}.json"
     base_md="${artifact_dir}/base/${target}.md"
@@ -995,8 +1208,8 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
         "${compare_script_dir}" \
         "${base_json}" \
         "${test_json}" \
-        "${compare_report_md}" \
-        "${compare_report_log}"; then
+        "${legacy_compare_script}" \
+        "${legacy_compare_script_dir}"; then
         compares_succeeded=$((compares_succeeded + 1))
       else
         any_failures=1
@@ -1054,8 +1267,6 @@ if [[ "${#PYTHON_FILTERS[@]}" -gt 0 ]]; then
     test_py_md="${artifact_dir}/test/${py_target_name}.md"
     base_py_run_log="${artifact_dir}/logs/run.base.${py_target_name}.log"
     test_py_run_log="${artifact_dir}/logs/run.test.${py_target_name}.log"
-    compare_py_report_md="${artifact_dir}/compare/${py_target_name}.md"
-    compare_py_report_log="${artifact_dir}/logs/compare.${py_target_name}.log"
 
     if run_python_target_for_side \
       "base" \
@@ -1089,9 +1300,7 @@ if [[ "${#PYTHON_FILTERS[@]}" -gt 0 ]]; then
         "${py_target_name}" \
         "${test_py_venv}" \
         "${base_py_json}" \
-        "${test_py_json}" \
-        "${compare_py_report_md}" \
-        "${compare_py_report_log}"; then
+        "${test_py_json}"; then
         py_compares_succeeded=$((py_compares_succeeded + 1))
       else
         any_failures=1

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -496,6 +496,9 @@ run_python_compare_target() {
       "${compare_cmd[@]}"; then
       robust_rc=1
     fi
+    if [[ "${display}" == "explain" ]] && ! normalize_explain_markdown_report "${compare_out}"; then
+      robust_rc=1
+    fi
   done
 
   legacy_compare_bin="$(resolve_legacy_compare_bin "${venv_path}" "${compare_bin}" || true)"
@@ -574,6 +577,148 @@ compare_log_path_for_display() {
   else
     printf "%s" "${artifact_dir}/logs/compare.${target_name}.${display}.log"
   fi
+}
+
+normalize_explain_markdown_report() {
+  local report_path="$1"
+  local tmp_path=""
+
+  [[ -s "${report_path}" ]] || return 0
+
+  tmp_path="$(mktemp "${report_path}.XXXXXX")"
+  if ! awk '
+    function clear_array(values, key) {
+      for (key in values) {
+        delete values[key]
+      }
+    }
+
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+
+    function split_markdown_row(line, cells,    i, c, depth, cell, count) {
+      clear_array(cells)
+      if (substr(line, 1, 1) != "|") {
+        return 0
+      }
+
+      depth = 0
+      cell = ""
+      count = 0
+      for (i = 2; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        if (c == "[") {
+          depth++
+        } else if (c == "]") {
+          if (depth > 0) {
+            depth--
+          }
+        }
+
+        if (c == "|" && depth == 0) {
+          count++
+          cells[count] = cell
+          cell = ""
+        } else {
+          cell = cell c
+        }
+      }
+
+      if (cell != "") {
+        count++
+        cells[count] = cell
+      }
+      return count
+    }
+
+    function replace_interval_pipes(value,    i, c, depth, out) {
+      depth = 0
+      out = ""
+      for (i = 1; i <= length(value); i++) {
+        c = substr(value, i, 1)
+        if (c == "[") {
+          depth++
+          out = out c
+        } else if (c == "]") {
+          if (depth > 0) {
+            depth--
+          }
+          out = out c
+        } else if (c == "|" && depth > 0) {
+          out = out "/"
+        } else {
+          out = out c
+        }
+      }
+      return out
+    }
+
+    function print_markdown_row(cells, count,    i, out) {
+      out = "|"
+      for (i = 1; i <= count; i++) {
+        out = out cells[i] "|"
+      }
+      print out
+    }
+
+    {
+      if (substr($0, 1, 1) != "|") {
+        clear_array(interval_columns)
+        interval_column_count = 0
+        print
+        next
+      }
+
+      cell_count = split_markdown_row($0, cells)
+      if (cell_count == 0) {
+        print
+        next
+      }
+
+      ref_interval_column = cell_count - 6
+      cmp_interval_column = cell_count - 5
+      found_interval_columns = \
+        ref_interval_column > 0 && \
+        trim(cells[ref_interval_column]) == "Ref [Lo | Ce | Hi]" && \
+        trim(cells[cmp_interval_column]) == "Cmp [Lo | Ce | Hi]" && \
+        trim(cells[cell_count - 4]) == "Ref Noise" && \
+        trim(cells[cell_count - 3]) == "Cmp Noise" && \
+        trim(cells[cell_count - 2]) == "Reason" && \
+        trim(cells[cell_count - 1]) == "Change" && \
+        trim(cells[cell_count]) == "Status"
+
+      if (found_interval_columns) {
+        clear_array(interval_columns)
+        interval_columns[ref_interval_column] = 1
+        interval_columns[cmp_interval_column] = 1
+        interval_column_count = 2
+        cells[ref_interval_column] = replace_interval_pipes(cells[ref_interval_column])
+        cells[cmp_interval_column] = replace_interval_pipes(cells[cmp_interval_column])
+        print_markdown_row(cells, cell_count)
+        next
+      }
+
+      if (interval_column_count > 0) {
+        for (i in interval_columns) {
+          if (i <= cell_count) {
+            cells[i] = replace_interval_pipes(cells[i])
+          }
+        }
+        print_markdown_row(cells, cell_count)
+        next
+      }
+
+      print
+    }
+  ' "${report_path}" > "${tmp_path}"; then
+    rm -f "${tmp_path}"
+    return 1
+  fi
+
+  mv "${tmp_path}" "${report_path}"
 }
 
 run_compare_command() {
@@ -735,6 +880,9 @@ run_compare_target() {
       "${compare_out}" \
       "${compare_log}" \
       "${compare_cmd[@]}"; then
+      robust_rc=1
+    fi
+    if [[ "${display}" == "explain" ]] && ! normalize_explain_markdown_report "${compare_out}"; then
       robust_rc=1
     fi
   done

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -46,6 +46,8 @@ Environment:
   CCCL_BENCH_TEST_BUILD_DIR  Optional preconfigured build tree for test path.
                              If either is set, both must be set.
   CCCL_BENCH_GPU_NAME        Optional GPU name included in artifact directory names.
+  CCCL_BENCH_NVBENCH_SHA     NVBench SHA/tag used for generated CUB build trees.
+                             Default: "main"
   CCCL_BENCH_BUILD_ROOT      Root directory for generated build trees.
                              Default: "/tmp/cccl-bench-builds"
 EOF
@@ -128,8 +130,15 @@ configure_build_tree() {
   local side="$3"
   local log_path="$4"
   local target_arch="$5"
+  local nvbench_sha="${CCCL_BENCH_NVBENCH_SHA:-main}"
   local -a cmake_cmd
-  cmake_cmd=(cmake --preset "cub-benchmark" -S "${src_path}" -B "${build_path}")
+  cmake_cmd=(
+    cmake
+    --preset "cub-benchmark"
+    -S "${src_path}"
+    -B "${build_path}"
+    "-DCCCL_NVBENCH_SHA=${nvbench_sha}"
+  )
   if [[ -n "${target_arch}" ]]; then
     cmake_cmd+=("-DCMAKE_CUDA_ARCHITECTURES=${target_arch}")
   fi

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -366,8 +366,7 @@ setup_python_venv() {
       python3 -m venv '${venv_path}'
       '${venv_path}/bin/pip' install --upgrade pip
       '${venv_path}/bin/pip' install -e '${cuda_cccl_dir}[bench-cu${cuda_major}]'
-      # cuda-cccl[bench-cuXX] installs cuda-bench[cuXX], not cuda-bench[compare].
-      '${venv_path}/bin/pip' install colorama jsondiff numpy tabulate
+      '${venv_path}/bin/pip' install 'cuda-bench[compare]>=0.3.0'
     "
   )
 

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -34,7 +34,7 @@ Options:
   --python-filter <regex>   Python benchmark regex filter (repeatable).
   --arch <arch>             CMAKE_CUDA_ARCHITECTURES for CUB builds.
   --nvbench-args <args>     Extra args passed to benchmark binaries/scripts.
-  --nvbench-compare-args <args>  Extra args passed to nvbench_compare.
+  --nvbench-compare-args <args>  Extra args passed to nvbench-compare-robust.
 
 Environment:
   CCCL_BENCH_ARTIFACT_ROOT   Root directory for outputs.
@@ -172,10 +172,10 @@ resolve_compare_script() {
   local build_path="$1"
   local nvbench_src="${build_path}/_deps/nvbench-src"
   local candidate=""
-  # Diff versions have the script at diff locations:
+  # Different versions have the script at different locations:
   for candidate in \
-    "${nvbench_src}/python/scripts/nvbench_compare.py" \
-    "${nvbench_src}/scripts/nvbench_compare.py"; do
+    "${nvbench_src}/python/scripts/nvbench_compare_robust.py" \
+    "${nvbench_src}/scripts/nvbench_compare_robust.py"; do
     if [[ -f "${candidate}" ]]; then
       printf "%s" "${candidate}"
       return 0
@@ -203,7 +203,7 @@ run_target_for_side() {
     "${binary_path}"
     -d 0
     "${NVBENCH_RUN_ARGS[@]}"
-    --json "${json_path}"
+    --jsonbin "${json_path}"
     --md "${md_path}"
   )
 
@@ -357,8 +357,8 @@ setup_python_venv() {
       python3 -m venv '${venv_path}'
       '${venv_path}/bin/pip' install --upgrade pip
       '${venv_path}/bin/pip' install -e '${cuda_cccl_dir}[bench-cu${cuda_major}]'
-      # nvbench-compare runtime deps (until cuda-bench declares them):
-      '${venv_path}/bin/pip' install colorama jsondiff tabulate
+      # cuda-cccl[bench-cuXX] installs cuda-bench[cuXX], not cuda-bench[compare].
+      '${venv_path}/bin/pip' install colorama jsondiff numpy tabulate
     "
   )
 
@@ -387,7 +387,7 @@ run_python_target_for_side() {
     "${script_path}"
     -d 0
     "${NVBENCH_RUN_ARGS[@]}"
-    --json "${json_path}"
+    --jsonbin "${json_path}"
     --md "${md_path}"
   )
 
@@ -410,7 +410,7 @@ run_python_compare_target() {
   local elapsed_s=0
   local rc=0
   local -a compare_cmd
-  compare_cmd=("${venv_path}/bin/nvbench-compare" --no-color "${NVBENCH_COMPARE_ARGS[@]}" "${base_json}" "${test_json}")
+  compare_cmd=("${venv_path}/bin/nvbench-compare-robust" --no-color "${NVBENCH_COMPARE_ARGS[@]}" "${base_json}" "${test_json}")
 
   : > "${compare_log}"
   echo "::group::${label}"
@@ -846,7 +846,7 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
     compare_script="$(resolve_compare_script "${base_build_dir}" || true)"
   fi
   if [[ -z "${compare_script}" ]]; then
-    die "Unable to locate nvbench_compare.py in build dependencies." 1
+    die "Unable to locate nvbench_compare_robust.py in build dependencies." 1
   fi
   compare_script_dir="$(dirname "${compare_script}")"
 

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -48,6 +48,16 @@ Environment:
   CCCL_BENCH_GPU_NAME        Optional GPU name included in artifact directory names.
   CCCL_BENCH_NVBENCH_SHA     NVBench SHA/tag used for generated CUB build trees.
                              Default: "main"
+  CCCL_BENCH_COMPARE_PYTHON  Optional Python executable used for CUB benchmark
+                             comparisons.
+  CCCL_BENCH_COMPARE_BIN     Optional nvbench-compare-robust executable used for
+                             Python benchmark comparisons.
+  CCCL_BENCH_DROP_AWS_CREDENTIALS
+                             If set to 1/ON/TRUE/YES, drop AWS and sccache
+                             credentials after CUB builds and before benchmark
+                             execution, comparison, and Python setup.
+  CCCL_BENCH_AWS_CONFIG_DIR  Optional AWS config directory to clear when
+                             CCCL_BENCH_DROP_AWS_CREDENTIALS is enabled.
   CCCL_BENCH_BUILD_ROOT      Root directory for generated build trees.
                              Default: "/tmp/cccl-bench-builds"
 EOF
@@ -130,7 +140,6 @@ configure_build_tree() {
   local side="$3"
   local log_path="$4"
   local target_arch="$5"
-  local nvbench_sha="${CCCL_BENCH_NVBENCH_SHA:-main}"
   local -a cmake_cmd
   cmake_cmd=(
     cmake
@@ -366,7 +375,9 @@ setup_python_venv() {
       python3 -m venv '${venv_path}'
       '${venv_path}/bin/pip' install --upgrade pip
       '${venv_path}/bin/pip' install -e '${cuda_cccl_dir}[bench-cu${cuda_major}]'
-      '${venv_path}/bin/pip' install 'cuda-bench[compare]>=0.3.0'
+      if [[ -z \"\${CCCL_BENCH_COMPARE_BIN:-}\" ]]; then
+        '${venv_path}/bin/pip' install 'cuda-bench[compare]>=0.3.0'
+      fi
     "
   )
 
@@ -417,8 +428,9 @@ run_python_compare_target() {
   local started_at=0
   local elapsed_s=0
   local rc=0
+  local compare_bin="${CCCL_BENCH_COMPARE_BIN:-${venv_path}/bin/nvbench-compare-robust}"
   local -a compare_cmd
-  compare_cmd=("${venv_path}/bin/nvbench-compare-robust" --no-color "${NVBENCH_COMPARE_ARGS[@]}" "${base_json}" "${test_json}")
+  compare_cmd=("${compare_bin}" --no-color "${NVBENCH_COMPARE_ARGS[@]}" "${base_json}" "${test_json}")
 
   : > "${compare_log}"
   echo "::group::${label}"
@@ -476,6 +488,50 @@ run_grouped_logged_command() {
   return "${rc}"
 }
 
+env_value_is_truthy() {
+  local value="$1"
+  case "${value}" in
+    1 | ON | On | on | TRUE | True | true | YES | Yes | yes)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+drop_aws_credentials_if_requested() {
+  if [[ "${aws_credentials_drop_done}" -ne 0 ]]; then
+    return 0
+  fi
+  aws_credentials_drop_done=1
+
+  if ! env_value_is_truthy "${CCCL_BENCH_DROP_AWS_CREDENTIALS:-}"; then
+    return 0
+  fi
+
+  echo
+  echo "Dropping AWS and sccache credentials before benchmark execution and Python setup."
+
+  if command -v sccache >/dev/null 2>&1; then
+    sccache --stop-server >/dev/null 2>&1 || true
+  fi
+
+  local var_name=""
+  for var_name in ${!AWS_@} ${!SCCACHE_@}; do
+    unset "${var_name}"
+  done
+
+  local aws_config_dir="${CCCL_BENCH_AWS_CONFIG_DIR:-}"
+  if [[ -n "${aws_config_dir}" ]]; then
+    if [[ "${aws_config_dir}" == "/" ]]; then
+      die "Refusing to clear AWS config directory: ${aws_config_dir}" 1
+    fi
+    mkdir -p "${aws_config_dir}"
+    rm -f "${aws_config_dir}/config" "${aws_config_dir}/credentials"
+  fi
+}
+
 run_compare_target() {
   local target="$1"
   local compare_script="$2"
@@ -490,8 +546,9 @@ run_compare_target() {
   local elapsed_s=0
   local rc=0
   local compare_pythonpath="${compare_script_dir}${PYTHONPATH:+:${PYTHONPATH}}"
+  local compare_python="${CCCL_BENCH_COMPARE_PYTHON:-python3}"
   local -a compare_cmd
-  compare_cmd=(python3 "${compare_script}" --no-color "${NVBENCH_COMPARE_ARGS[@]}" "${base_json}" "${test_json}")
+  compare_cmd=("${compare_python}" "${compare_script}" --no-color "${NVBENCH_COMPARE_ARGS[@]}" "${base_json}" "${test_json}")
 
   : > "${compare_log}"
   echo "::group::${label}"
@@ -580,6 +637,7 @@ write_summary() {
     if [[ "${#FILTERS[@]}" -gt 0 ]]; then
       echo "- Base build dir: \`${base_build_dir}\`"
       echo "- Test build dir: \`${test_build_dir}\`"
+      echo "- NVBench SHA/tag: \`${nvbench_sha}\`"
     fi
     echo "- CUB targets selected: ${#selected_targets[@]}"
     echo "- CUB comparisons attempted: ${compares_attempted}"
@@ -758,6 +816,7 @@ artifact_tag="$(sanitize_label "${artifact_tag}")"
 artifact_dir="${artifact_root}/${artifact_tag}"
 
 build_root="${CCCL_BENCH_BUILD_ROOT:-/tmp/cccl-bench-builds}"
+nvbench_sha="${CCCL_BENCH_NVBENCH_SHA:-main}"
 build_token="$(sanitize_label "${test_label}-${timestamp}-${base_label}")"
 base_build_dir="${build_root}/base-${build_token}"
 test_build_dir="${build_root}/test-${build_token}"
@@ -774,6 +833,7 @@ fi
 echo "Base source: ${BASE_PATH}"
 echo "Test source: ${TEST_PATH}"
 if [[ "${#FILTERS[@]}" -gt 0 ]]; then
+  echo "NVBench SHA/tag: ${nvbench_sha}"
   echo "CUB filters:"
   for filter in "${FILTERS[@]}"; do
     echo "  - ${filter}"
@@ -808,6 +868,7 @@ fi
 any_failures=0
 compares_attempted=0
 compares_succeeded=0
+aws_credentials_drop_done=0
 declare -a selected_targets=()
 py_compares_attempted=0
 py_compares_succeeded=0
@@ -880,6 +941,8 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
     test_build_all_rc=$?
     any_failures=1
   fi
+
+  drop_aws_credentials_if_requested
 
   for target in "${selected_targets[@]}"; do
     base_target_run_rc=125
@@ -961,6 +1024,8 @@ if [[ "${#PYTHON_FILTERS[@]}" -gt 0 ]]; then
   if [[ ! -d "${test_py_bench_dir}" ]]; then
     die "Python benchmarks directory not found in test tree: ${test_py_bench_dir}"
   fi
+
+  drop_aws_credentials_if_requested
 
   cuda_major="$(detect_cuda_major_version)"
   echo "Detected CUDA major version: ${cuda_major}"

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -441,8 +441,12 @@ resolve_legacy_compare_bin() {
   local candidate=""
 
   if [[ -n "${CCCL_BENCH_LEGACY_COMPARE_BIN:-}" ]]; then
-    printf "%s" "${CCCL_BENCH_LEGACY_COMPARE_BIN}"
-    return 0
+    if [[ -x "${CCCL_BENCH_LEGACY_COMPARE_BIN}" ]]; then
+      printf "%s" "${CCCL_BENCH_LEGACY_COMPARE_BIN}"
+      return 0
+    fi
+    echo "CCCL_BENCH_LEGACY_COMPARE_BIN is set but not executable: ${CCCL_BENCH_LEGACY_COMPARE_BIN}" >&2
+    return 1
   fi
 
   if [[ "${compare_bin}" == */* ]]; then
@@ -476,7 +480,7 @@ run_python_compare_target() {
   local robust_rc=0
   local -a compare_cmd
 
-  for display in intervals simple explain; do
+  for display in "${COMPARE_DISPLAYS[@]}"; do
     compare_out="$(compare_report_path_for_display "${target_name}" "${display}")"
     compare_log="$(compare_log_path_for_display "${target_name}" "${display}")"
     compare_cmd=(
@@ -860,7 +864,7 @@ run_compare_target() {
   local robust_rc=0
   local -a compare_cmd
 
-  for display in intervals simple explain; do
+  for display in "${COMPARE_DISPLAYS[@]}"; do
     compare_out="$(compare_report_path_for_display "${target}" "${display}")"
     compare_log="$(compare_log_path_for_display "${target}" "${display}")"
     compare_cmd=(
@@ -961,7 +965,7 @@ write_compare_report_details() {
   local summary="$1"
   local compare_report_file="$2"
 
-  if [[ ! -f "${compare_report_file}" ]]; then
+  if [[ ! -s "${compare_report_file}" ]]; then
     return 1
   fi
 
@@ -1026,7 +1030,7 @@ write_summary() {
       for target in "${selected_targets[@]}"; do
         echo
         echo "### \`${target}\`"
-        for display in intervals simple explain; do
+        for display in "${COMPARE_DISPLAYS[@]}"; do
           compare_report_file="$(compare_report_path_for_display "${target}" "${display}")"
           if write_compare_report_details "Robust ${display} output" "${compare_report_file}"; then
             reports_emitted=$((reports_emitted + 1))
@@ -1048,7 +1052,7 @@ write_summary() {
         py_target_name="$(python_path_to_target_name "${py_target_path}")"
         echo
         echo "### \`${py_target_name}\` (\`${py_target_path}\`)"
-        for display in intervals simple explain; do
+        for display in "${COMPARE_DISPLAYS[@]}"; do
           compare_report_file="$(compare_report_path_for_display "${py_target_name}" "${display}")"
           if write_compare_report_details "Robust ${display} output" "${compare_report_file}"; then
             reports_emitted=$((reports_emitted + 1))
@@ -1143,6 +1147,7 @@ parse_cli_args "$@"
 
 declare -a NVBENCH_RUN_ARGS
 declare -a NVBENCH_COMPARE_ARGS
+readonly -a COMPARE_DISPLAYS=(intervals simple explain)
 parse_quoted_args_to_array NVBENCH_RUN_ARGS "${NVBENCH_ARGS_STRING}" "--nvbench-args" \
   || die "Failed to parse --nvbench-args."
 parse_quoted_args_to_array NVBENCH_COMPARE_ARGS "${NVBENCH_COMPARE_ARGS_STRING}" "--nvbench-compare-args" \

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -725,29 +725,58 @@ normalize_explain_markdown_report() {
   mv "${tmp_path}" "${report_path}"
 }
 
-run_compare_command() {
+run_compare_command_impl() {
   local label="$1"
   local compare_out="$2"
   local compare_log="$3"
   shift 3
 
+  local -a env_prefixes=()
+  while [[ "$#" -gt 0 && "$1" == --env ]]; do
+    shift
+    env_prefixes+=("$1")
+    shift
+  done
+
   local started_at=0
   local elapsed_s=0
   local rc=0
+  local stderr_tmp=""
+  stderr_tmp="$(mktemp "${compare_log}.stderr.XXXXXX")"
 
   : > "${compare_out}"
   : > "${compare_log}"
   echo "::group::${label}"
-  print_shell_command "$@"
+
+  local -a print_env_args=()
+  local env_prefix=""
+  for env_prefix in "${env_prefixes[@]}"; do
+    print_env_args+=(--env "${env_prefix}")
+  done
+  print_shell_command "${print_env_args[@]}" "$@"
+
   started_at="${SECONDS}"
-  if "$@" \
-    > >(tee "${compare_out}" | tee -a "${compare_log}") \
-    2> >(tee -a "${compare_log}" >&2); then
+  if [[ "${#env_prefixes[@]}" -gt 0 ]]; then
+    if env "${env_prefixes[@]}" "$@" > "${compare_out}" 2> "${stderr_tmp}"; then
+      rc=0
+    else
+      rc=$?
+    fi
+  elif "$@" > "${compare_out}" 2> "${stderr_tmp}"; then
     rc=0
   else
     rc=$?
   fi
   elapsed_s=$((SECONDS - started_at))
+  if [[ -s "${compare_out}" ]]; then
+    cat "${compare_out}"
+    cat "${compare_out}" >> "${compare_log}"
+  fi
+  if [[ -s "${stderr_tmp}" ]]; then
+    cat "${stderr_tmp}" >&2
+    cat "${stderr_tmp}" >> "${compare_log}"
+  fi
+  rm -f "${stderr_tmp}"
   if [[ "${rc}" -ne 0 && ! -s "${compare_out}" ]]; then
     printf "_Compare command failed with rc=%s; see \`%s\` for stderr/log output._\n" \
       "${rc}" \
@@ -763,6 +792,10 @@ run_compare_command() {
   return "${rc}"
 }
 
+run_compare_command() {
+  run_compare_command_impl "$@"
+}
+
 run_compare_command_with_pythonpath() {
   local label="$1"
   local compare_pythonpath="$2"
@@ -770,37 +803,12 @@ run_compare_command_with_pythonpath() {
   local compare_log="$4"
   shift 4
 
-  local started_at=0
-  local elapsed_s=0
-  local rc=0
-
-  : > "${compare_out}"
-  : > "${compare_log}"
-  echo "::group::${label}"
-  print_shell_command --env "PYTHONPATH=${compare_pythonpath}" "$@"
-  started_at="${SECONDS}"
-  if PYTHONPATH="${compare_pythonpath}" \
-    "$@" \
-    > >(tee "${compare_out}" | tee -a "${compare_log}") \
-    2> >(tee -a "${compare_log}" >&2); then
-    rc=0
-  else
-    rc=$?
-  fi
-  elapsed_s=$((SECONDS - started_at))
-  if [[ "${rc}" -ne 0 && ! -s "${compare_out}" ]]; then
-    printf "_Compare command failed with rc=%s; see \`%s\` for stderr/log output._\n" \
-      "${rc}" \
-      "${compare_log#"${artifact_dir}"/}" \
-      > "${compare_out}"
-  fi
-  echo "::endgroup::"
-  if [[ "${rc}" -eq 0 ]]; then
-    echo "${label} completed in ${elapsed_s}s"
-  else
-    echo "${label} failed in ${elapsed_s}s (rc=${rc})"
-  fi
-  return "${rc}"
+  run_compare_command_impl \
+    "${label}" \
+    "${compare_out}" \
+    "${compare_log}" \
+    --env "PYTHONPATH=${compare_pythonpath}" \
+    "$@"
 }
 
 env_value_is_truthy() {

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -58,12 +58,6 @@ Environment:
   CCCL_BENCH_LEGACY_COMPARE_BIN
                              Optional nvbench-compare-legacy executable used for
                              Python benchmark comparisons.
-  CCCL_BENCH_DROP_AWS_CREDENTIALS
-                             If set to 1/ON/TRUE/YES, drop AWS and sccache
-                             credentials after CUB builds and before benchmark
-                             execution, comparison, and Python setup.
-  CCCL_BENCH_AWS_CONFIG_DIR  Optional AWS config directory to clear when
-                             CCCL_BENCH_DROP_AWS_CREDENTIALS is enabled.
   CCCL_BENCH_BUILD_ROOT      Root directory for generated build trees.
                              Default: "/tmp/cccl-bench-builds"
 EOF
@@ -812,50 +806,6 @@ run_compare_command_with_pythonpath() {
     "$@"
 }
 
-env_value_is_truthy() {
-  local value="$1"
-  case "${value}" in
-    1 | ON | On | on | TRUE | True | true | YES | Yes | yes)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
-drop_aws_credentials_if_requested() {
-  if [[ "${aws_credentials_drop_done}" -ne 0 ]]; then
-    return 0
-  fi
-  aws_credentials_drop_done=1
-
-  if ! env_value_is_truthy "${CCCL_BENCH_DROP_AWS_CREDENTIALS:-}"; then
-    return 0
-  fi
-
-  echo
-  echo "Dropping AWS and sccache credentials before benchmark execution and Python setup."
-
-  if command -v sccache >/dev/null 2>&1; then
-    sccache --stop-server >/dev/null 2>&1 || true
-  fi
-
-  local var_name=""
-  for var_name in ${!AWS_@} ${!SCCACHE_@}; do
-    unset "${var_name}"
-  done
-
-  local aws_config_dir="${CCCL_BENCH_AWS_CONFIG_DIR:-}"
-  if [[ -n "${aws_config_dir}" ]]; then
-    if [[ "${aws_config_dir}" == "/" ]]; then
-      die "Refusing to clear AWS config directory: ${aws_config_dir}" 1
-    fi
-    mkdir -p "${aws_config_dir}"
-    rm -f "${aws_config_dir}/config" "${aws_config_dir}/credentials"
-  fi
-}
-
 run_compare_target() {
   local target="$1"
   local compare_script="$2"
@@ -1274,7 +1224,6 @@ fi
 any_failures=0
 compares_attempted=0
 compares_succeeded=0
-aws_credentials_drop_done=0
 declare -a selected_targets=()
 py_compares_attempted=0
 py_compares_succeeded=0
@@ -1357,8 +1306,6 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
     any_failures=1
   fi
 
-  drop_aws_credentials_if_requested
-
   for target in "${selected_targets[@]}"; do
     base_target_run_rc=125
     test_target_run_rc=125
@@ -1437,8 +1384,6 @@ if [[ "${#PYTHON_FILTERS[@]}" -gt 0 ]]; then
   if [[ ! -d "${test_py_bench_dir}" ]]; then
     die "Python benchmarks directory not found in test tree: ${test_py_bench_dir}"
   fi
-
-  drop_aws_credentials_if_requested
 
   cuda_major="$(detect_cuda_major_version)"
   echo "Detected CUDA major version: ${cuda_major}"

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -937,6 +937,42 @@ write_compare_report_details() {
   return 0
 }
 
+write_robust_summary_excerpt() {
+  local compare_report_file="$1"
+
+  if [[ ! -s "${compare_report_file}" ]]; then
+    return 1
+  fi
+
+  awk '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+
+    {
+      if (!printing && trim($0) == "# Summary") {
+        print "**Robust comparison summary**"
+        print ""
+        printing = 1
+        skip_leading_blanks = 1
+        emitted = 1
+        next
+      }
+      if (printing) {
+        if (skip_leading_blanks && trim($0) == "") {
+          next
+        }
+        skip_leading_blanks = 0
+        print
+      }
+    }
+
+    END { exit emitted ? 0 : 1 }
+  ' "${compare_report_file}"
+}
+
 write_summary() {
   local summary_file="$1"
   local target=""
@@ -1007,6 +1043,8 @@ write_summary() {
       for target in "${selected_targets[@]}"; do
         echo
         echo "### \`${target}\`"
+        compare_report_file="$(compare_report_path_for_display "${target}" "intervals")"
+        write_robust_summary_excerpt "${compare_report_file}" || true
         for display in "${COMPARE_DISPLAYS[@]}"; do
           compare_report_file="$(compare_report_path_for_display "${target}" "${display}")"
           if write_compare_report_details "Robust ${display} output" "${compare_report_file}"; then
@@ -1029,6 +1067,8 @@ write_summary() {
         py_target_name="$(python_path_to_target_name "${py_target_path}")"
         echo
         echo "### \`${py_target_name}\` (\`${py_target_path}\`)"
+        compare_report_file="$(compare_report_path_for_display "${py_target_name}" "intervals")"
+        write_robust_summary_excerpt "${compare_report_file}" || true
         for display in "${COMPARE_DISPLAYS[@]}"; do
           compare_report_file="$(compare_report_path_for_display "${py_target_name}" "${display}")"
           if write_compare_report_details "Robust ${display} output" "${compare_report_file}"; then

--- a/ci/bench/parse_bench_matrix.sh
+++ b/ci/bench/parse_bench_matrix.sh
@@ -74,7 +74,8 @@ jq -cn \
           "cub_filters": $cub_filters,
           "python_filters": $python_filters,
           "nvbench_args": ($cfg.nvbench_args // ""),
-          "nvbench_compare_args": ($cfg.nvbench_compare_args // "")
+          "nvbench_compare_args": ($cfg.nvbench_compare_args // ""),
+          "nvbench_compare_legacy_args": ($cfg.nvbench_compare_legacy_args // "")
         }
     ]
   }'

--- a/cmake/CCCLGetDependencies.cmake
+++ b/cmake/CCCLGetDependencies.cmake
@@ -78,7 +78,7 @@ endmacro()
 
 set(
   CCCL_NVBENCH_SHA
-  "56d552687e6a462a812d6f046f5a85a07f13c9f3"
+  "d4ccbc05a8f1974ee6374ec24b9b065ae76b77e1"
   CACHE STRING
   "SHA/tag to use for CCCL's NVBench."
 )


### PR DESCRIPTION
## Description

This PR switch `bench.yaml` workflow to save benchmark data with binary sidecars storing bulk data for durations and frequencies. 

Use of `nvbench-compare` script is replaced with use of `nvbench-compare-robust` which takes bulk data into account. 
The new script introduces `AMBG` (ambiguous/undecided) classification, designated for comparisons where making determination between `FAST`/`SLOW`/`SAME` is difficult.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Closes #10635 

## Checklist
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
