### PR TITLE
[cudax] Make mapping purely group's constructor parameter

### DIFF
--- a/cudax/include/cuda/experimental/__group/fwd.cuh
+++ b/cudax/include/cuda/experimental/__group/fwd.cuh
@@ -66,7 +66,7 @@ class this_cluster;
 template <class _Hierarchy>
 class this_grid;
 
-template <class _Unit, class _ParentGroup, class _Mapping, class _Synchronizer>
+template <class _Unit, class _ParentGroup, class _MappingResult, class _Synchronizer>
 class group;
 
 // mappings

--- a/cudax/include/cuda/experimental/__group/group.cuh
+++ b/cudax/include/cuda/experimental/__group/group.cuh
@@ -48,7 +48,30 @@
 
 namespace cuda::experimental
 {
-template <class _Unit, class _ParentGroup, class _Mapping, class _Synchronizer>
+template <class _Unit, class _ParentGroup>
+[[nodiscard]] _CCCL_DEVICE_API constexpr auto __get_initial_mapping_result(const _ParentGroup& __parent) noexcept
+{
+  using _ParentMappingResult = typename _ParentGroup::__mapping_result_type;
+  using _MappingResult =
+    ::cuda::experimental::__mapping_result<1,
+                                           ::cuda::experimental::__static_count_query_group<_Unit, _ParentGroup>(),
+                                           _ParentMappingResult::is_always_exhaustive(),
+                                           _ParentMappingResult::is_always_contiguous()>;
+  return _MappingResult{
+    1,
+    0,
+    ::cuda::experimental::__count_query_group<unsigned, _Unit>(__parent),
+    ::cuda::experimental::__rank_query_group<unsigned, _Unit>(__parent),
+    __parent.__mapping_result().lane_mask()};
+}
+
+template <class _Unit, class _ParentGroup, class _Mapping>
+using __group_mapping_result_t = decltype(::cuda::std::declval<const _Mapping&>().map(
+  ::cuda::std::declval<const _Unit&>(),
+  ::cuda::std::declval<const _ParentGroup&>(),
+  ::cuda::experimental::__get_initial_mapping_result<_Unit>(::cuda::std::declval<const _ParentGroup&>())));
+
+template <class _Unit, class _ParentGroup, class _MappingResult, class _Synchronizer>
 class group
 {
   static_assert(__is_hierarchy_level_v<_Unit>);
@@ -59,42 +82,21 @@ class group
 
   // todo(dabayer): static_assert that _Unit is (under) typename _ParentGroup::unit_type
 
-  [[nodiscard]] _CCCL_DEVICE_API static constexpr auto
-  __get_initial_mapping_result(const _ParentGroup& __parent) noexcept
-  {
-    using _ParentMappingResult = typename _ParentGroup::__mapping_result_type;
-    using _MappingResult =
-      ::cuda::experimental::__mapping_result<1,
-                                             ::cuda::experimental::__static_count_query_group<_Unit, _ParentGroup>(),
-                                             _ParentMappingResult::is_always_exhaustive(),
-                                             _ParentMappingResult::is_always_contiguous()>;
-    return _MappingResult{
-      1,
-      0,
-      ::cuda::experimental::__count_query_group<unsigned, _Unit>(__parent),
-      ::cuda::experimental::__rank_query_group<unsigned, _Unit>(__parent),
-      __parent.__mapping_result().lane_mask()};
-  }
-
-  using _ParentMappingResult = typename _ParentGroup::__mapping_result_type;
-  using _MappingResult       = decltype(::cuda::std::declval<const _Mapping&>().map(
-    ::cuda::std::declval<const _Unit&>(),
-    ::cuda::std::declval<const _ParentGroup&>(),
-    __get_initial_mapping_result(::cuda::std::declval<const _ParentGroup&>())));
-  using _SynchronizerInstance =
-    __group_synchronizer_instance_t<_Synchronizer, _Unit, _ParentGroup, _Mapping, _MappingResult>;
+  using _ParentMappingResult  = typename _ParentGroup::__mapping_result_type;
+  using _SynchronizerInstance = __group_synchronizer_instance_t<_Synchronizer, _Unit, _ParentGroup, _MappingResult>;
   static_assert(__group_mapping_result<_MappingResult>);
 
   typename _ParentGroup::hierarchy_type __hier_;
-  _Mapping __mapping_;
   _MappingResult __mapping_result_;
   _Synchronizer __synchronizer_;
   _SynchronizerInstance __synchronizer_instance_;
 
+  template <class _Mapping>
   [[nodiscard]] _CCCL_DEVICE_API static _MappingResult
   __do_mapping(const _Unit& __unit, const _Mapping& __mapping, const _ParentGroup& __parent) noexcept
   {
-    const auto __mapping_result = __mapping.map(__unit, __parent, __get_initial_mapping_result(__parent));
+    const auto __mapping_result =
+      __mapping.map(__unit, __parent, ::cuda::experimental::__get_initial_mapping_result<_Unit>(__parent));
     if (__mapping_result.is_valid())
     {
       _CCCL_ASSERT(__mapping_result.group_rank() < __mapping_result.group_count(), "invalid group rank");
@@ -122,7 +124,6 @@ class group
     const _Unit& __unit,
     const _Synchronizer& __synchronizer,
     const _ParentGroup& __parent,
-    const _Mapping& __mapping,
     const _MappingResult& __mapping_result) noexcept
   {
     // Do not invoke the synchronizer instance creation for threads that are not part of the parent group. On the other
@@ -135,39 +136,32 @@ class group
         return _SynchronizerInstance::invalid();
       }
     }
-    return __synchronizer.make_instance(__unit, __parent, __mapping, __mapping_result);
+    return __synchronizer.make_instance(__unit, __parent, __mapping_result);
   }
 
 public:
   using unit_type             = _Unit;
   using level_type            = typename _ParentGroup::level_type;
   using hierarchy_type        = typename _ParentGroup::hierarchy_type;
-  using mapping_type          = _Mapping;
   using __mapping_result_type = _MappingResult;
   using synchronizer_type     = _Synchronizer;
 
+  _CCCL_TEMPLATE(class _Mapping)
+  _CCCL_REQUIRES(::cuda::std::is_same_v<_MappingResult, __group_mapping_result_t<_Unit, _ParentGroup, _Mapping>>)
   _CCCL_DEVICE_API explicit group(
     const _Unit& __unit,
     const _ParentGroup& __parent,
     const _Mapping& __mapping,
     const _Synchronizer& __synchronizer) noexcept
       : __hier_{__parent.hierarchy()}
-      , __mapping_{__mapping}
-      , __mapping_result_{__do_mapping(__unit, __mapping_, __parent)}
+      , __mapping_result_{__do_mapping(__unit, __mapping, __parent)}
       , __synchronizer_{__synchronizer}
-      , __synchronizer_instance_{
-          __make_synchronizer_instance(__unit, __synchronizer_, __parent, __mapping_, __mapping_result_)}
+      , __synchronizer_instance_{__make_synchronizer_instance(__unit, __synchronizer_, __parent, __mapping_result_)}
   {}
 
   [[nodiscard]] _CCCL_DEVICE_API const hierarchy_type& hierarchy() const noexcept
   {
     return __hier_;
-  }
-
-  // todo(dabayer): Do we want to expose mapping getter?
-  [[nodiscard]] _CCCL_DEVICE_API const mapping_type& mapping() const noexcept
-  {
-    return __mapping_;
   }
 
   // todo(dabayer): Do we want to expose mapping result getter?
@@ -252,7 +246,7 @@ public:
 _CCCL_TEMPLATE(class _Unit, class _ParentGroup, class _Mapping, class _Synchronizer)
 _CCCL_REQUIRES(__is_hierarchy_level_v<_Unit> _CCCL_AND is_group<_ParentGroup>)
 _CCCL_DEDUCTION_GUIDE_ATTRIBUTES group(const _Unit&, const _ParentGroup&, const _Mapping&, const _Synchronizer&)
-  -> group<_Unit, _ParentGroup, _Mapping, _Synchronizer>;
+  -> group<_Unit, _ParentGroup, __group_mapping_result_t<_Unit, _ParentGroup, _Mapping>, _Synchronizer>;
 } // namespace cuda::experimental
 
 #endif // !_CCCL_DOXYGEN_INVOKED

--- a/cudax/include/cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh
@@ -102,12 +102,9 @@ public:
     return __barriers_;
   }
 
-  template <class _Unit, class _ParentGroup, class _Mapping, class _MappingResult>
-  [[nodiscard]] _CCCL_DEVICE_API __synchronizer_instance make_instance(
-    const _Unit&,
-    const _ParentGroup& __parent,
-    const _Mapping& __mapping,
-    const _MappingResult& __mapping_result) const noexcept
+  template <class _Unit, class _ParentGroup, class _MappingResult>
+  [[nodiscard]] _CCCL_DEVICE_API __synchronizer_instance
+  make_instance(const _Unit&, const _ParentGroup& __parent, const _MappingResult& __mapping_result) const noexcept
   {
     using _Level = typename _ParentGroup::level_type;
 

--- a/cudax/include/cuda/experimental/__group/synchronizer/lane_synchronizer.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizer/lane_synchronizer.cuh
@@ -71,9 +71,9 @@ public:
 
   _CCCL_HIDE_FROM_ABI explicit lane_synchronizer() = default;
 
-  template <class _Unit, class _ParentGroup, class _Mapping, class _MappingResult>
-  [[nodiscard]] _CCCL_DEVICE_API __synchronizer_instance make_instance(
-    const _Unit&, const _ParentGroup&, const _Mapping&, const _MappingResult& __mapping_result) const noexcept
+  template <class _Unit, class _ParentGroup, class _MappingResult>
+  [[nodiscard]] _CCCL_DEVICE_API __synchronizer_instance
+  make_instance(const _Unit&, const _ParentGroup&, const _MappingResult& __mapping_result) const noexcept
   {
     static_assert(::cuda::std::is_same_v<_Unit, thread_level>, "_Unit must be cuda::thread_level");
     static_assert(__group_mapping_result<_MappingResult>);

--- a/cudax/include/cuda/experimental/__group/this_group.cuh
+++ b/cudax/include/cuda/experimental/__group/this_group.cuh
@@ -118,7 +118,6 @@ class __this_group_base
 public:
   using unit_type             = _Level;
   using level_type            = _Level;
-  using mapping_type          = void;
   using __mapping_result_type = __this_mapping_result<_Level>;
   using hierarchy_type        = _Hierarchy;
   using synchronizer_type     = level_synchronizer;
@@ -144,9 +143,6 @@ public:
   {
     return __hier_;
   }
-
-  // this groups don't have a mapping type
-  auto mapping() const = delete;
 
   // todo(dabayer): Do we want to expose mapping result getter?
   [[nodiscard]] _CCCL_DEVICE_API const __mapping_result_type& __mapping_result() const noexcept

--- a/cudax/include/cuda/experimental/__group/traits.cuh
+++ b/cudax/include/cuda/experimental/__group/traits.cuh
@@ -31,15 +31,10 @@
 
 namespace cuda::experimental
 {
-template <class _Mapping, class _Unit, class _ParentGroup>
-using __group_mapping_result_t = decltype(::cuda::std::declval<_Mapping>().map(
-  ::cuda::std::declval<_Unit>(), ::cuda::std::declval<const _ParentGroup&>()));
-
-template <class _Synchronizer, class _Unit, class _ParentGroup, class _Mapping, class _MappingResult>
+template <class _Synchronizer, class _Unit, class _ParentGroup, class _MappingResult>
 using __group_synchronizer_instance_t = decltype(::cuda::std::declval<_Synchronizer>().make_instance(
   ::cuda::std::declval<const _Unit&>(),
   ::cuda::std::declval<const _ParentGroup&>(),
-  ::cuda::std::declval<const _Mapping&>(),
   ::cuda::std::declval<const _MappingResult&>()));
 
 template <class _Tp, class = void>

--- a/cudax/test/group/group.cu
+++ b/cudax/test/group/group.cu
@@ -72,9 +72,8 @@ __device__ void test_common_properties(const Hierarchy&, Group& group)
   }
 }
 
-template <class ParentGroup, cuda::std::size_t N, class Synchronizer>
-__device__ void
-test_queries(const cudax::group<cuda::thread_level, ParentGroup, cudax::group_by<N>, Synchronizer>& group)
+template <class ParentGroup, class MappingResult, class Synchronizer>
+__device__ void test_queries(const cudax::group<cuda::thread_level, ParentGroup, MappingResult, Synchronizer>& group)
 {
   // todo(dabayer): These queries end up in `error: expression must have a constant value`, when group is taken by
   // reference. Can we find a solution that works without copying the group?
@@ -118,9 +117,6 @@ __device__ void test_group_by_group(Unit unit, Level level, Config config)
     cudax::barrier_synchronizer synchronizer{barriers};
     cudax::group group{unit, parent_group, mapping, synchronizer};
 
-    static_assert(
-      cuda::std::is_same_v<cudax::group<Unit, decltype(parent_group), decltype(mapping), decltype(synchronizer)>,
-                           decltype(group)>);
     test_common_properties<Unit, Level>(config.hierarchy(), group);
     test_queries(group);
     group.sync();
@@ -132,9 +128,6 @@ __device__ void test_group_by_group(Unit unit, Level level, Config config)
     cudax::barrier_synchronizer synchronizer{barriers};
     cudax::group group{unit, parent_group, mapping, synchronizer};
 
-    static_assert(
-      cuda::std::is_same_v<cudax::group<Unit, decltype(parent_group), decltype(mapping), decltype(synchronizer)>,
-                           decltype(group)>);
     test_common_properties<Unit, Level>(config.hierarchy(), group);
     test_queries(group);
     group.sync();

--- a/cudax/test/group/synchronizer/barrier_synchronizer.cu
+++ b/cudax/test/group/synchronizer/barrier_synchronizer.cu
@@ -99,9 +99,8 @@ __device__ void test_barrier_synchronizer(const Level& level, Config config)
     const cudax::group_by mapping{4};
     const cudax::barrier_synchronizer synchronizer{barriers};
 
-    const auto mapping_result = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
-    const auto synchronizer_instance =
-      synchronizer.make_instance(cuda::gpu_thread, parent_group, mapping, mapping_result);
+    const auto mapping_result        = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
+    const auto synchronizer_instance = synchronizer.make_instance(cuda::gpu_thread, parent_group, mapping_result);
 
     // Test do_sync(...).
     static_assert(

--- a/cudax/test/group/synchronizer/lane_synchronizer.cu
+++ b/cudax/test/group/synchronizer/lane_synchronizer.cu
@@ -40,9 +40,8 @@ __device__ void test_lane_synchronizer(const Level& level, Config config)
     const cudax::group_by mapping{2};
     const Synchronizer synchronizer{};
 
-    const auto mapping_result = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
-    const auto synchronizer_instance =
-      synchronizer.make_instance(cuda::gpu_thread, parent_group, mapping, mapping_result);
+    const auto mapping_result        = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
+    const auto synchronizer_instance = synchronizer.make_instance(cuda::gpu_thread, parent_group, mapping_result);
 
     // Test do_sync(...).
     static_assert(

--- a/cudax/test/group/this_group.cu
+++ b/cudax/test/group/this_group.cu
@@ -35,7 +35,6 @@ __device__ void test_common_properties(const Hierarchy&, Group& group)
   // Test types
   static_assert(cuda::std::is_same_v<Level, typename Group::unit_type>);
   static_assert(cuda::std::is_same_v<Level, typename Group::level_type>);
-  static_assert(cuda::std::is_same_v<void, typename Group::mapping_type>);
   static_assert(cuda::std::is_same_v<cudax::level_synchronizer, typename Group::synchronizer_type>);
 
   // Test that the group can be queried for it's hierarchy.


### PR DESCRIPTION
In the past, I thought that a group might be studied for it's mapping type. But lately I came to a conclusion, that you basically don't care what mappings were applied to the group. What you care about are the properties stored in the mapping result. If there is not enough information, we need to improve mapping result.

This approach allows us to completely remove mapping from group's properties. There will be also less groups instantiations.