### PR TITLE
Add NVRTC compatibility diagnostics to unsupported Thrust headers

### DIFF
--- a/thrust/testing/CMakeLists.txt
+++ b/thrust/testing/CMakeLists.txt
@@ -15,6 +15,7 @@ endmacro()
 # In the TBB backend, reduce_by_key does not currently work with transform_output_iterator
 # https://github.com/NVIDIA/thrust/issues/1811
 thrust_declare_test_restrictions(transform_output_iterator_reduce_by_key CPP.CPP CPP.OMP CPP.CUDA)
+thrust_declare_test_restrictions(nvrtc_unsupported_headers CPP.CUDA)
 
 function(thrust_is_catch2_test result_var test_src)
   # If the test_src contains the substring "catch2_test_", `result_var` will be set to TRUE.

--- a/thrust/testing/catch2_test_nvrtc_unsupported_headers.cmake
+++ b/thrust/testing/catch2_test_nvrtc_unsupported_headers.cmake
@@ -1,7 +1,11 @@
 cccl_get_cudatoolkit()
 
 get_filename_component(nvrtc_cccl_source_dir "${Thrust_SOURCE_DIR}" DIRECTORY)
-list(GET CUDAToolkit_INCLUDE_DIRS 0 nvrtc_ctk_include_dir)
+
+set(nvrtc_ctk_paths)
+foreach (nvrtc_ctk_include_dir IN LISTS CUDAToolkit_INCLUDE_DIRS)
+  string(APPEND nvrtc_ctk_paths "  \"-I${nvrtc_ctk_include_dir}\",\n")
+endforeach()
 
 configure_file(
   "${Thrust_SOURCE_DIR}/testing/cmake/nvrtc_args.h.in"

--- a/thrust/testing/catch2_test_nvrtc_unsupported_headers.cmake
+++ b/thrust/testing/catch2_test_nvrtc_unsupported_headers.cmake
@@ -1,0 +1,13 @@
+cccl_get_cudatoolkit()
+
+get_filename_component(nvrtc_cccl_source_dir "${Thrust_SOURCE_DIR}" DIRECTORY)
+list(GET CUDAToolkit_INCLUDE_DIRS 0 nvrtc_ctk_include_dir)
+
+configure_file(
+  "${Thrust_SOURCE_DIR}/testing/cmake/nvrtc_args.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/nvrtc_args.h"
+)
+
+target_include_directories(${test_target} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+
+target_link_libraries(${test_target} PRIVATE CUDA::nvrtc)

--- a/thrust/testing/catch2_test_nvrtc_unsupported_headers.cu
+++ b/thrust/testing/catch2_test_nvrtc_unsupported_headers.cu
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <string>
+#include <vector>
 
 #include <nvrtc.h>
 #include <nvrtc_args.h>
@@ -57,10 +58,14 @@ TEST_CASE("Unsupported headers emit an NVRTC diagnostic", "[nvrtc]")
     "thrust/universal_vector.h"};
 
   const std::string standard = std::string{"-std=c++"} + std::to_string(_CCCL_STD_VER - 2000);
-  const std::array<const char*, 5> options{
-    nvrtc_cub_path, nvrtc_thrust_path, nvrtc_libcudacxx_path, nvrtc_ctk_path, standard.c_str()};
+  std::vector<const char*> options{nvrtc_cub_path, nvrtc_thrust_path, nvrtc_libcudacxx_path};
+  for (const char* const nvrtc_ctk_path : nvrtc_ctk_paths)
+  {
+    options.push_back(nvrtc_ctk_path);
+  }
+  options.push_back(standard.c_str());
 
-  for (const char* header : unsupported_headers)
+  for (const char* const header : unsupported_headers)
   {
     INFO("header = " << header);
 
@@ -75,15 +80,24 @@ TEST_CASE("Unsupported headers emit an NVRTC diagnostic", "[nvrtc]")
     const nvrtcResult compile_result = nvrtcCompileProgram(program, static_cast<int>(options.size()), options.data());
 
     std::size_t log_size{};
-    REQUIRE(NVRTC_SUCCESS == nvrtcGetProgramLogSize(program, &log_size));
+    const nvrtcResult get_log_size_result = nvrtcGetProgramLogSize(program, &log_size);
 
-    std::string log(log_size, '\0');
-    REQUIRE(NVRTC_SUCCESS == nvrtcGetProgramLog(program, log.data()));
+    std::string log;
+    nvrtcResult get_log_result = get_log_size_result;
+    if (NVRTC_SUCCESS == get_log_size_result)
+    {
+      log.resize(log_size);
+      get_log_result = nvrtcGetProgramLog(program, log.data());
+    }
+
+    const nvrtcResult destroy_result = nvrtcDestroyProgram(&program);
+
+    REQUIRE(NVRTC_SUCCESS == get_log_size_result);
+    REQUIRE(NVRTC_SUCCESS == get_log_result);
+    REQUIRE(NVRTC_SUCCESS == destroy_result);
 
     INFO("NVRTC log = " << log);
     CHECK(NVRTC_ERROR_COMPILATION == compile_result);
     CHECK(log.find(expected_diagnostic) != std::string::npos);
-
-    REQUIRE(NVRTC_SUCCESS == nvrtcDestroyProgram(&program));
   }
 }

--- a/thrust/testing/catch2_test_nvrtc_unsupported_headers.cu
+++ b/thrust/testing/catch2_test_nvrtc_unsupported_headers.cu
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+#include <thrust/detail/config.h>
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include <nvrtc.h>
+#include <nvrtc_args.h>
+
+#include "catch2_test_helper.h"
+
+TEST_CASE("Unsupported headers emit an NVRTC diagnostic", "[nvrtc]")
+{
+  constexpr std::array unsupported_headers{
+    "thrust/allocate_unique.h",
+    "thrust/device_allocator.h",
+    "thrust/device_delete.h",
+    "thrust/device_free.h",
+    "thrust/device_make_unique.h",
+    "thrust/device_malloc.h",
+    "thrust/device_malloc_allocator.h",
+    "thrust/device_new.h",
+    "thrust/device_new_allocator.h",
+    "thrust/device_vector.h",
+    "thrust/host_vector.h",
+    "thrust/mr/allocator.h",
+    "thrust/mr/device_memory_resource.h",
+    "thrust/mr/disjoint_pool.h",
+    "thrust/mr/disjoint_sync_pool.h",
+    "thrust/mr/disjoint_tls_pool.h",
+    "thrust/mr/fancy_pointer_resource.h",
+    "thrust/mr/host_memory_resource.h",
+    "thrust/mr/memory_resource.h",
+    "thrust/mr/new.h",
+    "thrust/mr/polymorphic_adaptor.h",
+    "thrust/mr/pool.h",
+    "thrust/mr/pool_options.h",
+    "thrust/mr/sync_pool.h",
+    "thrust/mr/tls_pool.h",
+    "thrust/mr/universal_memory_resource.h",
+    "thrust/mr/validator.h",
+    "thrust/per_device_resource.h",
+    "thrust/system/cpp/memory.h",
+    "thrust/system/cpp/memory_resource.h",
+    "thrust/system/cpp/vector.h",
+    "thrust/system/cuda/error.h",
+    "thrust/system/cuda/memory.h",
+    "thrust/system/cuda/memory_resource.h",
+    "thrust/system/cuda/vector.h",
+    "thrust/system/error_code.h",
+    "thrust/system/system_error.h",
+    "thrust/system_error.h",
+    "thrust/universal_allocator.h",
+    "thrust/universal_vector.h"};
+
+  const std::string standard = std::string{"-std=c++"} + std::to_string(_CCCL_STD_VER - 2000);
+  const std::array<const char*, 5> options{
+    nvrtc_cub_path, nvrtc_thrust_path, nvrtc_libcudacxx_path, nvrtc_ctk_path, standard.c_str()};
+
+  for (const char* header : unsupported_headers)
+  {
+    INFO("header = " << header);
+
+    const std::string source = std::string{"#include <"} + header + ">\n";
+    const std::string expected_diagnostic =
+      std::string{"Including <"} + header + "> is not supported when compiling with NVRTC";
+
+    nvrtcProgram program{};
+    REQUIRE(NVRTC_SUCCESS
+            == nvrtcCreateProgram(&program, source.c_str(), "nvrtc_unsupported_header_test.cu", 0, nullptr, nullptr));
+
+    const nvrtcResult compile_result = nvrtcCompileProgram(program, static_cast<int>(options.size()), options.data());
+
+    std::size_t log_size{};
+    REQUIRE(NVRTC_SUCCESS == nvrtcGetProgramLogSize(program, &log_size));
+
+    std::string log(log_size, '\0');
+    REQUIRE(NVRTC_SUCCESS == nvrtcGetProgramLog(program, log.data()));
+
+    INFO("NVRTC log = " << log);
+    CHECK(NVRTC_ERROR_COMPILATION == compile_result);
+    CHECK(log.find(expected_diagnostic) != std::string::npos);
+
+    REQUIRE(NVRTC_SUCCESS == nvrtcDestroyProgram(&program));
+  }
+}

--- a/thrust/testing/catch2_test_nvrtc_unsupported_headers.cu
+++ b/thrust/testing/catch2_test_nvrtc_unsupported_headers.cu
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <thrust/detail/config.h>
 

--- a/thrust/testing/cmake/nvrtc_args.h.in
+++ b/thrust/testing/cmake/nvrtc_args.h.in
@@ -6,4 +6,5 @@
 inline constexpr char nvrtc_cub_path[]        = "-I@nvrtc_cccl_source_dir@/cub";
 inline constexpr char nvrtc_thrust_path[]     = "-I@Thrust_SOURCE_DIR@";
 inline constexpr char nvrtc_libcudacxx_path[] = "-I@nvrtc_cccl_source_dir@/libcudacxx/include";
-inline constexpr char nvrtc_ctk_path[]        = "-I@nvrtc_ctk_include_dir@";
+inline constexpr const char* nvrtc_ctk_paths[] = {
+@nvrtc_ctk_paths@};

--- a/thrust/testing/cmake/nvrtc_args.h.in
+++ b/thrust/testing/cmake/nvrtc_args.h.in
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+#pragma once
+
+inline constexpr char nvrtc_cub_path[]        = "-I@nvrtc_cccl_source_dir@/cub";
+inline constexpr char nvrtc_thrust_path[]     = "-I@Thrust_SOURCE_DIR@";
+inline constexpr char nvrtc_libcudacxx_path[] = "-I@nvrtc_cccl_source_dir@/libcudacxx/include";
+inline constexpr char nvrtc_ctk_path[]        = "-I@nvrtc_ctk_include_dir@";

--- a/thrust/testing/cmake/nvrtc_args.h.in
+++ b/thrust/testing/cmake/nvrtc_args.h.in
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #pragma once
 

--- a/thrust/thrust/allocate_unique.h
+++ b/thrust/thrust/allocate_unique.h
@@ -5,6 +5,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/allocate_unique.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/device_allocator.h
+++ b/thrust/thrust/device_allocator.h
@@ -10,6 +10,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/device_allocator.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/device_delete.h
+++ b/thrust/thrust/device_delete.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/device_delete.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/device_free.h
+++ b/thrust/thrust/device_free.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/device_free.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/device_make_unique.h
+++ b/thrust/thrust/device_make_unique.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/device_make_unique.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/device_malloc.h
+++ b/thrust/thrust/device_malloc.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/device_malloc.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/device_malloc_allocator.h
+++ b/thrust/thrust/device_malloc_allocator.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/device_malloc_allocator.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/device_new.h
+++ b/thrust/thrust/device_new.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/device_new.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/device_new_allocator.h
+++ b/thrust/thrust/device_new_allocator.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/device_new_allocator.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -10,6 +10,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/device_vector.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -10,6 +10,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/host_vector.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/allocator.h
+++ b/thrust/thrust/mr/allocator.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/allocator.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/device_memory_resource.h
+++ b/thrust/thrust/mr/device_memory_resource.h
@@ -5,6 +5,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/device_memory_resource.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/disjoint_pool.h
+++ b/thrust/thrust/mr/disjoint_pool.h
@@ -10,6 +10,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/disjoint_pool.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/disjoint_sync_pool.h
+++ b/thrust/thrust/mr/disjoint_sync_pool.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/disjoint_sync_pool.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/disjoint_tls_pool.h
+++ b/thrust/thrust/mr/disjoint_tls_pool.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/disjoint_tls_pool.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/fancy_pointer_resource.h
+++ b/thrust/thrust/mr/fancy_pointer_resource.h
@@ -5,6 +5,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/fancy_pointer_resource.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/host_memory_resource.h
+++ b/thrust/thrust/mr/host_memory_resource.h
@@ -5,6 +5,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/host_memory_resource.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/memory_resource.h
+++ b/thrust/thrust/mr/memory_resource.h
@@ -10,6 +10,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/memory_resource.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/new.h
+++ b/thrust/thrust/mr/new.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/new.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/polymorphic_adaptor.h
+++ b/thrust/thrust/mr/polymorphic_adaptor.h
@@ -5,6 +5,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/polymorphic_adaptor.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/pool.h
+++ b/thrust/thrust/mr/pool.h
@@ -11,6 +11,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/pool.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/pool_options.h
+++ b/thrust/thrust/mr/pool_options.h
@@ -10,6 +10,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/pool_options.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/sync_pool.h
+++ b/thrust/thrust/mr/sync_pool.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/sync_pool.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/tls_pool.h
+++ b/thrust/thrust/mr/tls_pool.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/tls_pool.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/universal_memory_resource.h
+++ b/thrust/thrust/mr/universal_memory_resource.h
@@ -5,6 +5,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/universal_memory_resource.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/mr/validator.h
+++ b/thrust/thrust/mr/validator.h
@@ -5,6 +5,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/mr/validator.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/per_device_resource.h
+++ b/thrust/thrust/per_device_resource.h
@@ -5,6 +5,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/per_device_resource.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/system/cpp/memory.h
+++ b/thrust/thrust/system/cpp/memory.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/system/cpp/memory.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/system/cpp/memory_resource.h
+++ b/thrust/thrust/system/cpp/memory_resource.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/system/cpp/memory_resource.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/system/cpp/vector.h
+++ b/thrust/thrust/system/cpp/vector.h
@@ -10,6 +10,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/system/cpp/vector.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/system/cuda/error.h
+++ b/thrust/thrust/system/cuda/error.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/system/cuda/error.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/system/cuda/memory.h
+++ b/thrust/thrust/system/cuda/memory.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/system/cuda/memory.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/system/cuda/memory_resource.h
+++ b/thrust/thrust/system/cuda/memory_resource.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/system/cuda/memory_resource.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/system/cuda/vector.h
+++ b/thrust/thrust/system/cuda/vector.h
@@ -10,6 +10,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/system/cuda/vector.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/system/error_code.h
+++ b/thrust/thrust/system/error_code.h
@@ -10,6 +10,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/system/error_code.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/system/system_error.h
+++ b/thrust/thrust/system/system_error.h
@@ -10,6 +10,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/system/system_error.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/system_error.h
+++ b/thrust/thrust/system_error.h
@@ -9,6 +9,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/system_error.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/universal_allocator.h
+++ b/thrust/thrust/universal_allocator.h
@@ -10,6 +10,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/universal_allocator.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/universal_vector.h
+++ b/thrust/thrust/universal_vector.h
@@ -10,6 +10,13 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+#  if _CCCL_COMPILER(NVRTC)
+#    error \
+      "Including <thrust/universal_vector.h> is not supported when compiling with NVRTC, which supports device code only. You can define CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK to disable this warning."
+#  endif // _CCCL_COMPILER(NVRTC)
+#endif // CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)


### PR DESCRIPTION
## Description

Adds clear NVRTC compatibility diagnostics to 40 public Thrust headers that depend on host-side functionality.

When one of these headers is compiled with NVRTC, compilation now stops immediately with an informative error instead of failing later with unrelated implementation errors.

The diagnostics follow the existing CUB pattern and can be disabled with `CCCL_DISABLE_NVRTC_COMPATIBILITY_CHECK`.

This addresses the Thrust portion of #5405 for public headers that are clearly unsupported by NVRTC.

## Testing

Using NVHPC 26.5 and CUDA 13.2:

- Verified all 40 headers emit the intended diagnostic with NVRTC in C++17 and C++20.
- Verified all 40 changed headers compile normally in C++17 and C++20.
- Ran the configured pre-commit hooks, including TruffleHog and clang-format.
