### PR TITLE
[libcu++] Optimize tuple and pair constraint checks

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -305,6 +305,8 @@
 
 #if _CCCL_CHECK_BUILTIN(is_convertible_to) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
 #  define _CCCL_BUILTIN_IS_CONVERTIBLE_TO(...) __is_convertible_to(__VA_ARGS__)
+#elif _CCCL_CHECK_BUILTIN(is_convertible) // gcc 13 provides this
+#  define _CCCL_BUILTIN_IS_CONVERTIBLE_TO(...) __is_convertible(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(is_convertible_to)
 
 #if _CCCL_CHECK_BUILTIN(is_destructible) || _CCCL_COMPILER(MSVC)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -305,8 +305,6 @@
 
 #if _CCCL_CHECK_BUILTIN(is_convertible_to) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
 #  define _CCCL_BUILTIN_IS_CONVERTIBLE_TO(...) __is_convertible_to(__VA_ARGS__)
-#elif _CCCL_CHECK_BUILTIN(is_convertible) // gcc 13 provides this
-#  define _CCCL_BUILTIN_IS_CONVERTIBLE_TO(...) __is_convertible(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(is_convertible_to)
 
 #if _CCCL_CHECK_BUILTIN(is_destructible) || _CCCL_COMPILER(MSVC)

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -84,14 +84,14 @@ public:
     return static_cast<const type&&>(static_cast<const __tuple_leaf<_Ip, type>&&>(__base_).__get());
   }
 
-  // Going through an inline variable forces instantiation of the default constructors of all _Tp fr old GCC
-  template <class _Constraints = typename __tuple_constraints<_Tp...>::__default_construction,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  // Going through type alias forces instantiation of the default constructors of all _Tp for old GCC
+  template <__select_constructor _Constraints = __tuple_constraints<_Tp...>::__select_default_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple() noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
   {}
 
-  template <class _Constraints = typename __tuple_constraints<_Tp...>::__default_construction,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+  template <__select_constructor _Constraints = __tuple_constraints<_Tp...>::__select_default_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple() noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
   {}
 
@@ -101,16 +101,16 @@ public:
   _CCCL_HIDE_FROM_ABI tuple(tuple&&) = default;
 
   template <class _Alloc,
-            class _Constraints = typename __tuple_constraints<_Tp...>::__default_construction,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints = __tuple_constraints<_Tp...>::__select_default_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t,
                             _Alloc const& __a) noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
       : __base_(allocator_arg_t(), __a)
   {}
 
   template <class _Alloc,
-            class _Constraints = typename __tuple_constraints<_Tp...>::__default_construction,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints = __tuple_constraints<_Tp...>::__select_default_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t,
                                      _Alloc const& __a) noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
       : __base_(allocator_arg_t(), __a)
@@ -124,7 +124,7 @@ public:
 
   template <class _Constraints = typename __tuple_constraints<_Tp...>::__variadic_copy_construction,
             enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
-  _CCCL_API constexpr explicit tuple(const _Tp&... __t) noexcept((is_nothrow_copy_constructible_v<_Tp> && ...))
+  _CCCL_API explicit constexpr tuple(const _Tp&... __t) noexcept((is_nothrow_copy_constructible_v<_Tp> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, __t...)
   {}
 
@@ -177,7 +177,7 @@ public:
             enable_if_t<sizeof...(_Tp) != 0, int>                      = 0, // Help Clang disambiguate for CTAD
             class _Constraints                                         = _VariadicConstraints<_UTypes...>,
             enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
-  _CCCL_API constexpr explicit tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
+  _CCCL_API explicit constexpr tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
@@ -224,7 +224,7 @@ public:
             enable_if_t<(sizeof...(_UTypes) != 0), int>                = 0,
             class _Constraints                                         = _VariadicConstraintsLessRank<_UTypes...>,
             enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
-  _CCCL_API constexpr explicit tuple(_UTypes&&... __u)
+  _CCCL_API explicit constexpr tuple(_UTypes&&... __u)
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
@@ -245,14 +245,15 @@ public:
   template <class _UTuple>
   using _TupleLikeConstraints = typename __tuple_constraints<_Tp...>::template __tuple_like_construction<_UTuple>;
 
+  // MSVC needs this to be a type
   template <class _UTuple>
-  static constexpr bool __nothrow_tuple_like_construction =
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible<_UTuple>;
+  using _NothrowTupleLikeConstruction =
+    bool_constant<__tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible<_UTuple>>;
 
   template <class... _UTypes,
             class _Constraints                                         = _TupleLikeConstraints<tuple<_UTypes...>&>,
             enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(__nothrow_tuple_like_construction<tuple<_UTypes...>&>)
+  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(_NothrowTupleLikeConstruction<tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
@@ -260,7 +261,7 @@ public:
             class _Constraints                                         = _TupleLikeConstraints<tuple<_UTypes...>&>,
             enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>& __t) noexcept(
-    __nothrow_tuple_like_construction<tuple<_UTypes...>&>)
+    _NothrowTupleLikeConstruction<tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
@@ -275,7 +276,7 @@ public:
             class _Constraints = _TupleLikeConstraints<const tuple<_UTypes...>&>,
             enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
-    __nothrow_tuple_like_construction<const tuple<_UTypes...>&>)
+    _NothrowTupleLikeConstruction<const tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
@@ -283,7 +284,7 @@ public:
             class _Constraints = _TupleLikeConstraints<const tuple<_UTypes...>&>,
             enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
-    __nothrow_tuple_like_construction<const tuple<_UTypes...>&>)
+    _NothrowTupleLikeConstruction<const tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
@@ -297,7 +298,7 @@ public:
   template <class... _UTypes,
             class _Constraints                                         = _TupleLikeConstraints<tuple<_UTypes...>&&>,
             enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(__nothrow_tuple_like_construction<tuple<_UTypes...>&&>)
+  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(_NothrowTupleLikeConstruction<tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
@@ -305,7 +306,7 @@ public:
             class _Constraints                                         = _TupleLikeConstraints<tuple<_UTypes...>&&>,
             enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>&& __t) noexcept(
-    __nothrow_tuple_like_construction<tuple<_UTypes...>&&>)
+    _NothrowTupleLikeConstruction<tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
@@ -320,7 +321,7 @@ public:
             class _Constraints = _TupleLikeConstraints<const tuple<_UTypes...>&&>,
             enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
-    __nothrow_tuple_like_construction<const tuple<_UTypes...>&&>)
+    _NothrowTupleLikeConstruction<const tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
@@ -328,7 +329,7 @@ public:
             class _Constraints = _TupleLikeConstraints<const tuple<_UTypes...>&&>,
             enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
-    __nothrow_tuple_like_construction<const tuple<_UTypes...>&&>)
+    _NothrowTupleLikeConstruction<const tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
@@ -350,7 +351,7 @@ public:
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
             class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
             enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(__nothrow_tuple_like_construction<_Tuple>)
+  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLikeConstruction<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
 
@@ -358,7 +359,7 @@ public:
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
             class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
             enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
-  _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(__nothrow_tuple_like_construction<_Tuple>)
+  _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLikeConstruction<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
 
@@ -377,7 +378,7 @@ public:
             class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
             enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
-    __nothrow_tuple_like_construction<_Tuple>)
+    _NothrowTupleLikeConstruction<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
   {}
 
@@ -387,7 +388,7 @@ public:
             class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
             enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
-    __nothrow_tuple_like_construction<_Tuple>)
+    _NothrowTupleLikeConstruction<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
   {}
 
@@ -408,7 +409,7 @@ public:
   template <class _Constraints = typename __tuple_constraints<_Tp...>::__const_copy_assignable,
             enable_if_t<_Constraints::__can_assign, int> = 0>
   _CCCL_API constexpr const tuple& operator=(const tuple& __t) const
-    noexcept((is_nothrow_copy_assignable_v<_Tp> && ...))
+    noexcept((is_nothrow_copy_assignable_v<const _Tp> && ...))
   {
     ::cuda::std::__memberwise_copy_assign(*this, __t, __make_tuple_indices_t<sizeof...(_Tp)>{});
     return *this;
@@ -417,7 +418,8 @@ public:
   // [tuple.assign]-12
   template <class _Constraints = typename __tuple_constraints<_Tp...>::__const_move_assignable,
             enable_if_t<_Constraints::__can_assign, int> = 0>
-  _CCCL_API constexpr const tuple& operator=(tuple&& __t) const noexcept((is_nothrow_move_assignable_v<_Tp> && ...))
+  _CCCL_API constexpr const tuple& operator=(tuple&& __t) const
+    noexcept((is_nothrow_assignable_v<const _Tp&, _Tp> && ...))
   {
     ::cuda::std::__memberwise_forward_assign(
       *this, ::cuda::std::move(__t), __type_list<_Tp...>{}, __make_tuple_indices_t<sizeof...(_Tp)>{});
@@ -574,24 +576,24 @@ public:
 
   _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
   _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_UTypes...>)
-  [[nodiscard]] _CCCL_API constexpr bool operator>(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
-  {
-    return __rhs.__tuple_less_than(*this, __make_tuple_indices_t<sizeof...(_Tp)>{});
-  }
-
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
-  _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator>=(const tuple<_UTypes...>& __rhs) const
     noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return !__tuple_less_than(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
-  _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_UTypes...>)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_UTypes...>)
+  _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_Tp...>)
+  [[nodiscard]] _CCCL_API constexpr bool operator>(const tuple<_UTypes...>& __rhs) const
+    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_Tp...>)
+  {
+    return __rhs.__tuple_less_than(*this, __make_tuple_indices_t<sizeof...(_Tp)>{});
+  }
+
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_UTypes...>)
+  _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_Tp...>)
   [[nodiscard]] _CCCL_API constexpr bool operator<=(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
+    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_Tp...>)
   {
     return !__rhs.__tuple_less_than(*this, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -85,13 +85,13 @@ public:
   }
 
   // Going through an inline variable forces instantiation of the default constructors of all _Tp fr old GCC
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+  template <class _Constraints = typename __tuple_constraints<_Tp...>::__default_construction,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple() noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
   {}
 
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+  template <class _Constraints = typename __tuple_constraints<_Tp...>::__default_construction,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple() noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
   {}
 
@@ -101,149 +101,132 @@ public:
   _CCCL_HIDE_FROM_ABI tuple(tuple&&) = default;
 
   template <class _Alloc,
-            __select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+            class _Constraints = typename __tuple_constraints<_Tp...>::__default_construction,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t,
                             _Alloc const& __a) noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
       : __base_(allocator_arg_t(), __a)
   {}
 
   template <class _Alloc,
-            __select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+            class _Constraints = typename __tuple_constraints<_Tp...>::__default_construction,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t,
                                      _Alloc const& __a) noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
       : __base_(allocator_arg_t(), __a)
   {}
 
-  template <__select_constructor _Trait = __tuple_select_variadic_copy_constructible_v<__tuple_types<_Tp...>>,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
-  _CCCL_API constexpr tuple(const _Tp&... __t) noexcept(__tuple_all_nothrow_copy_constructible_v<_Tp...>)
+  template <class _Constraints = typename __tuple_constraints<_Tp...>::__variadic_copy_construction,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(const _Tp&... __t) noexcept((is_nothrow_copy_constructible_v<_Tp> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, __t...)
   {}
 
-  template <__select_constructor _Trait = __tuple_select_variadic_copy_constructible_v<__tuple_types<_Tp...>>,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
-  _CCCL_API constexpr explicit tuple(const _Tp&... __t) noexcept(__tuple_all_nothrow_copy_constructible_v<_Tp...>)
+  template <class _Constraints = typename __tuple_constraints<_Tp...>::__variadic_copy_construction,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+  _CCCL_API constexpr explicit tuple(const _Tp&... __t) noexcept((is_nothrow_copy_constructible_v<_Tp> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, __t...)
   {}
 
   template <class _Alloc,
             enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait           = __tuple_select_variadic_copy_constructible_v<__tuple_types<_Tp...>>,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+            class _Constraints                    = typename __tuple_constraints<_Tp...>::__variadic_copy_construction,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, const _Tp&... __t) noexcept(
-    __tuple_all_nothrow_copy_constructible_v<_Tp...>)
+    (is_nothrow_copy_constructible_v<_Tp> && ...))
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, __t...)
   {}
 
   template <class _Alloc,
             enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait           = __tuple_select_variadic_copy_constructible_v<__tuple_types<_Tp...>>,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+            class _Constraints                    = typename __tuple_constraints<_Tp...>::__variadic_copy_construction,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t, const _Alloc& __a, const _Tp&... __t) noexcept(
-    __tuple_all_nothrow_copy_constructible_v<_Tp...>)
+    (is_nothrow_copy_constructible_v<_Tp> && ...))
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, __t...)
   {}
 
   template <class _Alloc,
-            __select_constructor _Trait = __tuple_select_variadic_copy_constructible_v<__tuple_types<_Tp...>>,
-            enable_if_t<__can_construct<_Trait>, int> = 0>
+            class _Constraints = typename __tuple_constraints<_Tp...>::__variadic_copy_construction,
+            enable_if_t<_Constraints::__can_construct, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, const tuple& __t) noexcept(
-    __tuple_all_nothrow_copy_constructible_v<_Tp...>)
+    (is_nothrow_copy_constructible_v<_Tp> && ...))
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, __t)
   {}
 
   template <class _Alloc,
-            __select_constructor _Trait = __tuple_select_variadic_move_constructible_v<__tuple_types<_Tp...>>,
-            enable_if_t<__can_construct<_Trait>, int> = 0>
+            class _Constraints = typename __tuple_constraints<_Tp...>::__variadic_move_construction,
+            enable_if_t<_Constraints::__can_construct, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, tuple&& __t) noexcept(
-    __tuple_all_nothrow_move_constructible_v<_Tp...>)
+    (is_nothrow_move_constructible_v<_Tp> && ...))
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::move(__t))
   {}
 
-  // Old MSVC chokes about a static constexpr variable needing an initializer. Work around by using a type
   template <class... _UTypes>
-  using _VariadicConstraints =
-    integral_constant<__select_constructor,
-                      __tuple_select_variadic_constructible_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>>;
-
-  template <class... _UTypes>
-  using _NothrowVariadic =
-    bool_constant<__tuple_all_nothrow_constructible_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>>;
+  using _VariadicConstraints = typename __tuple_constraints<_Tp...>::template __variadic_construction<_UTypes...>;
 
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int>                = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
-  _CCCL_API constexpr tuple(_UTypes&&... __u) noexcept(_NothrowVariadic<_UTypes...>::value)
+            enable_if_t<sizeof...(_Tp) != 0, int>                      = 0, // Help Clang disambiguate for CTAD
+            class _Constraints                                         = _VariadicConstraints<_UTypes...>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int>                = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
-  _CCCL_API constexpr explicit tuple(_UTypes&&... __u) noexcept(_NothrowVariadic<_UTypes...>::value)
+            enable_if_t<sizeof...(_Tp) != 0, int>                      = 0, // Help Clang disambiguate for CTAD
+            class _Constraints                                         = _VariadicConstraints<_UTypes...>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+  _CCCL_API constexpr explicit tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int>  = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait            = _VariadicConstraints<_UTypes...>::value,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+            enable_if_t<sizeof...(_Tp) != 0, int>        = 0, // Help Clang disambiguate for CTAD
+            class _Constraints                           = _VariadicConstraints<_UTypes...>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr tuple(_UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+            class _Constraints                                         = _VariadicConstraints<_UTypes...>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API inline tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
-    _NothrowVariadic<_UTypes...>::value)
+    (is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+            class _Constraints                                         = _VariadicConstraints<_UTypes...>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API inline explicit tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
-    _NothrowVariadic<_UTypes...>::value)
+    (is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Trait            = _VariadicConstraints<_UTypes...>::value,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+            class _Constraints                           = _VariadicConstraints<_UTypes...>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes>
-  using _VariadicConstraintsLessRank = integral_constant<
-    __select_constructor,
-    __tuple_select_variadic_constructible_less_rank_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>>;
+  using _VariadicConstraintsLessRank =
+    typename __tuple_constraints<_Tp...>::template __variadic_construction_less_rank<_UTypes...>;
 
   template <class... _UTypes,
-            enable_if_t<(sizeof...(_UTypes) < sizeof...(_Tp)), int> = 0,
-            enable_if_t<(sizeof...(_UTypes) != 0), int>             = 0,
-            __select_constructor _Trait                             = _VariadicConstraintsLessRank<_UTypes...>::value,
-            enable_if_t<__can_construct_explicitly<_Trait>, int>    = 0>
+            enable_if_t<(sizeof...(_UTypes) < sizeof...(_Tp)), int>    = 0,
+            enable_if_t<(sizeof...(_UTypes) != 0), int>                = 0,
+            class _Constraints                                         = _VariadicConstraintsLessRank<_UTypes...>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API constexpr explicit tuple(_UTypes&&... __u)
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
-
-#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  template <class... _UTypes,
-            enable_if_t<(sizeof...(_UTypes) < sizeof...(_Tp)), int> = 0,
-            enable_if_t<(sizeof...(_UTypes) != 0), int>             = 0,
-            __select_constructor _Trait                             = _VariadicConstraintsLessRank<_UTypes...>::value,
-            enable_if_t<__is_deleted<_Trait>, int>                  = 0>
-  constexpr tuple(_UTypes&&...) = delete;
-#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   // Horrible hack to make tuple_of_iterator_references work
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
@@ -260,97 +243,99 @@ public:
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
   template <class _UTuple>
-  using _TupleLikeConstraints = integral_constant<
-    __select_constructor,
-    __tuple_select_tuple_like_constructible_v<_UTuple, __tuple_types<_Tp...>, __make_tuple_indices_t<sizeof...(_Tp)>>>;
+  using _TupleLikeConstraints = typename __tuple_constraints<_Tp...>::template __tuple_like_construction<_UTuple>;
 
   template <class _UTuple>
-  using _NothrowTupleLike = bool_constant<
-    __tuple_nothrow_tuple_like_constructible_v<_UTuple, __tuple_types<_Tp...>, __make_tuple_indices_t<sizeof...(_Tp)>>>;
+  static constexpr bool __nothrow_tuple_like_construction =
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible<_UTuple>;
 
   template <class... _UTypes,
-            __select_constructor _Trait                          = _TupleLikeConstraints<tuple<_UTypes...>&>::value,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
-  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(_NothrowTupleLike<tuple<_UTypes...>&>::value)
+            class _Constraints                                         = _TupleLikeConstraints<tuple<_UTypes...>&>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(__nothrow_tuple_like_construction<tuple<_UTypes...>&>)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
-            __select_constructor _Trait                          = _TupleLikeConstraints<tuple<_UTypes...>&>::value,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
-  _CCCL_API explicit constexpr tuple(tuple<_UTypes...>& __t) noexcept(_NothrowTupleLike<tuple<_UTypes...>&>::value)
+            class _Constraints                                         = _TupleLikeConstraints<tuple<_UTypes...>&>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+  _CCCL_API explicit constexpr tuple(tuple<_UTypes...>& __t) noexcept(
+    __nothrow_tuple_like_construction<tuple<_UTypes...>&>)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            __select_constructor _Trait            = _TupleLikeConstraints<tuple<_UTypes...>&>::value,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+            class _Constraints                           = _TupleLikeConstraints<tuple<_UTypes...>&>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            __select_constructor _Trait = _TupleLikeConstraints<const tuple<_UTypes...>&>::value,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
-  _CCCL_API constexpr tuple(const tuple<_UTypes...>& __t) noexcept(_NothrowTupleLike<const tuple<_UTypes...>&>::value)
+            class _Constraints = _TupleLikeConstraints<const tuple<_UTypes...>&>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
+    __nothrow_tuple_like_construction<const tuple<_UTypes...>&>)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
-            __select_constructor _Trait = _TupleLikeConstraints<const tuple<_UTypes...>&>::value,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+            class _Constraints = _TupleLikeConstraints<const tuple<_UTypes...>&>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
-    _NothrowTupleLike<const tuple<_UTypes...>&>::value)
+    __nothrow_tuple_like_construction<const tuple<_UTypes...>&>)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            __select_constructor _Trait            = _TupleLikeConstraints<const tuple<_UTypes...>&>::value,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+            class _Constraints                           = _TupleLikeConstraints<const tuple<_UTypes...>&>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            __select_constructor _Trait                          = _TupleLikeConstraints<tuple<_UTypes...>&&>::value,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
-  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(_NothrowTupleLike<tuple<_UTypes...>&&>::value)
+            class _Constraints                                         = _TupleLikeConstraints<tuple<_UTypes...>&&>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(__nothrow_tuple_like_construction<tuple<_UTypes...>&&>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
-            __select_constructor _Trait                          = _TupleLikeConstraints<tuple<_UTypes...>&&>::value,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
-  _CCCL_API explicit constexpr tuple(tuple<_UTypes...>&& __t) noexcept(_NothrowTupleLike<tuple<_UTypes...>&&>::value)
+            class _Constraints                                         = _TupleLikeConstraints<tuple<_UTypes...>&&>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+  _CCCL_API explicit constexpr tuple(tuple<_UTypes...>&& __t) noexcept(
+    __nothrow_tuple_like_construction<tuple<_UTypes...>&&>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            __select_constructor _Trait            = _TupleLikeConstraints<tuple<_UTypes...>&&>::value,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+            class _Constraints                           = _TupleLikeConstraints<tuple<_UTypes...>&&>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            __select_constructor _Trait = _TupleLikeConstraints<const tuple<_UTypes...>&&>::value,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
-  _CCCL_API constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(_NothrowTupleLike<const tuple<_UTypes...>&&>::value)
+            class _Constraints = _TupleLikeConstraints<const tuple<_UTypes...>&&>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
+    __nothrow_tuple_like_construction<const tuple<_UTypes...>&&>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
-            __select_constructor _Trait = _TupleLikeConstraints<const tuple<_UTypes...>&&>::value,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+            class _Constraints = _TupleLikeConstraints<const tuple<_UTypes...>&&>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
-    _NothrowTupleLike<const tuple<_UTypes...>&&>::value)
+    __nothrow_tuple_like_construction<const tuple<_UTypes...>&&>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            __select_constructor _Trait            = _TupleLikeConstraints<const tuple<_UTypes...>&&>::value,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+            class _Constraints                           = _TupleLikeConstraints<const tuple<_UTypes...>&&>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr tuple(const tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
@@ -363,25 +348,25 @@ public:
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
-            enable_if_t<__can_construct_implicitly<_Trait>, int>       = 0>
-  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLike<_Tuple>::value)
+            class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(__nothrow_tuple_like_construction<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
 
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
-            enable_if_t<__can_construct_explicitly<_Trait>, int>       = 0>
-  _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLike<_Tuple>::value)
+            class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+  _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(__nothrow_tuple_like_construction<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
-            enable_if_t<__is_deleted<_Trait>, int>                     = 0>
+            class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
+            enable_if_t<_Constraints::__is_deleted, int>               = 0>
   constexpr tuple(_Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
   // NOLINTEND(bugprone-forwarding-reference-overload)
@@ -389,19 +374,20 @@ public:
   template <class _Alloc,
             class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
-            enable_if_t<__can_construct_implicitly<_Trait>, int>       = 0>
-  _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(_NothrowTupleLike<_Tuple>::value)
+            class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
+    __nothrow_tuple_like_construction<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
   {}
 
   template <class _Alloc,
             class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
-            enable_if_t<__can_construct_explicitly<_Trait>, int>       = 0>
+            class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
-    _NothrowTupleLike<_Tuple>::value)
+    __nothrow_tuple_like_construction<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
   {}
 
@@ -409,8 +395,8 @@ public:
   template <class _Alloc,
             class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
-            enable_if_t<__is_deleted<_Trait>, int>                     = 0>
+            class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
+            enable_if_t<_Constraints::__is_deleted, int>               = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
@@ -419,31 +405,35 @@ public:
   _CCCL_HIDE_FROM_ABI tuple& operator=(tuple&& __t)      = default;
 
   // [tuple.assign]-5
-  template <__select_assignment _Trait             = __tuple_select_const_copy_assignable_v<__tuple_types<_Tp...>>,
-            enable_if_t<__can_assign<_Trait>, int> = 0>
-  _CCCL_API constexpr const tuple& operator=(const tuple& __t) const noexcept(__can_nothrow_assign<_Trait>)
+  template <class _Constraints = typename __tuple_constraints<_Tp...>::__const_copy_assignable,
+            enable_if_t<_Constraints::__can_assign, int> = 0>
+  _CCCL_API constexpr const tuple& operator=(const tuple& __t) const
+    noexcept((is_nothrow_copy_assignable_v<_Tp> && ...))
   {
     ::cuda::std::__memberwise_copy_assign(*this, __t, __make_tuple_indices_t<sizeof...(_Tp)>{});
     return *this;
   }
 
   // [tuple.assign]-12
-  template <__select_assignment _Trait             = __tuple_select_const_move_assignable_v<__tuple_types<_Tp...>>,
-            enable_if_t<__can_assign<_Trait>, int> = 0>
-  _CCCL_API constexpr const tuple& operator=(tuple&& __t) const noexcept(__can_nothrow_assign<_Trait>)
+  template <class _Constraints = typename __tuple_constraints<_Tp...>::__const_move_assignable,
+            enable_if_t<_Constraints::__can_assign, int> = 0>
+  _CCCL_API constexpr const tuple& operator=(tuple&& __t) const noexcept((is_nothrow_move_assignable_v<_Tp> && ...))
   {
     ::cuda::std::__memberwise_forward_assign(
       *this, ::cuda::std::move(__t), __type_list<_Tp...>{}, __make_tuple_indices_t<sizeof...(_Tp)>{});
     return *this;
   }
 
+  template <bool _IsConst, class... _UTypes>
+  using _ConvertingAssignable =
+    typename __tuple_constraints<_Tp...>::template __converting_assignable<_IsConst, _UTypes...>;
+
   // [tuple.assign]-15
   template <class... _UTypes,
-            __select_assignment _Trait = __tuple_select_converting_assignable_v</*__is_const=*/false,
-                                                                                __tuple_types<_Tp...>,
-                                                                                __tuple_types<const _UTypes&...>>,
-            enable_if_t<__can_assign<_Trait>, int> = 0>
-  _CCCL_API constexpr tuple& operator=(const tuple<_UTypes...>& __t) noexcept(__can_nothrow_assign<_Trait>)
+            class _Constraints = _ConvertingAssignable</*__is_const=*/false, const _UTypes&...>,
+            enable_if_t<_Constraints::__can_assign, int> = 0>
+  _CCCL_API constexpr tuple&
+  operator=(const tuple<_UTypes...>& __t) noexcept((is_nothrow_assignable_v<_Tp&, const _UTypes&> && ...))
   {
     ::cuda::std::__memberwise_copy_assign(*this, __t, __make_tuple_indices_t<sizeof...(_Tp)>{});
     return *this;
@@ -451,23 +441,20 @@ public:
 
   // [tuple.assign]-18
   template <class... _UTypes,
-            __select_assignment _Trait = __tuple_select_converting_assignable_v</*__is_const=*/true,
-                                                                                __tuple_types<_Tp...>,
-                                                                                __tuple_types<const _UTypes&...>>,
-            enable_if_t<__can_assign<_Trait>, int> = 0>
-  _CCCL_API constexpr const tuple& operator=(const tuple<_UTypes...>& __t) const noexcept(__can_nothrow_assign<_Trait>)
+            class _Constraints = _ConvertingAssignable</*__is_const=*/true, const _UTypes&...>,
+            enable_if_t<_Constraints::__can_assign, int> = 0>
+  _CCCL_API constexpr const tuple& operator=(const tuple<_UTypes...>& __t) const
+    noexcept((is_nothrow_assignable_v<const _Tp&, const _UTypes&> && ...))
   {
     ::cuda::std::__memberwise_copy_assign(*this, __t, __make_tuple_indices_t<sizeof...(_Tp)>{});
     return *this;
   }
 
   // [tuple.assign]-21
-  template <
-    class... _UTypes,
-    __select_assignment _Trait =
-      __tuple_select_converting_assignable_v</*__is_const=*/false, __tuple_types<_Tp...>, __tuple_types<_UTypes...>>,
-    enable_if_t<__can_assign<_Trait>, int> = 0>
-  _CCCL_API constexpr tuple& operator=(tuple<_UTypes...>&& __t) noexcept(__can_nothrow_assign<_Trait>)
+  template <class... _UTypes,
+            class _Constraints                           = _ConvertingAssignable</*__is_const=*/false, _UTypes...>,
+            enable_if_t<_Constraints::__can_assign, int> = 0>
+  _CCCL_API constexpr tuple& operator=(tuple<_UTypes...>&& __t) noexcept((is_nothrow_assignable_v<_Tp&, _UTypes> && ...))
   {
     ::cuda::std::__memberwise_forward_assign(
       *this, ::cuda::std::move(__t), __type_list<_UTypes...>(), __make_tuple_indices_t<sizeof...(_Tp)>{});
@@ -475,27 +462,28 @@ public:
   }
 
   // [tuple.assign]-24
-  template <
-    class... _UTypes,
-    __select_assignment _Trait =
-      __tuple_select_converting_assignable_v</*__is_const=*/true, __tuple_types<_Tp...>, __tuple_types<_UTypes...>>,
-    enable_if_t<__can_assign<_Trait>, int> = 0>
-  _CCCL_API constexpr const tuple& operator=(tuple<_UTypes...>&& __t) const noexcept(__can_nothrow_assign<_Trait>)
+  template <class... _UTypes,
+            class _Constraints                           = _ConvertingAssignable</*__is_const=*/true, _UTypes...>,
+            enable_if_t<_Constraints::__can_assign, int> = 0>
+  _CCCL_API constexpr const tuple& operator=(tuple<_UTypes...>&& __t) const
+    noexcept((is_nothrow_assignable_v<const _Tp&, _UTypes> && ...))
   {
     ::cuda::std::__memberwise_forward_assign(
       *this, ::cuda::std::move(__t), __type_list<_UTypes...>(), __make_tuple_indices_t<sizeof...(_Tp)>{});
     return *this;
   }
 
+  template <bool _IsConst, class _UTuple>
+  using _TupleLikeAssignable =
+    typename __tuple_constraints<_Tp...>::template __tuple_like_assignable<_IsConst, _UTuple>;
+
   // [tuple.assign]-39
   template <class _UTuple,
             enable_if_t<!__is_cuda_std_tuple<remove_cvref_t<_UTuple>>, int> = 0,
-            __select_assignment _Trait = __tuple_select_tuple_like_assignable_v</*__is_const=*/false,
-                                                                                _UTuple,
-                                                                                __tuple_types<_Tp...>,
-                                                                                __make_tuple_indices_t<sizeof...(_Tp)>>,
-            enable_if_t<__can_assign<_Trait>, int> = 0>
-  _CCCL_API constexpr tuple& operator=(_UTuple&& __t) noexcept(__can_nothrow_assign<_Trait>)
+            class _Constraints                           = _TupleLikeAssignable</*__is_const=*/false, _UTuple>,
+            enable_if_t<_Constraints::__can_assign, int> = 0>
+  _CCCL_API constexpr tuple& operator=(_UTuple&& __t) noexcept(
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_assignable</*__is_const=*/false, _UTuple>)
   {
     ::cuda::std::__memberwise_tuple_assign(
       *this, ::cuda::std::forward<_UTuple>(__t), __make_tuple_indices_t<sizeof...(_Tp)>{});
@@ -505,12 +493,10 @@ public:
   // [tuple.assign]-42
   template <class _UTuple,
             enable_if_t<!__is_cuda_std_tuple<remove_cvref_t<_UTuple>>, int> = 0,
-            __select_assignment _Trait = __tuple_select_tuple_like_assignable_v</*__is_const=*/true,
-                                                                                _UTuple,
-                                                                                __tuple_types<_Tp...>,
-                                                                                __make_tuple_indices_t<sizeof...(_Tp)>>,
-            enable_if_t<__can_assign<_Trait>, int> = 0>
-  _CCCL_API constexpr const tuple& operator=(_UTuple&& __t) const noexcept(__can_nothrow_assign<_Trait>)
+            class _Constraints                           = _TupleLikeAssignable</*__is_const=*/true, _UTuple>,
+            enable_if_t<_Constraints::__can_assign, int> = 0>
+  _CCCL_API constexpr const tuple& operator=(_UTuple&& __t) const
+    noexcept(__tuple_constraints<_Tp...>::template __nothrow_tuple_like_assignable</*__is_const=*/true, _UTuple>)
   {
     ::cuda::std::__memberwise_tuple_assign(
       *this, ::cuda::std::forward<_UTuple>(__t), __make_tuple_indices_t<sizeof...(_Tp)>{});
@@ -527,44 +513,37 @@ public:
     __t.swap(__u);
   }
 
-  template <class... _UTypes>
-  using _ComparisonConstraints =
-    decltype(::cuda::std::__tuple_is_comparable(__tuple_types<_Tp...>{}, __tuple_types<_UTypes...>{}));
-
   _CCCL_EXEC_CHECK_DISABLE
-  template <class... _UTypes, size_t... _Indices, class _Constraints = _ComparisonConstraints<_UTypes...>>
+  template <class... _UTypes, size_t... _Indices, class _Constraints = __tuple_constraints<_Tp...>>
   [[nodiscard]] _CCCL_API constexpr bool __equal(const tuple<_UTypes...>& __other, __tuple_indices<_Indices...>) const
-    noexcept(_Constraints::__nothrow_equality_comparable)
+    noexcept(_Constraints::template __is_nothrow_equality_comparable_v<_UTypes...>)
   {
     using ::cuda::std::get;
     return ((get<_Indices>(*this) == get<_Indices>(__other)) && ...);
   }
 
   // Not a friend function because MSVC has issues with nested namespaces and thrust::tuple
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__equality_comparable)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
+  _CCCL_REQUIRES(_Constraints::template __is_equality_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator==(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_equality_comparable)
+    noexcept(_Constraints::template __is_nothrow_equality_comparable_v<_UTypes...>)
   {
     return __equal(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__equality_comparable)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
+  _CCCL_REQUIRES(_Constraints::template __is_equality_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator!=(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_equality_comparable)
+    noexcept(_Constraints::template __is_nothrow_equality_comparable_v<_UTypes...>)
   {
     return !__equal(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <class... _UTypes,
-            size_t _CurrentIndex,
-            size_t... _Indices,
-            class _Constraints = _ComparisonConstraints<_UTypes...>>
+  template <class... _UTypes, size_t _CurrentIndex, size_t... _Indices, class _Constraints = __tuple_constraints<_Tp...>>
   [[nodiscard]] _CCCL_API constexpr bool
   __tuple_less_than(const tuple<_UTypes...>& __other, __tuple_indices<_CurrentIndex, _Indices...>) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
   {
     using ::cuda::std::get;
     if constexpr (sizeof...(_Indices) == 0)
@@ -585,34 +564,34 @@ public:
     }
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__less_than_comparable)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
+  _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator<(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return __tuple_less_than(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__less_than_comparable)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
+  _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator>(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return __rhs.__tuple_less_than(*this, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__less_than_comparable)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
+  _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator>=(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return !__tuple_less_than(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__less_than_comparable)
+  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = __tuple_constraints<_Tp...>)
+  _CCCL_REQUIRES(_Constraints::template __is_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator<=(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(_Constraints::template __is_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return !__rhs.__tuple_less_than(*this, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -279,18 +279,20 @@ struct __tuple_constraints
     else
     { // MSVC has issues with constexpr variables here, so no constexpr variable
       using __arg_list        = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_UTypes)>;
-      using __arg_constraints = typename decltype(::cuda::std::__tuple_get_constraints(
-        __arg_list{}))::template __variadic_construction<_UTypes...>;
-      if constexpr (!__arg_constraints::__can_construct)
+      using __arg_constraints = decltype(::cuda::std::__tuple_get_constraints(__arg_list{}));
+      if constexpr (__arg_constraints::template __select_variadic_constructible<_UTypes...>()
+                      == __select_constructor::__invalid
+                    || __arg_constraints::template __select_variadic_constructible<_UTypes...>()
+                         == __select_constructor::__deleted)
       {
         return __select_constructor::__invalid;
       }
       else
       {
         using __defaulted_list = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_Types), sizeof...(_UTypes)>;
-        using __defaulted_constraints = _ConstructorConstraint<decltype(::cuda::std::__tuple_get_constraints(
-          __defaulted_list{}))::__select_default_constructible()>;
-        if constexpr (__defaulted_constraints::__can_construct)
+        using __defaulted_constraints = decltype(::cuda::std::__tuple_get_constraints(__defaulted_list{}));
+        if constexpr (__defaulted_constraints::__select_default_constructible() == __select_constructor::__implicit
+                      || __defaulted_constraints::__select_default_constructible() == __select_constructor::__explicit)
         {
           return __select_constructor::__explicit;
         }

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -230,6 +230,10 @@ struct __tuple_constraints
       { // [tuple.cnstr]-12.1: negation<is_same<remove_cvref_t<U0>, tuple>> if sizeof...(Types) is 1
         return __select_constructor::__invalid;
       }
+      else if constexpr (is_same_v<_UType, const _Type&> || is_same_v<_UType, _Type&&>)
+      {
+        return __select_constructor::__invalid;
+      }
       else if constexpr (!is_constructible_v<_Type, _UType>)
       { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
         return __select_constructor::__invalid;

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -99,7 +99,6 @@ struct __tuple_constraints
       return __select_constructor::__explicit;
     }
   }
-  using __default_construction = _ConstructorConstraint<__select_default_constructible()>;
 
   template <int = 0>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
@@ -285,8 +284,8 @@ struct __tuple_constraints
       else
       {
         using __defaulted_list = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_Types), sizeof...(_UTypes)>;
-        using __defaulted_constraints =
-          typename decltype(::cuda::std::__tuple_get_constraints(__defaulted_list{}))::__default_construction;
+        using __defaulted_constraints = _ConstructorConstraint<decltype(::cuda::std::__tuple_get_constraints(
+          __defaulted_list{}))::__select_default_constructible()>;
         if constexpr (__defaulted_constraints::__can_construct)
         {
           return __select_constructor::__explicit;
@@ -543,14 +542,40 @@ struct __tuple_constraints
 
   // Comparisons
   template <class... _UTypes>
-  static constexpr bool __is_equality_comparable_v = (__is_cpp17_equality_comparable_v<_Types, _UTypes> && ...);
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool __is_equality_comparable() noexcept
+  {
+    if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
+    {
+      return false;
+    }
+    else
+    {
+      return (__is_cpp17_equality_comparable_v<_Types, _UTypes> && ...);
+    }
+  }
+
+  template <class... _UTypes>
+  static constexpr bool __is_equality_comparable_v = __is_equality_comparable<_UTypes...>();
 
   template <class... _UTypes>
   static constexpr bool __is_nothrow_equality_comparable_v =
     (__is_cpp17_nothrow_equality_comparable_v<_Types, _UTypes> && ...);
 
   template <class... _UTypes>
-  static constexpr bool __is_less_than_comparable_v = (__is_cpp17_less_than_comparable_v<_Types, _UTypes> && ...);
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool __is_less_than_comparable() noexcept
+  {
+    if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
+    {
+      return false;
+    }
+    else
+    {
+      return (__is_cpp17_less_than_comparable_v<_Types, _UTypes> && ...);
+    }
+  }
+
+  template <class... _UTypes>
+  static constexpr bool __is_less_than_comparable_v = __is_less_than_comparable<_UTypes...>();
 
   template <class... _UTypes>
   static constexpr bool __is_nothrow_less_than_comparable_v =

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -63,25 +63,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-template <class... _Types>
-inline constexpr bool __tuple_all_nothrow_copy_constructible_v = (is_nothrow_copy_constructible_v<_Types> && ...);
-
-template <class... _Types>
-inline constexpr bool __tuple_all_nothrow_move_constructible_v = (is_nothrow_move_constructible_v<_Types> && ...);
-
-template <class, class>
-inline constexpr bool __tuple_all_nothrow_constructible_v = false;
-
-template <class... _Types, class... _UTypes>
-inline constexpr bool __tuple_all_nothrow_constructible_v<__tuple_types<_Types...>, __tuple_types<_UTypes...>> =
-  (is_nothrow_constructible_v<_Types, _UTypes> && ...);
-
-template <class... _Types>
-inline constexpr bool __tuple_all_copy_assignable_v = (is_copy_assignable_v<_Types> && ...);
-
-template <class... _Types>
-inline constexpr bool __tuple_all_move_assignable_v = (is_move_assignable_v<_Types> && ...);
-
 // __tuple_like_with_size
 template <class _Tuple, size_t _ExpectedSize, bool = __tuple_like<_Tuple>>
 inline constexpr bool __tuple_like_with_size = false;
@@ -91,99 +72,177 @@ inline constexpr bool __tuple_like_with_size<_Tuple, _ExpectedSize, true> =
   _ExpectedSize == tuple_size<remove_cvref_t<_Tuple>>::value;
 
 template <class... _Types>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_default_constructible(__tuple_types<_Types...>) noexcept
+struct __tuple_constraints;
+
+template <class... _Types>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __tuple_get_constraints(__tuple_types<_Types...>) noexcept
 {
-  if constexpr (!(is_default_constructible_v<_Types> && ...))
-  {
-    return __select_constructor::__invalid;
-  }
-  else if constexpr ((__is_implicitly_default_constructible<_Types>::value && ...))
-  {
-    return __select_constructor::__implicit;
-  }
-  else
-  {
-    return __select_constructor::__explicit;
-  }
+  return __tuple_constraints<_Types...>{};
 }
 
 template <class... _Types>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_variadic_copy_constructible(__tuple_types<_Types...>) noexcept
+struct __tuple_constraints
 {
-  if constexpr (!(is_copy_constructible_v<_Types> && ...))
+  template <int = 0>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor __select_default_constructible() noexcept
   {
-    return __select_constructor::__invalid;
+    if constexpr (!(is_default_constructible_v<_Types> && ...))
+    {
+      return __select_constructor::__invalid;
+    }
+    else if constexpr ((__is_implicitly_default_constructible<_Types>::value && ...))
+    {
+      return __select_constructor::__implicit;
+    }
+    else
+    {
+      return __select_constructor::__explicit;
+    }
   }
-  else if constexpr ((is_convertible_v<const _Types&, _Types> && ...))
-  {
-    return __select_constructor::__implicit;
-  }
-  else
-  {
-    return __select_constructor::__explicit;
-  }
-}
+  using __default_construction = _ConstructorConstraint<__select_default_constructible()>;
 
-template <class _TupleTypes>
-inline constexpr __select_constructor __tuple_select_variadic_copy_constructible_v =
-  ::cuda::std::__tuple_select_variadic_copy_constructible(_TupleTypes{});
-
-template <class... _Types>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_variadic_move_constructible(__tuple_types<_Types...>) noexcept
-{
-  if constexpr (!(is_move_constructible_v<_Types> && ...))
+  template <int = 0>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
+  __select_variadic_copy_constructible() noexcept
   {
-    return __select_constructor::__invalid;
+    if constexpr (!(is_copy_constructible_v<_Types> && ...))
+    {
+      return __select_constructor::__invalid;
+    }
+    else if constexpr ((is_convertible_v<const _Types&, _Types> && ...))
+    {
+      return __select_constructor::__implicit;
+    }
+    else
+    {
+      return __select_constructor::__explicit;
+    }
   }
-  else if constexpr ((is_convertible_v<_Types&&, _Types> && ...))
-  {
-    return __select_constructor::__implicit;
-  }
-  else
-  {
-    return __select_constructor::__explicit;
-  }
-}
+  using __variadic_copy_construction = _ConstructorConstraint<__select_variadic_copy_constructible()>;
 
-template <class _TupleTypes>
-inline constexpr __select_constructor __tuple_select_variadic_move_constructible_v =
-  ::cuda::std::__tuple_select_variadic_move_constructible(_TupleTypes{});
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
+  __select_variadic_move_constructible() noexcept
+  {
+    if constexpr (!(is_move_constructible_v<_Types> && ...))
+    {
+      return __select_constructor::__invalid;
+    }
+    else if constexpr ((is_convertible_v<_Types&&, _Types> && ...))
+    {
+      return __select_constructor::__implicit;
+    }
+    else
+    {
+      return __select_constructor::__explicit;
+    }
+  }
+  using __variadic_move_construction = _ConstructorConstraint<__select_variadic_move_constructible()>;
 
-template <class... _Types, class... _UTypes>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_variadic_constructible(__tuple_types<_Types...>, __tuple_types<_UTypes...>) noexcept
-{
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
-  { // [tuple.cnstr]-13.1: sizeof...(Types) equals sizeof...(UTypes),
-    return __select_constructor::__invalid;
+  template <class... _UTypes, enable_if_t<sizeof...(_UTypes) != 1, int> = 0>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor __select_variadic_constructible() noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
+    { // [tuple.cnstr]-13.1: sizeof...(Types) equals sizeof...(UTypes),
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (sizeof...(_Types) == 0)
+    { // [tuple.cnstr]-13.2: sizeof...(Types) >= 1,
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (sizeof...(_Types) == 2 || sizeof...(_Types) == 3)
+    { // [tuple.cnstr]-12.2: otherwise, if sizeof...(Types) is 2 or 3
+      using _U0 = __type_index_c<0, _UTypes...>;
+      using _T0 = __type_index_c<0, _Types...>;
+      if constexpr (!is_same_v<remove_cvref_t<_U0>, allocator_arg_t> || is_same_v<remove_cvref_t<_T0>, allocator_arg_t>)
+      { // [tuple.cnstr]-13.3: !is_same_v<remove_cvref_t<U0>, allocator_arg_t> || is_same_v<remove_cvref_t<T0>,
+        // allocator_arg_t>>
+        if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
+        { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
+          return __select_constructor::__invalid;
+        }
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+        else if constexpr ((reference_constructs_from_temporary_v<_Types, _UTypes&&> || ...))
+        { // [tuple.cnstr]-15: This constructor is defined as deleted if
+          // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
+          return __select_constructor::__deleted;
+        }
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+        else if constexpr (!(is_convertible_v<_UTypes, _Types> && ...))
+        { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
+          return __select_constructor::__explicit;
+        }
+        else
+        {
+          return __select_constructor::__implicit;
+        }
+      }
+      else
+      {
+        return __select_constructor::__invalid;
+      }
+    }
+    else if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
+    { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
+      return __select_constructor::__invalid;
+    }
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+    else if constexpr ((reference_constructs_from_temporary_v<_Types, _UTypes&&> || ...))
+    { // [tuple.cnstr]-15: This constructor is defined as deleted if
+      // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
+      return __select_constructor::__deleted;
+    }
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+    else if constexpr (!(is_convertible_v<_UTypes, _Types> && ...))
+    { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
+      return __select_constructor::__explicit;
+    }
+    else
+    {
+      return __select_constructor::__implicit;
+    }
+    // NOLINTEND(bugprone-branch-clone)
   }
-  else if constexpr (sizeof...(_Types) == 0)
-  { // [tuple.cnstr]-13.2: sizeof...(Types) >= 1,
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (sizeof...(_Types) == 2 || sizeof...(_Types) == 3)
-  { // [tuple.cnstr]-12.2: otherwise, if sizeof...(Types) is 2 or 3
-    using _U0 = __type_index_c<0, _UTypes...>;
-    using _T0 = __type_index_c<0, _Types...>;
-    if constexpr (!is_same_v<remove_cvref_t<_U0>, allocator_arg_t> || is_same_v<remove_cvref_t<_T0>, allocator_arg_t>)
-    { // [tuple.cnstr]-13.3: !is_same_v<remove_cvref_t<U0>, allocator_arg_t> || is_same_v<remove_cvref_t<T0>,
-      // allocator_arg_t>>
-      if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
+
+  template <class _UType>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor __select_variadic_constructible() noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (sizeof...(_Types) != 1)
+    { // [tuple.cnstr]-13.1: sizeof...(Types) equals sizeof...(UTypes),
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (sizeof...(_Types) == 0)
+    { // [tuple.cnstr]-13.2: sizeof...(Types) >= 1,
+      return __select_constructor::__invalid;
+    }
+    else
+    {
+      using _Type = __type_index_c<0, _Types...>;
+      // Reject unpacking a tuple_of_iterator_references through the 1-arg variadic constructor so the
+      // dedicated constructor is used instead. Do allow it if the original type is a tuple_of_iterator_references
+      // though
+      if constexpr (__is_tuple_of_iterator_references_v<remove_cvref_t<_UType>>
+                    && !__is_tuple_of_iterator_references_v<remove_cvref_t<_Type>>)
+      {
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (is_same_v<remove_cvref_t<_UType>, tuple<_Type>>)
+      { // [tuple.cnstr]-12.1: negation<is_same<remove_cvref_t<U0>, tuple>> if sizeof...(Types) is 1
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (!is_constructible_v<_Type, _UType>)
       { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
         return __select_constructor::__invalid;
       }
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-      else if constexpr ((reference_constructs_from_temporary_v<_Types, _UTypes&&> || ...))
+      else if constexpr (reference_constructs_from_temporary_v<_Type, _UType&&>)
       { // [tuple.cnstr]-15: This constructor is defined as deleted if
         // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
         return __select_constructor::__deleted;
       }
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-      else if constexpr (!(is_convertible_v<_UTypes, _Types> && ...))
+      else if constexpr (!is_convertible_v<_UType, _Type>)
       { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
         return __select_constructor::__explicit;
       }
@@ -192,449 +251,311 @@ __tuple_select_variadic_constructible(__tuple_types<_Types...>, __tuple_types<_U
         return __select_constructor::__implicit;
       }
     }
-    else
+    // NOLINTEND(bugprone-branch-clone)
+  }
+  template <class... _UTypes>
+  using __variadic_construction = _ConstructorConstraint<__select_variadic_constructible<_UTypes...>()>;
+
+  template <class... _UTypes>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
+  __select_variadic_constructible_less_rank() noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (!(sizeof...(_UTypes) < sizeof...(_Types)))
     {
       return __select_constructor::__invalid;
     }
-  }
-  else if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
-  { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
-    return __select_constructor::__invalid;
-  }
-#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  else if constexpr ((reference_constructs_from_temporary_v<_Types, _UTypes&&> || ...))
-  { // [tuple.cnstr]-15: This constructor is defined as deleted if
-    // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
-    return __select_constructor::__deleted;
-  }
-#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-  else if constexpr (!(is_convertible_v<_UTypes, _Types> && ...))
-  { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
-    return __select_constructor::__explicit;
-  }
-  else
-  {
-    return __select_constructor::__implicit;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
-
-template <class _Type, class _UType>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_variadic_constructible(__tuple_types<_Type>, __tuple_types<_UType>) noexcept
-{
-  // NOLINTBEGIN(bugprone-branch-clone)
-  // Reject unpacking a tuple_of_iterator_references through the 1-arg variadic constructor so the
-  // dedicated constructor is used instead. Do allow it if the original type is a tuple_of_iterator_references though
-  if constexpr (__is_tuple_of_iterator_references_v<remove_cvref_t<_UType>>
-                && !__is_tuple_of_iterator_references_v<remove_cvref_t<_Type>>)
-  {
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (is_same_v<remove_cvref_t<_UType>, tuple<_Type>>)
-  { // [tuple.cnstr]-12.1: negation<is_same<remove_cvref_t<U0>, tuple>> if sizeof...(Types) is 1
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!is_constructible_v<_Type, _UType>)
-  { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
-    return __select_constructor::__invalid;
-  }
-#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  else if constexpr (reference_constructs_from_temporary_v<_Type, _UType&&>)
-  { // [tuple.cnstr]-15: This constructor is defined as deleted if
-    // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
-    return __select_constructor::__deleted;
-  }
-#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-  else if constexpr (!is_convertible_v<_UType, _Type>)
-  { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
-    return __select_constructor::__explicit;
-  }
-  else
-  {
-    return __select_constructor::__implicit;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
-
-template <class _TupleTypes, class _TupleUTypes>
-inline constexpr __select_constructor __tuple_select_variadic_constructible_v =
-  ::cuda::std::__tuple_select_variadic_constructible(_TupleTypes{}, _TupleUTypes{});
-
-template <class... _Types, class... _UTypes>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_variadic_constructible_less_rank(__tuple_types<_Types...>, __tuple_types<_UTypes...>) noexcept
-{
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (!(sizeof...(_UTypes) < sizeof...(_Types)))
-  {
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (sizeof...(_UTypes) == 0)
-  {
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (sizeof...(_UTypes) == 1 && (is_same_v<remove_cvref_t<_UTypes>, tuple<_Types...>> && ...))
-  { // Avoid this shadowing the copy / move constructors
-    return __select_constructor::__invalid;
-  }
-  else
-  { // MSVC has issues with constexpr variables here, so no `__can_construct<_Trait>` or constexpr variable
-    using __arg_list = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_UTypes)>;
-    if constexpr (::cuda::std::__tuple_select_variadic_constructible(__arg_list{}, __tuple_types<_UTypes...>{})
-                    == __select_constructor::__invalid
-                  || ::cuda::std::__tuple_select_variadic_constructible(__arg_list{}, __tuple_types<_UTypes...>{})
-                       == __select_constructor::__deleted)
+    else if constexpr (sizeof...(_UTypes) == 0)
     {
       return __select_constructor::__invalid;
     }
+    else if constexpr (sizeof...(_UTypes) == 1 && (is_same_v<remove_cvref_t<_UTypes>, tuple<_Types...>> && ...))
+    { // Avoid this shadowing the copy / move constructors
+      return __select_constructor::__invalid;
+    }
     else
-    {
-      using __defaulted_list = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_Types), sizeof...(_UTypes)>;
-      if constexpr (::cuda::std::__tuple_select_default_constructible(__defaulted_list{})
-                      == __select_constructor::__invalid
-                    || ::cuda::std::__tuple_select_default_constructible(__defaulted_list{})
-                         == __select_constructor::__deleted)
+    { // MSVC has issues with constexpr variables here, so no constexpr variable
+      using __arg_list        = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_UTypes)>;
+      using __arg_constraints = typename decltype(::cuda::std::__tuple_get_constraints(
+        __arg_list{}))::template __variadic_construction<_UTypes...>;
+      if constexpr (!__arg_constraints::__can_construct)
       {
         return __select_constructor::__invalid;
       }
       else
       {
-        return __select_constructor::__explicit;
+        using __defaulted_list = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_Types), sizeof...(_UTypes)>;
+        using __defaulted_constraints =
+          typename decltype(::cuda::std::__tuple_get_constraints(__defaulted_list{}))::__default_construction;
+        if constexpr (__defaulted_constraints::__can_construct)
+        {
+          return __select_constructor::__explicit;
+        }
+        else
+        {
+          return __select_constructor::__invalid;
+        }
       }
     }
+    // NOLINTEND(bugprone-branch-clone)
   }
-  _CCCL_UNREACHABLE();
-  // NOLINTEND(bugprone-branch-clone)
-}
+  template <class... _UTypes>
+  using __variadic_construction_less_rank =
+    _ConstructorConstraint<__select_variadic_constructible_less_rank<_UTypes...>()>;
 
-template <class _TupleTypes, class _TupleUTypes>
-inline constexpr __select_constructor __tuple_select_variadic_constructible_less_rank_v =
-  ::cuda::std::__tuple_select_variadic_constructible_less_rank(_TupleTypes{}, _TupleUTypes{});
-
-_CCCL_EXEC_CHECK_DISABLE
-template <class _UTuple, class... _Types, size_t... _Indices>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_tuple_like_constructible(__tuple_types<_Types...>, __tuple_indices<_Indices...>) noexcept
-{
-  using ::cuda::std::get;
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
-  { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (is_same_v<_UTuple, const tuple<_Types...>&> || is_same_v<_UTuple, tuple<_Types...>&&>)
-  { // Prefers the copy/move constructor
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (sizeof...(_Types) == 0)
-  { // Avoids issues with the size 1 constructor below
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!__tuple_like_with_size<_UTuple, sizeof...(_Types)>)
-  { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
-    // [tuple#cnstr]-25.1: sizeof...(Types) is 2,
-    // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!(is_constructible_v<_Types, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
-  { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-    // [tuple.cnstr]-25.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-    // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-    return __select_constructor::__invalid;
-  }
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _UTuple, size_t... _Indices>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
+  __select_tuple_like_constructible(__tuple_indices<_Indices...>) noexcept
+  {
+    if constexpr (sizeof...(_Types) != sizeof...(_Indices))
+    {
+      return __select_constructor::__invalid;
+    }
+    else
+    {
+      using ::cuda::std::get;
+      // NOLINTBEGIN(bugprone-branch-clone)
+      if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
+      { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (is_same_v<_UTuple, const tuple<_Types...>&> || is_same_v<_UTuple, tuple<_Types...>&&>)
+      { // Prefers the copy/move constructor
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (sizeof...(_Types) == 0)
+      { // Avoids issues with the size 1 constructor below
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (!__tuple_like_with_size<_UTuple, sizeof...(_Types)>)
+      { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
+        // [tuple#cnstr]-25.1: sizeof...(Types) is 2,
+        // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (!(is_constructible_v<_Types, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
+      { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
+        // [tuple.cnstr]-25.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
+        // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
+        return __select_constructor::__invalid;
+      }
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  else if constexpr ((reference_constructs_from_temporary_v<_Types,
-                                                            decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))>
-                      || ...))
-  { // [tuple.cnstr]-23: This constructor is defined as deleted if
-    // [tuple.cnstr]-27: This constructor is defined as deleted if
-    // [tuple.cnstr]-31: This constructor is defined as deleted if
-    // (reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...) is true
-    return __select_constructor::__deleted;
-  }
+      else if constexpr ((reference_constructs_from_temporary_v<_Types,
+                                                                decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))>
+                          || ...))
+      { // [tuple.cnstr]-23: This constructor is defined as deleted if
+        // [tuple.cnstr]-27: This constructor is defined as deleted if
+        // [tuple.cnstr]-31: This constructor is defined as deleted if
+        // (reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...) is true
+        return __select_constructor::__deleted;
+      }
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-  else if constexpr (!(is_convertible_v<decltype(get<_Indices>(::cuda::std::declval<_UTuple>())), _Types> && ...))
-  { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
-    // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
-    // [tuple.cnstr]-31: The expression inside explicit is equivalent to:
-    // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
-    return __select_constructor::__explicit;
+      else if constexpr (!(is_convertible_v<decltype(get<_Indices>(::cuda::std::declval<_UTuple>())), _Types> && ...))
+      { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
+        // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
+        // [tuple.cnstr]-31: The expression inside explicit is equivalent to:
+        // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
+        return __select_constructor::__explicit;
+      }
+      else
+      {
+        return __select_constructor::__implicit;
+      }
+    }
+    // NOLINTEND(bugprone-branch-clone)
   }
-  else
-  {
-    return __select_constructor::__implicit;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
 
-_CCCL_EXEC_CHECK_DISABLE
-template <class _UTuple, class _Type, size_t _Index>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_tuple_like_constructible(__tuple_types<_Type>, __tuple_indices<_Index>) noexcept
-{
-  using ::cuda::std::get;
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
-  { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (is_same_v<_UTuple, const tuple<_Type>&> || is_same_v<_UTuple, tuple<_Type>&&>)
-  { // Prefers the copy/move constructor
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!__tuple_like_with_size<_UTuple, 1>)
-  { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
-    // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (__is_cuda_std_tuple<remove_cvref_t<_UTuple>>
-                     && is_same_v<_Type, tuple_element_t<_Index, remove_cvref_t<_UTuple>>>)
-  { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1
-    // [tuple#cnstr]-21.3: is_same_v<T, U> is false
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (is_constructible_v<_Type, _UTuple>)
-  { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
-    // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (is_convertible_v<_UTuple, _Type>)
-  { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
-    // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!is_constructible_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
-  { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-    // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-    return __select_constructor::__invalid;
-  }
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _UTuple, size_t _Index>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
+  __select_tuple_like_constructible(__tuple_indices<_Index>) noexcept
+  {
+    if constexpr (sizeof...(_Types) != 1)
+    {
+      return __select_constructor::__invalid;
+    }
+    else
+    {
+      using _Type = __type_index_c<0, _Types...>;
+      using ::cuda::std::get;
+      // NOLINTBEGIN(bugprone-branch-clone)
+      if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
+      { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (is_same_v<_UTuple, const tuple<_Type>&> || is_same_v<_UTuple, tuple<_Type>&&>)
+      { // Prefers the copy/move constructor
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (!__tuple_like_with_size<_UTuple, 1>)
+      { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
+        // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (__is_cuda_std_tuple<remove_cvref_t<_UTuple>>
+                         && is_same_v<_Type, tuple_element_t<_Index, remove_cvref_t<_UTuple>>>)
+      { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1
+        // [tuple#cnstr]-21.3: is_same_v<T, U> is false
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (is_constructible_v<_Type, _UTuple>)
+      { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
+        // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (is_convertible_v<_UTuple, _Type>)
+      { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
+        // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (!is_constructible_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
+      { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
+        // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
+        return __select_constructor::__invalid;
+      }
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  else if constexpr (reference_constructs_from_temporary_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
-  { // [tuple.cnstr]-23: This constructor is defined as deleted if
-    // [tuple.cnstr]-31: This constructor is defined as deleted if
-    // (reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...) is true
-    return __select_constructor::__deleted;
-  }
+      else if constexpr (reference_constructs_from_temporary_v<_Type,
+                                                               decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
+      { // [tuple.cnstr]-23: This constructor is defined as deleted if
+        // [tuple.cnstr]-31: This constructor is defined as deleted if
+        // (reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...) is true
+        return __select_constructor::__deleted;
+      }
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-  else if constexpr (!is_convertible_v<decltype(get<_Index>(::cuda::std::declval<_UTuple>())), _Type>)
-  { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
-    // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
-    // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
-    return __select_constructor::__explicit;
+      else if constexpr (!is_convertible_v<decltype(get<_Index>(::cuda::std::declval<_UTuple>())), _Type>)
+      { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
+        // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
+        // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
+        return __select_constructor::__explicit;
+      }
+      else
+      {
+        return __select_constructor::__implicit;
+      }
+    }
+    // NOLINTEND(bugprone-branch-clone)
   }
-  else
+  template <class _UTuple>
+  using __tuple_like_construction =
+    _ConstructorConstraint<__select_tuple_like_constructible<_UTuple>(__make_tuple_indices_t<sizeof...(_Types)>{})>;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _UTuple, size_t... _Indices>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool
+  __nothrow_tuple_like_constructible_(__tuple_indices<_Indices...>) noexcept
   {
-    return __select_constructor::__implicit;
+    using ::cuda::std::get;
+    return (is_nothrow_constructible_v<_Types, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...);
   }
-  // NOLINTEND(bugprone-branch-clone)
-}
+  template <class _UTuple>
+  static constexpr bool __nothrow_tuple_like_constructible =
+    __nothrow_tuple_like_constructible_<_UTuple>(__make_tuple_indices_t<sizeof...(_Types)>{});
 
-template <class _UTuple, class _TupleTypes, class _TupleIndices>
-inline constexpr __select_constructor __tuple_select_tuple_like_constructible_v =
-  ::cuda::std::__tuple_select_tuple_like_constructible<_UTuple>(_TupleTypes{}, _TupleIndices{});
+  // Assignments
+  static constexpr bool __all_copy_assignable = (is_copy_assignable_v<_Types> && ...);
+  static constexpr bool __all_move_assignable = (is_move_assignable_v<_Types> && ...);
 
-_CCCL_EXEC_CHECK_DISABLE
-template <class _UTuple, class _Type, class... _Types, size_t _Index, size_t... _Indices>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL bool
-__tuple_nothrow_tuple_like_constructible(__tuple_types<_Type, _Types...>, __tuple_indices<_Index, _Indices...>) noexcept
-{
-  using ::cuda::std::get;
-  if constexpr (!is_nothrow_constructible_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
+  // [tuple.assign]-5: is_copy_assignable_v<const Types> is true for all i.
+  using __const_copy_assignable = _AssignmentConstraint<(is_copy_assignable_v<const _Types> && ...)>;
+  // [tuple.assign]-12: is_assignable_v<const Types&, Types> is true for all i.
+  using __const_move_assignable = _AssignmentConstraint<(is_assignable_v<const _Types&, _Types> && ...)>;
+
+  template <bool _IsConst, class... _UTypes>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool __select_converting_assignable() noexcept
   {
-    return false;
-  }
-  else if constexpr (sizeof...(_Types) != 0)
-  {
-    return ::cuda::std::__tuple_nothrow_tuple_like_constructible<_UTuple>(
-      __tuple_types<_Types...>{}, __tuple_indices<_Indices...>{});
-  }
-  else
-  {
-    return true;
-  }
-}
-
-template <class _UTuple>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL bool
-__tuple_nothrow_tuple_like_constructible(__tuple_types<>, __tuple_indices<>) noexcept
-{
-  return true;
-}
-
-template <class _UTuple, class _TupleTypes, class _TupleIndices>
-inline constexpr bool __tuple_nothrow_tuple_like_constructible_v =
-  ::cuda::std::__tuple_nothrow_tuple_like_constructible<_UTuple>(_TupleTypes{}, _TupleIndices{});
-
-struct _InvalidTupleComparison
-{
-  static constexpr bool __equality_comparable         = false;
-  static constexpr bool __nothrow_equality_comparable = false;
-
-  static constexpr bool __less_than_comparable         = false;
-  static constexpr bool __nothrow_less_than_comparable = false;
-};
-
-template <class, class>
-struct _TupleComparableTraits;
-
-template <class... _Types, class... _UTypes>
-struct _TupleComparableTraits<__tuple_types<_Types...>, __tuple_types<_UTypes...>>
-{
-  static constexpr bool __equality_comparable = (__is_cpp17_equality_comparable_v<_Types, _UTypes> && ...);
-  static constexpr bool __nothrow_equality_comparable =
-    (__is_cpp17_nothrow_equality_comparable_v<_Types, _UTypes> && ...);
-
-  static constexpr bool __less_than_comparable = (__is_cpp17_less_than_comparable_v<_Types, _UTypes> && ...);
-  static constexpr bool __nothrow_less_than_comparable =
-    (__is_cpp17_nothrow_less_than_comparable_v<_Types, _UTypes> && ...);
-};
-
-template <class... _Types, class... _UTypes, enable_if_t<(sizeof...(_Types) == sizeof...(_UTypes)), int> = 0>
-[[nodiscard]]
-_CCCL_API _CCCL_CONSTEVAL auto __tuple_is_comparable(__tuple_types<_Types...>, __tuple_types<_UTypes...>) noexcept
-  -> _TupleComparableTraits<__tuple_types<_Types...>, __tuple_types<_UTypes...>>;
-template <class>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __tuple_is_comparable(...) noexcept -> _InvalidTupleComparison;
-
-template <class... _Types>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_assignment
-__tuple_select_const_copy_assignable(__tuple_types<_Types...>) noexcept
-{
-  if constexpr (!(is_copy_assignable_v<const _Types> && ...))
-  { // [tuple.assign]-5: is_copy_assignable_v<const Types> is true for all i.
-    return __select_assignment::__invalid;
-  }
-  else if constexpr ((is_nothrow_copy_assignable_v<const _Types> && ...))
-  {
-    return __select_assignment::__is_nothrow;
-  }
-  else
-  {
-    return __select_assignment::__may_throw;
-  }
-}
-
-template <class _TupleTypes>
-inline constexpr __select_assignment __tuple_select_const_copy_assignable_v =
-  ::cuda::std::__tuple_select_const_copy_assignable(_TupleTypes{});
-
-template <class... _Types>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_assignment
-__tuple_select_const_move_assignable(__tuple_types<_Types...>) noexcept
-{
-  if constexpr (!(is_assignable_v<const _Types&, _Types> && ...))
-  { // [tuple.assign]-12: is_assignable_v<const Types&, Types> is true for all i.
-    return __select_assignment::__invalid;
-  }
-  else if constexpr ((is_nothrow_assignable_v<const _Types&, _Types> && ...))
-  {
-    return __select_assignment::__is_nothrow;
-  }
-  else
-  {
-    return __select_assignment::__may_throw;
-  }
-}
-
-template <class _TupleTypes>
-inline constexpr __select_assignment __tuple_select_const_move_assignable_v =
-  ::cuda::std::__tuple_select_const_move_assignable(_TupleTypes{});
-
-template <bool _IsConst, class... _Types, class... _UTypes>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_assignment
-__tuple_select_converting_assignable(__tuple_types<_Types...>, __tuple_types<_UTypes...>) noexcept
-{
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
-  { // [tuple.assign]-15.1: sizeof...(Types) equals sizeof...(UTypes) and
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (is_same_v<tuple<_Types...>, tuple<_UTypes...>>)
-  { // Disambiguate the non-converting assignments
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (_IsConst)
-  {
-    if constexpr ((is_assignable_v<const _Types&, _UTypes> && ...))
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
+    { // [tuple.assign]-15.1: sizeof...(Types) equals sizeof...(UTypes) and
+      return false;
+    }
+    else if constexpr (is_same_v<tuple<_Types...>, tuple<_UTypes...>>)
+    { // Disambiguate the non-converting assignments
+      return false;
+    }
+    else if constexpr (_IsConst)
     { // [tuple.assign]-18.2: is_assignable_v<const Types&, const UTypes&> is true for all i.
       // [tuple.assign]-24.2: is_assignable_v<const Types&, UTypes> is true for all i.
-      return (is_nothrow_assignable_v<const _Types&, _UTypes> && ...)
-             ? __select_assignment::__is_nothrow
-             : __select_assignment::__may_throw;
+      return (is_assignable_v<const _Types&, _UTypes> && ...);
     }
     else
-    {
-      return __select_assignment::__invalid;
+    { // [tuple.assign]-15.2: is_assignable_v<Types&, const UTypes&> is true for all i.
+      // [tuple.assign]-21.2: is_assignable_v<Types&, UTypes> is true for all i.
+      return (is_assignable_v<_Types&, _UTypes> && ...);
     }
+    // NOLINTEND(bugprone-branch-clone)
   }
-  else if constexpr ((is_assignable_v<_Types&, _UTypes> && ...))
-  { // [tuple.assign]-15.2: is_assignable_v<Types&, const UTypes&> is true for all i.
-    // [tuple.assign]-21.2: is_assignable_v<Types&, UTypes> is true for all i.
-    return (is_nothrow_assignable_v<_Types&, _UTypes> && ...)
-           ? __select_assignment::__is_nothrow
-           : __select_assignment::__may_throw;
-  }
-  else
-  {
-    return __select_assignment::__invalid;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
+  template <bool _IsConst, class... _UTypes>
+  using __converting_assignable = _AssignmentConstraint<__select_converting_assignable<_IsConst, _UTypes...>()>;
 
-template <bool _IsConst, class _TupleTypes, class _TupleUTypes>
-inline constexpr __select_assignment __tuple_select_converting_assignable_v =
-  ::cuda::std::__tuple_select_converting_assignable<_IsConst>(_TupleTypes{}, _TupleUTypes{});
-
-_CCCL_EXEC_CHECK_DISABLE
-template <bool _IsConst, class _UTuple, class... _Types, size_t... _Indices>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_assignment
-__tuple_select_tuple_like_assignable(__tuple_types<_Types...>, __tuple_indices<_Indices...>) noexcept
-{
-  using ::cuda::std::get;
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (is_same_v<remove_cvref_t<_UTuple>, tuple<_Types...>>)
-  { // [tuple.assign]-39.1: different-from<UTuple, tuple>
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
-  { // [tuple.assign]-39.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (!__tuple_like_with_size<_UTuple, sizeof...(_Types)>)
-  { // [tuple.assign]-39.3: sizeof...(Types) equals tuple_size_v<remove_cvref_t<UTuple>>, and
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (_IsConst)
+  _CCCL_EXEC_CHECK_DISABLE
+  template <bool _IsConst, class _UTuple, size_t... _Indices>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool
+  __select_tuple_like_assignable(__tuple_indices<_Indices...>) noexcept
   {
-    if constexpr ((is_assignable_v<const _Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
+    using ::cuda::std::get;
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (is_same_v<remove_cvref_t<_UTuple>, tuple<_Types...>>)
+    { // [tuple.assign]-39.1: different-from<UTuple, tuple>
+      return false;
+    }
+    else if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
+    { // [tuple.assign]-39.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
+      return false;
+    }
+    else if constexpr (!__tuple_like_with_size<_UTuple, sizeof...(_Types)>)
+    { // [tuple.assign]-39.3: sizeof...(Types) equals tuple_size_v<remove_cvref_t<UTuple>>, and
+      return false;
+    }
+    else if constexpr (_IsConst)
     { // [tuple.assign]-42.4: is_assignable_v<const T_i&, decltype(get<i>(std::forward<UTuple>(u)))> is true for
       // all i
-      return (is_nothrow_assignable_v<const _Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...)
-             ? __select_assignment::__is_nothrow
-             : __select_assignment::__may_throw;
+      return (is_assignable_v<const _Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...);
+    }
+    else
+    { // [tuple.assign]-39.4: is_assignable_v<T_i&, decltype(get<i>(std::forward<UTuple>(u)))> is true for all i
+      return (is_assignable_v<_Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...);
+    }
+    // NOLINTEND(bugprone-branch-clone)
+  }
+  template <bool _IsConst, class _UTuple>
+  using __tuple_like_assignable = _AssignmentConstraint<__select_tuple_like_assignable<_IsConst, _UTuple>(
+    __make_tuple_indices_t<sizeof...(_Types)>{})>;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  template <bool _IsConst, class _UTuple, size_t... _Indices>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool
+  __nothrow_tuple_like_assignable_(__tuple_indices<_Indices...>) noexcept
+  {
+    using ::cuda::std::get;
+    if constexpr (_IsConst)
+    {
+      return (is_nothrow_assignable_v<const _Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...);
     }
     else
     {
-      return __select_assignment::__invalid;
+      return (is_nothrow_assignable_v<_Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...);
     }
   }
-  else if constexpr ((is_assignable_v<_Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
-  { // [tuple.assign]-39.4: is_assignable_v<T_i&, decltype(get<i>(std::forward<UTuple>(u)))> is true for all i
-    return (is_nothrow_assignable_v<_Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...)
-           ? __select_assignment::__is_nothrow
-           : __select_assignment::__may_throw;
-  }
-  else
-  {
-    return __select_assignment::__invalid;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
+  template <bool _IsConst, class _UTuple>
+  static constexpr bool __nothrow_tuple_like_assignable =
+    __nothrow_tuple_like_assignable_<_IsConst, _UTuple>(__make_tuple_indices_t<sizeof...(_Types)>{});
 
-template <bool _IsConst, class _UTuple, class _TupleTypes, class _TupleIndices>
-inline constexpr __select_assignment __tuple_select_tuple_like_assignable_v =
-  ::cuda::std::__tuple_select_tuple_like_assignable<_IsConst, _UTuple>(_TupleTypes{}, _TupleIndices{});
+  // Comparisons
+  template <class... _UTypes>
+  static constexpr bool __is_equality_comparable_v = (__is_cpp17_equality_comparable_v<_Types, _UTypes> && ...);
+
+  template <class... _UTypes>
+  static constexpr bool __is_nothrow_equality_comparable_v =
+    (__is_cpp17_nothrow_equality_comparable_v<_Types, _UTypes> && ...);
+
+  template <class... _UTypes>
+  static constexpr bool __is_less_than_comparable_v = (__is_cpp17_less_than_comparable_v<_Types, _UTypes> && ...);
+
+  template <class... _UTypes>
+  static constexpr bool __is_nothrow_less_than_comparable_v =
+    (__is_cpp17_nothrow_less_than_comparable_v<_Types, _UTypes> && ...);
+};
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_leaf.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_leaf.h
@@ -412,8 +412,8 @@ template <size_t... _Indx, class... _Tp>
 struct _CCCL_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...>
     : public __tuple_leaf<_Indx, _Tp>...
     , public __tuple_impl_sfinae_helper<__tuple_impl<__tuple_indices<_Indx...>, _Tp...>,
-                                        __tuple_all_copy_assignable_v<_Tp...>,
-                                        __tuple_all_move_assignable_v<_Tp...>>
+                                        __tuple_constraints<_Tp...>::__all_copy_assignable,
+                                        __tuple_constraints<_Tp...>::__all_move_assignable>
 {
   _CCCL_HIDE_FROM_ABI constexpr __tuple_impl() = default;
 

--- a/libcudacxx/include/cuda/std/__type_traits/sfinae_traits.h
+++ b/libcudacxx/include/cuda/std/__type_traits/sfinae_traits.h
@@ -34,27 +34,20 @@ enum class __select_constructor
 };
 
 template <__select_constructor _Trait>
-inline constexpr bool __can_construct_implicitly = _Trait == __select_constructor::__implicit;
-template <__select_constructor _Trait>
-inline constexpr bool __can_construct_explicitly = _Trait == __select_constructor::__explicit;
-template <__select_constructor _Trait>
-inline constexpr bool __can_construct =
-  (_Trait == __select_constructor::__implicit) || (_Trait == __select_constructor::__explicit);
-template <__select_constructor _Trait>
-inline constexpr bool __is_deleted = _Trait == __select_constructor::__deleted;
-
-//! @brief Determines whether an assignment is valid and also whether it does not throw
-enum class __select_assignment
+struct _ConstructorConstraint
 {
-  __invalid, //!< The assignment is invalid
-  __is_nothrow, //!< The assignment is valid and noexcept
-  __may_throw, //!< The assignment is valid but may throw
+  static constexpr bool __can_construct_implicitly = _Trait == __select_constructor::__implicit;
+  static constexpr bool __can_construct_explicitly = _Trait == __select_constructor::__explicit;
+  static constexpr bool __can_construct =
+    _Trait == __select_constructor::__implicit || _Trait == __select_constructor::__explicit;
+  static constexpr bool __is_deleted = _Trait == __select_constructor::__deleted;
 };
 
-template <__select_assignment _Trait>
-inline constexpr bool __can_assign = _Trait != __select_assignment::__invalid;
-template <__select_assignment _Trait>
-inline constexpr bool __can_nothrow_assign = _Trait == __select_assignment::__is_nothrow;
+template <bool _Trait>
+struct _AssignmentConstraint
+{
+  static constexpr bool __can_assign = _Trait == true;
+};
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -76,6 +76,42 @@ template <class _T1, class _T2>
 struct __pair_constraints
 {
   _CCCL_EXEC_CHECK_DISABLE
+  template <class _U1, class _U2>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor __select_variadic_constructible() noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (!is_constructible_v<_T1, _U1>)
+    { // [pairs#pair]-11.1: is_constructible<T1, U1> is true
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (!is_constructible_v<_T2, _U2>)
+    { // [pairs#pair]-11.2: is_constructible<T2, U2> is true
+      return __select_constructor::__invalid;
+    }
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+    else if constexpr (reference_constructs_from_temporary_v<_T1, _U1&&>
+                       || reference_constructs_from_temporary_v<_T2, _U2&&>)
+    { // [pairs#pair]-13: This constructor is defined as deleted if
+      // reference_constructs_from_temporary_v<T1, U1&&> or
+      // reference_constructs_from_temporary_v<T2, U2&&> is true
+      return __select_constructor::__deleted;
+    }
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+    else if constexpr (is_convertible_v<_U1, _T1> && is_convertible_v<_U2, _T2>)
+    { // [pairs#pair]-13 !is_convertible_v<U1, T1> || !is_convertible_v<U2, T2>
+      return __select_constructor::__implicit;
+    }
+    else
+    {
+      return __select_constructor::__explicit;
+    }
+    // NOLINTEND(bugprone-branch-clone)
+  }
+
+  template <class _U1, class _U2>
+  using __variadic_construction = _ConstructorConstraint<__select_variadic_constructible<_U1, _U2>()>;
+
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor __select_pair_like_constructible() noexcept
   {
@@ -177,8 +213,8 @@ struct __pair_base
   _T2 second;
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__default_construction,
-            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
+  template <__select_constructor _Constraints = __tuple_constraints<_T1, _T2>::__select_default_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr __pair_base() noexcept(is_nothrow_default_constructible_v<_T1>
                                              && is_nothrow_default_constructible_v<_T2>)
       : first()
@@ -186,8 +222,8 @@ struct __pair_base
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__default_construction,
-            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
+  template <__select_constructor _Constraints = __tuple_constraints<_T1, _T2>::__select_default_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr __pair_base() noexcept(
     is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : first()
@@ -219,8 +255,8 @@ struct __pair_base<_T1, _T2, true>
   _T2 second;
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__default_construction,
-            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
+  template <__select_constructor _Constraints = __tuple_constraints<_T1, _T2>::__select_default_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr __pair_base() noexcept(is_nothrow_default_constructible_v<_T1>
                                              && is_nothrow_default_constructible_v<_T2>)
       : first()
@@ -228,8 +264,8 @@ struct __pair_base<_T1, _T2, true>
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__default_construction,
-            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
+  template <__select_constructor _Constraints = __tuple_constraints<_T1, _T2>::__select_default_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr __pair_base() noexcept(
     is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : first()
@@ -289,14 +325,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   using first_type  = _T1;
   using second_type = _T2;
 
-  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__default_construction,
-            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
+  template <__select_constructor _Constraints = __tuple_constraints<_T1, _T2>::__select_default_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair() noexcept(is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : __base()
   {}
 
-  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__default_construction,
-            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
+  template <__select_constructor _Constraints = __tuple_constraints<_T1, _T2>::__select_default_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair() noexcept(is_nothrow_default_constructible_v<_T1>
                                                && is_nothrow_default_constructible_v<_T2>)
       : __base()
@@ -322,7 +358,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1         = _T1,
             class _U2         = _T2,
-            class _Constraint = typename __tuple_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
+            class _Constraint = typename __pair_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
             enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
@@ -331,7 +367,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1         = _T1,
             class _U2         = _T2,
-            class _Constraint = typename __tuple_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
+            class _Constraint = typename __pair_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
             enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
@@ -341,7 +377,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1         = _T1,
             class _U2         = _T2,
-            class _Constraint = typename __tuple_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
+            class _Constraint = typename __pair_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
             enable_if_t<_Constraint::__is_deleted, int> = 0>
   constexpr pair(_U1&&, _U2&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -72,118 +72,102 @@ _CCCL_BEGIN_NV_DIAG_SUPPRESS(1770) // type qualifiers are ignored (underlying ty
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_EXEC_CHECK_DISABLE
-template <class _UPair, class _T1, class _T2>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor __pair_select_pair_like_constructible() noexcept
+template <class _T1, class _T2>
+struct __pair_constraints
 {
-  using ::cuda::std::get;
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UPair>>)
-  { // [pairs#pair]-15.1: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!__pair_like<_UPair>)
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _UPair>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor __select_pair_like_constructible() noexcept
   {
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!is_constructible_v<_T1, decltype(get<0>(::cuda::std::declval<_UPair>()))>)
-  { // [pairs#pair]-15.2: is_constructible<T1, decltype(get<0>(std::forward<UTuple>(u)))>... is true
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!is_constructible_v<_T2, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
-  { // [pairs#pair]-15.3: is_constructible<T2, decltype(get<1>(std::forward<UTuple>(u)))>... is true
-    return __select_constructor::__invalid;
-  }
-#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  else if constexpr (reference_constructs_from_temporary_v<_T1, decltype(get<0>(::cuda::std::declval<_UPair>()))>
-                     || reference_constructs_from_temporary_v<_T2, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
-  { // [pairs#pair]-17: This constructor is defined as deleted if
-    // reference_constructs_from_temporary_v<T1, decltype(get<0>(FWD(u)))> or
-    // reference_constructs_from_temporary_v<T2, decltype(get<1>(FWD(u)))> is true
-    return __select_constructor::__deleted;
-  }
-#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-  else if constexpr (is_convertible_v<decltype(get<0>(::cuda::std::declval<_UPair>())), _T1>
-                     && is_convertible_v<decltype(get<1>(::cuda::std::declval<_UPair>())), _T2>)
-  { // [pairs#pair]-17 !is_convertible_v<decltype(get<0>(FWD(u))), T1> &&
-    //                 !is_convertible_v<decltype(get<1>(FWD(u))), T2>
-    return __select_constructor::__implicit;
-  }
-  else
-  {
-    return __select_constructor::__explicit;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
-
-template <class _UPair, class _T1, class _T2>
-inline constexpr __select_constructor __pair_select_pair_like_constructible_v =
-  ::cuda::std::__pair_select_pair_like_constructible<_UPair, _T1, _T2>();
-
-_CCCL_EXEC_CHECK_DISABLE
-template <bool _IsConst, class _UPair, class _T1, class _T2>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_assignment __pair_select_pair_like_assignable() noexcept
-{
-  using ::cuda::std::get;
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (is_same_v<remove_cvref_t<_UPair>, pair<_T1, _T2>>)
-  { // [pairs.pair]-42.1: different-from<UPair, pair>
-    // [pairs.pair]-45.1: different-from<UPair, pair>
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UPair>>)
-  { // [pairs.pair]-42.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
-    // [pairs.pair]-45.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (!__pair_like<_UPair>)
-  { // [pairs.pair]-42: pair-like P
-    // [pairs.pair]-45: pair-like P
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (_IsConst)
-  {
-    if constexpr (!is_assignable_v<const _T1&, decltype(get<0>(::cuda::std::declval<_UPair>()))>)
-    { // [pairs.pair]-45.3: is_assignable_v<const T1&, decltype(get<0>(std::forward<P>(p)))> is true
-      return __select_assignment::__invalid;
+    using ::cuda::std::get;
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UPair>>)
+    { // [pairs#pair]-15.1: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
+      return __select_constructor::__invalid;
     }
-    else if constexpr (!is_assignable_v<const _T2&, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
-    { // [pairs.pair]-45.4: is_assignable_v<const T2&, decltype(get<1>(std::forward<P>(p)))> is true
-      return __select_assignment::__invalid;
-    }
-    else if constexpr (is_nothrow_assignable_v<const _T1&, decltype(get<0>(::cuda::std::declval<_UPair>()))>
-                       && is_nothrow_assignable_v<const _T2&, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
+    else if constexpr (!__pair_like<_UPair>)
     {
-      return __select_assignment::__is_nothrow;
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (!is_constructible_v<_T1, decltype(get<0>(::cuda::std::declval<_UPair>()))>)
+    { // [pairs#pair]-15.2: is_constructible<T1, decltype(get<0>(std::forward<UTuple>(u)))>... is true
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (!is_constructible_v<_T2, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
+    { // [pairs#pair]-15.3: is_constructible<T2, decltype(get<1>(std::forward<UTuple>(u)))>... is true
+      return __select_constructor::__invalid;
+    }
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+    else if constexpr (reference_constructs_from_temporary_v<_T1, decltype(get<0>(::cuda::std::declval<_UPair>()))>
+                       || reference_constructs_from_temporary_v<_T2, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
+    { // [pairs#pair]-17: This constructor is defined as deleted if
+      // reference_constructs_from_temporary_v<T1, decltype(get<0>(FWD(u)))> or
+      // reference_constructs_from_temporary_v<T2, decltype(get<1>(FWD(u)))> is true
+      return __select_constructor::__deleted;
+    }
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+    else if constexpr (is_convertible_v<decltype(get<0>(::cuda::std::declval<_UPair>())), _T1>
+                       && is_convertible_v<decltype(get<1>(::cuda::std::declval<_UPair>())), _T2>)
+    { // [pairs#pair]-17 !is_convertible_v<decltype(get<0>(FWD(u))), T1> &&
+      //                 !is_convertible_v<decltype(get<1>(FWD(u))), T2>
+      return __select_constructor::__implicit;
     }
     else
     {
-      return __select_assignment::__may_throw;
+      return __select_constructor::__explicit;
     }
+    // NOLINTEND(bugprone-branch-clone)
   }
-  else if constexpr (!is_assignable_v<_T1&, decltype(get<0>(::cuda::std::declval<_UPair>()))>)
-  { // [pairs.pair]-42.3: is_assignable_v<const T1&, decltype(get<0>(std::forward<P>(p)))> is true
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (!is_assignable_v<_T2&, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
-  { // [pairs.pair]-42.4: is_assignable_v<const T2&, decltype(get<1>(std::forward<P>(p)))> is true
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (is_nothrow_assignable_v<_T1&, decltype(get<0>(::cuda::std::declval<_UPair>()))>
-                     && is_nothrow_assignable_v<_T2&, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
-  {
-    return __select_assignment::__is_nothrow;
-  }
-  else
-  {
-    return __select_assignment::__may_throw;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
 
-template <bool _IsConst, class _UPair, class _T1, class _T2>
-inline constexpr __select_assignment __pair_select_pair_like_assignable_v =
-  ::cuda::std::__pair_select_pair_like_assignable<_IsConst, _UPair, _T1, _T2>();
+  template <class _UPair>
+  using __pair_like_construction = _ConstructorConstraint<__select_pair_like_constructible<_UPair>()>;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  template <bool _IsConst, class _UPair>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool __select_pair_like_assignable() noexcept
+  {
+    using ::cuda::std::get;
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (is_same_v<remove_cvref_t<_UPair>, pair<_T1, _T2>>)
+    { // [pairs.pair]-42.1: different-from<UPair, pair>
+      // [pairs.pair]-45.1: different-from<UPair, pair>
+      return false;
+    }
+    else if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UPair>>)
+    { // [pairs.pair]-42.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
+      // [pairs.pair]-45.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
+      return false;
+    }
+    else if constexpr (!__pair_like<_UPair>)
+    { // [pairs.pair]-42: pair-like P
+      // [pairs.pair]-45: pair-like P
+      return false;
+    }
+    else if constexpr (_IsConst)
+    {
+      if constexpr (!is_assignable_v<const _T1&, decltype(get<0>(::cuda::std::declval<_UPair>()))>)
+      { // [pairs.pair]-45.3: is_assignable_v<const T1&, decltype(get<0>(std::forward<P>(p)))> is true
+        return false;
+      }
+      else
+      { // [pairs.pair]-45.4: is_assignable_v<const T2&, decltype(get<1>(std::forward<P>(p)))> is true
+        return is_assignable_v<const _T2&, decltype(get<1>(::cuda::std::declval<_UPair>()))>;
+      }
+    }
+    else if constexpr (!is_assignable_v<_T1&, decltype(get<0>(::cuda::std::declval<_UPair>()))>)
+    { // [pairs.pair]-42.3: is_assignable_v<const T1&, decltype(get<0>(std::forward<P>(p)))> is true
+      return false;
+    }
+    else
+    { // [pairs.pair]-42.4: is_assignable_v<const T2&, decltype(get<1>(std::forward<P>(p)))> is true
+      return is_assignable_v<_T2&, decltype(get<1>(::cuda::std::declval<_UPair>()))>;
+    }
+    // NOLINTEND(bugprone-branch-clone)
+  }
+
+  template <bool _IsConst, class _UPair>
+  using __pair_like_assignment = _AssignmentConstraint<__select_pair_like_assignable<_IsConst, _UPair>()>;
+};
 
 // base class to ensure `is_trivially_copyable` when possible
 template <class _T1, class _T2, bool = __must_synthesize_assignment_v<_T1> || __must_synthesize_assignment_v<_T2>>
@@ -193,8 +177,8 @@ struct __pair_base
   _T2 second;
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__default_construction,
+            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr __pair_base() noexcept(is_nothrow_default_constructible_v<_T1>
                                              && is_nothrow_default_constructible_v<_T2>)
       : first()
@@ -202,8 +186,8 @@ struct __pair_base
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__default_construction,
+            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr __pair_base() noexcept(
     is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : first()
@@ -235,8 +219,8 @@ struct __pair_base<_T1, _T2, true>
   _T2 second;
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__default_construction,
+            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr __pair_base() noexcept(is_nothrow_default_constructible_v<_T1>
                                              && is_nothrow_default_constructible_v<_T2>)
       : first()
@@ -244,8 +228,8 @@ struct __pair_base<_T1, _T2, true>
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__default_construction,
+            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr __pair_base() noexcept(
     is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : first()
@@ -305,14 +289,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   using first_type  = _T1;
   using second_type = _T2;
 
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__default_construction,
+            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair() noexcept(is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : __base()
   {}
 
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__default_construction,
+            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair() noexcept(is_nothrow_default_constructible_v<_T1>
                                                && is_nothrow_default_constructible_v<_T2>)
       : __base()
@@ -323,53 +307,53 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   _CCCL_HIDE_FROM_ABI pair(pair&&)      = default;
 
   // element wise constructors
-  template <__select_constructor _Trait = __tuple_select_variadic_copy_constructible_v<__tuple_types<_T1, _T2>>,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__variadic_copy_construction,
+            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(const _T1& __t1, const _T2& __t2) noexcept(
     is_nothrow_copy_constructible_v<_T1> && is_nothrow_copy_constructible_v<_T2>)
       : __base(__t1, __t2)
   {}
-  template <__select_constructor _Trait = __tuple_select_variadic_copy_constructible_v<__tuple_types<_T1, _T2>>,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__variadic_copy_construction,
+            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(const _T1& __t1, const _T2& __t2) noexcept(
     is_nothrow_copy_constructible_v<_T1> && is_nothrow_copy_constructible_v<_T2>)
       : __base(__t1, __t2)
   {}
 
-  template <class _U1 = _T1,
-            class _U2 = _T2,
-            __select_constructor _Trait =
-              __tuple_select_variadic_constructible_v<__tuple_types<_T1, _T2>, __tuple_types<_U1, _U2>>,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+  template <class _U1         = _T1,
+            class _U2         = _T2,
+            class _Constraint = typename __tuple_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
+            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::forward<_U1>(__u1), ::cuda::std::forward<_U2>(__u2))
   {}
 
-  template <class _U1 = _T1,
-            class _U2 = _T2,
-            __select_constructor _Trait =
-              __tuple_select_variadic_constructible_v<__tuple_types<_T1, _T2>, __tuple_types<_U1, _U2>>,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+  template <class _U1         = _T1,
+            class _U2         = _T2,
+            class _Constraint = typename __tuple_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
+            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::forward<_U1>(__u1), ::cuda::std::forward<_U2>(__u2))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  template <class _U1 = _T1,
-            class _U2 = _T2,
-            __select_constructor _Trait =
-              __tuple_select_variadic_constructible_v<__tuple_types<_T1, _T2>, __tuple_types<_U1, _U2>>,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  template <class _U1         = _T1,
+            class _U2         = _T2,
+            class _Constraint = typename __tuple_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
+            enable_if_t<_Constraint::__is_deleted, int> = 0>
   constexpr pair(_U1&&, _U2&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
+  template <class _UPair>
+  using __pair_like_constructible = typename __pair_constraints<_T1, _T2>::template __pair_like_construction<_UPair>;
 
   // converting constructors
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&, _T1, _T2>,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+            class _Constraint                                         = __pair_like_constructible<pair<_U1, _U2>&>,
+            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1&> && is_nothrow_constructible_v<_T2, _U2&>)
       : __base(__p.first, __p.second)
@@ -377,8 +361,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&, _T1, _T2>,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+            class _Constraint                                         = __pair_like_constructible<pair<_U1, _U2>&>,
+            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1&> && is_nothrow_constructible_v<_T2, _U2&>)
       : __base(__p.first, __p.second)
@@ -387,15 +371,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            __select_constructor _Trait            = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&, _T1, _T2>,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+            class _Constraint                           = __pair_like_constructible<pair<_U1, _U2>&>,
+            enable_if_t<_Constraint::__is_deleted, int> = 0>
   constexpr pair(pair<_U1, _U2>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&, _T1, _T2>,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+            class _Constraint = __pair_like_constructible<const pair<_U1, _U2>&>,
+            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(const pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
@@ -403,8 +387,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&, _T1, _T2>,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+            class _Constraint = __pair_like_constructible<const pair<_U1, _U2>&>,
+            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(const pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
@@ -413,15 +397,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&, _T1, _T2>,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+            class _Constraint                           = __pair_like_constructible<const pair<_U1, _U2>&>,
+            enable_if_t<_Constraint::__is_deleted, int> = 0>
   constexpr pair(const pair<_U1, _U2>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&&, _T1, _T2>,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+            class _Constraint                                         = __pair_like_constructible<pair<_U1, _U2>&&>,
+            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
@@ -429,8 +413,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&&, _T1, _T2>,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+            class _Constraint                                         = __pair_like_constructible<pair<_U1, _U2>&&>,
+            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
@@ -439,15 +423,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&&, _T1, _T2>,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+            class _Constraint                           = __pair_like_constructible<pair<_U1, _U2>&&>,
+            enable_if_t<_Constraint::__is_deleted, int> = 0>
   constexpr pair(pair<_U1, _U2>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&&, _T1, _T2>,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+            class _Constraint = __pair_like_constructible<const pair<_U1, _U2>&&>,
+            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(const pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1> && is_nothrow_constructible_v<_T2, const _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
@@ -455,8 +439,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&&, _T1, _T2>,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+            class _Constraint = __pair_like_constructible<const pair<_U1, _U2>&&>,
+            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(const pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1> && is_nothrow_constructible_v<_T2, const _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
@@ -465,8 +449,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&&, _T1, _T2>,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+            class _Constraint                           = __pair_like_constructible<const pair<_U1, _U2>&&>,
+            enable_if_t<_Constraint::__is_deleted, int> = 0>
   constexpr pair(const pair<_U1, _U2>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
@@ -474,8 +458,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<_UPair, _T1, _T2>,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+            class _Constraint                                          = __pair_like_constructible<_UPair>,
+            enable_if_t<_Constraint::__can_construct_implicitly, int>  = 0>
   _CCCL_API constexpr pair(_UPair&& __p) noexcept(
     is_nothrow_constructible_v<_T1, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
     && is_nothrow_constructible_v<_T2, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)
@@ -492,8 +476,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<_UPair, _T1, _T2>,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+            class _Constraint                                          = __pair_like_constructible<_UPair>,
+            enable_if_t<_Constraint::__can_construct_explicitly, int>  = 0>
   _CCCL_API explicit constexpr pair(_UPair&& __p) noexcept(
     is_nothrow_constructible_v<_T1, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
     && is_nothrow_constructible_v<_T2, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)
@@ -504,8 +488,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
-            __select_constructor _Trait            = __pair_select_pair_like_constructible_v<_UPair, _T1, _T2>,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+            class _Constraint                                          = __pair_like_constructible<_UPair>,
+            enable_if_t<_Constraint::__is_deleted, int>                = 0>
   _CCCL_API constexpr pair(_UPair&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
   // NOLINTEND(bugprone-forwarding-reference-overload)
@@ -574,14 +558,20 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
     return *this;
   }
 
+  template <bool _IsConst, class _UPair>
+  using __pair_like_assignable =
+    typename __pair_constraints<_T1, _T2>::template __pair_like_assignment<_IsConst, _UPair>;
+
   // ``get`` will specifically only move the sub-object, it's therefore OK to
   // "move" the outer pair twice
   // NOLINTBEGIN(bugprone-use-after-move)
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
-            __select_assignment _Trait = __pair_select_pair_like_assignable_v</*__is_const=*/false, _UPair, _T1, _T2>,
-            enable_if_t<__can_assign<_Trait>, int> = 0>
-  _CCCL_API constexpr pair& operator=(_UPair&& __p) noexcept(__can_nothrow_assign<_Trait>)
+            class _Constraint                           = __pair_like_assignable</*__is_const=*/false, _UPair>,
+            enable_if_t<_Constraint::__can_assign, int> = 0>
+  _CCCL_API constexpr pair& operator=(_UPair&& __p) noexcept(
+    is_nothrow_assignable_v<_T1&, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
+    && is_nothrow_assignable_v<_T2&, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)
   {
     using ::cuda::std::get;
     this->first  = get<0>(::cuda::std::forward<_UPair>(__p));
@@ -591,9 +581,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
-            __select_assignment _Trait = __pair_select_pair_like_assignable_v</*__is_const=*/true, _UPair, _T1, _T2>,
-            enable_if_t<__can_assign<_Trait>, int> = 0>
-  _CCCL_API constexpr const pair& operator=(_UPair&& __p) const noexcept(__can_nothrow_assign<_Trait>)
+            class _Constraint                           = __pair_like_assignable</*__is_const=*/true, _UPair>,
+            enable_if_t<_Constraint::__can_assign, int> = 0>
+  _CCCL_API constexpr const pair& operator=(_UPair&& __p) const noexcept(
+    is_nothrow_assignable_v<const _T1&, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
+    && is_nothrow_assignable_v<const _T2&, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)
   {
     using ::cuda::std::get;
     this->first  = get<0>(::cuda::std::forward<_UPair>(__p));

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_const_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_const_move.pass.cpp
@@ -114,7 +114,7 @@ TEST_FUNC constexpr bool test()
   }
 
   // This segfaults MSVC trying to determine is_nothrow_constructible
-#if !TEST_COMPILER(MSVC)
+#if !TEST_COMPILER(MSVC) && !TEST_COMPILER(GCC, <, 12)
   // sizeof...(Types) == 1 && is_convertible_v<decltype(u), T>
   {
     const cuda::std::tuple<CvtFromConstTupleRefRef> t1{};
@@ -128,7 +128,7 @@ TEST_FUNC constexpr bool test()
     cuda::std::tuple<ConvertibleFrom<ExplicitCtrFromConstTupleRefRef>> t2{cuda::std::move(t1)};
     assert(!constMoveCtrCalled(cuda::std::get<0>(t2).v));
   }
-#endif // !TEST_COMPILER(MSVC)
+#endif // !TEST_COMPILER(MSVC) && !TEST_COMPILER(GCC, <, 12)
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
@@ -77,11 +77,11 @@ TEST_FUNC void test_primary_template()
     cuda::std::tuple t1(T{});
     static_assert(cuda::std::is_same_v<decltype(t1), cuda::std::tuple<T>>);
 
-#if TEST_COMPILER(GCC, <, 11)
+#if !TEST_COMPILER(GCC, <, 12) // GCC fails to deduct here, also with std::tuple
     const T v{};
     cuda::std::tuple t2(T{}, 101l, v);
     static_assert(cuda::std::is_same_v<decltype(t2), cuda::std::tuple<T, long, T>>);
-#endif // TEST_COMPILER(GCC, <, 11)
+#endif // !TEST_COMPILER(GCC, <, 12)
   }
   { // Testing (4)
     int x = 101;


### PR DESCRIPTION
It seems the current approach with the constraints is a bit costly

Try to go with a single struct per type and use type aliases in the SFINAE expressions to hopefully defer instantiation