### PR TITLE
[Cub] Limit lookahead atomic size

### DIFF
--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -43,7 +43,9 @@ namespace detail::warpspeed
 {
 [[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL ::cuda::std::size_t max_native_atomic_size() noexcept
 {
-#if _CCCL_CUDA_COMPILER(NVHPC)
+#if !_CCCL_HAS_INT128()
+  return 8;
+#elif _CCCL_CUDA_COMPILER(NVHPC)
   return 8;
 #else // ^^^ _CCCL_CUDA_COMPILER(NVHPC) ^^^ / vvv !_CCCL_CUDA_COMPILER(NVHPC)  vvv
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90, (return 16;), (return 8;))


### PR DESCRIPTION
We cannot use int128 if its not there