### PR TITLE
Fall back to memcpy when possible for CUB DeviceCopy

### DIFF
--- a/cub/cub/device/dispatch/dispatch_copy_mdspan.cuh
+++ b/cub/cub/device/dispatch/dispatch_copy_mdspan.cuh
@@ -21,8 +21,14 @@
 #include <cub/device/dispatch/tuning/tuning_transform.cuh>
 #include <cub/util_debug.cuh>
 
+#include <cuda/__algorithm/copy.h>
 #include <cuda/__functional/always_true_false.h>
+#include <cuda/__functional/call_or.h>
+#include <cuda/__stream/stream_ref.h>
+#include <cuda/__type_traits/is_trivially_copyable.h>
+#include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__functional/identity.h>
+#include <cuda/std/__host_stdlib/stdexcept>
 #include <cuda/std/mdspan>
 
 CUB_NAMESPACE_BEGIN
@@ -64,13 +70,42 @@ copy(::cuda::std::mdspan<T_In, E_In, L_In, A_In> mdspan_in,
   if (mdspan_in.is_exhaustive() && mdspan_out.is_exhaustive()
       && detail::have_same_strides(mdspan_in.mapping(), mdspan_out.mapping()))
   {
-    return cub::DeviceTransform::__transform_internal(
-      ::cuda::std::make_tuple(mdspan_in.data_handle()),
-      mdspan_out.data_handle(),
-      mdspan_in.size(),
-      ::cuda::always_true{},
-      ::cuda::std::identity{},
-      env);
+    if constexpr (::cuda::std::same_as<T_In, T_Out>
+                  && ::cuda::__detail::__can_mdspan_copy_bytes<T_In, E_In, L_In, T_Out, E_Out, L_Out>)
+    {
+      _CCCL_TRY
+      {
+        ::cuda::copy_bytes(
+          ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{::cudaStream_t{}}, env), mdspan_in, mdspan_out);
+      }
+      _CCCL_CATCH (const ::cuda::cuda_error& __e)
+      {
+        return __e.status();
+      }
+#if _CCCL_HOSTED()
+      _CCCL_CATCH (const ::std::invalid_argument& __e)
+      {
+        static_cast<void>(__e);
+        return ::cudaErrorInvalidValue;
+      }
+#endif // _CCCL_HOSTED
+      _CCCL_CATCH_ALL
+      {
+        return ::cudaErrorUnknown;
+      }
+
+      return ::cudaSuccess;
+    }
+    else
+    {
+      return cub::DeviceTransform::__transform_internal(
+        ::cuda::std::make_tuple(mdspan_in.data_handle()),
+        mdspan_out.data_handle(),
+        mdspan_in.size(),
+        ::cuda::always_true{},
+        ::cuda::std::identity{},
+        env);
+    }
   }
   // TODO (fbusato): add ForEachInLayout when mdspan_in and mdspan_out have compatible layouts
   // Compatible layouts could use more efficient iteration patterns

--- a/cub/cub/device/dispatch/dispatch_copy_mdspan.cuh
+++ b/cub/cub/device/dispatch/dispatch_copy_mdspan.cuh
@@ -21,8 +21,14 @@
 #include <cub/device/dispatch/tuning/tuning_transform.cuh>
 #include <cub/util_debug.cuh>
 
+#include <cuda/__algorithm/copy.h>
 #include <cuda/__functional/always_true_false.h>
+#include <cuda/__stream/get_stream.h>
+#include <cuda/__stream/stream_ref.h>
+#include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__functional/identity.h>
+#include <cuda/std/__host_stdlib/stdexcept>
+#include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/mdspan>
 
 CUB_NAMESPACE_BEGIN
@@ -47,6 +53,46 @@ struct copy_mdspan_t
   }
 };
 
+template <class _MDSpanIn, class _MDSpanOut, class _Env>
+[[nodiscard]] _CCCL_HOST_API ::cudaError_t
+__copy_mdspan_bytes(::cuda::stream_ref __stream, _MDSpanIn&& __mdspan_in, _MDSpanOut&& __mdspan_out, const _Env& __env)
+{
+  _CCCL_TRY
+  {
+    ::cuda::copy_bytes(__stream, __mdspan_in, __mdspan_out);
+  }
+  _CCCL_CATCH (const ::cuda::cuda_error& __e)
+  {
+    return __e.status();
+  }
+#if _CCCL_HOSTED()
+  _CCCL_CATCH (const ::std::invalid_argument& __e)
+  {
+    static_cast<void>(__e);
+    return ::cudaErrorInvalidValue;
+  }
+#endif // _CCCL_HOSTED
+  _CCCL_CATCH_ALL
+  {
+    return ::cudaErrorUnknown;
+  }
+
+  return ::cudaSuccess;
+}
+
+template <class _MDSpanIn, class _MDSpanOut, class _Env>
+[[nodiscard]] CUB_RUNTIME_FUNCTION ::cudaError_t
+__transform_copy(_MDSpanIn&& __mdspan_in, _MDSpanOut&& __mdspan_out, const _Env& __env)
+{
+  return CUB_NS_QUALIFIER::DeviceTransform::__transform_internal(
+    ::cuda::std::make_tuple(__mdspan_in.data_handle()),
+    __mdspan_out.data_handle(),
+    __mdspan_in.size(),
+    ::cuda::always_true{},
+    ::cuda::std::identity{},
+    __env);
+}
+
 template <typename T_In,
           typename E_In,
           typename L_In,
@@ -64,13 +110,34 @@ copy(::cuda::std::mdspan<T_In, E_In, L_In, A_In> mdspan_in,
   if (mdspan_in.is_exhaustive() && mdspan_out.is_exhaustive()
       && detail::have_same_strides(mdspan_in.mapping(), mdspan_out.mapping()))
   {
-    return cub::DeviceTransform::__transform_internal(
-      ::cuda::std::make_tuple(mdspan_in.data_handle()),
-      mdspan_out.data_handle(),
-      mdspan_in.size(),
-      ::cuda::always_true{},
-      ::cuda::std::identity{},
-      env);
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (::cuda::std::same_as<T_In, T_Out>
+                  && ::cuda::__detail::__can_mdspan_copy_bytes<T_In, E_In, L_In, T_Out, E_Out, L_Out>
+                  && ::cuda::std::__is_callable_v<::cuda::get_stream_t, const EnvT&>)
+    {
+      NV_IF_TARGET(
+        NV_IS_HOST,
+        ({
+          auto __stream = ::cuda::get_stream(env);
+
+          // cuda::copy_bytes() builds an __ensure_current_context(stream_ref), which calls
+          // cuStreamGetCtx(). That driver call rejects the NULL stream with
+          // CUDA_ERROR_INVALID_VALUE. Use the transform path, which goes through the runtime
+          // API and accepts the NULL stream.
+          if (__stream.get() == nullptr)
+          {
+            return CUB_NS_QUALIFIER::detail::copy_mdspan::__transform_copy(mdspan_in, mdspan_out, env);
+          }
+
+          return CUB_NS_QUALIFIER::detail::copy_mdspan::__copy_mdspan_bytes(__stream, mdspan_in, mdspan_out, env);
+        }),
+        (return CUB_NS_QUALIFIER::detail::copy_mdspan::__transform_copy(mdspan_in, mdspan_out, env);))
+    }
+    else
+    {
+      return CUB_NS_QUALIFIER::detail::copy_mdspan::__transform_copy(mdspan_in, mdspan_out, env);
+    }
+    // NOLINTEND(bugprone-branch-clone)
   }
   // TODO (fbusato): add ForEachInLayout when mdspan_in and mdspan_out have compatible layouts
   // Compatible layouts could use more efficient iteration patterns

--- a/cub/cub/device/dispatch/dispatch_copy_mdspan.cuh
+++ b/cub/cub/device/dispatch/dispatch_copy_mdspan.cuh
@@ -115,23 +115,22 @@ copy(::cuda::std::mdspan<T_In, E_In, L_In, A_In> mdspan_in,
                   && ::cuda::__detail::__can_mdspan_copy_bytes<T_In, E_In, L_In, T_Out, E_Out, L_Out>
                   && ::cuda::std::__is_callable_v<::cuda::get_stream_t, const EnvT&>)
     {
-      NV_IF_TARGET(
-        NV_IS_HOST,
-        ({
-          auto __stream = ::cuda::get_stream(env);
+      NV_IF_TARGET(NV_IS_HOST,
+                   ({
+                     auto __stream = ::cuda::get_stream(env);
 
-          // cuda::copy_bytes() builds an __ensure_current_context(stream_ref), which calls
-          // cuStreamGetCtx(). That driver call rejects the NULL stream with
-          // CUDA_ERROR_INVALID_VALUE. Use the transform path, which goes through the runtime
-          // API and accepts the NULL stream.
-          if (__stream.get() == nullptr)
-          {
-            return CUB_NS_QUALIFIER::detail::copy_mdspan::__transform_copy(mdspan_in, mdspan_out, env);
-          }
+                     // cuda::copy_bytes() builds an __ensure_current_context(stream_ref), which calls
+                     // cuStreamGetCtx(). That driver call rejects the NULL stream with
+                     // CUDA_ERROR_INVALID_VALUE. Use the transform path, which goes through the runtime
+                     // API and accepts the NULL stream.
+                     if (__stream.get() == nullptr)
+                     {
+                       return CUB_NS_QUALIFIER::detail::copy_mdspan::__transform_copy(mdspan_in, mdspan_out, env);
+                     }
 
-          return CUB_NS_QUALIFIER::detail::copy_mdspan::__copy_mdspan_bytes(__stream, mdspan_in, mdspan_out, env);
-        }),
-        (return CUB_NS_QUALIFIER::detail::copy_mdspan::__transform_copy(mdspan_in, mdspan_out, env);))
+                     return CUB_NS_QUALIFIER::detail::copy_mdspan::__copy_mdspan_bytes(__stream, mdspan_in, mdspan_out);
+                   }),
+                   (return CUB_NS_QUALIFIER::detail::copy_mdspan::__transform_copy(mdspan_in, mdspan_out, env);))
     }
     else
     {

--- a/cub/cub/device/dispatch/dispatch_copy_mdspan.cuh
+++ b/cub/cub/device/dispatch/dispatch_copy_mdspan.cuh
@@ -115,22 +115,27 @@ copy(::cuda::std::mdspan<T_In, E_In, L_In, A_In> mdspan_in,
                   && ::cuda::__detail::__can_mdspan_copy_bytes<T_In, E_In, L_In, T_Out, E_Out, L_Out>
                   && ::cuda::std::__is_callable_v<::cuda::get_stream_t, const EnvT&>)
     {
-      NV_IF_TARGET(NV_IS_HOST,
-                   ({
-                     auto __stream = ::cuda::get_stream(env);
+      NV_IF_TARGET(
+        NV_IS_HOST,
+        ({
+          auto __stream = ::cuda::get_stream(env);
 
-                     // cuda::copy_bytes() builds an __ensure_current_context(stream_ref), which calls
-                     // cuStreamGetCtx(). That driver call rejects the NULL stream with
-                     // CUDA_ERROR_INVALID_VALUE. Use the transform path, which goes through the runtime
-                     // API and accepts the NULL stream.
-                     if (__stream.get() == nullptr)
-                     {
-                       return CUB_NS_QUALIFIER::detail::copy_mdspan::__transform_copy(mdspan_in, mdspan_out, env);
-                     }
+          // cuda::copy_bytes() builds an __ensure_current_context(stream_ref), which calls
+          // cuStreamGetCtx(). That driver call rejects the NULL stream with
+          // CUDA_ERROR_INVALID_VALUE. Use the transform path, which goes through the runtime
+          // API and accepts the NULL stream.
+          //
+          // Likewise, we cannot retrieve the context for a stream that is capturings so we
+          // need to call the kernel.
+          if (__stream.get() == nullptr
+              || (::cuda::__driver::__streamIsCapturing(__stream.get()) == ::CU_STREAM_CAPTURE_STATUS_ACTIVE))
+          {
+            return CUB_NS_QUALIFIER::detail::copy_mdspan::__transform_copy(mdspan_in, mdspan_out, env);
+          }
 
-                     return CUB_NS_QUALIFIER::detail::copy_mdspan::__copy_mdspan_bytes(__stream, mdspan_in, mdspan_out);
-                   }),
-                   (return CUB_NS_QUALIFIER::detail::copy_mdspan::__transform_copy(mdspan_in, mdspan_out, env);))
+          return CUB_NS_QUALIFIER::detail::copy_mdspan::__copy_mdspan_bytes(__stream, mdspan_in, mdspan_out);
+        }),
+        (return CUB_NS_QUALIFIER::detail::copy_mdspan::__transform_copy(mdspan_in, mdspan_out, env);))
     }
     else
     {

--- a/cub/cub/device/dispatch/dispatch_copy_mdspan.cuh
+++ b/cub/cub/device/dispatch/dispatch_copy_mdspan.cuh
@@ -53,9 +53,9 @@ struct copy_mdspan_t
   }
 };
 
-template <class _MDSpanIn, class _MDSpanOut, class _Env>
+template <class _MDSpanIn, class _MDSpanOut>
 [[nodiscard]] _CCCL_HOST_API ::cudaError_t
-__copy_mdspan_bytes(::cuda::stream_ref __stream, _MDSpanIn&& __mdspan_in, _MDSpanOut&& __mdspan_out, const _Env& __env)
+__copy_mdspan_bytes(::cuda::stream_ref __stream, _MDSpanIn&& __mdspan_in, _MDSpanOut&& __mdspan_out)
 {
   _CCCL_TRY
   {

--- a/libcudacxx/include/cuda/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/__algorithm/copy.h
@@ -68,6 +68,12 @@ struct copy_configuration
 
 namespace __detail
 {
+template <class _SrcTp, class _DstTp>
+_CCCL_CONCEPT __can_span_copy_bytes = _CCCL_REQUIRES_EXPR((_SrcTp, _DstTp), )(
+  requires((!::cuda::std::is_const_v<_DstTp>) ),
+  requires(::cuda::is_trivially_copyable_v<_SrcTp>),
+  requires(::cuda::is_trivially_copyable_v<_DstTp>));
+
 template <typename _SrcTy, ::cuda::std::size_t _SrcSize, typename _DstTy, ::cuda::std::size_t _DstSize>
 _CCCL_HOST_API void __copy_bytes_impl(
   stream_ref __stream,
@@ -75,8 +81,7 @@ _CCCL_HOST_API void __copy_bytes_impl(
   ::cuda::std::span<_DstTy, _DstSize> __dst,
   [[maybe_unused]] copy_configuration __config)
 {
-  static_assert(!::cuda::std::is_const_v<_DstTy>, "Copy destination can't be const");
-  static_assert(::cuda::is_trivially_copyable_v<_SrcTy> && ::cuda::is_trivially_copyable_v<_DstTy>);
+  static_assert(__can_span_copy_bytes<_SrcTy, _DstTy>);
 
   // If neither are dynamic_extent then they are a number, and in that case we can check at compile-time
   if constexpr ((_SrcSize != ::cuda::std::dynamic_extent) && (_DstSize != ::cuda::std::dynamic_extent))
@@ -117,6 +122,13 @@ _CCCL_HOST_API void __copy_bytes_impl(
 #  endif // _CCCL_CTK_BELOW(13, 0)
 }
 
+template <class _SrcTp, class _SrcExtents, class _SrcLayout, class _DstTp, class _DstExtents, class _DstLayout>
+_CCCL_CONCEPT __can_mdspan_copy_bytes =
+  _CCCL_REQUIRES_EXPR((_SrcTp, _SrcExtents, _SrcLayout, _DstTp, _DstExtents, _DstLayout), )(
+    requires(__can_span_copy_bytes<_SrcTp, _DstTp>),
+    requires(::cuda::std::is_constructible_v<_DstExtents, _SrcExtents>),
+    requires(::cuda::std::is_same_v<_SrcLayout, _DstLayout>));
+
 template <typename _SrcElem,
           typename _SrcExtents,
           typename _SrcLayout,
@@ -131,10 +143,7 @@ _CCCL_HOST_API void __copy_bytes_impl(
   ::cuda::std::mdspan<_DstElem, _DstExtents, _DstLayout, _DstAccessor> __dst,
   copy_configuration __config)
 {
-  static_assert(::cuda::std::is_constructible_v<_DstExtents, _SrcExtents>,
-                "Multidimensional copy requires both source and destination extents to be compatible");
-  static_assert(::cuda::std::is_same_v<_SrcLayout, _DstLayout>,
-                "Multidimensional copy requires both source and destination layouts to match");
+  static_assert(__can_mdspan_copy_bytes<_SrcElem, _SrcExtents, _SrcLayout, _DstElem, _DstExtents, _DstLayout>);
 
   // Check only destination, because the layout of destination is the same as source
   if (!__dst.is_exhaustive())

--- a/libcudacxx/include/cuda/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/__algorithm/copy.h
@@ -140,7 +140,7 @@ _CCCL_HOST_API void __copy_bytes_impl(
   ::cuda::std::mdspan<_DstElem, _DstExtents, _DstLayout, _DstAccessor> __dst,
   copy_configuration __config)
 {
-  static_assert(__can_mdspan_copy_bytes<_SrcElem, _SrcExtents, _SrcLayout, _DstExtents, _DstExtents, _DstLayout>);
+  static_assert(__can_mdspan_copy_bytes<_SrcElem, _SrcExtents, _SrcLayout, _DstElem, _DstExtents, _DstLayout>);
 
   // Check only destination, because the layout of destination is the same as source
   if (!__dst.is_exhaustive())

--- a/libcudacxx/include/cuda/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/__algorithm/copy.h
@@ -65,6 +65,12 @@ struct copy_configuration
 
 namespace __detail
 {
+template <class _SrcTp, class _DstTp>
+_CCCL_CONCEPT __can_span_copy_bytes = _CCCL_REQUIRES_EXPR((_SrcTp, _DstTp), )(
+  requires((!::cuda::std::is_const_v<_DstTp>) ),
+  requires(::cuda::is_trivially_copyable_v<_SrcTp>),
+  requires(::cuda::is_trivially_copyable_v<_DstTp>));
+
 template <typename _SrcTy, ::cuda::std::size_t _SrcSize, typename _DstTy, ::cuda::std::size_t _DstSize>
 _CCCL_HOST_API void __copy_bytes_impl(
   stream_ref __stream,
@@ -72,8 +78,7 @@ _CCCL_HOST_API void __copy_bytes_impl(
   ::cuda::std::span<_DstTy, _DstSize> __dst,
   [[maybe_unused]] copy_configuration __config)
 {
-  static_assert(!::cuda::std::is_const_v<_DstTy>, "Copy destination can't be const");
-  static_assert(::cuda::is_trivially_copyable_v<_SrcTy> && ::cuda::is_trivially_copyable_v<_DstTy>);
+  static_assert(__can_span_copy_bytes<_SrcTy, _DstTy>);
 
   // If neither are dynamic_extent then they are a number, and in that case we can check at compile-time
   if constexpr ((_SrcSize != ::cuda::std::dynamic_extent) && (_DstSize != ::cuda::std::dynamic_extent))
@@ -114,6 +119,13 @@ _CCCL_HOST_API void __copy_bytes_impl(
 #  endif // _CCCL_CTK_BELOW(13, 0)
 }
 
+template <class _SrcTp, class _SrcExtents, class _SrcLayout, class _DstTp, class _DstExtents, class _DstLayout>
+_CCCL_CONCEPT __can_mdspan_copy_bytes =
+  _CCCL_REQUIRES_EXPR((_SrcTp, _SrcExtents, _SrcLayout, _DstTp, _DstExtents, _DstLayout), )(
+    requires(__can_span_copy_bytes<_SrcTp, _DstTp>),
+    requires(::cuda::std::is_constructible_v<_DstExtents, _SrcExtents>),
+    requires(::cuda::std::is_same_v<_SrcLayout, _DstLayout>));
+
 template <typename _SrcElem,
           typename _SrcExtents,
           typename _SrcLayout,
@@ -128,10 +140,7 @@ _CCCL_HOST_API void __copy_bytes_impl(
   ::cuda::std::mdspan<_DstElem, _DstExtents, _DstLayout, _DstAccessor> __dst,
   copy_configuration __config)
 {
-  static_assert(::cuda::std::is_constructible_v<_DstExtents, _SrcExtents>,
-                "Multidimensional copy requires both source and destination extents to be compatible");
-  static_assert(::cuda::std::is_same_v<_SrcLayout, _DstLayout>,
-                "Multidimensional copy requires both source and destination layouts to match");
+  static_assert(__can_mdspan_copy_bytes<_SrcElem, _SrcExtents, _SrcLayout, _DstExtents, _DstExtents, _DstLayout>);
 
   // Check only destination, because the layout of destination is the same as source
   if (!__dst.is_exhaustive())

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -1016,145 +1016,147 @@ __graphKernelNodeSetAttribute(::CUgraphNode __node, ::CUkernelNodeAttrID __id, c
   ::CUdevice __peer_dev) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceCanAccessPeer);
+  return static_cast<::cudaError_t>(__driver_fn(&__result, __dev, __peer_dev));
+}
 
-  // Green contexts
+// Green contexts
 
 #  if _CCCL_CTK_AT_LEAST(12, 5)
-  // Add actual resource description input once exposure is ready
-  [[nodiscard]] _CCCL_HOST_API inline ::CUgreenCtx __greenCtxCreate(::CUdevice __dev)
-  {
-    ::CUgreenCtx __result;
-    static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxCreate, cuGreenCtxCreate, 12, 5);
-    ::cuda::__driver::__call_driver_fn(
-      __driver_fn, "Failed to create a green context", &__result, nullptr, __dev, ::CU_GREEN_CTX_DEFAULT_STREAM);
-    return __result;
-  }
+// Add actual resource description input once exposure is ready
+[[nodiscard]] _CCCL_HOST_API inline ::CUgreenCtx __greenCtxCreate(::CUdevice __dev)
+{
+  ::CUgreenCtx __result;
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxCreate, cuGreenCtxCreate, 12, 5);
+  ::cuda::__driver::__call_driver_fn(
+    __driver_fn, "Failed to create a green context", &__result, nullptr, __dev, ::CU_GREEN_CTX_DEFAULT_STREAM);
+  return __result;
+}
 
-  [[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __greenCtxDestroyNoThrow(
-    ::CUgreenCtx __green_ctx) noexcept // NOLINT(bugprone-exception-escape)
-  {
-    static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxDestroy, cuGreenCtxDestroy, 12, 5);
-    return static_cast<::cudaError_t>(__driver_fn(__green_ctx));
-  }
-  [[nodiscard]] _CCCL_HOST_API inline ::CUcontext __ctxFromGreenCtx(::CUgreenCtx __green_ctx)
-  {
-    ::CUcontext __result;
-    static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuCtxFromGreenCtx, cuCtxFromGreenCtx, 12, 5);
-    ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to convert a green context", &__result, __green_ctx);
-    return __result;
-  }
+[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
+__greenCtxDestroyNoThrow(::CUgreenCtx __green_ctx) noexcept // NOLINT(bugprone-exception-escape)
+{
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxDestroy, cuGreenCtxDestroy, 12, 5);
+  return static_cast<::cudaError_t>(__driver_fn(__green_ctx));
+}
+[[nodiscard]] _CCCL_HOST_API inline ::CUcontext __ctxFromGreenCtx(::CUgreenCtx __green_ctx)
+{
+  ::CUcontext __result;
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuCtxFromGreenCtx, cuCtxFromGreenCtx, 12, 5);
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to convert a green context", &__result, __green_ctx);
+  return __result;
+}
 #  endif // _CCCL_CTK_AT_LEAST(12, 5)
 
 #  if _CCCL_CTK_AT_LEAST(13, 0)
-  [[nodiscard]] _CCCL_HOST_API inline unsigned long long __greenCtxGetId(::CUgreenCtx __green_ctx)
-  {
-    static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxGetId, cuGreenCtxGetId, 13, 0);
-    unsigned long long __id;
-    ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the ID of a green context", __green_ctx, &__id);
-    return __id;
-  }
+[[nodiscard]] _CCCL_HOST_API inline unsigned long long __greenCtxGetId(::CUgreenCtx __green_ctx)
+{
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxGetId, cuGreenCtxGetId, 13, 0);
+  unsigned long long __id;
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the ID of a green context", __green_ctx, &__id);
+  return __id;
+}
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
 
-  [[nodiscard]] _CCCL_HOST_API inline ::cuda::std::size_t __cutensormap_size_bytes(
-    ::cuda::std::size_t __num_items, ::CUtensorMapDataType __data_type)
+[[nodiscard]] _CCCL_HOST_API inline ::cuda::std::size_t
+__cutensormap_size_bytes(::cuda::std::size_t __num_items, ::CUtensorMapDataType __data_type)
+{
+  constexpr auto __max_size = ::cuda::std::numeric_limits<::cuda::std::size_t>::max();
+  switch (__data_type)
   {
-    constexpr auto __max_size = ::cuda::std::numeric_limits<::cuda::std::size_t>::max();
-    switch (__data_type)
-    {
-      case ::CU_TENSOR_MAP_DATA_TYPE_UINT8:
+    case ::CU_TENSOR_MAP_DATA_TYPE_UINT8:
 #  if _CCCL_CTK_AT_LEAST(12, 8)
-      case ::CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B:
+    case ::CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B:
 #  endif // _CCCL_CTK_AT_LEAST(12, 8)
-        return __num_items;
-      case ::CU_TENSOR_MAP_DATA_TYPE_UINT16:
-      case ::CU_TENSOR_MAP_DATA_TYPE_BFLOAT16:
-      case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT16:
-        if (__num_items > __max_size / 2)
-        {
-          _CCCL_THROW(::std::invalid_argument, "Number of items must be less than or equal to 2^64 / 2");
-        }
-        return __num_items * 2;
-      case ::CU_TENSOR_MAP_DATA_TYPE_INT32:
-      case ::CU_TENSOR_MAP_DATA_TYPE_UINT32:
-      case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT32:
-      case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT32_FTZ:
-      case ::CU_TENSOR_MAP_DATA_TYPE_TFLOAT32:
-      case ::CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ:
-        if (__num_items > __max_size / 4)
-        {
-          _CCCL_THROW(::std::invalid_argument, "Number of items must be less than or equal to 2^64 / 4");
-        }
-        return __num_items * 4;
-      case ::CU_TENSOR_MAP_DATA_TYPE_INT64:
-      case ::CU_TENSOR_MAP_DATA_TYPE_UINT64:
-      case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT64:
-        if (__num_items > __max_size / 8)
-        {
-          _CCCL_THROW(::std::invalid_argument, "Number of items must be less than or equal to 2^64 / 8");
-        }
-        return __num_items * 8;
+      return __num_items;
+    case ::CU_TENSOR_MAP_DATA_TYPE_UINT16:
+    case ::CU_TENSOR_MAP_DATA_TYPE_BFLOAT16:
+    case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT16:
+      if (__num_items > __max_size / 2)
+      {
+        _CCCL_THROW(::std::invalid_argument, "Number of items must be less than or equal to 2^64 / 2");
+      }
+      return __num_items * 2;
+    case ::CU_TENSOR_MAP_DATA_TYPE_INT32:
+    case ::CU_TENSOR_MAP_DATA_TYPE_UINT32:
+    case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT32:
+    case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT32_FTZ:
+    case ::CU_TENSOR_MAP_DATA_TYPE_TFLOAT32:
+    case ::CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ:
+      if (__num_items > __max_size / 4)
+      {
+        _CCCL_THROW(::std::invalid_argument, "Number of items must be less than or equal to 2^64 / 4");
+      }
+      return __num_items * 4;
+    case ::CU_TENSOR_MAP_DATA_TYPE_INT64:
+    case ::CU_TENSOR_MAP_DATA_TYPE_UINT64:
+    case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT64:
+      if (__num_items > __max_size / 8)
+      {
+        _CCCL_THROW(::std::invalid_argument, "Number of items must be less than or equal to 2^64 / 8");
+      }
+      return __num_items * 8;
 #  if _CCCL_CTK_AT_LEAST(12, 8)
-      case ::CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B:
-      case ::CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B:
-        return __num_items / 2;
+    case ::CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B:
+    case ::CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B:
+      return __num_items / 2;
 #  endif // _CCCL_CTK_AT_LEAST(12, 8)
-    }
-    return 0; // MSVC workaround
   }
+  return 0; // MSVC workaround
+}
 
-  [[nodiscard]] _CCCL_HOST_API inline ::CUtensorMap __tensorMapEncodeTiled(
-    ::CUtensorMapDataType __tensorDataType,
-    ::cuda::std::uint32_t __tensorRank,
-    void* __globalAddress,
-    const ::cuda::std::uint64_t* __globalDim,
-    const ::cuda::std::uint64_t* __globalStrides,
-    const ::cuda::std::uint32_t* __boxDim,
-    const ::cuda::std::uint32_t* __elementStrides,
-    ::CUtensorMapInterleave __interleave,
-    ::CUtensorMapSwizzle __swizzle,
-    ::CUtensorMapL2promotion __l2Promotion,
-    ::CUtensorMapFloatOOBfill __oobFill)
+[[nodiscard]] _CCCL_HOST_API inline ::CUtensorMap __tensorMapEncodeTiled(
+  ::CUtensorMapDataType __tensorDataType,
+  ::cuda::std::uint32_t __tensorRank,
+  void* __globalAddress,
+  const ::cuda::std::uint64_t* __globalDim,
+  const ::cuda::std::uint64_t* __globalStrides,
+  const ::cuda::std::uint32_t* __boxDim,
+  const ::cuda::std::uint32_t* __elementStrides,
+  ::CUtensorMapInterleave __interleave,
+  ::CUtensorMapSwizzle __swizzle,
+  ::CUtensorMapL2promotion __l2Promotion,
+  ::CUtensorMapFloatOOBfill __oobFill)
+{
+  ::CUtensorMap __tensorMap{};
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuTensorMapEncodeTiled);
+  __call_driver_fn(
+    __driver_fn,
+    "Failed to encode TMA descriptor",
+    &__tensorMap,
+    __tensorDataType,
+    __tensorRank,
+    __globalAddress,
+    __globalDim,
+    __globalStrides,
+    __boxDim,
+    __elementStrides,
+    __interleave,
+    __swizzle,
+    __l2Promotion,
+    __oobFill);
+  // workaround for nvbug 5736804
+  if (::cuda::__driver::__version_below(13, 2))
   {
-    ::CUtensorMap __tensorMap{};
-    static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuTensorMapEncodeTiled);
-    __call_driver_fn(
-      __driver_fn,
-      "Failed to encode TMA descriptor",
-      &__tensorMap,
-      __tensorDataType,
-      __tensorRank,
-      __globalAddress,
-      __globalDim,
-      __globalStrides,
-      __boxDim,
-      __elementStrides,
-      __interleave,
-      __swizzle,
-      __l2Promotion,
-      __oobFill);
-    // workaround for nvbug 5736804
-    if (::cuda::__driver::__version_below(13, 2))
+    const auto __tensor_req_size                = __globalDim[__tensorRank - 1] * __globalStrides[__tensorRank - 1];
+    ::cuda::std::size_t __tensor_req_size_bytes = 0;
+    __tensor_req_size_bytes   = ::cuda::__driver::__cutensormap_size_bytes(__tensor_req_size, __tensorDataType);
+    const auto __tensorMapPtr = reinterpret_cast<::cuda::std::uint64_t*>(&__tensorMap);
+    if (__tensor_req_size_bytes < 128 * 1024) // 128 KiB
     {
-      const auto __tensor_req_size                = __globalDim[__tensorRank - 1] * __globalStrides[__tensorRank - 1];
-      ::cuda::std::size_t __tensor_req_size_bytes = 0;
-      __tensor_req_size_bytes   = ::cuda::__driver::__cutensormap_size_bytes(__tensor_req_size, __tensorDataType);
-      const auto __tensorMapPtr = reinterpret_cast<::cuda::std::uint64_t*>(&__tensorMap);
-      if (__tensor_req_size_bytes < 128 * 1024) // 128 KiB
-      {
-        __tensorMapPtr[1] &= ~(::cuda::std::uint64_t{1} << 21); // clear the bit
-      }
-      else
-      {
-        __tensorMapPtr[1] |= ::cuda::std::uint64_t{1} << 21; // set the bit
-      }
+      __tensorMapPtr[1] &= ~(::cuda::std::uint64_t{1} << 21); // clear the bit
     }
-    return __tensorMap;
+    else
+    {
+      __tensorMapPtr[1] |= ::cuda::std::uint64_t{1} << 21; // set the bit
+    }
   }
+  return __tensorMap;
+}
 
 #  undef _CCCLRT_GET_DRIVER_FUNCTION
 #  undef _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED
 
-  _CCCL_END_NAMESPACE_CUDA_DRIVER
+_CCCL_END_NAMESPACE_CUDA_DRIVER
 
 #  include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -778,6 +778,15 @@ __streamDestroyNoThrow(::CUstream __stream) noexcept // NOLINT(bugprone-exceptio
   return static_cast<::cudaError_t>(__driver_fn(__stream));
 }
 
+[[nodiscard]] _CCCL_HOST_API inline ::CUstreamCaptureStatus __streamIsCapturing(::CUstream __stream)
+{
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamIsCapturing);
+  ::CUstreamCaptureStatus __ret{};
+
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the capture status of a stream", __stream, &__ret);
+  return __ret;
+}
+
 // Event management
 
 [[nodiscard]] _CCCL_HOST_API inline ::CUevent __eventCreate(unsigned __flags)
@@ -1007,147 +1016,145 @@ __graphKernelNodeSetAttribute(::CUgraphNode __node, ::CUkernelNodeAttrID __id, c
   ::CUdevice __peer_dev) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceCanAccessPeer);
-  return static_cast<::cudaError_t>(__driver_fn(&__result, __dev, __peer_dev));
-}
 
-// Green contexts
+  // Green contexts
 
 #  if _CCCL_CTK_AT_LEAST(12, 5)
-// Add actual resource description input once exposure is ready
-[[nodiscard]] _CCCL_HOST_API inline ::CUgreenCtx __greenCtxCreate(::CUdevice __dev)
-{
-  ::CUgreenCtx __result;
-  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxCreate, cuGreenCtxCreate, 12, 5);
-  ::cuda::__driver::__call_driver_fn(
-    __driver_fn, "Failed to create a green context", &__result, nullptr, __dev, ::CU_GREEN_CTX_DEFAULT_STREAM);
-  return __result;
-}
+  // Add actual resource description input once exposure is ready
+  [[nodiscard]] _CCCL_HOST_API inline ::CUgreenCtx __greenCtxCreate(::CUdevice __dev)
+  {
+    ::CUgreenCtx __result;
+    static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxCreate, cuGreenCtxCreate, 12, 5);
+    ::cuda::__driver::__call_driver_fn(
+      __driver_fn, "Failed to create a green context", &__result, nullptr, __dev, ::CU_GREEN_CTX_DEFAULT_STREAM);
+    return __result;
+  }
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
-__greenCtxDestroyNoThrow(::CUgreenCtx __green_ctx) noexcept // NOLINT(bugprone-exception-escape)
-{
-  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxDestroy, cuGreenCtxDestroy, 12, 5);
-  return static_cast<::cudaError_t>(__driver_fn(__green_ctx));
-}
-[[nodiscard]] _CCCL_HOST_API inline ::CUcontext __ctxFromGreenCtx(::CUgreenCtx __green_ctx)
-{
-  ::CUcontext __result;
-  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuCtxFromGreenCtx, cuCtxFromGreenCtx, 12, 5);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to convert a green context", &__result, __green_ctx);
-  return __result;
-}
+  [[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __greenCtxDestroyNoThrow(
+    ::CUgreenCtx __green_ctx) noexcept // NOLINT(bugprone-exception-escape)
+  {
+    static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxDestroy, cuGreenCtxDestroy, 12, 5);
+    return static_cast<::cudaError_t>(__driver_fn(__green_ctx));
+  }
+  [[nodiscard]] _CCCL_HOST_API inline ::CUcontext __ctxFromGreenCtx(::CUgreenCtx __green_ctx)
+  {
+    ::CUcontext __result;
+    static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuCtxFromGreenCtx, cuCtxFromGreenCtx, 12, 5);
+    ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to convert a green context", &__result, __green_ctx);
+    return __result;
+  }
 #  endif // _CCCL_CTK_AT_LEAST(12, 5)
 
 #  if _CCCL_CTK_AT_LEAST(13, 0)
-[[nodiscard]] _CCCL_HOST_API inline unsigned long long __greenCtxGetId(::CUgreenCtx __green_ctx)
-{
-  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxGetId, cuGreenCtxGetId, 13, 0);
-  unsigned long long __id;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the ID of a green context", __green_ctx, &__id);
-  return __id;
-}
+  [[nodiscard]] _CCCL_HOST_API inline unsigned long long __greenCtxGetId(::CUgreenCtx __green_ctx)
+  {
+    static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxGetId, cuGreenCtxGetId, 13, 0);
+    unsigned long long __id;
+    ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the ID of a green context", __green_ctx, &__id);
+    return __id;
+  }
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
 
-[[nodiscard]] _CCCL_HOST_API inline ::cuda::std::size_t
-__cutensormap_size_bytes(::cuda::std::size_t __num_items, ::CUtensorMapDataType __data_type)
-{
-  constexpr auto __max_size = ::cuda::std::numeric_limits<::cuda::std::size_t>::max();
-  switch (__data_type)
+  [[nodiscard]] _CCCL_HOST_API inline ::cuda::std::size_t __cutensormap_size_bytes(
+    ::cuda::std::size_t __num_items, ::CUtensorMapDataType __data_type)
   {
-    case ::CU_TENSOR_MAP_DATA_TYPE_UINT8:
+    constexpr auto __max_size = ::cuda::std::numeric_limits<::cuda::std::size_t>::max();
+    switch (__data_type)
+    {
+      case ::CU_TENSOR_MAP_DATA_TYPE_UINT8:
 #  if _CCCL_CTK_AT_LEAST(12, 8)
-    case ::CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B:
+      case ::CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B:
 #  endif // _CCCL_CTK_AT_LEAST(12, 8)
-      return __num_items;
-    case ::CU_TENSOR_MAP_DATA_TYPE_UINT16:
-    case ::CU_TENSOR_MAP_DATA_TYPE_BFLOAT16:
-    case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT16:
-      if (__num_items > __max_size / 2)
-      {
-        _CCCL_THROW(::std::invalid_argument, "Number of items must be less than or equal to 2^64 / 2");
-      }
-      return __num_items * 2;
-    case ::CU_TENSOR_MAP_DATA_TYPE_INT32:
-    case ::CU_TENSOR_MAP_DATA_TYPE_UINT32:
-    case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT32:
-    case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT32_FTZ:
-    case ::CU_TENSOR_MAP_DATA_TYPE_TFLOAT32:
-    case ::CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ:
-      if (__num_items > __max_size / 4)
-      {
-        _CCCL_THROW(::std::invalid_argument, "Number of items must be less than or equal to 2^64 / 4");
-      }
-      return __num_items * 4;
-    case ::CU_TENSOR_MAP_DATA_TYPE_INT64:
-    case ::CU_TENSOR_MAP_DATA_TYPE_UINT64:
-    case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT64:
-      if (__num_items > __max_size / 8)
-      {
-        _CCCL_THROW(::std::invalid_argument, "Number of items must be less than or equal to 2^64 / 8");
-      }
-      return __num_items * 8;
+        return __num_items;
+      case ::CU_TENSOR_MAP_DATA_TYPE_UINT16:
+      case ::CU_TENSOR_MAP_DATA_TYPE_BFLOAT16:
+      case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT16:
+        if (__num_items > __max_size / 2)
+        {
+          _CCCL_THROW(::std::invalid_argument, "Number of items must be less than or equal to 2^64 / 2");
+        }
+        return __num_items * 2;
+      case ::CU_TENSOR_MAP_DATA_TYPE_INT32:
+      case ::CU_TENSOR_MAP_DATA_TYPE_UINT32:
+      case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT32:
+      case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT32_FTZ:
+      case ::CU_TENSOR_MAP_DATA_TYPE_TFLOAT32:
+      case ::CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ:
+        if (__num_items > __max_size / 4)
+        {
+          _CCCL_THROW(::std::invalid_argument, "Number of items must be less than or equal to 2^64 / 4");
+        }
+        return __num_items * 4;
+      case ::CU_TENSOR_MAP_DATA_TYPE_INT64:
+      case ::CU_TENSOR_MAP_DATA_TYPE_UINT64:
+      case ::CU_TENSOR_MAP_DATA_TYPE_FLOAT64:
+        if (__num_items > __max_size / 8)
+        {
+          _CCCL_THROW(::std::invalid_argument, "Number of items must be less than or equal to 2^64 / 8");
+        }
+        return __num_items * 8;
 #  if _CCCL_CTK_AT_LEAST(12, 8)
-    case ::CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B:
-    case ::CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B:
-      return __num_items / 2;
+      case ::CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B:
+      case ::CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B:
+        return __num_items / 2;
 #  endif // _CCCL_CTK_AT_LEAST(12, 8)
+    }
+    return 0; // MSVC workaround
   }
-  return 0; // MSVC workaround
-}
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUtensorMap __tensorMapEncodeTiled(
-  ::CUtensorMapDataType __tensorDataType,
-  ::cuda::std::uint32_t __tensorRank,
-  void* __globalAddress,
-  const ::cuda::std::uint64_t* __globalDim,
-  const ::cuda::std::uint64_t* __globalStrides,
-  const ::cuda::std::uint32_t* __boxDim,
-  const ::cuda::std::uint32_t* __elementStrides,
-  ::CUtensorMapInterleave __interleave,
-  ::CUtensorMapSwizzle __swizzle,
-  ::CUtensorMapL2promotion __l2Promotion,
-  ::CUtensorMapFloatOOBfill __oobFill)
-{
-  ::CUtensorMap __tensorMap{};
-  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuTensorMapEncodeTiled);
-  __call_driver_fn(
-    __driver_fn,
-    "Failed to encode TMA descriptor",
-    &__tensorMap,
-    __tensorDataType,
-    __tensorRank,
-    __globalAddress,
-    __globalDim,
-    __globalStrides,
-    __boxDim,
-    __elementStrides,
-    __interleave,
-    __swizzle,
-    __l2Promotion,
-    __oobFill);
-  // workaround for nvbug 5736804
-  if (::cuda::__driver::__version_below(13, 2))
+  [[nodiscard]] _CCCL_HOST_API inline ::CUtensorMap __tensorMapEncodeTiled(
+    ::CUtensorMapDataType __tensorDataType,
+    ::cuda::std::uint32_t __tensorRank,
+    void* __globalAddress,
+    const ::cuda::std::uint64_t* __globalDim,
+    const ::cuda::std::uint64_t* __globalStrides,
+    const ::cuda::std::uint32_t* __boxDim,
+    const ::cuda::std::uint32_t* __elementStrides,
+    ::CUtensorMapInterleave __interleave,
+    ::CUtensorMapSwizzle __swizzle,
+    ::CUtensorMapL2promotion __l2Promotion,
+    ::CUtensorMapFloatOOBfill __oobFill)
   {
-    const auto __tensor_req_size                = __globalDim[__tensorRank - 1] * __globalStrides[__tensorRank - 1];
-    ::cuda::std::size_t __tensor_req_size_bytes = 0;
-    __tensor_req_size_bytes   = ::cuda::__driver::__cutensormap_size_bytes(__tensor_req_size, __tensorDataType);
-    const auto __tensorMapPtr = reinterpret_cast<::cuda::std::uint64_t*>(&__tensorMap);
-    if (__tensor_req_size_bytes < 128 * 1024) // 128 KiB
+    ::CUtensorMap __tensorMap{};
+    static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuTensorMapEncodeTiled);
+    __call_driver_fn(
+      __driver_fn,
+      "Failed to encode TMA descriptor",
+      &__tensorMap,
+      __tensorDataType,
+      __tensorRank,
+      __globalAddress,
+      __globalDim,
+      __globalStrides,
+      __boxDim,
+      __elementStrides,
+      __interleave,
+      __swizzle,
+      __l2Promotion,
+      __oobFill);
+    // workaround for nvbug 5736804
+    if (::cuda::__driver::__version_below(13, 2))
     {
-      __tensorMapPtr[1] &= ~(::cuda::std::uint64_t{1} << 21); // clear the bit
+      const auto __tensor_req_size                = __globalDim[__tensorRank - 1] * __globalStrides[__tensorRank - 1];
+      ::cuda::std::size_t __tensor_req_size_bytes = 0;
+      __tensor_req_size_bytes   = ::cuda::__driver::__cutensormap_size_bytes(__tensor_req_size, __tensorDataType);
+      const auto __tensorMapPtr = reinterpret_cast<::cuda::std::uint64_t*>(&__tensorMap);
+      if (__tensor_req_size_bytes < 128 * 1024) // 128 KiB
+      {
+        __tensorMapPtr[1] &= ~(::cuda::std::uint64_t{1} << 21); // clear the bit
+      }
+      else
+      {
+        __tensorMapPtr[1] |= ::cuda::std::uint64_t{1} << 21; // set the bit
+      }
     }
-    else
-    {
-      __tensorMapPtr[1] |= ::cuda::std::uint64_t{1} << 21; // set the bit
-    }
+    return __tensorMap;
   }
-  return __tensorMap;
-}
 
 #  undef _CCCLRT_GET_DRIVER_FUNCTION
 #  undef _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED
 
-_CCCL_END_NAMESPACE_CUDA_DRIVER
+  _CCCL_END_NAMESPACE_CUDA_DRIVER
 
 #  include <cuda/std/__cccl/epilogue.h>
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

If the types are trivial (and the same!) and the mdspans both cover a complete linear region of memory, then we can fall back to a byte-copy instead of launching (or instantiating) a CUB kernel to do the same. Since this might use a copy engine rather than regular GPU resources it allows better overlap of compute and data movement.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
