### PR TITLE
libcu++: atomics SASS FileCheck suite for basic atomic operations

### DIFF
--- a/.github/actions/workflow-build/build-workflow.py
+++ b/.github/actions/workflow-build/build-workflow.py
@@ -1094,7 +1094,9 @@ def validate_tags(matrix_job, ignore_required=False):
                 "The codegen_filecheck job requires a codegen_target tag.",
             )
         )
-    if not has_codegen_job and "codegen_target" in matrix_job:
+    if "codegen_target" in matrix_job and any(
+        job != "codegen_filecheck" for job in jobs
+    ):
         raise Exception(
             error_message_with_matrix_job(
                 matrix_job,

--- a/.github/actions/workflow-build/build-workflow.py
+++ b/.github/actions/workflow-build/build-workflow.py
@@ -335,6 +335,19 @@ def get_job_type_info(job):
 
 
 @memoize_result
+def get_codegen_target(codegen_target):
+    if codegen_target not in matrix_yaml["codegen_targets"]:
+        raise Exception(
+            f"Unknown codegen target '{codegen_target}'. Valid options are: "
+            + ", ".join(matrix_yaml["codegen_targets"].keys())
+        )
+
+    result = matrix_yaml["codegen_targets"][codegen_target]
+    result["id"] = codegen_target
+    return result
+
+
+@memoize_result
 def get_tag_info(tag):
     if tag not in matrix_yaml["tags"].keys():
         raise Exception(
@@ -364,6 +377,7 @@ def get_all_matrix_job_tags_sorted():
     sorted_important_tags = [
         "project",
         "jobs",
+        "codegen_target",
         "cudacxx",
         "cxx",
         "ctk",
@@ -432,6 +446,10 @@ def generate_dispatch_group_name(matrix_job):
 
 def generate_dispatch_job_name(matrix_job, job_type):
     job_info = get_job_type_info(job_type)
+    job_name = job_info["name"]
+    if "codegen_target" in matrix_job:
+        codegen_target = get_codegen_target(matrix_job["codegen_target"])
+        job_name += f" {codegen_target['name']}"
     cpu_str = matrix_job["cpu"]
     if job_info["gpu"]:
         gpu = get_gpu(matrix_job["gpu"])
@@ -470,7 +488,7 @@ def generate_dispatch_job_name(matrix_job, job_type):
         else ""
     )
 
-    return f"[{config_tag}] {job_info['name']}({cpu_str}{gpu_str}){extra_info}"
+    return f"[{config_tag}] {job_name}({cpu_str}{gpu_str}){extra_info}"
 
 
 def generate_dispatch_job_runner(matrix_job, job_type):
@@ -556,6 +574,13 @@ def generate_dispatch_job_command(matrix_job, job_type):
         command += f' -py-version "{py_version}"'
     if py_ctk_mode:
         command += f' -ctk-mode "{py_ctk_mode}"'
+    if "codegen_target" in matrix_job:
+        codegen_target = get_codegen_target(matrix_job["codegen_target"])
+        command += f' -target "{codegen_target["cmake_target"]}"'
+        command += (
+            " -cmake-options "
+            f'"-DLIBCUDACXX_CODEGEN_FILECHECK_TESTS={codegen_target["id"]}"'
+        )
     if extra_args:
         command += f" {extra_args}"
 
@@ -598,6 +623,11 @@ def generate_dispatch_job_origin(matrix_job, job_type):
 
     if "args" in origin_job and not origin_job["args"]:
         del origin_job["args"]
+
+    if "codegen_target" in origin_job:
+        origin_job["codegen_target"] = get_codegen_target(origin_job["codegen_target"])[
+            "name"
+        ]
 
     origin["matrix_job"] = origin_job
 
@@ -1053,6 +1083,31 @@ def validate_tags(matrix_job, ignore_required=False):
             raise Exception(
                 error_message_with_matrix_job(matrix_job, f"Unknown tag '{tag}'")
             )
+
+    jobs = matrix_job.get("jobs", [])
+    jobs = jobs if isinstance(jobs, list) else [jobs]
+    has_codegen_job = "codegen_filecheck" in jobs
+    if has_codegen_job and "codegen_target" not in matrix_job:
+        raise Exception(
+            error_message_with_matrix_job(
+                matrix_job,
+                "The codegen_filecheck job requires a codegen_target tag.",
+            )
+        )
+    if not has_codegen_job and "codegen_target" in matrix_job:
+        raise Exception(
+            error_message_with_matrix_job(
+                matrix_job,
+                "The codegen_target tag is only valid for codegen_filecheck jobs.",
+            )
+        )
+    if "codegen_target" in matrix_job:
+        codegen_targets = matrix_job["codegen_target"]
+        codegen_targets = (
+            codegen_targets if isinstance(codegen_targets, list) else [codegen_targets]
+        )
+        for codegen_target in codegen_targets:
+            get_codegen_target(codegen_target)
 
     if "gpu" in matrix_job:
         gpus = (

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -146,6 +146,16 @@
       }
     },
     {
+      "name": "libcudacxx-codegen-filecheck",
+      "displayName": "libcu++: Codegen FileCheck",
+      "inherits": "libcudacxx",
+      "cacheVariables": {
+        "CMAKE_CUDA_ARCHITECTURES": "80",
+        "LIBCUDACXX_CODEGEN_FILECHECK_TESTS": "all",
+        "LIBCUDACXX_REQUIRE_CODEGEN_TEST_TOOLS": true
+      }
+    },
+    {
       "name": "libcudacxx-cpp17",
       "displayName": "libcu++: C++17",
       "inherits": "libcudacxx",
@@ -530,11 +540,18 @@
         "libcudacxx.test.public_headers_host_only",
         "libcudacxx.test.lit.precompile",
         "libcudacxx.test.nvtarget",
+        "libcudacxx.test.c2h_all",
+        "libcudacxx.test.debugging"
+      ]
+    },
+    {
+      "name": "libcudacxx-codegen-filecheck",
+      "configurePreset": "libcudacxx-codegen-filecheck",
+      "targets": [
         "libcudacxx.test.atomics.ptx",
         "libcudacxx.test.atomics.sass",
         "libcudacxx.test.simd.ptx",
-        "libcudacxx.test.c2h_all",
-        "libcudacxx.test.debugging"
+        "libcudacxx.test.simd.sass"
       ]
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -531,6 +531,7 @@
         "libcudacxx.test.lit.precompile",
         "libcudacxx.test.nvtarget",
         "libcudacxx.test.atomics.ptx",
+        "libcudacxx.test.atomics.sass",
         "libcudacxx.test.simd.ptx",
         "libcudacxx.test.c2h_all",
         "libcudacxx.test.debugging"

--- a/ci/build_libcudacxx.sh
+++ b/ci/build_libcudacxx.sh
@@ -4,13 +4,51 @@ set -euo pipefail
 
 ci_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
+build_target=""
+codegen_tests=false
+common_args=()
+while [[ $# -ne 0 ]]; do
+  case "$1" in
+    -codegen-tests)
+      codegen_tests=true
+      shift
+      ;;
+    -target)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: -target requires a value" >&2
+        exit 1
+      fi
+      build_target="$2"
+      shift 2
+      ;;
+    *)
+      common_args+=("$1")
+      shift
+      ;;
+  esac
+done
+set -- "${common_args[@]}"
+
 # shellcheck source=ci/build_common.sh
 source "${ci_dir}/build_common.sh"
 
 print_environment_details
 
 PRESET="libcudacxx"
+if $codegen_tests; then
+  PRESET="libcudacxx-codegen-filecheck"
+fi
+
 CMAKE_OPTIONS=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}" "-DCMAKE_CUDA_STANDARD=${CXX_STANDARD}")
+
+if [[ -n "$build_target" ]]; then
+  configure_preset "$PRESET" "$PRESET" "${CMAKE_OPTIONS[@]}"
+  if ! $CONFIGURE_ONLY; then
+    build_preset "$PRESET" "$PRESET" --target "$build_target"
+  fi
+  print_time_summary
+  exit 0
+fi
 
 upload_test_artifacts=false
 if [[ -n "${GITHUB_ACTIONS:-}" ]] && "${ci_dir}/util/workflow/has_consumers.sh"; then

--- a/ci/build_libcudacxx.sh
+++ b/ci/build_libcudacxx.sh
@@ -4,54 +4,13 @@ set -euo pipefail
 
 ci_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-build_target=""
-codegen_tests=false
-common_args=()
-while [[ $# -ne 0 ]]; do
-  case "$1" in
-    -codegen-tests)
-      codegen_tests=true
-      shift
-      ;;
-    -target)
-      if [[ $# -lt 2 ]]; then
-        echo "Error: -target requires a value" >&2
-        exit 1
-      fi
-      build_target="$2"
-      shift 2
-      ;;
-    *)
-      common_args+=("$1")
-      shift
-      ;;
-  esac
-done
-set -- "${common_args[@]}"
-
 # shellcheck source=ci/build_common.sh
 source "${ci_dir}/build_common.sh"
 
 print_environment_details
 
 PRESET="libcudacxx"
-BUILD_OPTIONS=()
-if $codegen_tests; then
-  PRESET="libcudacxx-codegen-filecheck"
-  # Report every FileCheck failure in the requested suite.
-  BUILD_OPTIONS=(-- -k 0)
-fi
-
 CMAKE_OPTIONS=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}" "-DCMAKE_CUDA_STANDARD=${CXX_STANDARD}")
-
-if [[ -n "$build_target" ]]; then
-  configure_preset "$PRESET" "$PRESET" "${CMAKE_OPTIONS[@]}"
-  if ! $CONFIGURE_ONLY; then
-    build_preset "$PRESET" "$PRESET" --target "$build_target" "${BUILD_OPTIONS[@]}"
-  fi
-  print_time_summary
-  exit 0
-fi
 
 upload_test_artifacts=false
 if [[ -n "${GITHUB_ACTIONS:-}" ]] && "${ci_dir}/util/workflow/has_consumers.sh"; then

--- a/ci/build_libcudacxx.sh
+++ b/ci/build_libcudacxx.sh
@@ -35,8 +35,11 @@ source "${ci_dir}/build_common.sh"
 print_environment_details
 
 PRESET="libcudacxx"
+BUILD_OPTIONS=()
 if $codegen_tests; then
   PRESET="libcudacxx-codegen-filecheck"
+  # Report every FileCheck failure in the requested suite.
+  BUILD_OPTIONS=(-- -k 0)
 fi
 
 CMAKE_OPTIONS=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}" "-DCMAKE_CUDA_STANDARD=${CXX_STANDARD}")
@@ -44,7 +47,7 @@ CMAKE_OPTIONS=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}" "-DCMAKE_CUDA_STANDARD=${C
 if [[ -n "$build_target" ]]; then
   configure_preset "$PRESET" "$PRESET" "${CMAKE_OPTIONS[@]}"
   if ! $CONFIGURE_ONLY; then
-    build_preset "$PRESET" "$PRESET" --target "$build_target"
+    build_preset "$PRESET" "$PRESET" --target "$build_target" "${BUILD_OPTIONS[@]}"
   fi
   print_time_summary
   exit 0

--- a/ci/codegen_filecheck_libcudacxx.sh
+++ b/ci/codegen_filecheck_libcudacxx.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ci_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+build_target=""
+common_args=()
+while [[ $# -ne 0 ]]; do
+  case "$1" in
+    -target)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: -target requires a value" >&2
+        exit 1
+      fi
+      build_target="$2"
+      shift 2
+      ;;
+    *)
+      common_args+=("$1")
+      shift
+      ;;
+  esac
+done
+set -- "${common_args[@]}"
+
+if [[ -z "$build_target" ]]; then
+  echo "Error: -target is required" >&2
+  exit 1
+fi
+
+# shellcheck source=ci/build_common.sh
+source "${ci_dir}/build_common.sh"
+
+print_environment_details
+
+PRESET="libcudacxx-codegen-filecheck"
+CMAKE_OPTIONS=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}" "-DCMAKE_CUDA_STANDARD=${CXX_STANDARD}")
+
+configure_preset "$PRESET" "$PRESET" "${CMAKE_OPTIONS[@]}"
+if ! $CONFIGURE_ONLY; then
+  # Report every FileCheck failure in the requested suite.
+  build_preset "$PRESET" "$PRESET" --target "$build_target" -- -k 0
+fi
+
+print_time_summary

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -660,7 +660,7 @@ jobs:
   # libcudacxx:
   nvrtc: { gpu: true, name: 'NVRTC' }
   verify_codegen: { gpu: false, name: 'VerifyCodegen' }
-  codegen_filecheck: { gpu: false, name: 'libcu++ Codegen FileCheck', invoke: { prefix: 'build', args: '-codegen-tests' } }
+  codegen_filecheck: { gpu: false, name: 'libcu++ Codegen FileCheck' }
 
   # CUB:
   build_nolid: { name: 'BuildNoLaunch',     gpu: false, invoke: { prefix: 'build', args: '-no-lid'} }

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -206,18 +206,6 @@ workflows:
     - {project: 'libcudacxx', jobs: ['build'], std: 'max', cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda', sm: '70;80;90;100;120'}
     - {project: 'libcudacxx', jobs: ['nvrtc'], std: 'max', gpu: 't4', sm: 'gpu'}
     - {project: 'libcudacxx', jobs: ['verify_codegen']}
-    # libcu++ Codegen FileCheck: common architectures use the full suite matrix;
-    # suite-specific architectures are added separately.
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.0', cxx: ['gcc12', 'clang14'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: [75, 80, 90]}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: 'simd-sass', sm: [103, '120f']}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: 'simd-sass', sm: [103, '120f']}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: 'simd-sass', sm: [103, '120f']}
     # CUB - Specialized, testing default SM
     - {project: 'cub', jobs: ['test_nolid', 'test_lid0'], std: 'max', cxx: ['gcc', 'msvc'], gpu: 'rtxa6000', sm: 'gpu'}
     - {project: 'cub', jobs: ['build_nolid', 'build_lid0'], std: 'max', cxx: 'clang'}

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -110,6 +110,18 @@ workflows:
     - {jobs: ['test_gpu'], project: 'thrust', cmake_options: '-DTHRUST_DISPATCH_TYPE=Force32bit', gpu: 'rtx4090'}
     - {jobs: ['nvrtc'], project: 'libcudacxx', std: 'all', gpu: 'rtx2080', sm: 'gpu'}
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
+    # libcu++ Codegen FileCheck: common architectures use the full suite matrix;
+    # suite-specific architectures are added separately.
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.0', cxx: ['gcc12', 'clang14'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: [75, 80, 90]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: 'simd-sass', sm: [103, '120f']}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: 'simd-sass', sm: [103, '120f']}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: 'simd-sass', sm: [103, '120f']}
     # c.parallel -- pinned to gcc13 / msvc2022 to match python
     - {jobs: ['test'], project: 'cccl_c_parallel', ctk: '12.X', cxx: ['gcc13', 'msvc2022'], gpu: ['t4']}
     - {jobs: ['test'], project: 'cccl_c_parallel', ctk: '13.X', cxx: ['gcc13', 'msvc2022'], gpu: ['rtx2080', 'l4', 'h100']}
@@ -194,6 +206,18 @@ workflows:
     - {project: 'libcudacxx', jobs: ['build'], std: 'max', cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda', sm: '70;80;90;100;120'}
     - {project: 'libcudacxx', jobs: ['nvrtc'], std: 'max', gpu: 't4', sm: 'gpu'}
     - {project: 'libcudacxx', jobs: ['verify_codegen']}
+    # libcu++ Codegen FileCheck: common architectures use the full suite matrix;
+    # suite-specific architectures are added separately.
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.0', cxx: ['gcc12', 'clang14'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: [75, 80, 90]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: 'simd-sass', sm: [103, '120f']}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: 'simd-sass', sm: [103, '120f']}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: 'simd-sass', sm: [103, '120f']}
     # CUB - Specialized, testing default SM
     - {project: 'cub', jobs: ['test_nolid', 'test_lid0'], std: 'max', cxx: ['gcc', 'msvc'], gpu: 'rtxa6000', sm: 'gpu'}
     - {project: 'cub', jobs: ['build_nolid', 'build_lid0'], std: 'max', cxx: 'clang'}
@@ -297,6 +321,18 @@ workflows:
     # NVRTC tests don't currently support 12.0:
     - {jobs: ['nvrtc'],          project: 'libcudacxx', ctk: [        '12.X', '13.0', '13.X'], cxx: 'gcc12', std: 'all', gpu: 'rtx2080', sm: 'gpu'}
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
+    # libcu++ Codegen FileCheck: common architectures use the full suite matrix;
+    # suite-specific architectures are added separately.
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.0', cxx: ['gcc12', 'clang14'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: [75, 80, 90]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: 'simd-sass', sm: [103, '120f']}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: 'simd-sass', sm: [103, '120f']}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: 'simd-sass', sm: [103, '120f']}
     # c.parallel -- pinned to gcc13 / msvc2022 to match python
     - {jobs: ['test'],  project: ['cccl_c_parallel'], ctk: '12.X', cxx: ['gcc13', 'msvc2022'], gpu: ['t4']}
     - {jobs: ['test'],  project: ['cccl_c_parallel'], ctk: '13.X', cxx: ['gcc13', 'msvc2022'], gpu: ['rtx2080', 'l4', 'h100']}
@@ -406,6 +442,18 @@ workflows:
     # NVRTC tests don't currently support 12.0:
     - {jobs: ['nvrtc'],          project: 'libcudacxx', ctk: [        '12.X', '13.0', '13.X'], cxx: 'gcc12', std: 'all', gpu: 'rtx2080', sm: 'gpu'}
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
+    # libcu++ Codegen FileCheck: common architectures use the full suite matrix;
+    # suite-specific architectures are added separately.
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.0', cxx: ['gcc12', 'clang14'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: [75, 80, 90]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: 'simd-sass', sm: [103, '120f']}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: 'simd-sass', sm: [103, '120f']}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: 'simd-sass', sm: [103, '120f']}
     # c.parallel -- pinned to gcc13 / msvc2022 to match python
     - {jobs: ['test'],  project: ['cccl_c_parallel'], ctk: '12.X', cxx: ['gcc13', 'msvc2022'], gpu: ['t4']}
     - {jobs: ['test'],  project: ['cccl_c_parallel'], ctk: '13.X', cxx: ['gcc13', 'msvc2022'], gpu: ['rtx2080', 'l4', 'h100']}
@@ -624,6 +672,7 @@ jobs:
   # libcudacxx:
   nvrtc: { gpu: true, name: 'NVRTC' }
   verify_codegen: { gpu: false, name: 'VerifyCodegen' }
+  codegen_filecheck: { gpu: false, name: 'libcu++ Codegen FileCheck', invoke: { prefix: 'build', args: '-codegen-tests' } }
 
   # CUB:
   build_nolid: { name: 'BuildNoLaunch',     gpu: false, invoke: { prefix: 'build', args: '-no-lid'} }
@@ -672,6 +721,12 @@ jobs:
   # Only used for generating devcontainers. No scripts actually exist for these:
   dc:     { gpu: false }
   dc_ext: { gpu: false, cuda_ext: true }
+
+codegen_targets:
+  atomics-ptx: { name: 'Atomics PTX', cmake_target: 'libcudacxx.test.atomics.ptx' }
+  atomics-sass: { name: 'Atomics SASS', cmake_target: 'libcudacxx.test.atomics.sass' }
+  simd-ptx: { name: 'SIMD PTX', cmake_target: 'libcudacxx.test.simd.ptx' }
+  simd-sass: { name: 'SIMD SASS', cmake_target: 'libcudacxx.test.simd.sass' }
 
 # Projects have the following properties:
 #
@@ -800,9 +855,11 @@ gpus:
 #  - required: Whether the tag is required. Default is false.
 #  - default: The default value for the tag. Default is null.
 tags:
-   # An array of jobs (e.g. 'build', 'test', 'nvrtc', 'infra', 'verify_codegen', ...)
+   # An array of jobs (e.g. 'build', 'test', 'nvrtc', 'infra', 'verify_codegen', 'codegen_filecheck', ...)
    # See the `jobs` map.
   jobs: { required: true }
+  # FileCheck codegen suite selected by a codegen_filecheck job.
+  codegen_target: { required: false }
   # CUDA ToolKit version
   # See the `ctks` map.
   ctk: { default: '13.X' }

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -110,18 +110,18 @@ workflows:
     - {jobs: ['test_gpu'], project: 'thrust', cmake_options: '-DTHRUST_DISPATCH_TYPE=Force32bit', gpu: 'rtx4090'}
     - {jobs: ['nvrtc'], project: 'libcudacxx', std: 'all', gpu: 'rtx2080', sm: 'gpu'}
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
-    # libcu++ Codegen FileCheck: common architectures use the full suite matrix;
-    # suite-specific architectures are added separately.
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.0', cxx: ['gcc12', 'clang14'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: [75, 80, 90]}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: 'simd-sass', sm: [103, '120f']}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: ['gcc15', 'clang20'], codegen_target: 'simd-sass', sm: [103, '120f']}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
-    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: ['gcc15', 'clang21'], codegen_target: 'simd-sass', sm: [103, '120f']}
+    # libcu++ Codegen FileCheck: PRs use one GCC host compiler per CTK.
+    # Suite-specific architectures are added separately.
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.0', cxx: 'gcc12', codegen_target: ['atomics-ptx', 'atomics-sass'], sm: [75, 80, 90]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: 'gcc14', codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: 'gcc14', codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: 'gcc14', codegen_target: 'simd-sass', sm: [103, '120f']}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: 'gcc15', codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: 'gcc15', codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '13.0', cxx: 'gcc15', codegen_target: 'simd-sass', sm: [103, '120f']}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: 'gcc15', codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: 'gcc15', codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
+    - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: 'gcc15', codegen_target: 'simd-sass', sm: [103, '120f']}
     # c.parallel -- pinned to gcc13 / msvc2022 to match python
     - {jobs: ['test'], project: 'cccl_c_parallel', ctk: '12.X', cxx: ['gcc13', 'msvc2022'], gpu: ['t4']}
     - {jobs: ['test'], project: 'cccl_c_parallel', ctk: '13.X', cxx: ['gcc13', 'msvc2022'], gpu: ['rtx2080', 'l4', 'h100']}
@@ -309,8 +309,8 @@ workflows:
     # NVRTC tests don't currently support 12.0:
     - {jobs: ['nvrtc'],          project: 'libcudacxx', ctk: [        '12.X', '13.0', '13.X'], cxx: 'gcc12', std: 'all', gpu: 'rtx2080', sm: 'gpu'}
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
-    # libcu++ Codegen FileCheck: common architectures use the full suite matrix;
-    # suite-specific architectures are added separately.
+    # libcu++ Codegen FileCheck: nightly covers the GCC and Clang host compilers
+    # supported by each CTK. Suite-specific architectures are added separately.
     - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.0', cxx: ['gcc12', 'clang14'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: [75, 80, 90]}
     - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
     - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}
@@ -430,8 +430,8 @@ workflows:
     # NVRTC tests don't currently support 12.0:
     - {jobs: ['nvrtc'],          project: 'libcudacxx', ctk: [        '12.X', '13.0', '13.X'], cxx: 'gcc12', std: 'all', gpu: 'rtx2080', sm: 'gpu'}
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
-    # libcu++ Codegen FileCheck: common architectures use the full suite matrix;
-    # suite-specific architectures are added separately.
+    # libcu++ Codegen FileCheck: weekly covers the GCC and Clang host compilers
+    # supported by each CTK. Suite-specific architectures are added separately.
     - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.0', cxx: ['gcc12', 'clang14'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: [75, 80, 90]}
     - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass', 'simd-ptx', 'simd-sass'], sm: [80, 90, 100, 120]}
     - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', ctk: '12.X', cxx: ['gcc14', 'clang19'], codegen_target: ['atomics-ptx', 'atomics-sass'], sm: 75}

--- a/libcudacxx/test/CMakeLists.txt
+++ b/libcudacxx/test/CMakeLists.txt
@@ -97,7 +97,69 @@ if (LIBCUDACXX_TEST_WITH_NVRTC)
 endif()
 
 add_subdirectory(nvtarget)
-include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CodegenTest.cmake")
-add_subdirectory(atomic_codegen)
-add_subdirectory(simd_codegen)
+
+set(
+  LIBCUDACXX_CODEGEN_FILECHECK_TESTS
+  ""
+  CACHE STRING
+  "Semicolon-separated libcu++ FileCheck codegen suites to enable (all, atomics-ptx, atomics-sass, simd-ptx, simd-sass)."
+)
+set(
+  libcudacxx_codegen_filecheck_valid_suites
+  all
+  atomics-ptx
+  atomics-sass
+  simd-ptx
+  simd-sass
+)
+foreach (suite IN LISTS LIBCUDACXX_CODEGEN_FILECHECK_TESTS)
+  if (NOT suite IN_LIST libcudacxx_codegen_filecheck_valid_suites)
+    message(
+      FATAL_ERROR
+      "Unknown libcu++ FileCheck codegen suite '${suite}'. Expected one of: ${libcudacxx_codegen_filecheck_valid_suites}"
+    )
+  endif()
+endforeach()
+
+if (LIBCUDACXX_CODEGEN_FILECHECK_TESTS)
+  include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CodegenTest.cmake")
+
+  if (
+    all IN_LIST LIBCUDACXX_CODEGEN_FILECHECK_TESTS
+    OR atomics-ptx IN_LIST LIBCUDACXX_CODEGEN_FILECHECK_TESTS
+  )
+    set(libcudacxx_codegen_filecheck_atomics_ptx ON)
+  endif()
+  if (
+    all IN_LIST LIBCUDACXX_CODEGEN_FILECHECK_TESTS
+    OR atomics-sass IN_LIST LIBCUDACXX_CODEGEN_FILECHECK_TESTS
+  )
+    set(libcudacxx_codegen_filecheck_atomics_sass ON)
+  endif()
+  if (
+    all IN_LIST LIBCUDACXX_CODEGEN_FILECHECK_TESTS
+    OR simd-ptx IN_LIST LIBCUDACXX_CODEGEN_FILECHECK_TESTS
+  )
+    set(libcudacxx_codegen_filecheck_simd_ptx ON)
+  endif()
+  if (
+    all IN_LIST LIBCUDACXX_CODEGEN_FILECHECK_TESTS
+    OR simd-sass IN_LIST LIBCUDACXX_CODEGEN_FILECHECK_TESTS
+  )
+    set(libcudacxx_codegen_filecheck_simd_sass ON)
+  endif()
+
+  if (
+    libcudacxx_codegen_filecheck_atomics_ptx
+    OR libcudacxx_codegen_filecheck_atomics_sass
+  )
+    add_subdirectory(atomic_codegen)
+  endif()
+  if (
+    libcudacxx_codegen_filecheck_simd_ptx
+    OR libcudacxx_codegen_filecheck_simd_sass
+  )
+    add_subdirectory(simd_codegen)
+  endif()
+endif()
 add_subdirectory(debugging)

--- a/libcudacxx/test/atomic_codegen/CMakeLists.txt
+++ b/libcudacxx/test/atomic_codegen/CMakeLists.txt
@@ -33,3 +33,5 @@ foreach (arch IN LISTS atomic_codegen_cuda_archs)
     COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1
   )
 endforeach()
+
+add_subdirectory(sass)

--- a/libcudacxx/test/atomic_codegen/CMakeLists.txt
+++ b/libcudacxx/test/atomic_codegen/CMakeLists.txt
@@ -1,37 +1,36 @@
-add_custom_target(libcudacxx.test.atomics.ptx)
+if (libcudacxx_codegen_filecheck_atomics_ptx)
+  add_custom_target(libcudacxx.test.atomics.ptx)
 
-set(libcudacxx_atomic_codegen_tests)
-if (NOT "NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
-  file(GLOB libcudacxx_atomic_codegen_tests CONFIGURE_DEPENDS "*.cu")
+  set(libcudacxx_atomic_codegen_tests)
+  if (NOT "NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
+    file(GLOB libcudacxx_atomic_codegen_tests CONFIGURE_DEPENDS "*.cu")
+  endif()
+
+  if (libcudacxx_atomic_codegen_tests)
+    libcudacxx_codegen_check_tools(libcudacxx_codegen_tests_enabled)
+    if (libcudacxx_codegen_tests_enabled)
+      libcudacxx_codegen_get_cuda_architectures(atomic_codegen_cuda_archs PTX)
+      if (atomic_codegen_cuda_archs)
+        foreach (arch IN LISTS atomic_codegen_cuda_archs)
+          libcudacxx_codegen_add_ptx_tests(
+            AGGREGATE_TARGET libcudacxx.test.atomics.ptx
+            TARGET_PREFIX atomic_codegen
+            ARCH "${arch}"
+            CHECK_PREFIXES SMXX
+            TESTS ${libcudacxx_atomic_codegen_tests}
+            COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1
+          )
+        endforeach()
+      else()
+        message(
+          STATUS
+          "No compatible CUDA architectures requested; skipping atomic PTX codegen tests"
+        )
+      endif()
+    endif()
+  endif()
 endif()
 
-if (NOT libcudacxx_atomic_codegen_tests)
-  return()
+if (libcudacxx_codegen_filecheck_atomics_sass)
+  add_subdirectory(sass)
 endif()
-
-libcudacxx_codegen_check_tools(libcudacxx_codegen_tests_enabled)
-if (NOT libcudacxx_codegen_tests_enabled)
-  return()
-endif()
-
-libcudacxx_codegen_get_cuda_architectures(atomic_codegen_cuda_archs PTX)
-if (NOT atomic_codegen_cuda_archs)
-  message(
-    STATUS
-    "No compatible CUDA architectures requested; skipping atomic codegen tests"
-  )
-  return()
-endif()
-
-foreach (arch IN LISTS atomic_codegen_cuda_archs)
-  libcudacxx_codegen_add_ptx_tests(
-    AGGREGATE_TARGET libcudacxx.test.atomics.ptx
-    TARGET_PREFIX atomic_codegen
-    ARCH "${arch}"
-    CHECK_PREFIXES SMXX
-    TESTS ${libcudacxx_atomic_codegen_tests}
-    COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1
-  )
-endforeach()
-
-add_subdirectory(sass)

--- a/libcudacxx/test/atomic_codegen/CMakeLists.txt
+++ b/libcudacxx/test/atomic_codegen/CMakeLists.txt
@@ -1,36 +1,43 @@
-if (libcudacxx_codegen_filecheck_atomics_ptx)
-  add_custom_target(libcudacxx.test.atomics.ptx)
-
-  set(libcudacxx_atomic_codegen_tests)
-  if (NOT "NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
-    file(GLOB libcudacxx_atomic_codegen_tests CONFIGURE_DEPENDS "*.cu")
-  endif()
-
-  if (libcudacxx_atomic_codegen_tests)
-    libcudacxx_codegen_check_tools(libcudacxx_codegen_tests_enabled)
-    if (libcudacxx_codegen_tests_enabled)
-      libcudacxx_codegen_get_cuda_architectures(atomic_codegen_cuda_archs PTX)
-      if (atomic_codegen_cuda_archs)
-        foreach (arch IN LISTS atomic_codegen_cuda_archs)
-          libcudacxx_codegen_add_ptx_tests(
-            AGGREGATE_TARGET libcudacxx.test.atomics.ptx
-            TARGET_PREFIX atomic_codegen
-            ARCH "${arch}"
-            CHECK_PREFIXES SMXX
-            TESTS ${libcudacxx_atomic_codegen_tests}
-            COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1
-          )
-        endforeach()
-      else()
-        message(
-          STATUS
-          "No compatible CUDA architectures requested; skipping atomic PTX codegen tests"
-        )
-      endif()
-    endif()
-  endif()
-endif()
-
 if (libcudacxx_codegen_filecheck_atomics_sass)
   add_subdirectory(sass)
 endif()
+
+if (NOT libcudacxx_codegen_filecheck_atomics_ptx)
+  return()
+endif()
+
+add_custom_target(libcudacxx.test.atomics.ptx)
+
+if ("NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
+  return()
+endif()
+
+file(GLOB libcudacxx_atomic_codegen_tests CONFIGURE_DEPENDS "*.cu")
+if (NOT libcudacxx_atomic_codegen_tests)
+  return()
+endif()
+
+libcudacxx_codegen_check_tools(libcudacxx_codegen_tests_enabled)
+if (NOT libcudacxx_codegen_tests_enabled)
+  return()
+endif()
+
+libcudacxx_codegen_get_cuda_architectures(atomic_codegen_cuda_archs PTX)
+if (NOT atomic_codegen_cuda_archs)
+  message(
+    STATUS
+    "No compatible CUDA architectures requested; skipping atomic PTX codegen tests"
+  )
+  return()
+endif()
+
+foreach (arch IN LISTS atomic_codegen_cuda_archs)
+  libcudacxx_codegen_add_ptx_tests(
+    AGGREGATE_TARGET libcudacxx.test.atomics.ptx
+    TARGET_PREFIX atomic_codegen
+    ARCH "${arch}"
+    CHECK_PREFIXES SMXX
+    TESTS ${libcudacxx_atomic_codegen_tests}
+    COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1
+  )
+endforeach()

--- a/libcudacxx/test/atomic_codegen/CMakeLists.txt
+++ b/libcudacxx/test/atomic_codegen/CMakeLists.txt
@@ -2,7 +2,7 @@ add_custom_target(libcudacxx.test.atomics.ptx)
 
 set(libcudacxx_atomic_codegen_tests)
 if (NOT "NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
-  file(GLOB libcudacxx_atomic_codegen_tests "*.cu")
+  file(GLOB libcudacxx_atomic_codegen_tests CONFIGURE_DEPENDS "*.cu")
 endif()
 
 if (NOT libcudacxx_atomic_codegen_tests)

--- a/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
+++ b/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 set(libcudacxx_atomic_codegen_tests)
 if (NOT "NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
-  file(GLOB libcudacxx_atomic_codegen_tests "*.cu")
+  file(GLOB libcudacxx_atomic_codegen_tests CONFIGURE_DEPENDS "*.cu")
 endif()
 
 if (NOT libcudacxx_atomic_codegen_tests)
@@ -80,11 +80,9 @@ else()
   # with CUDA 12.4 and newer.
   if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.4)
     list(
-      REMOVE_ITEM libcudacxx_atomic_codegen_tests
-      "${CMAKE_CURRENT_SOURCE_DIR}/compare_exchange_types_128_atomic_ref.cu"
-      "${CMAKE_CURRENT_SOURCE_DIR}/exchange_types_128_atomic_ref.cu"
-      "${CMAKE_CURRENT_SOURCE_DIR}/load_types_128_atomic_ref.cu"
-      "${CMAKE_CURRENT_SOURCE_DIR}/store_types_128_atomic_ref.cu"
+      FILTER libcudacxx_atomic_codegen_tests
+      EXCLUDE
+      REGEX "_types_128_atomic_ref[.]cu$"
     )
   endif()
 endif()

--- a/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
+++ b/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
@@ -1,0 +1,99 @@
+##===----------------------------------------------------------------------===##
+##
+## Part of libcu++ in the CUDA C++ Core Libraries,
+## under the Apache License v2.0 with LLVM Exceptions.
+## See https://llvm.org/LICENSE.txt for license information.
+## SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+## SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+##
+##===----------------------------------------------------------------------===##
+
+add_custom_target(libcudacxx.test.atomics.sass)
+
+if (NOT CMAKE_CUDA_COMPILER_ID STREQUAL NVIDIA)
+  message("-- Skipping atomic SASS codegen tests without NVCC")
+  return()
+endif()
+
+# Generate SASS for the numeric real architectures requested by the build.
+set(atomic_codegen_sass_cuda_archs)
+foreach (arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
+  if (arch MATCHES "^([0-9]+)(-real)?$")
+    set(arch_number "${CMAKE_MATCH_1}")
+    if (arch_number GREATER_EQUAL 75)
+      list(APPEND atomic_codegen_sass_cuda_archs "${arch_number}")
+    endif()
+  endif()
+endforeach()
+list(REMOVE_DUPLICATES atomic_codegen_sass_cuda_archs)
+
+if (NOT atomic_codegen_sass_cuda_archs)
+  message(
+    "-- Skipping atomic SASS codegen tests without numeric real CUDA architectures"
+  )
+  return()
+endif()
+
+if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.1)
+  set(atomic_codegen_sass_cuda_version_prefix CUDA12-0)
+else()
+  set(atomic_codegen_sass_cuda_version_prefix CUDA12-1-PLUS)
+endif()
+
+set(libcudacxx_atomic_codegen_tests)
+if (NOT "NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
+  file(GLOB libcudacxx_atomic_codegen_tests "*.cu")
+endif()
+
+if (NOT libcudacxx_atomic_codegen_tests)
+  return()
+endif()
+
+libcudacxx_codegen_check_tools(libcudacxx_codegen_tests_enabled)
+if (NOT libcudacxx_codegen_tests_enabled)
+  return()
+endif()
+
+include(CheckSourceCompiles)
+include(CMakePushCheckState)
+cmake_push_check_state(RESET)
+list(APPEND CMAKE_REQUIRED_INCLUDES "${libcudacxx_SOURCE_DIR}/include")
+check_source_compiles(
+  CUDA
+  [[
+    #include <cuda/std/__cccl/extended_data_types.h>
+
+    #if !_CCCL_HAS_INT128()
+    #  error "128-bit integers are not supported"
+    #endif
+
+    int main() { return 0; }
+  ]]
+  libcudacxx_atomic_codegen_has_int128
+)
+cmake_pop_check_state()
+
+if (NOT libcudacxx_atomic_codegen_has_int128)
+  list(FILTER libcudacxx_atomic_codegen_tests EXCLUDE REGEX "_types_128_")
+else()
+  # Native 128-bit atomic_ref operations require the PTX ISA 8.4 path available
+  # with CUDA 12.4 and newer.
+  if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.4)
+    list(
+      REMOVE_ITEM libcudacxx_atomic_codegen_tests
+      "${CMAKE_CURRENT_SOURCE_DIR}/compare_exchange_types_128_atomic_ref.cu"
+      "${CMAKE_CURRENT_SOURCE_DIR}/exchange_types_128_atomic_ref.cu"
+      "${CMAKE_CURRENT_SOURCE_DIR}/load_types_128_atomic_ref.cu"
+      "${CMAKE_CURRENT_SOURCE_DIR}/store_types_128_atomic_ref.cu"
+    )
+  endif()
+endif()
+
+libcudacxx_codegen_add_sass_tests(
+  AGGREGATE_TARGET libcudacxx.test.atomics.sass
+  TARGET_PREFIX atomic_codegen
+  ARCHITECTURES ${atomic_codegen_sass_cuda_archs}
+  CHECK_PREFIXES ${atomic_codegen_sass_cuda_version_prefix}
+  TESTS ${libcudacxx_atomic_codegen_tests}
+  COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1
+)

--- a/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
+++ b/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
@@ -15,21 +15,11 @@ if (NOT CMAKE_CUDA_COMPILER_ID STREQUAL NVIDIA)
   return()
 endif()
 
-# Generate SASS for the numeric real architectures requested by the build.
-set(atomic_codegen_sass_cuda_archs)
-foreach (arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
-  if (arch MATCHES "^([0-9]+)(-real)?$")
-    set(arch_number "${CMAKE_MATCH_1}")
-    if (arch_number GREATER_EQUAL 75)
-      list(APPEND atomic_codegen_sass_cuda_archs "${arch_number}")
-    endif()
-  endif()
-endforeach()
-list(REMOVE_DUPLICATES atomic_codegen_sass_cuda_archs)
-
+libcudacxx_codegen_get_cuda_architectures(atomic_codegen_sass_cuda_archs SASS)
 if (NOT atomic_codegen_sass_cuda_archs)
   message(
-    "-- Skipping atomic SASS codegen tests without numeric real CUDA architectures"
+    STATUS
+    "No compatible CUDA architectures requested; skipping atomic SASS codegen tests"
   )
   return()
 endif()

--- a/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
+++ b/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
@@ -81,10 +81,13 @@ else()
   endif()
 endif()
 
+# Restrict FileCheck to the wrapper so instructions in outlined helpers cannot
+# mask an inlining regression.
 libcudacxx_codegen_add_sass_tests(
   AGGREGATE_TARGET libcudacxx.test.atomics.sass
   TARGET_PREFIX atomic_codegen
   ARCHITECTURES ${atomic_codegen_sass_cuda_archs}
+  DUMP_FUNCTIONS atomic_codegen_test
   CHECK_PREFIXES ${atomic_codegen_sass_cuda_version_prefix}
   TESTS ${libcudacxx_atomic_codegen_tests}
   COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1

--- a/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
+++ b/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
@@ -64,6 +64,10 @@ check_source_compiles(
 cmake_pop_check_state()
 
 if (NOT libcudacxx_atomic_codegen_has_int128)
+  message(
+    STATUS
+    "Skipping 128-bit atomic SASS codegen tests: 128-bit integers are not supported"
+  )
   list(FILTER libcudacxx_atomic_codegen_tests EXCLUDE REGEX "_types_128_")
 else()
   # Native 128-bit atomic_ref operations require the PTX ISA 8.4 path available

--- a/libcudacxx/test/atomic_codegen/sass/atomic_codegen_helpers.h
+++ b/libcudacxx/test/atomic_codegen/sass/atomic_codegen_helpers.h
@@ -46,4 +46,16 @@ using csa = cuda::std::atomic<T>;
 template <typename T, cuda::thread_scope>
 using csar = cuda::std::atomic_ref<T>;
 
+template <typename T, cuda::thread_scope Scope>
+using vca = volatile cuda::atomic<T, Scope>;
+
+template <typename T, cuda::thread_scope Scope>
+using vcar = cuda::atomic_ref<volatile T, Scope>;
+
+template <typename T, cuda::thread_scope>
+using vcsa = volatile cuda::std::atomic<T>;
+
+template <typename T, cuda::thread_scope>
+using vcsar = cuda::std::atomic_ref<volatile T>;
+
 #endif // _LIBCUDACXX_TEST_ATOMIC_CODEGEN_SASS_ATOMIC_CODEGEN_HELPERS_H

--- a/libcudacxx/test/atomic_codegen/sass/atomic_codegen_helpers.h
+++ b/libcudacxx/test/atomic_codegen/sass/atomic_codegen_helpers.h
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX_TEST_ATOMIC_CODEGEN_SASS_ATOMIC_CODEGEN_HELPERS_H
+#define _LIBCUDACXX_TEST_ATOMIC_CODEGEN_SASS_ATOMIC_CODEGEN_HELPERS_H
+
+#include <cuda/atomic>
+
+struct __half;
+struct __nv_bfloat16;
+
+using f16  = __half;
+using bf16 = __nv_bfloat16;
+
+inline constexpr auto tsb = cuda::thread_scope_block;
+inline constexpr auto tsd = cuda::thread_scope_device;
+inline constexpr auto tss = cuda::thread_scope_system;
+
+inline constexpr auto mor  = cuda::std::memory_order_relaxed;
+inline constexpr auto moa  = cuda::std::memory_order_acquire;
+inline constexpr auto more = cuda::std::memory_order_release;
+inline constexpr auto moar = cuda::std::memory_order_acq_rel;
+inline constexpr auto mosc = cuda::std::memory_order_seq_cst;
+
+#if _CCCL_HAS_INT128()
+using i128 = __int128_t;
+using u128 = __uint128_t;
+#endif // _CCCL_HAS_INT128()
+
+template <typename T, cuda::thread_scope Scope>
+using ca = cuda::atomic<T, Scope>;
+
+template <typename T, cuda::thread_scope Scope>
+using car = cuda::atomic_ref<T, Scope>;
+
+template <typename T, cuda::thread_scope>
+using csa = cuda::std::atomic<T>;
+
+template <typename T, cuda::thread_scope>
+using csar = cuda::std::atomic_ref<T>;
+
+#endif // _LIBCUDACXX_TEST_ATOMIC_CODEGEN_SASS_ATOMIC_CODEGEN_HELPERS_H

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_apis.cu
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
+// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ bool atomic_compare_exchange(TEMPLATE<int32_t, SCOPE>& atom, int32_t& expected, int32_t desired)
+{
+  return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_apis.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ bool atomic_compare_exchange(TEMPLATE<int32_t, SCOPE>& atom, int32_t& expected, int32_t desired)
+extern "C" __device__ bool atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, int32_t& expected, int32_t desired)
 {
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_apis.cu
@@ -37,7 +37,7 @@ extern "C" __device__ bool atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_apis.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
 // %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
-// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order rr=mor,mor,,non_seq_cst,no_acquire,no_membar:ar=moa,mor,,non_seq_cst,acquire,no_membar:aa=moa,moa,,non_seq_cst,acquire,no_membar:er=more,mor,ALL,non_seq_cst,no_acquire,membar:br=moar,mor,ALL,non_seq_cst,acquire,membar:ba=moar,moa,ALL,non_seq_cst,acquire,membar:sr=mosc,mor,SC,seq_cst,acquire,membar:sa=mosc,moa,SC,seq_cst,acquire,membar:ss=mosc,mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -25,11 +27,19 @@ extern "C" __device__ bool atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_single_order.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_single_order.cu
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SINGLE_ORDER,OVERLOAD_KIND overload single=1,single:pair=0,pair
+// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,mor,,no_membar:acquire=moa,moa,,no_membar:release=more,mor,ALL,membar:acq_rel=moar,moa,ALL,membar:seq_cst=mosc,mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ bool
+atomic_compare_exchange(cuda::atomic_ref<int32_t, cuda::thread_scope_device>& atom, int32_t& expected, int32_t desired)
+{
+#if SINGLE_ORDER
+  return atom.CAS(expected, desired, SUCCESS_ORDER);
+#else // ^^^ SINGLE_ORDER ^^^ / vvv !SINGLE_ORDER vvv
+  return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
+#endif // !SINGLE_ORDER
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].GPU{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}ATOM.E.CAS.STRONG.GPU{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_single_order.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_single_order.cu
@@ -39,7 +39,7 @@ atomic_codegen_test(cuda::atomic_ref<int32_t, cuda::thread_scope_device>& atom, 
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}ATOM.E.CAS.STRONG.GPU{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_single_order.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_single_order.cu
@@ -16,8 +16,8 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ bool
-atomic_compare_exchange(cuda::atomic_ref<int32_t, cuda::thread_scope_device>& atom, int32_t& expected, int32_t desired)
+extern "C" __device__ bool
+atomic_codegen_test(cuda::atomic_ref<int32_t, cuda::thread_scope_device>& atom, int32_t& expected, int32_t desired)
 {
 #if SINGLE_ORDER
   return atom.CAS(expected, desired, SUCCESS_ORDER);
@@ -28,7 +28,7 @@ atomic_compare_exchange(cuda::atomic_ref<int32_t, cuda::thread_scope_device>& at
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].GPU{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_single_order.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_single_order.cu
@@ -9,9 +9,11 @@
 //===----------------------------------------------------------------------===//
 
 // clang-format off
-// %PARAM% SINGLE_ORDER,OVERLOAD_KIND overload single=1,single:pair=0,pair
+// %PARAM% SINGLE_ORDER,OVERLOAD_KIND,FILECHECK_PREFIX_SCOPE overload single=1,single,non_block:pair=0,pair,non_block
 // %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
-// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,mor,,no_membar:acquire=moa,moa,,no_membar:release=more,mor,ALL,membar:acq_rel=moar,moa,ALL,membar:seq_cst=mosc,mosc,SC,membar
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,moa,,non_seq_cst,acquire,no_membar:release=more,mor,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,moa,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -30,10 +32,16 @@ atomic_codegen_test(cuda::atomic_ref<int32_t, cuda::thread_scope_device>& atom, 
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].GPU{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}ATOM.E.CAS.STRONG.GPU{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types.cu
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
+// %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
+// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ bool atomic_compare_exchange(TEMPLATE<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+{
+  return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types.cu
@@ -17,14 +17,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ bool atomic_compare_exchange(TEMPLATE<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+extern "C" __device__ bool atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
 {
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types.cu
@@ -12,7 +12,9 @@
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
 // %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
 // %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
-// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order rr=mor,mor,,non_seq_cst,no_acquire,no_membar:ar=moa,mor,,non_seq_cst,acquire,no_membar:aa=moa,moa,,non_seq_cst,acquire,no_membar:er=more,mor,ALL,non_seq_cst,no_acquire,membar:br=moar,mor,ALL,non_seq_cst,acquire,membar:ba=moar,moa,ALL,non_seq_cst,acquire,membar:sr=mosc,mor,SC,seq_cst,acquire,membar:sa=mosc,moa,SC,seq_cst,acquire,membar:ss=mosc,mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -26,11 +28,19 @@ extern "C" __device__ bool atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types.cu
@@ -38,7 +38,7 @@ extern "C" __device__ bool atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic.cu
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER order rr=mor,mor:ar=moa,mor:aa=moa,moa:er=more,mor:br=moar,mor:ba=moar,moa:sr=mosc,mor:sa=mosc,moa:ss=mosc,mosc
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ bool atomic_compare_exchange(cuda::atomic<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+{
+  return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
+}
+
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-NOT: {{.*}}MEMBAR.SC.{{.*}}
+; SMXX: {{.*}}BSSY [[SYNC:B[0-9]+]], {{.*}}
+; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{(\.U32)?}}.AND [[LOCK_ACQUIRED:P[0-9]+]], PT, [[LOCK_STATE]], 0x1, PT{{.*}}
+; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
+; SMXX: {{.*}}{{@!?}}[[LOCK_ACQUIRED]] BRA{{(\.U)?}} {{.*}}
+; SMXX: {{.*}}BSYNC [[SYNC]]{{.*}}
+; SMXX: {{.*}}LD.E.128{{(\.SYS)?}} {{R[0-9]+}}, {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}
+; SMXX: {{.*}}LD.E.128{{(\.SYS)?}} {{R[0-9]+}}, {{.*}}
+; SMXX: {{.*}}LOP3.LUT [[CAS_RESULT_PRED:P[0-9]+]], RZ, {{R[0-9]+}}, {{R[0-9]+}}, RZ, 0xfc, [[CAS_RESULT_PRED]]{{.*}}
+; CUDA12-0: {{.*}}SEL [[STORE_DATA:R[0-9]+]], {{R[0-9]+}}, {{R[0-9]+}}, ![[CAS_RESULT_PRED]]{{.*}}
+; CUDA12-0: {{.*}}SEL [[STORE_ADDR:R[0-9]+]], [[BASE_ADDR]], {{R[0-9]+}}, ![[CAS_RESULT_PRED]]{{.*}}
+; CUDA12-0: {{.*}}SEL {{R[0-9]+}}, RZ, 0x1, [[CAS_RESULT_PRED]]{{.*}}
+; CUDA12-0: {{.*}}ST.E.128{{(\.SYS)?}} {{.*\[}}[[STORE_ADDR]]{{(\.64)?\].*}}, [[STORE_DATA]]{{.*}}
+; CUDA12-0-NOT: {{.*}}ST.E.128{{(\.SYS)?}} {{.*}}
+; CUDA12-1-PLUS: {{.*}}@[[CAS_RESULT_PRED]] ST.E.128{{(\.SYS)?}} {{.*}}
+; CUDA12-1-PLUS: {{.*}}@![[CAS_RESULT_PRED]] ST.E.128{{(\.SYS)?}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}
+; SMXX: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic.cu
@@ -36,17 +36,16 @@ __device__ bool atomic_compare_exchange(cuda::atomic<TYPE, SCOPE>& atom, TYPE& e
 ; SMXX: {{.*}}BSYNC [[SYNC]]{{.*}}
 ; SMXX: {{.*}}LD.E.128{{(\.SYS)?}} {{R[0-9]+}}, {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}
 ; SMXX: {{.*}}LD.E.128{{(\.SYS)?}} {{R[0-9]+}}, {{.*}}
-; SMXX: {{.*}}LOP3.LUT [[CAS_RESULT_PRED:P[0-9]+]], RZ, {{R[0-9]+}}, {{R[0-9]+}}, RZ, 0xfc, [[CAS_RESULT_PRED]]{{.*}}
-; CUDA12-0: {{.*}}SEL [[STORE_DATA:R[0-9]+]], {{R[0-9]+}}, {{R[0-9]+}}, ![[CAS_RESULT_PRED]]{{.*}}
-; CUDA12-0: {{.*}}SEL [[STORE_ADDR:R[0-9]+]], [[BASE_ADDR]], {{R[0-9]+}}, ![[CAS_RESULT_PRED]]{{.*}}
-; CUDA12-0: {{.*}}SEL {{R[0-9]+}}, RZ, 0x1, [[CAS_RESULT_PRED]]{{.*}}
-; CUDA12-0: {{.*}}ST.E.128{{(\.SYS)?}} {{.*\[}}[[STORE_ADDR]]{{(\.64)?\].*}}, [[STORE_DATA]]{{.*}}
-; CUDA12-0-NOT: {{.*}}ST.E.128{{(\.SYS)?}} {{.*}}
-; CUDA12-1-PLUS: {{.*}}@[[CAS_RESULT_PRED]] ST.E.128{{(\.SYS)?}} {{.*}}
-; CUDA12-1-PLUS: {{.*}}@![[CAS_RESULT_PRED]] ST.E.128{{(\.SYS)?}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}
-; SMXX: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
-; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; SMXX: {{.*}}{{LOP3\.LUT|ISETP\.NE[^ ]*}} [[CAS_RESULT_PRED:P[0-9]+]], {{.*}}
+; CUDA12-0-DAG: {{.*}}SEL [[STORE_DATA:R[0-9]+]], {{R[0-9]+}}, {{R[0-9]+}}, ![[CAS_RESULT_PRED]]{{.*}}
+; CUDA12-0-DAG: {{.*}}SEL [[STORE_ADDR:R[0-9]+]], [[BASE_ADDR]], {{R[0-9]+}}, ![[CAS_RESULT_PRED]]{{.*}}
+; CUDA12-0-DAG: {{.*}}SEL {{R[0-9]+}}, RZ, 0x1, [[CAS_RESULT_PRED]]{{.*}}
+; CUDA12-0-DAG: {{.*}}ST.E.128{{(\.SYS)?}} {{.*\[}}[[STORE_ADDR]]{{(\.64)?\].*}}, [[STORE_DATA]]{{.*}}
+; CUDA12-1-PLUS-DAG: {{.*}}@[[CAS_RESULT_PRED]] ST.E.128{{(\.SYS)?}} {{.*}}
+; CUDA12-1-PLUS-DAG: {{.*}}@![[CAS_RESULT_PRED]] ST.E.128{{(\.SYS)?}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}
+; SMXX-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; BLOCK-DAG: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; NON_BLOCK-DAG: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic.cu
@@ -13,6 +13,10 @@
 // %PARAM% TYPE type i128:u128
 // %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
 // %PARAM% SUCCESS_ORDER,FAILURE_ORDER order rr=mor,mor:ar=moa,mor:aa=moa,moa:er=more,mor:br=moar,mor:ba=moar,moa:sr=mosc,mor:sa=mosc,moa:ss=mosc,mosc
+// %FILECHECK% PREFIX_COMBINE sm75,cuda12-0
+// %FILECHECK% PREFIX_COMBINE sm80,cuda12-0,block
+// %FILECHECK% PREFIX_COMBINE sm80,cuda12-0,non_block
+// %FILECHECK% PREFIX_COMBINE sm90,cuda12-0
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -42,13 +46,16 @@ extern "C" __device__ bool atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; SMXX: {{.*}}{{LOP3\.LUT|ISETP\.NE[^ ]*}} [[CAS_RESULT_PRED:P[0-9]+]], {{.*}}
 ; CUDA12-0-DAG: {{.*}}SEL [[STORE_DATA:R[0-9]+]], {{R[0-9]+}}, {{R[0-9]+}}, ![[CAS_RESULT_PRED]]{{.*}}
 ; CUDA12-0-DAG: {{.*}}SEL [[STORE_ADDR:R[0-9]+]], [[BASE_ADDR]], {{R[0-9]+}}, ![[CAS_RESULT_PRED]]{{.*}}
+; SM90_CUDA12-0-DAG: {{.*}}SEL {{R[0-9]+}}, RZ, 0x1, [[CAS_RESULT_PRED]]{{.*}}
 ; CUDA12-0-DAG: {{.*}}ST.E.128{{(\.SYS)?}} {{.*\[}}[[STORE_ADDR]]{{(\.64)?\].*}}, [[STORE_DATA]]{{.*}}
 ; CUDA12-1-PLUS-DAG: {{.*}}@[[CAS_RESULT_PRED]] ST.E.128{{(\.SYS)?}} {{.*}}
 ; CUDA12-1-PLUS-DAG: {{.*}}@![[CAS_RESULT_PRED]] ST.E.128{{(\.SYS)?}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}
 ; SMXX: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM80_CUDA12-0_BLOCK: {{.*}}SEL {{R[0-9]+}}, RZ, 0x1, [[CAS_RESULT_PRED]]{{.*}}
 ; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
 ; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
-; CUDA12-0: {{.*}}SEL {{R[0-9]+}}, RZ, 0x1, [[CAS_RESULT_PRED]]{{.*}}
+; SM75_CUDA12-0: {{.*}}SEL {{R[0-9]+}}, RZ, 0x1, [[CAS_RESULT_PRED]]{{.*}}
+; SM80_CUDA12-0_NON_BLOCK: {{.*}}SEL {{R[0-9]+}}, RZ, 0x1, [[CAS_RESULT_PRED]]{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic.cu
@@ -32,20 +32,23 @@ extern "C" __device__ bool atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
 ; SMXX-DAG: {{.*}}ISETP.NE{{(\.U32)?}}.AND [[LOCK_ACQUIRED:P[0-9]+]], PT, [[LOCK_STATE]], 0x1, PT{{.*}}
 ; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}{{@!?}}[[LOCK_ACQUIRED]] BRA{{(\.U)?}} {{.*}}
+; SM75: {{.*}}@[[LOCK_ACQUIRED]] BRA{{(\.U)?}} {{.*}}
+; SM75: {{.*}}LOP3.LUT [[RETRY_PRED:P[0-9]+]], {{.*}}
+; SM75: {{.*}}@![[RETRY_PRED]] BRA{{(\.U)?}} {{.*}}
+; SM80-PLUS: {{.*}}@![[LOCK_ACQUIRED]] BRA{{(\.U)?}} {{.*}}
 ; SMXX: {{.*}}BSYNC [[SYNC]]{{.*}}
 ; SMXX: {{.*}}LD.E.128{{(\.SYS)?}} {{R[0-9]+}}, {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}
 ; SMXX: {{.*}}LD.E.128{{(\.SYS)?}} {{R[0-9]+}}, {{.*}}
 ; SMXX: {{.*}}{{LOP3\.LUT|ISETP\.NE[^ ]*}} [[CAS_RESULT_PRED:P[0-9]+]], {{.*}}
 ; CUDA12-0-DAG: {{.*}}SEL [[STORE_DATA:R[0-9]+]], {{R[0-9]+}}, {{R[0-9]+}}, ![[CAS_RESULT_PRED]]{{.*}}
 ; CUDA12-0-DAG: {{.*}}SEL [[STORE_ADDR:R[0-9]+]], [[BASE_ADDR]], {{R[0-9]+}}, ![[CAS_RESULT_PRED]]{{.*}}
-; CUDA12-0-DAG: {{.*}}SEL {{R[0-9]+}}, RZ, 0x1, [[CAS_RESULT_PRED]]{{.*}}
 ; CUDA12-0-DAG: {{.*}}ST.E.128{{(\.SYS)?}} {{.*\[}}[[STORE_ADDR]]{{(\.64)?\].*}}, [[STORE_DATA]]{{.*}}
 ; CUDA12-1-PLUS-DAG: {{.*}}@[[CAS_RESULT_PRED]] ST.E.128{{(\.SYS)?}} {{.*}}
 ; CUDA12-1-PLUS-DAG: {{.*}}@![[CAS_RESULT_PRED]] ST.E.128{{(\.SYS)?}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}
-; SMXX-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; BLOCK-DAG: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
-; NON_BLOCK-DAG: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; SMXX: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; CUDA12-0: {{.*}}SEL {{R[0-9]+}}, RZ, 0x1, [[CAS_RESULT_PRED]]{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic.cu
@@ -17,7 +17,7 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ bool atomic_compare_exchange(cuda::atomic<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+extern "C" __device__ bool atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
 {
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
@@ -25,7 +25,7 @@ __device__ bool atomic_compare_exchange(cuda::atomic<TYPE, SCOPE>& atom, TYPE& e
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}MEMBAR.SC.{{.*}}
 ; SMXX: {{.*}}BSSY [[SYNC:B[0-9]+]], {{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic_ref.cu
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ bool atomic_compare_exchange(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+{
+  return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
+}
+
+// clang-format off
+/*
+
+; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-DAG: {{.*}}LD.E.128{{(\.SYS)?}} [[EXPECTED:R[0-9]+]], {{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; SMXX: {{.*}}ST.E.128{{(\.SYS)?}} {{.*}}, [[OLD]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic_ref.cu
@@ -17,7 +17,7 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ bool atomic_compare_exchange(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+extern "C" __device__ bool atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
 {
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
@@ -25,7 +25,7 @@ __device__ bool atomic_compare_exchange(cuda::atomic_ref<TYPE, SCOPE>& atom, TYP
 // clang-format off
 /*
 
-; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic_ref.cu
@@ -42,7 +42,7 @@ extern "C" __device__ bool atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ST.E.128{{(\.SYS)?}} {{.*}}, [[OLD]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_128_atomic_ref.cu
@@ -12,7 +12,9 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type i128:u128
 // %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
-// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order rr=mor,mor,,non_seq_cst,no_acquire,no_membar:ar=moa,mor,,non_seq_cst,acquire,no_membar:aa=moa,moa,,non_seq_cst,acquire,no_membar:er=more,mor,ALL,non_seq_cst,no_acquire,membar:br=moar,mor,ALL,non_seq_cst,acquire,membar:ba=moar,moa,ALL,non_seq_cst,acquire,membar:sr=mosc,mor,SC,seq_cst,acquire,membar:sa=mosc,moa,SC,seq_cst,acquire,membar:ss=mosc,mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -28,13 +30,21 @@ extern "C" __device__ bool atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-DAG: {{.*}}LD.E.128{{(\.SYS)?}} [[EXPECTED:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ST.E.128{{(\.SYS)?}} {{.*}}, [[OLD]]{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic.cu
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ bool atomic_compare_exchange(cuda::atomic<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+{
+  return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic.cu
@@ -41,7 +41,7 @@ extern "C" __device__ bool atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic.cu
@@ -20,14 +20,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ bool atomic_compare_exchange(cuda::atomic<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+extern "C" __device__ bool atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
 {
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic.cu
@@ -12,7 +12,9 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
 // %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
-// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order rr=mor,mor,,non_seq_cst,no_acquire,no_membar:ar=moa,mor,,non_seq_cst,acquire,no_membar:aa=moa,moa,,non_seq_cst,acquire,no_membar:er=more,mor,ALL,non_seq_cst,no_acquire,membar:br=moar,mor,ALL,non_seq_cst,acquire,membar:ba=moar,moa,ALL,non_seq_cst,acquire,membar:sr=mosc,mor,SC,seq_cst,acquire,membar:sa=mosc,moa,SC,seq_cst,acquire,membar:ss=mosc,mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -29,11 +31,19 @@ extern "C" __device__ bool atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,FILECHECK_PREFIX_ORDER order rr=mor,mor,no_membar:ar=moa,mor,no_membar:aa=moa,moa,no_membar:er=more,mor,release:br=moar,mor,release:ba=moar,moa,release:sr=mosc,mor,seq_cst:sa=mosc,moa,seq_cst:ss=mosc,mosc,seq_cst
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ bool atomic_compare_exchange(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+{
+  return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]], 0xfffffffc, {{.*}}
+; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
@@ -30,7 +30,7 @@ __device__ bool atomic_compare_exchange(cuda::atomic_ref<TYPE, SCOPE>& atom, TYP
 ; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
-; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]], 0xfffffffc, {{.*}}
+; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
@@ -20,14 +20,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ bool atomic_compare_exchange(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+extern "C" __device__ bool atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
 {
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
@@ -46,7 +46,7 @@ extern "C" __device__ bool atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
@@ -12,7 +12,9 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
 // %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
-// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,FILECHECK_PREFIX_ORDER order rr=mor,mor,no_membar:ar=moa,mor,no_membar:aa=moa,moa,no_membar:er=more,mor,release:br=moar,mor,release:ba=moar,moa,release:sr=mosc,mor,seq_cst:sa=mosc,moa,seq_cst:ss=mosc,mosc,seq_cst
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order rr=mor,mor,non_seq_cst,no_acquire,no_membar:ar=moa,mor,non_seq_cst,acquire,no_membar:aa=moa,moa,non_seq_cst,acquire,no_membar:er=more,mor,non_seq_cst,no_acquire,release:br=moar,mor,non_seq_cst,acquire,release:ba=moar,moa,non_seq_cst,acquire,release:sr=mosc,mor,seq_cst,acquire,seq_cst:sa=mosc,moa,seq_cst,acquire,seq_cst:ss=mosc,mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -30,8 +32,13 @@ extern "C" __device__ bool atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
@@ -39,6 +46,9 @@ extern "C" __device__ bool atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_apis.cu
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
+// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ bool atomic_compare_exchange(TEMPLATE<int32_t, SCOPE>& atom, int32_t& expected, int32_t desired)
+{
+  return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_apis.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
 // %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
-// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order rr=mor,mor,,non_seq_cst,no_acquire,no_membar:ar=moa,mor,,non_seq_cst,acquire,no_membar:aa=moa,moa,,non_seq_cst,acquire,no_membar:er=more,mor,ALL,non_seq_cst,no_acquire,membar:br=moar,mor,ALL,non_seq_cst,acquire,membar:ba=moar,moa,ALL,non_seq_cst,acquire,membar:sr=mosc,mor,SC,seq_cst,acquire,membar:sa=mosc,moa,SC,seq_cst,acquire,membar:ss=mosc,mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -26,12 +28,20 @@ extern "C" __device__ bool atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_apis.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ bool atomic_compare_exchange(TEMPLATE<int32_t, SCOPE>& atom, int32_t& expected, int32_t desired)
+extern "C" __device__ bool atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, int32_t& expected, int32_t desired)
 {
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_apis.cu
@@ -39,7 +39,7 @@ extern "C" __device__ bool atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types.cu
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
+// %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
+// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ bool atomic_compare_exchange(TEMPLATE<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+{
+  return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types.cu
@@ -40,7 +40,7 @@ extern "C" __device__ bool atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types.cu
@@ -12,7 +12,9 @@
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
 // %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
 // %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
-// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order rr=mor,mor,,non_seq_cst,no_acquire,no_membar:ar=moa,mor,,non_seq_cst,acquire,no_membar:aa=moa,moa,,non_seq_cst,acquire,no_membar:er=more,mor,ALL,non_seq_cst,no_acquire,membar:br=moar,mor,ALL,non_seq_cst,acquire,membar:ba=moar,moa,ALL,non_seq_cst,acquire,membar:sr=mosc,mor,SC,seq_cst,acquire,membar:sa=mosc,moa,SC,seq_cst,acquire,membar:ss=mosc,mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -27,12 +29,20 @@ extern "C" __device__ bool atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types.cu
@@ -17,14 +17,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ bool atomic_compare_exchange(TEMPLATE<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+extern "C" __device__ bool atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
 {
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_128_atomic_ref.cu
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ bool atomic_compare_exchange(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+{
+  return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
+}
+
+// clang-format off
+/*
+
+; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-DAG: {{.*}}LD.E.128{{(\.SYS)?}} [[EXPECTED:R[0-9]+]], {{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; SMXX: {{.*}}ST.E.128{{(\.SYS)?}} {{.*}}, [[OLD]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_128_atomic_ref.cu
@@ -44,7 +44,7 @@ atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_128_atomic_ref.cu
@@ -17,7 +17,8 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ bool atomic_compare_exchange(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+extern "C" __device__ bool
+atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
 {
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
@@ -25,7 +26,7 @@ __device__ bool atomic_compare_exchange(cuda::atomic_ref<volatile TYPE, SCOPE>& 
 // clang-format off
 /*
 
-; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_128_atomic_ref.cu
@@ -12,7 +12,9 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type i128:u128
 // %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
-// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order rr=mor,mor,,non_seq_cst,no_acquire,no_membar:ar=moa,mor,,non_seq_cst,acquire,no_membar:aa=moa,moa,,non_seq_cst,acquire,no_membar:er=more,mor,ALL,non_seq_cst,no_acquire,membar:br=moar,mor,ALL,non_seq_cst,acquire,membar:ba=moar,moa,ALL,non_seq_cst,acquire,membar:sr=mosc,mor,SC,seq_cst,acquire,membar:sa=mosc,moa,SC,seq_cst,acquire,membar:ss=mosc,mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -29,14 +31,22 @@ atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected
 ; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-DAG: {{.*}}LD.E.128{{(\.SYS)?}} [[EXPECTED:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
 ; SMXX: {{.*}}ST.E.128{{(\.SYS)?}} {{.*}}, [[OLD]]{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic.cu
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ bool atomic_compare_exchange(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+{
+  return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic.cu
@@ -11,7 +11,8 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
-// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// Strong compare-exchange may retry internally using weak compare-exchange; only the weak overload must contain one CAS.
+// %PARAM% CAS,FILECHECK_PREFIX_SINGLE_CAS cas compare_exchange_weak=compare_exchange_weak,single_cas:compare_exchange_strong=compare_exchange_strong,smxx
 // %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
 // clang-format on
 
@@ -37,7 +38,7 @@ __device__ bool atomic_compare_exchange(volatile cuda::atomic<TYPE, SCOPE>& atom
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; SINGLE_CAS-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic.cu
@@ -13,7 +13,9 @@
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
 // Strong compare-exchange may retry internally using weak compare-exchange; only the weak overload must contain one CAS.
 // %PARAM% CAS,FILECHECK_PREFIX_SINGLE_CAS cas compare_exchange_weak=compare_exchange_weak,single_cas:compare_exchange_strong=compare_exchange_strong,smxx
-// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order rr=mor,mor,,no_membar:ar=moa,mor,,no_membar:aa=moa,moa,,no_membar:er=more,mor,ALL,membar:br=moar,mor,ALL,membar:ba=moar,moa,ALL,membar:sr=mosc,mor,SC,membar:sa=mosc,moa,SC,membar:ss=mosc,mosc,SC,membar
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order rr=mor,mor,,non_seq_cst,no_acquire,no_membar:ar=moa,mor,,non_seq_cst,acquire,no_membar:aa=moa,moa,,non_seq_cst,acquire,no_membar:er=more,mor,ALL,non_seq_cst,no_acquire,membar:br=moar,mor,ALL,non_seq_cst,acquire,membar:ba=moar,moa,ALL,non_seq_cst,acquire,membar:sr=mosc,mor,SC,seq_cst,acquire,membar:sa=mosc,moa,SC,seq_cst,acquire,membar:ss=mosc,mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -31,12 +33,20 @@ extern "C" __device__ bool atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SINGLE_CAS-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic.cu
@@ -21,14 +21,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ bool atomic_compare_exchange(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+extern "C" __device__ bool atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
 {
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic.cu
@@ -44,7 +44,7 @@ extern "C" __device__ bool atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic_ref.cu
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,FILECHECK_PREFIX_ORDER order rr=mor,mor,no_membar:ar=moa,mor,no_membar:aa=moa,moa,no_membar:er=more,mor,release:br=moar,mor,release:ba=moar,moa,release:sr=mosc,mor,seq_cst:sa=mosc,moa,seq_cst:ss=mosc,mosc,seq_cst
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ bool atomic_compare_exchange(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+{
+  return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]], 0xfffffffc, {{.*}}
+; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic_ref.cu
@@ -11,7 +11,8 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
-// %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
+// Strong compare-exchange may retry internally using weak compare-exchange; only the weak overload must contain one CAS.
+// %PARAM% CAS,FILECHECK_PREFIX_SINGLE_CAS cas compare_exchange_weak=compare_exchange_weak,single_cas:compare_exchange_strong=compare_exchange_strong,smxx
 // %PARAM% SUCCESS_ORDER,FAILURE_ORDER,FILECHECK_PREFIX_ORDER order rr=mor,mor,no_membar:ar=moa,mor,no_membar:aa=moa,moa,no_membar:er=more,mor,release:br=moar,mor,release:ba=moar,moa,release:sr=mosc,mor,seq_cst:sa=mosc,moa,seq_cst:ss=mosc,mosc,seq_cst
 // clang-format on
 
@@ -31,7 +32,7 @@ __device__ bool atomic_compare_exchange(cuda::atomic_ref<volatile TYPE, SCOPE>& 
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
-; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]], 0xfffffffc, {{.*}}
+; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
@@ -45,7 +46,7 @@ __device__ bool atomic_compare_exchange(cuda::atomic_ref<volatile TYPE, SCOPE>& 
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; SINGLE_CAS-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic_ref.cu
@@ -13,7 +13,9 @@
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
 // Strong compare-exchange may retry internally using weak compare-exchange; only the weak overload must contain one CAS.
 // %PARAM% CAS,FILECHECK_PREFIX_SINGLE_CAS cas compare_exchange_weak=compare_exchange_weak,single_cas:compare_exchange_strong=compare_exchange_strong,smxx
-// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,FILECHECK_PREFIX_ORDER order rr=mor,mor,no_membar:ar=moa,mor,no_membar:aa=moa,moa,no_membar:er=more,mor,release:br=moar,mor,release:ba=moar,moa,release:sr=mosc,mor,seq_cst:sa=mosc,moa,seq_cst:ss=mosc,mosc,seq_cst
+// %PARAM% SUCCESS_ORDER,FAILURE_ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order rr=mor,mor,non_seq_cst,no_acquire,no_membar:ar=moa,mor,non_seq_cst,acquire,no_membar:aa=moa,moa,non_seq_cst,acquire,no_membar:er=more,mor,non_seq_cst,no_acquire,release:br=moar,mor,non_seq_cst,acquire,release:ba=moar,moa,non_seq_cst,acquire,release:sr=mosc,mor,seq_cst,acquire,seq_cst:sa=mosc,moa,seq_cst,acquire,seq_cst:ss=mosc,mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -33,8 +35,13 @@ atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
@@ -46,6 +53,9 @@ atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SINGLE_CAS-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic_ref.cu
@@ -21,14 +21,15 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ bool atomic_compare_exchange(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
+extern "C" __device__ bool
+atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected, TYPE desired)
 {
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_compare_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic_ref.cu
@@ -53,7 +53,7 @@ atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]]{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_apis.cu
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_exchange(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+{
+  return atom.exchange(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, R4, {{.*}}, R6{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, R4, {{.*}}, R6{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/exchange_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_apis.cu
@@ -15,14 +15,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_exchange(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
 {
   return atom.exchange(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_apis.cu
@@ -10,7 +10,9 @@
 
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -24,11 +26,19 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, R4, {{.*}}, R6{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, R4, {{.*}}, R6{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/exchange_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_apis.cu
@@ -36,7 +36,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, R4, {{.*}}, R6{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, R4, {{.*}}, R6{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types.cu
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
+// %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_exchange(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.exchange(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.EXCH[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, R4, {{.*}}, R6{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.EXCH[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, R4, {{.*}}, R6{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_exchange(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.exchange(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types.cu
@@ -37,7 +37,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, R4, {{.*}}, R6{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, R4, {{.*}}, R6{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
 // %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -25,11 +27,19 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, R4, {{.*}}, R6{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, R4, {{.*}}, R6{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic.cu
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% ORDER order mor:moa:more:moar:mosc
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_exchange(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.exchange(value, ORDER);
+}
+
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-NOT: {{.*}}MEMBAR.SC.{{.*}}
+; SMXX: {{.*}}BSSY [[SYNC:B[0-9]+]], {{.*}}
+; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{(\.U32)?}}.AND [[LOCK_FREE:P[0-9]+]], PT, [[LOCK_STATE]], 0x1, PT{{.*}}
+; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
+; SMXX: {{.*}}{{@!?}}[[LOCK_FREE]] BRA{{(\.U)?}} {{.*}}
+; SMXX: {{.*}}BSYNC [[SYNC]]{{.*}}
+; SMXX: {{.*}}LD.E.128{{(\.SYS)?}} R4, {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}
+; SMXX: {{.*}}ST.E.128{{(\.SYS)?}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; SMXX: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic.cu
@@ -29,9 +29,12 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; SMXX: {{.*}}BSSY [[SYNC:B[0-9]+]], {{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{(\.U32)?}}.AND [[LOCK_FREE:P[0-9]+]], PT, [[LOCK_STATE]], 0x1, PT{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{(\.U32)?}}.AND [[LOCK_ACQUIRED:P[0-9]+]], PT, [[LOCK_STATE]], 0x1, PT{{.*}}
 ; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}{{@!?}}[[LOCK_FREE]] BRA{{(\.U)?}} {{.*}}
+; SM75: {{.*}}@[[LOCK_ACQUIRED]] BRA{{(\.U)?}} {{.*}}
+; SM75: {{.*}}LOP3.LUT [[RETRY_PRED:P[0-9]+]], {{.*}}
+; SM75: {{.*}}@![[RETRY_PRED]] BRA{{(\.U)?}} {{.*}}
+; SM80-PLUS: {{.*}}@![[LOCK_ACQUIRED]] BRA{{(\.U)?}} {{.*}}
 ; SMXX: {{.*}}BSYNC [[SYNC]]{{.*}}
 ; SMXX: {{.*}}LD.E.128{{(\.SYS)?}} R4, {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}
 ; SMXX: {{.*}}ST.E.128{{(\.SYS)?}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}, R8{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic.cu
@@ -16,7 +16,7 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_exchange(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.exchange(value, ORDER);
 }
@@ -24,7 +24,7 @@ __device__ auto atomic_exchange(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}MEMBAR.SC.{{.*}}
 ; SMXX: {{.*}}BSSY [[SYNC:B[0-9]+]], {{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic_ref.cu
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_exchange(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.exchange(value, ORDER);
+}
+
+/*
+
+; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH.STRONG{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH.STRONG{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.EXCH.128.STRONG.{{CTA|SM}} PT, R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.EXCH.128.STRONG.[[SASS_SCOPE]] PT, R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH.STRONG{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic_ref.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_exchange(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.exchange(value, ORDER);
 }
 
 /*
 
-; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH.STRONG{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic_ref.cu
@@ -40,7 +40,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.128.STRONG.{{CTA|SM}} PT, R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.128.STRONG.[[SASS_SCOPE]] PT, R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH.STRONG{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_128_atomic_ref.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type i128:u128
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -27,12 +29,20 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH.STRONG{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH.STRONG{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.128.STRONG.{{CTA|SM}} PT, R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.128.STRONG.[[SASS_SCOPE]] PT, R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH.STRONG{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic.cu
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_exchange(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.exchange(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic.cu
@@ -19,14 +19,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_exchange(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.exchange(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -28,11 +30,19 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic.cu
@@ -40,7 +40,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic_ref.cu
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_exchange(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.exchange(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SMXX-DAG: {{.*}}LOP3.LUT [[A:R[0-9]+]], [[ATOM_ADDR]], 0xfffffffc, {{.*}}
+; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[E:R[0-9]+]], {{.*\[}}[[A]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[E:R[0-9]+]], {{.*\[}}[[A]]{{(\.64)?\].*}}
+; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
+; SMXX: {{.*}}ISETP.NE{{.*}} [[C]], [[E]], {{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic_ref.cu
@@ -19,14 +19,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_exchange(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.exchange(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[A:R[0-9]+]], [[ATOM_ADDR]], 0xfffffffc, {{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic_ref.cu
@@ -45,10 +45,10 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
-; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}} [[C]], [[E]], {{.*}}
+; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[C]], [[E]], {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic_ref.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -29,8 +31,13 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[A:R[0-9]+]], [[ATOM_ADDR]], 0xfffffffc, {{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[E:R[0-9]+]], {{.*\[}}[[A]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[E:R[0-9]+]], {{.*\[}}[[A]]{{(\.64)?\].*}}
 ; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
@@ -38,6 +45,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[C]], [[E]], {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic_ref.cu
@@ -45,7 +45,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[C]], [[E]], {{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_apis.cu
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_exchange(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+{
+  return atom.exchange(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, R4, {{.*}}, R6{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, R4, {{.*}}, R6{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_apis.cu
@@ -15,14 +15,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_exchange(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
 {
   return atom.exchange(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_apis.cu
@@ -38,7 +38,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, R4, {{.*}}, R6{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, R4, {{.*}}, R6{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_apis.cu
@@ -10,7 +10,9 @@
 
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -25,12 +27,20 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, R4, {{.*}}, R6{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, R4, {{.*}}, R6{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types.cu
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
+// %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_exchange(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.exchange(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK: {{.*}}ATOM.E.EXCH[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, R4, {{.*}}, R6{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.EXCH[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, R4, {{.*}}, R6{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_exchange(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.exchange(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types.cu
@@ -39,7 +39,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, R4, {{.*}}, R6{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, R4, {{.*}}, R6{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
 // %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -26,12 +28,20 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, R4, {{.*}}, R6{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, R4, {{.*}}, R6{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_128_atomic_ref.cu
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_exchange(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.exchange(value, ORDER);
+}
+
+/*
+
+; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH.STRONG{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH.STRONG{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.EXCH.128.STRONG.{{CTA|SM}} PT, R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.EXCH.128.STRONG.[[SASS_SCOPE]] PT, R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_128_atomic_ref.cu
@@ -42,7 +42,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.128.STRONG.{{CTA|SM}} PT, R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.128.STRONG.[[SASS_SCOPE]] PT, R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_128_atomic_ref.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type i128:u128
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -28,13 +30,21 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH.STRONG{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.128.STRONG.{{CTA|SM}} PT, R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.128.STRONG.[[SASS_SCOPE]] PT, R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_128_atomic_ref.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_exchange(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.exchange(value, ORDER);
 }
 
 /*
 
-; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH.STRONG{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic.cu
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_exchange(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.exchange(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic.cu
@@ -19,14 +19,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_exchange(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.exchange(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic.cu
@@ -42,7 +42,7 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -29,12 +31,20 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic_ref.cu
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_exchange(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.exchange(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; SMXX-DAG: {{.*}}LOP3.LUT [[A:R[0-9]+]], [[ATOM_ADDR]], 0xfffffffc, {{.*}}
+; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[E:R[0-9]+]], {{.*\[}}[[A]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[E:R[0-9]+]], {{.*\[}}[[A]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
+; SMXX: {{.*}}ISETP.NE{{.*}} [[C]], [[E]], {{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic_ref.cu
@@ -49,7 +49,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[C]], [[E]], {{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic_ref.cu
@@ -19,14 +19,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_exchange(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.exchange(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_exchange.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic_ref.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -30,8 +32,13 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[A:R[0-9]+]], [[ATOM_ADDR]], 0xfffffffc, {{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[E:R[0-9]+]], {{.*\[}}[[A]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[E:R[0-9]+]], {{.*\[}}[[A]]{{(\.64)?\].*}}
@@ -42,6 +49,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[C]], [[E]], {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic_ref.cu
@@ -49,10 +49,10 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
-; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}} [[C]], [[E]], {{.*}}
+; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[C]], [[E]], {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_apis.cu
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_load(TEMPLATE<int32_t, SCOPE>& atom)
+{
+  return atom.load(ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} R4, {{.*}}
+; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] R4, {{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/load_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_apis.cu
@@ -36,7 +36,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} R4, {{.*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] R4, {{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_apis.cu
@@ -10,7 +10,9 @@
 
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,no_acquire,non_sc:acquire=moa,acquire,non_sc:seq_cst=mosc,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -24,11 +26,19 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} R4, {{.*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] R4, {{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/load_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_apis.cu
@@ -15,14 +15,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_load(TEMPLATE<int32_t, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 {
   return atom.load(ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types.cu
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
+// %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_load(TEMPLATE<TYPE, SCOPE>& atom)
+{
+  return atom.load(ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} R4, {{.*}}
+; NON_BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] R4, {{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/load_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
 // %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,no_acquire,non_sc:acquire=moa,acquire,non_sc:seq_cst=mosc,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -25,11 +27,19 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom)
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} R4, {{.*}}
 ; NON_BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] R4, {{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/load_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_load(TEMPLATE<TYPE, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom)
 {
   return atom.load(ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types.cu
@@ -37,7 +37,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom)
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} R4, {{.*}}
 ; NON_BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] R4, {{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic.cu
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% ORDER order mor:moa:mosc
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_load(cuda::atomic<TYPE, SCOPE>& atom)
+{
+  return atom.load(ORDER);
+}
+
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-NOT: {{.*}}MEMBAR.SC.{{.*}}
+; SMXX: {{.*}}BSSY [[SYNC:B[0-9]+]], {{.*}}
+; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{(\.U32)?}}.AND [[LOCK_FREE:P[0-9]+]], PT, [[LOCK_STATE]], 0x1, PT{{.*}}
+; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
+; SMXX: {{.*}}{{@!?}}[[LOCK_FREE]] BRA{{(\.U)?}} {{.*}}
+; SMXX: {{.*}}BSYNC [[SYNC]]{{.*}}
+; SMXX: {{.*}}LD.E.128{{(\.SYS)?}} R4, {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}
+; SMXX: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic.cu
@@ -16,7 +16,7 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_load(cuda::atomic<TYPE, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom)
 {
   return atom.load(ORDER);
 }
@@ -24,7 +24,7 @@ __device__ auto atomic_load(cuda::atomic<TYPE, SCOPE>& atom)
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}MEMBAR.SC.{{.*}}
 ; SMXX: {{.*}}BSSY [[SYNC:B[0-9]+]], {{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic.cu
@@ -29,9 +29,12 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom)
 ; SMXX: {{.*}}BSSY [[SYNC:B[0-9]+]], {{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{(\.U32)?}}.AND [[LOCK_FREE:P[0-9]+]], PT, [[LOCK_STATE]], 0x1, PT{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{(\.U32)?}}.AND [[LOCK_ACQUIRED:P[0-9]+]], PT, [[LOCK_STATE]], 0x1, PT{{.*}}
 ; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}{{@!?}}[[LOCK_FREE]] BRA{{(\.U)?}} {{.*}}
+; SM75: {{.*}}@[[LOCK_ACQUIRED]] BRA{{(\.U)?}} {{.*}}
+; SM75: {{.*}}LOP3.LUT [[RETRY_PRED:P[0-9]+]], {{.*}}
+; SM75: {{.*}}@![[RETRY_PRED]] BRA{{(\.U)?}} {{.*}}
+; SM80-PLUS: {{.*}}@![[LOCK_ACQUIRED]] BRA{{(\.U)?}} {{.*}}
 ; SMXX: {{.*}}BSYNC [[SYNC]]{{.*}}
 ; SMXX: {{.*}}LD.E.128{{(\.SYS)?}} R4, {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}
 ; SMXX: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic_ref.cu
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_load(cuda::atomic_ref<TYPE, SCOPE>& atom)
+{
+  return atom.load(ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_SC-NOT: {{.*}}MEMBAR.SC.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK: {{.*}}LD.E.128.STRONG.{{CTA|SM}} R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}LD.E.128.STRONG.[[SASS_SCOPE]] R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic_ref.cu
@@ -38,7 +38,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}LD.E.128.STRONG.{{CTA|SM}} R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.128.STRONG.[[SASS_SCOPE]] R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic_ref.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type i128:u128
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,no_acquire,non_sc:acquire=moa,acquire,non_sc:seq_cst=mosc,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -26,11 +28,19 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.SC.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}LD.E.128.STRONG.{{CTA|SM}} R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.128.STRONG.[[SASS_SCOPE]] R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_128_atomic_ref.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_load(cuda::atomic_ref<TYPE, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& atom)
 {
   return atom.load(ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic.cu
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_load(cuda::atomic<TYPE, SCOPE>& atom)
+{
+  return atom.load(ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*}}
+; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,no_acquire,non_sc:acquire=moa,acquire,non_sc:seq_cst=mosc,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -28,11 +30,19 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom)
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic.cu
@@ -19,14 +19,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_load(cuda::atomic<TYPE, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom)
 {
   return atom.load(ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic.cu
@@ -40,7 +40,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom)
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic_ref.cu
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE,SASS_SIZE type i8=int8_t,.U8:u8=uint8_t,.U8:i16=int16_t,.U16:u16=uint16_t,.U16:f16=f16,.U16:bf16=bf16,.U16
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_load(cuda::atomic_ref<TYPE, SCOPE>& atom)
+{
+  return atom.load(ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic_ref.cu
@@ -19,14 +19,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_load(cuda::atomic_ref<TYPE, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& atom)
 {
   return atom.load(ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic_ref.cu
@@ -41,7 +41,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_types_8_16_atomic_ref.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE,SASS_SIZE type i8=int8_t,.U8:u8=uint8_t,.U8:i16=int16_t,.U16:u16=uint16_t,.U16:f16=f16,.U16:bf16=bf16,.U16
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,no_acquire,non_sc:acquire=moa,acquire,non_sc:seq_cst=mosc,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -29,11 +31,19 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_apis.cu
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_load(TEMPLATE<int32_t, SCOPE>& atom)
+{
+  return atom.load(ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} R4, {{.*}}
+; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] R4, {{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; SMXX-NOT: {{.*}}LDL{{.*}}
+; SMXX-NOT: {{.*}}STL{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_apis.cu
@@ -38,7 +38,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} R4, {{.*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] R4, {{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_apis.cu
@@ -15,14 +15,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_load(TEMPLATE<int32_t, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 {
   return atom.load(ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_apis.cu
@@ -10,7 +10,9 @@
 
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,no_acquire,non_sc:acquire=moa,acquire,non_sc:seq_cst=mosc,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -25,12 +27,20 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} R4, {{.*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] R4, {{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; SMXX-NOT: {{.*}}LDL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types.cu
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
+// %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_load(TEMPLATE<TYPE, SCOPE>& atom)
+{
+  return atom.load(ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} R4, {{.*}}
+; NON_BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] R4, {{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; SMXX-NOT: {{.*}}LDL{{.*}}
+; SMXX-NOT: {{.*}}STL{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_load(TEMPLATE<TYPE, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom)
 {
   return atom.load(ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
 // %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,no_acquire,non_sc:acquire=moa,acquire,non_sc:seq_cst=mosc,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -26,12 +28,20 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom)
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} R4, {{.*}}
 ; NON_BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] R4, {{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; SMXX-NOT: {{.*}}LDL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types.cu
@@ -39,7 +39,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom)
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} R4, {{.*}}
 ; NON_BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] R4, {{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types_128_atomic_ref.cu
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_load(cuda::atomic_ref<volatile TYPE, SCOPE>& atom)
+{
+  return atom.load(ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_SC-NOT: {{.*}}MEMBAR.SC.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK: {{.*}}LD.E.128.STRONG.{{CTA|SM}} R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}LD.E.128.STRONG.[[SASS_SCOPE]] R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}LD.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types_128_atomic_ref.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type i128:u128
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,no_acquire,non_sc:acquire=moa,acquire,non_sc:seq_cst=mosc,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -27,12 +29,20 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.SC.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}LD.E.128.STRONG.{{CTA|SM}} R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.128.STRONG.[[SASS_SCOPE]] R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types_128_atomic_ref.cu
@@ -40,7 +40,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}LD.E.128.STRONG.{{CTA|SM}} R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.128.STRONG.[[SASS_SCOPE]] R4, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types_128_atomic_ref.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_load(cuda::atomic_ref<volatile TYPE, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom)
 {
   return atom.load(ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic.cu
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_load(volatile cuda::atomic<TYPE, SCOPE>& atom)
+{
+  return atom.load(ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*}}
+; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,no_acquire,non_sc:acquire=moa,acquire,non_sc:seq_cst=mosc,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -29,12 +31,20 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic.cu
@@ -42,7 +42,7 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic.cu
@@ -19,14 +19,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_load(volatile cuda::atomic<TYPE, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE>& atom)
 {
   return atom.load(ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic_ref.cu
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
+// %PARAM% TYPE,SASS_SIZE type i8=int8_t,.U8:u8=uint8_t,.U8:i16=int16_t,.U16:u16=uint16_t,.U16:f16=f16,.U16:bf16=bf16,.U16
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_load(cuda::atomic_ref<volatile TYPE, SCOPE>& atom)
+{
+  return atom.load(ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic_ref.cu
@@ -43,7 +43,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic_ref.cu
@@ -19,14 +19,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_load(cuda::atomic_ref<volatile TYPE, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom)
 {
   return atom.load(ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_load.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/load_volatile_types_8_16_atomic_ref.cu
@@ -11,7 +11,9 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE,SASS_SIZE type i8=int8_t,.U8:u8=uint8_t,.U8:i16=int16_t,.U16:u16=uint16_t,.U16:f16=f16,.U16:bf16=bf16,.U16
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,non_sc:acquire=moa,non_sc:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,no_acquire,non_sc:acquire=moa,acquire,non_sc:seq_cst=mosc,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -30,12 +32,20 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SC-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SC-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_apis.cu
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ void atomic_store(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+{
+  atom.store(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*}}, R6{{.*}}
+; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*}}, R6{{.*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/store_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_apis.cu
@@ -27,8 +27,8 @@ __device__ void atomic_store(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
-; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*}}, R6{{.*}}
-; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*}}, R6{{.*}}
+; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*}}, {{R[0-9]+}}{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_apis.cu
@@ -10,7 +10,8 @@
 
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_membar:release=more,ALL,non_seq_cst,membar:seq_cst=mosc,SC,seq_cst,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -24,11 +25,17 @@ extern "C" __device__ void atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_apis.cu
@@ -15,14 +15,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ void atomic_store(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+extern "C" __device__ void atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
 {
   atom.store(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types.cu
@@ -28,8 +28,8 @@ __device__ void atomic_store(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
-; BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{.*}}, R6{{.*}}
-; NON_BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{.*}}, R6{{.*}}
+; BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{.*}}, {{R[0-9]+}}{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types.cu
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
+// %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ void atomic_store(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+{
+  atom.store(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{.*}}, R6{{.*}}
+; NON_BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{.*}}, R6{{.*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/store_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ void atomic_store(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ void atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 {
   atom.store(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types.cu
@@ -11,7 +11,8 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
 // %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_membar:release=more,ALL,non_seq_cst,membar:seq_cst=mosc,SC,seq_cst,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -25,11 +26,17 @@ extern "C" __device__ void atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic.cu
@@ -33,7 +33,7 @@ __device__ void atomic_store(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 ; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}{{@!?}}[[LOCK_FREE]] BRA{{(\.U)?}} {{.*}}
 ; SMXX: {{.*}}BSYNC [[SYNC]]{{.*}}
-; SMXX: {{.*}}ST.E.128{{(\.SYS)?}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; SMXX: {{.*}}ST.E.128{{(\.SYS)?}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}{{.*}}
 ; SMXX: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
 ; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
 ; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic.cu
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% ORDER order mor:more:mosc
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ void atomic_store(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+{
+  atom.store(value, ORDER);
+}
+
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-NOT: {{.*}}MEMBAR.SC.{{.*}}
+; SMXX: {{.*}}BSSY [[SYNC:B[0-9]+]], {{.*}}
+; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{(\.U32)?}}.AND [[LOCK_FREE:P[0-9]+]], PT, [[LOCK_STATE]], 0x1, PT{{.*}}
+; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
+; SMXX: {{.*}}{{@!?}}[[LOCK_FREE]] BRA{{(\.U)?}} {{.*}}
+; SMXX: {{.*}}BSYNC [[SYNC]]{{.*}}
+; SMXX: {{.*}}ST.E.128{{(\.SYS)?}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; SMXX: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*\[}}[[BASE_ADDR]]{{(\.64)?\+0x10\].*}}, RZ{{.*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic.cu
@@ -29,9 +29,12 @@ extern "C" __device__ void atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; SMXX: {{.*}}BSSY [[SYNC:B[0-9]+]], {{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.EXCH.STRONG.[[SASS_SCOPE]] PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{(\.U32)?}}.AND [[LOCK_FREE:P[0-9]+]], PT, [[LOCK_STATE]], 0x1, PT{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{(\.U32)?}}.AND [[LOCK_ACQUIRED:P[0-9]+]], PT, [[LOCK_STATE]], 0x1, PT{{.*}}
 ; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}{{@!?}}[[LOCK_FREE]] BRA{{(\.U)?}} {{.*}}
+; SM75: {{.*}}@[[LOCK_ACQUIRED]] BRA{{(\.U)?}} {{.*}}
+; SM75: {{.*}}LOP3.LUT [[RETRY_PRED:P[0-9]+]], {{.*}}
+; SM75: {{.*}}@![[RETRY_PRED]] BRA{{(\.U)?}} {{.*}}
+; SM80-PLUS: {{.*}}@![[LOCK_ACQUIRED]] BRA{{(\.U)?}} {{.*}}
 ; SMXX: {{.*}}BSYNC [[SYNC]]{{.*}}
 ; SMXX: {{.*}}ST.E.128{{(\.SYS)?}} {{.*\[}}[[BASE_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}{{.*}}
 ; SMXX: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic.cu
@@ -16,7 +16,7 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ void atomic_store(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ void atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 {
   atom.store(value, ORDER);
 }
@@ -24,7 +24,7 @@ __device__ void atomic_store(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}MEMBAR.SC.{{.*}}
 ; SMXX: {{.*}}BSSY [[SYNC:B[0-9]+]], {{.*}}
 ; BLOCK: {{.*}}ATOM.E.EXCH.STRONG.{{CTA|SM}} PT, [[LOCK_STATE:R[0-9]+]], {{.*\[}}[[BASE_ADDR:R[0-9]+]]{{(\.64)?\+0x10\].*}}, {{R[0-9]+}}{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic_ref.cu
@@ -29,8 +29,8 @@ __device__ void atomic_store(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
-; BLOCK: {{.*}}ST.E.128.STRONG.{{CTA|SM}} {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
-; NON_BLOCK: {{.*}}ST.E.128.STRONG.[[SASS_SCOPE]] {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; BLOCK: {{.*}}ST.E.128.STRONG.{{CTA|SM}} {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ST.E.128.STRONG.[[SASS_SCOPE]] {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic_ref.cu
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ void atomic_store(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+{
+  atom.store(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK: {{.*}}ST.E.128.STRONG.{{CTA|SM}} {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; NON_BLOCK: {{.*}}ST.E.128.STRONG.[[SASS_SCOPE]] {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic_ref.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ void atomic_store(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ void atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
 {
   atom.store(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_128_atomic_ref.cu
@@ -11,7 +11,8 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type i128:u128
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_membar:release=more,ALL,non_seq_cst,membar:seq_cst=mosc,SC,seq_cst,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -26,11 +27,17 @@ extern "C" __device__ void atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}ST.E.128.STRONG.{{CTA|SM}} {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ST.E.128.STRONG.[[SASS_SCOPE]] {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_8_16_atomic.cu
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ void atomic_store(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+{
+  atom.store(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}}{{.*}}
+; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/store_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_8_16_atomic.cu
@@ -11,7 +11,8 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_membar:release=more,ALL,non_seq_cst,membar:seq_cst=mosc,SC,seq_cst,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -28,11 +29,17 @@ extern "C" __device__ void atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_8_16_atomic.cu
@@ -19,14 +19,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ void atomic_store(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ void atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 {
   atom.store(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_8_16_atomic_ref.cu
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE,SASS_SIZE type i8=int8_t,.U8:u8=uint8_t,.U8:i16=int16_t,.U16:u16=uint16_t,.U16:f16=f16,.U16:bf16=bf16,.U16
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ void atomic_store(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+{
+  atom.store(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/store_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_8_16_atomic_ref.cu
@@ -19,14 +19,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ void atomic_store(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ void atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
 {
   atom.store(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_types_8_16_atomic_ref.cu
@@ -11,7 +11,8 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE,SASS_SIZE type i8=int8_t,.U8:u8=uint8_t,.U8:i16=int16_t,.U16:u16=uint16_t,.U16:f16=f16,.U16:bf16=bf16,.U16
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_membar:release=more,ALL,non_seq_cst,membar:seq_cst=mosc,SC,seq_cst,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -29,11 +30,17 @@ extern "C" __device__ void atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_apis.cu
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ void atomic_store(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+{
+  atom.store(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*}}, R6{{.*}}
+; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*}}, R6{{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_apis.cu
@@ -10,7 +10,8 @@
 
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_membar:release=more,ALL,non_seq_cst,membar:seq_cst=mosc,SC,seq_cst,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -25,13 +26,19 @@ extern "C" __device__ void atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}} {{.*}}, R6{{.*}}
 ; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]] {{.*}}, R6{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_apis.cu
@@ -15,14 +15,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ void atomic_store(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+extern "C" __device__ void atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
 {
   atom.store(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_types.cu
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
+// %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ void atomic_store(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+{
+  atom.store(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{.*}}, R6{{.*}}
+; NON_BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{.*}}, R6{{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_types.cu
@@ -11,7 +11,8 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
 // %PARAM% TYPE,SASS_SIZE type i32=int32_t,:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64:f32=float,:f64=double,.64:ptr1=char*,.64:ptr4=int32_t*,.64
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_membar:release=more,ALL,non_seq_cst,membar:seq_cst=mosc,SC,seq_cst,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -26,13 +27,19 @@ extern "C" __device__ void atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{.*}}, R6{{.*}}
 ; NON_BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{.*}}, R6{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_types.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ void atomic_store(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ void atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 {
   atom.store(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_types_128_atomic_ref.cu
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ void atomic_store(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+{
+  atom.store(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; BLOCK: {{.*}}ST.E.128.STRONG.{{CTA|SM}} {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; NON_BLOCK: {{.*}}ST.E.128.STRONG.[[SASS_SCOPE]] {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_types_128_atomic_ref.cu
@@ -16,14 +16,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ void atomic_store(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ void atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
 {
   atom.store(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_types_128_atomic_ref.cu
@@ -11,7 +11,8 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type i128:u128
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_membar:release=more,ALL,non_seq_cst,membar:seq_cst=mosc,SC,seq_cst,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -27,13 +28,19 @@ extern "C" __device__ void atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; BLOCK: {{.*}}ST.E.128.STRONG.{{CTA|SM}} {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
 ; NON_BLOCK: {{.*}}ST.E.128.STRONG.[[SASS_SCOPE]] {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, R8{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*\[}}[[ATOM_ADDR]]{{(\.64)?(\+0x[0-9a-f]+)?\].*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_types_8_16_atomic.cu
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ void atomic_store(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+{
+  atom.store(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}}{{.*}}
+; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_types_8_16_atomic.cu
@@ -19,14 +19,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ void atomic_store(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ void atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 {
   atom.store(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_types_8_16_atomic.cu
@@ -11,7 +11,8 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_membar:release=more,ALL,non_seq_cst,membar:seq_cst=mosc,SC,seq_cst,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -29,13 +30,19 @@ extern "C" __device__ void atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}ST.E.STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ST.E.STRONG.[[SASS_SCOPE]]{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_types_8_16_atomic_ref.cu
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
+// %PARAM% TYPE,SASS_SIZE type i8=int8_t,.U8:u8=uint8_t,.U8:i16=int16_t,.U16:u16=uint16_t,.U16:f16=f16,.U16:bf16=bf16,.U16
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ void atomic_store(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+{
+  atom.store(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}
+; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_types_8_16_atomic_ref.cu
@@ -11,7 +11,8 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE,SASS_SIZE type i8=int8_t,.U8:u8=uint8_t,.U8:i16=int16_t,.U16:u16=uint16_t,.U16:f16=f16,.U16:bf16=bf16,.U16
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:release=more,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_membar:release=more,ALL,non_seq_cst,membar:seq_cst=mosc,SC,seq_cst,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -30,13 +31,19 @@ extern "C" __device__ void atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
 ; BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.{{CTA|SM}} {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}ST.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NEXT: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/store_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/store_volatile_types_8_16_atomic_ref.cu
@@ -19,14 +19,14 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ void atomic_store(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ void atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
 {
   atom.store(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_store.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-NOT: {{.*}}ST.E{{.*}}.STRONG{{.*}}

--- a/libcudacxx/test/cmake/CodegenTest.cmake
+++ b/libcudacxx/test/cmake/CodegenTest.cmake
@@ -219,7 +219,13 @@ function(
   test_path
   check_prefixes
 )
-  cmake_parse_arguments(arg "" "DUMP_MODE" "CHECK_DEFINITIONS" ${ARGN})
+  cmake_parse_arguments(
+    arg
+    ""
+    "DUMP_MODE;DUMP_FUNCTIONS"
+    "CHECK_DEFINITIONS"
+    ${ARGN}
+  )
 
   string(REGEX REPLACE "[^A-Za-z0-9_]" "_" check_suffix "${check_prefixes}")
   set(check_target_name "${target_path}.${check_suffix}.check")
@@ -236,6 +242,7 @@ function(
     COMMAND
       "${CMAKE_COMMAND}" -E env
         "CUOBJDUMP=${libcudacxx_codegen_cuobjdump}"
+        "CUOBJDUMP_FUNCTIONS=${arg_DUMP_FUNCTIONS}"
         "FILECHECK=${libcudacxx_codegen_filecheck}"
         "${libcudacxx_codegen_bash}"
         "${libcudacxx_codegen_dump_and_check}"
@@ -259,6 +266,7 @@ function(libcudacxx_codegen_add_test)
     ARCH
     TEST
     VARIANT
+    DUMP_FUNCTIONS
   )
   set(multi_value_args CHECK_PREFIXES CHECK_DEFINITIONS COMPILE_DEFINITIONS)
   cmake_parse_arguments(
@@ -324,6 +332,7 @@ function(libcudacxx_codegen_add_test)
       "${arg_TEST}"
       "${check_prefix}"
       DUMP_MODE "${dump_mode}"
+      DUMP_FUNCTIONS "${arg_DUMP_FUNCTIONS}"
       CHECK_DEFINITIONS ${arg_CHECK_DEFINITIONS}
     )
   endforeach()
@@ -393,7 +402,7 @@ endfunction()
 
 function(libcudacxx_codegen_add_sass_tests)
   set(options)
-  set(one_value_args AGGREGATE_TARGET TARGET_PREFIX)
+  set(one_value_args AGGREGATE_TARGET TARGET_PREFIX DUMP_FUNCTIONS)
   set(multi_value_args ARCHITECTURES CHECK_PREFIXES TESTS COMPILE_DEFINITIONS)
   cmake_parse_arguments(
     arg
@@ -499,6 +508,7 @@ function(libcudacxx_codegen_add_sass_tests)
           CODE_KIND sass
           ARCH ${arch}
           TEST "${test_path}"
+          DUMP_FUNCTIONS "${arg_DUMP_FUNCTIONS}"
           CHECK_PREFIXES "${combined_check_prefixes}"
           COMPILE_DEFINITIONS ${arg_COMPILE_DEFINITIONS}
         )
@@ -532,6 +542,7 @@ function(libcudacxx_codegen_add_sass_tests)
             ARCH ${arch}
             TEST "${test_path}"
             VARIANT "${variant_label}"
+            DUMP_FUNCTIONS "${arg_DUMP_FUNCTIONS}"
             CHECK_PREFIXES "${combined_check_prefixes}"
             CHECK_DEFINITIONS ${variant_check_definitions}
             COMPILE_DEFINITIONS

--- a/libcudacxx/test/cmake/CodegenTest.cmake
+++ b/libcudacxx/test/cmake/CodegenTest.cmake
@@ -17,6 +17,12 @@ option(
 )
 
 function(libcudacxx_codegen_check_tools out_var)
+  if (LIBCUDACXX_REQUIRE_CODEGEN_TEST_TOOLS)
+    set(require_codegen_tools TRUE)
+  else()
+    set(require_codegen_tools FALSE)
+  endif()
+
   get_property(
     tools_available
     GLOBAL
@@ -53,7 +59,7 @@ function(libcudacxx_codegen_check_tools out_var)
 
   if (missing_tools)
     list(JOIN missing_tools ", " missing_tools)
-    if (LIBCUDACXX_REQUIRE_CODEGEN_TEST_TOOLS)
+    if (require_codegen_tools)
       message(
         FATAL_ERROR
         "Tools required by libcu++ codegen tests were not found: ${missing_tools}"

--- a/libcudacxx/test/cmake/CodegenTest.cmake
+++ b/libcudacxx/test/cmake/CodegenTest.cmake
@@ -260,12 +260,7 @@ function(libcudacxx_codegen_add_test)
     TEST
     VARIANT
   )
-  set(
-    multi_value_args
-    CHECK_PREFIXES
-    CHECK_DEFINITIONS
-    COMPILE_DEFINITIONS
-  )
+  set(multi_value_args CHECK_PREFIXES CHECK_DEFINITIONS COMPILE_DEFINITIONS)
   cmake_parse_arguments(
     arg
     "${options}"
@@ -399,13 +394,7 @@ endfunction()
 function(libcudacxx_codegen_add_sass_tests)
   set(options)
   set(one_value_args AGGREGATE_TARGET TARGET_PREFIX)
-  set(
-    multi_value_args
-    ARCHITECTURES
-    CHECK_PREFIXES
-    TESTS
-    COMPILE_DEFINITIONS
-  )
+  set(multi_value_args ARCHITECTURES CHECK_PREFIXES TESTS COMPILE_DEFINITIONS)
   cmake_parse_arguments(
     arg
     "${options}"
@@ -415,6 +404,11 @@ function(libcudacxx_codegen_add_sass_tests)
   )
 
   foreach (test_path IN LISTS arg_TESTS)
+    set_property(
+      DIRECTORY
+      APPEND
+      PROPERTY CMAKE_CONFIGURE_DEPENDS "${test_path}"
+    )
     file(READ "${test_path}" test_contents)
     cccl_parse_variant_params(
       "${test_path}"
@@ -442,13 +436,17 @@ function(libcudacxx_codegen_add_sass_tests)
     endif()
 
     set(test_archs)
+    set(has_arch_specific_checks FALSE)
     foreach (arch IN LISTS arg_ARCHITECTURES)
       libcudacxx_codegen_get_sass_check_prefixes(
         check_prefixes
-        has_arch_specific_checks
+        arch_has_specific_checks
         "${test_contents}"
         "${arch}"
       )
+      if (arch_has_specific_checks)
+        set(has_arch_specific_checks TRUE)
+      endif()
       if (NOT "${check_prefixes}" STREQUAL "SMXX")
         list(APPEND test_archs "${arch}")
       endif()

--- a/libcudacxx/test/cmake/CodegenTest.cmake
+++ b/libcudacxx/test/cmake/CodegenTest.cmake
@@ -213,6 +213,94 @@ function(
 endfunction()
 
 function(
+  libcudacxx_codegen_resolve_filecheck_prefixes
+  out_target_prefixes
+  out_filecheck_prefixes
+  test_path
+  input_prefixes
+)
+  file(READ "${test_path}" test_contents)
+  file(
+    STRINGS "${test_path}"
+    prefix_combine_directives
+    REGEX "%FILECHECK%[ ]+PREFIX_COMBINE"
+  )
+
+  if (NOT prefix_combine_directives)
+    set(${out_target_prefixes} "${input_prefixes}" PARENT_SCOPE)
+    set(${out_filecheck_prefixes} "${input_prefixes}" PARENT_SCOPE)
+    return()
+  endif()
+
+  string(REPLACE "," ";" active_prefixes "${input_prefixes}")
+  set(combination_components)
+  set(active_combinations)
+
+  foreach (directive IN LISTS prefix_combine_directives)
+    if (
+      NOT
+        directive
+          MATCHES
+          "^[ ]*//[ ]+%FILECHECK%[ ]+PREFIX_COMBINE[ ]+([A-Za-z][A-Za-z0-9_-]*([ ]*,[ ]*[A-Za-z][A-Za-z0-9_-]*)+)[ ]*$"
+    )
+      message(
+        FATAL_ERROR
+        "Malformed PREFIX_COMBINE directive in ${test_path}: ${directive}"
+      )
+    endif()
+
+    set(components "${CMAKE_MATCH_1}")
+    string(REPLACE " " "" components "${components}")
+    string(REPLACE "," ";" components "${components}")
+    set(normalized_components)
+    set(combination_is_active TRUE)
+    foreach (component IN LISTS components)
+      string(TOUPPER "${component}" component)
+      list(APPEND normalized_components "${component}")
+      list(APPEND combination_components "${component}")
+      if (NOT component IN_LIST active_prefixes)
+        set(combination_is_active FALSE)
+      endif()
+    endforeach()
+
+    if (combination_is_active)
+      list(JOIN normalized_components "_" combined_prefix)
+      list(APPEND active_combinations "${combined_prefix}")
+    endif()
+  endforeach()
+
+  list(REMOVE_DUPLICATES combination_components)
+  list(REMOVE_DUPLICATES active_combinations)
+
+  # A prefix used only as a PREFIX_COMBINE component is an input to a combined
+  # prefix, not a standalone FileCheck prefix. This permits semantic markers
+  # such as ACQUIRE without requiring a dummy ACQUIRE directive.
+  set(standalone_prefixes)
+  foreach (prefix IN LISTS active_prefixes)
+    if (prefix IN_LIST combination_components)
+      string(
+        REGEX MATCH
+        "; ${prefix}(:|-[A-Z]+:)"
+        has_standalone_directive
+        "${test_contents}"
+      )
+      if (NOT has_standalone_directive)
+        continue()
+      endif()
+    endif()
+    list(APPEND standalone_prefixes "${prefix}")
+  endforeach()
+
+  set(filecheck_prefixes ${standalone_prefixes} ${active_combinations})
+  list(REMOVE_DUPLICATES standalone_prefixes)
+  list(REMOVE_DUPLICATES filecheck_prefixes)
+  list(JOIN standalone_prefixes "," standalone_prefixes)
+  list(JOIN filecheck_prefixes "," filecheck_prefixes)
+  set(${out_target_prefixes} "${standalone_prefixes}" PARENT_SCOPE)
+  set(${out_filecheck_prefixes} "${filecheck_prefixes}" PARENT_SCOPE)
+endfunction()
+
+function(
   libcudacxx_codegen_add_check_target
   target_path
   target_name
@@ -227,7 +315,19 @@ function(
     ${ARGN}
   )
 
-  string(REGEX REPLACE "[^A-Za-z0-9_]" "_" check_suffix "${check_prefixes}")
+  libcudacxx_codegen_resolve_filecheck_prefixes(
+    target_check_prefixes
+    filecheck_prefixes
+    "${test_path}"
+    "${check_prefixes}"
+  )
+  string(
+    REGEX REPLACE
+    "[^A-Za-z0-9_]"
+    "_"
+    check_suffix
+    "${target_check_prefixes}"
+  )
   set(check_target_name "${target_path}.${check_suffix}.check")
 
   set(filecheck_definitions)
@@ -248,7 +348,7 @@ function(
         "${libcudacxx_codegen_dump_and_check}"
         $<TARGET_FILE:${target_name}>
         "${test_path}"
-        "${check_prefixes}"
+        "${filecheck_prefixes}"
         "${arg_DUMP_MODE}"
         ${filecheck_definitions}
     # gersemi: on
@@ -355,6 +455,9 @@ function(
   foreach (definition IN LISTS ARGN)
     if (definition MATCHES "^FILECHECK_PREFIX_[A-Za-z0-9_]+=(.*)$")
       set(check_prefix "${CMAKE_MATCH_1}")
+      if (check_prefix STREQUAL "")
+        continue()
+      endif()
       if (NOT check_prefix MATCHES "^[A-Za-z][A-Za-z0-9_-]*$")
         message(
           FATAL_ERROR

--- a/libcudacxx/test/cmake/CodegenTest.cmake
+++ b/libcudacxx/test/cmake/CodegenTest.cmake
@@ -8,6 +8,8 @@
 ##
 ##===----------------------------------------------------------------------===##
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../cmake/CCCLTestParams.cmake")
+
 option(
   LIBCUDACXX_REQUIRE_CODEGEN_TEST_TOOLS
   "Fail configuration when tools required by libcu++ codegen tests are missing."
@@ -211,8 +213,15 @@ function(
   test_path
   check_prefixes
 )
+  cmake_parse_arguments(arg "" "DUMP_MODE" "CHECK_DEFINITIONS" ${ARGN})
+
   string(REGEX REPLACE "[^A-Za-z0-9_]" "_" check_suffix "${check_prefixes}")
   set(check_target_name "${target_path}.${check_suffix}.check")
+
+  set(filecheck_definitions)
+  foreach (definition IN LISTS arg_CHECK_DEFINITIONS)
+    list(APPEND filecheck_definitions "-D${definition}")
+  endforeach()
 
   add_custom_target(
     ${check_target_name}
@@ -227,7 +236,8 @@ function(
         $<TARGET_FILE:${target_name}>
         "${test_path}"
         "${check_prefixes}"
-        ${ARGN}
+        "${arg_DUMP_MODE}"
+        ${filecheck_definitions}
     # gersemi: on
   )
   cccl_ensure_metatargets(${check_target_name})
@@ -242,8 +252,14 @@ function(libcudacxx_codegen_add_test)
     CODE_KIND
     ARCH
     TEST
+    VARIANT
   )
-  set(multi_value_args CHECK_PREFIXES COMPILE_DEFINITIONS)
+  set(
+    multi_value_args
+    CHECK_PREFIXES
+    CHECK_DEFINITIONS
+    COMPILE_DEFINITIONS
+  )
   cmake_parse_arguments(
     arg
     "${options}"
@@ -259,6 +275,10 @@ function(libcudacxx_codegen_add_test)
     target_name
     "${arg_TARGET_PREFIX}_${arg_CODE_KIND}_sm${arg_ARCH}_${test_name}"
   )
+  if (arg_VARIANT)
+    string(APPEND test_target_path ".${arg_VARIANT}")
+    string(APPEND target_name ".${arg_VARIANT}")
+  endif()
 
   add_library(${target_name} STATIC "${arg_TEST}")
   libcudacxx_codegen_set_cuda_arch(${target_name} "${arg_ARCH}")
@@ -275,7 +295,7 @@ function(libcudacxx_codegen_add_test)
     )
   endif()
 
-  set(dump_options)
+  set(dump_mode --dump-ptx)
   if (arg_CODE_KIND STREQUAL "ptx")
     # Clang stopped emitting PTX in clang20. Add flags to re-enable it.
     if (
@@ -288,7 +308,7 @@ function(libcudacxx_codegen_add_test)
       )
     endif()
   else()
-    list(APPEND dump_options --dump-sass)
+    set(dump_mode --dump-sass)
     if (arg_SEPARABLE_COMPILATION)
       # CMake supplies the compile phase, so request relocatable device code
       # without adding a second compile-phase option via -dc.
@@ -302,9 +322,47 @@ function(libcudacxx_codegen_add_test)
       ${target_name}
       "${arg_TEST}"
       "${check_prefix}"
-      ${dump_options}
+      DUMP_MODE "${dump_mode}"
+      CHECK_DEFINITIONS ${arg_CHECK_DEFINITIONS}
     )
   endforeach()
+endfunction()
+
+# Separate variant definitions used as codegen test metadata from ordinary
+# definitions. FILECHECK_PREFIX_<name>=<prefix> adds the upper-case form of
+# <prefix> to the FileCheck invocation for that variant; all other definitions
+# are available to both the compiler and FileCheck.
+function(
+  libcudacxx_codegen_get_variant_options
+  out_compile_definitions
+  out_check_definitions
+  out_check_prefixes
+)
+  set(compile_definitions)
+  set(check_definitions)
+  set(check_prefixes)
+
+  foreach (definition IN LISTS ARGN)
+    if (definition MATCHES "^FILECHECK_PREFIX_[A-Za-z0-9_]+=(.*)$")
+      set(check_prefix "${CMAKE_MATCH_1}")
+      if (NOT check_prefix MATCHES "^[A-Za-z][A-Za-z0-9_-]*$")
+        message(
+          FATAL_ERROR
+          "Invalid FileCheck prefix '${check_prefix}' in '${definition}'"
+        )
+      endif()
+      string(TOUPPER "${check_prefix}" check_prefix)
+      list(APPEND check_prefixes "${check_prefix}")
+    else()
+      list(APPEND compile_definitions "${definition}")
+      list(APPEND check_definitions "${definition}")
+    endif()
+  endforeach()
+
+  list(REMOVE_DUPLICATES check_prefixes)
+  set(${out_compile_definitions} "${compile_definitions}" PARENT_SCOPE)
+  set(${out_check_definitions} "${check_definitions}" PARENT_SCOPE)
+  set(${out_check_prefixes} "${check_prefixes}" PARENT_SCOPE)
 endfunction()
 
 function(libcudacxx_codegen_add_ptx_tests)
@@ -335,7 +393,13 @@ endfunction()
 function(libcudacxx_codegen_add_sass_tests)
   set(options)
   set(one_value_args AGGREGATE_TARGET TARGET_PREFIX)
-  set(multi_value_args ARCHITECTURES TESTS COMPILE_DEFINITIONS)
+  set(
+    multi_value_args
+    ARCHITECTURES
+    CHECK_PREFIXES
+    TESTS
+    COMPILE_DEFINITIONS
+  )
   cmake_parse_arguments(
     arg
     "${options}"
@@ -346,6 +410,18 @@ function(libcudacxx_codegen_add_sass_tests)
 
   foreach (test_path IN LISTS arg_TESTS)
     file(READ "${test_path}" test_contents)
+    cccl_parse_variant_params(
+      "${test_path}"
+      num_variants
+      variant_labels
+      variant_definitions
+    )
+    cccl_log_variant_params(
+      "${test_path}"
+      ${num_variants}
+      variant_labels
+      variant_definitions
+    )
     string(
       REGEX MATCH
       "; SM[0-9]+[af]-PLUS(:|-[A-Z]+:)"
@@ -396,17 +472,70 @@ function(libcudacxx_codegen_add_sass_tests)
         "${test_contents}"
         "${arch}"
       )
+      string(REPLACE "," ";" common_check_prefixes "${check_prefixes}")
+      foreach (check_prefix IN LISTS arg_CHECK_PREFIXES)
+        string(
+          REGEX MATCH
+          "; ${check_prefix}(:|-[A-Z]+:)"
+          has_check_prefix
+          "${test_contents}"
+        )
+        if (has_check_prefix)
+          list(APPEND common_check_prefixes "${check_prefix}")
+        endif()
+      endforeach()
+      list(REMOVE_DUPLICATES common_check_prefixes)
 
-      libcudacxx_codegen_add_test(
-        ${test_options}
-        AGGREGATE_TARGET ${arg_AGGREGATE_TARGET}
-        TARGET_PREFIX ${arg_TARGET_PREFIX}
-        CODE_KIND sass
-        ARCH ${arch}
-        TEST "${test_path}"
-        CHECK_PREFIXES "${check_prefixes}"
-        COMPILE_DEFINITIONS ${arg_COMPILE_DEFINITIONS}
-      )
+      if (num_variants EQUAL 0)
+        list(JOIN common_check_prefixes "," combined_check_prefixes)
+        libcudacxx_codegen_add_test(
+          ${test_options}
+          AGGREGATE_TARGET ${arg_AGGREGATE_TARGET}
+          TARGET_PREFIX ${arg_TARGET_PREFIX}
+          CODE_KIND sass
+          ARCH ${arch}
+          TEST "${test_path}"
+          CHECK_PREFIXES "${combined_check_prefixes}"
+          COMPILE_DEFINITIONS ${arg_COMPILE_DEFINITIONS}
+        )
+      else()
+        math(EXPR last_variant "${num_variants} - 1")
+        foreach (variant_index RANGE ${last_variant})
+          cccl_get_variant_data(
+            variant_labels
+            variant_definitions
+            ${variant_index}
+            variant_label
+            definitions
+          )
+          libcudacxx_codegen_get_variant_options(
+            variant_compile_definitions
+            variant_check_definitions
+            variant_check_prefixes
+            ${definitions}
+          )
+
+          set(combined_check_prefixes ${common_check_prefixes})
+          list(APPEND combined_check_prefixes ${variant_check_prefixes})
+          list(REMOVE_DUPLICATES combined_check_prefixes)
+          list(JOIN combined_check_prefixes "," combined_check_prefixes)
+
+          libcudacxx_codegen_add_test(
+            ${test_options}
+            AGGREGATE_TARGET ${arg_AGGREGATE_TARGET}
+            TARGET_PREFIX ${arg_TARGET_PREFIX}
+            CODE_KIND sass
+            ARCH ${arch}
+            TEST "${test_path}"
+            VARIANT "${variant_label}"
+            CHECK_PREFIXES "${combined_check_prefixes}"
+            CHECK_DEFINITIONS ${variant_check_definitions}
+            COMPILE_DEFINITIONS
+              ${arg_COMPILE_DEFINITIONS}
+              ${variant_compile_definitions}
+          )
+        endforeach()
+      endif()
     endforeach()
   endforeach()
 endfunction()

--- a/libcudacxx/test/cmake/CodegenTest.cmake
+++ b/libcudacxx/test/cmake/CodegenTest.cmake
@@ -168,7 +168,14 @@ function(
     has_arch_prefix
     "${test_contents}"
   )
-  if (has_arch_prefix)
+  string(TOUPPER "${test_contents}" uppercase_test_contents)
+  string(
+    REGEX MATCH
+    "%FILECHECK%[ ]+PREFIX_COMBINE[ ]+${arch_prefix}[ ]*,"
+    has_arch_combined_prefix
+    "${uppercase_test_contents}"
+  )
+  if (has_arch_prefix OR has_arch_combined_prefix)
     list(APPEND check_prefixes "${arch_prefix}")
   endif()
 
@@ -280,7 +287,7 @@ function(
     if (prefix IN_LIST combination_components)
       string(
         REGEX MATCH
-        "; ${prefix}(:|-[A-Z]+:)"
+        "; ${prefix}(:|-LABEL:|-NOT:|-NEXT:|-SAME:|-DAG:|-COUNT(-[0-9]+)?:|-EMPTY:)"
         has_standalone_directive
         "${test_contents}"
       )

--- a/libcudacxx/test/codegen/dump_and_check.bash
+++ b/libcudacxx/test/codegen/dump_and_check.bash
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-## Usage: dump_and_check test.a test.cu PREFIXES [cuobjdump-mode]
+## Usage: dump_and_check test.a test.cu PREFIXES cuobjdump-mode [FileCheck-options...]
 input_archive="${1}"
 input_testfile="${2}"
 input_prefix="${3}"
-dump_mode="${4:---dump-ptx}"
+shift 3
+dump_mode="${1:---dump-ptx}"
+if (( $# > 0 )); then
+  shift
+fi
 filecheck="${FILECHECK:-FileCheck}"
 cuobjdump="${CUOBJDUMP:-cuobjdump}"
 
-"${cuobjdump}" "${dump_mode}" "${input_archive}" \
-  | "${filecheck}" --match-full-lines --check-prefixes="${input_prefix}" "${input_testfile}"
+if [[ "${dump_mode}" == "--dump-sass" ]]; then
+  # cuobjdump prints each instruction's control word on a separate line. Remove
+  # those lines so FileCheck -NEXT describes adjacent SASS instructions.
+  "${cuobjdump}" "${dump_mode}" "${input_archive}" \
+    | sed -E '\|^[[:space:]]*/\* 0x[[:xdigit:]]+ \*/[[:space:]]*$|d' \
+    | "${filecheck}" --match-full-lines --check-prefixes="${input_prefix}" "$@" "${input_testfile}"
+else
+  "${cuobjdump}" "${dump_mode}" "${input_archive}" \
+    | "${filecheck}" --match-full-lines --check-prefixes="${input_prefix}" "$@" "${input_testfile}"
+fi

--- a/libcudacxx/test/codegen/dump_and_check.bash
+++ b/libcudacxx/test/codegen/dump_and_check.bash
@@ -19,13 +19,8 @@ if [[ -n "${dump_functions}" ]]; then
   cuobjdump_options+=(--function "${dump_functions}")
 fi
 
-if [[ "${dump_mode}" == "--dump-sass" ]]; then
-  # cuobjdump prints each instruction's control word on a separate line. Remove
-  # those lines so FileCheck -NEXT describes adjacent SASS instructions.
-  "${cuobjdump}" "${cuobjdump_options[@]}" "${input_archive}" \
-    | sed -E '\|^[[:space:]]*/\* 0x[[:xdigit:]]+ \*/[[:space:]]*$|d' \
-    | "${filecheck}" --match-full-lines --check-prefixes="${input_prefix}" "$@" "${input_testfile}"
-else
-  "${cuobjdump}" "${cuobjdump_options[@]}" "${input_archive}" \
-    | "${filecheck}" --match-full-lines --check-prefixes="${input_prefix}" "$@" "${input_testfile}"
-fi
+# cuobjdump prints each SASS instruction's control word on a separate line.
+# Remove those lines so FileCheck -NEXT describes adjacent SASS instructions.
+"${cuobjdump}" "${cuobjdump_options[@]}" "${input_archive}" \
+  | sed -E '\|^[[:space:]]*/\* 0x[[:xdigit:]]+ \*/[[:space:]]*$|d' \
+  | "${filecheck}" --match-full-lines --check-prefixes="${input_prefix}" "$@" "${input_testfile}"

--- a/libcudacxx/test/codegen/dump_and_check.bash
+++ b/libcudacxx/test/codegen/dump_and_check.bash
@@ -10,16 +10,22 @@ dump_mode="${1:---dump-ptx}"
 if (( $# > 0 )); then
   shift
 fi
+dump_functions="${CUOBJDUMP_FUNCTIONS:-}"
 filecheck="${FILECHECK:-FileCheck}"
 cuobjdump="${CUOBJDUMP:-cuobjdump}"
+
+cuobjdump_options=("${dump_mode}")
+if [[ -n "${dump_functions}" ]]; then
+  cuobjdump_options+=(--function "${dump_functions}")
+fi
 
 if [[ "${dump_mode}" == "--dump-sass" ]]; then
   # cuobjdump prints each instruction's control word on a separate line. Remove
   # those lines so FileCheck -NEXT describes adjacent SASS instructions.
-  "${cuobjdump}" "${dump_mode}" "${input_archive}" \
+  "${cuobjdump}" "${cuobjdump_options[@]}" "${input_archive}" \
     | sed -E '\|^[[:space:]]*/\* 0x[[:xdigit:]]+ \*/[[:space:]]*$|d' \
     | "${filecheck}" --match-full-lines --check-prefixes="${input_prefix}" "$@" "${input_testfile}"
 else
-  "${cuobjdump}" "${dump_mode}" "${input_archive}" \
+  "${cuobjdump}" "${cuobjdump_options[@]}" "${input_archive}" \
     | "${filecheck}" --match-full-lines --check-prefixes="${input_prefix}" "$@" "${input_testfile}"
 fi

--- a/libcudacxx/test/simd_codegen/CMakeLists.txt
+++ b/libcudacxx/test/simd_codegen/CMakeLists.txt
@@ -8,8 +8,12 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-add_custom_target(libcudacxx.test.simd.ptx)
-add_custom_target(libcudacxx.test.simd.sass)
+if (libcudacxx_codegen_filecheck_simd_ptx)
+  add_custom_target(libcudacxx.test.simd.ptx)
+endif()
+if (libcudacxx_codegen_filecheck_simd_sass)
+  add_custom_target(libcudacxx.test.simd.sass)
+endif()
 
 #-----------------------------------------------------------------------------------------------------------------------
 # SETUP: skip unsupported compilers, find tools, set up CUDA architectures
@@ -61,43 +65,48 @@ if (NOT simd_codegen_ptx_cuda_archs AND NOT simd_codegen_sass_cuda_archs)
   return()
 endif()
 
-if (simd_codegen_ptx_cuda_archs)
-  add_subdirectory(load_store)
-else()
-  message(
-    STATUS
-    "No compatible CUDA architectures requested; skipping simd PTX codegen tests"
-  )
-endif()
-
-if (simd_codegen_sass_cuda_archs)
-  set(simd_codegen_sass_tests)
-  file(
-    GLOB simd_codegen_sass_tests
-    "floating_point/*.cu"
-    "integer/*.cu"
-    "min_max/*.cu"
-  )
-
-  # The 8-bit arithmetic and min/max tests require the PTX ISA 9.2 8-bit SIMD
-  # path available with CUDA 13.2 and newer.
-  if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.2)
-    list(
-      REMOVE_ITEM simd_codegen_sass_tests
-      "${CMAKE_CURRENT_SOURCE_DIR}/integer/arithmetic_u8x4.cu"
-      "${CMAKE_CURRENT_SOURCE_DIR}/min_max/min_max_i8x4.cu"
+if (libcudacxx_codegen_filecheck_simd_ptx)
+  if (simd_codegen_ptx_cuda_archs)
+    add_subdirectory(load_store)
+  else()
+    message(
+      STATUS
+      "No compatible CUDA architectures requested; skipping simd PTX codegen tests"
     )
   endif()
+endif()
 
-  libcudacxx_codegen_add_sass_tests(
-    AGGREGATE_TARGET libcudacxx.test.simd.sass
-    TARGET_PREFIX simd_codegen
-    ARCHITECTURES ${simd_codegen_sass_cuda_archs}
-    TESTS ${simd_codegen_sass_tests}
-  )
-else()
-  message(
-    STATUS
-    "No compatible CUDA architectures requested; skipping simd SASS codegen tests"
-  )
+if (libcudacxx_codegen_filecheck_simd_sass)
+  if (simd_codegen_sass_cuda_archs)
+    set(simd_codegen_sass_tests)
+    file(
+      GLOB simd_codegen_sass_tests
+      CONFIGURE_DEPENDS
+      "floating_point/*.cu"
+      "integer/*.cu"
+      "min_max/*.cu"
+    )
+
+    # The 8-bit arithmetic and min/max tests require the PTX ISA 9.2 8-bit SIMD
+    # path available with CUDA 13.2 and newer.
+    if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.2)
+      list(
+        REMOVE_ITEM simd_codegen_sass_tests
+        "${CMAKE_CURRENT_SOURCE_DIR}/integer/arithmetic_u8x4.cu"
+        "${CMAKE_CURRENT_SOURCE_DIR}/min_max/min_max_i8x4.cu"
+      )
+    endif()
+
+    libcudacxx_codegen_add_sass_tests(
+      AGGREGATE_TARGET libcudacxx.test.simd.sass
+      TARGET_PREFIX simd_codegen
+      ARCHITECTURES ${simd_codegen_sass_cuda_archs}
+      TESTS ${simd_codegen_sass_tests}
+    )
+  else()
+    message(
+      STATUS
+      "No compatible CUDA architectures requested; skipping simd SASS codegen tests"
+    )
+  endif()
 endif()


### PR DESCRIPTION
## Description

Resolves #10664.

This PR introduces a first SASS FileCheck suite for the atomic codegen, which includes a wide coverage of volatile and non-volatile codegen results for load, store, exchange, compare_exchange_weak, and compare_exchange_strong.

This PR is larger in scope than follow ups for other operations will be; this is because it also establishes the general shape of the SASS FileCheck suite for atomics, as well as the new CI jobs for libcu++ codegen testing, separated from regular libcu++ testing jobs. 

This PR introduces a non-trivial number of new CI jobs, though most of them are themselves quite trivial. Here's a breakdown of the relevant numbers:

1. Total new jobs added: 66
2. Total libcu++ jobs before: 63
3. Total libcu++ jobs after: 129
4. Total jobs at large before: 527
5. Total jobs at large after: 593

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
