### PR TITLE
[Tile] Disable execution checks in thrust defaulted constructors

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/sequence_access.h
+++ b/libcudacxx/include/cuda/std/__cccl/sequence_access.h
@@ -24,60 +24,65 @@
 
 // We need to define hidden friends for {cr,r,}{begin,end} of our containers as we will otherwise encounter ambigouities
 #define _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(_ClassName, _ConstIter)                                                       \
-  [[nodiscard]] _CCCL_API friend iterator begin(_ClassName& __sequence) noexcept(noexcept(__sequence.begin()))         \
-  {                                                                                                                    \
-    return __sequence.begin();                                                                                         \
-  }                                                                                                                    \
-  [[nodiscard]] _CCCL_API friend _ConstIter begin(const _ClassName& __sequence) noexcept(noexcept(__sequence.begin())) \
-  {                                                                                                                    \
-    return __sequence.begin();                                                                                         \
-  }                                                                                                                    \
-  [[nodiscard]] _CCCL_API friend iterator end(_ClassName& __sequence) noexcept(noexcept(__sequence.end()))             \
-  {                                                                                                                    \
-    return __sequence.end();                                                                                           \
-  }                                                                                                                    \
-  [[nodiscard]] _CCCL_API friend _ConstIter end(const _ClassName& __sequence) noexcept(noexcept(__sequence.end()))     \
-  {                                                                                                                    \
-    return __sequence.end();                                                                                           \
-  }                                                                                                                    \
-  [[nodiscard]] _CCCL_API friend _ConstIter cbegin(const _ClassName& __sequence) noexcept(                             \
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend iterator begin(_ClassName& __sequence) noexcept(                          \
     noexcept(__sequence.begin()))                                                                                      \
   {                                                                                                                    \
     return __sequence.begin();                                                                                         \
   }                                                                                                                    \
-  [[nodiscard]] _CCCL_API friend _ConstIter cend(const _ClassName& __sequence) noexcept(noexcept(__sequence.end()))    \
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend _ConstIter begin(const _ClassName& __sequence) noexcept(                  \
+    noexcept(__sequence.begin()))                                                                                      \
+  {                                                                                                                    \
+    return __sequence.begin();                                                                                         \
+  }                                                                                                                    \
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend iterator end(_ClassName& __sequence) noexcept(noexcept(__sequence.end())) \
+  {                                                                                                                    \
+    return __sequence.end();                                                                                           \
+  }                                                                                                                    \
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend _ConstIter end(const _ClassName& __sequence) noexcept(                    \
+    noexcept(__sequence.end()))                                                                                        \
+  {                                                                                                                    \
+    return __sequence.end();                                                                                           \
+  }                                                                                                                    \
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend _ConstIter cbegin(const _ClassName& __sequence) noexcept(                 \
+    noexcept(__sequence.begin()))                                                                                      \
+  {                                                                                                                    \
+    return __sequence.begin();                                                                                         \
+  }                                                                                                                    \
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend _ConstIter cend(const _ClassName& __sequence) noexcept(                   \
+    noexcept(__sequence.end()))                                                                                        \
   {                                                                                                                    \
     return __sequence.end();                                                                                           \
   }
-#define _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(_ClassName, _ConstRevIter)                                          \
-  [[nodiscard]] _CCCL_API friend reverse_iterator rbegin(_ClassName& __sequence) noexcept(                           \
-    noexcept(__sequence.rbegin()))                                                                                   \
-  {                                                                                                                  \
-    return __sequence.rbegin();                                                                                      \
-  }                                                                                                                  \
-  [[nodiscard]] _CCCL_API friend _ConstRevIter rbegin(const _ClassName& __sequence) noexcept(                        \
-    noexcept(__sequence.rbegin()))                                                                                   \
-  {                                                                                                                  \
-    return __sequence.rbegin();                                                                                      \
-  }                                                                                                                  \
-  [[nodiscard]] _CCCL_API friend reverse_iterator rend(_ClassName& __sequence) noexcept(noexcept(__sequence.rend())) \
-  {                                                                                                                  \
-    return __sequence.rend();                                                                                        \
-  }                                                                                                                  \
-  [[nodiscard]] _CCCL_API friend _ConstRevIter rend(const _ClassName& __sequence) noexcept(                          \
-    noexcept(__sequence.rend()))                                                                                     \
-  {                                                                                                                  \
-    return __sequence.rend();                                                                                        \
-  }                                                                                                                  \
-  [[nodiscard]] _CCCL_API friend _ConstRevIter crbegin(const _ClassName& __sequence) noexcept(                       \
-    noexcept(__sequence.rbegin()))                                                                                   \
-  {                                                                                                                  \
-    return __sequence.rbegin();                                                                                      \
-  }                                                                                                                  \
-  [[nodiscard]] _CCCL_API friend _ConstRevIter crend(const _ClassName& __sequence) noexcept(                         \
-    noexcept(__sequence.rend()))                                                                                     \
-  {                                                                                                                  \
-    return __sequence.rend();                                                                                        \
+#define _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(_ClassName, _ConstRevIter)                                \
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend reverse_iterator rbegin(_ClassName& __sequence) noexcept(     \
+    noexcept(__sequence.rbegin()))                                                                         \
+  {                                                                                                        \
+    return __sequence.rbegin();                                                                            \
+  }                                                                                                        \
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend _ConstRevIter rbegin(const _ClassName& __sequence) noexcept(  \
+    noexcept(__sequence.rbegin()))                                                                         \
+  {                                                                                                        \
+    return __sequence.rbegin();                                                                            \
+  }                                                                                                        \
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend reverse_iterator rend(_ClassName& __sequence) noexcept(       \
+    noexcept(__sequence.rend()))                                                                           \
+  {                                                                                                        \
+    return __sequence.rend();                                                                              \
+  }                                                                                                        \
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend _ConstRevIter rend(const _ClassName& __sequence) noexcept(    \
+    noexcept(__sequence.rend()))                                                                           \
+  {                                                                                                        \
+    return __sequence.rend();                                                                              \
+  }                                                                                                        \
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend _ConstRevIter crbegin(const _ClassName& __sequence) noexcept( \
+    noexcept(__sequence.rbegin()))                                                                         \
+  {                                                                                                        \
+    return __sequence.rbegin();                                                                            \
+  }                                                                                                        \
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend _ConstRevIter crend(const _ClassName& __sequence) noexcept(   \
+    noexcept(__sequence.rend()))                                                                           \
+  {                                                                                                        \
+    return __sequence.rend();                                                                              \
   }
 
 #endif // __CCCL_SEQUENCE_ACCESS_H

--- a/thrust/testing/device_delete.cu
+++ b/thrust/testing/device_delete.cu
@@ -38,6 +38,7 @@ void TestDeviceDeleteDestructorInvocation()
 }
 DECLARE_UNITTEST(TestDeviceDeleteDestructorInvocation);
 
+#if !_CCCL_TILE_COMPILATION() // Virtual functions are not supported in tile mode
 // based on: https://github.com/NVIDIA/cccl/issues/6132
 struct base
 {
@@ -89,3 +90,4 @@ void TestDeviceDeleteVirtualDestructorInvocation()
   }
 }
 DECLARE_UNITTEST(TestDeviceDeleteVirtualDestructorInvocation);
+#endif // !_CCCL_TILE_COMPILATION()

--- a/thrust/thrust/detail/allocator/tagged_allocator.h
+++ b/thrust/thrust/detail/allocator/tagged_allocator.h
@@ -61,6 +61,7 @@ public:
     using other = tagged_allocator<U, Tag, Pointer>;
   }; // end rebind
 
+  _CCCL_EXEC_CHECK_DISABLE
   tagged_allocator() = default;
 
   tagged_allocator(const tagged_allocator&) = default;

--- a/thrust/thrust/detail/pointer.h
+++ b/thrust/thrust/detail/pointer.h
@@ -170,11 +170,13 @@ public:
 
   /*! \p pointer's default constructor initializes its encapsulated pointer to \c 0
    */
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE pointer()
       : super_t(static_cast<Element*>(nullptr))
   {}
 
   // NOTE: This is needed so that Thrust smart pointers can be used in `std::unique_ptr`.
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE pointer(::cuda::std::nullptr_t)
       : super_t(static_cast<Element*>(nullptr))
   {}

--- a/thrust/thrust/detail/pointer.h
+++ b/thrust/thrust/detail/pointer.h
@@ -171,13 +171,13 @@ public:
   /*! \p pointer's default constructor initializes its encapsulated pointer to \c 0
    */
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_HOST_DEVICE pointer()
+  _CCCL_API pointer()
       : super_t(static_cast<Element*>(nullptr))
   {}
 
   // NOTE: This is needed so that Thrust smart pointers can be used in `std::unique_ptr`.
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_HOST_DEVICE pointer(::cuda::std::nullptr_t)
+  _CCCL_API pointer(::cuda::std::nullptr_t)
       : super_t(static_cast<Element*>(nullptr))
   {}
 
@@ -187,8 +187,9 @@ public:
    *  \tparam OtherElement \p OtherElement shall be convertible to \p Element.
    */
   // XXX consider making the pointer implementation a template parameter which defaults to Element *
+  _CCCL_EXEC_CHECK_DISABLE
   template <typename OtherElement>
-  _CCCL_HOST_DEVICE explicit pointer(OtherElement* ptr)
+  _CCCL_API explicit pointer(OtherElement* ptr)
       : super_t(ptr)
   {}
 
@@ -199,17 +200,19 @@ public:
    *  \tparam OtherPointer The tag associated with \p OtherPointer shall be convertible to \p Tag,
    *                       and its element type shall be convertible to \p Element.
    */
+  _CCCL_EXEC_CHECK_DISABLE
   template <typename OtherPointer, detail::enable_if_pointer_is_convertible_t<OtherPointer, pointer>* = nullptr>
-  _CCCL_HOST_DEVICE pointer(const OtherPointer& other)
+  _CCCL_API pointer(const OtherPointer& other)
       : super_t(static_cast<Element*>(::cuda::std::to_address(other)))
   {}
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Doxygen cannot handle this constructor and creates a duplicate ID with the ctor above
   // OtherPointer's element_type shall be void
   // OtherPointer's system shall be convertible to Tag
+  _CCCL_EXEC_CHECK_DISABLE
   template <typename OtherPointer,
             detail::enable_if_void_pointer_is_system_convertible_t<OtherPointer, pointer>* = nullptr>
-  _CCCL_HOST_DEVICE explicit pointer(const OtherPointer& other)
+  _CCCL_API explicit pointer(const OtherPointer& other)
       : super_t(static_cast<Element*>(::cuda::std::to_address(other)))
   {}
 #endif
@@ -217,7 +220,8 @@ public:
   // assignment
 
   // NOTE: This is needed so that Thrust smart pointers can be used in `std::unique_ptr`.
-  _CCCL_HOST_DEVICE derived_type& operator=(::cuda::std::nullptr_t)
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_API derived_type& operator=(::cuda::std::nullptr_t)
   {
     super_t::base_reference() = nullptr;
     return static_cast<derived_type&>(*this);
@@ -232,8 +236,9 @@ public:
    *  \tparam OtherPointer The tag associated with \p OtherPointer shall be convertible to \p Tag,
    *                       and its element type shall be convertible to \p Element.
    */
+  _CCCL_EXEC_CHECK_DISABLE
   template <typename OtherPointer>
-  _CCCL_HOST_DEVICE detail::enable_if_pointer_is_convertible_t<OtherPointer, pointer, derived_type&>
+  _CCCL_API detail::enable_if_pointer_is_convertible_t<OtherPointer, pointer, derived_type&>
   operator=(const OtherPointer& other)
   {
     super_t::base_reference() = ::cuda::std::to_address(other);

--- a/thrust/thrust/detail/seq.h
+++ b/thrust/thrust/detail/seq.h
@@ -21,6 +21,7 @@ struct seq_t
     : system::detail::sequential::execution_policy<seq_t>
     , allocator_aware_execution_policy<system::detail::sequential::execution_policy>
 {
+  _CCCL_EXEC_CHECK_DISABLE
   constexpr seq_t() = default;
 
   // allow any execution_policy to convert to the sequential one. required for minimum_system to pick it

--- a/thrust/thrust/device_allocator.h
+++ b/thrust/thrust/device_allocator.h
@@ -120,6 +120,7 @@ public:
   };
 
   /*! Default constructor has no effect. */
+  _CCCL_EXEC_CHECK_DISABLE
   device_allocator() = default;
 
   /*! Copy constructor has no effect. */

--- a/thrust/thrust/device_ptr.h
+++ b/thrust/thrust/device_ptr.h
@@ -76,6 +76,7 @@ private:
   using super_t = thrust::pointer<T, thrust::device_system_tag, thrust::device_reference<T>, thrust::device_ptr<T>>;
 
 public:
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HIDE_FROM_ABI device_ptr() = default;
 
   /*! \brief Construct a null \c device_ptr.

--- a/thrust/thrust/iterator/constant_iterator.h
+++ b/thrust/thrust/iterator/constant_iterator.h
@@ -119,6 +119,7 @@ public:
   //! \endcond
 
   //! Default constructor initializes this \p constant_iterator's constant using its default constructor
+  _CCCL_EXEC_CHECK_DISABLE
   constant_iterator() = default;
 
   //! Copy constructor copies the value of another \p constant_iterator with related System type.

--- a/thrust/thrust/iterator/detail/normal_iterator.h
+++ b/thrust/thrust/iterator/detail/normal_iterator.h
@@ -33,6 +33,7 @@ class normal_iterator : public iterator_adaptor<normal_iterator<Pointer>, Pointe
   using super_t = iterator_adaptor<normal_iterator<Pointer>, Pointer>;
 
 public:
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HIDE_FROM_ABI normal_iterator() = default;
 
   _CCCL_HOST_DEVICE normal_iterator(Pointer p)

--- a/thrust/thrust/iterator/detail/tagged_iterator.h
+++ b/thrust/thrust/iterator/detail/tagged_iterator.h
@@ -39,6 +39,7 @@ class tagged_iterator : public make_tagged_iterator_base<Iterator, Tag>
   using super_t = make_tagged_iterator_base<Iterator, Tag>;
 
 public:
+  _CCCL_EXEC_CHECK_DISABLE
   tagged_iterator() = default;
 
   _CCCL_HOST_DEVICE explicit tagged_iterator(Iterator x)

--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -121,6 +121,7 @@ public:
   using super_t = ::cuda::std::tuple<Ts...>;
   using super_t::super_t;
 
+  _CCCL_EXEC_CHECK_DISABLE
   tuple_of_iterator_references() = default;
 
   // allow implicit construction from cuda::std::tuple<refs>

--- a/thrust/thrust/iterator/iterator_adaptor.h
+++ b/thrust/thrust/iterator/iterator_adaptor.h
@@ -27,9 +27,13 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
 #include <thrust/detail/use_default.h>
 #include <thrust/iterator/detail/iterator_adaptor_base.h>
 #include <thrust/iterator/iterator_facade.h>
+
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_default_constructible.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -131,6 +135,7 @@ protected:
 public:
   /*! \p iterator_adaptor's default constructor does nothing.
    */
+  _CCCL_EXEC_CHECK_DISABLE
   iterator_adaptor() = default;
 
   /*! This constructor copies from a given instance of the \p Base iterator.

--- a/thrust/thrust/iterator/iterator_adaptor.h
+++ b/thrust/thrust/iterator/iterator_adaptor.h
@@ -141,7 +141,7 @@ public:
   /*! This constructor copies from a given instance of the \p Base iterator.
    */
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_HOST_DEVICE explicit iterator_adaptor(Base const& iter)
+  _CCCL_API explicit iterator_adaptor(Base const& iter)
       : m_iterator(iter)
   {}
 

--- a/thrust/thrust/iterator/permutation_iterator.h
+++ b/thrust/thrust/iterator/permutation_iterator.h
@@ -127,6 +127,7 @@ permutation_iterator : public detail::make_permutation_iterator_base<ElementIter
 
 public:
   //! Null constructor calls the null constructor of this \p permutation_iterator's element iterator.
+  _CCCL_EXEC_CHECK_DISABLE
   permutation_iterator() = default;
 
   //! Constructor accepts an \c ElementIterator into a range of values and an \c IndexIterator into a range of indices

--- a/thrust/thrust/iterator/strided_iterator.h
+++ b/thrust/thrust/iterator/strided_iterator.h
@@ -76,6 +76,7 @@ public:
   static_assert(::cuda::std::is_convertible_v<decltype(StrideHolder::value), difference_type>,
                 "The stride must be convertible to the iterator's difference_type");
 
+  _CCCL_EXEC_CHECK_DISABLE
   strided_iterator() = default;
 
   //! @brief Creates a strided_iterator from an existing iterator and a stride.

--- a/thrust/thrust/iterator/tabulate_output_iterator.h
+++ b/thrust/thrust/iterator/tabulate_output_iterator.h
@@ -114,6 +114,7 @@ public:
   friend class iterator_core_access;
   //! \endcond
 
+  _CCCL_EXEC_CHECK_DISABLE
   tabulate_output_iterator() = default;
 
   //!  This constructor takes as argument a \c BinaryFunction and copies it to a new \p tabulate_output_iterator

--- a/thrust/thrust/iterator/transform_input_output_iterator.h
+++ b/thrust/thrust/iterator/transform_input_output_iterator.h
@@ -160,6 +160,7 @@ public:
   friend class iterator_core_access;
   //! \endcond
 
+  _CCCL_EXEC_CHECK_DISABLE
   transform_input_output_iterator() = default;
 
   //!  This constructor takes as argument a \c Iterator an \c InputFunction and an

--- a/thrust/thrust/iterator/transform_iterator.h
+++ b/thrust/thrust/iterator/transform_iterator.h
@@ -222,8 +222,10 @@ public:
   friend class iterator_core_access;
   //! \endcond
 
+  _CCCL_EXEC_CHECK_DISABLE
   transform_iterator() = default;
 
+  _CCCL_EXEC_CHECK_DISABLE
   transform_iterator(transform_iterator const&) = default;
 
   //! This constructor takes as arguments an \c Iterator and an \c AdaptableUnaryFunction and copies them to a new \p

--- a/thrust/thrust/iterator/transform_output_iterator.h
+++ b/thrust/thrust/iterator/transform_output_iterator.h
@@ -132,6 +132,7 @@ public:
   friend class iterator_core_access;
   //! \endcond
 
+  _CCCL_EXEC_CHECK_DISABLE
   transform_output_iterator() = default;
 
   //! This constructor takes as argument an \c OutputIterator and an \c UnaryFunction and copies them to a new \p

--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -177,6 +177,7 @@ public:
   //! The underlying iterator tuple type. Alias to zip_iterator's first template argument.
   using iterator_tuple = IteratorTuple;
 
+  _CCCL_EXEC_CHECK_DISABLE
   zip_iterator() = default;
 
   //! This constructor creates a new \p zip_iterator from a \p tuple of iterators.


### PR DESCRIPTION
We have issues with execution checks in synthesized constructors, so mark the checks aas explicitly disabled