### PR TITLE
Use iters + num_items on inner most level of MGMN algorithms

### DIFF
--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/common.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/common.h
@@ -100,24 +100,28 @@ template <class _Tp, class _Resource, class _Env>
   }
 }
 
-template <class _InputRangeOfRanges, class _RangeOfOutputIt, class _EnvRange>
+template <class _InputRangeOfIters, class _RangeOfOutputIt, class _EnvRange>
 struct __in_range_out_it_properties
 {
-  using __input_type  = ::cuda::std::ranges::range_value_t<::cuda::std::ranges::range_reference_t<_InputRangeOfRanges>>;
-  using __output_type = ::cuda::std::iter_value_t<::cuda::std::ranges::range_reference_t<_RangeOfOutputIt>>;
+  using __input_iter_type _CCCL_NODEBUG =
+    ::cuda::std::remove_cvref_t<::cuda::std::ranges::range_reference_t<_InputRangeOfIters>>;
+  using __input_type _CCCL_NODEBUG = ::cuda::std::iter_value_t<__input_iter_type>;
+  using __output_type _CCCL_NODEBUG =
+    ::cuda::std::iter_value_t<::cuda::std::ranges::range_reference_t<_RangeOfOutputIt>>;
 
-  using __env_type = ::cuda::std::ranges::range_value_t<_EnvRange>;
+  using __env_type _CCCL_NODEBUG = ::cuda::std::ranges::range_value_t<_EnvRange>;
 
-  using __resource_type = ::cuda::experimental::__detail::__resource_type_for<__env_type>;
+  using __resource_type _CCCL_NODEBUG = ::cuda::experimental::__detail::__resource_type_for<__env_type>;
 
-  using __buffer_type = ::cuda::__buffer_type_for_props<__output_type, typename __resource_type::default_queries>;
+  using __buffer_type _CCCL_NODEBUG =
+    ::cuda::__buffer_type_for_props<__output_type, typename __resource_type::default_queries>;
 };
 
-template <class _RangeOfRanges>
-_CCCL_CONCEPT __range_of_sized_random_access_ranges = _CCCL_REQUIRES_EXPR((_RangeOfRanges), )(
-  requires(::cuda::std::ranges::forward_range<_RangeOfRanges>),
-  requires(::cuda::std::ranges::sized_range<_RangeOfRanges>),
-  requires(::cuda::std::ranges::random_access_range<::cuda::std::ranges::range_reference_t<_RangeOfRanges>>));
+template <class _RangeOfIters>
+_CCCL_CONCEPT __range_of_random_access_iterators = _CCCL_REQUIRES_EXPR((_RangeOfIters), )(
+  requires(::cuda::std::ranges::forward_range<_RangeOfIters>),
+  requires(::cuda::std::random_access_iterator<
+           ::cuda::std::remove_cvref_t<::cuda::std::ranges::range_reference_t<_RangeOfIters>>>));
 
 template <class _RangeOfIters, class _Tp>
 _CCCL_CONCEPT __range_of_output_iters = _CCCL_REQUIRES_EXPR((_RangeOfIters, _Tp), )(

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/common.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/common.h
@@ -95,25 +95,30 @@ template <class _Tp, class _Resource, class _Env>
   }
 }
 
-template <class _InputRangeOfRanges, class _RangeOfOutputIt, class _EnvRange>
+template <class _InputRangeOfIters, class _RangeOfOutputIt, class _EnvRange>
 struct __in_range_out_it_properties
 {
-  using __input_type  = ::cuda::std::ranges::range_value_t<::cuda::std::ranges::range_reference_t<_InputRangeOfRanges>>;
-  using __output_type = ::cuda::std::iter_value_t<::cuda::std::ranges::range_reference_t<_RangeOfOutputIt>>;
+  using __input_iter_type _CCCL_NODEBUG =
+    ::cuda::std::remove_cvref_t<::cuda::std::ranges::range_reference_t<_InputRangeOfIters>>;
+  using __input_type _CCCL_NODEBUG = ::cuda::std::iter_value_t<__input_iter_type>;
+  using __output_type _CCCL_NODEBUG =
+    ::cuda::std::iter_value_t<::cuda::std::ranges::range_reference_t<_RangeOfOutputIt>>;
 
-  using __env_type = ::cuda::std::ranges::range_value_t<_EnvRange>;
+  using __env_type _CCCL_NODEBUG = ::cuda::std::ranges::range_value_t<_EnvRange>;
 
-  using __resource_type = ::cuda::std::remove_cvref_t<decltype(::cuda::experimental::__detail::__resource_from_env(
-    ::cuda::std::declval<__env_type>(), ::cuda::std::declval<::cuda::device_ref>()))>;
+  using __resource_type _CCCL_NODEBUG =
+    ::cuda::std::remove_cvref_t<decltype(::cuda::experimental::__detail::__resource_from_env(
+      ::cuda::std::declval<__env_type>(), ::cuda::std::declval<::cuda::device_ref>()))>;
 
-  using __buffer_type = ::cuda::__buffer_type_for_props<__output_type, typename __resource_type::default_queries>;
+  using __buffer_type _CCCL_NODEBUG =
+    ::cuda::__buffer_type_for_props<__output_type, typename __resource_type::default_queries>;
 };
 
-template <class _RangeOfRanges>
-_CCCL_CONCEPT __range_of_sized_random_access_ranges = _CCCL_REQUIRES_EXPR((_RangeOfRanges), )(
-  requires(::cuda::std::ranges::forward_range<_RangeOfRanges>),
-  requires(::cuda::std::ranges::sized_range<_RangeOfRanges>),
-  requires(::cuda::std::ranges::random_access_range<::cuda::std::ranges::range_reference_t<_RangeOfRanges>>));
+template <class _RangeOfIters>
+_CCCL_CONCEPT __range_of_random_access_iterators = _CCCL_REQUIRES_EXPR((_RangeOfIters), )(
+  requires(::cuda::std::ranges::forward_range<_RangeOfIters>),
+  requires(::cuda::std::random_access_iterator<
+           ::cuda::std::remove_cvref_t<::cuda::std::ranges::range_reference_t<_RangeOfIters>>>));
 
 template <class _RangeOfIters, class _Tp>
 _CCCL_CONCEPT __range_of_output_iters = _CCCL_REQUIRES_EXPR((_RangeOfIters, _Tp), )(

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h
@@ -30,21 +30,13 @@
 #include <cuda/__runtime/ensure_current_context.h>
 #include <cuda/__stream/get_stream.h>
 #include <cuda/__stream/stream_ref.h>
-#include <cuda/std/__concepts/assignable.h>
-#include <cuda/std/__concepts/constructible.h>
-#include <cuda/std/__concepts/convertible_to.h>
-#include <cuda/std/__concepts/invocable.h>
-#include <cuda/std/__concepts/movable.h>
 #include <cuda/std/__concepts/same_as.h>
-#include <cuda/std/__functional/invoke.h>
 #include <cuda/std/__iterator/concepts.h>
-#include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__memory/addressof.h>
 #include <cuda/std/__memory/pointer_traits.h>
 #include <cuda/std/__ranges/concepts.h>
 #include <cuda/std/__ranges/size.h>
 #include <cuda/std/__ranges/zip_view.h>
-#include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/__type_traits/remove_reference.h>
 #include <cuda/std/__utility/move.h>
@@ -64,14 +56,15 @@ namespace cuda::experimental
 {
 namespace __detail::__reduce
 {
-template <class _Buffer, class _Comm, class _Env, class _InputRange, class _Tp, class _BinaryOp>
+template <class _Buffer, class _Comm, class _Env, class _InputIt, class _SizeT, class _Tp, class _BinaryOp>
 [[nodiscard]] _CCCL_HOST_API _Buffer __local_reduction(
   const ::cuda::std::int32_t __ROOT_RANK,
   _Comm&& __comm,
   const _Env& __env,
-  _InputRange&& __inputs,
+  _InputIt __input_it,
+  const _SizeT& __num_items,
   const _Tp& __init,
-  _BinaryOp __op,
+  const _BinaryOp& __op,
   const _Tp& __ident)
 {
   const auto& __logical_device = __comm.logical_device();
@@ -87,8 +80,6 @@ template <class _Buffer, class _Comm, class _Env, class _InputRange, class _Tp, 
   ::cuda::stream_ref __stream = ::cuda::get_stream(__env);
   auto __resource = ::cuda::experimental::__detail::__resource_from_env(__env, __logical_device.underlying_device());
 
-  static_assert(::cuda::std::ranges::sized_range<_InputRange>);
-
   // Allocate enough storage so that we can use the buffer directly in an in-place comm all
   // gather/all reduce call. Those calls require that the receive buffer is of size nranks *
   // sendcount.
@@ -101,13 +92,13 @@ template <class _Buffer, class _Comm, class _Env, class _InputRange, class _Tp, 
   __CUDAX_MULTI_GPU_DISPATCH(
     __logical_device,
     CUB_NS_QUALIFIER::DeviceReduce::Reduce,
-    ::cuda::std::ranges::begin(__inputs),
+    __input_it,
     // Similarly to above, prepare for the comm calls later. In order for those to be
     // in-place, the sendbuff = recvbuff + rank, so we need to place our partial result
     // there
     __buff.begin() + __rank,
-    ::cuda::std::ranges::size(__inputs),
-    ::cuda::std::move(__op),
+    __num_items,
+    __op,
     __rank == __ROOT_RANK ? __init : __ident,
     __env);
 
@@ -167,29 +158,6 @@ _CCCL_HOST_API void __two_stage_gather_reduction(
 }
 } // namespace __detail::__reduce
 
-template <class _Fn, class _Tp, class _Iter, class _Up>
-_CCCL_CONCEPT __indirectly_binary_reducible_impl = _CCCL_REQUIRES_EXPR((_Fn, _Tp, _Iter, _Up), )(
-  requires(::cuda::std::movable<_Tp>),
-  requires(::cuda::std::movable<_Up>),
-  requires(::cuda::std::convertible_to<_Tp, _Up>),
-  requires(::cuda::std::invocable<_Fn&, _Up, ::cuda::std::iter_reference_t<_Iter>>),
-  requires(
-    ::cuda::std::assignable_from<_Up&, ::cuda::std::invoke_result_t<_Fn&, _Up, ::cuda::std::iter_reference_t<_Iter>>>));
-
-template <class _Fn, class _Tp, class _Iter>
-_CCCL_CONCEPT __indirectly_binary_reducible = _CCCL_REQUIRES_EXPR((_Fn, _Tp, _Iter), )(
-  requires(::cuda::std::copy_constructible<_Fn>),
-  requires(::cuda::std::indirectly_readable<_Iter>),
-  requires(::cuda::std::invocable<_Fn&, _Tp, ::cuda::std::iter_reference_t<_Iter>>),
-  requires(::cuda::std::convertible_to<
-           ::cuda::std::invoke_result_t<_Fn&, _Tp, ::cuda::std::iter_reference_t<_Iter>>,
-           ::cuda::std::decay_t<::cuda::std::invoke_result_t<_Fn&, _Tp, ::cuda::std::iter_reference_t<_Iter>>>>),
-  requires(__indirectly_binary_reducible_impl<
-           _Fn,
-           _Tp,
-           _Iter,
-           ::cuda::std::decay_t<::cuda::std::invoke_result_t<_Fn&, _Tp, ::cuda::std::iter_reference_t<_Iter>>>>));
-
 //! @brief Reduce each input range over its communicator and write one result per output
 //! iterator.
 //!
@@ -209,16 +177,8 @@ _CCCL_CONCEPT __indirectly_binary_reducible = _CCCL_REQUIRES_EXPR((_Fn, _Tp, _It
 //! example, consider a scenario where there are 8 GPUs and 4 processes such that each
 //! process owns 2 GPUs. Then the user would call this routine on each process, passing in both
 //! local arrays:
-//! @code{.cpp}
-//! device_buffer gpu_0_data = ...;
-//! device_buffer gpu_1_data = ...;
 //!
-//! cudax::reduce({comm0, comm1},
-//!               {env_0, env_1},
-//!               {gpu_0_data, gpu_1_data},
-//!               {out_0, out_1},
-//!               ...)
-//! @endcode
+//! @snippet reduce/range_basic.cu reduce
 //!
 //! All ranges must have the same length. The algorithm will cap iteration to the shortest
 //! length, but this should not be relied upon and may change at any time, for any reason. So
@@ -232,43 +192,36 @@ _CCCL_CONCEPT __indirectly_binary_reducible = _CCCL_REQUIRES_EXPR((_Fn, _Tp, _It
 //! element is 0. For maximum and minimum, the identity values are INT_MIN, and INT_MAX
 //! respectively.
 //!
-//! @tparam _Policy The return value policy. Currently only `broadcasted_t` is supported.
-//! @tparam _CommRange The range of communicators. Each element must model the communicator
-//!         concept.
-//! @tparam _EnvRange The range of execution environments. Each environment supplies the
-//!         stream and optional memory resource used for its communicator.
-//! @tparam _InputRangeOfRanges The range whose elements are the per-communicator input
-//!         ranges. Each element must be a sized random-access range.
-//! @tparam _RangeOfOutputIt The range of output iterators, one per communicator.
-//! @tparam _Tp The reduction and result value type. Deduced by default from the output
-//!         element type.
-//! @tparam _BinaryOp The binary reduction operator type. Defaults to `::cuda::std::plus<>`.
-//!
-//! @param[in] __policy The result policy object.
+//! @param[in] __policy The result policy object. Currently must be `cudax::broadcasted`.
 //! @param[in] __comms The range of communicators.
 //! @param[in] __envs The range of execution environments. The execution environment must
 //!                   contain a stream.
-//! @param[in] __range_of_inputs The range of per-communicator input ranges to reduce.
-//! @param[out] __outputs The range of output iterators receiving the per-communicator results.
+//! @param[in] __input_iters The range of per-communicator input iterators to reduce.
+//! @param[in] __num_items_range A range of sizes per input iterator to reduce.
+//! @param[out] __output_iters The range of output iterators receiving the per-communicator results.
 //! @param[in] __init The initial value seeding each reduction.
 //! @param[in] __op The binary reduction operator.
 //! @param[in] __ident The identity element to be used in case of empty ranges.
-_CCCL_TEMPLATE(class _Policy,
-               class _CommRange,
-               class _EnvRange,
-               class _InputRangeRange,
-               class _OutputItRange,
-               class _Tp = ::cuda::std::ranges::range_value_t<::cuda::std::ranges::range_reference_t<_InputRangeRange>>,
-               class _BinaryOp = ::cuda::std::plus<>)
+_CCCL_TEMPLATE(
+  class _Policy,
+  class _CommRange,
+  class _EnvRange,
+  class _InputIterRange,
+  class _SizeTRange,
+  class _OutputIterRange,
+  class _Tp       = ::cuda::std::iter_value_t<::cuda::std::ranges::range_reference_t<_InputIterRange>>,
+  class _BinaryOp = ::cuda::std::plus<>)
 _CCCL_REQUIRES(__range_of_communicators<_CommRange> _CCCL_AND ::cuda::std::ranges::forward_range<_EnvRange> _CCCL_AND
-                 __detail::__range_of_sized_random_access_ranges<_InputRangeRange> _CCCL_AND
-                   __detail::__range_of_output_iters<_OutputItRange, _Tp>)
+                 __detail::__range_of_random_access_iterators<_InputIterRange>
+                   _CCCL_AND ::cuda::std::ranges::forward_range<_SizeTRange> _CCCL_AND
+                     __detail::__range_of_output_iters<_OutputIterRange, _Tp>)
 _CCCL_HOST_API void reduce(
   [[maybe_unused]] const __result_policy_base<_Policy>& __policy,
   _CommRange&& __comms,
   _EnvRange&& __envs,
-  _InputRangeRange&& __range_of_inputs,
-  _OutputItRange&& __outputs,
+  _InputIterRange&& __input_iters,
+  _SizeTRange&& __num_items_range,
+  _OutputIterRange&& __output_iters,
   _Tp __init     = {},
   _BinaryOp __op = {},
   _Tp __ident    = ::cuda::identity_element<_BinaryOp, _Tp>())
@@ -279,12 +232,9 @@ _CCCL_HOST_API void reduce(
                 "github.com/NVIDIA/cccl/issue requesting support for your specified policy.");
 
   using __properties =
-    ::cuda::experimental::__detail::__in_range_out_it_properties<_InputRangeRange, _OutputItRange, _EnvRange>;
+    ::cuda::experimental::__detail::__in_range_out_it_properties<_InputIterRange, _OutputIterRange, _EnvRange>;
 
-  static_assert(__indirectly_binary_reducible<
-                _BinaryOp,
-                _Tp,
-                ::cuda::std::ranges::iterator_t<::cuda::std::ranges::range_reference_t<_InputRangeRange>>>);
+  static_assert(::cuda::std::__indirectly_binary_reducible<_BinaryOp, _Tp, typename __properties::__input_iter_type>);
 
   // Could use ::cuda::std::invocable here, but it is overkill (compile-time wise). We know
   // that get_stream_t is a normal CPO and normally callable.
@@ -305,65 +255,63 @@ _CCCL_HOST_API void reduce(
   __partials.reserve(__num_local);
   // TODO(jfaibussowit): can just be ranges::zip | ranges::transform | ranges::to() (and then
   // we don't need to do the env, and buffer type deduction upfront)
-  for (auto&& [__comm, __env, __inputs] : ::cuda::std::ranges::views::zip(__comms, __envs, __range_of_inputs))
+  for (auto&& [__comm, __env, __input_it, __num_items] :
+       ::cuda::std::ranges::views::zip(__comms, __envs, __input_iters, __num_items_range))
   {
     __partials.emplace_back(
       ::cuda::experimental::__detail::__reduce::__local_reduction<typename __properties::__buffer_type>(
-        /*__ROOT_RANK=*/0, __comm, __env, __inputs, __init, __op, __ident));
+        /*__ROOT_RANK=*/0, __comm, __env, __input_it, __num_items, __init, __op, __ident));
   }
 
   if constexpr (::cuda::experimental::__has_all_reduce<::cuda::std::ranges::range_value_t<_CommRange>,
                                                        typename __properties::__output_type*,
                                                        _BinaryOp>)
   {
-    ::cuda::experimental::__detail::__reduce::__direct_reduction(__comms, __outputs, __op, &__partials);
+    ::cuda::experimental::__detail::__reduce::__direct_reduction(__comms, __output_iters, __op, &__partials);
   }
   else
   {
     ::cuda::experimental::__detail::__reduce::__two_stage_gather_reduction(
-      __comms, __envs, __outputs, __op, &__partials);
+      __comms, __envs, __output_iters, __op, &__partials);
   }
 }
 
 //! @brief Reduce a single input range over a single communicator using the given execution
 //! environment.
 //!
-//! Convenience wrapper that forwards a single `(communicator, environment, input range,
-//! output iterator)` to the range-based overload. See the range overload for further
-//! discussion.
+//! Convenience wrapper that forwards a single `(communicator, environment, input iterator,
+//! input size, output iterator)` to the range-based overload. See the range overload for
+//! further discussion.
 //!
-//! @tparam _Policy The return value policy. Currently only `broadcasted_t` is supported.
-//! @tparam _Comm The communicator type. Must model the communicator concept.
-//! @tparam _Env The execution environment type. Supplies the stream and optional memory
-//!              resource.
-//! @tparam _InputRange The input range type. Must be a random-access range.
-//! @tparam _OutputIt The output iterator type.
-//! @tparam _Tp The reduction and result value type.
-//! @tparam _BinaryOp The binary reduction operator type. Defaults to `::cuda::std::plus<>`.
+//! @snippet reduce/single_comm_basic.cu reduce_single_range
 //!
-//! @param[in] __policy The result policy object.
+//! @param[in] __policy The result policy object. Currently must be `cudax::broadcasted`.
 //! @param[in] __comm The communicator.
 //! @param[in] __env The execution environment. Must contain a stream.
-//! @param[in] __input The input range to reduce.
-//! @param[out] __output The output iterator receiving the result.
+//! @param[in] __input_iter The input iterator to reduce.
+//! @param[in] __num_items The number of items in `__input_iter` to reduce.
+//! @param[out] __output_iter The output iterator receiving the result.
 //! @param[in] __init The initial value seeding the reduction.
 //! @param[in] __op The binary reduction operator.
 //! @param[in] __ident The identity element to be used in case of empty ranges.
-_CCCL_TEMPLATE(class _Policy,
-               class _Comm,
-               class _Env,
-               class _InputRange,
-               class _OutputIt,
-               class _Tp       = ::cuda::std::ranges::range_value_t<_InputRange>,
-               class _BinaryOp = ::cuda::std::plus<>)
-_CCCL_REQUIRES(__communicator<_Comm> _CCCL_AND ::cuda::std::ranges::random_access_range<_InputRange>
+_CCCL_TEMPLATE(
+  class _Policy,
+  class _Comm,
+  class _Env,
+  class _InputIt,
+  class _SizeT,
+  class _OutputIt,
+  class _Tp       = ::cuda::std::iter_value_t<_InputIt>,
+  class _BinaryOp = ::cuda::std::plus<>)
+_CCCL_REQUIRES(__communicator<_Comm> _CCCL_AND ::cuda::std::random_access_iterator<_InputIt>
                  _CCCL_AND ::cuda::std::output_iterator<_OutputIt, _Tp>)
 _CCCL_HOST_API void reduce(
   const __result_policy_base<_Policy>& __policy,
   _Comm&& __comm,
   _Env&& __env,
-  _InputRange&& __input,
-  _OutputIt __output,
+  _InputIt __input_iter,
+  _SizeT __num_items,
+  _OutputIt __output_iter,
   _Tp __init     = {},
   _BinaryOp __op = {},
   _Tp __ident    = ::cuda::identity_element<_BinaryOp, _Tp>())
@@ -372,8 +320,9 @@ _CCCL_HOST_API void reduce(
     __policy,
     ::cuda::std::span<::cuda::std::remove_reference_t<_Comm>, 1>{::cuda::std::addressof(__comm), 1},
     ::cuda::std::span<::cuda::std::remove_reference_t<_Env>, 1>{::cuda::std::addressof(__env), 1},
-    ::cuda::std::span<::cuda::std::remove_reference_t<_InputRange>, 1>{::cuda::std::addressof(__input), 1},
-    ::cuda::std::span<_OutputIt, 1>{::cuda::std::addressof(__output), 1},
+    ::cuda::std::span<_InputIt, 1>{::cuda::std::addressof(__input_iter), 1},
+    ::cuda::std::span<_SizeT, 1>{::cuda::std::addressof(__num_items), 1},
+    ::cuda::std::span<_OutputIt, 1>{::cuda::std::addressof(__output_iter), 1},
     ::cuda::std::move(__init),
     ::cuda::std::move(__op),
     ::cuda::std::move(__ident));

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h
@@ -184,8 +184,15 @@ _CCCL_HOST_API void __two_stage_gather_reduction(
 //! length, but this should not be relied upon and may change at any time, for any reason. So
 //! differing lengths is effectively undefined behavior.
 //!
-//! After this call returns, all local output iterators will hold the same value. In that sense
-//! this routine is similar to an "all reduce".
+//! Each size in `__num_items_range` may be a plain integral value, or a deferred argument such
+//! as `cuda::args::deferred`. A deferred size holds a pointer or iterator to device memory and
+//! is read in stream order when the reduction runs, so its value need not be known on the host
+//! at the time of the call. This lets a preceding device-side computation produce the number of
+//! items to reduce:
+//!
+//! @snippet reduce/range_deferred.cu reduce_deferred
+//!
+//! A deferred size must be valid and reachable in stream order on the device that reduces it.
 //!
 //! The identity element should survive reduction with any other value, returning the original
 //! value unchanged. For example, for integers/floats and `cuda::std::plus`, the identity
@@ -197,7 +204,8 @@ _CCCL_HOST_API void __two_stage_gather_reduction(
 //! @param[in] __envs The range of execution environments. The execution environment must
 //!                   contain a stream.
 //! @param[in] __input_iters The range of per-communicator input iterators to reduce.
-//! @param[in] __num_items_range A range of sizes per input iterator to reduce.
+//! @param[in] __num_items_range A range of sizes per input iterator to reduce. Each size may be
+//!                              an integral value or a deferred argument.
 //! @param[out] __output_iters The range of output iterators receiving the per-communicator results.
 //! @param[in] __init The initial value seeding each reduction.
 //! @param[in] __op The binary reduction operator.
@@ -285,11 +293,19 @@ _CCCL_HOST_API void reduce(
 //!
 //! @snippet reduce/single_comm_basic.cu reduce_single_range
 //!
+//! `__num_items` may be a plain integral value, or a deferred argument such as
+//! `cuda::args::deferred`. A deferred size holds a pointer or iterator to device memory and is
+//! read in stream order when the reduction runs, so its value need not be known on the host at
+//! the time of the call:
+//!
+//! @snippet reduce/single_comm_deferred.cu reduce_single_range_deferred
+//!
 //! @param[in] __policy The result policy object. Currently must be `cudax::broadcasted`.
 //! @param[in] __comm The communicator.
 //! @param[in] __env The execution environment. Must contain a stream.
 //! @param[in] __input_iter The input iterator to reduce.
-//! @param[in] __num_items The number of items in `__input_iter` to reduce.
+//! @param[in] __num_items The number of items in `__input_iter` to reduce. May be an integral
+//!                        value or a deferred argument.
 //! @param[out] __output_iter The output iterator receiving the result.
 //! @param[in] __init The initial value seeding the reduction.
 //! @param[in] __op The binary reduction operator.

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/scan/scan.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/scan/scan.h
@@ -30,7 +30,6 @@
 #include <cuda/__functional/operator_properties.h>
 #include <cuda/__nvtx/nvtx.h>
 #include <cuda/__stream/get_stream.h>
-#include <cuda/std/__execution/env.h>
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__iterator/readable_traits.h>
@@ -69,16 +68,18 @@ template <__kind _Kind,
           class _Policy,
           class _CommRange,
           class _EnvRange,
-          class _InputRangeRange,
-          class _OutputItRange,
+          class _InputIterRange,
+          class _SizeTRange,
+          class _OutputIterRange,
           class _Tp,
           class _BinaryOp>
 _CCCL_HOST_API void __scan(
   const __result_policy_base<_Policy>&,
   _CommRange&& __comms,
   _EnvRange&& __envs,
-  _InputRangeRange&& __range_of_inputs,
-  _OutputItRange&& __outputs,
+  _InputIterRange&& __input_iters,
+  _SizeTRange&& __num_items_range,
+  _OutputIterRange&& __output_iters,
   _Tp __init,
   _BinaryOp __op,
   _Tp __ident)
@@ -89,12 +90,9 @@ _CCCL_HOST_API void __scan(
                 "github.com/NVIDIA/cccl/issue requesting support for your specified policy.");
 
   using __properties =
-    ::cuda::experimental::__detail::__in_range_out_it_properties<_InputRangeRange, _OutputItRange, _EnvRange>;
+    ::cuda::experimental::__detail::__in_range_out_it_properties<_InputIterRange, _OutputIterRange, _EnvRange>;
 
-  static_assert(::cuda::experimental::__indirectly_binary_reducible<
-                _BinaryOp,
-                _Tp,
-                ::cuda::std::ranges::iterator_t<::cuda::std::ranges::range_reference_t<_InputRangeRange>>>);
+  static_assert(::cuda::std::__indirectly_binary_reducible<_BinaryOp, _Tp, typename __properties::__input_iter_type>);
 
   // Could use ::cuda::std::invocable here, but it is overkill (compile-time wise). We know
   // that get_stream_t is a normal CPO and normally callable.
@@ -111,20 +109,18 @@ _CCCL_HOST_API void __scan(
   _CCCL_NVTX_RANGE_SCOPE(
     _Kind == __kind::__exclusive ? "cuda::experimental::exclusive_scan" : "cuda::experimental::inclusive_scan");
 
-  using __properties =
-    ::cuda::experimental::__detail::__in_range_out_it_properties<_InputRangeRange, _OutputItRange, _EnvRange>;
-
   constexpr auto __ROOT_RANK = 0;
   auto __partials            = ::std::vector<typename __properties::__buffer_type>{};
 
   __partials.reserve(__num_local);
   // TODO(jfaibussowit): can just be ranges::zip | ranges::transform | ranges::to() (and then
   // we don't need to do the env, and buffer type deduction upfront)
-  for (auto&& [__comm, __env, __inputs] : ::cuda::std::ranges::views::zip(__comms, __envs, __range_of_inputs))
+  for (auto&& [__comm, __env, __input_it, __num_items] :
+       ::cuda::std::ranges::views::zip(__comms, __envs, __input_iters, __num_items_range))
   {
     __partials.emplace_back(
       ::cuda::experimental::__detail::__reduce::__local_reduction<typename __properties::__buffer_type>(
-        __ROOT_RANK, __comm, __env, __inputs, __init, __op, __ident));
+        __ROOT_RANK, __comm, __env, __input_it, __num_items, __init, __op, __ident));
   }
 
   {
@@ -165,8 +161,8 @@ _CCCL_HOST_API void __scan(
   // rank 2: [21]
   //
   // Then later we can do the proper prefix scan using __prefix as the initializer for it.
-  for (auto&& [__comm, __env, __part, __inputs, __out] :
-       ::cuda::std::ranges::views::zip(__comms, __envs, __partials, __range_of_inputs, __outputs))
+  for (auto&& [__comm, __env, __part, __input_it, __num_items, __out] :
+       ::cuda::std::ranges::views::zip(__comms, __envs, __partials, __input_iters, __num_items_range, __output_iters))
   {
     auto __prefix = ::cuda::experimental::__detail::__make_safe_uninitialized_buffer<_Tp>(
       __part.stream(), __part.memory_resource(), /*__size=*/1, __env);
@@ -204,11 +200,11 @@ _CCCL_HOST_API void __scan(
       __CUDAX_MULTI_GPU_DISPATCH(
         __comm.logical_device(),
         CUB_NS_QUALIFIER::DeviceScan::ExclusiveScan,
-        ::cuda::std::ranges::begin(__inputs),
+        __input_it,
         __out,
         __op,
         /*__init=*/__future_type{__prefix.begin()},
-        ::cuda::std::ranges::size(__inputs),
+        __num_items,
         __env);
     }
     else
@@ -216,11 +212,11 @@ _CCCL_HOST_API void __scan(
       __CUDAX_MULTI_GPU_DISPATCH(
         __comm.logical_device(),
         CUB_NS_QUALIFIER::DeviceScan::InclusiveScanInit,
-        ::cuda::std::ranges::begin(__inputs),
+        __input_it,
         __out,
         __op,
         /*__init=*/::cuda::args::deferred{__prefix.begin()},
-        ::cuda::std::ranges::size(__inputs),
+        __num_items,
         __env);
     }
   }
@@ -236,17 +232,17 @@ _CCCL_HOST_API void __scan(
 //! `__init` with all preceding elements in the logical sequence. Empty input ranges contribute
 //! no elements.
 //!
-//! The communicators, environments, input ranges, and output iterators are iterated in
-//! lockstep. Each tuple describes one local communicator rank. This overload is intended for
-//! a thread or process that owns multiple local GPUs. For example, if each process owns two
-//! GPUs, each process can pass both local ranks in one call, as shown in the test below.
+//! The communicators, environments, input iterators, input sizes, and output iterators are
+//! iterated in lockstep. Each tuple describes one local communicator rank. This overload is
+//! intended for a thread or process that owns multiple local GPUs. For example, if each process
+//! owns two GPUs, each process can pass both local ranks in one call, as shown in the test below.
 //!
 //! @snippet exclusive_scan/range_basic.cu exclusive_scan
 //!
-//! All four outer ranges must have the same length. The algorithm caps lockstep iteration at
+//! All five outer ranges must have the same length. The algorithm caps lockstep iteration at
 //! the shortest range, but this must not be relied upon and may change at any time. Each
 //! output iterator must refer to writable device-accessible storage for at least as many
-//! values as the corresponding input range contains.
+//! values as the corresponding input size gives.
 //!
 //! Every communicator rank must participate in the collective call. `__init`, `__op`, and
 //! `__ident` must describe the same operation on every rank. `__op` must be associative, and
@@ -256,41 +252,37 @@ _CCCL_HOST_API void __scan(
 //! Each environment supplies the stream and optional memory resource for its local rank. The
 //! results are ready after the work enqueued on the corresponding streams completes.
 //!
-//! @tparam _Policy The return value policy. Currently only `distributed_t` is supported.
-//! @tparam _CommRange The range of communicators. Each element must model the communicator
-//!         concept.
-//! @tparam _EnvRange The range of execution environments.
-//! @tparam _InputRangeRange The range whose elements are the per-communicator input ranges.
-//!         Each element must be a sized random-access range.
-//! @tparam _OutputItRange The range of output iterators, one per communicator.
-//! @tparam _Tp The scan value type. Deduced by default from the input element type.
-//! @tparam _BinaryOp The binary scan operator type. Defaults to `::cuda::std::plus<>`.
-//!
-//! @param[in] __policy The result policy object.
+//! @param[in] __policy The result policy object. Currently must be `cudax::distributed`.
 //! @param[in] __comms The range of communicators.
 //! @param[in] __envs The range of execution environments. Each environment must contain a
 //!                   stream.
-//! @param[in] __range_of_inputs The range of per-communicator input ranges to scan.
-//! @param[out] __outputs The range of output iterators receiving the per-communicator results.
+//! @param[in] __input_iters The range of per-communicator input iterators to scan.
+//! @param[in] __num_items_range A range of sizes per input iterator to scan.
+//! @param[out] __output_iters The range of output iterators receiving the per-communicator
+//!                            results.
 //! @param[in] __init The initial value for the scan.
 //! @param[in] __op The associative binary scan operator.
 //! @param[in] __ident The identity element for `__op`.
-_CCCL_TEMPLATE(class _Policy,
-               class _CommRange,
-               class _EnvRange,
-               class _InputRangeRange,
-               class _OutputItRange,
-               class _Tp = ::cuda::std::ranges::range_value_t<::cuda::std::ranges::range_reference_t<_InputRangeRange>>,
-               class _BinaryOp = ::cuda::std::plus<>)
+_CCCL_TEMPLATE(
+  class _Policy,
+  class _CommRange,
+  class _EnvRange,
+  class _InputIterRange,
+  class _SizeTRange,
+  class _OutputIterRange,
+  class _Tp       = ::cuda::std::iter_value_t<::cuda::std::ranges::range_reference_t<_InputIterRange>>,
+  class _BinaryOp = ::cuda::std::plus<>)
 _CCCL_REQUIRES(__range_of_communicators<_CommRange> _CCCL_AND ::cuda::std::ranges::forward_range<_EnvRange> _CCCL_AND
-                 __detail::__range_of_sized_random_access_ranges<_InputRangeRange> _CCCL_AND
-                   __detail::__range_of_output_iters<_OutputItRange, _Tp>)
+                 __detail::__range_of_random_access_iterators<_InputIterRange>
+                   _CCCL_AND ::cuda::std::ranges::forward_range<_SizeTRange> _CCCL_AND
+                     __detail::__range_of_output_iters<_OutputIterRange, _Tp>)
 _CCCL_HOST_API void exclusive_scan(
   const __result_policy_base<_Policy>& __policy,
   _CommRange&& __comms,
   _EnvRange&& __envs,
-  _InputRangeRange&& __range_of_inputs,
-  _OutputItRange&& __outputs,
+  _InputIterRange&& __input_iters,
+  _SizeTRange&& __num_items_range,
+  _OutputIterRange&& __output_iters,
   _Tp __init     = {},
   _BinaryOp __op = {},
   _Tp __ident    = ::cuda::identity_element<_BinaryOp, _Tp>())
@@ -299,8 +291,9 @@ _CCCL_HOST_API void exclusive_scan(
     __policy,
     ::cuda::std::forward<_CommRange>(__comms),
     ::cuda::std::forward<_EnvRange>(__envs),
-    ::cuda::std::forward<_InputRangeRange>(__range_of_inputs),
-    ::cuda::std::forward<_OutputItRange>(__outputs),
+    ::cuda::std::forward<_InputIterRange>(__input_iters),
+    ::cuda::std::forward<_SizeTRange>(__num_items_range),
+    ::cuda::std::forward<_OutputIterRange>(__output_iters),
     ::cuda::std::move(__init),
     ::cuda::std::move(__op),
     ::cuda::std::move(__ident));
@@ -310,56 +303,51 @@ _CCCL_HOST_API void exclusive_scan(
 //!
 //! Treats the input ranges from all communicator ranks as one logical sequence, with the
 //! ranges concatenated in ascending communicator rank order. Writes the portion of the
-//! exclusive scan corresponding to `__comm` to `__output`. The first output element in the
+//! exclusive scan corresponding to `__comm` to `__output_iter`. The first output element in the
 //! logical sequence is `__init`. Every other output element is the reduction of `__init` with
 //! all preceding elements in the logical sequence.
 //!
-//! This convenience overload forwards one communicator, environment, input range, and output
-//! iterator to the range-based overload. It is intended for a thread or process that owns one
-//! local GPU.
+//! This convenience overload forwards one communicator, environment, input iterator, input
+//! size, and output iterator to the range-based overload. It is intended for a thread or process
+//! that owns one local GPU.
 //!
 //! @snippet exclusive_scan/single_comm_basic.cu exclusive_scan_single_range
 //!
 //! Every communicator rank must participate in the collective call. `__init`, `__op`, and
 //! `__ident` must describe the same operation on every rank. `__op` must be associative, and
-//! `__ident` must be an identity element for `__op`. `__output` must refer to writable
-//! device-accessible storage for at least as many values as `__input` contains.
+//! `__ident` must be an identity element for `__op`. `__output_iter` must refer to writable
+//! device-accessible storage for at least `__num_items` values.
 //!
 //! The environment supplies the stream and optional memory resource for the local rank. The
 //! results are ready after the work enqueued on that stream completes.
 //!
-//! @tparam _Policy The return value policy. Currently only `distributed_t` is supported.
-//! @tparam _Comm The communicator type. Must model the communicator concept.
-//! @tparam _Env The execution environment type. Supplies the stream and optional memory
-//!              resource.
-//! @tparam _InputRange The input range type. Must be a sized random-access range.
-//! @tparam _OutputIt The output iterator type.
-//! @tparam _Tp The scan value type. Deduced by default from the input element type.
-//! @tparam _BinaryOp The binary scan operator type. Defaults to `::cuda::std::plus<>`.
-//!
-//! @param[in] __policy The result policy object.
+//! @param[in] __policy The result policy object. Currently must be `cudax::distributed`.
 //! @param[in] __comm The communicator.
 //! @param[in] __env The execution environment. Must contain a stream.
-//! @param[in] __input The input range to scan.
-//! @param[out] __output The output iterator receiving the local scan results.
+//! @param[in] __input_iter The input iterator to scan.
+//! @param[in] __num_items The number of items in `__input_iter` to scan.
+//! @param[out] __output_iter The output iterator receiving the local scan results.
 //! @param[in] __init The initial value for the scan.
 //! @param[in] __op The associative binary scan operator.
 //! @param[in] __ident The identity element for `__op`.
-_CCCL_TEMPLATE(class _Policy,
-               class _Comm,
-               class _Env,
-               class _InputRange,
-               class _OutputIt,
-               class _Tp       = ::cuda::std::ranges::range_value_t<_InputRange>,
-               class _BinaryOp = ::cuda::std::plus<>)
-_CCCL_REQUIRES(__communicator<_Comm> _CCCL_AND ::cuda::std::ranges::random_access_range<_InputRange>
+_CCCL_TEMPLATE(
+  class _Policy,
+  class _Comm,
+  class _Env,
+  class _InputIt,
+  class _SizeT,
+  class _OutputIt,
+  class _Tp       = ::cuda::std::iter_value_t<_InputIt>,
+  class _BinaryOp = ::cuda::std::plus<>)
+_CCCL_REQUIRES(__communicator<_Comm> _CCCL_AND ::cuda::std::random_access_iterator<_InputIt>
                  _CCCL_AND ::cuda::std::output_iterator<_OutputIt, _Tp>)
 _CCCL_HOST_API void exclusive_scan(
   const __result_policy_base<_Policy>& __policy,
   _Comm&& __comm,
   _Env&& __env,
-  _InputRange&& __input,
-  _OutputIt __output,
+  _InputIt __input_iter,
+  _SizeT __num_items,
+  _OutputIt __output_iter,
   _Tp __init     = {},
   _BinaryOp __op = {},
   _Tp __ident    = ::cuda::identity_element<_BinaryOp, _Tp>())
@@ -368,8 +356,9 @@ _CCCL_HOST_API void exclusive_scan(
     __policy,
     ::cuda::std::span<::cuda::std::remove_reference_t<_Comm>, 1>{::cuda::std::addressof(__comm), 1},
     ::cuda::std::span<::cuda::std::remove_reference_t<_Env>, 1>{::cuda::std::addressof(__env), 1},
-    ::cuda::std::span<::cuda::std::remove_reference_t<_InputRange>, 1>{::cuda::std::addressof(__input), 1},
-    ::cuda::std::span<_OutputIt, 1>{::cuda::std::addressof(__output), 1},
+    ::cuda::std::span<_InputIt, 1>{::cuda::std::addressof(__input_iter), 1},
+    ::cuda::std::span<_SizeT, 1>{::cuda::std::addressof(__num_items), 1},
+    ::cuda::std::span<_OutputIt, 1>{::cuda::std::addressof(__output_iter), 1},
     ::cuda::std::move(__init),
     ::cuda::std::move(__op),
     ::cuda::std::move(__ident));
@@ -383,17 +372,17 @@ _CCCL_HOST_API void exclusive_scan(
 //! is the reduction of `__init` with all input elements through the corresponding position in
 //! the logical sequence. Empty input ranges contribute no elements.
 //!
-//! The communicators, environments, input ranges, and output iterators are iterated in
-//! lockstep. Each tuple describes one local communicator rank. This overload is intended for
-//! a thread or process that owns multiple local GPUs. For example, if each process owns two
-//! GPUs, each process can pass both local ranks in one call, as shown in the test below.
+//! The communicators, environments, input iterators, input sizes, and output iterators are
+//! iterated in lockstep. Each tuple describes one local communicator rank. This overload is
+//! intended for a thread or process that owns multiple local GPUs. For example, if each process
+//! owns two GPUs, each process can pass both local ranks in one call, as shown in the test below.
 //!
 //! @snippet inclusive_scan/range_basic.cu inclusive_scan
 //!
-//! All four outer ranges must have the same length. The algorithm caps lockstep iteration at
+//! All five outer ranges must have the same length. The algorithm caps lockstep iteration at
 //! the shortest range, but this must not be relied upon and may change at any time. Each
 //! output iterator must refer to writable device-accessible storage for at least as many
-//! values as the corresponding input range contains.
+//! values as the corresponding input size gives.
 //!
 //! Every communicator rank must participate in the collective call. `__init`, `__op`, and
 //! `__ident` must describe the same operation on every rank. `__op` must be associative, and
@@ -403,41 +392,37 @@ _CCCL_HOST_API void exclusive_scan(
 //! Each environment supplies the stream and optional memory resource for its local rank. The
 //! results are ready after the work enqueued on the corresponding streams completes.
 //!
-//! @tparam _Policy The return value policy. Currently only `distributed_t` is supported.
-//! @tparam _CommRange The range of communicators. Each element must model the communicator
-//!         concept.
-//! @tparam _EnvRange The range of execution environments.
-//! @tparam _InputRangeRange The range whose elements are the per-communicator input ranges.
-//!         Each element must be a sized random-access range.
-//! @tparam _OutputItRange The range of output iterators, one per communicator.
-//! @tparam _Tp The scan value type. Deduced by default from the input element type.
-//! @tparam _BinaryOp The binary scan operator type. Defaults to `::cuda::std::plus<>`.
-//!
-//! @param[in] __policy The result policy object.
+//! @param[in] __policy The result policy object. Currently must be `cudax::distributed`.
 //! @param[in] __comms The range of communicators.
 //! @param[in] __envs The range of execution environments. Each environment must contain a
 //!                   stream.
-//! @param[in] __range_of_inputs The range of per-communicator input ranges to scan.
-//! @param[out] __outputs The range of output iterators receiving the per-communicator results.
+//! @param[in] __input_iters The range of per-communicator input iterators to scan.
+//! @param[in] __num_items_range A range of sizes per input iterator to scan.
+//! @param[out] __output_iters The range of output iterators receiving the per-communicator
+//!                            results.
 //! @param[in] __init The initial value for the scan.
 //! @param[in] __op The associative binary scan operator.
 //! @param[in] __ident The identity element for `__op`.
-_CCCL_TEMPLATE(class _Policy,
-               class _CommRange,
-               class _EnvRange,
-               class _InputRangeRange,
-               class _OutputItRange,
-               class _Tp = ::cuda::std::ranges::range_value_t<::cuda::std::ranges::range_reference_t<_InputRangeRange>>,
-               class _BinaryOp = ::cuda::std::plus<>)
+_CCCL_TEMPLATE(
+  class _Policy,
+  class _CommRange,
+  class _EnvRange,
+  class _InputIterRange,
+  class _SizeTRange,
+  class _OutputIterRange,
+  class _Tp       = ::cuda::std::iter_value_t<::cuda::std::ranges::range_reference_t<_InputIterRange>>,
+  class _BinaryOp = ::cuda::std::plus<>)
 _CCCL_REQUIRES(__range_of_communicators<_CommRange> _CCCL_AND ::cuda::std::ranges::forward_range<_EnvRange> _CCCL_AND
-                 __detail::__range_of_sized_random_access_ranges<_InputRangeRange> _CCCL_AND
-                   __detail::__range_of_output_iters<_OutputItRange, _Tp>)
+                 __detail::__range_of_random_access_iterators<_InputIterRange>
+                   _CCCL_AND ::cuda::std::ranges::forward_range<_SizeTRange> _CCCL_AND
+                     __detail::__range_of_output_iters<_OutputIterRange, _Tp>)
 _CCCL_HOST_API void inclusive_scan(
   const __result_policy_base<_Policy>& __policy,
   _CommRange&& __comms,
   _EnvRange&& __envs,
-  _InputRangeRange&& __range_of_inputs,
-  _OutputItRange&& __outputs,
+  _InputIterRange&& __input_iters,
+  _SizeTRange&& __num_items_range,
+  _OutputIterRange&& __output_iters,
   _Tp __init     = {},
   _BinaryOp __op = {},
   _Tp __ident    = ::cuda::identity_element<_BinaryOp, _Tp>())
@@ -446,8 +431,9 @@ _CCCL_HOST_API void inclusive_scan(
     __policy,
     ::cuda::std::forward<_CommRange>(__comms),
     ::cuda::std::forward<_EnvRange>(__envs),
-    ::cuda::std::forward<_InputRangeRange>(__range_of_inputs),
-    ::cuda::std::forward<_OutputItRange>(__outputs),
+    ::cuda::std::forward<_InputIterRange>(__input_iters),
+    ::cuda::std::forward<_SizeTRange>(__num_items_range),
+    ::cuda::std::forward<_OutputIterRange>(__output_iters),
     ::cuda::std::move(__init),
     ::cuda::std::move(__op),
     ::cuda::std::move(__ident));
@@ -457,56 +443,51 @@ _CCCL_HOST_API void inclusive_scan(
 //!
 //! Treats the input ranges from all communicator ranks as one logical sequence, with the
 //! ranges concatenated in ascending communicator rank order. Writes the portion of the
-//! inclusive scan corresponding to `__comm` to `__output`. Each output element is the reduction
-//! of `__init` with all input elements through the corresponding position in the logical
-//! sequence.
+//! inclusive scan corresponding to `__comm` to `__output_iter`. Each output element is the
+//! reduction of `__init` with all input elements through the corresponding position in the
+//! logical sequence.
 //!
-//! This convenience overload forwards one communicator, environment, input range, and output
-//! iterator to the range-based overload. It is intended for a thread or process that owns one
-//! local GPU.
+//! This convenience overload forwards one communicator, environment, input iterator, input
+//! size, and output iterator to the range-based overload. It is intended for a thread or process
+//! that owns one local GPU.
 //!
 //! @snippet inclusive_scan/single_comm_basic.cu inclusive_scan_single_range
 //!
 //! Every communicator rank must participate in the collective call. `__init`, `__op`, and
 //! `__ident` must describe the same operation on every rank. `__op` must be associative, and
-//! `__ident` must be an identity element for `__op`. `__output` must refer to writable
-//! device-accessible storage for at least as many values as `__input` contains.
+//! `__ident` must be an identity element for `__op`. `__output_iter` must refer to writable
+//! device-accessible storage for at least `__num_items` values.
 //!
 //! The environment supplies the stream and optional memory resource for the local rank. The
 //! results are ready after the work enqueued on that stream completes.
 //!
-//! @tparam _Policy The return value policy. Currently only `distributed_t` is supported.
-//! @tparam _Comm The communicator type. Must model the communicator concept.
-//! @tparam _Env The execution environment type. Supplies the stream and optional memory
-//!              resource.
-//! @tparam _InputRange The input range type. Must be a sized random-access range.
-//! @tparam _OutputIt The output iterator type.
-//! @tparam _Tp The scan value type. Deduced by default from the input element type.
-//! @tparam _BinaryOp The binary scan operator type. Defaults to `::cuda::std::plus<>`.
-//!
-//! @param[in] __policy The result policy object.
+//! @param[in] __policy The result policy object. Currently must be `cudax::distributed`.
 //! @param[in] __comm The communicator.
 //! @param[in] __env The execution environment. Must contain a stream.
-//! @param[in] __input The input range to scan.
-//! @param[out] __output The output iterator receiving the local scan results.
+//! @param[in] __input_iter The input iterator to scan.
+//! @param[in] __num_items The number of items in `__input_iter` to scan.
+//! @param[out] __output_iter The output iterator receiving the local scan results.
 //! @param[in] __init The initial value for the scan.
 //! @param[in] __op The associative binary scan operator.
 //! @param[in] __ident The identity element for `__op`.
-_CCCL_TEMPLATE(class _Policy,
-               class _Comm,
-               class _Env,
-               class _InputRange,
-               class _OutputIt,
-               class _Tp       = ::cuda::std::ranges::range_value_t<_InputRange>,
-               class _BinaryOp = ::cuda::std::plus<>)
-_CCCL_REQUIRES(__communicator<_Comm> _CCCL_AND ::cuda::std::ranges::random_access_range<_InputRange>
+_CCCL_TEMPLATE(
+  class _Policy,
+  class _Comm,
+  class _Env,
+  class _InputIt,
+  class _SizeT,
+  class _OutputIt,
+  class _Tp       = ::cuda::std::iter_value_t<_InputIt>,
+  class _BinaryOp = ::cuda::std::plus<>)
+_CCCL_REQUIRES(__communicator<_Comm> _CCCL_AND ::cuda::std::random_access_iterator<_InputIt>
                  _CCCL_AND ::cuda::std::output_iterator<_OutputIt, _Tp>)
 _CCCL_HOST_API void inclusive_scan(
   const __result_policy_base<_Policy>& __policy,
   _Comm&& __comm,
   _Env&& __env,
-  _InputRange&& __input,
-  _OutputIt __output,
+  _InputIt __input_iter,
+  _SizeT __num_items,
+  _OutputIt __output_iter,
   _Tp __init     = {},
   _BinaryOp __op = {},
   _Tp __ident    = ::cuda::identity_element<_BinaryOp, _Tp>())
@@ -515,8 +496,9 @@ _CCCL_HOST_API void inclusive_scan(
     __policy,
     ::cuda::std::span<::cuda::std::remove_reference_t<_Comm>, 1>{::cuda::std::addressof(__comm), 1},
     ::cuda::std::span<::cuda::std::remove_reference_t<_Env>, 1>{::cuda::std::addressof(__env), 1},
-    ::cuda::std::span<::cuda::std::remove_reference_t<_InputRange>, 1>{::cuda::std::addressof(__input), 1},
-    ::cuda::std::span<_OutputIt, 1>{::cuda::std::addressof(__output), 1},
+    ::cuda::std::span<_InputIt, 1>{::cuda::std::addressof(__input_iter), 1},
+    ::cuda::std::span<_SizeT, 1>{::cuda::std::addressof(__num_items), 1},
+    ::cuda::std::span<_OutputIt, 1>{::cuda::std::addressof(__output_iter), 1},
     ::cuda::std::move(__init),
     ::cuda::std::move(__op),
     ::cuda::std::move(__ident));

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/data_exchange.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/data_exchange.h
@@ -152,14 +152,15 @@ _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
 //! @brief Compute, per destination rank, how many local keys it is owed and where they land.
 template <class _Tp, class _Env, class _BinaryOp>
-template <class _CommRange, class _EnvRange, class _InputRange>
+template <class _CommRange, class _EnvRange, class _InputIterRange, class _SizeTRange>
 _CCCL_HOST_API ::std::vector<
   typename _HSSSorter<_Tp, _Env, _BinaryOp>::template __resizable_buffer_type<::cuda::std::size_t>>
 _HSSSorter<_Tp, _Env, _BinaryOp>::__compute_send_counts_and_offsets(
   const __local_setup_result_type& __setup,
   _CommRange&& __comms,
   _EnvRange&& __envs,
-  _InputRange&& __local_inputs,
+  _InputIterRange&& __input_iters,
+  _SizeTRange&& __num_items_range,
   const _BinaryOp& __cmp,
   const ::std::vector<__per_comm_histogramming_result_type>& __hist_results,
   ::std::vector<__resizable_buffer_type<::cuda::std::uint64_t>>* __local_current_offsets)
@@ -184,12 +185,13 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__compute_send_counts_and_offsets(
   __local_current_offsets->reserve(__num_local);
 
   {
-    auto __comm_it  = ::cuda::std::ranges::begin(__comms);
-    auto __env_it   = ::cuda::std::ranges::begin(__envs);
-    auto __input_it = ::cuda::std::ranges::begin(__local_inputs);
+    auto __comm_it      = ::cuda::std::ranges::begin(__comms);
+    auto __env_it       = ::cuda::std::ranges::begin(__envs);
+    auto __input_it     = ::cuda::std::ranges::begin(__input_iters);
+    auto __num_items_it = ::cuda::std::ranges::begin(__num_items_range);
 
     for (::cuda::std::size_t __idx = 0; __idx < __num_local;
-         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__input_it)
+         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__input_it, (void) ++__num_items_it)
     {
       const auto& __hist   = __hist_results[__idx].__hist;
       const auto& __I_j    = __hist_results[__idx].__splitters.__I_j;
@@ -241,13 +243,13 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__compute_send_counts_and_offsets(
       // histogramming phase, but ultimately it does something very similar here. I wonder if we
       // can't just reuse the histogram directly here. There is a lot of repeated information
       // here.
-      const auto* __input_begin = ::cuda::std::to_address(::cuda::std::ranges::begin(*__input_it));
+      const auto* __input_begin = ::cuda::std::to_address(*__input_it);
       using __input_it_t        = ::cuda::std::remove_cvref_t<decltype(__input_begin)>;
 
       auto __op =
         __send_count_and_offset_fn<__bucket_count_fn<__input_it_t, __bucket_to_splitter_key_fn<_Tp>, _BinaryOp>>{
           {__input_begin,
-           ::cuda::std::to_address(::cuda::std::ranges::end(*__input_it)),
+           __input_begin + *__num_items_it,
            // This is doing double duty here. Not only do we use it to calculate the actual size
            // of each bin, but we also use the __rank() function to calculate the offsets.
            __bucket_to_splitter_key_fn<_Tp>{
@@ -363,16 +365,17 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__make_recv_buffers(
 
 //! @brief Send the keys in `[S(d - 1), S(d))` to rank `d`, then merge the runs each rank receives.
 //!
-//! `__local_inputs` must be locally sorted and `__hist_results` carry finalized brackets
-//! from `__histogramming_phase`.
+//! The keys in `__input_iters` must be locally sorted and `__hist_results` carry finalized
+//! brackets from `__histogramming_phase`.
 template <class _Tp, class _Env, class _BinaryOp>
-template <class _CommRange, class _EnvRange, class _InputRange>
+template <class _CommRange, class _EnvRange, class _InputIterRange, class _SizeTRange>
 _CCCL_HOST_API typename _HSSSorter<_Tp, _Env, _BinaryOp>::__data_exchange_result_type
 _HSSSorter<_Tp, _Env, _BinaryOp>::__data_exchange(
   const __local_setup_result_type& __setup,
   _CommRange&& __comms,
   _EnvRange&& __envs,
-  _InputRange&& __local_inputs,
+  _InputIterRange&& __input_iters,
+  _SizeTRange&& __num_items_range,
   const _BinaryOp& __cmp,
   const ::std::vector<__per_comm_histogramming_result_type>& __hist_results)
 {
@@ -384,21 +387,21 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__data_exchange(
 
   auto __local_recvd = [&] {
     const auto __local_counts = __compute_send_counts_and_offsets(
-      __setup, __comms, __envs, __local_inputs, __cmp, __hist_results, &__local_current_offsets);
+      __setup, __comms, __envs, __input_iters, __num_items_range, __cmp, __hist_results, &__local_current_offsets);
 
     return __make_recv_buffers(__comms, __envs, __comm_size, __local_counts, &__local_h_counts);
   }();
 
   {
     auto __comm_it  = ::cuda::std::ranges::begin(__comms);
-    auto __input_it = ::cuda::std::ranges::begin(__local_inputs);
+    auto __input_it = ::cuda::std::ranges::begin(__input_iters);
     auto&& __guard  = __comm_it->group_guard();
 
     for (::cuda::std::size_t __idx = 0; __idx < __num_local; (void) ++__idx, (void) ++__comm_it, (void) ++__input_it)
     {
       __comm_it->all_to_all_v(
         __guard,
-        ::cuda::std::to_address(::cuda::std::ranges::begin(*__input_it)),
+        ::cuda::std::to_address(*__input_it),
         __h_column(__local_h_counts, __comm_size, __idx, __h_send_counts_column).data(),
         __h_column(__local_h_counts, __comm_size, __idx, __h_send_displs_column).data(),
         __local_recvd[__idx].data(),
@@ -411,11 +414,10 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__data_exchange(
   // Merge the p received sorted runs into this phase's output.
   //
   // The merged keys stay in a stream-ordered buffer rather than being written back into the
-  // caller's range: `__local_inputs` is the send buffer of the `all_to_all_v` enqueued above, and
-  // resizing it here would both alias that in-flight collective and, for a container whose growth
-  // reallocates through a synchronous allocator, block this rank inside a region where its peers
-  // are waiting on a collective it has not yet joined. The caller's range is written exactly once,
-  // at the very end of the rebalance phase, when nothing is in flight.
+  // caller's storage: the keys behind `__input_iters` are the send buffer of the `all_to_all_v`
+  // enqueued above, and writing them here would alias that in-flight collective. The caller's
+  // storage is written exactly once, at the very end of the rebalance phase, when nothing is in
+  // flight.
   ::std::vector<__resizable_buffer_type<_Tp>> __local_merged;
 
   __local_merged.reserve(__num_local);

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/execute.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/execute.h
@@ -28,6 +28,7 @@
 #include <cuda/std/__ranges/access.h>
 #include <cuda/std/__ranges/concepts.h>
 #include <cuda/std/__ranges/size.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
 
 #include <cuda/experimental/__multi_gpu/algorithm/common.h>
 #include <cuda/experimental/__multi_gpu/algorithm/sort/hss/data_exchange.h>
@@ -51,12 +52,13 @@ _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 //! the algorithm defined in "Histogram Sort with Sampling" by Harsh
 //! et. al. (arxiv.org/abs/1803.01237, alternatively dl.acm.org/doi/10.1145/3323165.3323184)
 template <class _Tp, class _Env, class _BinaryOp>
-template <class _Policy, class _CommRange, class _EnvRange, class _InputRange>
+template <class _Policy, class _CommRange, class _EnvRange, class _InputIterRange, class _SizeTRange>
 _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__execute(
   const __result_policy_base<_Policy>&,
   _CommRange&& __comms,
   _EnvRange&& __envs,
-  _InputRange&& __local_inputs,
+  _InputIterRange&& __input_iters,
+  _SizeTRange&& __num_items_range,
   _BinaryOp __cmp)
 {
   static_assert(::cuda::std::same_as<_Policy, distributed_t>,
@@ -64,15 +66,18 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__execute(
                 "github.com/NVIDIA/cccl/issue requesting support for your specified policy.");
   static_assert(::cuda::std::ranges::sized_range<_CommRange>);
 
+  static_assert(::cuda::std::is_arithmetic_v<::cuda::std::ranges::range_value_t<_SizeTRange>>,
+                "Non arithmetic size types not yet supported. Please open an issue at "
+                "github.com/NVIDIA/cccl/issue requesting support for your specified type.");
+
   // TODO(jfaibussowit):
   //
-  // We should consider supporting random-access ranges too, but then we need temp buffers for
+  // We should consider supporting random-access iterators too, but then we need temp buffers for
   // the various comms calls.
   //
   // We cannot assert the following because thrust iterators don't play nice with it.
 #if 0
-  using __base_iter =
-    ::cuda::std::ranges::iterator_t<::cuda::std::remove_cvref_t<::cuda::std::ranges::range_reference_t<_InputRange>>>;
+  using __base_iter = ::cuda::std::remove_cvref_t<::cuda::std::ranges::range_reference_t<_InputIterRange>>;
 
   static_assert(::cuda::std::__has_contiguous_traversal<__base_iter>);
 #endif
@@ -82,16 +87,17 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__execute(
     const auto __num_local_inputs = ::cuda::std::ranges::size(__comms);
     auto __comm_it                = ::cuda::std::ranges::begin(__comms);
     auto __env_it                 = ::cuda::std::ranges::begin(__envs);
-    auto __input_it               = ::cuda::std::ranges::begin(__local_inputs);
+    auto __input_it               = ::cuda::std::ranges::begin(__input_iters);
+    auto __num_items_it           = ::cuda::std::ranges::begin(__num_items_range);
 
     for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs;
-         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__input_it)
+         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__input_it, (void) ++__num_items_it)
     {
       __CUDAX_MULTI_GPU_DISPATCH(
         __comm_it->logical_device(),
         CUB_NS_QUALIFIER::DeviceMergeSort::SortKeys,
-        ::cuda::std::ranges::begin(*__input_it),
-        ::cuda::std::ranges::size(*__input_it),
+        *__input_it,
+        *__num_items_it,
         __cmp,
         *__env_it);
     }
@@ -105,7 +111,7 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__execute(
     return;
   }
 
-  const auto __setup = __local_setup(__comms, __envs, __local_inputs, __comm_size);
+  const auto __setup = __local_setup(__comms, __envs, __num_items_range, __comm_size);
 
   // 0 global elements, or all global elements are on the local rank
   if (__setup.__N == 0)
@@ -114,12 +120,12 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__execute(
   }
 
   auto __exchange_result = [&] {
-    auto __hist_results = __histogramming_phase(__setup, __comms, __envs, __local_inputs, __cmp);
+    auto __hist_results = __histogramming_phase(__setup, __comms, __envs, __input_iters, __num_items_range, __cmp);
 
-    return __data_exchange(__setup, __comms, __envs, __local_inputs, __cmp, __hist_results);
+    return __data_exchange(__setup, __comms, __envs, __input_iters, __num_items_range, __cmp, __hist_results);
   }();
 
-  __rebalance_to_original_counts(__setup, __comms, __envs, __local_inputs, __exchange_result);
+  __rebalance_to_original_counts(__setup, __comms, __envs, __input_iters, __num_items_range, __exchange_result);
 }
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/histogramming.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/histogramming.h
@@ -131,10 +131,11 @@ _CCCL_KERNEL_ATTRIBUTES void __sample_probes_kernel(
 
 //! @brief Launch the sampling kernel to draw sample keys from each rank's local input.
 template <class _Tp, class _Env, class _BinaryOp>
-template <class _CommRange, class _InputRange>
+template <class _CommRange, class _InputIterRange, class _SizeTRange>
 _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__local_sampling(
   _CommRange&& __comms,
-  _InputRange&& __local_inputs,
+  _InputIterRange&& __input_iters,
+  _SizeTRange&& __num_items_range,
   ::cuda::std::int32_t __j,
   double __sampling_probability,
   const _BinaryOp& __cmp,
@@ -150,11 +151,12 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__local_sampling(
 
   const auto __num_local_inputs = ::cuda::std::ranges::size(__comms);
   auto __comm_it                = ::cuda::std::ranges::begin(__comms);
-  auto __input_it               = ::cuda::std::ranges::begin(__local_inputs);
+  auto __input_it               = ::cuda::std::ranges::begin(__input_iters);
+  auto __num_items_it           = ::cuda::std::ranges::begin(__num_items_range);
   auto& __scratch               = *__local_scratch;
 
   for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs;
-       (void) ++__idx, (void) ++__comm_it, (void) ++__input_it)
+       (void) ++__idx, (void) ++__comm_it, (void) ++__input_it, (void) ++__num_items_it)
   {
     const auto __rank   = __comm_it->rank();
     auto& __all_samples = __scratch[__idx].__all_samples;
@@ -167,7 +169,8 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__local_sampling(
     const auto __seed =
       (static_cast<::cuda::std::uint64_t>(__j) * 0x129381294235245ULL) ^ static_cast<::cuda::std::uint64_t>(__rank);
 
-    const auto& __I_j = __local_hist_results[__idx].__splitters.__I_j;
+    const auto& __I_j  = __local_hist_results[__idx].__splitters.__I_j;
+    const auto* __keys = ::cuda::std::to_address(*__input_it);
 
     ::cuda::launch(
       // All inputs should be on the same stream here
@@ -177,8 +180,8 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__local_sampling(
         __sample_probes_kernel<::cuda::std::remove_cvref_t<decltype(__launch_config)>, _Tp, _BinaryOp>,
       ::cuda::std::philox4x64{__seed},
       __sampling_probability,
-      ::cuda::std::to_address(::cuda::std::ranges::begin(*__input_it)),
-      ::cuda::std::to_address(::cuda::std::ranges::end(*__input_it)),
+      __keys,
+      __keys + *__num_items_it,
       __I_j,
       __cmp,
       // Each rank samples directly into its own slot of `__all_samples` so that we can
@@ -413,41 +416,39 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__gather_and_merge_probes(
 
 //! @brief Compute and globally reduce the per-probe histogram of the local keys.
 template <class _Tp, class _Env, class _BinaryOp>
-template <class _CommRange, class _EnvRange, class _InputRange>
+template <class _CommRange, class _EnvRange, class _InputIterRange, class _SizeTRange>
 _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__compute_histogram(
   _CommRange&& __comms,
   _EnvRange&& __envs,
-  _InputRange&& __range_of_local_keys,
+  _InputIterRange&& __key_iters,
+  _SizeTRange&& __num_items_range,
   const _BinaryOp& __cmp,
   ::std::vector<__per_comm_histogramming_result_type>* __local_hist_results)
 {
   const auto __num_local_inputs = ::cuda::std::ranges::size(__comms);
 
   {
-    auto __comm_it = ::cuda::std::ranges::begin(__comms);
-    auto __env_it  = ::cuda::std::ranges::begin(__envs);
-    auto __keys_it = ::cuda::std::ranges::begin(__range_of_local_keys);
+    auto __comm_it      = ::cuda::std::ranges::begin(__comms);
+    auto __env_it       = ::cuda::std::ranges::begin(__envs);
+    auto __keys_it      = ::cuda::std::ranges::begin(__key_iters);
+    auto __num_items_it = ::cuda::std::ranges::begin(__num_items_range);
 
     for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs;
-         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__keys_it)
+         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__keys_it, (void) ++__num_items_it)
     {
       auto& __hist               = (*__local_hist_results)[__idx].__hist;
       auto& __probes             = (*__local_hist_results)[__idx].__splitters.__probes;
       const auto __num_probes    = __probes.size();
       const auto __num_buckets   = __num_probes + 1;
-      const auto* __keys_first   = ::cuda::std::to_address(::cuda::std::ranges::begin(*__keys_it));
+      const auto* __keys_first   = ::cuda::std::to_address(*__keys_it);
       const auto* __probes_first = __probes.data();
 
       __hist.resize_discard(__hist.stream(), __num_buckets, ::cuda::no_init);
 
-      auto __op = __bucket_count_fn<::cuda::std::remove_cvref_t<decltype(__keys_first)>,
-                                    ::cuda::std::remove_cvref_t<decltype(__probes_first)>,
-                                    _BinaryOp>{
-        __keys_first,
-        ::cuda::std::to_address(::cuda::std::ranges::end(*__keys_it)),
-        __probes_first,
-        __num_probes,
-        __cmp};
+      auto __op =
+        __bucket_count_fn<::cuda::std::remove_cvref_t<decltype(__keys_first)>,
+                          ::cuda::std::remove_cvref_t<decltype(__probes_first)>,
+                          _BinaryOp>{__keys_first, __keys_first + *__num_items_it, __probes_first, __num_probes, __cmp};
 
       __CUDAX_MULTI_GPU_DISPATCH(
         __comm_it->logical_device(),
@@ -515,14 +516,15 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__update_intervals(
 }
 
 template <class _Tp, class _Env, class _BinaryOp>
-template <class _CommRange, class _EnvRange, class _InputRange>
+template <class _CommRange, class _EnvRange, class _InputIterRange, class _SizeTRange>
 [[nodiscard]]
 _CCCL_HOST_API ::std::vector<typename _HSSSorter<_Tp, _Env, _BinaryOp>::__per_comm_histogramming_result_type>
 _HSSSorter<_Tp, _Env, _BinaryOp>::__histogramming_phase(
   const __local_setup_result_type& __setup,
   _CommRange&& __comms,
   _EnvRange&& __envs,
-  _InputRange&& __local_inputs,
+  _InputIterRange&& __input_iters,
+  _SizeTRange&& __num_items_range,
   const _BinaryOp& __cmp)
 {
   const auto __comm_size                       = __setup.__comm_size;
@@ -583,14 +585,23 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__histogramming_phase(
       __cap_displs[__r + 1] = __cap_displs[__r] + ::cuda::std::max(__cap, ::cuda::std::size_t{1});
     }
 
-    __local_sampling(__comms, __local_inputs, __j, __prob, __cmp, __local_hist_results, __cap_displs, &__local_scratch);
+    __local_sampling(
+      __comms,
+      __input_iters,
+      __num_items_range,
+      __j,
+      __prob,
+      __cmp,
+      __local_hist_results,
+      __cap_displs,
+      &__local_scratch);
 
     __exchange_sample_counts(__comms, /*mut ref*/ __recvcounts, &__local_scratch);
 
     __gather_and_merge_probes(
       __comms, __envs, __cmp, __recvcounts, __cap_displs, &__local_scratch, &__local_hist_results);
 
-    __compute_histogram(__comms, __envs, __local_inputs, __cmp, &__local_hist_results);
+    __compute_histogram(__comms, __envs, __input_iters, __num_items_range, __cmp, &__local_hist_results);
 
     // Tighten the brackets, which are also the next round's sampling intervals
     __update_intervals(__comms, __envs, __N, &__local_hist_results);

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/local_setup.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/local_setup.h
@@ -49,10 +49,10 @@ _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
 //! @brief Measure the per-rank sizes, desired offsets, and global key count for the sort.
 template <class _Tp, class _Env, class _BinaryOp>
-template <class _CommRange, class _EnvRange, class _InputRange>
+template <class _CommRange, class _EnvRange, class _SizeTRange>
 [[nodiscard]] _CCCL_HOST_API typename _HSSSorter<_Tp, _Env, _BinaryOp>::__local_setup_result_type
 _HSSSorter<_Tp, _Env, _BinaryOp>::__local_setup(
-  _CommRange&& __comms, _EnvRange&& __envs, _InputRange&& __local_inputs, ::cuda::std::int32_t __comm_size)
+  _CommRange&& __comms, _EnvRange&& __envs, _SizeTRange&& __num_items_range, ::cuda::std::int32_t __comm_size)
 {
   const auto __num_local_inputs = ::cuda::std::ranges::size(__comms);
 
@@ -61,12 +61,12 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__local_setup(
   __all_local_sizes.reserve(__num_local_inputs);
 
   {
-    auto __comm_it  = ::cuda::std::ranges::begin(__comms);
-    auto __env_it   = ::cuda::std::ranges::begin(__envs);
-    auto __input_it = ::cuda::std::ranges::begin(__local_inputs);
+    auto __comm_it      = ::cuda::std::ranges::begin(__comms);
+    auto __env_it       = ::cuda::std::ranges::begin(__envs);
+    auto __num_items_it = ::cuda::std::ranges::begin(__num_items_range);
 
     for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs;
-         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__input_it)
+         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__num_items_it)
     {
       __all_local_sizes.emplace_back(::cuda::make_buffer<::cuda::std::uint64_t>(
         ::cuda::get_stream(*__env_it),
@@ -74,7 +74,7 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__local_setup(
         __comm_size,
         // Technically, we only need to write this value at entry rank(), but that would
         // require a whole separate memcpy call which honestly does not seem worth it.
-        static_cast<::cuda::std::uint64_t>(::cuda::std::ranges::size(*__input_it)),
+        static_cast<::cuda::std::uint64_t>(*__num_items_it),
         ::cuda::experimental::__detail::__sanitize_buffer_env(*__env_it)));
     }
   }

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/rebalance.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/rebalance.h
@@ -104,12 +104,13 @@ _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
 //! @brief Redistribute the globally sorted keys back to each rank's original per-rank size.
 template <class _Tp, class _Env, class _BinaryOp>
-template <class _CommRange, class _EnvRange, class _InputRange>
+template <class _CommRange, class _EnvRange, class _InputIterRange, class _SizeTRange>
 _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__rebalance_to_original_counts(
   const __local_setup_result_type& __setup,
   _CommRange&& __comms,
   _EnvRange&& __envs,
-  _InputRange&& __local_inputs,
+  _InputIterRange&& __input_iters,
+  _SizeTRange&& __num_items_range,
   const __data_exchange_result_type& __exchange_results)
 {
   // At this point we have sorted a huge pile of numbers across several GPUs. Near the end,
@@ -163,12 +164,12 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__rebalance_to_original_co
   __local_rebalanced.reserve(__num_local_inputs);
 
   {
-    auto __comm_it  = ::cuda::std::ranges::begin(__comms);
-    auto __input_it = ::cuda::std::ranges::begin(__local_inputs);
-    auto __env_it   = ::cuda::std::ranges::begin(__envs);
+    auto __comm_it      = ::cuda::std::ranges::begin(__comms);
+    auto __num_items_it = ::cuda::std::ranges::begin(__num_items_range);
+    auto __env_it       = ::cuda::std::ranges::begin(__envs);
 
     for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs;
-         (void) ++__idx, (void) ++__comm_it, (void) ++__input_it, (void) ++__env_it)
+         (void) ++__idx, (void) ++__comm_it, (void) ++__num_items_it, (void) ++__env_it)
     {
       auto __counts = ::cuda::make_buffer<::cuda::std::size_t>(
         __exchange_results.__local_current_offsets[__idx].stream(),
@@ -218,7 +219,7 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__rebalance_to_original_co
       __local_rebalanced.emplace_back(
         __counts.stream(),
         __counts.memory_resource(),
-        ::cuda::std::ranges::size(*__input_it),
+        *__num_items_it,
         ::cuda::no_init,
         ::cuda::experimental::__detail::__sanitize_buffer_env(*__env_it));
     }
@@ -246,14 +247,15 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__rebalance_to_original_co
   }
 
   {
-    auto __comm_it  = ::cuda::std::ranges::begin(__comms);
-    auto __env_it   = ::cuda::std::ranges::begin(__envs);
-    auto __input_it = ::cuda::std::ranges::begin(__local_inputs);
+    auto __comm_it      = ::cuda::std::ranges::begin(__comms);
+    auto __env_it       = ::cuda::std::ranges::begin(__envs);
+    auto __input_it     = ::cuda::std::ranges::begin(__input_iters);
+    auto __num_items_it = ::cuda::std::ranges::begin(__num_items_range);
 
     for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs;
-         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__input_it)
+         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__input_it, (void) ++__num_items_it)
     {
-      const auto __n = ::cuda::std::ranges::size(*__input_it);
+      const auto __n = *__num_items_it;
 
       _CCCL_VERIFY(__n == __local_rebalanced[__idx].size(), "Incorrect sizing for temp storage");
 
@@ -261,7 +263,7 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__rebalance_to_original_co
         __comm_it->logical_device(),
         CUB_NS_QUALIFIER::DeviceCopy::Copy,
         ::cuda::std::mdspan{__local_rebalanced[__idx].data(), __local_rebalanced[__idx].size()},
-        ::cuda::std::mdspan{::cuda::std::to_address(::cuda::std::ranges::begin(*__input_it)), __n},
+        ::cuda::std::mdspan{::cuda::std::to_address(*__input_it), __n},
         *__env_it);
     }
   }

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/sorter.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/sorter.h
@@ -124,25 +124,27 @@ public:
   using __data_exchange_result_type _CCCL_NODEBUG          = _DataExchangeResult<_Tp, __resizable_buffer_type>;
 
 private:
-  template <class _CommRange, class _EnvRange, class _InputRange>
+  template <class _CommRange, class _EnvRange, class _SizeTRange>
   [[nodiscard]] _CCCL_HOST_API static __local_setup_result_type __local_setup(
-    _CommRange&& __comms, _EnvRange&& __envs, _InputRange&& __local_inputs, ::cuda::std::int32_t __comm_size);
+    _CommRange&& __comms, _EnvRange&& __envs, _SizeTRange&& __num_items_range, ::cuda::std::int32_t __comm_size);
 
   // Histogram helpers
   // ------------------------------------------------------------------------------------------
 
-  template <class _CommRange, class _EnvRange, class _InputRange>
+  template <class _CommRange, class _EnvRange, class _InputIterRange, class _SizeTRange>
   [[nodiscard]] _CCCL_HOST_API static ::std::vector<__per_comm_histogramming_result_type> __histogramming_phase(
     const __local_setup_result_type& __setup,
     _CommRange&& __comms,
     _EnvRange&& __envs,
-    _InputRange&& __local_inputs,
+    _InputIterRange&& __input_iters,
+    _SizeTRange&& __num_items_range,
     const _BinaryOp& __cmp);
 
-  template <class _CommRange, class _InputRange>
+  template <class _CommRange, class _InputIterRange, class _SizeTRange>
   _CCCL_HOST_API static void __local_sampling(
     _CommRange&& __comms,
-    _InputRange&& __local_inputs,
+    _InputIterRange&& __input_iters,
+    _SizeTRange&& __num_items_range,
     ::cuda::std::int32_t __j,
     double __sampling_probability,
     const _BinaryOp& __cmp,
@@ -172,11 +174,12 @@ private:
     ::std::vector<__per_comm_sampling_scratch_type>* __local_scratch,
     ::std::vector<__per_comm_histogramming_result_type>* __local_hist_results);
 
-  template <class _CommRange, class _EnvRange, class _InputRange>
+  template <class _CommRange, class _EnvRange, class _InputIterRange, class _SizeTRange>
   _CCCL_HOST_API static void __compute_histogram(
     _CommRange&& __comms,
     _EnvRange&& __envs,
-    _InputRange&& __range_of_local_keys,
+    _InputIterRange&& __key_iters,
+    _SizeTRange&& __num_items_range,
     const _BinaryOp& __cmp,
     ::std::vector<__per_comm_histogramming_result_type>* __local_hist_results);
 
@@ -189,13 +192,14 @@ private:
 
   // ------------------------------------------------------------------------------------------
 
-  template <class _CommRange, class _EnvRange, class _InputRange>
+  template <class _CommRange, class _EnvRange, class _InputIterRange, class _SizeTRange>
   [[nodiscard]] _CCCL_HOST_API static ::std::vector<__resizable_buffer_type<::cuda::std::size_t>>
   __compute_send_counts_and_offsets(
     const __local_setup_result_type& __setup,
     _CommRange&& __comms,
     _EnvRange&& __envs,
-    _InputRange&& __local_inputs,
+    _InputIterRange&& __input_iters,
+    _SizeTRange&& __num_items_range,
     const _BinaryOp& __cmp,
     const ::std::vector<__per_comm_histogramming_result_type>& __hist_results,
     ::std::vector<__resizable_buffer_type<::cuda::std::uint64_t>>* __local_current_offsets);
@@ -208,12 +212,13 @@ private:
     const ::std::vector<__resizable_buffer_type<::cuda::std::size_t>>& __local_counts,
     ::std::vector<::cuda::std::size_t>* __h_counts);
 
-  template <class _CommRange, class _EnvRange, class _InputRange>
+  template <class _CommRange, class _EnvRange, class _InputIterRange, class _SizeTRange>
   [[nodiscard]] _CCCL_HOST_API static __data_exchange_result_type __data_exchange(
     const __local_setup_result_type& __setup,
     _CommRange&& __comms,
     _EnvRange&& __envs,
-    _InputRange&& __local_inputs,
+    _InputIterRange&& __input_iters,
+    _SizeTRange&& __num_items_range,
     const _BinaryOp& __cmp,
     const ::std::vector<__per_comm_histogramming_result_type>& __hist_results);
 
@@ -241,21 +246,23 @@ private:
 
   // ------------------------------------------------------------------------------------------
 
-  template <class _CommRange, class _EnvRange, class _InputRange>
+  template <class _CommRange, class _EnvRange, class _InputIterRange, class _SizeTRange>
   _CCCL_HOST_API static void __rebalance_to_original_counts(
     const __local_setup_result_type& __setup,
     _CommRange&& __comms,
     _EnvRange&& __envs,
-    _InputRange&& __local_inputs,
+    _InputIterRange&& __input_iters,
+    _SizeTRange&& __num_items_range,
     const __data_exchange_result_type& __exchange_result);
 
 public:
-  template <class _Policy, class _CommRange, class _EnvRange, class _InputRange>
+  template <class _Policy, class _CommRange, class _EnvRange, class _InputIterRange, class _SizeTRange>
   _CCCL_HOST_API static void __execute(
     const __result_policy_base<_Policy>&,
     _CommRange&& __comms,
     _EnvRange&& __envs,
-    _InputRange&& __local_inputs,
+    _InputIterRange&& __input_iters,
+    _SizeTRange&& __num_items_range,
     _BinaryOp __cmp);
 };
 

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/sort.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/sort.h
@@ -24,6 +24,8 @@
 
 #include <cuda/__nvtx/nvtx.h>
 #include <cuda/std/__functional/operations.h>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/readable_traits.h>
 #include <cuda/std/__memory/addressof.h>
 #include <cuda/std/__ranges/concepts.h>
 #include <cuda/std/__ranges/size.h>
@@ -47,58 +49,55 @@ namespace cuda::experimental
 {
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-//! @brief Sort input ranges distributed over a communicator in place.
+//! @brief Sort inputs distributed over a communicator in place.
 //!
-//! Treats the input ranges from all communicator ranks as one logical sequence and sorts it
-//! with respect to `__cmp`. Each rank's input range is overwritten with the slice of the
-//! globally sorted sequence belonging to that rank, with the slices ordered by ascending
-//! communicator rank. The number of elements each rank holds is unchanged, so a rank's input
-//! range keeps its original size even though the values it receives may have originated on
-//! other ranks. Sorting is not stable, and elements that compare equivalent may end up on any
-//! rank that the equivalent run spans.
+//! Treats the inputs from all communicator ranks as one logical sequence and sorts it with
+//! respect to `__cmp`. Each rank's input is overwritten with the slice of the globally sorted
+//! sequence belonging to that rank, with the slices ordered by ascending communicator rank. The
+//! number of elements each rank holds is unchanged, so a rank keeps its original size even
+//! though the values it receives may have originated on other ranks. Sorting is not stable, and
+//! elements that compare equivalent may end up on any rank that the equivalent run spans.
 //!
-//! The communicators, environments, and input ranges are iterated in lockstep. Each tuple
-//! describes one local communicator rank. This overload is intended for a thread or process
-//! that owns multiple local GPUs. For example, if each process owns two GPUs, each process can
-//! pass both local ranks in one call, as shown in the test below.
+//! The communicators, environments, input iterators, and input sizes are iterated in lockstep.
+//! Each tuple describes one local communicator rank. This overload is intended for a thread or
+//! process that owns multiple local GPUs. For example, if each process owns two GPUs, each
+//! process can pass both local ranks in one call, as shown in the test below.
 //!
 //! @snippet sort/range_basic.cu sort
 //!
-//! All three outer ranges must have the same length. The algorithm caps lockstep iteration at
+//! All four outer ranges must have the same length. The algorithm caps lockstep iteration at
 //! the shortest range, but this must not be relied upon and may change at any time. Each input
-//! range must refer to writable device-accessible storage, and its iterators must be
-//! contiguous.
+//! iterator must refer to writable device-accessible storage for at least as many values as the
+//! corresponding input size gives, and must be contiguous.
 //!
 //! Every communicator rank must participate in the collective call, including ranks whose input
-//! range is empty. `__cmp` must describe the same strict weak ordering on every rank.
+//! is empty. `__cmp` must describe the same strict weak ordering on every rank.
 //!
 //! Each environment supplies the *required* stream and optional memory resource for its local
 //! rank, and is also forwarded to the underlying CUB algorithms, so it may carry any
 //! parameters CUB recognizes.
 //!
-//! @tparam _Policy The result policy. Currently only `distributed_t` is supported.
-//! @tparam _CommRange The range of communicators. Each element must model the communicator
-//!         concept.
-//! @tparam _EnvRange The range of execution environments.
-//! @tparam _InputRange The range whose elements are the per-communicator input ranges. Each
-//!         element must be a sized random-access range.
-//! @tparam _BinaryOp The comparator type. Defaults to `::cuda::std::less<>`.
-//!
-//! @param[in] __policy The result policy object. Only `cudax::distributed` is currently supported.
+//! @param[in] __policy The result policy object. Currently must be `cudax::distributed`.
 //! @param[in] __comms The range of communicators.
 //! @param[in] __envs The range of execution environments. Each environment must contain a
 //!                   stream.
-//! @param[in,out] __range_of_input_ranges The range of per-communicator key ranges, sorted in
-//!                place.
+//! @param[in,out] __input_iters The range of per-communicator key iterators, sorted in place.
+//! @param[in] __num_items_range A range of sizes per input iterator to sort.
 //! @param[in] __cmp The comparator defining the sorted order.
-_CCCL_TEMPLATE(
-  class _Policy, class _CommRange, class _EnvRange, class _InputRange, class _BinaryOp = ::cuda::std::less<>)
+_CCCL_TEMPLATE(class _Policy,
+               class _CommRange,
+               class _EnvRange,
+               class _InputIterRange,
+               class _SizeTRange,
+               class _BinaryOp = ::cuda::std::less<>)
 _CCCL_REQUIRES(__range_of_communicators<_CommRange> _CCCL_AND ::cuda::std::ranges::forward_range<_EnvRange>
-                 _CCCL_AND ::cuda::experimental::__detail::__range_of_sized_random_access_ranges<_InputRange>)
+                 _CCCL_AND ::cuda::experimental::__detail::__range_of_random_access_iterators<_InputIterRange>
+                   _CCCL_AND ::cuda::std::ranges::forward_range<_SizeTRange>)
 void sort(const __result_policy_base<_Policy>& __policy,
           _CommRange&& __comms,
           _EnvRange&& __envs,
-          _InputRange&& __range_of_input_ranges,
+          _InputIterRange&& __input_iters,
+          _SizeTRange&& __num_items_range,
           _BinaryOp __cmp = {})
 {
   using _Env = ::cuda::std::ranges::range_value_t<_EnvRange>;
@@ -116,67 +115,65 @@ void sort(const __result_policy_base<_Policy>& __policy,
   _CCCL_NVTX_RANGE_SCOPE("cuda::experimental::sort");
 
   using _Tp =
-    ::cuda::std::ranges::range_value_t<::cuda::std::remove_cvref_t<::cuda::std::ranges::range_reference_t<_InputRange>>>;
+    ::cuda::std::iter_value_t<::cuda::std::remove_cvref_t<::cuda::std::ranges::range_reference_t<_InputIterRange>>>;
 
   ::cuda::experimental::__detail::__hss_sort::_HSSSorter<_Tp, _Env, ::cuda::std::remove_cvref_t<_BinaryOp>>::__execute(
     __policy,
     ::cuda::std::forward<_CommRange>(__comms),
     ::cuda::std::forward<_EnvRange>(__envs),
-    ::cuda::std::forward<_InputRange>(__range_of_input_ranges),
+    ::cuda::std::forward<_InputIterRange>(__input_iters),
+    ::cuda::std::forward<_SizeTRange>(__num_items_range),
     ::cuda::std::move(__cmp));
 }
 
-//! @brief Sort a single input range over one communicator in place.
+//! @brief Sort a single input over one communicator in place.
 //!
-//! Treats the input ranges from all communicator ranks as one logical sequence and sorts it
-//! with respect to `__cmp`. `__input` is overwritten with the slice of the globally sorted
-//! sequence belonging to `__comm`, with the slices ordered by ascending communicator rank.
-//! `__input` keeps its original size, even though the values it receives may have originated on
-//! other ranks. Sorting is not stable.
+//! Treats the inputs from all communicator ranks as one logical sequence and sorts it with
+//! respect to `__cmp`. `__input_iter` is overwritten with the slice of the globally sorted
+//! sequence belonging to `__comm`, with the slices ordered by ascending communicator rank. The
+//! local input keeps its original size, even though the values it receives may have originated
+//! on other ranks. Sorting is not stable.
 //!
-//! This convenience overload forwards one communicator, environment, and input range to the
-//! range-based overload. It is intended for a thread or process that owns one local GPU. See
-//! the range overload for a description of the algorithm.
+//! This convenience overload forwards one communicator, environment, input iterator, and input
+//! size to the range-based overload. It is intended for a thread or process that owns one local
+//! GPU. See the range overload for a description of the algorithm.
 //!
 //! @snippet sort/single_comm_basic.cu sort_single_range
 //!
 //! Every communicator rank must participate in the collective call, including ranks whose input
-//! range is empty, and `__cmp` must describe the same strict weak ordering on every rank.
-//! Because each call takes part in a collective on a single communicator, a caller that owns
-//! several local ranks must issue those calls concurrently, for example one thread per rank;
-//! issuing them serially on one thread deadlocks. Prefer the range overload in that case.
+//! is empty, and `__cmp` must describe the same strict weak ordering on every rank. Because each
+//! call takes part in a collective on a single communicator, a caller that owns several local
+//! ranks must issue those calls concurrently, for example one thread per rank; issuing them
+//! serially on one thread deadlocks. Prefer the range overload in that case.
 //!
-//! `__input` must refer to writable device-accessible storage and its iterators must be
-//! contiguous, since the range is handed to the communicator collectives directly.
+//! `__input_iter` must refer to writable device-accessible storage for at least `__num_items`
+//! values and must be contiguous, since it is handed to the communicator collectives directly.
 //!
 //! The environment supplies the stream and optional memory resource for the local rank, and is
 //! also forwarded to the underlying CUB algorithms.
 //!
-//! @tparam _Policy The result policy. Currently only `distributed_t` is supported.
-//! @tparam _Comm The communicator type. Must model the communicator concept.
-//! @tparam _Env The execution environment type. Supplies the stream and optional memory
-//!              resource.
-//! @tparam _InputRange The input range type. Must be a sized random-access range.
-//! @tparam _BinaryOp The comparator type. Defaults to `::cuda::std::less<>`.
-//!
-//! @param[in] __policy The result policy object. Only `cudax::distributed` is currently supported.
+//! @param[in] __policy The result policy object. Currently must be `cudax::distributed`.
 //! @param[in] __comm The communicator.
 //! @param[in] __env The execution environment. Must contain a stream.
-//! @param[in,out] __input The local key range, sorted in place.
+//! @param[in,out] __input_iter The local key iterator, sorted in place.
+//! @param[in] __num_items The number of items in `__input_iter` to sort.
 //! @param[in] __cmp The comparator defining the sorted order.
-_CCCL_TEMPLATE(class _Policy, class _Comm, class _Env, class _InputRange, class _BinaryOp = ::cuda::std::less<>)
-_CCCL_REQUIRES(__communicator<_Comm> _CCCL_AND ::cuda::std::ranges::random_access_range<_InputRange>)
+_CCCL_TEMPLATE(
+  class _Policy, class _Comm, class _Env, class _InputIt, class _SizeT, class _BinaryOp = ::cuda::std::less<>)
+_CCCL_REQUIRES(__communicator<_Comm> _CCCL_AND ::cuda::std::random_access_iterator<_InputIt>)
 void sort(const __result_policy_base<_Policy>& __policy,
           _Comm&& __comm,
           _Env&& __env,
-          _InputRange&& __input,
+          _InputIt __input_iter,
+          _SizeT __num_items,
           _BinaryOp __cmp = {})
 {
   ::cuda::experimental::sort(
     __policy,
     ::cuda::std::span<::cuda::std::remove_reference_t<_Comm>, 1>{::cuda::std::addressof(__comm), 1},
     ::cuda::std::span<::cuda::std::remove_reference_t<_Env>, 1>{::cuda::std::addressof(__env), 1},
-    ::cuda::std::span<::cuda::std::remove_reference_t<_InputRange>, 1>{::cuda::std::addressof(__input), 1},
+    ::cuda::std::span<_InputIt, 1>{::cuda::std::addressof(__input_iter), 1},
+    ::cuda::std::span<_SizeT, 1>{::cuda::std::addressof(__num_items), 1},
     ::cuda::std::move(__cmp));
 }
 

--- a/cudax/include/cuda/experimental/__utility/result_policy.cuh
+++ b/cudax/include/cuda/experimental/__utility/result_policy.cuh
@@ -28,7 +28,7 @@
 namespace cuda::experimental
 {
 template <class _Derived>
-struct __result_policy_base
+struct __result_policy_base // NOLINT(bugprone-crtp-constructor-accessibility)
 {
   using __derived_type _CCCL_NODEBUG_ALIAS = _Derived;
 };

--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/range_basic.cu
@@ -17,6 +17,7 @@
 #include <cuda/std/execution>
 #include <cuda/std/functional>
 #include <cuda/std/limits>
+#include <cuda/std/ranges>
 #include <cuda/std/span>
 #include <cuda/std/type_traits>
 
@@ -111,19 +112,27 @@ void do_exclusive_scan(
   cuda::std::span<cudax::nccl_communicator_ref> comms,
   const std::vector<Env>& envs,
   std::vector<cuda::device_buffer<T>>& in,
-  std::vector<typename cuda::device_buffer<T>::iterator>& outputs,
+  std::vector<cuda::device_buffer<T>>& out,
   const T& init,
   const T& ident,
   Op op)
 {
-  const auto envs_size    = envs.size();
-  const auto in_copy      = in;
-  const auto outputs_copy = outputs;
+  const auto envs_size = envs.size();
+  const auto in_copy   = in;
 
   INFO("init = " << init);
   INFO("ident = " << ident);
 
-  cudax::exclusive_scan(cudax::distributed, comms, envs, in, outputs, init, op, ident);
+  cudax::exclusive_scan(
+    cudax::distributed,
+    comms,
+    envs,
+    in | cuda::std::views::transform(cuda::std::ranges::begin),
+    in | cuda::std::views::transform(cuda::std::ranges::size),
+    out | cuda::std::views::transform(cuda::std::ranges::begin),
+    init,
+    op,
+    ident);
 
   // cuda::std::execution::env has no operator==, so we can only compare the sizes.
   REQUIRE(envs.size() == envs_size);
@@ -134,7 +143,6 @@ void do_exclusive_scan(
     INFO("device = " << i);
     REQUIRE_THAT(in[i], Equals(in_copy[i]));
   }
-  REQUIRE_THAT(outputs, Catch::Matchers::Equals(outputs_copy));
 }
 } // namespace
 
@@ -164,15 +172,14 @@ MULTI_GPU_TEST("exclusive_scan documentation example", c2h::type_list<int>)
     outputs.emplace_back(cuda::make_device_buffer<int>(streams[i], device, input_values.size(), cuda::no_init));
   }
 
-  std::vector<typename cuda::device_buffer<int>::iterator> output_iterators = make_output_iterators(outputs);
-
   cudax::exclusive_scan(
     cudax::distributed,
     comms,
     // Passing streams as the environment directly
     streams,
-    inputs,
-    output_iterators,
+    inputs | cuda::std::views::transform(cuda::std::ranges::begin),
+    inputs | cuda::std::views::transform(cuda::std::ranges::size),
+    outputs | cuda::std::views::transform(cuda::std::ranges::begin),
     /*__init=*/0);
 
   constexpr cuda::std::array expected_rank_0{0, 1};
@@ -224,9 +231,7 @@ MULTI_GPU_TEST("exclusive_scan, one element per rank", value_types, operators)
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_exclusive_scan(comms, envs, in, outputs, init, ident, Op{});
+  do_exclusive_scan(comms, envs, in, out, init, ident, Op{});
 
   for (cuda::std::size_t i = 0; i < out.size(); ++i)
   {
@@ -277,9 +282,7 @@ MULTI_GPU_TEST("exclusive_scan, multiple elements per rank", value_types, operat
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_exclusive_scan(comms, envs, in, outputs, init, ident, Op{});
+  do_exclusive_scan(comms, envs, in, out, init, ident, Op{});
 
   for (cuda::std::size_t i = 0; i < out.size(); ++i)
   {
@@ -331,9 +334,7 @@ MULTI_GPU_TEST("exclusive_scan, some ranks empty", value_types, operators)
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_exclusive_scan(comms, envs, in, outputs, init, ident, Op{});
+  do_exclusive_scan(comms, envs, in, out, init, ident, Op{});
 
   for (cuda::std::size_t i = 0; i < out.size(); ++i)
   {
@@ -374,9 +375,7 @@ MULTI_GPU_TEST("exclusive_scan, all ranks empty", value_types, operators)
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_exclusive_scan(comms, envs, in, outputs, init, ident, Op{});
+  do_exclusive_scan(comms, envs, in, out, init, ident, Op{});
 
   for (cuda::std::size_t i = 0; i < out.size(); ++i)
   {

--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/range_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/range_defaults.cu
@@ -16,6 +16,7 @@
 #include <cuda/std/execution>
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
+#include <cuda/std/ranges>
 
 #include <cuda/experimental/__multi_gpu/algorithm/scan/scan.h>
 
@@ -59,8 +60,6 @@ MULTI_GPU_TEST("exclusive_scan, range overloads default values", )
     envs.emplace_back(streams[i]);
   }
 
-  auto outputs = make_output_iterators(out);
-
   const auto expected_values = [&] {
     std::vector<T> reference(static_cast<cuda::std::size_t>(comms.front().size()) * values_per_rank);
 
@@ -86,27 +85,60 @@ MULTI_GPU_TEST("exclusive_scan, range overloads default values", )
     }
   };
 
+  auto input_iters = in | cuda::std::views::transform(cuda::std::ranges::begin);
+  auto input_sizes = in | cuda::std::views::transform(cuda::std::ranges::size);
+
   SECTION("Default init, op, ident (all)")
   {
-    cudax::exclusive_scan(cudax::distributed, comms, envs, in, outputs);
+    cudax::exclusive_scan(
+      cudax::distributed,
+      comms,
+      envs,
+      input_iters,
+      input_sizes,
+      out | cuda::std::views::transform(cuda::std::ranges::begin));
     check_outputs();
   }
 
   SECTION("Default op, ident")
   {
-    cudax::exclusive_scan(cudax::distributed, comms, envs, in, outputs, init);
+    cudax::exclusive_scan(
+      cudax::distributed,
+      comms,
+      envs,
+      input_iters,
+      input_sizes,
+      out | cuda::std::views::transform(cuda::std::ranges::begin),
+      init);
     check_outputs();
   }
 
   SECTION("Default ident")
   {
-    cudax::exclusive_scan(cudax::distributed, comms, envs, in, outputs, init, op);
+    cudax::exclusive_scan(
+      cudax::distributed,
+      comms,
+      envs,
+      input_iters,
+      input_sizes,
+      out | cuda::std::views::transform(cuda::std::ranges::begin),
+      init,
+      op);
     check_outputs();
   }
 
   SECTION("Default none")
   {
-    cudax::exclusive_scan(cudax::distributed, comms, envs, in, outputs, init, op, ident);
+    cudax::exclusive_scan(
+      cudax::distributed,
+      comms,
+      envs,
+      input_iters,
+      input_sizes,
+      out | cuda::std::views::transform(cuda::std::ranges::begin),
+      init,
+      op,
+      ident);
     check_outputs();
   }
 }

--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_basic.cu
@@ -131,15 +131,14 @@ void run_case(cuda::std::span<cudax::nccl_communicator_ref> comms,
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  const auto in_copy      = in;
-  auto outputs            = make_output_iterators(out);
-  const auto outputs_copy = outputs;
+  const auto in_copy = in;
 
   INFO("init = " << init);
   INFO("ident = " << ident);
 
   run_threaded(comms.size(), [&](cuda::std::size_t i) {
-    cudax::exclusive_scan(cudax::distributed, comms[i], envs[i], in[i], outputs[i], init, op, ident);
+    cudax::exclusive_scan(
+      cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
   });
 
   REQUIRE(in.size() == in_copy.size());
@@ -153,7 +152,6 @@ void run_case(cuda::std::span<cudax::nccl_communicator_ref> comms,
 
     REQUIRE_THAT(out[i], Equals(expected));
   }
-  REQUIRE_THAT(outputs, Catch::Matchers::Equals(outputs_copy));
 }
 } // namespace
 
@@ -184,7 +182,8 @@ MULTI_GPU_TEST("exclusive_scan single-comm documentation example", c2h::type_lis
     auto input  = cuda::make_device_buffer<int>(environment, device, input_values);
     auto output = cuda::make_device_buffer<int>(environment, device, input_values.size(), cuda::no_init);
 
-    cudax::exclusive_scan(cudax::distributed, communicator, environment, input, output.begin(), /*__init=*/0);
+    cudax::exclusive_scan(
+      cudax::distributed, communicator, environment, input.begin(), input.size(), output.begin(), /*__init=*/0);
 
     // Every rank contributes {1, 2}, so rank r starts with a prefix of 3 * r.
     const auto rank = communicator.rank();

--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_defaults.cu
@@ -59,8 +59,6 @@ MULTI_GPU_TEST("exclusive_scan single-comm, overloads default values", )
     envs.emplace_back(streams[i]);
   }
 
-  auto outputs = make_output_iterators(out);
-
   const auto expected_values = [&] {
     std::vector<T> reference(static_cast<cuda::std::size_t>(comms.front().size()) * values_per_rank);
 
@@ -89,7 +87,7 @@ MULTI_GPU_TEST("exclusive_scan single-comm, overloads default values", )
   SECTION("Default init, op, ident (all)")
   {
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::exclusive_scan(cudax::distributed, comms[i], envs[i], in[i], outputs[i]);
+      cudax::exclusive_scan(cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin());
     });
     check_outputs();
   }
@@ -97,7 +95,7 @@ MULTI_GPU_TEST("exclusive_scan single-comm, overloads default values", )
   SECTION("Default op, ident")
   {
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::exclusive_scan(cudax::distributed, comms[i], envs[i], in[i], outputs[i], init);
+      cudax::exclusive_scan(cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init);
     });
     check_outputs();
   }
@@ -105,7 +103,8 @@ MULTI_GPU_TEST("exclusive_scan single-comm, overloads default values", )
   SECTION("Default ident")
   {
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::exclusive_scan(cudax::distributed, comms[i], envs[i], in[i], outputs[i], init, op);
+      cudax::exclusive_scan(
+        cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op);
     });
     check_outputs();
   }
@@ -113,7 +112,8 @@ MULTI_GPU_TEST("exclusive_scan single-comm, overloads default values", )
   SECTION("Default none")
   {
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::exclusive_scan(cudax::distributed, comms[i], envs[i], in[i], outputs[i], init, op, ident);
+      cudax::exclusive_scan(
+        cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
     });
     check_outputs();
   }

--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/range_basic.cu
@@ -17,6 +17,7 @@
 #include <cuda/std/execution>
 #include <cuda/std/functional>
 #include <cuda/std/limits>
+#include <cuda/std/ranges>
 #include <cuda/std/span>
 #include <cuda/std/type_traits>
 
@@ -111,19 +112,27 @@ void do_inclusive_scan(
   cuda::std::span<cudax::nccl_communicator_ref> comms,
   const std::vector<Env>& envs,
   std::vector<cuda::device_buffer<T>>& in,
-  std::vector<typename cuda::device_buffer<T>::iterator>& outputs,
+  std::vector<cuda::device_buffer<T>>& out,
   const T& init,
   const T& ident,
   Op op)
 {
-  const auto envs_size    = envs.size();
-  const auto in_copy      = in;
-  const auto outputs_copy = outputs;
+  const auto envs_size = envs.size();
+  const auto in_copy   = in;
 
   INFO("init = " << init);
   INFO("ident = " << ident);
 
-  cudax::inclusive_scan(cudax::distributed, comms, envs, in, outputs, init, op, ident);
+  cudax::inclusive_scan(
+    cudax::distributed,
+    comms,
+    envs,
+    in | cuda::std::views::transform(cuda::std::ranges::begin),
+    in | cuda::std::views::transform(cuda::std::ranges::size),
+    out | cuda::std::views::transform(cuda::std::ranges::begin),
+    init,
+    op,
+    ident);
 
   // cuda::std::execution::env has no operator==, so we can only compare the sizes.
   REQUIRE(envs.size() == envs_size);
@@ -134,7 +143,6 @@ void do_inclusive_scan(
     INFO("device = " << i);
     REQUIRE_THAT(in[i], Equals(in_copy[i]));
   }
-  REQUIRE_THAT(outputs, Catch::Matchers::Equals(outputs_copy));
 }
 } // namespace
 
@@ -164,15 +172,14 @@ MULTI_GPU_TEST("inclusive_scan documentation example", c2h::type_list<int>)
     outputs.emplace_back(cuda::make_device_buffer<int>(streams[i], device, input_values.size(), cuda::no_init));
   }
 
-  std::vector<typename cuda::device_buffer<int>::iterator> output_iterators = make_output_iterators(outputs);
-
   cudax::inclusive_scan(
     cudax::distributed,
     comms,
     // Passing streams as the environment directly
     streams,
-    inputs,
-    output_iterators,
+    inputs | cuda::std::views::transform(cuda::std::ranges::begin),
+    inputs | cuda::std::views::transform(cuda::std::ranges::size),
+    outputs | cuda::std::views::transform(cuda::std::ranges::begin),
     /*__init=*/0);
 
   constexpr cuda::std::array expected_rank_0{1, 3};
@@ -224,9 +231,7 @@ MULTI_GPU_TEST("inclusive_scan, one element per rank", value_types, operators)
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_inclusive_scan(comms, envs, in, outputs, init, ident, Op{});
+  do_inclusive_scan(comms, envs, in, out, init, ident, Op{});
 
   for (cuda::std::size_t i = 0; i < out.size(); ++i)
   {
@@ -278,9 +283,7 @@ MULTI_GPU_TEST("inclusive_scan, multiple elements per rank", value_types, operat
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_inclusive_scan(comms, envs, in, outputs, init, ident, Op{});
+  do_inclusive_scan(comms, envs, in, out, init, ident, Op{});
 
   for (cuda::std::size_t i = 0; i < out.size(); ++i)
   {
@@ -332,9 +335,7 @@ MULTI_GPU_TEST("inclusive_scan, some ranks empty", value_types, operators)
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_inclusive_scan(comms, envs, in, outputs, init, ident, Op{});
+  do_inclusive_scan(comms, envs, in, out, init, ident, Op{});
 
   for (cuda::std::size_t i = 0; i < out.size(); ++i)
   {
@@ -375,9 +376,7 @@ MULTI_GPU_TEST("inclusive_scan, all ranks empty", value_types, operators)
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_inclusive_scan(comms, envs, in, outputs, init, ident, Op{});
+  do_inclusive_scan(comms, envs, in, out, init, ident, Op{});
 
   for (cuda::std::size_t i = 0; i < out.size(); ++i)
   {

--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/range_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/range_defaults.cu
@@ -16,6 +16,7 @@
 #include <cuda/std/execution>
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
+#include <cuda/std/ranges>
 
 #include <cuda/experimental/__multi_gpu/algorithm/scan/scan.h>
 
@@ -59,8 +60,6 @@ MULTI_GPU_TEST("inclusive_scan, range overloads default values", )
     envs.emplace_back(streams[i]);
   }
 
-  auto outputs = make_output_iterators(out);
-
   const auto expected_values = [&] {
     std::vector<T> reference(static_cast<cuda::std::size_t>(comms.front().size()) * values_per_rank);
 
@@ -86,27 +85,60 @@ MULTI_GPU_TEST("inclusive_scan, range overloads default values", )
     }
   };
 
+  auto input_iters = in | cuda::std::views::transform(cuda::std::ranges::begin);
+  auto input_sizes = in | cuda::std::views::transform(cuda::std::ranges::size);
+
   SECTION("Default init, op, ident (all)")
   {
-    cudax::inclusive_scan(cudax::distributed, comms, envs, in, outputs);
+    cudax::inclusive_scan(
+      cudax::distributed,
+      comms,
+      envs,
+      input_iters,
+      input_sizes,
+      out | cuda::std::views::transform(cuda::std::ranges::begin));
     check_outputs();
   }
 
   SECTION("Default op, ident")
   {
-    cudax::inclusive_scan(cudax::distributed, comms, envs, in, outputs, init);
+    cudax::inclusive_scan(
+      cudax::distributed,
+      comms,
+      envs,
+      input_iters,
+      input_sizes,
+      out | cuda::std::views::transform(cuda::std::ranges::begin),
+      init);
     check_outputs();
   }
 
   SECTION("Default ident")
   {
-    cudax::inclusive_scan(cudax::distributed, comms, envs, in, outputs, init, op);
+    cudax::inclusive_scan(
+      cudax::distributed,
+      comms,
+      envs,
+      input_iters,
+      input_sizes,
+      out | cuda::std::views::transform(cuda::std::ranges::begin),
+      init,
+      op);
     check_outputs();
   }
 
   SECTION("Default none")
   {
-    cudax::inclusive_scan(cudax::distributed, comms, envs, in, outputs, init, op, ident);
+    cudax::inclusive_scan(
+      cudax::distributed,
+      comms,
+      envs,
+      input_iters,
+      input_sizes,
+      out | cuda::std::views::transform(cuda::std::ranges::begin),
+      init,
+      op,
+      ident);
     check_outputs();
   }
 }

--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_basic.cu
@@ -131,15 +131,14 @@ void run_case(cuda::std::span<cudax::nccl_communicator_ref> comms,
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  const auto in_copy      = in;
-  auto outputs            = make_output_iterators(out);
-  const auto outputs_copy = outputs;
+  const auto in_copy = in;
 
   INFO("init = " << init);
   INFO("ident = " << ident);
 
   run_threaded(comms.size(), [&](cuda::std::size_t i) {
-    cudax::inclusive_scan(cudax::distributed, comms[i], envs[i], in[i], outputs[i], init, op, ident);
+    cudax::inclusive_scan(
+      cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
   });
 
   REQUIRE(in.size() == in_copy.size());
@@ -153,7 +152,6 @@ void run_case(cuda::std::span<cudax::nccl_communicator_ref> comms,
 
     REQUIRE_THAT(out[i], Equals(expected));
   }
-  REQUIRE_THAT(outputs, Catch::Matchers::Equals(outputs_copy));
 }
 } // namespace
 
@@ -184,7 +182,8 @@ MULTI_GPU_TEST("inclusive_scan single-comm documentation example", c2h::type_lis
     auto input  = cuda::make_device_buffer<int>(environment, device, input_values);
     auto output = cuda::make_device_buffer<int>(environment, device, input_values.size(), cuda::no_init);
 
-    cudax::inclusive_scan(cudax::distributed, communicator, environment, input, output.begin(), /*__init=*/0);
+    cudax::inclusive_scan(
+      cudax::distributed, communicator, environment, input.begin(), input.size(), output.begin(), /*__init=*/0);
 
     // Every rank contributes {1, 2}, so rank r starts with a prefix of 3 * r.
     const auto rank = communicator.rank();

--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_defaults.cu
@@ -59,8 +59,6 @@ MULTI_GPU_TEST("inclusive_scan single-comm, overloads default values", )
     envs.emplace_back(streams[i]);
   }
 
-  auto outputs = make_output_iterators(out);
-
   const auto expected_values = [&] {
     std::vector<T> reference(static_cast<cuda::std::size_t>(comms.front().size()) * values_per_rank);
 
@@ -89,7 +87,7 @@ MULTI_GPU_TEST("inclusive_scan single-comm, overloads default values", )
   SECTION("Default init, op, ident (all)")
   {
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::inclusive_scan(cudax::distributed, comms[i], envs[i], in[i], outputs[i]);
+      cudax::inclusive_scan(cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin());
     });
     check_outputs();
   }
@@ -97,7 +95,7 @@ MULTI_GPU_TEST("inclusive_scan single-comm, overloads default values", )
   SECTION("Default op, ident")
   {
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::inclusive_scan(cudax::distributed, comms[i], envs[i], in[i], outputs[i], init);
+      cudax::inclusive_scan(cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init);
     });
     check_outputs();
   }
@@ -105,7 +103,8 @@ MULTI_GPU_TEST("inclusive_scan single-comm, overloads default values", )
   SECTION("Default ident")
   {
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::inclusive_scan(cudax::distributed, comms[i], envs[i], in[i], outputs[i], init, op);
+      cudax::inclusive_scan(
+        cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op);
     });
     check_outputs();
   }
@@ -113,7 +112,8 @@ MULTI_GPU_TEST("inclusive_scan single-comm, overloads default values", )
   SECTION("Default none")
   {
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::inclusive_scan(cudax::distributed, comms[i], envs[i], in[i], outputs[i], init, op, ident);
+      cudax::inclusive_scan(
+        cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
     });
     check_outputs();
   }

--- a/cudax/test/multi_gpu/algorithms/reduce/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/range_basic.cu
@@ -11,9 +11,12 @@
 #include <cuda/buffer>
 #include <cuda/functional>
 #include <cuda/memory_resource>
+#include <cuda/std/array>
+#include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/execution>
 #include <cuda/std/functional>
+#include <cuda/std/ranges>
 #include <cuda/std/type_traits>
 
 #include <cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h>
@@ -81,19 +84,27 @@ template <class Env, class T, class Op>
 void do_reduce(cuda::std::span<cudax::nccl_communicator_ref> comms,
                const std::vector<Env>& envs,
                std::vector<cuda::device_buffer<T>>& in,
-               std::vector<typename cuda::device_buffer<T>::iterator>& outputs,
+               std::vector<cuda::device_buffer<T>>& out,
                const T& init,
                const T& ident,
                Op op)
 {
-  const auto envs_size    = envs.size();
-  const auto in_copy      = in;
-  const auto outputs_copy = outputs;
+  const auto envs_size = envs.size();
+  const auto in_copy   = in;
 
   INFO("init = " << init);
   INFO("ident = " << ident);
 
-  cudax::reduce(cudax::broadcasted, comms, envs, in, outputs, init, op, ident);
+  cudax::reduce(
+    cudax::broadcasted,
+    comms,
+    envs,
+    in | cuda::std::views::transform(cuda::std::ranges::begin),
+    in | cuda::std::views::transform(cuda::std::ranges::size),
+    out | cuda::std::views::transform(cuda::std::ranges::begin),
+    init,
+    op,
+    ident);
 
   // cuda::std::execution::env has no operator==, so we can only compare the sizes.
   REQUIRE(envs.size() == envs_size);
@@ -104,9 +115,56 @@ void do_reduce(cuda::std::span<cudax::nccl_communicator_ref> comms,
     INFO("device = " << i);
     REQUIRE_THAT(in[i], Equals(in_copy[i]));
   }
-  REQUIRE_THAT(outputs, Catch::Matchers::Equals(outputs_copy));
 }
 } // namespace
+
+MULTI_GPU_TEST("reduce documentation example", c2h::type_list<int>)
+{
+  auto comms = this->communicators();
+
+  if (comms.size() != 2)
+  {
+    SKIP("The reduce documentation example requires exactly two local GPUs");
+  }
+
+  auto streams_owned = nccl_test_util::make_streams();
+  // Convert to stream_ref directly, cuda::stream on their own cant be passed directly to CUB
+  auto streams = std::vector<cuda::stream_ref>{streams_owned.begin(), streams_owned.end()};
+
+  //! [reduce]
+  constexpr cuda::std::array input_values{1, 2};
+  std::vector<cuda::device_buffer<int>> inputs;
+  std::vector<cuda::device_buffer<int>> outputs;
+
+  for (cuda::std::size_t i = 0; i < comms.size(); ++i)
+  {
+    const auto device = comms[i].logical_device().underlying_device();
+
+    inputs.emplace_back(cuda::make_device_buffer<int>(streams[i], device, input_values));
+    outputs.emplace_back(cuda::make_device_buffer<int>(streams[i], device, 1, cuda::no_init));
+  }
+
+  cudax::reduce(
+    cudax::broadcasted,
+    comms,
+    // Passing streams as the environment directly
+    streams,
+    inputs | cuda::std::views::transform(cuda::std::ranges::begin),
+    inputs | cuda::std::views::transform(cuda::std::ranges::size),
+    outputs | cuda::std::views::transform(cuda::std::ranges::begin),
+    /*__init=*/0);
+
+  // Every rank contributes {1, 2}, so every output holds the sum over all ranks. `reduce`
+  // broadcasts the result, so both local outputs hold the same value.
+  const auto expected_value = 3 * comms.front().size();
+  const auto expected_0 =
+    cuda::make_buffer<int>(outputs[0].stream(), cuda::mr::legacy_pinned_memory_resource{}, 1, expected_value);
+  const auto expected_1 =
+    cuda::make_buffer<int>(outputs[1].stream(), cuda::mr::legacy_pinned_memory_resource{}, 1, expected_value);
+  REQUIRE_THAT(outputs[0], Equals(expected_0));
+  REQUIRE_THAT(outputs[1], Equals(expected_1));
+  //! [reduce]
+}
 
 MULTI_GPU_TEST("reduce, one element per rank", value_types, operators)
 {
@@ -141,9 +199,7 @@ MULTI_GPU_TEST("reduce, one element per rank", value_types, operators)
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_reduce(comms, envs, in, outputs, init, ident, Op{});
+  do_reduce(comms, envs, in, out, init, ident, Op{});
 
   const T expected = [&] {
     std::vector<T> reference;
@@ -202,9 +258,7 @@ MULTI_GPU_TEST("reduce, multiple elements per rank", value_types, operators)
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_reduce(comms, envs, in, outputs, init, ident, Op{});
+  do_reduce(comms, envs, in, out, init, ident, Op{});
 
   const T expected = [&] {
     std::vector<T> reference;
@@ -269,9 +323,7 @@ MULTI_GPU_TEST("reduce, some ranks empty", value_types, operators)
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_reduce(comms, envs, in, outputs, init, ident, Op{});
+  do_reduce(comms, envs, in, out, init, ident, Op{});
 
   const T expected = [&] {
     std::vector<T> reference;
@@ -324,9 +376,7 @@ MULTI_GPU_TEST("reduce, all ranks empty", value_types, operators)
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_reduce(comms, envs, in, outputs, init, ident, Op{});
+  do_reduce(comms, envs, in, out, init, ident, Op{});
 
   // Reducing nothing seeded by `init` yields `init`, exactly like `std::accumulate` over an empty
   // range.

--- a/cudax/test/multi_gpu/algorithms/reduce/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/range_basic.cu
@@ -9,7 +9,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <cuda/buffer>
-#include <cuda/functional>
 #include <cuda/memory_resource>
 #include <cuda/std/array>
 #include <cuda/std/cstddef>
@@ -17,7 +16,6 @@
 #include <cuda/std/execution>
 #include <cuda/std/functional>
 #include <cuda/std/ranges>
-#include <cuda/std/type_traits>
 
 #include <cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h>
 
@@ -28,56 +26,11 @@
 #include <nccl_test_common.h>
 #include <testing.cuh>
 
+#include "reduce_common.cuh"
+#include <c2h/catch2_test_helper.h>
+
 namespace
 {
-struct custom_plus
-{
-  template <class T>
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr T operator()(const T& lhs, const T& rhs) const
-  {
-    return lhs + rhs;
-  }
-};
-
-using custom_value = c2h::custom_type_t<c2h::accumulateable_t, c2h::less_comparable_t, c2h::equal_comparable_t>;
-using value_types  = c2h::type_list<cuda::std::int32_t, float, custom_value>;
-using operators    = c2h::type_list<::cuda::std::plus<>, ::cuda::maximum<>, custom_plus>;
-
-static_assert(cudax::nccl_transportable<custom_value>);
-
-template <typename T>
-T make_value(int i)
-{
-  return static_cast<T>(i);
-}
-
-template <>
-custom_value make_value<>(int i)
-{
-  custom_value ret{};
-
-  ret.key = static_cast<std::size_t>(i);
-  ret.val = static_cast<std::size_t>(i);
-  return ret;
-};
-
-template <class T, class Op>
-[[nodiscard]] T get_identity()
-{
-  if constexpr (cuda::std::is_same_v<Op, cuda::std::plus<>> || cuda::std::is_same_v<Op, custom_plus>)
-  {
-    return make_value<T>(0);
-  }
-  else if constexpr (cuda::std::is_same_v<Op, cuda::maximum<>>)
-  {
-    return cuda::std::numeric_limits<T>::lowest();
-  }
-  else
-  {
-    static_assert(cuda::std::__always_false_v<T, Op>, "Add handling");
-  }
-}
-
 // Run the full reduction, wait for it to finish, and check that `reduce` left its argument ranges
 // untouched. This boilerplate is identical for every test regardless of how the inputs are shaped.
 template <class Env, class T, class Op>

--- a/cudax/test/multi_gpu/algorithms/reduce/range_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/range_defaults.cu
@@ -12,6 +12,7 @@
 #include <cuda/memory_resource>
 #include <cuda/std/cstdint>
 #include <cuda/std/execution>
+#include <cuda/std/ranges>
 #include <cuda/std/type_traits>
 
 #include <cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h>
@@ -54,8 +55,6 @@ MULTI_GPU_TEST("reduce, range overloads default values", )
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
   const auto expected = [&] {
     std::vector<T> reference;
 
@@ -72,7 +71,13 @@ MULTI_GPU_TEST("reduce, range overloads default values", )
 
   SECTION("Default init, op, ident (all)")
   {
-    cudax::reduce(cudax::broadcasted, comms, envs, in, outputs);
+    cudax::reduce(
+      cudax::broadcasted,
+      comms,
+      envs,
+      in | cuda::std::views::transform(cuda::std::ranges::begin),
+      in | cuda::std::views::transform(cuda::std::ranges::size),
+      out | cuda::std::views::transform(cuda::std::ranges::begin));
 
     for (const auto& buf : out)
     {
@@ -82,7 +87,14 @@ MULTI_GPU_TEST("reduce, range overloads default values", )
 
   SECTION("Default op, ident")
   {
-    cudax::reduce(cudax::broadcasted, comms, envs, in, outputs, init);
+    cudax::reduce(
+      cudax::broadcasted,
+      comms,
+      envs,
+      in | cuda::std::views::transform(cuda::std::ranges::begin),
+      in | cuda::std::views::transform(cuda::std::ranges::size),
+      out | cuda::std::views::transform(cuda::std::ranges::begin),
+      init);
 
     for (const auto& buf : out)
     {
@@ -92,7 +104,15 @@ MULTI_GPU_TEST("reduce, range overloads default values", )
 
   SECTION("Default ident")
   {
-    cudax::reduce(cudax::broadcasted, comms, envs, in, outputs, init, op);
+    cudax::reduce(
+      cudax::broadcasted,
+      comms,
+      envs,
+      in | cuda::std::views::transform(cuda::std::ranges::begin),
+      in | cuda::std::views::transform(cuda::std::ranges::size),
+      out | cuda::std::views::transform(cuda::std::ranges::begin),
+      init,
+      op);
 
     for (const auto& buf : out)
     {
@@ -102,7 +122,16 @@ MULTI_GPU_TEST("reduce, range overloads default values", )
 
   SECTION("Default none")
   {
-    cudax::reduce(cudax::broadcasted, comms, envs, in, outputs, init, op, ident);
+    cudax::reduce(
+      cudax::broadcasted,
+      comms,
+      envs,
+      in | cuda::std::views::transform(cuda::std::ranges::begin),
+      in | cuda::std::views::transform(cuda::std::ranges::size),
+      out | cuda::std::views::transform(cuda::std::ranges::begin),
+      init,
+      op,
+      ident);
 
     for (const auto& buf : out)
     {

--- a/cudax/test/multi_gpu/algorithms/reduce/range_deferred.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/range_deferred.cu
@@ -8,20 +8,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/argument>
 #include <cuda/buffer>
 #include <cuda/memory_resource>
-#include <cuda/std/array>
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/execution>
 #include <cuda/std/functional>
+#include <cuda/std/ranges>
 
 #include <cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h>
 
-#include <exception>
-#include <future>
+#include <algorithm>
 #include <numeric>
-#include <string>
 #include <vector>
 
 #include <algorithm_common.h>
@@ -33,31 +32,42 @@
 
 namespace
 {
-// Drive the reduction through the single-communicator overload of `reduce`, one thread per
-// rank. That overload opens its own NCCL group on a single communicator, so issuing the
-// per-rank calls serially on one thread would deadlock at `ncclGroupEnd`. Running each rank on
-// its own thread lets the per-thread groups rendezvous across ranks. Only the `reduce` call
-// happens on the worker threads; every Catch2 assertion runs on the main thread after the
-// join, since the assertion macros are not safe to fire concurrently.
+using count_type = cuda::std::int32_t;
+
+// Run the full reduction, wait for it to finish, and check that `reduce` left its argument ranges
+// untouched. This boilerplate is identical for every test regardless of how the inputs are shaped.
 template <class Env, class T, class Op>
-void do_reduce_threaded(
+void do_reduce_deferred(
   cuda::std::span<cudax::nccl_communicator_ref> comms,
-  std::vector<Env>& envs,
+  const std::vector<Env>& envs,
   std::vector<cuda::device_buffer<T>>& in,
+  std::vector<cuda::device_buffer<count_type>>& num_items,
   std::vector<cuda::device_buffer<T>>& out,
   const T& init,
   const T& ident,
   Op op)
 {
-  const auto in_copy = in;
+  const auto envs_size = envs.size();
+  const auto in_copy   = in;
 
   INFO("init = " << init);
   INFO("ident = " << ident);
 
-  run_threaded(comms.size(), [&](cuda::std::size_t i) {
-    cudax::reduce(cudax::broadcasted, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
-  });
+  cudax::reduce(
+    cudax::broadcasted,
+    comms,
+    envs,
+    in | cuda::std::views::transform(cuda::std::ranges::begin),
+    num_items | cuda::std::views::transform([](auto& buf) {
+      return cuda::args::deferred{buf.begin()};
+    }),
+    out | cuda::std::views::transform(cuda::std::ranges::begin),
+    init,
+    op,
+    ident);
 
+  // cuda::std::execution::env has no operator==, so we can only compare the sizes.
+  REQUIRE(envs.size() == envs_size);
   // Reduction call should not modify the inputs in any ways
   REQUIRE(in.size() == in_copy.size());
   for (cuda::std::size_t i = 0; i < in.size(); ++i)
@@ -68,62 +78,7 @@ void do_reduce_threaded(
 }
 } // namespace
 
-MULTI_GPU_TEST("reduce single-comm documentation example", c2h::type_list<int>)
-{
-  auto comms = this->communicators();
-
-  if (comms.size() != 2)
-  {
-    SKIP("The reduce documentation example requires exactly two local GPUs");
-  }
-
-  auto streams_owned = nccl_test_util::make_streams();
-  auto streams       = std::vector<cuda::stream_ref>{streams_owned.begin(), streams_owned.end()};
-
-  // Must be pre-allocated since it is written to by threads
-  std::vector<std::string> failed(comms.front().size());
-
-  // Every communicator rank must invoke the collective concurrently.
-  run_threaded(comms.size(), [&](cuda::std::size_t i) {
-    auto& communicator = comms[i];
-    auto& stream       = streams[i];
-    // Rename the stream to env for the example
-    auto& env = stream;
-
-    //! [reduce_single_range]
-    constexpr cuda::std::array input_values{1, 2};
-    const auto device = communicator.logical_device().underlying_device();
-
-    auto input  = cuda::make_device_buffer<int>(stream, device, input_values);
-    auto output = cuda::make_device_buffer<int>(stream, device, 1, cuda::no_init);
-
-    cudax::reduce(cudax::broadcasted, communicator, env, input.begin(), input.size(), output.begin(), /*__init=*/0);
-
-    // Every rank contributes {1, 2}, so the reduction over all ranks is 3 * nranks. `reduce`
-    // broadcasts the result, so every rank sees the same value.
-    const auto expected =
-      cuda::make_buffer<int>(output.stream(), cuda::mr::legacy_pinned_memory_resource{}, 1, 3 * communicator.size());
-    //! [reduce_single_range]
-
-    // catch2 isn't thread safe by default, so we can't use the usual requires expression. So
-    // we roll a hacky version of it ourselves
-    if (const auto matcher = Equals(expected); !matcher.match(output))
-    {
-      failed[communicator.rank()] = matcher.describe();
-    }
-  });
-
-  for (cuda::std::size_t i = 0; i < failed.size(); ++i)
-  {
-    if (const auto& err_str = failed[i]; !err_str.empty())
-    {
-      INFO("rank: " << i);
-      REQUIRE(err_str == ""); // Should print the full error string
-    }
-  }
-}
-
-MULTI_GPU_TEST("reduce single-comm, one element per rank", value_types, operators)
+MULTI_GPU_TEST("reduce with deferred counts, one element per rank", value_types, operators)
 {
   using T  = c2h::get<0, TestType>;
   using Op = c2h::get<1, TestType>;
@@ -141,22 +96,28 @@ MULTI_GPU_TEST("reduce single-comm, one element per rank", value_types, operator
   // stream-ordered on the correct device. `reference` mirrors the contributions of every global
   // rank so we can fold them on the host exactly like `reduce` does on the device.
   std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<count_type>> num_items;
   std::vector<cuda::device_buffer<T>> out;
   std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
 
   in.reserve(comms.size());
+  num_items.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
     const auto values = {make_value<T>(comms[i].rank())};
+    const auto counts = {count_type{1}};
+
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
+    num_items.emplace_back(
+      cuda::make_device_buffer<count_type>(streams[i], comms[i].logical_device().underlying_device(), counts));
     out.emplace_back(
       cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  do_reduce_threaded(comms, envs, in, out, init, ident, Op{});
+  do_reduce_deferred(comms, envs, in, num_items, out, init, ident, Op{});
 
   const T expected = [&] {
     std::vector<T> reference;
@@ -178,7 +139,7 @@ MULTI_GPU_TEST("reduce single-comm, one element per rank", value_types, operator
   }
 }
 
-MULTI_GPU_TEST("reduce single-comm, multiple elements per rank", value_types, operators)
+MULTI_GPU_TEST("reduce with deferred counts, multiple elements per rank", value_types, operators)
 {
   using T  = c2h::get<0, TestType>;
   using Op = c2h::get<1, TestType>;
@@ -196,10 +157,12 @@ MULTI_GPU_TEST("reduce single-comm, multiple elements per rank", value_types, op
   // also gets a one-element output buffer and an environment carrying its stream. `reference`
   // mirrors every global rank's ten contributions for the host-side fold.
   std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<count_type>> num_items;
   std::vector<cuda::device_buffer<T>> out;
   std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
 
   in.reserve(comms.size());
+  num_items.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
 
@@ -208,14 +171,17 @@ MULTI_GPU_TEST("reduce single-comm, multiple elements per rank", value_types, op
   {
     const auto v = make_value<T>(comms[i].rank());
     const std::vector<T> values(values_per_rank, v);
+    const auto counts = {count_type{values_per_rank}};
 
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
+    num_items.emplace_back(
+      cuda::make_device_buffer<count_type>(streams[i], comms[i].logical_device().underlying_device(), counts));
     out.emplace_back(
       cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  do_reduce_threaded(comms, envs, in, out, init, ident, Op{});
+  do_reduce_deferred(comms, envs, in, num_items, out, init, ident, Op{});
 
   const T expected = [&] {
     std::vector<T> reference;
@@ -239,7 +205,7 @@ MULTI_GPU_TEST("reduce single-comm, multiple elements per rank", value_types, op
   }
 }
 
-MULTI_GPU_TEST("reduce single-comm, some ranks empty", value_types, operators)
+MULTI_GPU_TEST("reduce with deferred counts, some ranks empty", value_types, operators)
 {
   using T  = c2h::get<0, TestType>;
   using Op = c2h::get<1, TestType>;
@@ -255,10 +221,12 @@ MULTI_GPU_TEST("reduce single-comm, some ranks empty", value_types, operators)
   // contributing nothing, exactly like `std::accumulate` over the surviving elements. `reference`
   // mirrors that for the host-side fold.
   std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<count_type>> num_items;
   std::vector<cuda::device_buffer<T>> out;
   std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
 
   in.reserve(comms.size());
+  num_items.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
 
@@ -275,12 +243,16 @@ MULTI_GPU_TEST("reduce single-comm, some ranks empty", value_types, operators)
     {
       in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device()));
     }
+    const auto counts = {rank % 2 == 0 ? count_type{values_per_rank} : count_type{0}};
+
+    num_items.emplace_back(
+      cuda::make_device_buffer<count_type>(streams[i], comms[i].logical_device().underlying_device(), counts));
     out.emplace_back(
       cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  do_reduce_threaded(comms, envs, in, out, init, ident, Op{});
+  do_reduce_deferred(comms, envs, in, num_items, out, init, ident, Op{});
 
   const T expected = [&] {
     std::vector<T> reference;
@@ -305,7 +277,7 @@ MULTI_GPU_TEST("reduce single-comm, some ranks empty", value_types, operators)
   }
 }
 
-MULTI_GPU_TEST("reduce single-comm, all ranks empty", value_types, operators)
+MULTI_GPU_TEST("reduce with deferred counts, all ranks empty", value_types, operators)
 {
   using T  = c2h::get<0, TestType>;
   using Op = c2h::get<1, TestType>;
@@ -316,28 +288,100 @@ MULTI_GPU_TEST("reduce single-comm, all ranks empty", value_types, operators)
   auto comms   = this->communicators();
   auto streams = nccl_test_util::make_streams();
 
-  // No rank contributes any element. Reducing nothing seeded by `init` is just `init`, so every
-  // output must equal `init` regardless of the operator.
+  // No rank contributes any element, so every deferred count is zero. Reducing nothing seeded by
+  // `init` is just `init`, so every output must equal `init` regardless of the operator.
   std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<count_type>> num_items;
   std::vector<cuda::device_buffer<T>> out;
   std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
 
   in.reserve(comms.size());
+  num_items.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
+    const auto counts = {count_type{0}};
+
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device()));
+    num_items.emplace_back(
+      cuda::make_device_buffer<count_type>(streams[i], comms[i].logical_device().underlying_device(), counts));
     out.emplace_back(
       cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  do_reduce_threaded(comms, envs, in, out, init, ident, Op{});
+  do_reduce_deferred(comms, envs, in, num_items, out, init, ident, Op{});
 
   // Reducing nothing seeded by `init` yields `init`, exactly like `std::accumulate` over an empty
   // range.
   const T expected = init;
+
+  for (const auto& buf : out)
+  {
+    const auto exp = cuda::make_buffer(buf.stream(), cuda::mr::legacy_pinned_memory_resource{}, 1, expected);
+
+    REQUIRE_THAT(buf, Equals(exp));
+  }
+}
+
+MULTI_GPU_TEST("reduce with deferred counts smaller than the input range", value_types, operators)
+{
+  using T  = c2h::get<0, TestType>;
+  using Op = c2h::get<1, TestType>;
+
+  const T init     = make_value<T>(GENERATE(0, 1, -1, 5));
+  const auto ident = get_identity<T, Op>();
+
+  auto comms   = this->communicators();
+  auto streams = nccl_test_util::make_streams();
+
+  // The tail past `counted_per_rank` holds poison values that would change the result of every
+  // operator under test, so a reduction that used the buffer size instead of the deferred count
+  // cannot produce the expected value.
+  std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<count_type>> num_items;
+  std::vector<cuda::device_buffer<T>> out;
+  std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
+
+  in.reserve(comms.size());
+  num_items.reserve(comms.size());
+  out.reserve(comms.size());
+  envs.reserve(comms.size());
+
+  constexpr auto values_per_rank  = 10;
+  constexpr auto counted_per_rank = 4;
+  constexpr auto poison           = 1000;
+  for (cuda::std::size_t i = 0; i < comms.size(); ++i)
+  {
+    const auto rank = comms[i].rank();
+    std::vector<T> values(values_per_rank, make_value<T>(poison));
+
+    std::fill(values.begin(), values.begin() + counted_per_rank, make_value<T>(rank));
+
+    const auto counts = {count_type{counted_per_rank}};
+
+    in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
+    num_items.emplace_back(
+      cuda::make_device_buffer<count_type>(streams[i], comms[i].logical_device().underlying_device(), counts));
+    out.emplace_back(
+      cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
+    envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
+  }
+
+  do_reduce_deferred(comms, envs, in, num_items, out, init, ident, Op{});
+
+  const T expected = [&] {
+    std::vector<T> reference;
+
+    reference.reserve(comms.front().size() * counted_per_rank);
+    for (int r = 0; r < comms.front().size(); ++r)
+    {
+      reference.insert(reference.end(), counted_per_rank, make_value<T>(r));
+    }
+
+    return std::accumulate(reference.begin(), reference.end(), init, Op{});
+  }();
 
   for (const auto& buf : out)
   {

--- a/cudax/test/multi_gpu/algorithms/reduce/range_deferred.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/range_deferred.cu
@@ -11,6 +11,7 @@
 #include <cuda/argument>
 #include <cuda/buffer>
 #include <cuda/memory_resource>
+#include <cuda/std/array>
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/execution>
@@ -77,6 +78,64 @@ void do_reduce_deferred(
   }
 }
 } // namespace
+
+MULTI_GPU_TEST("reduce deferred documentation example", c2h::type_list<int>)
+{
+  auto comms = this->communicators();
+
+  if (comms.size() != 2)
+  {
+    SKIP("The reduce documentation example requires exactly two local GPUs");
+  }
+
+  auto streams_owned = nccl_test_util::make_streams();
+  // Convert to stream_ref directly, cuda::stream on their own cant be passed directly to CUB
+  auto streams = std::vector<cuda::stream_ref>{streams_owned.begin(), streams_owned.end()};
+
+  //! [reduce_deferred]
+  constexpr cuda::std::array input_values{1, 2, 3, 4};
+  // Only the first two elements take part in the reduction. A real caller would have a
+  // preceding device-side step write this count.
+  constexpr cuda::std::array count_values{2};
+
+  std::vector<cuda::device_buffer<int>> inputs;
+  std::vector<cuda::device_buffer<int>> counts;
+  std::vector<cuda::device_buffer<int>> outputs;
+
+  for (cuda::std::size_t i = 0; i < comms.size(); ++i)
+  {
+    const auto device = comms[i].logical_device().underlying_device();
+
+    inputs.emplace_back(cuda::make_device_buffer<int>(streams[i], device, input_values));
+    counts.emplace_back(cuda::make_device_buffer<int>(streams[i], device, count_values));
+    outputs.emplace_back(cuda::make_device_buffer<int>(streams[i], device, 1, cuda::no_init));
+  }
+
+  cudax::reduce(
+    cudax::broadcasted,
+    comms,
+    streams,
+    inputs | cuda::std::views::transform(cuda::std::ranges::begin),
+    // The count is read on the device in stream order, so it need not be known on the host
+    // when `reduce` is called.
+    counts | cuda::std::views::transform([](auto& buf) {
+      return cuda::args::deferred{buf.begin()};
+    }),
+    outputs | cuda::std::views::transform(cuda::std::ranges::begin),
+    /*__init=*/0);
+
+  // Every rank contributes the first two of its four values, so every output holds
+  // `(1 + 2) * nranks`.
+  const auto expected_value = 3 * comms.front().size();
+  //! [reduce_deferred]
+
+  const auto expected_0 =
+    cuda::make_buffer<int>(outputs[0].stream(), cuda::mr::legacy_pinned_memory_resource{}, 1, expected_value);
+  const auto expected_1 =
+    cuda::make_buffer<int>(outputs[1].stream(), cuda::mr::legacy_pinned_memory_resource{}, 1, expected_value);
+  REQUIRE_THAT(outputs[0], Equals(expected_0));
+  REQUIRE_THAT(outputs[1], Equals(expected_1));
+}
 
 MULTI_GPU_TEST("reduce with deferred counts, one element per rank", value_types, operators)
 {

--- a/cudax/test/multi_gpu/algorithms/reduce/reduce_common.cuh
+++ b/cudax/test/multi_gpu/algorithms/reduce/reduce_common.cuh
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CUDAX_TEST_MULTI_GPU_ALGORITHMS_REDUCE_REDUCE_COMMON_CUH
+#define CUDAX_TEST_MULTI_GPU_ALGORITHMS_REDUCE_REDUCE_COMMON_CUH
+
+#include <cuda/functional>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+#include <cuda/std/functional>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include <nccl_test_common.h>
+
+#include <c2h/catch2_test_helper.h>
+
+struct custom_plus
+{
+  template <class T>
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr T operator()(const T& lhs, const T& rhs) const
+  {
+    return lhs + rhs;
+  }
+};
+
+using custom_value = c2h::custom_type_t<c2h::accumulateable_t, c2h::less_comparable_t, c2h::equal_comparable_t>;
+using value_types  = c2h::type_list<cuda::std::int32_t, float, custom_value>;
+using operators    = c2h::type_list<::cuda::std::plus<>, ::cuda::maximum<>, custom_plus>;
+
+static_assert(cudax::nccl_transportable<custom_value>);
+
+template <typename T>
+[[nodiscard]] inline T make_value(int i)
+{
+  return static_cast<T>(i);
+}
+
+template <>
+[[nodiscard]] inline custom_value make_value<>(int i)
+{
+  custom_value ret{};
+
+  ret.key = static_cast<std::size_t>(i);
+  ret.val = static_cast<std::size_t>(i);
+  return ret;
+}
+
+// Must cover every operator in operators
+template <class T, class Op>
+[[nodiscard]] T get_identity()
+{
+  if constexpr (cuda::std::is_same_v<Op, cuda::std::plus<>> || cuda::std::is_same_v<Op, custom_plus>)
+  {
+    return make_value<T>(0);
+  }
+  else if constexpr (cuda::std::is_same_v<Op, cuda::maximum<>>)
+  {
+    return cuda::std::numeric_limits<T>::lowest();
+  }
+  else
+  {
+    static_assert(cuda::std::__always_false_v<T, Op>, "Add handling");
+  }
+}
+
+#endif // CUDAX_TEST_MULTI_GPU_ALGORITHMS_REDUCE_REDUCE_COMMON_CUH

--- a/cudax/test/multi_gpu/algorithms/reduce/single_comm_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/single_comm_basic.cu
@@ -11,6 +11,8 @@
 #include <cuda/buffer>
 #include <cuda/functional>
 #include <cuda/memory_resource>
+#include <cuda/std/array>
+#include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/execution>
 #include <cuda/std/functional>
@@ -21,6 +23,7 @@
 #include <exception>
 #include <future>
 #include <numeric>
+#include <string>
 #include <vector>
 
 #include <algorithm_common.h>
@@ -88,19 +91,18 @@ void do_reduce_threaded(
   cuda::std::span<cudax::nccl_communicator_ref> comms,
   std::vector<Env>& envs,
   std::vector<cuda::device_buffer<T>>& in,
-  std::vector<typename cuda::device_buffer<T>::iterator>& outputs,
+  std::vector<cuda::device_buffer<T>>& out,
   const T& init,
   const T& ident,
   Op op)
 {
-  const auto in_copy      = in;
-  const auto outputs_copy = outputs;
+  const auto in_copy = in;
 
   INFO("init = " << init);
   INFO("ident = " << ident);
 
   run_threaded(comms.size(), [&](cuda::std::size_t i) {
-    cudax::reduce(cudax::broadcasted, comms[i], envs[i], in[i], outputs[i], init, op, ident);
+    cudax::reduce(cudax::broadcasted, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
   });
 
   // Reduction call should not modify the inputs in any ways
@@ -110,9 +112,63 @@ void do_reduce_threaded(
     INFO("device = " << i);
     REQUIRE_THAT(in[i], Equals(in_copy[i]));
   }
-  REQUIRE_THAT(outputs, Catch::Matchers::Equals(outputs_copy));
 }
 } // namespace
+
+MULTI_GPU_TEST("reduce single-comm documentation example", c2h::type_list<int>)
+{
+  auto comms = this->communicators();
+
+  if (comms.size() != 2)
+  {
+    SKIP("The reduce documentation example requires exactly two local GPUs");
+  }
+
+  auto streams_owned = nccl_test_util::make_streams();
+  auto streams       = std::vector<cuda::stream_ref>{streams_owned.begin(), streams_owned.end()};
+
+  // Must be pre-allocated since it is written to by threads
+  std::vector<std::string> failed(comms.front().size());
+
+  // Every communicator rank must invoke the collective concurrently.
+  run_threaded(comms.size(), [&](cuda::std::size_t i) {
+    auto& communicator = comms[i];
+    auto& stream       = streams[i];
+    // Rename the stream to env for the example
+    auto& env = stream;
+
+    //! [reduce_single_range]
+    constexpr cuda::std::array input_values{1, 2};
+    const auto device = communicator.logical_device().underlying_device();
+
+    auto input  = cuda::make_device_buffer<int>(stream, device, input_values);
+    auto output = cuda::make_device_buffer<int>(stream, device, 1, cuda::no_init);
+
+    cudax::reduce(cudax::broadcasted, communicator, env, input.begin(), input.size(), output.begin(), /*__init=*/0);
+
+    // Every rank contributes {1, 2}, so the reduction over all ranks is 3 * nranks. `reduce`
+    // broadcasts the result, so every rank sees the same value.
+    const auto expected =
+      cuda::make_buffer<int>(output.stream(), cuda::mr::legacy_pinned_memory_resource{}, 1, 3 * communicator.size());
+    //! [reduce_single_range]
+
+    // catch2 isn't thread safe by default, so we can't use the usual requires expression. So
+    // we roll a hacky version of it ourselves
+    if (const auto matcher = Equals(expected); !matcher.match(output))
+    {
+      failed[communicator.rank()] = matcher.describe();
+    }
+  });
+
+  for (cuda::std::size_t i = 0; i < failed.size(); ++i)
+  {
+    if (const auto& err_str = failed[i]; !err_str.empty())
+    {
+      INFO("rank: " << i);
+      REQUIRE(err_str == ""); // Should print the full error string
+    }
+  }
+}
 
 MULTI_GPU_TEST("reduce single-comm, one element per rank", value_types, operators)
 {
@@ -147,9 +203,7 @@ MULTI_GPU_TEST("reduce single-comm, one element per rank", value_types, operator
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_reduce_threaded(comms, envs, in, outputs, init, ident, Op{});
+  do_reduce_threaded(comms, envs, in, out, init, ident, Op{});
 
   const T expected = [&] {
     std::vector<T> reference;
@@ -208,9 +262,7 @@ MULTI_GPU_TEST("reduce single-comm, multiple elements per rank", value_types, op
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_reduce_threaded(comms, envs, in, outputs, init, ident, Op{});
+  do_reduce_threaded(comms, envs, in, out, init, ident, Op{});
 
   const T expected = [&] {
     std::vector<T> reference;
@@ -275,9 +327,7 @@ MULTI_GPU_TEST("reduce single-comm, some ranks empty", value_types, operators)
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_reduce_threaded(comms, envs, in, outputs, init, ident, Op{});
+  do_reduce_threaded(comms, envs, in, out, init, ident, Op{});
 
   const T expected = [&] {
     std::vector<T> reference;
@@ -330,9 +380,7 @@ MULTI_GPU_TEST("reduce single-comm, all ranks empty", value_types, operators)
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
-  do_reduce_threaded(comms, envs, in, outputs, init, ident, Op{});
+  do_reduce_threaded(comms, envs, in, out, init, ident, Op{});
 
   // Reducing nothing seeded by `init` yields `init`, exactly like `std::accumulate` over an empty
   // range.

--- a/cudax/test/multi_gpu/algorithms/reduce/single_comm_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/single_comm_defaults.cu
@@ -56,8 +56,6 @@ MULTI_GPU_TEST("reduce single-comm, overloads default values", )
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  auto outputs = make_output_iterators(out);
-
   const auto expected = [&] {
     std::vector<T> reference;
 
@@ -75,7 +73,7 @@ MULTI_GPU_TEST("reduce single-comm, overloads default values", )
   SECTION("Default init, op, ident (all)")
   {
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::reduce(cudax::broadcasted, comms[i], envs[i], in[i], outputs[i]);
+      cudax::reduce(cudax::broadcasted, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin());
     });
 
     for (const auto& buf : out)
@@ -87,7 +85,7 @@ MULTI_GPU_TEST("reduce single-comm, overloads default values", )
   SECTION("Default op, ident")
   {
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::reduce(cudax::broadcasted, comms[i], envs[i], in[i], outputs[i], init);
+      cudax::reduce(cudax::broadcasted, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init);
     });
 
     for (const auto& buf : out)
@@ -99,7 +97,7 @@ MULTI_GPU_TEST("reduce single-comm, overloads default values", )
   SECTION("Default ident")
   {
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::reduce(cudax::broadcasted, comms[i], envs[i], in[i], outputs[i], init, op);
+      cudax::reduce(cudax::broadcasted, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op);
     });
 
     for (const auto& buf : out)
@@ -111,7 +109,7 @@ MULTI_GPU_TEST("reduce single-comm, overloads default values", )
   SECTION("Default none")
   {
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::reduce(cudax::broadcasted, comms[i], envs[i], in[i], outputs[i], init, op, ident);
+      cudax::reduce(cudax::broadcasted, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
     });
 
     for (const auto& buf : out)

--- a/cudax/test/multi_gpu/algorithms/reduce/single_comm_deferred.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/single_comm_deferred.cu
@@ -8,9 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/argument>
 #include <cuda/buffer>
 #include <cuda/memory_resource>
-#include <cuda/std/array>
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/execution>
@@ -18,10 +18,8 @@
 
 #include <cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h>
 
-#include <exception>
-#include <future>
+#include <algorithm>
 #include <numeric>
-#include <string>
 #include <vector>
 
 #include <algorithm_common.h>
@@ -33,6 +31,8 @@
 
 namespace
 {
+using count_type = cuda::std::int32_t;
+
 // Drive the reduction through the single-communicator overload of `reduce`, one thread per
 // rank. That overload opens its own NCCL group on a single communicator, so issuing the
 // per-rank calls serially on one thread would deadlock at `ncclGroupEnd`. Running each rank on
@@ -40,10 +40,11 @@ namespace
 // happens on the worker threads; every Catch2 assertion runs on the main thread after the
 // join, since the assertion macros are not safe to fire concurrently.
 template <class Env, class T, class Op>
-void do_reduce_threaded(
+void do_reduce_deferred_threaded(
   cuda::std::span<cudax::nccl_communicator_ref> comms,
   std::vector<Env>& envs,
   std::vector<cuda::device_buffer<T>>& in,
+  std::vector<cuda::device_buffer<count_type>>& num_items,
   std::vector<cuda::device_buffer<T>>& out,
   const T& init,
   const T& ident,
@@ -55,7 +56,16 @@ void do_reduce_threaded(
   INFO("ident = " << ident);
 
   run_threaded(comms.size(), [&](cuda::std::size_t i) {
-    cudax::reduce(cudax::broadcasted, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
+    cudax::reduce(
+      cudax::broadcasted,
+      comms[i],
+      envs[i],
+      in[i].begin(),
+      cuda::args::deferred{num_items[i].begin()},
+      out[i].begin(),
+      init,
+      op,
+      ident);
   });
 
   // Reduction call should not modify the inputs in any ways
@@ -68,62 +78,7 @@ void do_reduce_threaded(
 }
 } // namespace
 
-MULTI_GPU_TEST("reduce single-comm documentation example", c2h::type_list<int>)
-{
-  auto comms = this->communicators();
-
-  if (comms.size() != 2)
-  {
-    SKIP("The reduce documentation example requires exactly two local GPUs");
-  }
-
-  auto streams_owned = nccl_test_util::make_streams();
-  auto streams       = std::vector<cuda::stream_ref>{streams_owned.begin(), streams_owned.end()};
-
-  // Must be pre-allocated since it is written to by threads
-  std::vector<std::string> failed(comms.front().size());
-
-  // Every communicator rank must invoke the collective concurrently.
-  run_threaded(comms.size(), [&](cuda::std::size_t i) {
-    auto& communicator = comms[i];
-    auto& stream       = streams[i];
-    // Rename the stream to env for the example
-    auto& env = stream;
-
-    //! [reduce_single_range]
-    constexpr cuda::std::array input_values{1, 2};
-    const auto device = communicator.logical_device().underlying_device();
-
-    auto input  = cuda::make_device_buffer<int>(stream, device, input_values);
-    auto output = cuda::make_device_buffer<int>(stream, device, 1, cuda::no_init);
-
-    cudax::reduce(cudax::broadcasted, communicator, env, input.begin(), input.size(), output.begin(), /*__init=*/0);
-
-    // Every rank contributes {1, 2}, so the reduction over all ranks is 3 * nranks. `reduce`
-    // broadcasts the result, so every rank sees the same value.
-    const auto expected =
-      cuda::make_buffer<int>(output.stream(), cuda::mr::legacy_pinned_memory_resource{}, 1, 3 * communicator.size());
-    //! [reduce_single_range]
-
-    // catch2 isn't thread safe by default, so we can't use the usual requires expression. So
-    // we roll a hacky version of it ourselves
-    if (const auto matcher = Equals(expected); !matcher.match(output))
-    {
-      failed[communicator.rank()] = matcher.describe();
-    }
-  });
-
-  for (cuda::std::size_t i = 0; i < failed.size(); ++i)
-  {
-    if (const auto& err_str = failed[i]; !err_str.empty())
-    {
-      INFO("rank: " << i);
-      REQUIRE(err_str == ""); // Should print the full error string
-    }
-  }
-}
-
-MULTI_GPU_TEST("reduce single-comm, one element per rank", value_types, operators)
+MULTI_GPU_TEST("reduce single-comm with a deferred count, one element per rank", value_types, operators)
 {
   using T  = c2h::get<0, TestType>;
   using Op = c2h::get<1, TestType>;
@@ -141,22 +96,28 @@ MULTI_GPU_TEST("reduce single-comm, one element per rank", value_types, operator
   // stream-ordered on the correct device. `reference` mirrors the contributions of every global
   // rank so we can fold them on the host exactly like `reduce` does on the device.
   std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<count_type>> num_items;
   std::vector<cuda::device_buffer<T>> out;
   std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
 
   in.reserve(comms.size());
+  num_items.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
     const auto values = {make_value<T>(comms[i].rank())};
+    const auto counts = {count_type{1}};
+
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
+    num_items.emplace_back(
+      cuda::make_device_buffer<count_type>(streams[i], comms[i].logical_device().underlying_device(), counts));
     out.emplace_back(
       cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  do_reduce_threaded(comms, envs, in, out, init, ident, Op{});
+  do_reduce_deferred_threaded(comms, envs, in, num_items, out, init, ident, Op{});
 
   const T expected = [&] {
     std::vector<T> reference;
@@ -178,7 +139,7 @@ MULTI_GPU_TEST("reduce single-comm, one element per rank", value_types, operator
   }
 }
 
-MULTI_GPU_TEST("reduce single-comm, multiple elements per rank", value_types, operators)
+MULTI_GPU_TEST("reduce single-comm with a deferred count, multiple elements per rank", value_types, operators)
 {
   using T  = c2h::get<0, TestType>;
   using Op = c2h::get<1, TestType>;
@@ -196,10 +157,12 @@ MULTI_GPU_TEST("reduce single-comm, multiple elements per rank", value_types, op
   // also gets a one-element output buffer and an environment carrying its stream. `reference`
   // mirrors every global rank's ten contributions for the host-side fold.
   std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<count_type>> num_items;
   std::vector<cuda::device_buffer<T>> out;
   std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
 
   in.reserve(comms.size());
+  num_items.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
 
@@ -208,14 +171,17 @@ MULTI_GPU_TEST("reduce single-comm, multiple elements per rank", value_types, op
   {
     const auto v = make_value<T>(comms[i].rank());
     const std::vector<T> values(values_per_rank, v);
+    const auto counts = {count_type{values_per_rank}};
 
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
+    num_items.emplace_back(
+      cuda::make_device_buffer<count_type>(streams[i], comms[i].logical_device().underlying_device(), counts));
     out.emplace_back(
       cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  do_reduce_threaded(comms, envs, in, out, init, ident, Op{});
+  do_reduce_deferred_threaded(comms, envs, in, num_items, out, init, ident, Op{});
 
   const T expected = [&] {
     std::vector<T> reference;
@@ -239,7 +205,7 @@ MULTI_GPU_TEST("reduce single-comm, multiple elements per rank", value_types, op
   }
 }
 
-MULTI_GPU_TEST("reduce single-comm, some ranks empty", value_types, operators)
+MULTI_GPU_TEST("reduce single-comm with a deferred count, some ranks empty", value_types, operators)
 {
   using T  = c2h::get<0, TestType>;
   using Op = c2h::get<1, TestType>;
@@ -255,10 +221,12 @@ MULTI_GPU_TEST("reduce single-comm, some ranks empty", value_types, operators)
   // contributing nothing, exactly like `std::accumulate` over the surviving elements. `reference`
   // mirrors that for the host-side fold.
   std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<count_type>> num_items;
   std::vector<cuda::device_buffer<T>> out;
   std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
 
   in.reserve(comms.size());
+  num_items.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
 
@@ -275,12 +243,16 @@ MULTI_GPU_TEST("reduce single-comm, some ranks empty", value_types, operators)
     {
       in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device()));
     }
+    const auto counts = {rank % 2 == 0 ? count_type{values_per_rank} : count_type{0}};
+
+    num_items.emplace_back(
+      cuda::make_device_buffer<count_type>(streams[i], comms[i].logical_device().underlying_device(), counts));
     out.emplace_back(
       cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  do_reduce_threaded(comms, envs, in, out, init, ident, Op{});
+  do_reduce_deferred_threaded(comms, envs, in, num_items, out, init, ident, Op{});
 
   const T expected = [&] {
     std::vector<T> reference;
@@ -305,7 +277,7 @@ MULTI_GPU_TEST("reduce single-comm, some ranks empty", value_types, operators)
   }
 }
 
-MULTI_GPU_TEST("reduce single-comm, all ranks empty", value_types, operators)
+MULTI_GPU_TEST("reduce single-comm with a deferred count, all ranks empty", value_types, operators)
 {
   using T  = c2h::get<0, TestType>;
   using Op = c2h::get<1, TestType>;
@@ -316,28 +288,100 @@ MULTI_GPU_TEST("reduce single-comm, all ranks empty", value_types, operators)
   auto comms   = this->communicators();
   auto streams = nccl_test_util::make_streams();
 
-  // No rank contributes any element. Reducing nothing seeded by `init` is just `init`, so every
-  // output must equal `init` regardless of the operator.
+  // No rank contributes any element, so every deferred count is zero. Reducing nothing seeded by
+  // `init` is just `init`, so every output must equal `init` regardless of the operator.
   std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<count_type>> num_items;
   std::vector<cuda::device_buffer<T>> out;
   std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
 
   in.reserve(comms.size());
+  num_items.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
+    const auto counts = {count_type{0}};
+
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device()));
+    num_items.emplace_back(
+      cuda::make_device_buffer<count_type>(streams[i], comms[i].logical_device().underlying_device(), counts));
     out.emplace_back(
       cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
     envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
   }
 
-  do_reduce_threaded(comms, envs, in, out, init, ident, Op{});
+  do_reduce_deferred_threaded(comms, envs, in, num_items, out, init, ident, Op{});
 
   // Reducing nothing seeded by `init` yields `init`, exactly like `std::accumulate` over an empty
   // range.
   const T expected = init;
+
+  for (const auto& buf : out)
+  {
+    const auto exp = cuda::make_buffer(buf.stream(), cuda::mr::legacy_pinned_memory_resource{}, 1, expected);
+
+    REQUIRE_THAT(buf, Equals(exp));
+  }
+}
+
+MULTI_GPU_TEST("reduce single-comm with a deferred count smaller than the input range", value_types, operators)
+{
+  using T  = c2h::get<0, TestType>;
+  using Op = c2h::get<1, TestType>;
+
+  const T init     = make_value<T>(GENERATE(0, 1, -1, 5));
+  const auto ident = get_identity<T, Op>();
+
+  auto comms   = this->communicators();
+  auto streams = nccl_test_util::make_streams();
+
+  // The tail past `counted_per_rank` holds poison values that would change the result of every
+  // operator under test, so a reduction that used the buffer size instead of the deferred count
+  // cannot produce the expected value.
+  std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<count_type>> num_items;
+  std::vector<cuda::device_buffer<T>> out;
+  std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
+
+  in.reserve(comms.size());
+  num_items.reserve(comms.size());
+  out.reserve(comms.size());
+  envs.reserve(comms.size());
+
+  constexpr auto values_per_rank  = 10;
+  constexpr auto counted_per_rank = 4;
+  constexpr auto poison           = 1000;
+  for (cuda::std::size_t i = 0; i < comms.size(); ++i)
+  {
+    const auto rank = comms[i].rank();
+    std::vector<T> values(values_per_rank, make_value<T>(poison));
+
+    std::fill(values.begin(), values.begin() + counted_per_rank, make_value<T>(rank));
+
+    const auto counts = {count_type{counted_per_rank}};
+
+    in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
+    num_items.emplace_back(
+      cuda::make_device_buffer<count_type>(streams[i], comms[i].logical_device().underlying_device(), counts));
+    out.emplace_back(
+      cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
+    envs.emplace_back(::cuda::std::execution::env{::cuda::stream_ref{streams[i]}});
+  }
+
+  do_reduce_deferred_threaded(comms, envs, in, num_items, out, init, ident, Op{});
+
+  const T expected = [&] {
+    std::vector<T> reference;
+
+    reference.reserve(comms.front().size() * counted_per_rank);
+    for (int r = 0; r < comms.front().size(); ++r)
+    {
+      reference.insert(reference.end(), counted_per_rank, make_value<T>(r));
+    }
+
+    return std::accumulate(reference.begin(), reference.end(), init, Op{});
+  }();
 
   for (const auto& buf : out)
   {

--- a/cudax/test/multi_gpu/algorithms/reduce/single_comm_deferred.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/single_comm_deferred.cu
@@ -11,6 +11,7 @@
 #include <cuda/argument>
 #include <cuda/buffer>
 #include <cuda/memory_resource>
+#include <cuda/std/array>
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/execution>
@@ -19,7 +20,10 @@
 #include <cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h>
 
 #include <algorithm>
+#include <exception>
+#include <future>
 #include <numeric>
+#include <string>
 #include <vector>
 
 #include <algorithm_common.h>
@@ -77,6 +81,74 @@ void do_reduce_deferred_threaded(
   }
 }
 } // namespace
+
+MULTI_GPU_TEST("reduce single-comm deferred documentation example", c2h::type_list<int>)
+{
+  auto comms = this->communicators();
+
+  if (comms.size() != 2)
+  {
+    SKIP("The reduce documentation example requires exactly two local GPUs");
+  }
+
+  auto streams_owned = nccl_test_util::make_streams();
+  auto streams       = std::vector<cuda::stream_ref>{streams_owned.begin(), streams_owned.end()};
+
+  // Must be pre-allocated since it is written to by threads
+  std::vector<std::string> failed(comms.front().size());
+
+  // Every communicator rank must invoke the collective concurrently.
+  run_threaded(comms.size(), [&](cuda::std::size_t i) {
+    auto& communicator = comms[i];
+    auto& stream       = streams[i];
+    // Rename the stream to env for the example
+    auto& env = stream;
+
+    //! [reduce_single_range_deferred]
+    constexpr cuda::std::array input_values{1, 2, 3, 4};
+    // Only the first two elements take part in the reduction. A real caller would have a
+    // preceding device-side step write this count.
+    constexpr cuda::std::array count_values{2};
+    const auto device = communicator.logical_device().underlying_device();
+
+    auto input  = cuda::make_device_buffer<int>(stream, device, input_values);
+    auto count  = cuda::make_device_buffer<int>(stream, device, count_values);
+    auto output = cuda::make_device_buffer<int>(stream, device, 1, cuda::no_init);
+
+    // The count is read on the device in stream order, so it need not be known on the host
+    // when `reduce` is called.
+    cudax::reduce(
+      cudax::broadcasted,
+      communicator,
+      env,
+      input.begin(),
+      cuda::args::deferred{count.begin()},
+      output.begin(),
+      /*__init=*/0);
+
+    // Every rank contributes the first two of its four values, so the reduction over all ranks
+    // is `(1 + 2) * nranks`. `reduce` broadcasts the result, so every rank sees the same value.
+    const auto expected =
+      cuda::make_buffer<int>(output.stream(), cuda::mr::legacy_pinned_memory_resource{}, 1, 3 * communicator.size());
+    //! [reduce_single_range_deferred]
+
+    // catch2 isn't thread safe by default, so we can't use the usual requires expression. So
+    // we roll a hacky version of it ourselves
+    if (const auto matcher = Equals(expected); !matcher.match(output))
+    {
+      failed[communicator.rank()] = matcher.describe();
+    }
+  });
+
+  for (cuda::std::size_t i = 0; i < failed.size(); ++i)
+  {
+    if (const auto& err_str = failed[i]; !err_str.empty())
+    {
+      INFO("rank: " << i);
+      REQUIRE(err_str == ""); // Should print the full error string
+    }
+  }
+}
 
 MULTI_GPU_TEST("reduce single-comm with a deferred count, one element per rank", value_types, operators)
 {

--- a/cudax/test/multi_gpu/algorithms/sort/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/sort/range_basic.cu
@@ -13,6 +13,7 @@
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/functional>
+#include <cuda/std/ranges>
 #include <cuda/std/span>
 
 #include <cuda/experimental/__multi_gpu/algorithm/sort/sort.h>
@@ -46,7 +47,12 @@ void check_sort_case(
   auto environments   = std::vector<cuda::stream_ref>{streams.begin(), streams.end()};
   auto device_vec     = sort_test_util::make_device_inputs(comms, environments, host_inputs);
 
-  cudax::sort(cudax::distributed, comms, environments, device_vec, cmp);
+  cudax::sort(cudax::distributed,
+              comms,
+              environments,
+              device_vec | cuda::std::views::transform(cuda::std::ranges::begin),
+              device_vec | cuda::std::views::transform(cuda::std::ranges::size),
+              cmp);
 
   sort_test_util::check_rank_sizes(comms, device_vec, host_inputs);
 
@@ -103,7 +109,8 @@ MULTI_GPU_TEST("sort documentation example", c2h::type_list<int>)
               comms,
               // Passing streams as the environment directly
               streams,
-              inputs);
+              inputs | cuda::std::views::transform(cuda::std::ranges::begin),
+              inputs | cuda::std::views::transform(cuda::std::ranges::size));
 
   // The sort is in place and each rank keeps its original element count, so the globally sorted
   // sequence {1, 2, 3, 4} is split back into two elements per rank, in ascending rank order.

--- a/cudax/test/multi_gpu/algorithms/sort/range_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/sort/range_defaults.cu
@@ -11,6 +11,7 @@
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/functional>
+#include <cuda/std/ranges>
 #include <cuda/std/span>
 
 #include <cuda/experimental/__multi_gpu/algorithm/sort/sort.h>
@@ -70,7 +71,11 @@ MULTI_GPU_TEST("sort, range overloads default values", )
   {
     auto device_vec = sort_test_util::make_device_inputs(comms, environments, host_inputs);
 
-    cudax::sort(cudax::distributed, comms, environments, device_vec);
+    cudax::sort(cudax::distributed,
+                comms,
+                environments,
+                device_vec | cuda::std::views::transform(cuda::std::ranges::begin),
+                device_vec | cuda::std::views::transform(cuda::std::ranges::size));
 
     check_sorted(device_vec);
   }
@@ -79,7 +84,12 @@ MULTI_GPU_TEST("sort, range overloads default values", )
   {
     auto device_vec = sort_test_util::make_device_inputs(comms, environments, host_inputs);
 
-    cudax::sort(cudax::distributed, comms, environments, device_vec, cmp);
+    cudax::sort(cudax::distributed,
+                comms,
+                environments,
+                device_vec | cuda::std::views::transform(cuda::std::ranges::begin),
+                device_vec | cuda::std::views::transform(cuda::std::ranges::size),
+                cmp);
 
     check_sorted(device_vec);
   }

--- a/cudax/test/multi_gpu/algorithms/sort/single_comm_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/sort/single_comm_basic.cu
@@ -53,7 +53,7 @@ void check_sort_case(
   auto device_vec     = sort_test_util::make_device_inputs(comms, environments, host_inputs);
 
   run_threaded(comms.size(), [&](cuda::std::size_t i) {
-    cudax::sort(cudax::distributed, comms[i], environments[i], device_vec[i], cmp);
+    cudax::sort(cudax::distributed, comms[i], environments[i], device_vec[i].begin(), device_vec[i].size(), cmp);
   });
 
   sort_test_util::check_rank_sizes(comms, device_vec, host_inputs);
@@ -113,7 +113,7 @@ MULTI_GPU_TEST("sort single-comm documentation example", c2h::type_list<int>)
 
     auto input = cuda::make_device_buffer<int>(environment, device, {high, high - 1});
 
-    cudax::sort(cudax::distributed, communicator, environment, input);
+    cudax::sort(cudax::distributed, communicator, environment, input.begin(), input.size());
 
     // The sort is in place and each rank keeps its original element count, so rank r ends up with
     // its two-element slice of the globally sorted sequence.

--- a/cudax/test/multi_gpu/algorithms/sort/single_comm_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/sort/single_comm_defaults.cu
@@ -76,7 +76,7 @@ MULTI_GPU_TEST("sort single-comm, overloads default values", )
     auto device_vec = sort_test_util::make_device_inputs(comms, environments, host_inputs);
 
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::sort(cudax::distributed, comms[i], environments[i], device_vec[i]);
+      cudax::sort(cudax::distributed, comms[i], environments[i], device_vec[i].begin(), device_vec[i].size());
     });
 
     check_sorted(device_vec);
@@ -87,7 +87,7 @@ MULTI_GPU_TEST("sort single-comm, overloads default values", )
     auto device_vec = sort_test_util::make_device_inputs(comms, environments, host_inputs);
 
     run_threaded(comms.size(), [&](cuda::std::size_t i) {
-      cudax::sort(cudax::distributed, comms[i], environments[i], device_vec[i], cmp);
+      cudax::sort(cudax::distributed, comms[i], environments[i], device_vec[i].begin(), device_vec[i].size(), cmp);
     });
 
     check_sorted(device_vec);

--- a/cudax/test/multi_gpu/include/algorithm_common.h
+++ b/cudax/test/multi_gpu/include/algorithm_common.h
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <exception>
 #include <future>
+#include <type_traits>
 #include <vector>
 
 #include <c2h/catch2_test_helper.h>
@@ -59,7 +60,8 @@ void run_threaded(cuda::std::size_t num_ranks, Fn fn)
           // std::async, and futures block in their destructor for task completion. So to make
           // this error message actually useful, we need to toss them all into the oubliette.
           [[maybe_unused]] auto* _ = new std::vector<std::future<void>>{std::move(futures)};
-          FAIL("Future for rank " << i << " timed out after " << timeout << ", likely a deadlock");
+          static_assert(std::is_same_v<std::remove_cv_t<decltype(timeout)>, std::chrono::seconds>);
+          FAIL("Future for rank " << i << " timed out after " << timeout.count() << "s, likely a deadlock");
           break;
         }
         case std::future_status::ready:

--- a/cudax/test/multi_gpu/include/algorithm_common.h
+++ b/cudax/test/multi_gpu/include/algorithm_common.h
@@ -54,9 +54,14 @@ void run_threaded(cuda::std::size_t num_ranks, Fn fn)
         case std::future_status::deferred:
           FAIL("Test should not use deferred execution, only async");
           break;
-        case std::future_status::timeout:
+        case std::future_status::timeout: {
+          // The standard gives no mechanism to abandon or cancel a task launched with
+          // std::async, and futures block in their destructor for task completion. So to make
+          // this error message actually useful, we need to toss them all into the oubliette.
+          [[maybe_unused]] auto* _ = new std::vector<std::future<void>>{std::move(futures)};
           FAIL("Future for rank " << i << " timed out after " << timeout << ", likely a deadlock");
           break;
+        }
         case std::future_status::ready:
           break;
       }

--- a/cudax/test/multi_gpu/include/algorithm_common.h
+++ b/cudax/test/multi_gpu/include/algorithm_common.h
@@ -10,28 +10,14 @@
 
 #pragma once
 
-#include <cuda/buffer>
 #include <cuda/std/cstddef>
 
+#include <chrono>
 #include <exception>
 #include <future>
 #include <vector>
 
-// One output iterator per local output buffer. Collected after `out` is fully built so the
-// iterators do not dangle across reallocations.
-template <class T>
-[[nodiscard]] std::vector<typename cuda::device_buffer<T>::iterator>
-make_output_iterators(std::vector<cuda::device_buffer<T>>& out)
-{
-  std::vector<typename cuda::device_buffer<T>::iterator> outputs;
-
-  outputs.reserve(out.size());
-  for (auto& buf : out)
-  {
-    outputs.push_back(buf.begin());
-  }
-  return outputs;
-}
+#include <c2h/catch2_test_helper.h>
 
 template <class Fn>
 void run_threaded(cuda::std::size_t num_ranks, Fn fn)
@@ -54,14 +40,35 @@ void run_threaded(cuda::std::size_t num_ranks, Fn fn)
   // one on a peer.
   std::exception_ptr error = nullptr;
 
-  for (auto& f : futures)
+  for (cuda::std::size_t i = 0; i < futures.size(); ++i)
   {
+    auto& f = futures[i];
+
+    REQUIRE(f.valid());
+
+    {
+      using namespace std::chrono_literals;
+      // Doing the timeout detection this way gives a much nicer error message than ctest or catch2.
+      switch (constexpr auto timeout = 15s; f.wait_for(timeout))
+      {
+        case std::future_status::deferred:
+          FAIL("Test should not use deferred execution, only async");
+          break;
+        case std::future_status::timeout:
+          FAIL("Future for rank " << i << " timed out after " << timeout << ", likely a deadlock");
+          break;
+        case std::future_status::ready:
+          break;
+      }
+    }
+
     try
     {
       f.get();
     }
     catch (...)
     {
+      INFO("rank " << i << " exception");
       if (!error)
       {
         error = std::current_exception();

--- a/libcudacxx/include/cuda/std/__iterator/concepts.h
+++ b/libcudacxx/include/cuda/std/__iterator/concepts.h
@@ -25,6 +25,7 @@
 #include <cuda/std/__concepts/assignable.h>
 #include <cuda/std/__concepts/common_reference_with.h>
 #include <cuda/std/__concepts/constructible.h>
+#include <cuda/std/__concepts/convertible_to.h>
 #include <cuda/std/__concepts/copyable.h>
 #include <cuda/std/__concepts/derived_from.h>
 #include <cuda/std/__concepts/equality_comparable.h>
@@ -45,6 +46,7 @@
 #include <cuda/std/__type_traits/add_pointer.h>
 #include <cuda/std/__type_traits/common_reference.h>
 #include <cuda/std/__type_traits/conjunction.h>
+#include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/remove_cv.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
@@ -710,6 +712,26 @@ template <class _Ip>
 inline constexpr bool __has_iter_concept<_Ip, void_t<typename _Ip::iterator_concept>> = true;
 
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
+
+template <class _Fn, class _Tp, class _Iter, class _Up>
+_CCCL_CONCEPT __indirectly_binary_reducible_impl = _CCCL_REQUIRES_EXPR((_Fn, _Tp, _Iter, _Up), )(
+  requires(movable<_Tp>),
+  requires(movable<_Up>),
+  requires(convertible_to<_Tp, _Up>),
+  requires(invocable<_Fn&, _Up, iter_reference_t<_Iter>>),
+  requires(assignable_from<_Up&, invoke_result_t<_Fn&, _Up, iter_reference_t<_Iter>>>));
+
+// Similar to __indirectly_binary_invokable. Asserts that for a given operator, type, and
+// iterator triple, that a general reduction is well formed, so _Fn(_Fn(_Tp, *_Iter), *_Iter)
+// etc is sane.
+template <class _Fn, class _Tp, class _Iter>
+_CCCL_CONCEPT __indirectly_binary_reducible = _CCCL_REQUIRES_EXPR((_Fn, _Tp, _Iter), )(
+  requires(copy_constructible<_Fn>),
+  requires(indirectly_readable<_Iter>),
+  requires(invocable<_Fn&, _Tp, iter_reference_t<_Iter>>),
+  requires(__invoke_constructible<_Fn&, _Tp, iter_reference_t<_Iter>>),
+  requires(
+    __indirectly_binary_reducible_impl<_Fn, _Tp, _Iter, decay_t<invoke_result_t<_Fn&, _Tp, iter_reference_t<_Iter>>>>));
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__ranges/ref_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/ref_view.h
@@ -67,7 +67,7 @@ public:
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__different_from<_Tp, ref_view> _CCCL_AND convertible_to<_Tp, _Range&> _CCCL_AND
                    __convertible_to_lvalue<_Tp, _Range>)
-  _CCCL_API constexpr ref_view(_Tp&& __t)
+  _CCCL_API constexpr ref_view(_Tp&& __t) // NOLINT(bugprone-forwarding-reference-overload)
       : view_interface<ref_view<_Range>>()
       , __range_(::cuda::std::addressof(static_cast<_Range&>(::cuda::std::forward<_Tp>(__t))))
   {}

--- a/libcudacxx/include/cuda/std/__ranges/subrange.h
+++ b/libcudacxx/include/cuda/std/__ranges/subrange.h
@@ -234,13 +234,13 @@ public:
 
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__subrange_from_range<_Iter, _Sent, _Kind, _Range, !_StoreSize>)
-  _CCCL_API constexpr subrange(_Range&& __range)
+  _CCCL_API constexpr subrange(_Range&& __range) // NOLINT(bugprone-forwarding-reference-overload)
       : subrange(::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__end_cpo{}(__range))
   {}
 
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__subrange_from_range<_Iter, _Sent, _Kind, _Range, _StoreSize>)
-  _CCCL_API constexpr subrange(_Range&& __range)
+  _CCCL_API constexpr subrange(_Range&& __range) // NOLINT(bugprone-forwarding-reference-overload)
       : subrange(__range, ::cuda::std::ranges::__size_cpo{}(__range))
   {}
 

--- a/libcudacxx/include/cuda/std/__ranges/transform_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/transform_view.h
@@ -167,18 +167,21 @@ public:
       return ::cuda::std::move(__current_);
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     [[nodiscard]] _CCCL_API constexpr decltype(auto) operator*() const
       noexcept(noexcept(::cuda::std::invoke(*__parent_->__func_, *__current_)))
     {
       return ::cuda::std::invoke(*__parent_->__func_, *__current_);
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_API constexpr __iterator& operator++()
     {
       ++__current_;
       return *this;
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_TEMPLATE(class _Base2 = _Base)
     _CCCL_REQUIRES((!forward_range<_Base2>) )
     _CCCL_API constexpr void operator++(int)
@@ -186,6 +189,7 @@ public:
       ++__current_;
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_TEMPLATE(class _Base2 = _Base)
     _CCCL_REQUIRES(forward_range<_Base2>)
     _CCCL_API constexpr __iterator operator++(int)
@@ -195,6 +199,7 @@ public:
       return __tmp;
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_TEMPLATE(class _Base2 = _Base)
     _CCCL_REQUIRES(bidirectional_range<_Base2>)
     _CCCL_API constexpr __iterator& operator--()
@@ -203,6 +208,7 @@ public:
       return *this;
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_TEMPLATE(class _Base2 = _Base)
     _CCCL_REQUIRES(bidirectional_range<_Base2>)
     _CCCL_API constexpr __iterator operator--(int)
@@ -212,6 +218,7 @@ public:
       return __tmp;
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_TEMPLATE(class _Base2 = _Base)
     _CCCL_REQUIRES(random_access_range<_Base2>)
     _CCCL_API constexpr __iterator& operator+=(difference_type __n)
@@ -220,6 +227,7 @@ public:
       return *this;
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_TEMPLATE(class _Base2 = _Base)
     _CCCL_REQUIRES(random_access_range<_Base2>)
     _CCCL_API constexpr __iterator& operator-=(difference_type __n)
@@ -228,6 +236,7 @@ public:
       return *this;
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_TEMPLATE(class _Base2 = _Base)
     _CCCL_REQUIRES(random_access_range<_Base2>)
     [[nodiscard]] _CCCL_API constexpr decltype(auto) operator[](difference_type __n) const
@@ -236,6 +245,7 @@ public:
       return ::cuda::std::invoke(*__parent_->__func_, __current_[__n]);
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Base2 = _Base>
     [[nodiscard]] _CCCL_API friend constexpr auto operator==(const __iterator& __x, const __iterator& __y)
       _CCCL_TRAILING_REQUIRES(bool)(equality_comparable<iterator_t<_Base2>>)
@@ -243,6 +253,7 @@ public:
       return __x.__current_ == __y.__current_;
     }
 #if _CCCL_STD_VER <= 2017
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Base2 = _Base>
     [[nodiscard]] _CCCL_API friend constexpr auto operator!=(const __iterator& __x, const __iterator& __y)
       _CCCL_TRAILING_REQUIRES(bool)(equality_comparable<iterator_t<_Base2>>)
@@ -251,6 +262,7 @@ public:
     }
 #endif // _CCCL_STD_VER <= 2017
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Base2 = _Base>
     [[nodiscard]] _CCCL_API friend constexpr auto operator<(const __iterator& __x, const __iterator& __y)
       _CCCL_TRAILING_REQUIRES(bool)(random_access_range<_Base2>)
@@ -258,6 +270,7 @@ public:
       return __x.__current_ < __y.__current_;
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Base2 = _Base>
     [[nodiscard]] _CCCL_API friend constexpr auto operator>(const __iterator& __x, const __iterator& __y)
       _CCCL_TRAILING_REQUIRES(bool)(random_access_range<_Base2>)
@@ -265,6 +278,7 @@ public:
       return __x.__current_ > __y.__current_;
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Base2 = _Base>
     [[nodiscard]] _CCCL_API friend constexpr auto operator<=(const __iterator& __x, const __iterator& __y)
       _CCCL_TRAILING_REQUIRES(bool)(random_access_range<_Base2>)
@@ -272,6 +286,7 @@ public:
       return __x.__current_ <= __y.__current_;
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Base2 = _Base>
     [[nodiscard]] _CCCL_API friend constexpr auto operator>=(const __iterator& __x, const __iterator& __y)
       _CCCL_TRAILING_REQUIRES(bool)(random_access_range<_Base2>)
@@ -280,6 +295,7 @@ public:
     }
 
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_TEMPLATE(class _Base2 = _Base)
     _CCCL_REQUIRES(random_access_range<_Base2> _CCCL_AND three_way_comparable<iterator_t<_Base>>)
     [[nodiscard]] _CCCL_API friend constexpr auto operator<=>(const __iterator& __x, const __iterator& __y)
@@ -288,6 +304,7 @@ public:
     }
 #endif // !_LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Base2 = _Base>
     [[nodiscard]] _CCCL_API friend constexpr auto operator+(__iterator __i, difference_type __n)
       _CCCL_TRAILING_REQUIRES(__iterator)(random_access_range<_Base2>)
@@ -295,6 +312,7 @@ public:
       return __iterator{*__i.__parent_, __i.__current_ + __n};
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Base2 = _Base>
     [[nodiscard]] _CCCL_API friend constexpr auto operator+(difference_type __n, __iterator __i)
       _CCCL_TRAILING_REQUIRES(__iterator)(random_access_range<_Base2>)
@@ -302,6 +320,7 @@ public:
       return __iterator{*__i.__parent_, __i.__current_ + __n};
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Base2 = _Base>
     [[nodiscard]] _CCCL_API friend constexpr auto operator-(__iterator __i, difference_type __n)
       _CCCL_TRAILING_REQUIRES(__iterator)(random_access_range<_Base2>)
@@ -309,6 +328,7 @@ public:
       return __iterator{*__i.__parent_, __i.__current_ - __n};
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Base2 = _Base>
     [[nodiscard]] _CCCL_API friend constexpr auto operator-(const __iterator& __x, const __iterator& __y)
       _CCCL_TRAILING_REQUIRES(difference_type)(sized_sentinel_for<iterator_t<_Base2>, iterator_t<_Base2>>)


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Switch from range-of-ranges to range-of-iters and range-of-sizes for MGMN algorithms.

Also add an example for `reduce()` while we are here and move the `__indirectly_binary_reducible` to a better home in libcu++.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
