### PR TITLE
Add stdpar smoke test for transform_reduce

### DIFF
--- a/test/stdpar/tests/transform_reduce.cpp
+++ b/test/stdpar/tests/transform_reduce.cpp
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA C++ Core Libraries, under the Apache License v2.0 with
+// LLVM Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/version>
+
+#include <cstddef>
+#include <execution>
+#include <numeric>
+#include <vector>
+
+// Ensure that we are indeed using the correct CCCL version
+static_assert(CCCL_MAJOR_VERSION == CMAKE_CCCL_VERSION_MAJOR);
+static_assert(CCCL_MINOR_VERSION == CMAKE_CCCL_VERSION_MINOR);
+static_assert(CCCL_PATCH_VERSION == CMAKE_CCCL_VERSION_PATCH);
+
+int main()
+{
+  constexpr std::size_t num_items = 1 << 16;
+  constexpr int input_value       = 2;
+  constexpr int input_weight      = 3;
+  const std::vector<int> values(num_items, input_value);
+  const std::vector<int> weights(num_items, input_weight);
+
+  constexpr int dot_product_init = 7;
+  const int dot_product =
+    std::transform_reduce(std::execution::par, values.begin(), values.end(), weights.begin(), dot_product_init);
+  constexpr int expected_dot_product = dot_product_init + int{num_items} * input_value * input_weight;
+
+  if (dot_product != expected_dot_product)
+  {
+    return 1;
+  }
+
+  constexpr auto maximum = [](const int lhs, const int rhs) {
+    return lhs < rhs ? rhs : lhs;
+  };
+
+  constexpr auto squared_difference = [](const int lhs, const int rhs) {
+    const int difference = lhs - rhs;
+    return difference * difference;
+  };
+
+  constexpr int maximum_init           = 0;
+  const int maximum_squared_difference = std::transform_reduce(
+    std::execution::par, values.begin(), values.end(), weights.begin(), maximum_init, maximum, squared_difference);
+  constexpr int input_difference                    = input_value - input_weight;
+  constexpr int expected_maximum_squared_difference = input_difference * input_difference;
+
+  if (maximum_squared_difference != expected_maximum_squared_difference)
+  {
+    return 1;
+  }
+
+  constexpr auto add = [](const int lhs, const int rhs) {
+    return lhs + rhs;
+  };
+
+  constexpr auto square = [](const int value) {
+    return value * value;
+  };
+
+  constexpr int sum_of_squares_init = 11;
+  const int sum_of_squares =
+    std::transform_reduce(std::execution::par, values.begin(), values.end(), sum_of_squares_init, add, square);
+  constexpr int expected_sum_of_squares = sum_of_squares_init + int{num_items} * input_value * input_value;
+
+  if (sum_of_squares != expected_sum_of_squares)
+  {
+    return 1;
+  }
+
+  constexpr int empty_init = 42;
+  const int empty_result =
+    std::transform_reduce(std::execution::par, values.begin(), values.begin(), weights.begin(), empty_init);
+
+  if (empty_result != empty_init)
+  {
+    return 1;
+  }
+
+  return 0;
+}

--- a/test/stdpar/tests/transform_reduce.cpp
+++ b/test/stdpar/tests/transform_reduce.cpp
@@ -24,13 +24,20 @@ int main()
   constexpr std::size_t num_items = 1 << 16;
   constexpr int input_value       = 2;
   constexpr int input_weight      = 3;
-  const std::vector<int> values(num_items, input_value);
-  const std::vector<int> weights(num_items, input_weight);
+  constexpr int sentinel_value    = 5;
+  constexpr int sentinel_weight   = 7;
+
+  std::vector<int> values(num_items, input_value);
+  std::vector<int> weights(num_items, input_weight);
+  values[num_items / 2]  = sentinel_value;
+  weights[num_items / 2] = sentinel_weight;
 
   constexpr int dot_product_init = 7;
   const int dot_product =
     std::transform_reduce(std::execution::par, values.begin(), values.end(), weights.begin(), dot_product_init);
-  constexpr int expected_dot_product = dot_product_init + int{num_items} * input_value * input_weight;
+  constexpr int regular_item_count = int{num_items} - 1;
+  constexpr int expected_dot_product =
+    dot_product_init + regular_item_count * input_value * input_weight + sentinel_value * sentinel_weight;
 
   if (dot_product != expected_dot_product)
   {
@@ -49,8 +56,8 @@ int main()
   constexpr int maximum_init           = 0;
   const int maximum_squared_difference = std::transform_reduce(
     std::execution::par, values.begin(), values.end(), weights.begin(), maximum_init, maximum, squared_difference);
-  constexpr int input_difference                    = input_value - input_weight;
-  constexpr int expected_maximum_squared_difference = input_difference * input_difference;
+  constexpr int sentinel_difference                 = sentinel_value - sentinel_weight;
+  constexpr int expected_maximum_squared_difference = sentinel_difference * sentinel_difference;
 
   if (maximum_squared_difference != expected_maximum_squared_difference)
   {
@@ -68,7 +75,8 @@ int main()
   constexpr int sum_of_squares_init = 11;
   const int sum_of_squares =
     std::transform_reduce(std::execution::par, values.begin(), values.end(), sum_of_squares_init, add, square);
-  constexpr int expected_sum_of_squares = sum_of_squares_init + int{num_items} * input_value * input_value;
+  constexpr int expected_sum_of_squares =
+    sum_of_squares_init + regular_item_count * input_value * input_value + sentinel_value * sentinel_value;
 
   if (sum_of_squares != expected_sum_of_squares)
   {


### PR DESCRIPTION
## Description

Adds an NVHPC stdpar smoke test for `std::transform_reduce` as part of #6486.

The test instantiates all three execution-policy overloads used by NVHPC's GPU stdpar backend:

- Two-range transformation with default reduction and transformation operations.
- Two-range transformation with custom reduction and binary transformation operations.
- One-range transformation with custom reduction and unary transformation operations.

It validates the returned reductions and empty-range behavior. It also verifies that the test is compiled against the CCCL version selected by CMake.

## Validation

- `pre-commit run --files test/stdpar/tests/transform_reduce.cpp`
- `stdpar_test_transform_reduce` CMake target in C++17 with NVHPC 26.5 and CUDA 13.2
- `stdpar_test_transform_reduce` CMake target in C++20 with NVHPC 26.5 and CUDA 13.2
- `-Minfo=stdpar` confirms all four calls are parallelized on GPU

## Checklist

- [x] New or existing tests cover these changes.
- [x] No documentation changes are needed.