### PR TITLE
[Tile] Disable execution checks in some tuple / pair helpers

### DIFF
--- a/libcudacxx/include/cuda/__iterator/constant_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/constant_iterator.h
@@ -110,6 +110,15 @@ public:
       : __store_()
   {}
 
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr constant_iterator(const constant_iterator&) = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr constant_iterator(constant_iterator&&) = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr constant_iterator& operator=(const constant_iterator&) = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr constant_iterator& operator=(constant_iterator&&) = default;
+
   //! @brief Creates a @c constant_iterator from a value. The index is set to zero
   //! @param __value The value to store in the @c constant_iterator
   _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__ranges/compressed_movable_box.h
+++ b/libcudacxx/include/cuda/std/__ranges/compressed_movable_box.h
@@ -647,6 +647,15 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1> : __compresse
   using __base1 = __compressed_box<0, _Elem1>;
 
   _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr __compressed_movable_box(const __compressed_movable_box&) = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr __compressed_movable_box(__compressed_movable_box&&) = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr __compressed_movable_box& operator=(const __compressed_movable_box&) = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr __compressed_movable_box& operator=(__compressed_movable_box&&) = default;
+
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Elem1_ = _Elem1)
   _CCCL_REQUIRES(is_default_constructible_v<_Elem1_>)
   _CCCL_API constexpr __compressed_movable_box() noexcept(is_nothrow_default_constructible_v<_Elem1_>)
@@ -689,6 +698,15 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2>
 {
   using __base1 = __compressed_box<0, _Elem1>;
   using __base2 = __compressed_box<1, _Elem2>;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr __compressed_movable_box(const __compressed_movable_box&) = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr __compressed_movable_box(__compressed_movable_box&&) = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr __compressed_movable_box& operator=(const __compressed_movable_box&) = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr __compressed_movable_box& operator=(__compressed_movable_box&&) = default;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Elem1_ = _Elem1, class _Elem2_ = _Elem2)
@@ -780,6 +798,15 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2, _Elem
   using __base1 = __compressed_box<0, _Elem1>;
   using __base2 = __compressed_box<1, _Elem2>;
   using __base3 = __compressed_box<2, _Elem3>;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr __compressed_movable_box(const __compressed_movable_box&) = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr __compressed_movable_box(__compressed_movable_box&&) = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr __compressed_movable_box& operator=(const __compressed_movable_box&) = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI constexpr __compressed_movable_box& operator=(__compressed_movable_box&&) = default;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Elem1_ = _Elem1, class _Elem2_ = _Elem2, class _Elem3_ = _Elem3)

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -95,8 +95,10 @@ public:
   _CCCL_API explicit constexpr tuple() noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
   {}
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HIDE_FROM_ABI tuple(tuple const&) = default;
-  _CCCL_HIDE_FROM_ABI tuple(tuple&&)      = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HIDE_FROM_ABI tuple(tuple&&) = default;
 
   template <class _Alloc,
             __select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_leaf.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_leaf.h
@@ -377,6 +377,7 @@ struct __tuple_like_constructor_tag
 
 // __tuple_impl
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Dest, class _Source, size_t... _Indices>
 _CCCL_API constexpr void __memberwise_copy_assign(_Dest& __dest, _Source const& __source, __tuple_indices<_Indices...>)
 {
@@ -384,6 +385,7 @@ _CCCL_API constexpr void __memberwise_copy_assign(_Dest& __dest, _Source const& 
   ((void) (get<_Indices>(__dest) = get<_Indices>(__source)), ...);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Dest, class _Source, class... _Up, size_t... _Indices>
 _CCCL_API constexpr void
 __memberwise_forward_assign(_Dest& __dest, _Source&& __source, __type_list<_Up...>, __tuple_indices<_Indices...>)
@@ -392,6 +394,7 @@ __memberwise_forward_assign(_Dest& __dest, _Source&& __source, __type_list<_Up..
   ((void) (get<_Indices>(__dest) = ::cuda::std::forward<_Up>(get<_Indices>(__source))), ...);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Dest, class _Source, size_t... _Indices>
 _CCCL_API constexpr void __memberwise_tuple_assign(_Dest& __dest, _Source&& __source, __tuple_indices<_Indices...>)
 {

--- a/libcudacxx/include/cuda/std/__utility/delegate_constructors.h
+++ b/libcudacxx/include/cuda/std/__utility/delegate_constructors.h
@@ -33,16 +33,19 @@
 #if _CCCL_COMPILER(NVRTC, <, 12, 6)
 #  define _CCCL_DELEGATE_CONSTRUCTORS(__class, __baseclass, ...)                                                       \
     using __base = __baseclass<__VA_ARGS__>;                                                                           \
+    _CCCL_EXEC_CHECK_DISABLE                                                                                           \
     _CCCL_TEMPLATE(class... _Args)                                                                                     \
     _CCCL_REQUIRES(::cuda::std::is_constructible_v<__base, _Args...>)                                                  \
     _CCCL_API constexpr __class(_Args&&... __args) noexcept(::cuda::std::is_nothrow_constructible_v<__base, _Args...>) \
         : __base(::cuda::std::forward<_Args>(__args)...)                                                               \
     {}                                                                                                                 \
+    _CCCL_EXEC_CHECK_DISABLE                                                                                           \
     _CCCL_HIDE_FROM_ABI constexpr __class() noexcept(::cuda::std::is_nothrow_default_constructible_v<__base>) = default;
 #else // ^^^ workaround ^^^ / vvv no workaround vvv
 #  define _CCCL_DELEGATE_CONSTRUCTORS(__class, __baseclass, ...) \
     using __base = __baseclass<__VA_ARGS__>;                     \
     using __base::__base;                                        \
+    _CCCL_EXEC_CHECK_DISABLE                                     \
     _CCCL_HIDE_FROM_ABI constexpr __class() noexcept(::cuda::std::is_nothrow_default_constructible_v<__base>) = default;
 #endif // ^^^ no workaround ^^^
 

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -602,6 +602,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   }
   // NOLINTEND(bugprone-use-after-move)
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr void swap(pair& __p) noexcept(is_nothrow_swappable_v<_T1> && is_nothrow_swappable_v<_T2>)
   {
     using ::cuda::std::swap;
@@ -610,6 +611,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   }
 
 #if _CCCL_STD_VER >= 2023
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr void swap(const pair& __p) const
     noexcept(is_nothrow_swappable_v<const _T1> && is_nothrow_swappable_v<const _T2>)
   {


### PR DESCRIPTION
Those were missed, because the use the ADL found overloads.

There are some additional warnings popping up from synthesized constructors, so disable them as well 