### PR TITLE
[CUB] Add docs describing how to run env-overloads with custom MR when cudaMallocAsync not available

### DIFF
--- a/cub/examples/device/example_device_env_memory_resource.cu
+++ b/cub/examples/device/example_device_env_memory_resource.cu
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+/// Example of DeviceReduce::Sum() using an environment with an explicitly provided
+/// memory resource, including a synchronous cudaMalloc-based fallback for devices
+/// without cudaMallocAsync support (e.g. Windows GPUs in TCC driver mode).
+
+// Ensure printing of CUDA runtime errors to console
+#define CUB_STDERR
+
+#include <cub/device/device_reduce.cuh>
+
+#include <thrust/device_vector.h>
+
+#include <cuda/devices>
+#include <cuda/memory_pool>
+#include <cuda/memory_resource>
+#include <cuda/stream>
+
+#include <cstdio>
+#include <stdexcept>
+
+#include "../../test/test_util.h"
+
+// example-begin env-mr-fallback-definition
+// A synchronous memory resource on top of cudaMalloc/cudaFree. Every allocation and
+// deallocation blocks the calling thread and synchronizes the device; passing it
+// explicitly makes that behavior a visible, deliberate choice. Allocations are made
+// on the device that is current at the time of the call.
+struct synchronous_memory_resource : cuda::mr::memory_resource_base<synchronous_memory_resource>
+{
+  [[nodiscard]] void* allocate_sync(size_t bytes, size_t alignment = cuda::mr::default_cuda_malloc_alignment)
+  {
+    if (alignment > cuda::mr::default_cuda_malloc_alignment || cuda::mr::default_cuda_malloc_alignment % alignment != 0)
+    {
+      throw std::invalid_argument("invalid alignment for synchronous_memory_resource");
+    }
+
+    void* ptr          = nullptr;
+    cudaError_t status = cudaMalloc(&ptr, bytes);
+    if (status != cudaSuccess)
+    {
+      throw std::runtime_error(cudaGetErrorString(status));
+    }
+
+    return ptr;
+  }
+
+  void deallocate_sync(void* ptr,
+                       [[maybe_unused]] size_t bytes,
+                       [[maybe_unused]] size_t alignment = cuda::mr::default_cuda_malloc_alignment) noexcept
+  {
+    cudaFree(ptr);
+  }
+
+  friend constexpr void get_property(synchronous_memory_resource const&, cuda::mr::device_accessible) noexcept {}
+
+  friend constexpr bool operator==(synchronous_memory_resource, synchronous_memory_resource) noexcept
+  {
+    return true;
+  }
+
+#if _CCCL_STD_VER <= 2017
+  friend constexpr bool operator!=(synchronous_memory_resource, synchronous_memory_resource) noexcept
+  {
+    return false;
+  }
+#endif
+};
+
+// Selects the default memory pool when the device supports cudaMallocAsync, and the
+// synchronous fallback otherwise.
+cuda::mr::any_resource<cuda::mr::device_accessible> make_device_resource(cuda::device_ref dev)
+{
+  if (dev.attribute(cuda::device_attributes::memory_pools_supported))
+  {
+    return cuda::mr::any_resource<cuda::mr::device_accessible>{cuda::device_default_memory_pool(dev)};
+  }
+
+  return cuda::mr::make_any_resource<cuda::mr::synchronous_resource_adapter<synchronous_memory_resource>,
+                                     cuda::mr::device_accessible>(synchronous_memory_resource{});
+}
+// example-end env-mr-fallback-definition
+
+bool g_verbose = false; // Whether to display input/output to console
+
+int main(int argc, char** argv)
+{
+  // Initialize command line and print usage
+  CommandLineArgs args(argc, argv);
+  if (args.CheckCmdLineFlag("help"))
+  {
+    printf("%s "
+           "[--n=<input items> "
+           "[--v] "
+           "\n",
+           argv[0]);
+    std::exit(0);
+  }
+
+  // Parse command line options
+  int num_items = 150;
+  g_verbose     = args.CheckCmdLineFlag("v");
+  args.GetCmdLineArgument("n", num_items);
+
+  printf("cub::DeviceReduce::Sum() %d items (%d-byte elements)\n", num_items, (int) sizeof(int));
+  fflush(stdout);
+
+  // Initialize problem and solution
+  std::vector<int> h_in(num_items);
+  int h_reference = 0;
+  for (int i = 0; i < num_items; ++i)
+  {
+    h_in[i] = i;
+    h_reference += i;
+  }
+
+  // Allocate and initialize device arrays
+  auto d_in = thrust::device_vector<int>(num_items, thrust::no_init);
+  thrust::copy(h_in.begin(), h_in.end(), d_in.begin());
+  auto d_out = thrust::device_vector<int>(1);
+
+  auto device = cuda::devices[0];
+  auto stream = cuda::stream{device};
+
+  // example-begin env-mr-fallback-run
+  auto mr  = make_device_resource(device);
+  auto env = cuda::std::execution::env{cuda::stream_ref{stream}, mr};
+
+  const cudaError_t error = cub::DeviceReduce::Sum(d_in.data(), d_out.data(), num_items, env);
+  // example-end env-mr-fallback-run
+  CubDebugExit(error);
+
+  // Check for correctness (and display results, if specified)
+  const int compare =
+    CompareDeviceResults(&h_reference, thrust::raw_pointer_cast(d_out.data()), 1, g_verbose, g_verbose);
+  printf("\t%s", compare ? "FAIL" : "PASS");
+  printf("\n\n");
+
+  return compare;
+}

--- a/cub/examples/device/example_device_env_memory_resource.cu
+++ b/cub/examples/device/example_device_env_memory_resource.cu
@@ -23,8 +23,8 @@
 #include "../../test/test_util.h"
 
 // example-begin env-mr-fallback-definition
-// A synchronous memory resource on top of cudaMalloc/cudaFree. Every allocation and
-// deallocation blocks the calling thread and synchronizes the device; passing it
+// A synchronous memory resource on top of cudaMalloc/cudaFree. Allocations block the
+// calling thread; deallocations additionally synchronize the device. Passing it
 // explicitly makes that behavior a visible, deliberate choice. Allocations are made
 // on the device that is current at the time of the call.
 struct synchronous_memory_resource : cuda::mr::memory_resource_base<synchronous_memory_resource>

--- a/docs/cub/environment.rst
+++ b/docs/cub/environment.rst
@@ -198,86 +198,29 @@ On devices without ``cudaMallocAsync`` support, pass a memory resource explicitl
 example below defines a synchronous memory resource on top of ``cudaMalloc``/``cudaFree``
 and selects between it and the default memory pool based on device support. Passing the
 resulting resource through the environment makes the synchronization behavior a visible,
-deliberate choice:
+deliberate choice (the required declarations are provided by ``<cuda/devices>``,
+``<cuda/memory_pool>``, ``<cuda/memory_resource>``, and ``<cuda/stream>``):
 
-.. code-block:: c++
-
-   #include <cuda/devices>
-   #include <cuda/memory_pool>
-   #include <cuda/memory_resource>
-
-   #include <cuda_runtime_api.h>
-
-   #include <stdexcept>
-
-   struct synchronous_memory_resource : cuda::mr::memory_resource_base<synchronous_memory_resource>
-   {
-     [[nodiscard]] void* allocate_sync(size_t bytes, size_t alignment = cuda::mr::default_cuda_malloc_alignment)
-     {
-       if (alignment > cuda::mr::default_cuda_malloc_alignment
-           || cuda::mr::default_cuda_malloc_alignment % alignment != 0)
-       {
-         throw std::invalid_argument("invalid alignment for synchronous_memory_resource");
-       }
-
-       void* ptr          = nullptr;
-       cudaError_t status = cudaMalloc(&ptr, bytes);
-       if (status != cudaSuccess)
-       {
-         throw std::runtime_error(cudaGetErrorString(status));
-       }
-
-       return ptr;
-     }
-
-     void deallocate_sync(
-       void* ptr,
-       [[maybe_unused]] size_t bytes,
-       [[maybe_unused]] size_t alignment = cuda::mr::default_cuda_malloc_alignment) noexcept
-     {
-       cudaFree(ptr);
-     }
-
-     friend constexpr void get_property(synchronous_memory_resource const&, cuda::mr::device_accessible) noexcept {}
-
-     friend constexpr bool operator==(synchronous_memory_resource, synchronous_memory_resource) noexcept
-     {
-       return true;
-     }
-
-   #if _CCCL_STD_VER <= 2017
-     friend constexpr bool operator!=(synchronous_memory_resource, synchronous_memory_resource) noexcept
-     {
-       return false;
-     }
-   #endif
-   };
-
-   cuda::mr::any_resource<cuda::mr::device_accessible> make_device_resource(cuda::device_ref dev)
-   {
-     if (dev.attribute(cuda::device_attributes::memory_pools_supported))
-     {
-       return cuda::mr::any_resource<cuda::mr::device_accessible>{cuda::device_default_memory_pool(dev)};
-     }
-
-     return cuda::mr::make_any_resource<
-       cuda::mr::synchronous_resource_adapter<synchronous_memory_resource>,
-       cuda::mr::device_accessible>(synchronous_memory_resource{});
-   }
+.. literalinclude:: ../../cub/examples/device/example_device_env_memory_resource.cu
+   :language: c++
+   :dedent:
+   :start-after: example-begin env-mr-fallback-definition
+   :end-before: example-end env-mr-fallback-definition
 
 The resource returned by ``make_device_resource`` can be passed to any algorithm that
 accepts an environment:
 
-.. code-block:: c++
-
-   auto mr  = make_device_resource(cuda::devices[0]);
-   auto env = cuda::std::execution::env{cuda::stream_ref{stream}, mr};
-
-   cub::DeviceReduce::Sum(d_input, d_output, num_items, env);
+.. literalinclude:: ../../cub/examples/device/example_device_env_memory_resource.cu
+   :language: c++
+   :dedent:
+   :start-after: example-begin env-mr-fallback-run
+   :end-before: example-end env-mr-fallback-run
 
 On devices without memory pool support, every allocation and deallocation made through
 this resource blocks the calling thread and synchronizes the device. That cost is
 inherent to ``cudaMalloc``/``cudaFree``; the explicit opt-in only makes it visible.
+Note that ``cudaMalloc`` allocates on the device that is *current* at the time of the
+call, so use the resource on the device it was created for.
 
 .. _cub-environment-reuse:
 

--- a/docs/cub/environment.rst
+++ b/docs/cub/environment.rst
@@ -172,10 +172,112 @@ or composed with other properties:
 
 Temporary storage is allocated from the memory resource on the algorithm's stream before
 execution and released on the same stream afterwards. When no memory resource is present
-in the environment, CUB falls back to a stream-ordered ``cudaMallocAsync``/``cudaFree``  allocator
-(see :ref:`Default behavior <cub-environment-fallback>`).
+in the environment, CUB falls back to a stream-ordered ``cudaMallocAsync``/``cudaFreeAsync``
+allocator (see :ref:`Default behavior <cub-environment-fallback>`).
 
 .. TODO: Add Guarantees sub-section after #9278 is merged.
+
+.. _cub-env-memory-resource-precondition:
+
+Devices without ``cudaMallocAsync`` support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. warning::
+
+   The environment-based API assumes the device supports ``cudaMallocAsync``, which the
+   default memory resource uses to allocate temporary storage. Where that is not the
+   case (e.g. TCC driver mode on Windows), the default resource fails with
+   ``cudaErrorNotSupported``.
+
+CUB deliberately does not fall back to ``cudaMalloc``/``cudaFree`` on such devices.
+``cudaFree`` synchronizes the entire device, so a hidden fallback would silently change
+the synchronization semantics of every algorithm call depending on the machine it runs
+on, with no indication in the calling code.
+
+On devices without ``cudaMallocAsync`` support, pass a memory resource explicitly. The
+example below defines a synchronous memory resource on top of ``cudaMalloc``/``cudaFree``
+and selects between it and the default memory pool based on device support. Passing the
+resulting resource through the environment makes the synchronization behavior a visible,
+deliberate choice:
+
+.. code-block:: c++
+
+   #include <cuda/devices>
+   #include <cuda/memory_pool>
+   #include <cuda/memory_resource>
+
+   #include <cuda_runtime_api.h>
+
+   #include <stdexcept>
+
+   struct legacy_device_memory_resource : cuda::mr::memory_resource_base<legacy_device_memory_resource>
+   {
+     [[nodiscard]] void* allocate_sync(size_t bytes, size_t alignment = cuda::mr::default_cuda_malloc_alignment)
+     {
+       if (alignment > cuda::mr::default_cuda_malloc_alignment
+           || cuda::mr::default_cuda_malloc_alignment % alignment != 0)
+       {
+         throw std::invalid_argument("invalid alignment for legacy_device_memory_resource");
+       }
+
+       void* ptr          = nullptr;
+       cudaError_t status = cudaMalloc(&ptr, bytes);
+       if (status != cudaSuccess)
+       {
+         throw std::runtime_error(cudaGetErrorString(status));
+       }
+
+       return ptr;
+     }
+
+     void deallocate_sync(
+       void* ptr,
+       [[maybe_unused]] size_t bytes,
+       [[maybe_unused]] size_t alignment = cuda::mr::default_cuda_malloc_alignment) noexcept
+     {
+       cudaFree(ptr);
+     }
+
+     friend constexpr void get_property(legacy_device_memory_resource const&, cuda::mr::device_accessible) noexcept {}
+
+     friend constexpr bool operator==(legacy_device_memory_resource, legacy_device_memory_resource) noexcept
+     {
+       return true;
+     }
+
+   #if _CCCL_STD_VER <= 2017
+     friend constexpr bool operator!=(legacy_device_memory_resource, legacy_device_memory_resource) noexcept
+     {
+       return false;
+     }
+   #endif
+   };
+
+   cuda::mr::any_resource<cuda::mr::device_accessible> make_device_resource(cuda::device_ref dev)
+   {
+     if (dev.attribute(cuda::device_attributes::memory_pools_supported))
+     {
+       return cuda::mr::any_resource<cuda::mr::device_accessible>{cuda::device_default_memory_pool(dev)};
+     }
+
+     return cuda::mr::make_any_resource<
+       cuda::mr::synchronous_resource_adapter<legacy_device_memory_resource>,
+       cuda::mr::device_accessible>(legacy_device_memory_resource{});
+   }
+
+The resource returned by ``make_device_resource`` can be passed to any algorithm that
+accepts an environment:
+
+.. code-block:: c++
+
+   auto mr  = make_device_resource(cuda::devices[0]);
+   auto env = cuda::std::execution::env{cuda::stream_ref{stream}, mr};
+
+   cub::DeviceReduce::Sum(d_input, d_output, num_items, env);
+
+On devices without memory pool support, every allocation and deallocation made through
+this resource blocks the calling thread and synchronizes the device. That cost is
+inherent to ``cudaMalloc``/``cudaFree``; the explicit opt-in only makes it visible.
 
 .. _cub-environment-reuse:
 
@@ -228,7 +330,9 @@ is passed at all):
      - The default CUDA stream (``cudaStream_t{}``).
    * - Memory resource
      - A stream-ordered allocator based on ``cudaMallocAsync``. Temporary storage is
-       allocated on the stream the algorithm runs on.
+       allocated on the stream the algorithm runs on. Requires device support for
+       ``cudaMallocAsync``; see
+       :ref:`Devices without cudaMallocAsync support <cub-env-memory-resource-precondition>`.
    * - Determinism
      - Algorithm-specific. See :ref:`cub-determinism`.
    * - Policy selector

--- a/docs/cub/environment.rst
+++ b/docs/cub/environment.rst
@@ -210,14 +210,14 @@ deliberate choice:
 
    #include <stdexcept>
 
-   struct legacy_device_memory_resource : cuda::mr::memory_resource_base<legacy_device_memory_resource>
+   struct synchronous_memory_resource : cuda::mr::memory_resource_base<synchronous_memory_resource>
    {
      [[nodiscard]] void* allocate_sync(size_t bytes, size_t alignment = cuda::mr::default_cuda_malloc_alignment)
      {
        if (alignment > cuda::mr::default_cuda_malloc_alignment
            || cuda::mr::default_cuda_malloc_alignment % alignment != 0)
        {
-         throw std::invalid_argument("invalid alignment for legacy_device_memory_resource");
+         throw std::invalid_argument("invalid alignment for synchronous_memory_resource");
        }
 
        void* ptr          = nullptr;
@@ -238,15 +238,15 @@ deliberate choice:
        cudaFree(ptr);
      }
 
-     friend constexpr void get_property(legacy_device_memory_resource const&, cuda::mr::device_accessible) noexcept {}
+     friend constexpr void get_property(synchronous_memory_resource const&, cuda::mr::device_accessible) noexcept {}
 
-     friend constexpr bool operator==(legacy_device_memory_resource, legacy_device_memory_resource) noexcept
+     friend constexpr bool operator==(synchronous_memory_resource, synchronous_memory_resource) noexcept
      {
        return true;
      }
 
    #if _CCCL_STD_VER <= 2017
-     friend constexpr bool operator!=(legacy_device_memory_resource, legacy_device_memory_resource) noexcept
+     friend constexpr bool operator!=(synchronous_memory_resource, synchronous_memory_resource) noexcept
      {
        return false;
      }
@@ -261,8 +261,8 @@ deliberate choice:
      }
 
      return cuda::mr::make_any_resource<
-       cuda::mr::synchronous_resource_adapter<legacy_device_memory_resource>,
-       cuda::mr::device_accessible>(legacy_device_memory_resource{});
+       cuda::mr::synchronous_resource_adapter<synchronous_memory_resource>,
+       cuda::mr::device_accessible>(synchronous_memory_resource{});
    }
 
 The resource returned by ``make_device_resource`` can be passed to any algorithm that

--- a/docs/cub/environment.rst
+++ b/docs/cub/environment.rst
@@ -216,9 +216,10 @@ accepts an environment:
    :start-after: example-begin env-mr-fallback-run
    :end-before: example-end env-mr-fallback-run
 
-On devices without memory pool support, every allocation and deallocation made through
-this resource blocks the calling thread and synchronizes the device. That cost is
-inherent to ``cudaMalloc``/``cudaFree``; the explicit opt-in only makes it visible.
+On devices without memory pool support, every allocation made through this resource
+blocks the calling thread, and every deallocation additionally synchronizes the device.
+That cost is inherent to ``cudaMalloc``/``cudaFree``; the explicit opt-in only makes it
+visible.
 Note that ``cudaMalloc`` allocates on the device that is *current* at the time of the
 call, so use the resource on the device it was created for.
 


### PR DESCRIPTION
Closes https://github.com/NVIDIA/cccl/issues/10716

`cudaMallocAsync` fails on devices without memory pool support, e.g. Windows drivers in TCC mode. <s>We should query `cudaDevAttrMemoryPoolsSupported` in `cub::detail::device_memory_resource` and fall back to `cudaMalloc/cudaFree` (much slower - maybe warn somehow?) so the environment-based device algorithm overloads work there.

Validated on an RTX A4000 (Windows Server 2025). I wrote a repro that fails in TCC mode before, passes in both TCC and WDDM after this fix.</s>

We choose not to circumvent the behavior by dispatching to `cudaMalloc/Free` when `cudaMallocAsync` is not available for two main reasons:

1. checking can become very expensive and redundant (very rarely is it no supported)
2. `cudaFree` blocks device on every level, inhibits performance and breaks execution guarantees silently

If user wants to run environment algorithms on a non supported workflow, they should explicitly pass an MR that dispatches to `cudaMalloc/Free` when Async is not available. This PR adds docs explaining that + code example of MR that can be used when Async is not available.
