### PR TITLE
Pretty printers maintenance

### DIFF
--- a/libcudacxx/share/libcudacxx/gdb/atomic.py
+++ b/libcudacxx/share/libcudacxx/gdb/atomic.py
@@ -36,7 +36,9 @@ def _is_atomic_ref(type_name: str) -> bool:
 
 def _complete_type_name(value_type: gdb.Type) -> str:
     """Return the complete public type name, including CUDA thread scope."""
-    value_type = value_type.strip_typedefs().unqualified()
+    value_type = (
+        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
+    )
     type_name = memory_resource.public_type_name(value_type)
     template_name = _template_name(type_name)
     if template_name not in {"cuda::atomic", "cuda::atomic_ref"}:
@@ -48,7 +50,9 @@ def _complete_type_name(value_type: gdb.Type) -> str:
 
 
 def _is_cuda_atomic(value_type: gdb.Type) -> bool:
-    value_type = value_type.strip_typedefs().unqualified()
+    value_type = (
+        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
+    )
     template_name = _template_name(memory_resource.public_type_name(value_type))
     return template_name in _ATOMIC_NAMES
 
@@ -58,7 +62,9 @@ def _reference_pointer(value: gdb.Value) -> gdb.Value:
 
 
 def _stored_value(value: gdb.Value, type_name: str) -> gdb.Value:
-    value_type = value.type.strip_typedefs().unqualified()
+    value_type = (
+        memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
+    )
     storage = value["__a"]
     stored = storage["__a_value"]
 
@@ -77,8 +83,11 @@ class AtomicPrinter:
     """Expose the value represented by a CUDA atomic without executing inferior code."""
 
     def __init__(self, value: gdb.Value) -> None:
+        value = memory_resource.strip_reference_value(value)
         self.value = value
-        self.type = value.type.strip_typedefs().unqualified()
+        self.type = (
+            memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
+        )
         self.type_name = _complete_type_name(self.type)
 
     def children(self) -> Iterator[tuple[str, gdb.Value]]:

--- a/libcudacxx/share/libcudacxx/gdb/atomic.py
+++ b/libcudacxx/share/libcudacxx/gdb/atomic.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from types import ModuleType
 
-import memory_resource
+import cccl_common
 
 import gdb
 import gdb.printing
@@ -26,34 +26,26 @@ _THREAD_SCOPE_NAMES = {
 }
 
 
-def _template_name(type_name: str) -> str:
-    return type_name.split("<", 1)[0]
-
-
 def _is_atomic_ref(type_name: str) -> bool:
-    return _template_name(type_name) in _ATOMIC_REF_NAMES
+    return cccl_common.template_name(type_name) in _ATOMIC_REF_NAMES
 
 
 def _complete_type_name(value_type: gdb.Type) -> str:
     """Return the complete public type name, including CUDA thread scope."""
-    value_type = (
-        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
-    )
-    type_name = memory_resource.public_type_name(value_type)
-    template_name = _template_name(type_name)
+    value_type = cccl_common.canonical_type(value_type)
+    type_name = cccl_common.public_type_name(value_type)
+    template_name = cccl_common.template_name(type_name)
     if template_name not in {"cuda::atomic", "cuda::atomic_ref"}:
         return type_name
 
-    value_type_name = memory_resource.public_type_name(value_type.template_argument(0))
+    value_type_name = cccl_common.public_type_name(value_type.template_argument(0))
     scope = int(value_type.template_argument(1))
     return f"{template_name}<{value_type_name}, cuda::thread_scope_{_THREAD_SCOPE_NAMES[scope]}>"
 
 
 def _is_cuda_atomic(value_type: gdb.Type) -> bool:
-    value_type = (
-        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
-    )
-    template_name = _template_name(memory_resource.public_type_name(value_type))
+    value_type = cccl_common.canonical_type(value_type)
+    template_name = cccl_common.template_name(cccl_common.public_type_name(value_type))
     return template_name in _ATOMIC_NAMES
 
 
@@ -62,9 +54,7 @@ def _reference_pointer(value: gdb.Value) -> gdb.Value:
 
 
 def _stored_value(value: gdb.Value, type_name: str) -> gdb.Value:
-    value_type = (
-        memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
-    )
+    value_type = cccl_common.canonical_type(value.type)
     storage = value["__a"]
     stored = storage["__a_value"]
 
@@ -83,11 +73,9 @@ class AtomicPrinter:
     """Expose the value represented by a CUDA atomic without executing inferior code."""
 
     def __init__(self, value: gdb.Value) -> None:
-        value = memory_resource.strip_reference_value(value)
+        value = cccl_common.strip_reference_value(value)
         self.value = value
-        self.type = (
-            memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
-        )
+        self.type = cccl_common.canonical_type(value.type)
         self.type_name = _complete_type_name(self.type)
 
     def children(self) -> Iterator[tuple[str, gdb.Value]]:

--- a/libcudacxx/share/libcudacxx/gdb/buffer.py
+++ b/libcudacxx/share/libcudacxx/gdb/buffer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from types import ModuleType
 
+import cccl_common
 import memory_resource
 
 import gdb
@@ -20,22 +21,8 @@ import gdb.printing
 _CUDA_MEMCPY_DEFAULT = 4
 
 
-def _template_name(value_type: gdb.Type) -> str:
-    return str(value_type).split("<", 1)[0]
-
-
-def _strip_reference(value_type: gdb.Type) -> gdb.Type:
-    # target() gives the referenced type, but on a non-reference it either
-    # resolves a typedef or raises, so test the code first.
-    if value_type.code in (gdb.TYPE_CODE_REF, gdb.TYPE_CODE_RVALUE_REF):
-        return value_type.target()
-    return value_type
-
-
 def _is_cuda_buffer(value_type: gdb.Type) -> bool:
-    # strip_typedefs resolves aliases that can hide accessibility properties.
-    value_type = _strip_reference(value_type).strip_typedefs().unqualified()
-    template_name = _template_name(value_type)
+    template_name = cccl_common.template_name(cccl_common.canonical_type(value_type))
     return (
         template_name.startswith("cuda::")
         and template_name.rsplit("::", 1)[-1] == "buffer"
@@ -46,11 +33,10 @@ class BufferPrinter:
     """Expose cuda::buffer metadata and elements to GDB."""
 
     def __init__(self, value: gdb.Value) -> None:
-        if value.type.code in (gdb.TYPE_CODE_REF, gdb.TYPE_CODE_RVALUE_REF):
-            value = value.referenced_value()
+        value = cccl_common.strip_reference_value(value)
         self.value = value
-        self.type = _strip_reference(value.type).strip_typedefs().unqualified()
-        self.type_name = memory_resource.public_type_name(self.type)
+        self.type = cccl_common.canonical_type(value.type)
+        self.type_name = cccl_common.public_type_name(self.type)
         self.value_type = self.type.template_argument(0)
 
         storage = value["__buf_"]

--- a/libcudacxx/share/libcudacxx/gdb/buffer.py
+++ b/libcudacxx/share/libcudacxx/gdb/buffer.py
@@ -24,9 +24,17 @@ def _template_name(value_type: gdb.Type) -> str:
     return str(value_type).split("<", 1)[0]
 
 
+def _strip_reference(value_type: gdb.Type) -> gdb.Type:
+    # target() gives the referenced type, but on a non-reference it either
+    # resolves a typedef or raises, so test the code first.
+    if value_type.code in (gdb.TYPE_CODE_REF, gdb.TYPE_CODE_RVALUE_REF):
+        return value_type.target()
+    return value_type
+
+
 def _is_cuda_buffer(value_type: gdb.Type) -> bool:
     # strip_typedefs resolves aliases that can hide accessibility properties.
-    value_type = value_type.strip_typedefs().unqualified()
+    value_type = _strip_reference(value_type).strip_typedefs().unqualified()
     template_name = _template_name(value_type)
     return (
         template_name.startswith("cuda::")
@@ -38,8 +46,10 @@ class BufferPrinter:
     """Expose cuda::buffer metadata and elements to GDB."""
 
     def __init__(self, value: gdb.Value) -> None:
+        if value.type.code in (gdb.TYPE_CODE_REF, gdb.TYPE_CODE_RVALUE_REF):
+            value = value.referenced_value()
         self.value = value
-        self.type = value.type.strip_typedefs().unqualified()
+        self.type = _strip_reference(value.type).strip_typedefs().unqualified()
         self.type_name = memory_resource.public_type_name(self.type)
         self.value_type = self.type.template_argument(0)
 

--- a/libcudacxx/share/libcudacxx/gdb/cccl_common.py
+++ b/libcudacxx/share/libcudacxx/gdb/cccl_common.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Type and value helpers shared by the CCCL GDB pretty printers."""
+
+from __future__ import annotations
+
+import re
+
+import gdb
+
+_ABI_NAMESPACE_PATTERN = re.compile(r"::__(?:\d+|version_bump_ver\d+_)(?=::)")
+_REFERENCE_CODES = (gdb.TYPE_CODE_REF, gdb.TYPE_CODE_RVALUE_REF)
+
+
+def public_type_name(value_type: gdb.Type) -> str:
+    """Return a type name without CUDA ABI inline namespaces."""
+    return _ABI_NAMESPACE_PATTERN.sub("", str(value_type))
+
+
+def template_name(value_type: gdb.Type | str) -> str:
+    """Return the part of a type name before the template argument list."""
+    name = value_type if isinstance(value_type, str) else str(value_type)
+    return name.split("<", 1)[0]
+
+
+def strip_reference(value_type: gdb.Type) -> gdb.Type:
+    """Return the referenced type, or the type itself if it is not a reference.
+
+    target() gives the referenced type, but on a non-reference it either
+    resolves a typedef or raises, so test the type code first.
+    """
+    if value_type.code in _REFERENCE_CODES:
+        return value_type.target()
+    return value_type
+
+
+def strip_reference_value(value: gdb.Value) -> gdb.Value:
+    """Return the referenced value, or the value itself if it is not a reference."""
+    if value.type.code in _REFERENCE_CODES:
+        return value.referenced_value()
+    return value
+
+
+def canonical_type(value_type: gdb.Type) -> gdb.Type:
+    """Return the type behind any reference, typedef, or cv-qualifier."""
+    return strip_reference(value_type).strip_typedefs().unqualified()
+
+
+def canonical_type_name(value_type: gdb.Type) -> str:
+    """Return the public name of the type behind any reference or typedef."""
+    return public_type_name(canonical_type(value_type))

--- a/libcudacxx/share/libcudacxx/gdb/complex.py
+++ b/libcudacxx/share/libcudacxx/gdb/complex.py
@@ -22,7 +22,9 @@ def _template_name(type_name: str) -> str:
 
 
 def _is_cuda_complex(value_type: gdb.Type) -> bool:
-    value_type = value_type.strip_typedefs().unqualified()
+    value_type = (
+        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
+    )
     template_name = _template_name(memory_resource.public_type_name(value_type))
     return template_name in _COMPLEX_NAMES
 
@@ -31,8 +33,11 @@ class ComplexPrinter:
     """Expose cuda::std::complex and cuda::complex parts to GDB."""
 
     def __init__(self, value: gdb.Value) -> None:
+        value = memory_resource.strip_reference_value(value)
         self.value = value
-        self.type = value.type.strip_typedefs().unqualified()
+        self.type = (
+            memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
+        )
         self.type_name = memory_resource.public_type_name(self.type)
 
     def children(self) -> Iterator[tuple[str, gdb.Value]]:

--- a/libcudacxx/share/libcudacxx/gdb/complex.py
+++ b/libcudacxx/share/libcudacxx/gdb/complex.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from types import ModuleType
 
-import memory_resource
+import cccl_common
 
 import gdb
 import gdb.printing
@@ -17,15 +17,9 @@ import gdb.printing
 _COMPLEX_NAMES = frozenset({"cuda::complex", "cuda::std::complex"})
 
 
-def _template_name(type_name: str) -> str:
-    return type_name.split("<", 1)[0]
-
-
 def _is_cuda_complex(value_type: gdb.Type) -> bool:
-    value_type = (
-        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
-    )
-    template_name = _template_name(memory_resource.public_type_name(value_type))
+    value_type = cccl_common.canonical_type(value_type)
+    template_name = cccl_common.template_name(cccl_common.public_type_name(value_type))
     return template_name in _COMPLEX_NAMES
 
 
@@ -33,12 +27,10 @@ class ComplexPrinter:
     """Expose cuda::std::complex and cuda::complex parts to GDB."""
 
     def __init__(self, value: gdb.Value) -> None:
-        value = memory_resource.strip_reference_value(value)
+        value = cccl_common.strip_reference_value(value)
         self.value = value
-        self.type = (
-            memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
-        )
-        self.type_name = memory_resource.public_type_name(self.type)
+        self.type = cccl_common.canonical_type(value.type)
+        self.type_name = cccl_common.public_type_name(self.type)
 
     def children(self) -> Iterator[tuple[str, gdb.Value]]:
         yield "real", self.value["__re_"]

--- a/libcudacxx/share/libcudacxx/gdb/event.py
+++ b/libcudacxx/share/libcudacxx/gdb/event.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from types import ModuleType
 
-import memory_resource
+import cccl_common
 
 import gdb
 import gdb.printing
@@ -18,19 +18,14 @@ _EVENT_NAMES = frozenset({"cuda::event", "cuda::event_ref", "cuda::timed_event"}
 
 
 def _event_type_name(value_type: gdb.Type) -> str | None:
-    value_type = (
-        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
-    )
-    type_name = memory_resource.public_type_name(value_type)
+    type_name = cccl_common.canonical_type_name(value_type)
     if type_name in _EVENT_NAMES:
         return type_name
     return None
 
 
 def _event_handle(value: gdb.Value) -> gdb.Value:
-    value_type = (
-        memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
-    )
+    value_type = cccl_common.canonical_type(value.type)
     value = value.cast(value_type)
     for field in value_type.fields():
         if field.name == "__event_":
@@ -47,12 +42,10 @@ class EventPrinter:
     """Expose the native handle stored by a cuda event type."""
 
     def __init__(self, value: gdb.Value) -> None:
-        value = memory_resource.strip_reference_value(value)
+        value = cccl_common.strip_reference_value(value)
         self.value = value
-        self.type = (
-            memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
-        )
-        self.type_name = memory_resource.public_type_name(self.type)
+        self.type = cccl_common.canonical_type(value.type)
+        self.type_name = cccl_common.public_type_name(self.type)
 
     def children(self) -> Iterator[tuple[str, gdb.Value]]:
         yield "handle", _event_handle(self.value)

--- a/libcudacxx/share/libcudacxx/gdb/event.py
+++ b/libcudacxx/share/libcudacxx/gdb/event.py
@@ -18,7 +18,9 @@ _EVENT_NAMES = frozenset({"cuda::event", "cuda::event_ref", "cuda::timed_event"}
 
 
 def _event_type_name(value_type: gdb.Type) -> str | None:
-    value_type = value_type.strip_typedefs().unqualified()
+    value_type = (
+        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
+    )
     type_name = memory_resource.public_type_name(value_type)
     if type_name in _EVENT_NAMES:
         return type_name
@@ -26,7 +28,9 @@ def _event_type_name(value_type: gdb.Type) -> str | None:
 
 
 def _event_handle(value: gdb.Value) -> gdb.Value:
-    value_type = value.type.strip_typedefs().unqualified()
+    value_type = (
+        memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
+    )
     value = value.cast(value_type)
     for field in value_type.fields():
         if field.name == "__event_":
@@ -43,8 +47,11 @@ class EventPrinter:
     """Expose the native handle stored by a cuda event type."""
 
     def __init__(self, value: gdb.Value) -> None:
+        value = memory_resource.strip_reference_value(value)
         self.value = value
-        self.type = value.type.strip_typedefs().unqualified()
+        self.type = (
+            memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
+        )
         self.type_name = memory_resource.public_type_name(self.type)
 
     def children(self) -> Iterator[tuple[str, gdb.Value]]:

--- a/libcudacxx/share/libcudacxx/gdb/inplace_vector.py
+++ b/libcudacxx/share/libcudacxx/gdb/inplace_vector.py
@@ -9,21 +9,15 @@ from __future__ import annotations
 from collections.abc import Iterator
 from types import ModuleType
 
-import memory_resource
+import cccl_common
 
 import gdb
 import gdb.printing
 
 
-def _template_name(type_name: str) -> str:
-    return type_name.split("<", 1)[0]
-
-
 def _is_cuda_inplace_vector(value_type: gdb.Type) -> bool:
-    value_type = (
-        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
-    )
-    template_name = _template_name(memory_resource.public_type_name(value_type))
+    value_type = cccl_common.canonical_type(value_type)
+    template_name = cccl_common.template_name(cccl_common.public_type_name(value_type))
     return template_name == "cuda::std::inplace_vector"
 
 
@@ -31,12 +25,10 @@ class InplaceVectorPrinter:
     """Expose cuda::std::inplace_vector size and constructed elements to GDB."""
 
     def __init__(self, value: gdb.Value) -> None:
-        value = memory_resource.strip_reference_value(value)
+        value = cccl_common.strip_reference_value(value)
         self.value = value
-        self.type = (
-            memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
-        )
-        self.type_name = memory_resource.public_type_name(self.type)
+        self.type = cccl_common.canonical_type(value.type)
+        self.type_name = cccl_common.public_type_name(self.type)
         self.element_type = self.type.template_argument(0)
         self.capacity = int(self.type.template_argument(1))
         # The zero-capacity specialization has no members at all; do not read any.

--- a/libcudacxx/share/libcudacxx/gdb/inplace_vector.py
+++ b/libcudacxx/share/libcudacxx/gdb/inplace_vector.py
@@ -20,7 +20,9 @@ def _template_name(type_name: str) -> str:
 
 
 def _is_cuda_inplace_vector(value_type: gdb.Type) -> bool:
-    value_type = value_type.strip_typedefs().unqualified()
+    value_type = (
+        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
+    )
     template_name = _template_name(memory_resource.public_type_name(value_type))
     return template_name == "cuda::std::inplace_vector"
 
@@ -29,8 +31,11 @@ class InplaceVectorPrinter:
     """Expose cuda::std::inplace_vector size and constructed elements to GDB."""
 
     def __init__(self, value: gdb.Value) -> None:
+        value = memory_resource.strip_reference_value(value)
         self.value = value
-        self.type = value.type.strip_typedefs().unqualified()
+        self.type = (
+            memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
+        )
         self.type_name = memory_resource.public_type_name(self.type)
         self.element_type = self.type.template_argument(0)
         self.capacity = int(self.type.template_argument(1))

--- a/libcudacxx/share/libcudacxx/gdb/memory_resource.py
+++ b/libcudacxx/share/libcudacxx/gdb/memory_resource.py
@@ -23,12 +23,30 @@ def public_type_name(value_type: gdb.Type) -> str:
     return _ABI_NAMESPACE_PATTERN.sub("", str(value_type))
 
 
+def strip_reference(value_type: gdb.Type) -> gdb.Type:
+    """Return the referenced type, or the type itself if it is not a reference.
+
+    target() gives the referenced type, but on a non-reference it either
+    resolves a typedef or raises, so test the type code first.
+    """
+    if value_type.code in (gdb.TYPE_CODE_REF, gdb.TYPE_CODE_RVALUE_REF):
+        return value_type.target()
+    return value_type
+
+
+def strip_reference_value(value: gdb.Value) -> gdb.Value:
+    """Return the referenced value, or the value itself if it is not a reference."""
+    if value.type.code in (gdb.TYPE_CODE_REF, gdb.TYPE_CODE_RVALUE_REF):
+        return value.referenced_value()
+    return value
+
+
 def _template_name(value_type: gdb.Type) -> str:
     return str(value_type).split("<", 1)[0]
 
 
 def _is_memory_resource(value_type: gdb.Type) -> bool:
-    value_type = value_type.strip_typedefs().unqualified()
+    value_type = strip_reference(value_type).strip_typedefs().unqualified()
     type_name = public_type_name(value_type)
     template_name = _template_name(value_type)
     return (
@@ -38,6 +56,7 @@ def _is_memory_resource(value_type: gdb.Type) -> bool:
 
 
 def memory_resource_description(value: gdb.Value) -> str:
+    value = strip_reference_value(value)
     value_type = value.type.strip_typedefs().unqualified()
     type_name = public_type_name(value_type)
     try:

--- a/libcudacxx/share/libcudacxx/gdb/memory_resource.py
+++ b/libcudacxx/share/libcudacxx/gdb/memory_resource.py
@@ -6,59 +6,30 @@
 
 from __future__ import annotations
 
-import re
 from types import ModuleType
+
+import cccl_common
 
 import gdb
 import gdb.printing
 
-_ABI_NAMESPACE_PATTERN = re.compile(r"::__(?:\d+|version_bump_ver\d+_)(?=::)")
 _RESOURCE_NAMES = frozenset(
     {"any_resource", "any_synchronous_resource", "basic_any_resource"}
 )
 
 
-def public_type_name(value_type: gdb.Type) -> str:
-    """Return a type name without CUDA ABI inline namespaces."""
-    return _ABI_NAMESPACE_PATTERN.sub("", str(value_type))
-
-
-def strip_reference(value_type: gdb.Type) -> gdb.Type:
-    """Return the referenced type, or the type itself if it is not a reference.
-
-    target() gives the referenced type, but on a non-reference it either
-    resolves a typedef or raises, so test the type code first.
-    """
-    if value_type.code in (gdb.TYPE_CODE_REF, gdb.TYPE_CODE_RVALUE_REF):
-        return value_type.target()
-    return value_type
-
-
-def strip_reference_value(value: gdb.Value) -> gdb.Value:
-    """Return the referenced value, or the value itself if it is not a reference."""
-    if value.type.code in (gdb.TYPE_CODE_REF, gdb.TYPE_CODE_RVALUE_REF):
-        return value.referenced_value()
-    return value
-
-
-def _template_name(value_type: gdb.Type) -> str:
-    return str(value_type).split("<", 1)[0]
-
-
 def _is_memory_resource(value_type: gdb.Type) -> bool:
-    value_type = strip_reference(value_type).strip_typedefs().unqualified()
-    type_name = public_type_name(value_type)
-    template_name = _template_name(value_type)
+    value_type = cccl_common.canonical_type(value_type)
+    type_name = cccl_common.public_type_name(value_type)
     return (
         type_name.startswith("cuda::mr::")
-        and template_name.rsplit("::", 1)[-1] in _RESOURCE_NAMES
+        and cccl_common.template_name(value_type).rsplit("::", 1)[-1] in _RESOURCE_NAMES
     )
 
 
 def memory_resource_description(value: gdb.Value) -> str:
-    value = strip_reference_value(value)
-    value_type = value.type.strip_typedefs().unqualified()
-    type_name = public_type_name(value_type)
+    value = cccl_common.strip_reference_value(value)
+    type_name = cccl_common.canonical_type_name(value.type)
     try:
         address = int(value.address)
     except (gdb.error, TypeError):

--- a/libcudacxx/share/libcudacxx/gdb/std_array.py
+++ b/libcudacxx/share/libcudacxx/gdb/std_array.py
@@ -9,21 +9,14 @@ from __future__ import annotations
 from collections.abc import Iterator
 from types import ModuleType
 
-import memory_resource
+import cccl_common
 
 import gdb
 import gdb.printing
 
 
-def _template_name(value_type: gdb.Type) -> str:
-    return str(value_type).split("<", 1)[0]
-
-
 def _is_cuda_array(value_type: gdb.Type) -> bool:
-    value_type = (
-        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
-    )
-    template_name = _template_name(value_type)
+    template_name = cccl_common.template_name(cccl_common.canonical_type(value_type))
     return (
         template_name.startswith("cuda::std::")
         and template_name.rsplit("::", 1)[-1] == "array"
@@ -34,12 +27,10 @@ class ArrayPrinter:
     """Expose cuda::std::array metadata and elements to GDB."""
 
     def __init__(self, value: gdb.Value) -> None:
-        value = memory_resource.strip_reference_value(value)
+        value = cccl_common.strip_reference_value(value)
         self.value = value
-        self.type = (
-            memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
-        )
-        self.type_name = memory_resource.public_type_name(self.type)
+        self.type = cccl_common.canonical_type(value.type)
+        self.type_name = cccl_common.public_type_name(self.type)
         self.size = int(self.type.template_argument(1))
 
     def children(self) -> Iterator[tuple[str, gdb.Value]]:

--- a/libcudacxx/share/libcudacxx/gdb/std_array.py
+++ b/libcudacxx/share/libcudacxx/gdb/std_array.py
@@ -20,7 +20,9 @@ def _template_name(value_type: gdb.Type) -> str:
 
 
 def _is_cuda_array(value_type: gdb.Type) -> bool:
-    value_type = value_type.strip_typedefs().unqualified()
+    value_type = (
+        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
+    )
     template_name = _template_name(value_type)
     return (
         template_name.startswith("cuda::std::")
@@ -32,8 +34,11 @@ class ArrayPrinter:
     """Expose cuda::std::array metadata and elements to GDB."""
 
     def __init__(self, value: gdb.Value) -> None:
+        value = memory_resource.strip_reference_value(value)
         self.value = value
-        self.type = value.type.strip_typedefs().unqualified()
+        self.type = (
+            memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
+        )
         self.type_name = memory_resource.public_type_name(self.type)
         self.size = int(self.type.template_argument(1))
 

--- a/libcudacxx/share/libcudacxx/gdb/stream.py
+++ b/libcudacxx/share/libcudacxx/gdb/stream.py
@@ -10,7 +10,7 @@ from collections.abc import Iterator
 from types import ModuleType
 from typing import NamedTuple
 
-import memory_resource
+import cccl_common
 
 import gdb
 import gdb.printing
@@ -37,8 +37,7 @@ class StreamInfo(NamedTuple):
 
 
 def _stream_type_name(value_type: gdb.Type) -> str | None:
-    value_type = value_type.strip_typedefs().unqualified()
-    type_name = memory_resource.public_type_name(value_type)
+    type_name = cccl_common.canonical_type_name(value_type)
     if type_name in _STREAM_TYPES:
         return type_name
     return None
@@ -166,6 +165,7 @@ class StreamPrinter:
     """Expose CUDA stream metadata to GDB."""
 
     def __init__(self, value: gdb.Value, type_name: str) -> None:
+        value = cccl_common.strip_reference_value(value)
         self.value = value
         self.type_name = type_name
         self.info = _stream_info(value["__stream"])

--- a/libcudacxx/share/libcudacxx/gdb/tuple.py
+++ b/libcudacxx/share/libcudacxx/gdb/tuple.py
@@ -9,23 +9,17 @@ from __future__ import annotations
 from collections.abc import Iterator
 from types import ModuleType
 
-import memory_resource
+import cccl_common
 
 import gdb
 import gdb.printing
 
 
-def _template_name(value_type: gdb.Type) -> str:
-    return str(value_type).split("<", 1)[0]
-
-
 def _is_cuda_tuple(value_type: gdb.Type) -> bool:
     # strip_typedefs resolves aliases that can hide accessibility properties.
-    value_type = (
-        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
-    )
-    public_name = memory_resource.public_type_name(value_type)
-    template_name = _template_name(value_type)
+    value_type = cccl_common.canonical_type(value_type)
+    public_name = cccl_common.public_type_name(value_type)
+    template_name = cccl_common.template_name(value_type)
     return (
         public_name.startswith("cuda::std::")
         and template_name.rsplit("::", 1)[-1] == "tuple"
@@ -72,11 +66,9 @@ class TuplePrinter:
     """Expose cuda::std::tuple elements to GDB."""
 
     def __init__(self, value: gdb.Value) -> None:
-        value = memory_resource.strip_reference_value(value)
+        value = cccl_common.strip_reference_value(value)
         self.value = value
-        self.type = (
-            memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
-        )
+        self.type = cccl_common.canonical_type(value.type)
         # A fully empty tuple (e.g. cuda::std::tuple<>) can compile to a type
         # with no debug-visible __base_ member at all.
         try:
@@ -92,7 +84,7 @@ class TuplePrinter:
             yield f"[{index}]", _leaf_element(base_value, field)
 
     def to_string(self) -> str:
-        return memory_resource.public_type_name(self.type)
+        return cccl_common.public_type_name(self.type)
 
 
 class TuplePrinterLookup(gdb.printing.PrettyPrinter):

--- a/libcudacxx/share/libcudacxx/gdb/tuple.py
+++ b/libcudacxx/share/libcudacxx/gdb/tuple.py
@@ -21,7 +21,9 @@ def _template_name(value_type: gdb.Type) -> str:
 
 def _is_cuda_tuple(value_type: gdb.Type) -> bool:
     # strip_typedefs resolves aliases that can hide accessibility properties.
-    value_type = value_type.strip_typedefs().unqualified()
+    value_type = (
+        memory_resource.strip_reference(value_type).strip_typedefs().unqualified()
+    )
     public_name = memory_resource.public_type_name(value_type)
     template_name = _template_name(value_type)
     return (
@@ -70,8 +72,11 @@ class TuplePrinter:
     """Expose cuda::std::tuple elements to GDB."""
 
     def __init__(self, value: gdb.Value) -> None:
+        value = memory_resource.strip_reference_value(value)
         self.value = value
-        self.type = value.type.strip_typedefs().unqualified()
+        self.type = (
+            memory_resource.strip_reference(value.type).strip_typedefs().unqualified()
+        )
         # A fully empty tuple (e.g. cuda::std::tuple<>) can compile to a type
         # with no debug-visible __base_ member at all.
         try:

--- a/libcudacxx/share/libcudacxx/lldb/atomic.py
+++ b/libcudacxx/share/libcudacxx/lldb/atomic.py
@@ -25,13 +25,27 @@ _THREAD_SCOPE_NAMES = {
 InternalDict = dict[str, object]
 
 
+def _deref(value: lldb.SBValue) -> lldb.SBValue:
+    if value.GetType().IsReferenceType():
+        return value.Dereference()
+    return value
+
+
 def _type_name(value_type: lldb.SBType) -> str:
-    return value_type.GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName() or ""
+    return (
+        value_type.GetCanonicalType()
+        .GetDereferencedType()
+        .GetUnqualifiedType()
+        .GetDisplayTypeName()
+        or ""
+    )
 
 
 def _complete_type_name(value_type: lldb.SBType) -> str:
     """Return the complete public type name, including default template arguments."""
-    value_type = value_type.GetCanonicalType().GetUnqualifiedType()
+    value_type = (
+        value_type.GetCanonicalType().GetDereferencedType().GetUnqualifiedType()
+    )
     type_name = value_type.GetName() or value_type.GetDisplayTypeName() or ""
     type_name = _ABI_NAMESPACE_PATTERN.sub("", type_name)
     type_name = type_name.replace("cuda::std::thread_scope_", "cuda::thread_scope_")
@@ -57,14 +71,16 @@ def _reference_pointer(value: lldb.SBValue) -> lldb.SBValue:
 
 
 def atomic_ref_summary(value: lldb.SBValue, _internal_dict: InternalDict) -> str | None:
-    pointer = _reference_pointer(value.GetNonSyntheticValue())
+    pointer = _reference_pointer(_deref(value).GetNonSyntheticValue())
     if not pointer.IsValid():
         return None
     return f"ptr={pointer.GetValueAsUnsigned(0):#x}"
 
 
 def _stored_value(value: lldb.SBValue, type_name: str) -> lldb.SBValue:
-    value_type = value.GetType().GetCanonicalType().GetUnqualifiedType()
+    value_type = (
+        value.GetType().GetCanonicalType().GetDereferencedType().GetUnqualifiedType()
+    )
     stored = _reference_pointer(value)
     if not stored.IsValid():
         return lldb.SBValue()
@@ -91,6 +107,8 @@ class AtomicSyntheticProvider:
     """Expose the value represented by a CUDA atomic as one synthetic child."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
+        if value.GetType().IsReferenceType():
+            value = value.Dereference()
         self.value = value.GetNonSyntheticValue()
         self.child = lldb.SBValue()
         self.update()

--- a/libcudacxx/share/libcudacxx/lldb/atomic.py
+++ b/libcudacxx/share/libcudacxx/lldb/atomic.py
@@ -8,11 +8,12 @@ from __future__ import annotations
 
 import re
 
+import cccl_common
+
 import lldb
 
 _ATOMIC_PATTERN = re.compile(r"^cuda::(?:std::)?atomic(?:_ref)?<.+>$")
 _ATOMIC_REF_PATTERN = re.compile(r"^cuda::(?:std::)?atomic_ref<.+>$")
-_ABI_NAMESPACE_PATTERN = re.compile(r"::__(?:\d+|version_bump_ver\d+_)(?=::)")
 _THREAD_SCOPE_VALUE_PATTERN = re.compile(
     r"\((?:enum )?cuda(?:::std)?::thread_scope\)\s*(10|[012])(?=\s*>)"
 )
@@ -25,29 +26,9 @@ _THREAD_SCOPE_NAMES = {
 InternalDict = dict[str, object]
 
 
-def _deref(value: lldb.SBValue) -> lldb.SBValue:
-    if value.GetType().IsReferenceType():
-        return value.Dereference()
-    return value
-
-
-def _type_name(value_type: lldb.SBType) -> str:
-    return (
-        value_type.GetCanonicalType()
-        .GetDereferencedType()
-        .GetUnqualifiedType()
-        .GetDisplayTypeName()
-        or ""
-    )
-
-
 def _complete_type_name(value_type: lldb.SBType) -> str:
-    """Return the complete public type name, including default template arguments."""
-    value_type = (
-        value_type.GetCanonicalType().GetDereferencedType().GetUnqualifiedType()
-    )
-    type_name = value_type.GetName() or value_type.GetDisplayTypeName() or ""
-    type_name = _ABI_NAMESPACE_PATTERN.sub("", type_name)
+    """Return the complete public type name, with thread scopes shown by name."""
+    type_name = cccl_common.public_type_name(value_type)
     type_name = type_name.replace("cuda::std::thread_scope_", "cuda::thread_scope_")
     return _THREAD_SCOPE_VALUE_PATTERN.sub(
         lambda match: f"cuda::thread_scope_{_THREAD_SCOPE_NAMES[int(match.group(1))]}",
@@ -56,11 +37,17 @@ def _complete_type_name(value_type: lldb.SBType) -> str:
 
 
 def is_cuda_atomic(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
-    return _ATOMIC_PATTERN.fullmatch(_type_name(value_type)) is not None
+    return (
+        _ATOMIC_PATTERN.fullmatch(cccl_common.canonical_type_name(value_type))
+        is not None
+    )
 
 
 def is_cuda_atomic_ref(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
-    return _ATOMIC_REF_PATTERN.fullmatch(_type_name(value_type)) is not None
+    return (
+        _ATOMIC_REF_PATTERN.fullmatch(cccl_common.canonical_type_name(value_type))
+        is not None
+    )
 
 
 def _reference_pointer(value: lldb.SBValue) -> lldb.SBValue:
@@ -71,16 +58,16 @@ def _reference_pointer(value: lldb.SBValue) -> lldb.SBValue:
 
 
 def atomic_ref_summary(value: lldb.SBValue, _internal_dict: InternalDict) -> str | None:
-    pointer = _reference_pointer(_deref(value).GetNonSyntheticValue())
+    pointer = _reference_pointer(
+        cccl_common.strip_reference_value(value).GetNonSyntheticValue()
+    )
     if not pointer.IsValid():
         return None
     return f"ptr={pointer.GetValueAsUnsigned(0):#x}"
 
 
 def _stored_value(value: lldb.SBValue, type_name: str) -> lldb.SBValue:
-    value_type = (
-        value.GetType().GetCanonicalType().GetDereferencedType().GetUnqualifiedType()
-    )
+    value_type = cccl_common.strip_reference(value.GetType())
     stored = _reference_pointer(value)
     if not stored.IsValid():
         return lldb.SBValue()
@@ -89,7 +76,7 @@ def _stored_value(value: lldb.SBValue, type_name: str) -> lldb.SBValue:
         return stored.Dereference().Clone("value")
 
     storage = value.GetChildMemberWithName("__a")
-    storage_type = _type_name(storage.GetType())
+    storage_type = cccl_common.canonical_type_name(storage.GetType())
     if "__atomic_small_storage<" in storage_type:
         stored = stored.GetChildMemberWithName("__a_value")
         if not stored.IsValid():
@@ -107,8 +94,7 @@ class AtomicSyntheticProvider:
     """Expose the value represented by a CUDA atomic as one synthetic child."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
-        if value.GetType().IsReferenceType():
-            value = value.Dereference()
+        value = cccl_common.strip_reference_value(value)
         self.value = value.GetNonSyntheticValue()
         self.child = lldb.SBValue()
         self.update()

--- a/libcudacxx/share/libcudacxx/lldb/buffer.py
+++ b/libcudacxx/share/libcudacxx/lldb/buffer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import re
 from typing import NamedTuple
 
+import cccl_common
 import memory_resource
 
 import lldb
@@ -32,19 +33,12 @@ class BufferInfo(NamedTuple):
 
 
 def is_cuda_buffer(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
-    type_name = (
-        value_type.GetCanonicalType()
-        .GetDereferencedType()
-        .GetUnqualifiedType()
-        .GetDisplayTypeName()
-        or ""
-    )
+    type_name = cccl_common.canonical_type_name(value_type)
     return _BUFFER_PATTERN.fullmatch(type_name) is not None
 
 
 def _buffer_info(value: lldb.SBValue) -> BufferInfo | None:
-    if value.GetType().IsReferenceType():
-        value = value.Dereference()
+    value = cccl_common.strip_reference_value(value)
     value = value.GetNonSyntheticValue()
     storage = value.GetChildMemberWithName("__buf_")
     if not storage.IsValid():
@@ -113,8 +107,7 @@ class BufferSyntheticProvider:
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
         self.declared_type = value.GetType()
-        if value.GetType().IsReferenceType():
-            value = value.Dereference()
+        value = cccl_common.strip_reference_value(value)
         self.value = value.GetNonSyntheticValue()
         self.host_copy = lldb.SBValue()
         self.clear()

--- a/libcudacxx/share/libcudacxx/lldb/buffer.py
+++ b/libcudacxx/share/libcudacxx/lldb/buffer.py
@@ -110,6 +110,7 @@ class BufferSyntheticProvider:
         value = cccl_common.strip_reference_value(value)
         self.value = value.GetNonSyntheticValue()
         self.host_copy = lldb.SBValue()
+        self.stop_id: int | None = None
         self.clear()
         self.update()
 
@@ -132,6 +133,7 @@ class BufferSyntheticProvider:
             if address:
                 self._evaluate(f"(void)free((void*){address:#x})")
         self.host_copy = lldb.SBValue()
+        self.stop_id = None
         self.size = 0
         self.data_address = 0
         self.value_type = lldb.SBType()
@@ -161,7 +163,20 @@ class BufferSyntheticProvider:
             return False
         return True
 
+    def _current_stop_id(self) -> int | None:
+        process = self.value.GetProcess()
+        return process.GetStopID() if process.IsValid() else None
+
     def update(self) -> bool:
+        # LLDB calls update() before every read of a synthetic value, so one
+        # print causes hundreds of calls. Copy the device memory only when the
+        # process has stopped again since the last copy. Anything that changes
+        # target memory must resume and re-stop the process, which includes a
+        # cudaMemcpy the user runs at this breakpoint, so this cannot report
+        # stale data.
+        if self.stop_id is not None and self._current_stop_id() == self.stop_id:
+            return True
+
         self.clear()
 
         info = _buffer_info(self.value)
@@ -173,6 +188,9 @@ class BufferSyntheticProvider:
         self.value_type = info.value_type
         self.value_size = self.value_type.GetByteSize()
         self._copy_to_host()
+        # The copy itself runs inferior calls that advance the stop ID, so
+        # record the value the next update() will see.
+        self.stop_id = self._current_stop_id()
         return True
 
     def num_children(self) -> int:

--- a/libcudacxx/share/libcudacxx/lldb/buffer.py
+++ b/libcudacxx/share/libcudacxx/lldb/buffer.py
@@ -33,12 +33,18 @@ class BufferInfo(NamedTuple):
 
 def is_cuda_buffer(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
     type_name = (
-        value_type.GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName() or ""
+        value_type.GetCanonicalType()
+        .GetDereferencedType()
+        .GetUnqualifiedType()
+        .GetDisplayTypeName()
+        or ""
     )
     return _BUFFER_PATTERN.fullmatch(type_name) is not None
 
 
 def _buffer_info(value: lldb.SBValue) -> BufferInfo | None:
+    if value.GetType().IsReferenceType():
+        value = value.Dereference()
     value = value.GetNonSyntheticValue()
     storage = value.GetChildMemberWithName("__buf_")
     if not storage.IsValid():
@@ -106,6 +112,9 @@ class BufferSyntheticProvider:
     """Expose cuda::buffer elements as LLDB synthetic children."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
+        self.declared_type = value.GetType()
+        if value.GetType().IsReferenceType():
+            value = value.Dereference()
         self.value = value.GetNonSyntheticValue()
         self.host_copy = lldb.SBValue()
         self.clear()
@@ -183,8 +192,7 @@ class BufferSyntheticProvider:
         # STL element access can preserve an alloc_traits::value_type typedef.
         # Report the canonical display name so LLDB shows cuda::buffer instead.
         return (
-            self.value.GetType()
-            .GetCanonicalType()
+            self.declared_type.GetCanonicalType()
             .GetUnqualifiedType()
             .GetDisplayTypeName()
             or ""

--- a/libcudacxx/share/libcudacxx/lldb/cccl_common.py
+++ b/libcudacxx/share/libcudacxx/lldb/cccl_common.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Type and value helpers shared by the CCCL LLDB pretty printers."""
+
+from __future__ import annotations
+
+import re
+
+import lldb
+
+_ABI_NAMESPACE_PATTERN = re.compile(r"::__(?:\d+|version_bump_ver\d+_)(?=::)")
+
+
+def strip_reference(value_type: lldb.SBType) -> lldb.SBType:
+    """Return the type behind any reference, typedef, or cv-qualifier.
+
+    GetDereferencedType() is a no-op on a non-reference, so it needs no guard.
+    """
+    return value_type.GetCanonicalType().GetDereferencedType().GetUnqualifiedType()
+
+
+def strip_reference_value(value: lldb.SBValue) -> lldb.SBValue:
+    """Return the referenced value, or the value itself if it is not a reference."""
+    if value.GetType().IsReferenceType():
+        return value.Dereference()
+    return value
+
+
+def canonical_type_name(value_type: lldb.SBType) -> str:
+    """Return the display name of the type behind any reference or typedef."""
+    return strip_reference(value_type).GetDisplayTypeName() or ""
+
+
+def public_type_name(value_type: lldb.SBType) -> str:
+    """Return the complete type name without CUDA ABI inline namespaces.
+
+    GetName() keeps default template arguments that GetDisplayTypeName() hides.
+    """
+    value_type = strip_reference(value_type)
+    type_name = value_type.GetName() or value_type.GetDisplayTypeName() or ""
+    return _ABI_NAMESPACE_PATTERN.sub("", type_name)

--- a/libcudacxx/share/libcudacxx/lldb/complex.py
+++ b/libcudacxx/share/libcudacxx/lldb/complex.py
@@ -17,7 +17,11 @@ InternalDict = dict[str, object]
 
 def is_cuda_complex(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
     type_name = (
-        value_type.GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName() or ""
+        value_type.GetCanonicalType()
+        .GetDereferencedType()
+        .GetUnqualifiedType()
+        .GetDisplayTypeName()
+        or ""
     )
     return _COMPLEX_PATTERN.fullmatch(type_name) is not None
 
@@ -26,6 +30,8 @@ class ComplexSyntheticProvider:
     """Expose complex real and imaginary parts as LLDB synthetic children."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
+        if value.GetType().IsReferenceType():
+            value = value.Dereference()
         self.value = value.GetNonSyntheticValue()
         self.update()
 

--- a/libcudacxx/share/libcudacxx/lldb/complex.py
+++ b/libcudacxx/share/libcudacxx/lldb/complex.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import re
 
+import cccl_common
+
 import lldb
 
 _COMPLEX_PATTERN = re.compile(r"^cuda::(?:std::)?complex<.+>$")
@@ -16,13 +18,7 @@ InternalDict = dict[str, object]
 
 
 def is_cuda_complex(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
-    type_name = (
-        value_type.GetCanonicalType()
-        .GetDereferencedType()
-        .GetUnqualifiedType()
-        .GetDisplayTypeName()
-        or ""
-    )
+    type_name = cccl_common.canonical_type_name(value_type)
     return _COMPLEX_PATTERN.fullmatch(type_name) is not None
 
 
@@ -30,8 +26,7 @@ class ComplexSyntheticProvider:
     """Expose complex real and imaginary parts as LLDB synthetic children."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
-        if value.GetType().IsReferenceType():
-            value = value.Dereference()
+        value = cccl_common.strip_reference_value(value)
         self.value = value.GetNonSyntheticValue()
         self.update()
 

--- a/libcudacxx/share/libcudacxx/lldb/event.py
+++ b/libcudacxx/share/libcudacxx/lldb/event.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import re
 
+import cccl_common
+
 import lldb
 
 _EVENT_PATTERN = re.compile(r"^cuda::(?:event|event_ref|timed_event)$")
@@ -15,20 +17,8 @@ _CHILD_NAME = "handle"
 InternalDict = dict[str, object]
 
 
-def _deref(value: lldb.SBValue) -> lldb.SBValue:
-    if value.GetType().IsReferenceType():
-        return value.Dereference()
-    return value
-
-
 def _event_type_name(value_type: lldb.SBType) -> str | None:
-    type_name = (
-        value_type.GetCanonicalType()
-        .GetDereferencedType()
-        .GetUnqualifiedType()
-        .GetDisplayTypeName()
-        or ""
-    )
+    type_name = cccl_common.canonical_type_name(value_type)
     if _EVENT_PATTERN.fullmatch(type_name) is not None:
         return type_name
     return None
@@ -39,15 +29,18 @@ def is_cuda_event(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool
 
 
 def _event_handle(value: lldb.SBValue) -> lldb.SBValue:
-    return _deref(value).GetNonSyntheticValue().GetChildMemberWithName("__event_")
+    return (
+        cccl_common.strip_reference_value(value)
+        .GetNonSyntheticValue()
+        .GetChildMemberWithName("__event_")
+    )
 
 
 class EventSyntheticProvider:
     """Expose the native handle stored by a cuda event type."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
-        if value.GetType().IsReferenceType():
-            value = value.Dereference()
+        value = cccl_common.strip_reference_value(value)
         self.value = value.GetNonSyntheticValue()
         self.handle = lldb.SBValue()
         self.type_name = ""

--- a/libcudacxx/share/libcudacxx/lldb/event.py
+++ b/libcudacxx/share/libcudacxx/lldb/event.py
@@ -15,9 +15,19 @@ _CHILD_NAME = "handle"
 InternalDict = dict[str, object]
 
 
+def _deref(value: lldb.SBValue) -> lldb.SBValue:
+    if value.GetType().IsReferenceType():
+        return value.Dereference()
+    return value
+
+
 def _event_type_name(value_type: lldb.SBType) -> str | None:
     type_name = (
-        value_type.GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName() or ""
+        value_type.GetCanonicalType()
+        .GetDereferencedType()
+        .GetUnqualifiedType()
+        .GetDisplayTypeName()
+        or ""
     )
     if _EVENT_PATTERN.fullmatch(type_name) is not None:
         return type_name
@@ -29,13 +39,15 @@ def is_cuda_event(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool
 
 
 def _event_handle(value: lldb.SBValue) -> lldb.SBValue:
-    return value.GetNonSyntheticValue().GetChildMemberWithName("__event_")
+    return _deref(value).GetNonSyntheticValue().GetChildMemberWithName("__event_")
 
 
 class EventSyntheticProvider:
     """Expose the native handle stored by a cuda event type."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
+        if value.GetType().IsReferenceType():
+            value = value.Dereference()
         self.value = value.GetNonSyntheticValue()
         self.handle = lldb.SBValue()
         self.type_name = ""

--- a/libcudacxx/share/libcudacxx/lldb/inplace_vector.py
+++ b/libcudacxx/share/libcudacxx/lldb/inplace_vector.py
@@ -18,7 +18,11 @@ def is_cuda_inplace_vector(
     value_type: lldb.SBType, _internal_dict: InternalDict
 ) -> bool:
     type_name = (
-        value_type.GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName() or ""
+        value_type.GetCanonicalType()
+        .GetDereferencedType()
+        .GetUnqualifiedType()
+        .GetDisplayTypeName()
+        or ""
     )
     return _INPLACE_VECTOR_PATTERN.fullmatch(type_name) is not None
 
@@ -27,9 +31,15 @@ def inplace_vector_summary(
     value: lldb.SBValue, _internal_dict: InternalDict
 ) -> str | None:
     """Summarize size and capacity like LLDB's std::vector formatter."""
+    if value.GetType().IsReferenceType():
+        value = value.Dereference()
     value = value.GetNonSyntheticValue()
     type_name = (
-        value.GetType().GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName()
+        value.GetType()
+        .GetCanonicalType()
+        .GetDereferencedType()
+        .GetUnqualifiedType()
+        .GetDisplayTypeName()
         or ""
     )
     match = _INPLACE_VECTOR_PATTERN.fullmatch(type_name)
@@ -49,6 +59,8 @@ class InplaceVectorSyntheticProvider:
     """Expose constructed cuda::std::inplace_vector elements as LLDB children."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
+        if value.GetType().IsReferenceType():
+            value = value.Dereference()
         self.value = value.GetNonSyntheticValue()
         self.update()
 

--- a/libcudacxx/share/libcudacxx/lldb/inplace_vector.py
+++ b/libcudacxx/share/libcudacxx/lldb/inplace_vector.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import re
 
+import cccl_common
+
 import lldb
 
 _INPLACE_VECTOR_PATTERN = re.compile(r"^cuda::std::inplace_vector<.+,\s*(\d+)>$")
@@ -17,13 +19,7 @@ InternalDict = dict[str, object]
 def is_cuda_inplace_vector(
     value_type: lldb.SBType, _internal_dict: InternalDict
 ) -> bool:
-    type_name = (
-        value_type.GetCanonicalType()
-        .GetDereferencedType()
-        .GetUnqualifiedType()
-        .GetDisplayTypeName()
-        or ""
-    )
+    type_name = cccl_common.canonical_type_name(value_type)
     return _INPLACE_VECTOR_PATTERN.fullmatch(type_name) is not None
 
 
@@ -31,17 +27,9 @@ def inplace_vector_summary(
     value: lldb.SBValue, _internal_dict: InternalDict
 ) -> str | None:
     """Summarize size and capacity like LLDB's std::vector formatter."""
-    if value.GetType().IsReferenceType():
-        value = value.Dereference()
+    value = cccl_common.strip_reference_value(value)
     value = value.GetNonSyntheticValue()
-    type_name = (
-        value.GetType()
-        .GetCanonicalType()
-        .GetDereferencedType()
-        .GetUnqualifiedType()
-        .GetDisplayTypeName()
-        or ""
-    )
+    type_name = cccl_common.canonical_type_name(value.GetType())
     match = _INPLACE_VECTOR_PATTERN.fullmatch(type_name)
     if match is None:
         return None
@@ -59,8 +47,7 @@ class InplaceVectorSyntheticProvider:
     """Expose constructed cuda::std::inplace_vector elements as LLDB children."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
-        if value.GetType().IsReferenceType():
-            value = value.Dereference()
+        value = cccl_common.strip_reference_value(value)
         self.value = value.GetNonSyntheticValue()
         self.update()
 

--- a/libcudacxx/share/libcudacxx/lldb/memory_resource.py
+++ b/libcudacxx/share/libcudacxx/lldb/memory_resource.py
@@ -18,7 +18,11 @@ InternalDict = dict[str, object]
 
 def is_memory_resource(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
     type_name = (
-        value_type.GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName() or ""
+        value_type.GetCanonicalType()
+        .GetDereferencedType()
+        .GetUnqualifiedType()
+        .GetDisplayTypeName()
+        or ""
     )
     return _RESOURCE_PATTERN.fullmatch(type_name) is not None
 
@@ -26,7 +30,11 @@ def is_memory_resource(value_type: lldb.SBType, _internal_dict: InternalDict) ->
 def memory_resource_description(value: lldb.SBValue) -> str:
     """Describe a type-erased resource using only public type information."""
     type_name = (
-        value.GetType().GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName()
+        value.GetType()
+        .GetCanonicalType()
+        .GetDereferencedType()
+        .GetUnqualifiedType()
+        .GetDisplayTypeName()
     )
     if not type_name:
         type_name = "type-erased resource"

--- a/libcudacxx/share/libcudacxx/lldb/memory_resource.py
+++ b/libcudacxx/share/libcudacxx/lldb/memory_resource.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import re
 
+import cccl_common
+
 import lldb
 
 _RESOURCE_PATTERN = re.compile(
@@ -17,25 +19,13 @@ InternalDict = dict[str, object]
 
 
 def is_memory_resource(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
-    type_name = (
-        value_type.GetCanonicalType()
-        .GetDereferencedType()
-        .GetUnqualifiedType()
-        .GetDisplayTypeName()
-        or ""
-    )
+    type_name = cccl_common.canonical_type_name(value_type)
     return _RESOURCE_PATTERN.fullmatch(type_name) is not None
 
 
 def memory_resource_description(value: lldb.SBValue) -> str:
     """Describe a type-erased resource using only public type information."""
-    type_name = (
-        value.GetType()
-        .GetCanonicalType()
-        .GetDereferencedType()
-        .GetUnqualifiedType()
-        .GetDisplayTypeName()
-    )
+    type_name = cccl_common.canonical_type_name(value.GetType())
     if not type_name:
         type_name = "type-erased resource"
 

--- a/libcudacxx/share/libcudacxx/lldb/std_array.py
+++ b/libcudacxx/share/libcudacxx/lldb/std_array.py
@@ -16,7 +16,11 @@ InternalDict = dict[str, object]
 
 def is_cuda_array(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
     type_name = (
-        value_type.GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName() or ""
+        value_type.GetCanonicalType()
+        .GetDereferencedType()
+        .GetUnqualifiedType()
+        .GetDisplayTypeName()
+        or ""
     )
     return _ARRAY_PATTERN.fullmatch(type_name) is not None
 
@@ -25,6 +29,8 @@ class ArraySyntheticProvider:
     """Expose cuda::std::array elements as LLDB synthetic children."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
+        if value.GetType().IsReferenceType():
+            value = value.Dereference()
         self.value = value.GetNonSyntheticValue()
         self.update()
 

--- a/libcudacxx/share/libcudacxx/lldb/std_array.py
+++ b/libcudacxx/share/libcudacxx/lldb/std_array.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import re
 
+import cccl_common
+
 import lldb
 
 _ARRAY_PATTERN = re.compile(r"^cuda::std::array<.+,\s*(\d+)>$")
@@ -15,13 +17,7 @@ InternalDict = dict[str, object]
 
 
 def is_cuda_array(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
-    type_name = (
-        value_type.GetCanonicalType()
-        .GetDereferencedType()
-        .GetUnqualifiedType()
-        .GetDisplayTypeName()
-        or ""
-    )
+    type_name = cccl_common.canonical_type_name(value_type)
     return _ARRAY_PATTERN.fullmatch(type_name) is not None
 
 
@@ -29,8 +25,7 @@ class ArraySyntheticProvider:
     """Expose cuda::std::array elements as LLDB synthetic children."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
-        if value.GetType().IsReferenceType():
-            value = value.Dereference()
+        value = cccl_common.strip_reference_value(value)
         self.value = value.GetNonSyntheticValue()
         self.update()
 

--- a/libcudacxx/share/libcudacxx/lldb/stream.py
+++ b/libcudacxx/share/libcudacxx/lldb/stream.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import re
 from typing import NamedTuple
 
+import cccl_common
+
 import lldb
 
 _STREAM_PATTERN = re.compile(r"^cuda::(?:stream|stream_ref)$")
@@ -105,14 +107,12 @@ class StreamSnapshot(NamedTuple):
 
 
 def is_cuda_stream(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
-    type_name = (
-        value_type.GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName() or ""
-    )
+    type_name = cccl_common.canonical_type_name(value_type)
     return _STREAM_PATTERN.fullmatch(type_name) is not None
 
 
 def _stream_handle(value: lldb.SBValue) -> lldb.SBValue:
-    value = value.GetNonSyntheticValue()
+    value = cccl_common.strip_reference_value(value).GetNonSyntheticValue()
     handle = value.GetChildMemberWithName("__stream")
     if handle.IsValid():
         return handle
@@ -207,6 +207,7 @@ def _query_stream_snapshot(value: lldb.SBValue, handle: int) -> StreamSnapshot |
 
 
 def stream_summary(value: lldb.SBValue, _internal_dict: InternalDict) -> str | None:
+    value = cccl_common.strip_reference_value(value)
     handle = _stream_handle(value)
     if not handle.IsValid() or handle.GetError().Fail():
         return None
@@ -235,7 +236,7 @@ class StreamSyntheticProvider:
     """Expose CUDA stream properties as LLDB synthetic children."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
-        self.value = value.GetNonSyntheticValue()
+        self.value = cccl_common.strip_reference_value(value).GetNonSyntheticValue()
         self.children: list[tuple[str, int, str]] = []
         self.summary_unique_id: int | None = None
         self.stop_id: int | None = None

--- a/libcudacxx/share/libcudacxx/lldb/tuple.py
+++ b/libcudacxx/share/libcudacxx/lldb/tuple.py
@@ -15,16 +15,26 @@ _LEAF_INDEX_PATTERN = re.compile(r"__tuple_leaf<(\d+),")
 InternalDict = dict[str, object]
 
 
+def _deref(value: lldb.SBValue) -> lldb.SBValue:
+    if value.GetType().IsReferenceType():
+        return value.Dereference()
+    return value
+
+
 def is_cuda_tuple(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
     type_name = (
-        value_type.GetCanonicalType().GetUnqualifiedType().GetDisplayTypeName() or ""
+        value_type.GetCanonicalType()
+        .GetDereferencedType()
+        .GetUnqualifiedType()
+        .GetDisplayTypeName()
+        or ""
     )
     return _TUPLE_PATTERN.fullmatch(type_name) is not None
 
 
 def _has_elements(value: lldb.SBValue) -> bool:
     # cuda::std::tuple<> can compile with no debug-visible __base_ member.
-    base = value.GetNonSyntheticValue().GetChildMemberWithName("__base_")
+    base = _deref(value).GetNonSyntheticValue().GetChildMemberWithName("__base_")
     return base.IsValid() and bool(_leaf_bases(base.GetType()))
 
 
@@ -136,6 +146,8 @@ class TupleSyntheticProvider:
     """Expose cuda::std::tuple elements as LLDB synthetic children."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
+        if value.GetType().IsReferenceType():
+            value = value.Dereference()
         self.value = value.GetNonSyntheticValue()
         self.leaves: list[tuple[int, lldb.SBTypeMember]] = []
         self.base: lldb.SBValue = lldb.SBValue()

--- a/libcudacxx/share/libcudacxx/lldb/tuple.py
+++ b/libcudacxx/share/libcudacxx/lldb/tuple.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import re
 
+import cccl_common
+
 import lldb
 
 _TUPLE_PATTERN = re.compile(r"^cuda::std::tuple<.*>$")
@@ -15,26 +17,18 @@ _LEAF_INDEX_PATTERN = re.compile(r"__tuple_leaf<(\d+),")
 InternalDict = dict[str, object]
 
 
-def _deref(value: lldb.SBValue) -> lldb.SBValue:
-    if value.GetType().IsReferenceType():
-        return value.Dereference()
-    return value
-
-
 def is_cuda_tuple(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
-    type_name = (
-        value_type.GetCanonicalType()
-        .GetDereferencedType()
-        .GetUnqualifiedType()
-        .GetDisplayTypeName()
-        or ""
-    )
+    type_name = cccl_common.canonical_type_name(value_type)
     return _TUPLE_PATTERN.fullmatch(type_name) is not None
 
 
 def _has_elements(value: lldb.SBValue) -> bool:
     # cuda::std::tuple<> can compile with no debug-visible __base_ member.
-    base = _deref(value).GetNonSyntheticValue().GetChildMemberWithName("__base_")
+    base = (
+        cccl_common.strip_reference_value(value)
+        .GetNonSyntheticValue()
+        .GetChildMemberWithName("__base_")
+    )
     return base.IsValid() and bool(_leaf_bases(base.GetType()))
 
 
@@ -146,8 +140,7 @@ class TupleSyntheticProvider:
     """Expose cuda::std::tuple elements as LLDB synthetic children."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
-        if value.GetType().IsReferenceType():
-            value = value.Dereference()
+        value = cccl_common.strip_reference_value(value)
         self.value = value.GetNonSyntheticValue()
         self.leaves: list[tuple[int, lldb.SBTypeMember]] = []
         self.base: lldb.SBValue = lldb.SBValue()

--- a/libcudacxx/test/debugging/CMakeLists.txt
+++ b/libcudacxx/test/debugging/CMakeLists.txt
@@ -160,10 +160,12 @@ function(libcudacxx_add_pretty_printer_test)
     NO_CLANG_TIDY
     SOURCES ${pretty_printer_SOURCES}
   )
+  target_link_libraries(${target_name} PRIVATE libcudacxx.compiler_interface)
+
   # Explicitly set max optimization, the printers should work even when everything is
   # compiled out.
   target_compile_options(${target_name} PRIVATE -O3)
-  target_link_libraries(${target_name} PRIVATE libcudacxx.compiler_interface)
+  target_compile_definitions(${target_name} PRIVATE NDEBUG)
 
   foreach (debugger IN LISTS LIBCUDACXX_SUPPORTED_DEBUGGERS)
     string(TOUPPER "${debugger}" DEBUGGER_UPPER)
@@ -182,14 +184,14 @@ function(libcudacxx_add_pretty_printer_test)
       NAME ${test_name}
       COMMAND
         # gersemi: off
-      "${Python_EXECUTABLE}" "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/run_pretty_printer_test.py"
-      --debugger "${debugger}"
-      --debugger-executable "${executable}"
-      --program "$<TARGET_FILE:${target_name}>"
-      --formatter-init "${formatter}"
-      --expected "${CMAKE_CURRENT_SOURCE_DIR}/${debugger}.expected"
-      --output-log "${CMAKE_CURRENT_BINARY_DIR}/${debugger}.log"
-      ${pretty_printer_CASES}
+        "${Python_EXECUTABLE}" "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/run_pretty_printer_test.py"
+        --debugger "${debugger}"
+        --debugger-executable "${executable}"
+        --program "$<TARGET_FILE:${target_name}>"
+        --formatter-init "${formatter}"
+        --expected "${CMAKE_CURRENT_SOURCE_DIR}/${debugger}.expected"
+        --output-log "${CMAKE_CURRENT_BINARY_DIR}/${debugger}.log"
+        ${pretty_printer_CASES}
       # gersemi: on
     )
     # Set an aggressive timeout because pretty printers should not be slow. If they are,

--- a/libcudacxx/test/debugging/CMakeLists.txt
+++ b/libcudacxx/test/debugging/CMakeLists.txt
@@ -164,7 +164,7 @@ function(libcudacxx_add_pretty_printer_test)
 
   # Explicitly set max optimization, the printers should work even when everything is
   # compiled out.
-  target_compile_options(${target_name} PRIVATE -O3)
+  target_compile_options(${target_name} PRIVATE -g -O3)
   target_compile_definitions(${target_name} PRIVATE NDEBUG)
 
   foreach (debugger IN LISTS LIBCUDACXX_SUPPORTED_DEBUGGERS)

--- a/libcudacxx/test/debugging/CMakeLists.txt
+++ b/libcudacxx/test/debugging/CMakeLists.txt
@@ -121,8 +121,8 @@ Arguments
 
 ``CASES``
   Ordered runner arguments describing the debugger stops and expressions. Each case
-  has the form ``--case <breakpoint> <caller-frame-index> <section-name>
-  <expression>``.
+  has the form ``--case <breakpoint> <section-name> <expression>``. The expression is
+  evaluated in the breakpoint function's own frame.
 
 #]=======================================================================]
 function(libcudacxx_add_pretty_printer_test)

--- a/libcudacxx/test/debugging/CMakeLists.txt
+++ b/libcudacxx/test/debugging/CMakeLists.txt
@@ -160,10 +160,9 @@ function(libcudacxx_add_pretty_printer_test)
     NO_CLANG_TIDY
     SOURCES ${pretty_printer_SOURCES}
   )
-  target_compile_options(
-    ${target_name}
-    PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-g> $<$<COMPILE_LANGUAGE:CUDA>:-O0>
-  )
+  # Explicitly set max optimization, the printers should work even when everything is
+  # compiled out.
+  target_compile_options(${target_name} PRIVATE -O3)
   target_link_libraries(${target_name} PRIVATE libcudacxx.compiler_interface)
 
   foreach (debugger IN LISTS LIBCUDACXX_SUPPORTED_DEBUGGERS)
@@ -193,7 +192,9 @@ function(libcudacxx_add_pretty_printer_test)
       ${pretty_printer_CASES}
       # gersemi: on
     )
-    set_tests_properties(${test_name} PROPERTIES TIMEOUT 60)
+    # Set an aggressive timeout because pretty printers should not be slow. If they are,
+    # then it's a problem with the printer and/or it is doing too much
+    set_tests_properties(${test_name} PROPERTIES TIMEOUT 10)
   endforeach()
 endfunction()
 

--- a/libcudacxx/test/debugging/array/CMakeLists.txt
+++ b/libcudacxx/test/debugging/array/CMakeLists.txt
@@ -3,11 +3,11 @@ libcudacxx_add_pretty_printer_test(
   SOURCES source.cu
   CASES
     # gersemi: off
-    --case inspect_normal 1 array.normal normal
-    --case inspect_empty 1 array.empty empty
-    --case inspect_nested 1 array.nested nested
-    --case inspect_alias 1 array.alias alias
-    --case inspect_before_update 1 array.update.before updated_values
-    --case inspect_after_update 1 array.update.after updated_values
+    --case inspect_normal array.normal values
+    --case inspect_empty array.empty values
+    --case inspect_nested array.nested values
+    --case inspect_alias array.alias values
+    --case inspect_before_update array.update.before values
+    --case inspect_after_update array.update.after values
     # gersemi: on
 )

--- a/libcudacxx/test/debugging/array/lldb.expected
+++ b/libcudacxx/test/debugging/array/lldb.expected
@@ -1,21 +1,21 @@
 =============== array.normal begin ===============
-(cuda::std::array<int, 3>)  ([0] = -7, [1] = 0, [2] = 42)
+(cuda::std::array<int, 3>) <address> ([0] = -7, [1] = 0, [2] = 42)
 =============== array.normal end ===============
 =============== array.empty begin ===============
-(cuda::std::array<int, 0>)
+(cuda::std::array<int, 0>) <address>
 =============== array.empty end ===============
 =============== array.nested begin ===============
-(cuda::std::array<cuda::std::array<int, 2>, 2>) {
+(cuda::std::array<cuda::std::array<int, 2>, 2>) <address>: {
   [0] = ([0] = 13, [1] = -5)
   [1] = ([0] = 0, [1] = 88)
 }
 =============== array.nested end ===============
 =============== array.alias begin ===============
-(cuda::std::array<int, 4>)  ([0] = -31, [1] = 17, [2] = 8, [3] = -64)
+(cuda::std::array<int, 4>) <address> ([0] = -31, [1] = 17, [2] = 8, [3] = -64)
 =============== array.alias end ===============
 =============== array.update.before begin ===============
-(cuda::std::array<int, 3>)  ([0] = 6, [1] = -91, [2] = 52)
+(cuda::std::array<int, 3>) <address> ([0] = 6, [1] = -91, [2] = 52)
 =============== array.update.before end ===============
 =============== array.update.after begin ===============
-(cuda::std::array<int, 3>)  ([0] = 3, [1] = 85, [2] = -12)
+(cuda::std::array<int, 3>) <address> ([0] = 3, [1] = 85, [2] = -12)
 =============== array.update.after end ===============

--- a/libcudacxx/test/debugging/array/source.cu
+++ b/libcudacxx/test/debugging/array/source.cu
@@ -4,42 +4,41 @@
 
 #include <cuda/std/array>
 
-template <class T>
-[[gnu::noinline]] void keep_for_debugger(const T& value)
-{
-  asm volatile("" : : "g"(&value) : "memory");
-}
+// Give the inspected parameter a stack location that survives optimization, so the
+// debugger can read it in this frame. Without this the parameter stays in a
+// caller-clobbered register and reads as unavailable at -O3.
+#define KEEP_FOR_DEBUGGER(values) asm volatile("" : : "g"(&(values)) : "memory")
 
 using array_alias = cuda::std::array<int, 4>;
 
 [[gnu::noinline]] void inspect_normal(const cuda::std::array<int, 3>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_empty(const cuda::std::array<int, 0>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_nested(const cuda::std::array<cuda::std::array<int, 2>, 2>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_alias(const array_alias& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_before_update(const cuda::std::array<int, 3>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_after_update(const cuda::std::array<int, 3>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 int main()

--- a/libcudacxx/test/debugging/atomic/CMakeLists.txt
+++ b/libcudacxx/test/debugging/atomic/CMakeLists.txt
@@ -3,24 +3,24 @@ libcudacxx_add_pretty_printer_test(
   SOURCES source.cu
   CASES
     # gersemi: off
-    --case inspect_integer 1 atomic.integer integer
-    --case inspect_boolean 1 atomic.boolean boolean
-    --case inspect_small_object 1 atomic.small_object small_object
-    --case inspect_floating_point 1 atomic.floating_point floating_point
-    --case inspect_pointer 1 atomic.pointer pointer
-    --case inspect_locked 1 atomic.locked locked
-    --case inspect_alias 1 atomic.alias alias
-    --case inspect_nested 1 atomic.nested nested
-    --case inspect_reference 1 atomic.reference reference
-    --case inspect_locked_reference 1 atomic.locked_reference locked_reference
-    --case inspect_cuda_integer 1 atomic.cuda_integer cuda_integer
-    --case inspect_cuda_reference 1 atomic.cuda_reference cuda_reference
-    --case inspect_cuda_device_integer 1 atomic.cuda_device_integer cuda_device_integer
-    --case inspect_cuda_block_reference 1 atomic.cuda_block_reference cuda_block_reference
-    --case inspect_cuda_thread_integer 1 atomic.cuda_thread_integer cuda_thread_integer
-    --case inspect_before_update 1 atomic.update.before updated
-    --case inspect_after_update 1 atomic.update.after updated
-    --case inspect_reference_before_update 1 atomic.reference_update.before updated_reference
-    --case inspect_reference_after_update 1 atomic.reference_update.after updated_reference
+    --case inspect_integer atomic.integer value
+    --case inspect_boolean atomic.boolean value
+    --case inspect_small_object atomic.small_object value
+    --case inspect_floating_point atomic.floating_point value
+    --case inspect_pointer atomic.pointer value
+    --case inspect_locked atomic.locked value
+    --case inspect_alias atomic.alias value
+    --case inspect_nested atomic.nested values
+    --case inspect_reference atomic.reference value
+    --case inspect_locked_reference atomic.locked_reference value
+    --case inspect_cuda_integer atomic.cuda_integer value
+    --case inspect_cuda_reference atomic.cuda_reference value
+    --case inspect_cuda_device_integer atomic.cuda_device_integer value
+    --case inspect_cuda_block_reference atomic.cuda_block_reference value
+    --case inspect_cuda_thread_integer atomic.cuda_thread_integer value
+    --case inspect_before_update atomic.update.before value
+    --case inspect_after_update atomic.update.after value
+    --case inspect_reference_before_update atomic.reference_update.before value
+    --case inspect_reference_after_update atomic.reference_update.after value
     # gersemi: on
 )

--- a/libcudacxx/test/debugging/atomic/lldb.expected
+++ b/libcudacxx/test/debugging/atomic/lldb.expected
@@ -1,78 +1,78 @@
 =============== atomic.integer begin ===============
-(cuda::std::atomic<int>)  (value = -7)
+(cuda::std::atomic<int>) <address> (value = -7)
 =============== atomic.integer end ===============
 =============== atomic.boolean begin ===============
-(cuda::std::atomic<bool>)  (value = true)
+(cuda::std::atomic<bool>) <address> (value = true)
 =============== atomic.boolean end ===============
 =============== atomic.small_object begin ===============
-(cuda::std::atomic<small_payload>) {
+(cuda::std::atomic<small_payload>) <address>: {
   value = (first = true, second = false)
 }
 =============== atomic.small_object end ===============
 =============== atomic.floating_point begin ===============
-(cuda::std::atomic<double>)  (value = -3.5)
+(cuda::std::atomic<double>) <address> (value = -3.5)
 =============== atomic.floating_point end ===============
 =============== atomic.pointer begin ===============
-(cuda::std::atomic<int *>) {
+(cuda::std::atomic<int *>) <address>: {
   value = <address>
 }
 =============== atomic.pointer end ===============
 =============== atomic.locked begin ===============
-(cuda::std::atomic<payload>) {
+(cuda::std::atomic<payload>) <address>: {
   value = (first = 13, second = -5, third = 88)
 }
 =============== atomic.locked end ===============
 =============== atomic.alias begin ===============
-(cuda::std::atomic<long long>)  (value = -31)
+(cuda::std::atomic<long long>) <address> (value = -31)
 =============== atomic.alias end ===============
 =============== atomic.nested begin ===============
-(cuda::std::array<cuda::std::atomic<int>, 2>) {
+(cuda::std::array<cuda::std::atomic<int>, 2>) <address>: {
   [0] = (value = 17)
   [1] = (value = -64)
 }
 =============== atomic.nested end ===============
 =============== atomic.reference begin ===============
-(cuda::std::atomic_ref<int>) ptr=<address> {
+(cuda::std::atomic_ref<int>) <address> ptr=<address>: {
   value = 52
 }
 =============== atomic.reference end ===============
 =============== atomic.locked_reference begin ===============
-(cuda::std::atomic_ref<payload>) ptr=<address> {
+(cuda::std::atomic_ref<payload>) <address> ptr=<address>: {
   value = (first = 6, second = -91, third = 3)
 }
 =============== atomic.locked_reference end ===============
 =============== atomic.cuda_integer begin ===============
-(cuda::atomic<int, cuda::thread_scope_system>)  (value = 41)
+(cuda::atomic<int, cuda::thread_scope_system>) <address> (value = 41)
 =============== atomic.cuda_integer end ===============
 =============== atomic.cuda_reference begin ===============
-(cuda::atomic_ref<int, cuda::thread_scope_system>) ptr=<address> {
+(cuda::atomic_ref<int, cuda::thread_scope_system>) <address> ptr=<address>: {
   value = -26
 }
 =============== atomic.cuda_reference end ===============
 =============== atomic.cuda_device_integer begin ===============
-(cuda::atomic<int, cuda::thread_scope_device>)  (value = 29)
+(cuda::atomic<int, cuda::thread_scope_device>) <address> (value = 29)
 =============== atomic.cuda_device_integer end ===============
 =============== atomic.cuda_block_reference begin ===============
-(cuda::atomic_ref<int, cuda::thread_scope_block>) ptr=<address> {
+(cuda::atomic_ref<int, cuda::thread_scope_block>) <address> ptr=<address>: {
   value = -38
 }
 =============== atomic.cuda_block_reference end ===============
 =============== atomic.cuda_thread_integer begin ===============
-(cuda::atomic<int, cuda::thread_scope_thread>)  (value = 17)
+(cuda::atomic<int, cuda::thread_scope_thread>) <address> (value = 17)
 =============== atomic.cuda_thread_integer end ===============
 =============== atomic.update.before begin ===============
-(cuda::std::atomic<int>)  (value = 85)
+(cuda::std::atomic<int>) <address> (value = 85)
 =============== atomic.update.before end ===============
 =============== atomic.update.after begin ===============
-(cuda::std::atomic<int>)  (value = 99)
+(cuda::std::atomic<int>) <address> (value = 99)
 =============== atomic.update.after end ===============
 =============== atomic.reference_update.before begin ===============
-(cuda::std::atomic_ref<int>) ptr=<address> {
+(cuda::std::atomic_ref<int>) <address> ptr=<address>: {
   value = -12
 }
 =============== atomic.reference_update.before end ===============
 =============== atomic.reference_update.after begin ===============
-(cuda::std::atomic_ref<int>) ptr=<address> {
+(cuda::std::atomic_ref<int>) <address> ptr=<address>: {
   value = 73
 }
 =============== atomic.reference_update.after end ===============

--- a/libcudacxx/test/debugging/atomic/source.cu
+++ b/libcudacxx/test/debugging/atomic/source.cu
@@ -6,11 +6,10 @@
 #include <cuda/std/array>
 #include <cuda/std/atomic>
 
-template <class T>
-[[gnu::noinline]] void keep_for_debugger(const T& value)
-{
-  asm volatile("" : : "g"(&value) : "memory");
-}
+// Give the inspected parameter a stack location that survives optimization, so the
+// debugger can read it in this frame. Without this the parameter stays in a
+// caller-clobbered register and reads as unavailable at -O3.
+#define KEEP_FOR_DEBUGGER(values) asm volatile("" : : "g"(&(values)) : "memory")
 
 struct alignas(16) payload
 {
@@ -33,97 +32,97 @@ using atomic_alias = cuda::std::atomic<long long>;
 
 [[gnu::noinline]] void inspect_integer(const cuda::std::atomic<int>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_boolean(const cuda::std::atomic<bool>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_small_object(const cuda::std::atomic<small_payload>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_floating_point(const cuda::std::atomic<double>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_pointer(const cuda::std::atomic<int*>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_locked(const cuda::std::atomic<payload>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_alias(const atomic_alias& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_nested(const cuda::std::array<cuda::std::atomic<int>, 2>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_reference(const cuda::std::atomic_ref<int>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_locked_reference(const cuda::std::atomic_ref<payload>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_cuda_integer(const cuda::atomic<int>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_cuda_reference(const cuda::atomic_ref<int>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_cuda_device_integer(const cuda::atomic<int, cuda::thread_scope_device>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_cuda_block_reference(const cuda::atomic_ref<int, cuda::thread_scope_block>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_cuda_thread_integer(const cuda::atomic<int, cuda::thread_scope_thread>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_before_update(const cuda::std::atomic<int>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_after_update(const cuda::std::atomic<int>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_reference_before_update(const cuda::std::atomic_ref<int>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_reference_after_update(const cuda::std::atomic_ref<int>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 int main()

--- a/libcudacxx/test/debugging/buffer/CMakeLists.txt
+++ b/libcudacxx/test/debugging/buffer/CMakeLists.txt
@@ -3,13 +3,13 @@ libcudacxx_add_pretty_printer_test(
   SOURCES source.cu
   CASES
     # gersemi: off
-    --case inspect_normal 1 buffer.normal normal_values
-    --case inspect_alias 1 buffer.alias aliased_values
-    --case inspect_vector 1 buffer.vector.0 "buffer_vector[0]"
-    --case inspect_vector 1 buffer.vector.1 "buffer_vector[1]"
-    --case inspect_host_device 1 buffer.host_device host_device_values
-    --case inspect_empty 1 buffer.empty empty_values
-    --case inspect_before_update 1 buffer.update.before updated_values
-    --case inspect_after_update 1 buffer.update.after updated_values
+    --case inspect_normal buffer.normal values
+    --case inspect_alias buffer.alias values
+    --case inspect_vector buffer.vector.0 "values[0]"
+    --case inspect_vector buffer.vector.1 "values[1]"
+    --case inspect_host_device buffer.host_device values
+    --case inspect_empty buffer.empty values
+    --case inspect_before_update buffer.update.before values
+    --case inspect_after_update buffer.update.after values
     # gersemi: on
 )

--- a/libcudacxx/test/debugging/buffer/lldb.expected
+++ b/libcudacxx/test/debugging/buffer/lldb.expected
@@ -1,5 +1,5 @@
 =============== buffer.normal begin ===============
-(cuda::buffer<int, cuda::mr::device_accessible>) mr=cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>, stream=<address>, size=10, align=4, data=<address> (device) {
+(const cuda::buffer<int, cuda::mr::device_accessible> &) <address> mr=cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>, stream=<address>, size=10, align=4, data=<address> (device): {
   [0] = -56
   [1] = 22
   [2] = 94
@@ -13,7 +13,7 @@
 }
 =============== buffer.normal end ===============
 =============== buffer.alias begin ===============
-(cuda::buffer<int, cuda::mr::device_accessible>) mr=cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>, stream=<address>, size=4, align=4, data=<address> (device) {
+(const cuda::buffer<int, cuda::mr::device_accessible> &) <address> mr=cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>, stream=<address>, size=4, align=4, data=<address> (device): {
   [0] = 17
   [1] = -31
   [2] = 8
@@ -35,7 +35,7 @@
 }
 =============== buffer.vector.1 end ===============
 =============== buffer.host_device begin ===============
-(cuda::buffer<int, cuda::mr::device_accessible, cuda::mr::host_accessible>) mr=cuda::mr::any_resource<cuda::mr::device_accessible, cuda::mr::host_accessible> @ <address>, stream=<address>, size=4, align=4, data=<address> (host/device) {
+(const cuda::buffer<int, cuda::mr::device_accessible, cuda::mr::host_accessible> &) <address> mr=cuda::mr::any_resource<cuda::mr::device_accessible, cuda::mr::host_accessible> @ <address>, stream=<address>, size=4, align=4, data=<address> (host/device): {
   [0] = 3
   [1] = 14
   [2] = -15
@@ -43,10 +43,10 @@
 }
 =============== buffer.host_device end ===============
 =============== buffer.empty begin ===============
-(cuda::buffer<int, cuda::mr::device_accessible>) mr=cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>, stream=<address>, size=0, align=4, data=0x0 (device)
+(const cuda::buffer<int, cuda::mr::device_accessible> &) <address> mr=cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>, stream=<address>, size=0, align=4, data=0x0 (device)
 =============== buffer.empty end ===============
 =============== buffer.update.before begin ===============
-(cuda::buffer<int, cuda::mr::device_accessible>) mr=cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>, stream=<address>, size=4, align=4, data=<address> (device) {
+(const cuda::buffer<int, cuda::mr::device_accessible> &) <address> mr=cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>, stream=<address>, size=4, align=4, data=<address> (device): {
   [0] = 1
   [1] = 2
   [2] = 3
@@ -54,7 +54,7 @@
 }
 =============== buffer.update.before end ===============
 =============== buffer.update.after begin ===============
-(cuda::buffer<int, cuda::mr::device_accessible>) mr=cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>, stream=<address>, size=4, align=4, data=<address> (device) {
+(const cuda::buffer<int, cuda::mr::device_accessible> &) <address> mr=cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>, stream=<address>, size=4, align=4, data=<address> (device): {
   [0] = -8
   [1] = 13
   [2] = 21

--- a/libcudacxx/test/debugging/buffer/source.cu
+++ b/libcudacxx/test/debugging/buffer/source.cu
@@ -11,49 +11,54 @@
 
 #include <cuda_runtime_api.h>
 
-template <class T>
-[[gnu::noinline]] void keep_for_debugger(const T& value)
-{
-  asm volatile("" : : "g"(&value) : "memory");
-}
+// Give the inspected parameter a stack location that survives optimization, so the
+// debugger can read it in this frame. Without this the parameter stays in a
+// caller-clobbered register and reads as unavailable at -O3.
+#define KEEP_FOR_DEBUGGER(values) asm volatile("" : : "g"(&(values)) : "memory")
 
 [[gnu::noinline]] void inspect_normal(const cuda::device_buffer<int>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 using device_buffer_alias = cuda::buffer<int, cuda::mr::device_accessible>;
 
 [[gnu::noinline]] void inspect_alias(const device_buffer_alias& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
+
+// An optimized build inlines every use of std::vector::operator[], so no
+// out-of-line copy is left for the debugger to call. Instantiate that one member
+// explicitly to keep a copy, which lets the debugger evaluate values[i]. A full
+// class instantiation does not compile because the buffer is move-only.
+template typename std::vector<cuda::device_buffer<int>>::const_reference
+  std::vector<cuda::device_buffer<int>>::operator[](size_type) const;
 
 [[gnu::noinline]] void inspect_vector(const std::vector<cuda::device_buffer<int>>& values)
 {
-  keep_for_debugger(values[0]);
-  keep_for_debugger(values[1]);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 template <class Buffer>
 [[gnu::noinline]] void inspect_host_device(const Buffer& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_empty(const cuda::device_buffer<int>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_before_update(const cuda::device_buffer<int>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_after_update(const cuda::device_buffer<int>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 int main()

--- a/libcudacxx/test/debugging/complex/CMakeLists.txt
+++ b/libcudacxx/test/debugging/complex/CMakeLists.txt
@@ -3,12 +3,12 @@ libcudacxx_add_pretty_printer_test(
   SOURCES source.cu
   CASES
     # gersemi: off
-    --case inspect_std_default 1 complex.std.default std_default
-    --case inspect_std_double 1 complex.std.double std_double
-    --case inspect_cuda_float 1 complex.cuda.float cuda_float
-    --case inspect_alias 1 complex.alias alias
-    --case inspect_nested 1 complex.nested nested
-    --case inspect_before_update 1 complex.update.before updated
-    --case inspect_after_update 1 complex.update.after updated
+    --case inspect_std_default complex.std.default value
+    --case inspect_std_double complex.std.double value
+    --case inspect_cuda_float complex.cuda.float value
+    --case inspect_alias complex.alias value
+    --case inspect_nested complex.nested values
+    --case inspect_before_update complex.update.before value
+    --case inspect_after_update complex.update.after value
     # gersemi: on
 )

--- a/libcudacxx/test/debugging/complex/lldb.expected
+++ b/libcudacxx/test/debugging/complex/lldb.expected
@@ -1,24 +1,24 @@
 =============== complex.std.default begin ===============
-(cuda::std::complex<float>)  (real = 0, imag = 0)
+(cuda::std::complex<float>) <address> (real = 0, imag = 0)
 =============== complex.std.default end ===============
 =============== complex.std.double begin ===============
-(cuda::std::complex<double>)  (real = 1.5, imag = -2.25)
+(cuda::std::complex<double>) <address> (real = 1.5, imag = -2.25)
 =============== complex.std.double end ===============
 =============== complex.cuda.float begin ===============
-(cuda::complex<float>)  (real = 0.5, imag = 42.5)
+(cuda::complex<float>) <address> (real = 0.5, imag = 42.5)
 =============== complex.cuda.float end ===============
 =============== complex.alias begin ===============
-(cuda::std::complex<float>)  (real = -3.5, imag = 0.25)
+(cuda::std::complex<float>) <address> (real = -3.5, imag = 0.25)
 =============== complex.alias end ===============
 =============== complex.nested begin ===============
-(cuda::std::array<cuda::std::complex<float>, 2>) {
+(cuda::std::array<cuda::std::complex<float>, 2>) <address>: {
   [0] = (real = 13.5, imag = -5.5)
   [1] = (real = 0.25, imag = 88.5)
 }
 =============== complex.nested end ===============
 =============== complex.update.before begin ===============
-(cuda::std::complex<double>)  (real = 6.5, imag = -91.5)
+(cuda::std::complex<double>) <address> (real = 6.5, imag = -91.5)
 =============== complex.update.before end ===============
 =============== complex.update.after begin ===============
-(cuda::std::complex<double>)  (real = 3.25, imag = 85.5)
+(cuda::std::complex<double>) <address> (real = 3.25, imag = 85.5)
 =============== complex.update.after end ===============

--- a/libcudacxx/test/debugging/complex/source.cu
+++ b/libcudacxx/test/debugging/complex/source.cu
@@ -6,47 +6,46 @@
 #include <cuda/std/array>
 #include <cuda/std/complex>
 
-template <class T>
-[[gnu::noinline]] void keep_for_debugger(const T& value)
-{
-  asm volatile("" : : "g"(&value) : "memory");
-}
+// Give the inspected parameter a stack location that survives optimization, so the
+// debugger can read it in this frame. Without this the parameter stays in a
+// caller-clobbered register and reads as unavailable at -O3.
+#define KEEP_FOR_DEBUGGER(values) asm volatile("" : : "g"(&(values)) : "memory")
 
 using complex_alias = cuda::std::complex<float>;
 
 [[gnu::noinline]] void inspect_std_default(const cuda::std::complex<float>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_std_double(const cuda::std::complex<double>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_cuda_float(const cuda::complex<float>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_alias(const complex_alias& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_nested(const cuda::std::array<cuda::std::complex<float>, 2>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_before_update(const cuda::std::complex<double>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_after_update(const cuda::std::complex<double>& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 int main()

--- a/libcudacxx/test/debugging/event/CMakeLists.txt
+++ b/libcudacxx/test/debugging/event/CMakeLists.txt
@@ -3,15 +3,15 @@ libcudacxx_add_pretty_printer_test(
   SOURCES source.cu
   CASES
     # gersemi: off
-    --case inspect_ref 1 event.ref event_reference
-    --case inspect_owning 1 event.owning owning_event
-    --case inspect_timed 1 event.timed timed_event
-    --case inspect_alias 1 event.alias aliased_event
-    --case inspect_null_ref 1 event.null_ref null_reference
-    --case inspect_no_init 1 event.no_init no_init_event
-    --case inspect_timed_no_init 1 event.timed_no_init no_init_timed_event
-    --case inspect_nested 1 event.nested nested_events
-    --case inspect_before_update 1 event.update.before updated_event
-    --case inspect_after_update 1 event.update.after updated_event
+    --case inspect_ref event.ref value
+    --case inspect_owning event.owning value
+    --case inspect_timed event.timed value
+    --case inspect_alias event.alias value
+    --case inspect_null_ref event.null_ref value
+    --case inspect_no_init event.no_init value
+    --case inspect_timed_no_init event.timed_no_init value
+    --case inspect_nested event.nested values
+    --case inspect_before_update event.update.before value
+    --case inspect_after_update event.update.after value
     # gersemi: on
 )

--- a/libcudacxx/test/debugging/event/lldb.expected
+++ b/libcudacxx/test/debugging/event/lldb.expected
@@ -1,33 +1,33 @@
 =============== event.ref begin ===============
-(cuda::event_ref)  (handle = <address>)
+(cuda::event_ref) <address> (handle = <address>)
 =============== event.ref end ===============
 =============== event.owning begin ===============
-(cuda::event)  (handle = <address>)
+(cuda::event) <address> (handle = <address>)
 =============== event.owning end ===============
 =============== event.timed begin ===============
-(cuda::timed_event)  (handle = <address>)
+(cuda::timed_event) <address> (handle = <address>)
 =============== event.timed end ===============
 =============== event.alias begin ===============
-(cuda::event_ref)  (handle = <address>)
+(cuda::event_ref) <address> (handle = <address>)
 =============== event.alias end ===============
 =============== event.null_ref begin ===============
-(cuda::event_ref)  (handle = 0x0000000000000000)
+(cuda::event_ref) <address> (handle = 0x0000000000000000)
 =============== event.null_ref end ===============
 =============== event.no_init begin ===============
-(cuda::event)  (handle = 0x0000000000000000)
+(cuda::event) <address> (handle = 0x0000000000000000)
 =============== event.no_init end ===============
 =============== event.timed_no_init begin ===============
-(cuda::timed_event)  (handle = 0x0000000000000000)
+(cuda::timed_event) <address> (handle = 0x0000000000000000)
 =============== event.timed_no_init end ===============
 =============== event.nested begin ===============
-(cuda::std::array<cuda::event_ref, 2>) {
+(cuda::std::array<cuda::event_ref, 2>) <address>: {
   [0] = (handle = <address>)
   [1] = (handle = 0x0000000000000000)
 }
 =============== event.nested end ===============
 =============== event.update.before begin ===============
-(cuda::event_ref)  (handle = 0x0000000000000000)
+(cuda::event_ref) <address> (handle = 0x0000000000000000)
 =============== event.update.before end ===============
 =============== event.update.after begin ===============
-(cuda::event_ref)  (handle = <address>)
+(cuda::event_ref) <address> (handle = <address>)
 =============== event.update.after end ===============

--- a/libcudacxx/test/debugging/event/source.cu
+++ b/libcudacxx/test/debugging/event/source.cu
@@ -5,62 +5,61 @@
 #include <cuda/std/array>
 #include <cuda/stream>
 
-template <class T>
-[[gnu::noinline]] void keep_for_debugger(const T& value)
-{
-  asm volatile("" : : "g"(&value) : "memory");
-}
+// Give the inspected parameter a stack location that survives optimization, so the
+// debugger can read it in this frame. Without this the parameter stays in a
+// caller-clobbered register and reads as unavailable at -O3.
+#define KEEP_FOR_DEBUGGER(values) asm volatile("" : : "g"(&(values)) : "memory")
 
 using event_ref_alias = cuda::event_ref;
 
 [[gnu::noinline]] void inspect_ref(const cuda::event_ref& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_owning(const cuda::event& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_timed(const cuda::timed_event& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_alias(const event_ref_alias& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_null_ref(const cuda::event_ref& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_no_init(const cuda::event& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_timed_no_init(const cuda::timed_event& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_nested(const cuda::std::array<cuda::event_ref, 2>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_before_update(const cuda::event_ref& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_after_update(const cuda::event_ref& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 int main()

--- a/libcudacxx/test/debugging/inplace_vector/CMakeLists.txt
+++ b/libcudacxx/test/debugging/inplace_vector/CMakeLists.txt
@@ -3,12 +3,12 @@ libcudacxx_add_pretty_printer_test(
   SOURCES source.cu
   CASES
     # gersemi: off
-    --case inspect_empty 1 inplace_vector.empty empty
-    --case inspect_partial 1 inplace_vector.partial partial
-    --case inspect_full 1 inplace_vector.full full
-    --case inspect_zero_capacity 1 inplace_vector.zero_capacity zero
-    --case inspect_nested 1 inplace_vector.nested nested
-    --case inspect_before_update 1 inplace_vector.update.before updated
-    --case inspect_after_update 1 inplace_vector.update.after updated
+    --case inspect_empty inplace_vector.empty values
+    --case inspect_partial inplace_vector.partial values
+    --case inspect_full inplace_vector.full values
+    --case inspect_zero_capacity inplace_vector.zero_capacity values
+    --case inspect_nested inplace_vector.nested values
+    --case inspect_before_update inplace_vector.update.before values
+    --case inspect_after_update inplace_vector.update.after values
     # gersemi: on
 )

--- a/libcudacxx/test/debugging/inplace_vector/lldb.expected
+++ b/libcudacxx/test/debugging/inplace_vector/lldb.expected
@@ -1,25 +1,25 @@
 =============== inplace_vector.empty begin ===============
-(cuda::std::inplace_vector<int, 4>) size=0, capacity=4
+(cuda::std::inplace_vector<int, 4>) <address> size=0, capacity=4
 =============== inplace_vector.empty end ===============
 =============== inplace_vector.partial begin ===============
-(cuda::std::inplace_vector<int, 5>) size=3, capacity=5 {
+(cuda::std::inplace_vector<int, 5>) <address> size=3, capacity=5: {
   [0] = -7
   [1] = 0
   [2] = 42
 }
 =============== inplace_vector.partial end ===============
 =============== inplace_vector.full begin ===============
-(cuda::std::inplace_vector<int, 3>) size=3, capacity=3 {
+(cuda::std::inplace_vector<int, 3>) <address> size=3, capacity=3: {
   [0] = 1
   [1] = 2
   [2] = 3
 }
 =============== inplace_vector.full end ===============
 =============== inplace_vector.zero_capacity begin ===============
-(cuda::std::inplace_vector<int, 0>) size=0, capacity=0
+(cuda::std::inplace_vector<int, 0>) <address> size=0, capacity=0
 =============== inplace_vector.zero_capacity end ===============
 =============== inplace_vector.nested begin ===============
-(cuda::std::inplace_vector<cuda::std::inplace_vector<int, 2>, 3>) size=2, capacity=3 {
+(cuda::std::inplace_vector<cuda::std::inplace_vector<int, 2>, 3>) <address> size=2, capacity=3: {
   [0] = size=2, capacity=2 {
     [0] = 13
     [1] = -5
@@ -30,13 +30,13 @@
 }
 =============== inplace_vector.nested end ===============
 =============== inplace_vector.update.before begin ===============
-(cuda::std::inplace_vector<int, 4>) size=2, capacity=4 {
+(cuda::std::inplace_vector<int, 4>) <address> size=2, capacity=4: {
   [0] = 6
   [1] = -91
 }
 =============== inplace_vector.update.before end ===============
 =============== inplace_vector.update.after begin ===============
-(cuda::std::inplace_vector<int, 4>) size=3, capacity=4 {
+(cuda::std::inplace_vector<int, 4>) <address> size=3, capacity=4: {
   [0] = 6
   [1] = -91
   [2] = 52

--- a/libcudacxx/test/debugging/inplace_vector/source.cu
+++ b/libcudacxx/test/debugging/inplace_vector/source.cu
@@ -4,47 +4,46 @@
 
 #include <cuda/std/inplace_vector>
 
-template <class T>
-[[gnu::noinline]] void keep_for_debugger(const T& value)
-{
-  asm volatile("" : : "g"(&value) : "memory");
-}
+// Give the inspected parameter a stack location that survives optimization, so the
+// debugger can read it in this frame. Without this the parameter stays in a
+// caller-clobbered register and reads as unavailable at -O3.
+#define KEEP_FOR_DEBUGGER(values) asm volatile("" : : "g"(&(values)) : "memory")
 
 using nested_vector = cuda::std::inplace_vector<cuda::std::inplace_vector<int, 2>, 3>;
 
 [[gnu::noinline]] void inspect_empty(const cuda::std::inplace_vector<int, 4>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_partial(const cuda::std::inplace_vector<int, 5>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_full(const cuda::std::inplace_vector<int, 3>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_zero_capacity(const cuda::std::inplace_vector<int, 0>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_nested(const nested_vector& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_before_update(const cuda::std::inplace_vector<int, 4>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_after_update(const cuda::std::inplace_vector<int, 4>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 int main()

--- a/libcudacxx/test/debugging/memory_resource/CMakeLists.txt
+++ b/libcudacxx/test/debugging/memory_resource/CMakeLists.txt
@@ -3,8 +3,8 @@ libcudacxx_add_pretty_printer_test(
   SOURCES source.cu
   CASES
     # gersemi: off
-    --case inspect_device 1 memory_resource.device device_resource
-    --case inspect_host_device 1 memory_resource.host_device host_device_resource
-    --case inspect_alias 1 memory_resource.alias aliased_resource
+    --case inspect_device memory_resource.device resource
+    --case inspect_host_device memory_resource.host_device resource
+    --case inspect_alias memory_resource.alias resource
     # gersemi: on
 )

--- a/libcudacxx/test/debugging/memory_resource/lldb.expected
+++ b/libcudacxx/test/debugging/memory_resource/lldb.expected
@@ -1,9 +1,9 @@
 =============== memory_resource.device begin ===============
-(const device_resource_type) cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>
+(const device_resource_type &) <address> cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>
 =============== memory_resource.device end ===============
 =============== memory_resource.host_device begin ===============
-(const host_device_resource_type) cuda::mr::any_resource<cuda::mr::device_accessible, cuda::mr::host_accessible> @ <address>
+(const host_device_resource_type &) <address> cuda::mr::any_resource<cuda::mr::device_accessible, cuda::mr::host_accessible> @ <address>
 =============== memory_resource.host_device end ===============
 =============== memory_resource.alias begin ===============
-(const resource_alias) cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>
+(const resource_alias &) <address> cuda::mr::any_resource<cuda::mr::device_accessible> @ <address>
 =============== memory_resource.alias end ===============

--- a/libcudacxx/test/debugging/memory_resource/source.cu
+++ b/libcudacxx/test/debugging/memory_resource/source.cu
@@ -4,11 +4,10 @@
 
 #include <cuda/memory_resource>
 
-template <class T>
-[[gnu::noinline]] void keep_for_debugger(const T& value)
-{
-  asm volatile("" : : "g"(&value) : "memory");
-}
+// Give the inspected parameter a stack location that survives optimization, so the
+// debugger can read it in this frame. Without this the parameter stays in a
+// caller-clobbered register and reads as unavailable at -O3.
+#define KEEP_FOR_DEBUGGER(values) asm volatile("" : : "g"(&(values)) : "memory")
 
 using device_resource_type      = cuda::mr::any_resource<cuda::mr::device_accessible>;
 using host_device_resource_type = cuda::mr::any_resource<cuda::mr::device_accessible, cuda::mr::host_accessible>;
@@ -16,17 +15,17 @@ using resource_alias            = device_resource_type;
 
 [[gnu::noinline]] void inspect_device(const device_resource_type& resource)
 {
-  keep_for_debugger(resource);
+  KEEP_FOR_DEBUGGER(resource);
 }
 
 [[gnu::noinline]] void inspect_host_device(const host_device_resource_type& resource)
 {
-  keep_for_debugger(resource);
+  KEEP_FOR_DEBUGGER(resource);
 }
 
 [[gnu::noinline]] void inspect_alias(const resource_alias& resource)
 {
-  keep_for_debugger(resource);
+  KEEP_FOR_DEBUGGER(resource);
 }
 
 int main()

--- a/libcudacxx/test/debugging/run_pretty_printer_test.py
+++ b/libcudacxx/test/debugging/run_pretty_printer_test.py
@@ -32,8 +32,10 @@ _MARKER_PATTERN = re.compile(
 )
 _LLDB_ECHO_PATTERN = re.compile(r"^\s*\(lldb\)\s")
 _GDB_VALUE_PREFIX_PATTERN = re.compile(r"^\s*\$\d+ = ")
+_TEMPLATE_PATTERN = re.compile(r">\s+>")
 _NONZERO_HEX_PATTERN = re.compile(r"\b0x(?!0+\b)[0-9a-fA-F]+\b")
 _STREAM_UNIQUE_ID_PATTERN = re.compile(r"(?<=unique_id=)\d+")
+_NUMERIC_LITERAL_PATTERN = re.compile(r"\b(\d+)[uUlL]*(?![\w.])")
 
 
 class HarnessError(RuntimeError):
@@ -533,9 +535,10 @@ def normalize_output(output: str, debugger: DebuggerAdapter) -> str:
     for line in output.splitlines():
         line = debugger.normalize_line(line.rstrip())
         # Some debuggers may print C++98 style > > for multiple templates.
-        line = re.sub(r">\s+>", ">>", line)
+        line = _TEMPLATE_PATTERN.sub(">>", line)
         line = _NONZERO_HEX_PATTERN.sub("<address>", line)
         line = _STREAM_UNIQUE_ID_PATTERN.sub("<id>", line)
+        line = _NUMERIC_LITERAL_PATTERN.sub(r"\1", line)
         normalized_lines.append(line)
     return "\n".join(normalized_lines) + "\n"
 

--- a/libcudacxx/test/debugging/run_pretty_printer_test.py
+++ b/libcudacxx/test/debugging/run_pretty_printer_test.py
@@ -54,13 +54,12 @@ class Debugger(StrEnum):
 @dataclass(frozen=True)
 class Case:
     breakpoint: str
-    frame: int
     section: str
     expression: str
 
 
 class CaseAction(argparse.Action):
-    """Parse and validate one four-part ``--case`` option."""
+    """Parse and validate one three-part ``--case`` option."""
 
     def __call__(
         self,
@@ -78,23 +77,17 @@ class CaseAction(argparse.Action):
         namespace : argparse.Namespace
             Namespace receiving parsed cases.
         values : Sequence[str]
-            Breakpoint, frame, section, and expression values.
+            Breakpoint, section, and expression values.
         option_string : str or None
             Option spelling that supplied the values.
 
         Raises
         ------
         SystemExit
-            If the frame, breakpoint, section, or expression is invalid, or if
-            the section name is duplicated.
+            If the breakpoint, section, or expression is invalid, or if the
+            section name is duplicated.
         """
-        breakpoint, raw_frame, section, expression = values
-        try:
-            frame = int(raw_frame)
-        except ValueError:
-            parser.error(f"invalid caller frame index {raw_frame!r}")
-        if frame < 0:
-            parser.error(f"caller frame index must be nonnegative: {frame}")
+        breakpoint, section, expression = values
         for label, value in (
             ("breakpoint", breakpoint),
             ("section", section),
@@ -106,7 +99,7 @@ class CaseAction(argparse.Action):
         cases: list[Case] = getattr(namespace, self.dest) or []
         if any(case.section == section for case in cases):
             parser.error(f"duplicate section name: {section}")
-        cases.append(Case(breakpoint, frame, section, expression))
+        cases.append(Case(breakpoint, section, expression))
         setattr(namespace, self.dest, cases)
 
 
@@ -177,19 +170,16 @@ class DebuggerAdapter(ABC):
         HarnessError
             If a completed breakpoint group is reopened later.
         """
-        closed_stops: set[tuple[str, int]] = set()
-        previous_stop: tuple[str, int] | None = None
+        closed_breakpoints: set[str] = set()
+        previous_breakpoint: str | None = None
         for case in cases:
-            stop = (case.breakpoint, case.frame)
-            if stop == previous_stop:
+            if case.breakpoint == previous_breakpoint:
                 continue
-            if stop in closed_stops:
-                raise HarnessError(
-                    f"breakpoint group {case.breakpoint!r} at frame {case.frame} was reopened"
-                )
-            if previous_stop is not None:
-                closed_stops.add(previous_stop)
-            previous_stop = stop
+            if case.breakpoint in closed_breakpoints:
+                raise HarnessError(f"breakpoint group {case.breakpoint!r} was reopened")
+            if previous_breakpoint is not None:
+                closed_breakpoints.add(previous_breakpoint)
+            previous_breakpoint = case.breakpoint
         return self._generate_commands(cases)
 
     @abstractmethod
@@ -287,14 +277,14 @@ class GDB(DebuggerAdapter):
             lines.append(f"break {case.breakpoint}")
             seen_breakpoints.add(case.breakpoint)
         lines.append("run")
-        previous_stop: tuple[str, int] | None = None
+        previous_breakpoint: str | None = None
         for case in cases:
-            stop = (case.breakpoint, case.frame)
-            if previous_stop is not None and stop != previous_stop:
+            if (
+                previous_breakpoint is not None
+                and case.breakpoint != previous_breakpoint
+            ):
                 lines.append("continue")
-            if stop != previous_stop:
-                lines.append(f"frame {case.frame}")
-            previous_stop = stop
+            previous_breakpoint = case.breakpoint
             begin = marker(case.section, "begin")
             end = marker(case.section, "end")
             expression = repr(case.expression)
@@ -377,14 +367,14 @@ class LLDB(DebuggerAdapter):
             lines.append(f"breakpoint set --name {case.breakpoint}")
             seen_breakpoints.add(case.breakpoint)
         lines.append("run")
-        previous_stop: tuple[str, int] | None = None
+        previous_breakpoint: str | None = None
         for case in cases:
-            stop = (case.breakpoint, case.frame)
-            if previous_stop is not None and stop != previous_stop:
+            if (
+                previous_breakpoint is not None
+                and case.breakpoint != previous_breakpoint
+            ):
                 lines.append("continue")
-            if stop != previous_stop:
-                lines.append(f"frame select {case.frame}")
-            previous_stop = stop
+            previous_breakpoint = case.breakpoint
             begin = marker(case.section, "begin")
             end = marker(case.section, "end")
             debugger_command = f"dwim-print -- {case.expression}"
@@ -604,7 +594,7 @@ def _parse_arguments(arguments: Sequence[str] | None) -> argparse.Namespace:
     parser.add_argument(
         "--case",
         dest="cases",
-        nargs=4,
+        nargs=3,
         action=CaseAction,
         default=None,
         required=True,

--- a/libcudacxx/test/debugging/stream/CMakeLists.txt
+++ b/libcudacxx/test/debugging/stream/CMakeLists.txt
@@ -3,20 +3,20 @@ libcudacxx_add_pretty_printer_test(
   SOURCES source.cu
   CASES
     # gersemi: off
-    --case inspect_without_context 1 stream.without_context owning_stream
-    --case inspect_owning 1 stream.owning owning_stream
-    --case inspect_ref 1 stream.ref stream_reference
-    --case inspect_alias 1 stream.alias aliased_stream
-    --case inspect_default 1 stream.default default_stream
-    --case inspect_legacy 1 stream.legacy legacy_stream
-    --case inspect_per_thread 1 stream.per_thread per_thread_stream
-    --case inspect_invalid 1 stream.invalid invalid_stream
-    --case inspect_moved_from 1 stream.moved_from moved_from_stream
-    --case inspect_summary 1 stream.summary summarized_streams
-    --case inspect_before_update 1 stream.update.before updated_stream
-    --case inspect_after_update 1 stream.update.after updated_stream
-    --case inspect_capturing 1 stream.capturing capture_stream
-    --case inspect_after_capture 1 stream.after_capture capture_stream
+    --case inspect_without_context stream.without_context value
+    --case inspect_owning stream.owning value
+    --case inspect_ref stream.ref value
+    --case inspect_alias stream.alias value
+    --case inspect_default stream.default value
+    --case inspect_legacy stream.legacy value
+    --case inspect_per_thread stream.per_thread value
+    --case inspect_invalid stream.invalid value
+    --case inspect_moved_from stream.moved_from value
+    --case inspect_summary stream.summary values
+    --case inspect_before_update stream.update.before value
+    --case inspect_after_update stream.update.after value
+    --case inspect_capturing stream.capturing value
+    --case inspect_after_capture stream.after_capture value
     # gersemi: on
 )
 

--- a/libcudacxx/test/debugging/stream/lldb.expected
+++ b/libcudacxx/test/debugging/stream/lldb.expected
@@ -1,5 +1,5 @@
 =============== stream.without_context begin ===============
-(const cuda::stream) handle=<address>, unique_id=<id> {
+(const cuda::stream &) <address> handle=<address>, unique_id=<id>: {
   device = 0
   priority = 0
   is_capturing = false
@@ -7,7 +7,7 @@
 }
 =============== stream.without_context end ===============
 =============== stream.owning begin ===============
-(const cuda::stream) handle=<address>, unique_id=<id> {
+(const cuda::stream &) <address> handle=<address>, unique_id=<id>: {
   device = 0
   priority = 0
   is_capturing = false
@@ -15,7 +15,7 @@
 }
 =============== stream.owning end ===============
 =============== stream.ref begin ===============
-(const cuda::stream_ref) handle=<address>, unique_id=<id> {
+(const cuda::stream_ref &) <address> handle=<address>, unique_id=<id>: {
   device = 0
   priority = 0
   is_capturing = false
@@ -23,7 +23,7 @@
 }
 =============== stream.ref end ===============
 =============== stream.alias begin ===============
-(const stream_ref_alias) handle=<address>, unique_id=<id> {
+(const stream_ref_alias &) <address> handle=<address>, unique_id=<id>: {
   device = 0
   priority = 0
   is_capturing = false
@@ -31,7 +31,7 @@
 }
 =============== stream.alias end ===============
 =============== stream.default begin ===============
-(const cuda::stream_ref) handle=default, unique_id=<id> {
+(const cuda::stream_ref &) <address> handle=default, unique_id=<id>: {
   device = 0
   priority = 0
   is_capturing = false
@@ -39,7 +39,7 @@
 }
 =============== stream.default end ===============
 =============== stream.legacy begin ===============
-(const cuda::stream_ref) handle=legacy, unique_id=<id> {
+(const cuda::stream_ref &) <address> handle=legacy, unique_id=<id>: {
   device = 0
   priority = 0
   is_capturing = false
@@ -47,7 +47,7 @@
 }
 =============== stream.legacy end ===============
 =============== stream.per_thread begin ===============
-(const cuda::stream_ref) handle=per-thread, unique_id=<id> {
+(const cuda::stream_ref &) <address> handle=per-thread, unique_id=<id>: {
   device = 0
   priority = 0
   is_capturing = false
@@ -55,13 +55,13 @@
 }
 =============== stream.per_thread end ===============
 =============== stream.invalid begin ===============
-(const cuda::stream_ref) handle=invalid, unique_id=unavailable
+(const cuda::stream_ref &) <address> handle=invalid, unique_id=unavailable
 =============== stream.invalid end ===============
 =============== stream.moved_from begin ===============
-(cuda::stream) handle=invalid, unique_id=unavailable
+(const cuda::stream &) <address> handle=invalid, unique_id=unavailable
 =============== stream.moved_from end ===============
 =============== stream.summary begin ===============
-(const std::vector<cuda::stream_ref>) size=3 {
+(const std::vector<cuda::stream_ref> &) <address> size=3: {
   [0] = handle=<address>, unique_id=<id> {
     device = 0
     priority = 0
@@ -78,7 +78,7 @@
 }
 =============== stream.summary end ===============
 =============== stream.update.before begin ===============
-(cuda::stream_ref) handle=default, unique_id=<id> {
+(const cuda::stream_ref &) <address> handle=default, unique_id=<id>: {
   device = 0
   priority = 0
   is_capturing = false
@@ -86,7 +86,7 @@
 }
 =============== stream.update.before end ===============
 =============== stream.update.after begin ===============
-(cuda::stream_ref) handle=<address>, unique_id=<id> {
+(const cuda::stream_ref &) <address> handle=<address>, unique_id=<id>: {
   device = 0
   priority = 0
   is_capturing = false
@@ -94,12 +94,12 @@
 }
 =============== stream.update.after end ===============
 =============== stream.capturing begin ===============
-(const cuda::stream) handle=<address>, unique_id=unavailable {
+(const cuda::stream &) <address> handle=<address>, unique_id=unavailable: {
   is_capturing = true
 }
 =============== stream.capturing end ===============
 =============== stream.after_capture begin ===============
-(const cuda::stream) handle=<address>, unique_id=<id> {
+(const cuda::stream &) <address> handle=<address>, unique_id=<id>: {
   device = 0
   priority = 0
   is_capturing = false

--- a/libcudacxx/test/debugging/stream/source.cu
+++ b/libcudacxx/test/debugging/stream/source.cu
@@ -10,82 +10,81 @@
 #include <cuda.h>
 #include <cuda_runtime_api.h>
 
-template <class T>
-[[gnu::noinline]] void keep_for_debugger(const T& value)
-{
-  asm volatile("" : : "g"(&value) : "memory");
-}
+// Give the inspected parameter a stack location that survives optimization, so the
+// debugger can read it in this frame. Without this the parameter stays in a
+// caller-clobbered register and reads as unavailable at -O3.
+#define KEEP_FOR_DEBUGGER(values) asm volatile("" : : "g"(&(values)) : "memory")
 
 [[gnu::noinline]] void inspect_owning(const cuda::stream& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_without_context(const cuda::stream& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_ref(const cuda::stream_ref& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 using stream_ref_alias = cuda::stream_ref;
 
 [[gnu::noinline]] void inspect_alias(const stream_ref_alias& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_default(const cuda::stream_ref& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_legacy(const cuda::stream_ref& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_per_thread(const cuda::stream_ref& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_invalid(const cuda::stream_ref& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_moved_from(const cuda::stream& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_summary(const std::vector<cuda::stream_ref>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_before_update(const cuda::stream_ref& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_after_update(const cuda::stream_ref& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_capturing(const cuda::stream& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 [[gnu::noinline]] void inspect_after_capture(const cuda::stream& value)
 {
-  keep_for_debugger(value);
+  KEEP_FOR_DEBUGGER(value);
 }
 
 int main()
@@ -154,6 +153,6 @@ int main()
   }
   inspect_after_capture(capture_stream);
 
-  keep_for_debugger(moved_to_stream);
+  KEEP_FOR_DEBUGGER(moved_to_stream);
   return 0;
 }

--- a/libcudacxx/test/debugging/tuple/CMakeLists.txt
+++ b/libcudacxx/test/debugging/tuple/CMakeLists.txt
@@ -3,21 +3,21 @@ libcudacxx_add_pretty_printer_test(
   SOURCES source.cu
   CASES
     # gersemi: off
-    --case inspect_basic 1 tuple.basic basic_values
-    --case inspect_empty 1 tuple.empty empty_values
-    --case inspect_single 1 tuple.single single_values
-    --case inspect_ebco 1 tuple.ebco ebco_values
-    --case inspect_ebco_first 1 tuple.ebco_first ebco_first_values
-    --case inspect_ebco_last 1 tuple.ebco_last ebco_last_values
-    --case inspect_ebco_adjacent 1 tuple.ebco_adjacent ebco_adjacent_values
-    --case inspect_pointer 1 tuple.pointer pointer_values
-    --case inspect_nested_empty 1 tuple.nested_empty nested_empty_values
-    --case inspect_nested 1 tuple.nested nested_values
-    --case inspect_reference 1 tuple.reference reference_values
-    --case inspect_const 1 tuple.const const_values
-    --case inspect_vector 1 tuple.vector.0 "tuple_vector[0]"
-    --case inspect_vector 1 tuple.vector.1 "tuple_vector[1]"
-    --case inspect_before_update 1 tuple.update.before mutable_values
-    --case inspect_after_update 1 tuple.update.after mutable_values
+    --case inspect_basic tuple.basic values
+    --case inspect_empty tuple.empty values
+    --case inspect_single tuple.single values
+    --case inspect_ebco tuple.ebco values
+    --case inspect_ebco_first tuple.ebco_first values
+    --case inspect_ebco_last tuple.ebco_last values
+    --case inspect_ebco_adjacent tuple.ebco_adjacent values
+    --case inspect_pointer tuple.pointer values
+    --case inspect_nested_empty tuple.nested_empty values
+    --case inspect_nested tuple.nested values
+    --case inspect_reference tuple.reference values
+    --case inspect_const tuple.const values
+    --case inspect_vector tuple.vector.0 "values[0]"
+    --case inspect_vector tuple.vector.1 "values[1]"
+    --case inspect_before_update tuple.update.before values
+    --case inspect_after_update tuple.update.after values
     # gersemi: on
 )

--- a/libcudacxx/test/debugging/tuple/lldb.expected
+++ b/libcudacxx/test/debugging/tuple/lldb.expected
@@ -1,59 +1,59 @@
 =============== tuple.basic begin ===============
-(cuda::std::tuple<int, double, char>) {
+(cuda::std::tuple<int, double, char>) <address>: {
   [0] = 42
   [1] = 3.1400000000000001
   [2] = 'x'
 }
 =============== tuple.basic end ===============
 =============== tuple.empty begin ===============
-(cuda::std::tuple<>) {}
+(cuda::std::tuple<>) <address> {}
 =============== tuple.empty end ===============
 =============== tuple.single begin ===============
-(cuda::std::tuple<int>) {
+(cuda::std::tuple<int>) <address>: {
   [0] = 7
 }
 =============== tuple.single end ===============
 =============== tuple.ebco begin ===============
-(cuda::std::tuple<int, empty_type, double>) {
+(cuda::std::tuple<int, empty_type, double>) <address>: {
   [0] = 9
   [1] = {}
   [2] = 2.5
 }
 =============== tuple.ebco end ===============
 =============== tuple.ebco_first begin ===============
-(cuda::std::tuple<empty_type, int>) {
+(cuda::std::tuple<empty_type, int>) <address>: {
   [0] = {}
   [1] = 21
 }
 =============== tuple.ebco_first end ===============
 =============== tuple.ebco_last begin ===============
-(cuda::std::tuple<int, empty_type>) {
+(cuda::std::tuple<int, empty_type>) <address>: {
   [0] = 22
   [1] = {}
 }
 =============== tuple.ebco_last end ===============
 =============== tuple.ebco_adjacent begin ===============
-(cuda::std::tuple<empty_type, empty_type, int>) {
+(cuda::std::tuple<empty_type, empty_type, int>) <address>: {
   [0] = {}
   [1] = {}
   [2] = 23
 }
 =============== tuple.ebco_adjacent end ===============
 =============== tuple.pointer begin ===============
-(cuda::std::tuple<int *, const char *>) {
+(cuda::std::tuple<int *, const char *>) <address>: {
   [0] = <address>
   [1] = <address> "tuple"
 }
 =============== tuple.pointer end ===============
 =============== tuple.nested_empty begin ===============
-(cuda::std::tuple<int, cuda::std::tuple<>, double>) {
+(cuda::std::tuple<int, cuda::std::tuple<>, double>) <address>: {
   [0] = 1
   [1] = {}
   [2] = 2.5
 }
 =============== tuple.nested_empty end ===============
 =============== tuple.nested begin ===============
-(cuda::std::tuple<int, cuda::std::tuple<double, char>>) {
+(cuda::std::tuple<int, cuda::std::tuple<double, char>>) <address>: {
   [0] = 1
   [1] = {
     [0] = 2.5
@@ -62,13 +62,13 @@
 }
 =============== tuple.nested end ===============
 =============== tuple.reference begin ===============
-(cuda::std::tuple<int &, double &>) {
+(cuda::std::tuple<int &, double &>) <address>: {
   [0] = 5
   [1] = 6.5
 }
 =============== tuple.reference end ===============
 =============== tuple.const begin ===============
-(cuda::std::tuple<int, double>) {
+(cuda::std::tuple<int, double>) <address>: {
   [0] = 11
   [1] = -12.5
 }
@@ -86,13 +86,13 @@
 }
 =============== tuple.vector.1 end ===============
 =============== tuple.update.before begin ===============
-(cuda::std::tuple<int, double>) {
+(cuda::std::tuple<int, double>) <address>: {
   [0] = 1
   [1] = 2.5
 }
 =============== tuple.update.before end ===============
 =============== tuple.update.after begin ===============
-(cuda::std::tuple<int, double>) {
+(cuda::std::tuple<int, double>) <address>: {
   [0] = 9
   [1] = -3.5
 }

--- a/libcudacxx/test/debugging/tuple/source.cu
+++ b/libcudacxx/test/debugging/tuple/source.cu
@@ -6,11 +6,10 @@
 
 #include <vector>
 
-template <class T>
-[[gnu::noinline]] void keep_for_debugger(const T& value)
-{
-  asm volatile("" : : "g"(&value) : "memory");
-}
+// Give the inspected parameter a stack location that survives optimization, so the
+// debugger can read it in this frame. Without this the parameter stays in a
+// caller-clobbered register and reads as unavailable at -O3.
+#define KEEP_FOR_DEBUGGER(values) asm volatile("" : : "g"(&(values)) : "memory")
 
 // An empty, non-final type triggers the tuple element's empty-base-class
 // optimization instead of storing the element in a __value_ data member.
@@ -19,22 +18,22 @@ struct empty_type
 
 [[gnu::noinline]] void inspect_basic(const cuda::std::tuple<int, double, char>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_empty(const cuda::std::tuple<>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_single(const cuda::std::tuple<int>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_ebco(const cuda::std::tuple<int, empty_type, double>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 // An empty leading element shares its storage offset with the element that
@@ -44,58 +43,63 @@ struct empty_type
 // mix these up unless every case is exercised on its own.
 [[gnu::noinline]] void inspect_ebco_first(const cuda::std::tuple<empty_type, int>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_ebco_last(const cuda::std::tuple<int, empty_type>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_ebco_adjacent(const cuda::std::tuple<empty_type, empty_type, int>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_pointer(const cuda::std::tuple<int*, const char*>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_nested_empty(const cuda::std::tuple<int, cuda::std::tuple<>, double>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_nested(const cuda::std::tuple<int, cuda::std::tuple<double, char>>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_reference(const cuda::std::tuple<int&, double&>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_const(const cuda::std::tuple<int, double>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
+
+// An optimized build inlines every use of std::vector::operator[], so no
+// out-of-line copy is left for the debugger to call. Instantiate that one member
+// explicitly to keep a copy, which lets the debugger evaluate values[i].
+template typename std::vector<cuda::std::tuple<int, int>>::const_reference
+  std::vector<cuda::std::tuple<int, int>>::operator[](size_type) const;
 
 [[gnu::noinline]] void inspect_vector(const std::vector<cuda::std::tuple<int, int>>& values)
 {
-  keep_for_debugger(values[0]);
-  keep_for_debugger(values[1]);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_before_update(const cuda::std::tuple<int, double>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 [[gnu::noinline]] void inspect_after_update(const cuda::std::tuple<int, double>& values)
 {
-  keep_for_debugger(values);
+  KEEP_FOR_DEBUGGER(values);
 }
 
 int main()


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

1. Tighten timeout for pretty printers
2. Compile them all in optimized mode
3. Properly handle printing references (previously this wouldn't match the printers, now it does)
4. Don't need to go up a frame to inspect values, we can just do it inside the function itself but then we need to inline the `asm()` call
5. Unify some of the repeated boilerplate code

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
