### PR TITLE
[libcu++] Fix set_stream docs note in cuda::buffer

### DIFF
--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -725,7 +725,9 @@ public:
 
   //! @brief Replaces the stored stream
   //! @param __new_stream the new stream
-  //! @note Always synchronizes with the old stream
+  //! @warning This does not synchronize between \p __new_stream and the current
+  //! stream. It is the user's responsibility to ensure proper stream order
+  //! going forward
   _CCCL_HOST_API constexpr void set_stream(stream_ref __new_stream)
   {
     __buf_.set_stream_unsynchronized(__new_stream);


### PR DESCRIPTION
We decided to remove the sync in https://github.com/NVIDIA/cccl/pull/5697, but the docs note was not changed. This PR changes it to a warning about the behavior.

Closes https://github.com/NVIDIA/cccl/issues/10649