### PR TITLE
Add `cub::DeviceReduce::ArgMin[Last]Max`

### DIFF
--- a/cub/benchmarks/bench/reduce/arg_minmax.cu
+++ b/cub/benchmarks/bench/reduce/arg_minmax.cu
@@ -56,8 +56,8 @@ void arg_minmax(nvbench::state& state, nvbench::type_list<T>)
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(
-      cub::DeviceReduce::ArgMinMax,
-      "ArgMinMax failed",
+      cub::DeviceReduce::ArgMinLastMax,
+      "ArgMinLastMax failed",
       d_in,
       d_out_extrema,
       d_out_indices,

--- a/cub/benchmarks/bench/reduce/arg_minmax.cu
+++ b/cub/benchmarks/bench/reduce/arg_minmax.cu
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <cub/device/device_reduce.cuh>
 #include <cub/device/dispatch/tuning/tuning_reduce.cuh>
@@ -37,8 +37,8 @@ void arg_minmax(nvbench::state& state, nvbench::type_list<T>)
   thrust::device_vector<offset_t> out_indices(2); // [0] = min index, [1] = max index
 
   const T* d_in           = thrust::raw_pointer_cast(in.data());
-  T* d_out_extrema        = thrust::raw_pointer_cast(out_extrema.data());
   offset_t* d_out_indices = thrust::raw_pointer_cast(out_indices.data());
+  T* d_out_extrema        = thrust::raw_pointer_cast(out_extrema.data());
 
   state.add_element_count(elements);
   state.add_global_memory_reads<T>(elements, "Size");

--- a/cub/benchmarks/bench/reduce/arg_minmax.cu
+++ b/cub/benchmarks/bench/reduce/arg_minmax.cu
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <cub/device/device_reduce.cuh>
+#include <cub/device/dispatch/tuning/tuning_reduce.cuh>
+
+#include <nvbench_helper.cuh>
+
+// %RANGE% TUNE_ITEMS_PER_THREAD ipt 7:24:1
+// %RANGE% TUNE_THREADS_PER_BLOCK tpb 128:1024:32
+// %RANGE% TUNE_ITEMS_PER_VEC_LOAD_POW2 ipv 1:2:1
+
+#if !TUNE_BASE
+struct tuned_policy_selector
+{
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::ReducePolicy
+  {
+    cub::ReducePassPolicy rp{
+      TUNE_THREADS_PER_BLOCK,
+      TUNE_ITEMS_PER_THREAD,
+      1 << TUNE_ITEMS_PER_VEC_LOAD_POW2,
+      cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+      cub::LOAD_DEFAULT};
+    return {rp, rp};
+  }
+};
+#endif // !TUNE_BASE
+
+template <typename T>
+void arg_minmax(nvbench::state& state, nvbench::type_list<T>)
+{
+  using offset_t = cuda::std::int64_t;
+
+  const auto elements         = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  thrust::device_vector<T> in = generate(elements);
+  thrust::device_vector<T> out_extrema(2); // [0] = min, [1] = max
+  thrust::device_vector<offset_t> out_indices(2); // [0] = min index, [1] = max index
+
+  const T* d_in           = thrust::raw_pointer_cast(in.data());
+  T* d_out_extrema        = thrust::raw_pointer_cast(out_extrema.data());
+  offset_t* d_out_indices = thrust::raw_pointer_cast(out_indices.data());
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements, "Size");
+  state.add_global_memory_writes<T>(2);
+  state.add_global_memory_writes<offset_t>(2);
+
+  caching_allocator_t alloc;
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::tune(tuned_policy_selector{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceReduce::ArgMinMax,
+      "ArgMinMax failed",
+      d_in,
+      d_out_extrema,
+      d_out_indices,
+      d_out_extrema + 1,
+      d_out_indices + 1,
+      static_cast<offset_t>(elements),
+      env);
+  });
+}
+
+NVBENCH_BENCH_TYPES(arg_minmax, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4));

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -2012,7 +2012,8 @@ public:
   }
 
 private:
-  template <typename InputIteratorT,
+  template <bool LastMax,
+            typename InputIteratorT,
             typename MinExtremumOutIteratorT,
             typename MinIndexOutIteratorT,
             typename MaxExtremumOutIteratorT,
@@ -2047,7 +2048,7 @@ private:
           d_max_out,
           d_max_index_out,
           static_cast<GlobalOffsetT>(num_items),
-          detail::arg_minmax_reduce_op<CompareOpT>{compare_op},
+          detail::arg_minmax_reduce_op<CompareOpT, LastMax>{compare_op},
           stream,
           tuning_env);
       });
@@ -2055,7 +2056,7 @@ private:
 
 public:
   //! @rst
-  //! Finds the device-wide first minimum and last maximum based on a given comparison operator, also returning their
+  //! Finds the device-wide first minimum and first maximum based on a given comparison operator, also returning their
   //! indices.
   //!
   //! .. versionadded:: 3.6.0
@@ -2064,7 +2065,7 @@ public:
   //! - The maximum value is written to ``d_max_out`` and its index is written to ``d_max_index_out``.
   //! - The offset type written to ``d_min_index_out`` and ``d_max_index_out`` is ``cuda::std::int64_t``.
   //! - On ties for the minimum, the smallest index is returned (first minimum).
-  //! - On ties for the maximum, the largest index is returned (last maximum).
+  //! - On ties for the maximum, the smallest index is returned (first maximum).
   //! - For zero-length inputs, no output is written.
   //! - Does not support non-commutative comparison operators.
   //! - The ranges ``[d_in, d_in + num_items)``, ``d_min_out``, ``d_min_index_out``, ``d_max_out``, and
@@ -2146,7 +2147,7 @@ public:
     const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMinMax");
-    return __arg_minmax(
+    return __arg_minmax<false>(
       d_temp_storage,
       temp_storage_bytes,
       d_in,
@@ -2184,7 +2185,7 @@ public:
     const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMinMax");
-    return __arg_minmax(
+    return __arg_minmax<false>(
       d_temp_storage,
       temp_storage_bytes,
       d_in,
@@ -2198,7 +2199,7 @@ public:
   }
 
   //! @rst
-  //! Finds the device-wide first minimum and last maximum in a single pass, also returning their indices.
+  //! Finds the device-wide first minimum and first maximum in a single pass, also returning their indices.
   //!
   //! .. versionadded:: 3.6.0
   //!
@@ -2206,7 +2207,7 @@ public:
   //! - The maximum value is written to ``d_max_out`` and its index is written to ``d_max_index_out``.
   //! - The offset type written to ``d_min_index_out`` and ``d_max_index_out`` is ``cuda::std::int64_t``.
   //! - On ties for the minimum, the smallest index is returned (first minimum).
-  //! - On ties for the maximum, the largest index is returned (last maximum).
+  //! - On ties for the maximum, the smallest index is returned (first maximum).
   //! - For zero-length inputs, no output is written.
   //! - Does not support non-commutative comparison operators.
   //! - The ranges ``[d_in, d_in + num_items)``, ``d_min_out``, ``d_min_index_out``, ``d_max_out``, and
@@ -2291,7 +2292,7 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMinMax");
     return detail::dispatch_with_env(env, [&](auto, void* storage, size_t& bytes, cudaStream_t) {
-      return __arg_minmax(
+      return __arg_minmax<false>(
         storage, bytes, d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, compare_op, env);
     });
   }
@@ -2320,7 +2321,152 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMinMax");
     return detail::dispatch_with_env(env, [&](auto, void* storage, size_t& bytes, cudaStream_t) {
-      return __arg_minmax(
+      return __arg_minmax<false>(
+        storage,
+        bytes,
+        d_in,
+        d_min_out,
+        d_min_index_out,
+        d_max_out,
+        d_max_index_out,
+        num_items,
+        ::cuda::std::less{},
+        env);
+    });
+  }
+
+  //! @rst
+  //! .. versionadded:: 3.6.0
+  //! @endrst
+  //!
+  //! @note Same as @ref ArgMinMax but returns the last maximum on ties.
+  _CCCL_TEMPLATE(typename InputIteratorT,
+                 typename MinExtremumOutIteratorT,
+                 typename MinIndexOutIteratorT,
+                 typename MaxExtremumOutIteratorT,
+                 typename MaxIndexOutIteratorT,
+                 typename CompareOpT,
+                 typename EnvT = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES((::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, CompareOpT>) )
+  CUB_RUNTIME_FUNCTION static cudaError_t ArgMinLastMax(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    MinExtremumOutIteratorT d_min_out,
+    MinIndexOutIteratorT d_min_index_out,
+    MaxExtremumOutIteratorT d_max_out,
+    MaxIndexOutIteratorT d_max_index_out,
+    ::cuda::std::int64_t num_items,
+    CompareOpT compare_op,
+    const EnvT& env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMinLastMax");
+    return __arg_minmax<true>(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_min_out,
+      d_min_index_out,
+      d_max_out,
+      d_max_index_out,
+      num_items,
+      compare_op,
+      env);
+  }
+
+  //! @rst
+  //! .. versionadded:: 3.6.0
+  //! @endrst
+  //!
+  //! @overload
+  //! @note Uses ``cuda::std::less`` as comparison operator
+  _CCCL_TEMPLATE(typename InputIteratorT,
+                 typename MinExtremumOutIteratorT,
+                 typename MinIndexOutIteratorT,
+                 typename MaxExtremumOutIteratorT,
+                 typename MaxIndexOutIteratorT,
+                 typename EnvT = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES((!::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, EnvT>) )
+  CUB_RUNTIME_FUNCTION static cudaError_t ArgMinLastMax(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    MinExtremumOutIteratorT d_min_out,
+    MinIndexOutIteratorT d_min_index_out,
+    MaxExtremumOutIteratorT d_max_out,
+    MaxIndexOutIteratorT d_max_index_out,
+    ::cuda::std::int64_t num_items,
+    const EnvT& env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMinLastMax");
+    return __arg_minmax<true>(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_min_out,
+      d_min_index_out,
+      d_max_out,
+      d_max_index_out,
+      num_items,
+      ::cuda::std::less{},
+      env);
+  }
+
+  //! @rst
+  //! .. versionadded:: 3.6.0
+  //! @endrst
+  //!
+  //! @note Same as @ref ArgMinMax but returns the last maximum on ties.
+  _CCCL_TEMPLATE(typename InputIteratorT,
+                 typename MinExtremumOutIteratorT,
+                 typename MinIndexOutIteratorT,
+                 typename MaxExtremumOutIteratorT,
+                 typename MaxIndexOutIteratorT,
+                 typename CompareOpT,
+                 typename EnvT = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES((::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, CompareOpT>) )
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ArgMinLastMax(
+    InputIteratorT d_in,
+    MinExtremumOutIteratorT d_min_out,
+    MinIndexOutIteratorT d_min_index_out,
+    MaxExtremumOutIteratorT d_max_out,
+    MaxIndexOutIteratorT d_max_index_out,
+    ::cuda::std::int64_t num_items,
+    CompareOpT compare_op,
+    const EnvT& env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMinLastMax");
+    return detail::dispatch_with_env(env, [&](auto, void* storage, size_t& bytes, cudaStream_t) {
+      return __arg_minmax<true>(
+        storage, bytes, d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, compare_op, env);
+    });
+  }
+
+  //! @rst
+  //! .. versionadded:: 3.6.0
+  //! @endrst
+  //!
+  //! @overload
+  //! @note Uses ``cuda::std::less`` as comparison operator
+  _CCCL_TEMPLATE(typename InputIteratorT,
+                 typename MinExtremumOutIteratorT,
+                 typename MinIndexOutIteratorT,
+                 typename MaxExtremumOutIteratorT,
+                 typename MaxIndexOutIteratorT,
+                 typename EnvT = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES((!::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, EnvT>) )
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ArgMinLastMax(
+    InputIteratorT d_in,
+    MinExtremumOutIteratorT d_min_out,
+    MinIndexOutIteratorT d_min_index_out,
+    MaxExtremumOutIteratorT d_max_out,
+    MaxIndexOutIteratorT d_max_index_out,
+    ::cuda::std::int64_t num_items,
+    const EnvT& env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMinLastMax");
+    return detail::dispatch_with_env(env, [&](auto, void* storage, size_t& bytes, cudaStream_t) {
+      return __arg_minmax<true>(
         storage,
         bytes,
         d_in,

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -2067,7 +2067,6 @@ public:
   //! - On ties for the maximum, the largest index is returned (last maximum).
   //! - For zero-length inputs, no output is written.
   //! - Does not support non-commutative comparison operators.
-  //! - Provides "run-to-run" determinism on the same GPU device.
   //! - The ranges ``[d_in, d_in + num_items)``, ``d_min_out``, ``d_min_index_out``, ``d_max_out``, and
   //!   ``d_max_index_out`` shall not overlap.
   //! - @devicestorage
@@ -2210,9 +2209,6 @@ public:
   //! - On ties for the maximum, the largest index is returned (last maximum).
   //! - For zero-length inputs, no output is written.
   //! - Does not support non-commutative comparison operators.
-  //! - Provides determinism based on the environment's determinism requirements.
-  //!   To request "run-to-run" determinism, pass ``cuda::execution::require(cuda::execution::determinism::run_to_run)``
-  //!   as the ``env`` parameter.
   //! - The ranges ``[d_in, d_in + num_items)``, ``d_min_out``, ``d_min_index_out``, ``d_max_out``, and
   //!   ``d_max_index_out`` shall not overlap.
   //!
@@ -2224,8 +2220,8 @@ public:
   //! .. literalinclude:: ../../../cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
   //!     :language: c++
   //!     :dedent:
-  //!     :start-after: example-begin argminmax-env-determinism
-  //!     :end-before: example-end argminmax-env-determinism
+  //!     :start-after: example-begin argminmax-env
+  //!     :end-before: example-end argminmax-env
   //!
   //! @endrst
   //!

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -43,8 +43,6 @@
 #include <cuda/__functional/call_or.h>
 #include <cuda/__functional/maximum.h>
 #include <cuda/__functional/minimum.h>
-#include <cuda/__iterator/counting_iterator.h>
-#include <cuda/__iterator/tabulate_output_iterator.h>
 #include <cuda/__memory_resource/get_memory_resource.h>
 #include <cuda/__stream/get_stream.h>
 #include <cuda/__stream/stream_ref.h>
@@ -68,73 +66,6 @@ namespace detail
 template <typename DeterminismT>
 inline constexpr bool is_non_deterministic_v =
   ::cuda::std::is_same_v<DeterminismT, ::cuda::execution::determinism::not_guaranteed_t>;
-
-template <typename T, typename IndexT>
-struct arg_minmax_accum_t
-{
-  T min_value;
-  T max_value;
-  IndexT min_index;
-  IndexT max_index;
-};
-
-// converts a counting index into an initial accumulator
-template <typename InputIteratorT, typename IndexT>
-struct arg_minmax_transform_op
-{
-  InputIteratorT d_in;
-
-  _CCCL_HOST_DEVICE auto operator()(IndexT idx) const -> arg_minmax_accum_t<it_value_t<InputIteratorT>, IndexT>
-  {
-    const auto val = d_in[idx];
-    return {val, val, idx, idx};
-  }
-};
-
-//! @brief Reduction operator for ArgMinMax: first minimum (smallest index on tie), last maximum (largest index on tie).
-template <typename T, typename IndexT, typename CompareOpT>
-struct arg_minmax_reduce_op
-{
-  CompareOpT compare_op;
-
-  _CCCL_HOST_DEVICE arg_minmax_accum_t<T, IndexT>
-  operator()(const arg_minmax_accum_t<T, IndexT>& a, const arg_minmax_accum_t<T, IndexT>& b) const
-  {
-    auto result = a;
-    // first minimum: strictly smaller wins; ties keep the smaller index
-    if (compare_op(b.min_value, a.min_value) || (!compare_op(a.min_value, b.min_value) && b.min_index < a.min_index))
-    {
-      result.min_value = b.min_value;
-      result.min_index = b.min_index;
-    }
-    // last maximum: strictly greater wins; ties keep the larger index
-    if (compare_op(a.max_value, b.max_value) || (!compare_op(b.max_value, a.max_value) && b.max_index > a.max_index))
-    {
-      result.max_value = b.max_value;
-      result.max_index = b.max_index;
-    }
-    return result;
-  }
-};
-
-//! @brief Output operator: unzips a combined argminmax_accum_t and writes to the four user-supplied iterators.
-template <typename MinExtremumOutT, typename MinIndexOutT, typename MaxExtremumOutT, typename MaxIndexOutT>
-struct unzip_and_write_arg_minmax_op
-{
-  MinExtremumOutT min_out;
-  MinIndexOutT min_index_out;
-  MaxExtremumOutT max_out;
-  MaxIndexOutT max_index_out;
-
-  template <typename IndexT, typename ResultT>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void operator()(IndexT, ResultT result)
-  {
-    *min_out       = result.min_value;
-    *min_index_out = result.min_index;
-    *max_out       = result.max_value;
-    *max_index_out = result.max_index;
-  }
-};
 } // namespace detail
 
 //! @rst
@@ -2098,31 +2029,60 @@ private:
     ::cuda::std::int64_t num_items,
     const EnvT& env)
   {
-    using ValueT = detail::it_value_t<InputIteratorT>;
-    using IndexT = ::cuda::std::int64_t;
+    static_assert(__validate_determinism_streaming_reduce<EnvT>(), "gpu_to_gpu determinism is not supported");
 
-    auto transform_op = detail::arg_minmax_transform_op<InputIteratorT, IndexT>{d_in};
-    auto reduce_op    = detail::arg_minmax_reduce_op<ValueT, IndexT, ::cuda::std::less<>>{{}};
-    auto unzip_op     = detail::unzip_and_write_arg_minmax_op<
-          MinExtremumOutIteratorT,
-          MinIndexOutIteratorT,
-          MaxExtremumOutIteratorT,
-          MaxIndexOutIteratorT>{d_min_out, d_min_index_out, d_max_out, d_max_index_out};
-    auto d_out = ::cuda::make_tabulate_output_iterator(::cuda::std::move(unzip_op));
+    using PerPartitionOffsetT = int;
+    using GlobalOffsetT       = ::cuda::std::int64_t;
 
     return detail::dispatch_with_env(
-      d_temp_storage, temp_storage_bytes, env, [&](auto, void* storage, size_t& bytes, cudaStream_t stream) {
-        return detail::reduce::dispatch(
+      d_temp_storage, temp_storage_bytes, env, [&](auto tuning_env, void* storage, size_t& bytes, cudaStream_t stream) {
+        return detail::reduce::dispatch_streaming_arg_minmax<PerPartitionOffsetT>(
           storage,
           bytes,
-          ::cuda::counting_iterator<IndexT, IndexT>{IndexT{0}},
-          d_out,
-          detail::make_num_items_dispatch_arg(num_items),
-          reduce_op,
-          detail::reduce::no_init,
+          d_in,
+          d_min_out,
+          d_min_index_out,
+          d_max_out,
+          d_max_index_out,
+          static_cast<GlobalOffsetT>(num_items),
           stream,
-          transform_op);
+          tuning_env);
       });
+  }
+
+  template <typename InputIteratorT,
+            typename MinExtremumOutIteratorT,
+            typename MinIndexOutIteratorT,
+            typename MaxExtremumOutIteratorT,
+            typename MaxIndexOutIteratorT,
+            typename EnvT>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t __arg_minmax(
+    InputIteratorT d_in,
+    MinExtremumOutIteratorT d_min_out,
+    MinIndexOutIteratorT d_min_index_out,
+    MaxExtremumOutIteratorT d_max_out,
+    MaxIndexOutIteratorT d_max_index_out,
+    ::cuda::std::int64_t num_items,
+    const EnvT& env)
+  {
+    static_assert(__validate_determinism_streaming_reduce<EnvT>(), "gpu_to_gpu determinism is not supported");
+
+    using PerPartitionOffsetT = int;
+    using GlobalOffsetT       = ::cuda::std::int64_t;
+
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return detail::reduce::dispatch_streaming_arg_minmax<PerPartitionOffsetT>(
+        storage,
+        bytes,
+        d_in,
+        d_min_out,
+        d_min_index_out,
+        d_max_out,
+        d_max_index_out,
+        static_cast<GlobalOffsetT>(num_items),
+        stream,
+        tuning_env);
+    });
   }
 
 public:
@@ -2341,9 +2301,7 @@ public:
     const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMinMax");
-    return detail::dispatch_with_env(env, [&](auto, void* storage, size_t& bytes, cudaStream_t) {
-      return __arg_minmax(storage, bytes, d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, env);
-    });
+    return __arg_minmax(d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, env);
   }
 
   //! @rst

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -2050,41 +2050,6 @@ private:
       });
   }
 
-  template <typename InputIteratorT,
-            typename MinExtremumOutIteratorT,
-            typename MinIndexOutIteratorT,
-            typename MaxExtremumOutIteratorT,
-            typename MaxIndexOutIteratorT,
-            typename EnvT>
-  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t __arg_minmax(
-    InputIteratorT d_in,
-    MinExtremumOutIteratorT d_min_out,
-    MinIndexOutIteratorT d_min_index_out,
-    MaxExtremumOutIteratorT d_max_out,
-    MaxIndexOutIteratorT d_max_index_out,
-    ::cuda::std::int64_t num_items,
-    const EnvT& env)
-  {
-    static_assert(__validate_determinism_streaming_reduce<EnvT>(), "gpu_to_gpu determinism is not supported");
-
-    using PerPartitionOffsetT = int;
-    using GlobalOffsetT       = ::cuda::std::int64_t;
-
-    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
-      return detail::reduce::dispatch_streaming_arg_minmax<PerPartitionOffsetT>(
-        storage,
-        bytes,
-        d_in,
-        d_min_out,
-        d_min_index_out,
-        d_max_out,
-        d_max_index_out,
-        static_cast<GlobalOffsetT>(num_items),
-        stream,
-        tuning_env);
-    });
-  }
-
 public:
   //! @rst
   //! Finds the device-wide first minimum and last maximum in a single pass, also returning their indices.
@@ -2301,7 +2266,9 @@ public:
     const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMinMax");
-    return __arg_minmax(d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, env);
+    return detail::dispatch_with_env(env, [&](auto, void* storage, size_t& bytes, cudaStream_t) {
+      return __arg_minmax(storage, bytes, d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, env);
+    });
   }
 
   //! @rst

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -2017,6 +2017,7 @@ private:
             typename MinIndexOutIteratorT,
             typename MaxExtremumOutIteratorT,
             typename MaxIndexOutIteratorT,
+            typename CompareOpT,
             typename EnvT>
   CUB_RUNTIME_FUNCTION static cudaError_t __arg_minmax(
     void* d_temp_storage,
@@ -2027,6 +2028,7 @@ private:
     MaxExtremumOutIteratorT d_max_out,
     MaxIndexOutIteratorT d_max_index_out,
     ::cuda::std::int64_t num_items,
+    CompareOpT compare_op,
     const EnvT& env)
   {
     static_assert(__validate_determinism_streaming_reduce<EnvT>(), "gpu_to_gpu determinism is not supported");
@@ -2045,6 +2047,7 @@ private:
           d_max_out,
           d_max_index_out,
           static_cast<GlobalOffsetT>(num_items),
+          detail::arg_minmax_reduce_op<CompareOpT>{compare_op},
           stream,
           tuning_env);
       });
@@ -2052,7 +2055,8 @@ private:
 
 public:
   //! @rst
-  //! Finds the device-wide first minimum and last maximum in a single pass, also returning their indices.
+  //! Finds the device-wide first minimum and last maximum based on a given comparison operator, also returning their
+  //! indices.
   //!
   //! .. versionadded:: 3.6.0
   //!
@@ -2067,46 +2071,6 @@ public:
   //! - The ranges ``[d_in, d_in + num_items)``, ``d_min_out``, ``d_min_index_out``, ``d_max_out``, and
   //!   ``d_max_index_out`` shall not overlap.
   //! - @devicestorage
-  //!
-  //! Snippet
-  //! +++++++++++++++++++++++++++++++++++++++++++++
-  //!
-  //! The code snippet below illustrates the argminmax-reduction of a device vector of ``int`` data elements.
-  //!
-  //! .. code-block:: c++
-  //!
-  //!    #include <cub/cub.cuh> // or equivalently <cub/device/device_reduce.cuh>
-  //!    #include <cuda/std/cstdint>
-  //!
-  //!    // Declare, allocate, and initialize device-accessible pointers
-  //!    // for input and output
-  //!    int                num_items;        // e.g., 7
-  //!    int                *d_in;            // e.g., [8, 6, -7, 5, 3, 1, -9]
-  //!    int                *d_min_out;       // memory for the minimum value
-  //!    cuda::std::int64_t *d_min_index_out; // memory for the index of the minimum value
-  //!    int                *d_max_out;       // memory for the maximum value
-  //!    cuda::std::int64_t *d_max_index_out; // memory for the index of the maximum value
-  //!    ...
-  //!
-  //!    // Determine temporary device storage requirements
-  //!    void     *d_temp_storage = nullptr;
-  //!    size_t   temp_storage_bytes = 0;
-  //!    cub::DeviceReduce::ArgMinMax(
-  //!      d_temp_storage, temp_storage_bytes,
-  //!      d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items);
-  //!
-  //!    // Allocate temporary storage
-  //!    cudaMalloc(&d_temp_storage, temp_storage_bytes);
-  //!
-  //!    // Run argminmax-reduction
-  //!    cub::DeviceReduce::ArgMinMax(
-  //!      d_temp_storage, temp_storage_bytes,
-  //!      d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items);
-  //!
-  //!    // d_min_out       <-- -9
-  //!    // d_min_index_out <-- 6
-  //!    // d_max_out       <-- 8
-  //!    // d_max_index_out <-- 0
   //!
   //! @endrst
   //!
@@ -2125,12 +2089,14 @@ public:
   //! @tparam MaxIndexOutIteratorT
   //!   **[inferred]** Output iterator type for recording the index of the maximum value
   //!
+  //! @tparam CompareOpT
+  //!   **[inferred]** Comparison operator type returning ``true`` if the first argument is less than the second
+  //!
   //! @tparam EnvT
   //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
   //!
   //! @param[in] d_temp_storage
-  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
-  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!   @devicestorage
   //!
   //! @param[in,out] temp_storage_bytes
   //!   Reference to size in bytes of ``d_temp_storage`` allocation
@@ -2153,16 +2119,60 @@ public:
   //! @param[in] num_items
   //!   Total number of input items (i.e., length of ``d_in``)
   //!
+  //! @param[in] compare_op
+  //!   Comparison operator returning ``true`` if the first argument is less than the second
+  //!
   //! @param[in] env
   //!   @rst
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
-  template <typename InputIteratorT,
-            typename MinExtremumOutIteratorT,
-            typename MinIndexOutIteratorT,
-            typename MaxExtremumOutIteratorT,
-            typename MaxIndexOutIteratorT,
-            typename EnvT = ::cuda::std::execution::env<>>
+  _CCCL_TEMPLATE(typename InputIteratorT,
+                 typename MinExtremumOutIteratorT,
+                 typename MinIndexOutIteratorT,
+                 typename MaxExtremumOutIteratorT,
+                 typename MaxIndexOutIteratorT,
+                 typename CompareOpT,
+                 typename EnvT = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES((::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, CompareOpT>) )
+  CUB_RUNTIME_FUNCTION static cudaError_t ArgMinMax(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    MinExtremumOutIteratorT d_min_out,
+    MinIndexOutIteratorT d_min_index_out,
+    MaxExtremumOutIteratorT d_max_out,
+    MaxIndexOutIteratorT d_max_index_out,
+    ::cuda::std::int64_t num_items,
+    CompareOpT compare_op,
+    const EnvT& env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMinMax");
+    return __arg_minmax(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_min_out,
+      d_min_index_out,
+      d_max_out,
+      d_max_index_out,
+      num_items,
+      compare_op,
+      env);
+  }
+
+  //! @rst
+  //! .. versionadded:: 3.6.0
+  //! @endrst
+  //!
+  //! @overload
+  //! @note Uses ``cuda::std::less`` as comparison operator
+  _CCCL_TEMPLATE(typename InputIteratorT,
+                 typename MinExtremumOutIteratorT,
+                 typename MinIndexOutIteratorT,
+                 typename MaxExtremumOutIteratorT,
+                 typename MaxIndexOutIteratorT,
+                 typename EnvT = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES((!::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, EnvT>) )
   CUB_RUNTIME_FUNCTION static cudaError_t ArgMinMax(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -2176,7 +2186,16 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMinMax");
     return __arg_minmax(
-      d_temp_storage, temp_storage_bytes, d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, env);
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_min_out,
+      d_min_index_out,
+      d_max_out,
+      d_max_index_out,
+      num_items,
+      ::cuda::std::less{},
+      env);
   }
 
   //! @rst
@@ -2246,16 +2265,51 @@ public:
   //! @param[in] num_items
   //!   Total number of input items (i.e., length of ``d_in``)
   //!
+  //! @param[in] compare_op
+  //!   Comparison operator returning ``true`` if the first argument is less than the second
+  //!
   //! @param[in] env
   //!   @rst
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
-  template <typename InputIteratorT,
-            typename MinExtremumOutIteratorT,
-            typename MinIndexOutIteratorT,
-            typename MaxExtremumOutIteratorT,
-            typename MaxIndexOutIteratorT,
-            typename EnvT = ::cuda::std::execution::env<>>
+  _CCCL_TEMPLATE(typename InputIteratorT,
+                 typename MinExtremumOutIteratorT,
+                 typename MinIndexOutIteratorT,
+                 typename MaxExtremumOutIteratorT,
+                 typename MaxIndexOutIteratorT,
+                 typename CompareOpT,
+                 typename EnvT = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES((::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, CompareOpT>) )
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ArgMinMax(
+    InputIteratorT d_in,
+    MinExtremumOutIteratorT d_min_out,
+    MinIndexOutIteratorT d_min_index_out,
+    MaxExtremumOutIteratorT d_max_out,
+    MaxIndexOutIteratorT d_max_index_out,
+    ::cuda::std::int64_t num_items,
+    CompareOpT compare_op,
+    const EnvT& env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMinMax");
+    return detail::dispatch_with_env(env, [&](auto, void* storage, size_t& bytes, cudaStream_t) {
+      return __arg_minmax(
+        storage, bytes, d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, compare_op, env);
+    });
+  }
+
+  //! @rst
+  //! .. versionadded:: 3.6.0
+  //! @endrst
+  //!
+  //! @overload
+  //! @note Uses ``cuda::std::less`` as comparison operator
+  _CCCL_TEMPLATE(typename InputIteratorT,
+                 typename MinExtremumOutIteratorT,
+                 typename MinIndexOutIteratorT,
+                 typename MaxExtremumOutIteratorT,
+                 typename MaxIndexOutIteratorT,
+                 typename EnvT = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES((!::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, EnvT>) )
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ArgMinMax(
     InputIteratorT d_in,
     MinExtremumOutIteratorT d_min_out,
@@ -2267,7 +2321,17 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMinMax");
     return detail::dispatch_with_env(env, [&](auto, void* storage, size_t& bytes, cudaStream_t) {
-      return __arg_minmax(storage, bytes, d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, env);
+      return __arg_minmax(
+        storage,
+        bytes,
+        d_in,
+        d_min_out,
+        d_min_index_out,
+        d_max_out,
+        d_max_index_out,
+        num_items,
+        ::cuda::std::less{},
+        env);
     });
   }
 

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -2112,16 +2112,16 @@ private:
 
     return detail::dispatch_with_env(
       d_temp_storage, temp_storage_bytes, env, [&](auto, void* storage, size_t& bytes, cudaStream_t stream) {
-        return TransformReduce(
+        return detail::reduce::dispatch(
           storage,
           bytes,
           ::cuda::counting_iterator<IndexT, IndexT>{IndexT{0}},
           d_out,
-          num_items,
+          detail::make_num_items_dispatch_arg(num_items),
           reduce_op,
-          transform_op,
           detail::reduce::no_init,
-          stream);
+          stream,
+          transform_op);
       });
   }
 
@@ -2341,7 +2341,9 @@ public:
     const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMinMax");
-    return __arg_minmax(d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, env);
+    return detail::dispatch_with_env(env, [&](auto, void* storage, size_t& bytes, cudaStream_t) {
+      return __arg_minmax(storage, bytes, d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, env);
+    });
   }
 
   //! @rst

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -43,6 +43,7 @@
 #include <cuda/__functional/call_or.h>
 #include <cuda/__functional/maximum.h>
 #include <cuda/__functional/minimum.h>
+#include <cuda/__iterator/counting_iterator.h>
 #include <cuda/__iterator/tabulate_output_iterator.h>
 #include <cuda/__memory_resource/get_memory_resource.h>
 #include <cuda/__stream/get_stream.h>
@@ -67,6 +68,73 @@ namespace detail
 template <typename DeterminismT>
 inline constexpr bool is_non_deterministic_v =
   ::cuda::std::is_same_v<DeterminismT, ::cuda::execution::determinism::not_guaranteed_t>;
+
+template <typename T, typename IndexT>
+struct arg_minmax_accum_t
+{
+  T min_value;
+  T max_value;
+  IndexT min_index;
+  IndexT max_index;
+};
+
+// converts a counting index into an initial accumulator
+template <typename InputIteratorT, typename IndexT>
+struct arg_minmax_transform_op
+{
+  InputIteratorT d_in;
+
+  _CCCL_HOST_DEVICE auto operator()(IndexT idx) const -> arg_minmax_accum_t<it_value_t<InputIteratorT>, IndexT>
+  {
+    const auto val = d_in[idx];
+    return {val, val, idx, idx};
+  }
+};
+
+//! @brief Reduction operator for ArgMinMax: first minimum (smallest index on tie), last maximum (largest index on tie).
+template <typename T, typename IndexT, typename CompareOpT>
+struct arg_minmax_reduce_op
+{
+  CompareOpT compare_op;
+
+  _CCCL_HOST_DEVICE arg_minmax_accum_t<T, IndexT>
+  operator()(const arg_minmax_accum_t<T, IndexT>& a, const arg_minmax_accum_t<T, IndexT>& b) const
+  {
+    auto result = a;
+    // first minimum: strictly smaller wins; ties keep the smaller index
+    if (compare_op(b.min_value, a.min_value) || (!compare_op(a.min_value, b.min_value) && b.min_index < a.min_index))
+    {
+      result.min_value = b.min_value;
+      result.min_index = b.min_index;
+    }
+    // last maximum: strictly greater wins; ties keep the larger index
+    if (compare_op(a.max_value, b.max_value) || (!compare_op(b.max_value, a.max_value) && b.max_index > a.max_index))
+    {
+      result.max_value = b.max_value;
+      result.max_index = b.max_index;
+    }
+    return result;
+  }
+};
+
+//! @brief Output operator: unzips a combined argminmax_accum_t and writes to the four user-supplied iterators.
+template <typename MinExtremumOutT, typename MinIndexOutT, typename MaxExtremumOutT, typename MaxIndexOutT>
+struct unzip_and_write_arg_minmax_op
+{
+  MinExtremumOutT min_out;
+  MinIndexOutT min_index_out;
+  MaxExtremumOutT max_out;
+  MaxIndexOutT max_index_out;
+
+  template <typename IndexT, typename ResultT>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void operator()(IndexT, ResultT result)
+  {
+    *min_out       = result.min_value;
+    *min_index_out = result.min_index;
+    *max_out       = result.max_value;
+    *max_index_out = result.max_index;
+  }
+};
 } // namespace detail
 
 //! @rst
@@ -2010,6 +2078,270 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMax");
     return __arg_min(d_in, d_max_out, d_index_out, num_items, ::cuda::std::greater{}, env);
+  }
+
+private:
+  template <typename InputIteratorT,
+            typename MinExtremumOutIteratorT,
+            typename MinIndexOutIteratorT,
+            typename MaxExtremumOutIteratorT,
+            typename MaxIndexOutIteratorT,
+            typename EnvT>
+  CUB_RUNTIME_FUNCTION static cudaError_t __arg_minmax(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    MinExtremumOutIteratorT d_min_out,
+    MinIndexOutIteratorT d_min_index_out,
+    MaxExtremumOutIteratorT d_max_out,
+    MaxIndexOutIteratorT d_max_index_out,
+    ::cuda::std::int64_t num_items,
+    const EnvT& env)
+  {
+    using ValueT = detail::it_value_t<InputIteratorT>;
+    using IndexT = ::cuda::std::int64_t;
+
+    auto transform_op = detail::arg_minmax_transform_op<InputIteratorT, IndexT>{d_in};
+    auto reduce_op    = detail::arg_minmax_reduce_op<ValueT, IndexT, ::cuda::std::less<>>{{}};
+    auto unzip_op     = detail::unzip_and_write_arg_minmax_op<
+          MinExtremumOutIteratorT,
+          MinIndexOutIteratorT,
+          MaxExtremumOutIteratorT,
+          MaxIndexOutIteratorT>{d_min_out, d_min_index_out, d_max_out, d_max_index_out};
+    auto d_out = ::cuda::make_tabulate_output_iterator(::cuda::std::move(unzip_op));
+
+    return detail::dispatch_with_env(
+      d_temp_storage, temp_storage_bytes, env, [&](auto, void* storage, size_t& bytes, cudaStream_t stream) {
+        return TransformReduce(
+          storage,
+          bytes,
+          ::cuda::counting_iterator<IndexT, IndexT>{IndexT{0}},
+          d_out,
+          num_items,
+          reduce_op,
+          transform_op,
+          detail::reduce::no_init,
+          stream);
+      });
+  }
+
+public:
+  //! @rst
+  //! Finds the device-wide first minimum and last maximum in a single pass, also returning their indices.
+  //!
+  //! .. versionadded:: 3.6.0
+  //!
+  //! - The minimum value is written to ``d_min_out`` and its index is written to ``d_min_index_out``.
+  //! - The maximum value is written to ``d_max_out`` and its index is written to ``d_max_index_out``.
+  //! - The offset type written to ``d_min_index_out`` and ``d_max_index_out`` is ``cuda::std::int64_t``.
+  //! - On ties for the minimum, the smallest index is returned (first minimum).
+  //! - On ties for the maximum, the largest index is returned (last maximum).
+  //! - For zero-length inputs, no output is written.
+  //! - Does not support non-commutative comparison operators.
+  //! - Provides "run-to-run" determinism on the same GPU device.
+  //! - The ranges ``[d_in, d_in + num_items)``, ``d_min_out``, ``d_min_index_out``, ``d_max_out``, and
+  //!   ``d_max_index_out`` shall not overlap.
+  //! - @devicestorage
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the argminmax-reduction of a device vector of ``int`` data elements.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh> // or equivalently <cub/device/device_reduce.cuh>
+  //!    #include <cuda/std/cstdint>
+  //!
+  //!    // Declare, allocate, and initialize device-accessible pointers
+  //!    // for input and output
+  //!    int                num_items;        // e.g., 7
+  //!    int                *d_in;            // e.g., [8, 6, -7, 5, 3, 1, -9]
+  //!    int                *d_min_out;       // memory for the minimum value
+  //!    cuda::std::int64_t *d_min_index_out; // memory for the index of the minimum value
+  //!    int                *d_max_out;       // memory for the maximum value
+  //!    cuda::std::int64_t *d_max_index_out; // memory for the index of the maximum value
+  //!    ...
+  //!
+  //!    // Determine temporary device storage requirements
+  //!    void     *d_temp_storage = nullptr;
+  //!    size_t   temp_storage_bytes = 0;
+  //!    cub::DeviceReduce::ArgMinMax(
+  //!      d_temp_storage, temp_storage_bytes,
+  //!      d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items);
+  //!
+  //!    // Allocate temporary storage
+  //!    cudaMalloc(&d_temp_storage, temp_storage_bytes);
+  //!
+  //!    // Run argminmax-reduction
+  //!    cub::DeviceReduce::ArgMinMax(
+  //!      d_temp_storage, temp_storage_bytes,
+  //!      d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items);
+  //!
+  //!    // d_min_out       <-- -9
+  //!    // d_min_index_out <-- 6
+  //!    // d_max_out       <-- 8
+  //!    // d_max_index_out <-- 0
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items (of some type `T`) @iterator
+  //!
+  //! @tparam MinExtremumOutIteratorT
+  //!   **[inferred]** Output iterator type for recording the minimum value
+  //!
+  //! @tparam MinIndexOutIteratorT
+  //!   **[inferred]** Output iterator type for recording the index of the minimum value
+  //!
+  //! @tparam MaxExtremumOutIteratorT
+  //!   **[inferred]** Output iterator type for recording the maximum value
+  //!
+  //! @tparam MaxIndexOutIteratorT
+  //!   **[inferred]** Output iterator type for recording the index of the maximum value
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of ``d_temp_storage`` allocation
+  //!
+  //! @param[in] d_in
+  //!   Iterator to the input sequence of data items
+  //!
+  //! @param[out] d_min_out
+  //!   Iterator to which the minimum value is written
+  //!
+  //! @param[out] d_min_index_out
+  //!   Iterator to which the index of the minimum value is written
+  //!
+  //! @param[out] d_max_out
+  //!   Iterator to which the maximum value is written
+  //!
+  //! @param[out] d_max_index_out
+  //!   Iterator to which the index of the maximum value is written
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of ``d_in``)
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename MinExtremumOutIteratorT,
+            typename MinIndexOutIteratorT,
+            typename MaxExtremumOutIteratorT,
+            typename MaxIndexOutIteratorT,
+            typename EnvT = ::cuda::std::execution::env<>>
+  CUB_RUNTIME_FUNCTION static cudaError_t ArgMinMax(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    MinExtremumOutIteratorT d_min_out,
+    MinIndexOutIteratorT d_min_index_out,
+    MaxExtremumOutIteratorT d_max_out,
+    MaxIndexOutIteratorT d_max_index_out,
+    ::cuda::std::int64_t num_items,
+    const EnvT& env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMinMax");
+    return __arg_minmax(
+      d_temp_storage, temp_storage_bytes, d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, env);
+  }
+
+  //! @rst
+  //! Finds the device-wide first minimum and last maximum in a single pass, also returning their indices.
+  //!
+  //! .. versionadded:: 3.6.0
+  //!
+  //! - The minimum value is written to ``d_min_out`` and its index is written to ``d_min_index_out``.
+  //! - The maximum value is written to ``d_max_out`` and its index is written to ``d_max_index_out``.
+  //! - The offset type written to ``d_min_index_out`` and ``d_max_index_out`` is ``cuda::std::int64_t``.
+  //! - On ties for the minimum, the smallest index is returned (first minimum).
+  //! - On ties for the maximum, the largest index is returned (last maximum).
+  //! - For zero-length inputs, no output is written.
+  //! - Does not support non-commutative comparison operators.
+  //! - Provides determinism based on the environment's determinism requirements.
+  //!   To request "run-to-run" determinism, pass ``cuda::execution::require(cuda::execution::determinism::run_to_run)``
+  //!   as the ``env`` parameter.
+  //! - The ranges ``[d_in, d_in + num_items)``, ``d_min_out``, ``d_min_index_out``, ``d_max_out``, and
+  //!   ``d_max_index_out`` shall not overlap.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the argminmax-reduction of a device vector of ``float`` data elements.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin argminmax-env-determinism
+  //!     :end-before: example-end argminmax-env-determinism
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items (of some type `T`) @iterator
+  //!
+  //! @tparam MinExtremumOutIteratorT
+  //!   **[inferred]** Output iterator type for recording the minimum value
+  //!
+  //! @tparam MinIndexOutIteratorT
+  //!   **[inferred]** Output iterator type for recording the index of the minimum value
+  //!
+  //! @tparam MaxExtremumOutIteratorT
+  //!   **[inferred]** Output iterator type for recording the maximum value
+  //!
+  //! @tparam MaxIndexOutIteratorT
+  //!   **[inferred]** Output iterator type for recording the index of the maximum value
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!
+  //! @param[in] d_in
+  //!   Iterator to the input sequence of data items
+  //!
+  //! @param[out] d_min_out
+  //!   Iterator to which the minimum value is written
+  //!
+  //! @param[out] d_min_index_out
+  //!   Iterator to which the index of the minimum value is written
+  //!
+  //! @param[out] d_max_out
+  //!   Iterator to which the maximum value is written
+  //!
+  //! @param[out] d_max_index_out
+  //!   Iterator to which the index of the maximum value is written
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of ``d_in``)
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename MinExtremumOutIteratorT,
+            typename MinIndexOutIteratorT,
+            typename MaxExtremumOutIteratorT,
+            typename MaxIndexOutIteratorT,
+            typename EnvT = ::cuda::std::execution::env<>>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ArgMinMax(
+    InputIteratorT d_in,
+    MinExtremumOutIteratorT d_min_out,
+    MinIndexOutIteratorT d_min_index_out,
+    MaxExtremumOutIteratorT d_max_out,
+    MaxIndexOutIteratorT d_max_index_out,
+    ::cuda::std::int64_t num_items,
+    const EnvT& env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMinMax");
+    return __arg_minmax(d_in, d_min_out, d_min_index_out, d_max_out, d_max_index_out, num_items, env);
   }
 
   //! @rst

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -2244,6 +2244,9 @@ public:
   //! @tparam MaxIndexOutIteratorT
   //!   **[inferred]** Output iterator type for recording the index of the maximum value
   //!
+  //! @tparam CompareOpT
+  //!   **[inferred]** Comparison operator type returning ``true`` if the first argument is less than the second
+  //!
   //! @tparam EnvT
   //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
   //!

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -931,7 +931,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   TransformOpT transform_op              = {},
   PolicySelector policy_selector         = {},
   KernelSource kernel_source             = {},
-  KernelLauncherFactory launcher_factory = {})
+  KernelLauncherFactory launcher_factory = {}) -> cudaError
 {
   using offset_t = num_items_offset_t<OffsetT>;
 

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -931,7 +931,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   TransformOpT transform_op              = {},
   PolicySelector policy_selector         = {},
   KernelSource kernel_source             = {},
-  KernelLauncherFactory launcher_factory = {}) -> cudaError
+  KernelLauncherFactory launcher_factory = {}) -> cudaError_t
 {
   using offset_t = num_items_offset_t<OffsetT>;
 

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
@@ -128,11 +128,11 @@ struct unzip_and_write_arg_extremum_op
   }
 };
 
-// Transform: KeyValuePair<OffsetT, T> produced by ArgIndexInputIterator → argminmax_accum_t<T, OffsetT>
+// transform the KeyValuePair<OffsetT, T> produced by ArgIndexInputIterator to argminmax_accum_t<T, OffsetT>
 template <typename T, typename OffsetT>
 struct kvp_to_argminmax_accum
 {
-  _CCCL_HOST_DEVICE detail::argminmax_accum_t<T, OffsetT> operator()(KeyValuePair<OffsetT, T> kv) const
+  _CCCL_HOST_DEVICE auto operator()(KeyValuePair<OffsetT, T> kv) const -> argminmax_accum_t<T, OffsetT>
   {
     return {kv.value, kv.value, kv.key, kv.key};
   }
@@ -160,17 +160,16 @@ struct local_to_global_minmax_op
   }
 };
 
-// Output operator: unzips a global argminmax_accum_t and writes to the four user-supplied iterators
 template <typename MinExtremumOutT, typename MinIndexOutT, typename MaxExtremumOutT, typename MaxIndexOutT>
-struct unzip_and_write_arg_minmax_op
+struct write_arg_minmax_result_op
 {
   MinExtremumOutT min_out;
   MinIndexOutT min_index_out;
   MaxExtremumOutT max_out;
   MaxIndexOutT max_index_out;
 
-  template <typename IndexT, typename ResultT>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void operator()(IndexT, ResultT result)
+  template <typename IndexT, typename T, typename GlobalOffsetT>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void operator()(IndexT, const argminmax_accum_t<T, GlobalOffsetT>& result)
   {
     *min_out       = result.min_value;
     *min_index_out = result.min_index;
@@ -230,7 +229,6 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_reduce
   using output_extremum_t         = detail::non_void_value_t<ExtremumOutIteratorT, input_value_t>;
   using default_policy_selector_t = detail::reduce::
     policy_selector_from_types<KeyValuePair<PerPartitionOffsetT, output_extremum_t>, PerPartitionOffsetT, ReductionOpT>;
-  using default_policy_t = decltype(default_policy_selector_t{}(::cuda::compute_capability{}));
   using policy_selector_t =
     ::cuda::std::execution::__query_result_or_t<TuningEnvT, ReducePolicy, default_policy_selector_t>;
 
@@ -415,17 +413,12 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
   cudaStream_t stream,
   const TuningEnvT& = {})
 {
-  using input_value_t     = detail::it_value_t<InputIteratorT>;
-  using output_extremum_t = detail::non_void_value_t<MinExtremumOutIteratorT, input_value_t>;
-
-  using reduce_op_t = detail::arg_minmax_reduce_op<>;
-
-  using per_partition_accum_t = detail::argminmax_accum_t<output_extremum_t, PerPartitionOffsetT>;
-  using global_accum_t        = detail::argminmax_accum_t<output_extremum_t, GlobalOffsetT>;
-
-  using default_policy_selector_t =
-    detail::reduce::policy_selector_from_types<per_partition_accum_t, PerPartitionOffsetT, reduce_op_t>;
-  using default_policy_t = decltype(default_policy_selector_t{}(::cuda::compute_capability{}));
+  using input_value_t             = it_value_t<InputIteratorT>;
+  using output_extremum_t         = non_void_value_t<MinExtremumOutIteratorT, input_value_t>;
+  using reduce_op_t               = arg_minmax_reduce_op<>;
+  using per_partition_accum_t     = argminmax_accum_t<output_extremum_t, PerPartitionOffsetT>;
+  using global_accum_t            = argminmax_accum_t<output_extremum_t, GlobalOffsetT>;
+  using default_policy_selector_t = policy_selector_from_types<per_partition_accum_t, PerPartitionOffsetT, reduce_op_t>;
   using policy_selector_t =
     ::cuda::std::execution::__query_result_or_t<TuningEnvT, ReducePolicy, default_policy_selector_t>;
 
@@ -435,10 +428,10 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
 
   // Tabulate output iterator that unzips the result and writes to the four user-provided output iterators
   auto d_result_out = ::cuda::make_tabulate_output_iterator(
-    unzip_and_write_arg_minmax_op<MinExtremumOutIteratorT,
-                                  MinIndexOutIteratorT,
-                                  MaxExtremumOutIteratorT,
-                                  MaxIndexOutIteratorT>{d_min_out, d_min_index_out, d_max_out, d_max_index_out});
+    write_arg_minmax_result_op<MinExtremumOutIteratorT,
+                               MinIndexOutIteratorT,
+                               MaxExtremumOutIteratorT,
+                               MaxIndexOutIteratorT>{d_min_out, d_min_index_out, d_max_out, d_max_index_out});
 
   // Wrapped input iterator to produce index-value tuples, i.e., <PerPartitionOffsetT, InputT>-tuples
   using arg_index_input_iterator_t = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT, output_extremum_t>;

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
@@ -129,9 +129,9 @@ struct unzip_and_write_arg_extremum_op
 };
 
 // transform the KeyValuePair<OffsetT, T> produced by ArgIndexInputIterator to argminmax_accum_t<T, OffsetT>
-template <typename T, typename OffsetT>
 struct kvp_to_argminmax_accum
 {
+  template <typename T, typename OffsetT>
   _CCCL_HOST_DEVICE auto operator()(KeyValuePair<OffsetT, T> kv) const -> argminmax_accum_t<T, OffsetT>
   {
     return {kv.value, kv.value, kv.key, kv.key};
@@ -418,7 +418,6 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
   using input_value_t         = it_value_t<InputIteratorT>;
   using output_extremum_t     = non_void_value_t<MinExtremumOutIteratorT, input_value_t>;
   using per_partition_accum_t = argminmax_accum_t<output_extremum_t, PerPartitionOffsetT>;
-  using global_accum_t        = argminmax_accum_t<output_extremum_t, GlobalOffsetT>;
   using default_policy_selector_t =
     policy_selector_from_types<per_partition_accum_t, PerPartitionOffsetT, ReductionOpT>;
   using policy_selector_t =
@@ -427,24 +426,6 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
 #  if _CCCL_HAS_CONCEPTS()
   static_assert(reduce_policy_selector<policy_selector_t>);
 #  endif // _CCCL_HAS_CONCEPTS()
-
-  // Tabulate output iterator that unzips the result and writes to the four user-provided output iterators
-  auto d_result_out = ::cuda::make_tabulate_output_iterator(
-    write_arg_minmax_result_op<MinExtremumOutIteratorT,
-                               MinIndexOutIteratorT,
-                               MaxExtremumOutIteratorT,
-                               MaxIndexOutIteratorT>{d_min_out, d_min_index_out, d_max_out, d_max_index_out});
-
-  // Wrapped input iterator to produce index-value tuples, i.e., <PerPartitionOffsetT, InputT>-tuples
-  using arg_index_input_iterator_t = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT, output_extremum_t>;
-
-  // The local-to-global promotion operator
-  using local_to_global_op_t = local_to_global_minmax_op<GlobalOffsetT>;
-
-  arg_index_input_iterator_t d_indexed_offset_in(d_in);
-
-  // Transforms the per-partition result to a global result by adding the current partition's offset
-  local_to_global_op_t local_to_global_op{GlobalOffsetT{0}};
 
   // Upper bound at which we want to cut the input into multiple partitions. Align to 4096 bytes for performance
   static constexpr PerPartitionOffsetT max_offset_size = ::cuda::std::numeric_limits<PerPartitionOffsetT>::max();
@@ -459,32 +440,42 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
   const auto largest_partition_size =
     is_single_partition ? static_cast<PerPartitionOffsetT>(num_items) : max_partition_size;
 
-  // Reduction operator type that enables accumulating per-partition results to a global reduction result
-  using accumulating_transform_output_op_t =
-    accumulating_transform_output_op<global_accum_t, local_to_global_op_t, ReductionOpT, decltype(d_result_out)>;
-  auto accumulating_out_op = accumulating_transform_output_op_t{
-    true, is_single_partition, nullptr, nullptr, d_result_out, local_to_global_op, reduce_op};
+  // Transforms the per-partition result to a global result by adding the current partition's offset
+  auto local_to_global_op = local_to_global_minmax_op<GlobalOffsetT>{GlobalOffsetT{0}};
 
-  // For zero-length inputs, no output is written (per API contract); all actual partitions are non-empty
-  const auto initial_value = no_init;
+  // output iterator that splits the accumulator and writes to the four user-provided output iterators
+  auto d_result_out = ::cuda::make_tabulate_output_iterator(
+    write_arg_minmax_result_op<MinExtremumOutIteratorT,
+                               MinIndexOutIteratorT,
+                               MaxExtremumOutIteratorT,
+                               MaxIndexOutIteratorT>{d_min_out, d_min_index_out, d_max_out, d_max_index_out});
 
-  void* allocations[2]       = {nullptr, nullptr};
-  size_t allocation_sizes[2] = {0, 2 * sizeof(global_accum_t)};
+  auto d_indexed_in = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT, output_extremum_t>(d_in);
+
+  // reduction operator type that enables accumulating per-partition results to a global reduction result
+  using global_accum_t = argminmax_accum_t<output_extremum_t, GlobalOffsetT>;
+  auto accumulating_out_op =
+    accumulating_transform_output_op<global_accum_t, decltype(local_to_global_op), ReductionOpT, decltype(d_result_out)>{
+      true, is_single_partition, nullptr, nullptr, d_result_out, local_to_global_op, reduce_op};
 
   // Query temporary storage requirements for per-partition reduction
-  reduce::dispatch<per_partition_accum_t>(
-    nullptr,
-    allocation_sizes[0],
-    d_indexed_offset_in,
-    ::cuda::make_tabulate_output_iterator(accumulating_out_op),
-    static_cast<PerPartitionOffsetT>(largest_partition_size),
-    reduce_op,
-    initial_value,
-    stream,
-    kvp_to_argminmax_accum<output_extremum_t, PerPartitionOffsetT>{},
-    policy_selector_t{});
+  void* allocations[2]       = {nullptr, nullptr};
+  size_t allocation_sizes[2] = {0, 2 * sizeof(global_accum_t)};
+  if (const auto error = CubDebug(reduce::dispatch<per_partition_accum_t>(
+        nullptr,
+        allocation_sizes[0],
+        d_indexed_in,
+        ::cuda::make_tabulate_output_iterator(accumulating_out_op),
+        static_cast<PerPartitionOffsetT>(largest_partition_size),
+        reduce_op,
+        no_init,
+        stream,
+        kvp_to_argminmax_accum{},
+        policy_selector_t{})))
+  {
+    return error;
+  }
 
-  // Alias the temporary allocations from the single storage blob (or compute the necessary size of the blob)
   if (const auto error = CubDebug(alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
   {
     return error;
@@ -497,7 +488,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
   }
 
   // Pointer to the double-buffer of global accumulators, which aggregate cross-partition results
-  global_accum_t* const d_global_aggregates = static_cast<global_accum_t*>(allocations[1]);
+  const auto d_global_aggregates = static_cast<global_accum_t*>(allocations[1]);
 
   accumulating_out_op.d_previous_aggregate = d_global_aggregates;
   accumulating_out_op.d_aggregate_out      = d_global_aggregates + 1;
@@ -508,20 +499,19 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
     const GlobalOffsetT remaining_items = (num_items - current_partition_offset);
     const GlobalOffsetT current_num_items =
       (remaining_items < max_partition_size) ? remaining_items : max_partition_size;
+    d_indexed_in = {d_in + current_partition_offset};
 
-    d_indexed_offset_in = arg_index_input_iterator_t(d_in + current_partition_offset);
-
-    if (const auto error = reduce::dispatch<per_partition_accum_t>(
+    if (const auto error = CubDebug(reduce::dispatch<per_partition_accum_t>(
           d_temp_storage,
           temp_storage_bytes,
-          d_indexed_offset_in,
+          d_indexed_in,
           ::cuda::make_tabulate_output_iterator(accumulating_out_op),
           static_cast<PerPartitionOffsetT>(current_num_items),
           reduce_op,
-          initial_value,
+          no_init,
           stream,
-          kvp_to_argminmax_accum<output_extremum_t, PerPartitionOffsetT>{},
-          policy_selector_t{}))
+          kvp_to_argminmax_accum{},
+          policy_selector_t{})))
     {
       return error;
     }

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
@@ -225,7 +225,9 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_reduce
   cudaStream_t stream,
   const TuningEnvT& = {})
 {
-  using input_value_t             = detail::it_value_t<InputIteratorT>;
+  using input_value_t = detail::it_value_t<InputIteratorT>;
+  // TODO(bgruber): we should use the input_value_t in the accumulator and for comparison, and only covert when writing
+  // the final result
   using output_extremum_t         = detail::non_void_value_t<ExtremumOutIteratorT, input_value_t>;
   using default_policy_selector_t = detail::reduce::
     policy_selector_from_types<KeyValuePair<PerPartitionOffsetT, output_extremum_t>, PerPartitionOffsetT, ReductionOpT>;
@@ -416,8 +418,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
   const TuningEnvT& = {})
 {
   using input_value_t         = it_value_t<InputIteratorT>;
-  using output_extremum_t     = non_void_value_t<MinExtremumOutIteratorT, input_value_t>;
-  using per_partition_accum_t = argminmax_accum_t<output_extremum_t, PerPartitionOffsetT>;
+  using per_partition_accum_t = argminmax_accum_t<input_value_t, PerPartitionOffsetT>;
   using default_policy_selector_t =
     policy_selector_from_types<per_partition_accum_t, PerPartitionOffsetT, ReductionOpT>;
   using policy_selector_t =
@@ -450,10 +451,10 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
                                MaxExtremumOutIteratorT,
                                MaxIndexOutIteratorT>{d_min_out, d_min_index_out, d_max_out, d_max_index_out});
 
-  auto d_indexed_in = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT, output_extremum_t>(d_in);
+  auto d_indexed_in = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT>(d_in);
 
   // reduction operator type that enables accumulating per-partition results to a global reduction result
-  using global_accum_t = argminmax_accum_t<output_extremum_t, GlobalOffsetT>;
+  using global_accum_t = argminmax_accum_t<input_value_t, GlobalOffsetT>;
   auto accumulating_out_op =
     accumulating_transform_output_op<global_accum_t, decltype(local_to_global_op), ReductionOpT, decltype(d_result_out)>{
       true, is_single_partition, nullptr, nullptr, d_result_out, local_to_global_op, reduce_op};

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
@@ -128,6 +128,57 @@ struct unzip_and_write_arg_extremum_op
   }
 };
 
+// Transform: KeyValuePair<OffsetT, T> produced by ArgIndexInputIterator → argminmax_accum_t<T, OffsetT>
+template <typename T, typename OffsetT>
+struct kvp_to_argminmax_accum
+{
+  _CCCL_HOST_DEVICE detail::argminmax_accum_t<T, OffsetT> operator()(KeyValuePair<OffsetT, T> kv) const
+  {
+    return {kv.value, kv.value, kv.key, kv.key};
+  }
+};
+
+// Local-to-global promotion for ArgMinMax: adds the partition offset to both min_index and max_index
+template <typename GlobalOffsetT>
+struct local_to_global_minmax_op
+{
+  GlobalOffsetT current_partition_offset;
+
+  _CCCL_HOST_DEVICE void advance(GlobalOffsetT partition_size)
+  {
+    current_partition_offset += partition_size;
+  }
+
+  template <typename T, typename PerPartitionOffsetT>
+  _CCCL_HOST_DEVICE detail::argminmax_accum_t<T, GlobalOffsetT>
+  operator()(const detail::argminmax_accum_t<T, PerPartitionOffsetT>& p) const
+  {
+    return {p.min_value,
+            p.max_value,
+            current_partition_offset + static_cast<GlobalOffsetT>(p.min_index),
+            current_partition_offset + static_cast<GlobalOffsetT>(p.max_index)};
+  }
+};
+
+// Output operator: unzips a global argminmax_accum_t and writes to the four user-supplied iterators
+template <typename MinExtremumOutT, typename MinIndexOutT, typename MaxExtremumOutT, typename MaxIndexOutT>
+struct unzip_and_write_arg_minmax_op
+{
+  MinExtremumOutT min_out;
+  MinIndexOutT min_index_out;
+  MaxExtremumOutT max_out;
+  MaxIndexOutT max_index_out;
+
+  template <typename IndexT, typename ResultT>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void operator()(IndexT, ResultT result)
+  {
+    *min_out       = result.min_value;
+    *min_index_out = result.min_index;
+    *max_out       = result.max_value;
+    *max_index_out = result.max_index;
+  }
+};
+
 /******************************************************************************
  * Single-problem streaming reduction dispatch
  *****************************************************************************/
@@ -304,6 +355,180 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_reduce
           initial_value,
           stream,
           ::cuda::std::identity{},
+          policy_selector_t{}))
+    {
+      return error;
+    }
+
+    // Whether the next partition will be the last partition
+    const bool next_partition_is_last =
+      (remaining_items - current_num_items) <= static_cast<GlobalOffsetT>(max_partition_size);
+    accumulating_out_op.advance(current_num_items, next_partition_is_last);
+  }
+
+  return cudaSuccess;
+}
+// Internal dispatch routine for computing a device-wide combined argument minimum and maximum in a single pass.
+// Streaming, here, refers to the approach used for large number of items that are processed in multiple partitions.
+//
+// @tparam PerPartitionOffsetT
+//   Offset type used as the index to access items within one partition
+//
+// @tparam InputIteratorT
+//   Random-access input iterator type for reading input items @iterator
+//
+// @tparam MinExtremumOutIteratorT
+//   Output iterator type for writing the minimum value
+//
+// @tparam MinIndexOutIteratorT
+//   Output iterator type for writing the index of the minimum value
+//
+// @tparam MaxExtremumOutIteratorT
+//   Output iterator type for writing the maximum value
+//
+// @tparam MaxIndexOutIteratorT
+//   Output iterator type for writing the index of the maximum value
+//
+// @tparam GlobalOffsetT
+//   Offset type used as the index to access items within the total input range
+//
+// @tparam TuningEnvT
+//   Tuning environment type
+//
+template <typename PerPartitionOffsetT,
+          typename InputIteratorT,
+          typename MinExtremumOutIteratorT,
+          typename MinIndexOutIteratorT,
+          typename MaxExtremumOutIteratorT,
+          typename MaxIndexOutIteratorT,
+          typename GlobalOffsetT,
+          typename TuningEnvT>
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax(
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  InputIteratorT d_in,
+  MinExtremumOutIteratorT d_min_out,
+  MinIndexOutIteratorT d_min_index_out,
+  MaxExtremumOutIteratorT d_max_out,
+  MaxIndexOutIteratorT d_max_index_out,
+  GlobalOffsetT num_items,
+  cudaStream_t stream,
+  const TuningEnvT& = {})
+{
+  using input_value_t     = detail::it_value_t<InputIteratorT>;
+  using output_extremum_t = detail::non_void_value_t<MinExtremumOutIteratorT, input_value_t>;
+
+  using reduce_op_t = detail::arg_minmax_reduce_op<>;
+
+  using per_partition_accum_t = detail::argminmax_accum_t<output_extremum_t, PerPartitionOffsetT>;
+  using global_accum_t        = detail::argminmax_accum_t<output_extremum_t, GlobalOffsetT>;
+
+  using default_policy_selector_t =
+    detail::reduce::policy_selector_from_types<per_partition_accum_t, PerPartitionOffsetT, reduce_op_t>;
+  using default_policy_t = decltype(default_policy_selector_t{}(::cuda::compute_capability{}));
+  using policy_selector_t =
+    ::cuda::std::execution::__query_result_or_t<TuningEnvT, ReducePolicy, default_policy_selector_t>;
+
+#  if _CCCL_HAS_CONCEPTS()
+  static_assert(reduce_policy_selector<policy_selector_t>);
+#  endif // _CCCL_HAS_CONCEPTS()
+
+  // Tabulate output iterator that unzips the result and writes to the four user-provided output iterators
+  auto d_result_out = ::cuda::make_tabulate_output_iterator(
+    unzip_and_write_arg_minmax_op<MinExtremumOutIteratorT,
+                                  MinIndexOutIteratorT,
+                                  MaxExtremumOutIteratorT,
+                                  MaxIndexOutIteratorT>{d_min_out, d_min_index_out, d_max_out, d_max_index_out});
+
+  // Wrapped input iterator to produce index-value tuples, i.e., <PerPartitionOffsetT, InputT>-tuples
+  using arg_index_input_iterator_t = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT, output_extremum_t>;
+
+  // The local-to-global promotion operator
+  using local_to_global_op_t = local_to_global_minmax_op<GlobalOffsetT>;
+
+  arg_index_input_iterator_t d_indexed_offset_in(d_in);
+
+  // The reduction operator (fixed to the default less<> comparator)
+  reduce_op_t reduce_op{};
+
+  // Transforms the per-partition result to a global result by adding the current partition's offset
+  local_to_global_op_t local_to_global_op{GlobalOffsetT{0}};
+
+  // Upper bound at which we want to cut the input into multiple partitions. Align to 4096 bytes for performance
+  static constexpr PerPartitionOffsetT max_offset_size = ::cuda::std::numeric_limits<PerPartitionOffsetT>::max();
+  static constexpr PerPartitionOffsetT max_partition_size =
+    max_offset_size - (max_offset_size % PerPartitionOffsetT{4096});
+
+  // Whether the given number of items fits into a single partition
+  const bool is_single_partition =
+    static_cast<GlobalOffsetT>(max_partition_size) >= static_cast<GlobalOffsetT>(num_items);
+
+  // The largest partition size ever encountered
+  const auto largest_partition_size =
+    is_single_partition ? static_cast<PerPartitionOffsetT>(num_items) : max_partition_size;
+
+  // Reduction operator type that enables accumulating per-partition results to a global reduction result
+  using accumulating_transform_output_op_t =
+    accumulating_transform_output_op<global_accum_t, local_to_global_op_t, reduce_op_t, decltype(d_result_out)>;
+  auto accumulating_out_op = accumulating_transform_output_op_t{
+    true, is_single_partition, nullptr, nullptr, d_result_out, local_to_global_op, reduce_op};
+
+  // For zero-length inputs, no output is written (per API contract); all actual partitions are non-empty
+  const auto initial_value = no_init;
+
+  void* allocations[2]       = {nullptr, nullptr};
+  size_t allocation_sizes[2] = {0, 2 * sizeof(global_accum_t)};
+
+  // Query temporary storage requirements for per-partition reduction
+  reduce::dispatch<per_partition_accum_t>(
+    nullptr,
+    allocation_sizes[0],
+    d_indexed_offset_in,
+    ::cuda::make_tabulate_output_iterator(accumulating_out_op),
+    static_cast<PerPartitionOffsetT>(largest_partition_size),
+    reduce_op,
+    initial_value,
+    stream,
+    kvp_to_argminmax_accum<output_extremum_t, PerPartitionOffsetT>{},
+    policy_selector_t{});
+
+  // Alias the temporary allocations from the single storage blob (or compute the necessary size of the blob)
+  if (const auto error = CubDebug(alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
+  {
+    return error;
+  }
+
+  // Return if the caller is simply requesting the size of the storage allocation
+  if (d_temp_storage == nullptr)
+  {
+    return cudaSuccess;
+  }
+
+  // Pointer to the double-buffer of global accumulators, which aggregate cross-partition results
+  global_accum_t* const d_global_aggregates = static_cast<global_accum_t*>(allocations[1]);
+
+  accumulating_out_op.d_previous_aggregate = d_global_aggregates;
+  accumulating_out_op.d_aggregate_out      = d_global_aggregates + 1;
+
+  for (GlobalOffsetT current_partition_offset = 0; current_partition_offset < static_cast<GlobalOffsetT>(num_items);
+       current_partition_offset += static_cast<GlobalOffsetT>(max_partition_size))
+  {
+    const GlobalOffsetT remaining_items = (num_items - current_partition_offset);
+    const GlobalOffsetT current_num_items =
+      (remaining_items < max_partition_size) ? remaining_items : max_partition_size;
+
+    d_indexed_offset_in = arg_index_input_iterator_t(d_in + current_partition_offset);
+
+    if (const auto error = reduce::dispatch<per_partition_accum_t>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_indexed_offset_in,
+          ::cuda::make_tabulate_output_iterator(accumulating_out_op),
+          static_cast<PerPartitionOffsetT>(current_num_items),
+          reduce_op,
+          initial_value,
+          stream,
+          kvp_to_argminmax_accum<output_extremum_t, PerPartitionOffsetT>{},
           policy_selector_t{}))
     {
       return error;

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
@@ -400,6 +400,7 @@ template <typename PerPartitionOffsetT,
           typename MaxExtremumOutIteratorT,
           typename MaxIndexOutIteratorT,
           typename GlobalOffsetT,
+          typename ReductionOpT,
           typename TuningEnvT>
 CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax(
   void* d_temp_storage,
@@ -410,15 +411,16 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
   MaxExtremumOutIteratorT d_max_out,
   MaxIndexOutIteratorT d_max_index_out,
   GlobalOffsetT num_items,
+  ReductionOpT reduce_op,
   cudaStream_t stream,
   const TuningEnvT& = {})
 {
-  using input_value_t             = it_value_t<InputIteratorT>;
-  using output_extremum_t         = non_void_value_t<MinExtremumOutIteratorT, input_value_t>;
-  using reduce_op_t               = arg_minmax_reduce_op<>;
-  using per_partition_accum_t     = argminmax_accum_t<output_extremum_t, PerPartitionOffsetT>;
-  using global_accum_t            = argminmax_accum_t<output_extremum_t, GlobalOffsetT>;
-  using default_policy_selector_t = policy_selector_from_types<per_partition_accum_t, PerPartitionOffsetT, reduce_op_t>;
+  using input_value_t         = it_value_t<InputIteratorT>;
+  using output_extremum_t     = non_void_value_t<MinExtremumOutIteratorT, input_value_t>;
+  using per_partition_accum_t = argminmax_accum_t<output_extremum_t, PerPartitionOffsetT>;
+  using global_accum_t        = argminmax_accum_t<output_extremum_t, GlobalOffsetT>;
+  using default_policy_selector_t =
+    policy_selector_from_types<per_partition_accum_t, PerPartitionOffsetT, ReductionOpT>;
   using policy_selector_t =
     ::cuda::std::execution::__query_result_or_t<TuningEnvT, ReducePolicy, default_policy_selector_t>;
 
@@ -441,9 +443,6 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
 
   arg_index_input_iterator_t d_indexed_offset_in(d_in);
 
-  // The reduction operator (fixed to the default less<> comparator)
-  reduce_op_t reduce_op{};
-
   // Transforms the per-partition result to a global result by adding the current partition's offset
   local_to_global_op_t local_to_global_op{GlobalOffsetT{0}};
 
@@ -462,7 +461,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
 
   // Reduction operator type that enables accumulating per-partition results to a global reduction result
   using accumulating_transform_output_op_t =
-    accumulating_transform_output_op<global_accum_t, local_to_global_op_t, reduce_op_t, decltype(d_result_out)>;
+    accumulating_transform_output_op<global_accum_t, local_to_global_op_t, ReductionOpT, decltype(d_result_out)>;
   auto accumulating_out_op = accumulating_transform_output_op_t{
     true, is_single_partition, nullptr, nullptr, d_result_out, local_to_global_op, reduce_op};
 

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
@@ -183,6 +183,131 @@ struct write_arg_minmax_result_op
  * Single-problem streaming reduction dispatch
  *****************************************************************************/
 
+template <typename PerPartitionAccumT,
+          typename GlobalAccumT,
+          typename PerPartitionOffsetT,
+          typename ArgIndexInputIteratorT,
+          typename InputIteratorT,
+          typename ResultOutIteratorT,
+          typename GlobalOffsetT,
+          typename ReductionOpT,
+          typename TransformOpT,
+          typename InitValueT,
+          typename PromoteToGlobalOpT,
+          typename TuningEnvT>
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_reduce_impl(
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  InputIteratorT d_in,
+  ResultOutIteratorT d_result_out,
+  GlobalOffsetT num_items,
+  ReductionOpT reduce_op,
+  TransformOpT transform_op,
+  InitValueT init_value,
+  PromoteToGlobalOpT promote_op,
+  cudaStream_t stream,
+  const TuningEnvT& = {})
+{
+  // Resolve the tuning policy from the (optional) tuning environment, defaulting to the type-derived policy
+  using default_policy_selector_t = policy_selector_from_types<PerPartitionAccumT, PerPartitionOffsetT, ReductionOpT>;
+  using policy_selector_t =
+    ::cuda::std::execution::__query_result_or_t<TuningEnvT, ReducePolicy, default_policy_selector_t>;
+
+#  if _CCCL_HAS_CONCEPTS()
+  static_assert(reduce_policy_selector<policy_selector_t>);
+#  endif // _CCCL_HAS_CONCEPTS()
+
+  // Upper bound at which we want to cut the input into multiple partitions. Align to 4096 bytes for performance reasons
+  static constexpr PerPartitionOffsetT max_offset_size = ::cuda::std::numeric_limits<PerPartitionOffsetT>::max();
+  static constexpr PerPartitionOffsetT max_partition_size =
+    max_offset_size - (max_offset_size % PerPartitionOffsetT{4096});
+
+  // Whether the given number of items fits into a single partition
+  const bool is_single_partition =
+    static_cast<GlobalOffsetT>(max_partition_size) >= static_cast<GlobalOffsetT>(num_items);
+
+  // The largest partition size ever encountered
+  const auto largest_partition_size =
+    is_single_partition ? static_cast<PerPartitionOffsetT>(num_items) : max_partition_size;
+
+  // The current partition's input iterator is an ArgIndex iterator that generates indices relative to the beginning of
+  // the current partition, i.e., [0, partition_size), offset by the current partition's offset
+  ArgIndexInputIteratorT d_indexed_in(d_in);
+
+  // Reduction operator that enables accumulating per-partition results to a global reduction result
+  auto accumulating_out_op =
+    accumulating_transform_output_op<GlobalAccumT, PromoteToGlobalOpT, ReductionOpT, ResultOutIteratorT>{
+      true, is_single_partition, nullptr, nullptr, d_result_out, promote_op, reduce_op};
+
+  // Query temporary storage requirements for per-partition reduction
+  void* allocations[2]       = {nullptr, nullptr};
+  size_t allocation_sizes[2] = {0, 2 * sizeof(GlobalAccumT)};
+  if (const auto error = CubDebug(reduce::dispatch<PerPartitionAccumT>(
+        nullptr,
+        allocation_sizes[0],
+        d_indexed_in,
+        ::cuda::make_tabulate_output_iterator(accumulating_out_op),
+        static_cast<PerPartitionOffsetT>(largest_partition_size),
+        reduce_op,
+        init_value,
+        stream,
+        transform_op,
+        policy_selector_t{})))
+  {
+    return error;
+  }
+
+  // Alias the temporary allocations from the single storage blob (or compute the necessary size of the blob)
+  if (const auto error = CubDebug(alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
+  {
+    return error;
+  }
+
+  // Return if the caller is simply requesting the size of the storage allocation
+  if (d_temp_storage == nullptr)
+  {
+    return cudaSuccess;
+  }
+
+  // Pointer to the double-buffer of global accumulators, which aggregate cross-partition results
+  GlobalAccumT* const d_global_aggregates = static_cast<GlobalAccumT*>(allocations[1]);
+
+  accumulating_out_op.d_previous_aggregate = d_global_aggregates;
+  accumulating_out_op.d_aggregate_out      = d_global_aggregates + 1;
+
+  for (GlobalOffsetT current_partition_offset = 0; current_partition_offset < static_cast<GlobalOffsetT>(num_items);
+       current_partition_offset += static_cast<GlobalOffsetT>(max_partition_size))
+  {
+    const GlobalOffsetT remaining_items = (num_items - current_partition_offset);
+    const GlobalOffsetT current_num_items =
+      (remaining_items < max_partition_size) ? remaining_items : max_partition_size;
+
+    d_indexed_in = ArgIndexInputIteratorT(d_in + current_partition_offset);
+
+    if (const auto error = CubDebug(reduce::dispatch<PerPartitionAccumT>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_indexed_in,
+          ::cuda::make_tabulate_output_iterator(accumulating_out_op),
+          static_cast<PerPartitionOffsetT>(current_num_items),
+          reduce_op,
+          init_value,
+          stream,
+          transform_op,
+          policy_selector_t{})))
+    {
+      return error;
+    }
+
+    // Whether the next partition will be the last partition
+    const bool next_partition_is_last =
+      (remaining_items - current_num_items) <= static_cast<GlobalOffsetT>(max_partition_size);
+    accumulating_out_op.advance(current_num_items, next_partition_is_last);
+  }
+
+  return cudaSuccess;
+}
+
 // Internal dispatch routine for computing a device-wide argument extremum, like `ArgMin` and `ArgMax`.
 // Streaming, here, refers to the approach used for large number of items that are processed in multiple partitions.
 //
@@ -224,65 +349,21 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_reduce
   GlobalOffsetT num_items,
   ReductionOpT reduce_op,
   cudaStream_t stream,
-  const TuningEnvT& = {})
+  const TuningEnvT& tuning_env = {})
 {
   using input_value_t = detail::it_value_t<InputIteratorT>;
   // TODO(bgruber): we should use the input_value_t in the accumulator and for comparison, and only covert when writing
   // the final result
-  using output_extremum_t         = detail::non_void_value_t<ExtremumOutIteratorT, input_value_t>;
-  using default_policy_selector_t = detail::reduce::
-    policy_selector_from_types<KeyValuePair<PerPartitionOffsetT, output_extremum_t>, PerPartitionOffsetT, ReductionOpT>;
-  using policy_selector_t =
-    ::cuda::std::execution::__query_result_or_t<TuningEnvT, ReducePolicy, default_policy_selector_t>;
+  using output_extremum_t     = detail::non_void_value_t<ExtremumOutIteratorT, input_value_t>;
+  using per_partition_accum_t = KeyValuePair<PerPartitionOffsetT, output_extremum_t>;
+  using global_accum_t        = KeyValuePair<GlobalOffsetT, output_extremum_t>;
 
-#  if _CCCL_HAS_CONCEPTS()
-  static_assert(reduce_policy_selector<policy_selector_t>);
-#  endif // _CCCL_HAS_CONCEPTS()
+  // Wrapped input iterator to produce index-value tuples, i.e., <PerPartitionOffsetT, InputT>-tuples
+  using arg_index_input_iterator_t = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT, output_extremum_t>;
 
   // Tabulate output iterator that unzips the result and writes it to the user-provided output iterators
   auto d_result_out = ::cuda::make_tabulate_output_iterator(
     detail::reduce::unzip_and_write_arg_extremum_op<ExtremumOutIteratorT, IndexOutIteratorT>{d_min_out, d_index_out});
-
-  // Wrapped input iterator to produce index-value tuples, i.e., <PerPartitionOffsetT, InputT>-tuples
-  // We make sure to offset the user-provided input iterator by the current partition's offset
-  using arg_index_input_iterator_t = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT, output_extremum_t>;
-
-  // The output tuple type (i.e., extremum plus index tuples)
-  using per_partition_accum_t = KeyValuePair<PerPartitionOffsetT, output_extremum_t>;
-  using global_accum_t        = KeyValuePair<GlobalOffsetT, output_extremum_t>;
-
-  // Unary promotion operator type that is used to transform a per-partition result to a global result
-  // operator()(per_partition_accum_t) -> global_accum_t
-  using local_to_global_op_t = local_to_global_op<GlobalOffsetT>;
-
-  // The current partition's input iterator is an ArgIndex iterator that generates indices relative to the beginning
-  // of the current partition, i.e., [0, partition_size) along with an OffsetIterator that offsets the user-provided
-  // input iterator by the current partition's offset
-  arg_index_input_iterator_t d_indexed_offset_in(d_in);
-
-  // Transforms the per-partition result to a global result by adding the current partition's offset to the arg result
-  // of a partition
-  local_to_global_op_t local_to_global_op{GlobalOffsetT{0}};
-
-  // Upper bound at which we want to cut the input into multiple partitions. Align to 4096 bytes for performance
-  // reasons
-  static constexpr PerPartitionOffsetT max_offset_size = ::cuda::std::numeric_limits<PerPartitionOffsetT>::max();
-  static constexpr PerPartitionOffsetT max_partition_size =
-    max_offset_size - (max_offset_size % PerPartitionOffsetT{4096});
-
-  // Whether the given number of items fits into a single partition
-  const bool is_single_partition =
-    static_cast<GlobalOffsetT>(max_partition_size) >= static_cast<GlobalOffsetT>(num_items);
-
-  // The largest partition size ever encountered
-  const auto largest_partition_size =
-    is_single_partition ? static_cast<PerPartitionOffsetT>(num_items) : max_partition_size;
-
-  // Reduction operator type that enables accumulating per-partition results to a global reduction result
-  using accumulating_transform_output_op_t =
-    accumulating_transform_output_op<global_accum_t, local_to_global_op_t, ReductionOpT, decltype(d_result_out)>;
-  auto accumulating_out_op = accumulating_transform_output_op_t{
-    true, is_single_partition, nullptr, nullptr, d_result_out, local_to_global_op, reduce_op};
 
   // Initial value for empty problems, according to documented contract
   const auto empty_problem_extremum = static_cast<output_extremum_t>([] {
@@ -303,72 +384,23 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_reduce
   }());
   auto initial_value = empty_problem_init_t<per_partition_accum_t>{{PerPartitionOffsetT{1}, empty_problem_extremum}};
 
-  void* allocations[2]       = {nullptr, nullptr};
-  size_t allocation_sizes[2] = {0, 2 * sizeof(global_accum_t)};
-
-  // Query temporary storage requirements for per-partition reduction
-  reduce::dispatch<per_partition_accum_t>(
-    nullptr,
-    allocation_sizes[0],
-    d_indexed_offset_in,
-    ::cuda::make_tabulate_output_iterator(accumulating_out_op),
-    static_cast<PerPartitionOffsetT>(largest_partition_size),
+  return dispatch_streaming_arg_reduce_impl<per_partition_accum_t,
+                                            global_accum_t,
+                                            PerPartitionOffsetT,
+                                            arg_index_input_iterator_t>(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in,
+    d_result_out,
+    num_items,
     reduce_op,
-    initial_value,
-    stream,
     ::cuda::std::identity{},
-    policy_selector_t{});
-
-  // Alias the temporary allocations from the single storage blob (or compute the necessary size of the blob)
-  if (const auto error = CubDebug(alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
-  {
-    return error;
-  }
-
-  // Return if the caller is simply requesting the size of the storage allocation
-  if (d_temp_storage == nullptr)
-  {
-    return cudaSuccess;
-  }
-
-  // Pointer to the double-buffer of global accumulators, which aggregate cross-partition results
-  global_accum_t* const d_global_aggregates = static_cast<global_accum_t*>(allocations[1]);
-
-  accumulating_out_op.d_previous_aggregate = d_global_aggregates;
-  accumulating_out_op.d_aggregate_out      = d_global_aggregates + 1;
-
-  for (GlobalOffsetT current_partition_offset = 0; current_partition_offset < static_cast<GlobalOffsetT>(num_items);
-       current_partition_offset += static_cast<GlobalOffsetT>(max_partition_size))
-  {
-    const GlobalOffsetT remaining_items = (num_items - current_partition_offset);
-    const GlobalOffsetT current_num_items =
-      (remaining_items < max_partition_size) ? remaining_items : max_partition_size;
-
-    d_indexed_offset_in = arg_index_input_iterator_t(d_in + current_partition_offset);
-
-    if (const auto error = reduce::dispatch<per_partition_accum_t>(
-          d_temp_storage,
-          temp_storage_bytes,
-          d_indexed_offset_in,
-          ::cuda::make_tabulate_output_iterator(accumulating_out_op),
-          static_cast<PerPartitionOffsetT>(current_num_items),
-          reduce_op,
-          initial_value,
-          stream,
-          ::cuda::std::identity{},
-          policy_selector_t{}))
-    {
-      return error;
-    }
-
-    // Whether the next partition will be the last partition
-    const bool next_partition_is_last =
-      (remaining_items - current_num_items) <= static_cast<GlobalOffsetT>(max_partition_size);
-    accumulating_out_op.advance(current_num_items, next_partition_is_last);
-  }
-
-  return cudaSuccess;
+    initial_value,
+    local_to_global_op<GlobalOffsetT>{GlobalOffsetT{0}},
+    stream,
+    tuning_env);
 }
+
 // Internal dispatch routine for computing a device-wide combined argument minimum and maximum in a single pass.
 // Streaming, here, refers to the approach used for large number of items that are processed in multiple partitions.
 //
@@ -416,34 +448,13 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
   GlobalOffsetT num_items,
   ReductionOpT reduce_op,
   cudaStream_t stream,
-  const TuningEnvT& = {})
+  const TuningEnvT& tuning_env = {})
 {
   using input_value_t         = it_value_t<InputIteratorT>;
   using per_partition_accum_t = argminmax_accum_t<input_value_t, PerPartitionOffsetT>;
-  using default_policy_selector_t =
-    policy_selector_from_types<per_partition_accum_t, PerPartitionOffsetT, ReductionOpT>;
-  using policy_selector_t =
-    ::cuda::std::execution::__query_result_or_t<TuningEnvT, ReducePolicy, default_policy_selector_t>;
+  using global_accum_t        = argminmax_accum_t<input_value_t, GlobalOffsetT>;
 
-#  if _CCCL_HAS_CONCEPTS()
-  static_assert(reduce_policy_selector<policy_selector_t>);
-#  endif // _CCCL_HAS_CONCEPTS()
-
-  // Upper bound at which we want to cut the input into multiple partitions. Align to 4096 bytes for performance
-  static constexpr PerPartitionOffsetT max_offset_size = ::cuda::std::numeric_limits<PerPartitionOffsetT>::max();
-  static constexpr PerPartitionOffsetT max_partition_size =
-    max_offset_size - (max_offset_size % PerPartitionOffsetT{4096});
-
-  // Whether the given number of items fits into a single partition
-  const bool is_single_partition =
-    static_cast<GlobalOffsetT>(max_partition_size) >= static_cast<GlobalOffsetT>(num_items);
-
-  // The largest partition size ever encountered
-  const auto largest_partition_size =
-    is_single_partition ? static_cast<PerPartitionOffsetT>(num_items) : max_partition_size;
-
-  // Transforms the per-partition result to a global result by adding the current partition's offset
-  auto local_to_global_op = local_to_global_minmax_op<GlobalOffsetT>{GlobalOffsetT{0}};
+  using arg_index_input_iterator_t = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT>;
 
   // output iterator that splits the accumulator and writes to the four user-provided output iterators
   auto d_result_out = ::cuda::make_tabulate_output_iterator(
@@ -452,79 +463,21 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_minmax
                                MaxExtremumOutIteratorT,
                                MaxIndexOutIteratorT>{d_min_out, d_min_index_out, d_max_out, d_max_index_out});
 
-  auto d_indexed_in = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT>(d_in);
-
-  // reduction operator type that enables accumulating per-partition results to a global reduction result
-  using global_accum_t = argminmax_accum_t<input_value_t, GlobalOffsetT>;
-  auto accumulating_out_op =
-    accumulating_transform_output_op<global_accum_t, decltype(local_to_global_op), ReductionOpT, decltype(d_result_out)>{
-      true, is_single_partition, nullptr, nullptr, d_result_out, local_to_global_op, reduce_op};
-
-  // Query temporary storage requirements for per-partition reduction
-  void* allocations[2]       = {nullptr, nullptr};
-  size_t allocation_sizes[2] = {0, 2 * sizeof(global_accum_t)};
-  if (const auto error = CubDebug(reduce::dispatch<per_partition_accum_t>(
-        nullptr,
-        allocation_sizes[0],
-        d_indexed_in,
-        ::cuda::make_tabulate_output_iterator(accumulating_out_op),
-        static_cast<PerPartitionOffsetT>(largest_partition_size),
-        reduce_op,
-        no_init,
-        stream,
-        kvp_to_argminmax_accum{},
-        policy_selector_t{})))
-  {
-    return error;
-  }
-
-  if (const auto error = CubDebug(alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
-  {
-    return error;
-  }
-
-  // Return if the caller is simply requesting the size of the storage allocation
-  if (d_temp_storage == nullptr)
-  {
-    return cudaSuccess;
-  }
-
-  // Pointer to the double-buffer of global accumulators, which aggregate cross-partition results
-  const auto d_global_aggregates = static_cast<global_accum_t*>(allocations[1]);
-
-  accumulating_out_op.d_previous_aggregate = d_global_aggregates;
-  accumulating_out_op.d_aggregate_out      = d_global_aggregates + 1;
-
-  for (GlobalOffsetT current_partition_offset = 0; current_partition_offset < static_cast<GlobalOffsetT>(num_items);
-       current_partition_offset += static_cast<GlobalOffsetT>(max_partition_size))
-  {
-    const GlobalOffsetT remaining_items = (num_items - current_partition_offset);
-    const GlobalOffsetT current_num_items =
-      (remaining_items < max_partition_size) ? remaining_items : max_partition_size;
-    d_indexed_in = {d_in + current_partition_offset};
-
-    if (const auto error = CubDebug(reduce::dispatch<per_partition_accum_t>(
-          d_temp_storage,
-          temp_storage_bytes,
-          d_indexed_in,
-          ::cuda::make_tabulate_output_iterator(accumulating_out_op),
-          static_cast<PerPartitionOffsetT>(current_num_items),
-          reduce_op,
-          no_init,
-          stream,
-          kvp_to_argminmax_accum{},
-          policy_selector_t{})))
-    {
-      return error;
-    }
-
-    // Whether the next partition will be the last partition
-    const bool next_partition_is_last =
-      (remaining_items - current_num_items) <= static_cast<GlobalOffsetT>(max_partition_size);
-    accumulating_out_op.advance(current_num_items, next_partition_is_last);
-  }
-
-  return cudaSuccess;
+  return dispatch_streaming_arg_reduce_impl<per_partition_accum_t,
+                                            global_accum_t,
+                                            PerPartitionOffsetT,
+                                            arg_index_input_iterator_t>(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in,
+    d_result_out,
+    num_items,
+    reduce_op,
+    kvp_to_argminmax_accum{},
+    no_init,
+    local_to_global_minmax_op<GlobalOffsetT>{GlobalOffsetT{0}},
+    stream,
+    tuning_env);
 }
 } // namespace detail::reduce
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
@@ -151,7 +151,7 @@ struct local_to_global_minmax_op
   }
 
   template <typename T, typename PerPartitionOffsetT>
-  _CCCL_HOST_DEVICE detail::argminmax_accum_t<T, GlobalOffsetT>
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE detail::argminmax_accum_t<T, GlobalOffsetT>
   operator()(const detail::argminmax_accum_t<T, PerPartitionOffsetT>& p) const
   {
     return {p.min_value,

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
@@ -132,7 +132,8 @@ struct unzip_and_write_arg_extremum_op
 struct kvp_to_argminmax_accum
 {
   template <typename T, typename OffsetT>
-  _CCCL_HOST_DEVICE auto operator()(KeyValuePair<OffsetT, T> kv) const -> argminmax_accum_t<T, OffsetT>
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE auto operator()(KeyValuePair<OffsetT, T> kv) const
+    -> argminmax_accum_t<T, OffsetT>
   {
     return {kv.value, kv.value, kv.key, kv.key};
   }

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -170,8 +170,9 @@ struct argminmax_accum_t
   IndexT max_index;
 };
 
-//! @brief Reduction operator for ArgMinMax: first minimum (smallest index on tie), last maximum (largest index on tie).
-template <typename CompareOpT = ::cuda::std::less<>>
+//! @brief Reduction operator for ArgMinMax: selects the first minimum (smallest index on tie) and, if LastMax is true,
+//! the last maximum (largest index on tie), otherwise the first maximum.
+template <typename CompareOpT = ::cuda::std::less<>, bool LastMax = false>
 struct arg_minmax_reduce_op : CompareOpT
 {
   template <typename T, typename IndexT>
@@ -186,8 +187,9 @@ struct arg_minmax_reduce_op : CompareOpT
       result.min_value = b.min_value;
       result.min_index = b.min_index;
     }
-    // last maximum: strictly greater wins; ties keep the larger index
-    if (less(a.max_value, b.max_value) || (!less(b.max_value, a.max_value) && b.max_index > a.max_index))
+    // maximum: strictly greater wins; ties keep the smaller index (first max) or larger index (last max)
+    const bool b_wins_tie = LastMax ? b.max_index > a.max_index : b.max_index < a.max_index;
+    if (less(a.max_value, b.max_value) || (!less(b.max_value, a.max_value) && b_wins_tie))
     {
       result.max_value = b.max_value;
       result.max_index = b.max_index;

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -199,9 +199,6 @@ struct arg_minmax_reduce_op : CompareOpT
 template <typename CompareOpT>
 arg_minmax_reduce_op(CompareOpT) -> arg_minmax_reduce_op<CompareOpT>;
 
-//! @brief Arg minmax functor using the default less-than comparator
-using arg_minmax = arg_minmax_reduce_op<>;
-
 template <typename ScanOpT>
 struct ScanBySegmentOp
 {

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -161,6 +161,47 @@ _CCCL_DEDUCTION_GUIDE_ATTRIBUTES swap_args(Predicate) -> swap_args<Predicate>;
 /// @brief Arg max functor (keeps the value and offset of the first occurrence of the larger item)
 using arg_max = arg_reduce_op<swap_args<::cuda::std::less<>>>;
 
+template <typename T, typename IndexT>
+struct argminmax_accum_t
+{
+  T min_value;
+  T max_value;
+  IndexT min_index;
+  IndexT max_index;
+};
+
+//! @brief Reduction operator for ArgMinMax: first minimum (smallest index on tie), last maximum (largest index on tie).
+template <typename CompareOpT = ::cuda::std::less<>>
+struct arg_minmax_reduce_op : CompareOpT
+{
+  template <typename T, typename IndexT>
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE argminmax_accum_t<T, IndexT>
+  operator()(const argminmax_accum_t<T, IndexT>& a, const argminmax_accum_t<T, IndexT>& b) const
+  {
+    const auto& less = static_cast<const CompareOpT&>(*this);
+    auto result      = a;
+    // first minimum: strictly smaller wins; ties keep the smaller index
+    if (less(b.min_value, a.min_value) || (!less(a.min_value, b.min_value) && b.min_index < a.min_index))
+    {
+      result.min_value = b.min_value;
+      result.min_index = b.min_index;
+    }
+    // last maximum: strictly greater wins; ties keep the larger index
+    if (less(a.max_value, b.max_value) || (!less(b.max_value, a.max_value) && b.max_index > a.max_index))
+    {
+      result.max_value = b.max_value;
+      result.max_index = b.max_index;
+    }
+    return result;
+  }
+};
+
+template <typename CompareOpT>
+arg_minmax_reduce_op(CompareOpT) -> arg_minmax_reduce_op<CompareOpT>;
+
+//! @brief Arg minmax functor using the default less-than comparator
+using arg_minmax = arg_minmax_reduce_op<>;
+
 template <typename ScanOpT>
 struct ScanBySegmentOp
 {

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -199,7 +199,7 @@ struct arg_minmax_reduce_op : CompareOpT
 };
 
 template <typename CompareOpT>
-arg_minmax_reduce_op(CompareOpT) -> arg_minmax_reduce_op<CompareOpT>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES arg_minmax_reduce_op(CompareOpT) -> arg_minmax_reduce_op<CompareOpT>;
 
 template <typename ScanOpT>
 struct ScanBySegmentOp

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "insert_nested_NVTX_range_guard.h"
 

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -25,6 +25,7 @@
 #include <c2h/extended_types.h>
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMinMax, device_arg_minmax);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMinLastMax, device_arg_minlastmax);
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -110,6 +111,47 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax basic correctness", "[reduce][arg_mi
   REQUIRE(max_index[0] == 0);
 }
 
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax basic correctness", "[reduce][arg_minlastmax]", CUB_SMALL)
+{
+  auto input     = thrust::device_vector<int>{8, 6, -7, 5, 3, 1, -9};
+  auto min_out   = thrust::device_vector<int>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<int>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+
+  auto error = cub::DeviceReduce::ArgMinLastMax(
+    d_temp_storage,
+    temp_storage_bytes,
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+  REQUIRE(error == cudaSuccess);
+
+  thrust::device_vector<char> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  error = cub::DeviceReduce::ArgMinLastMax(
+    d_temp_storage,
+    temp_storage_bytes,
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == -9);
+  REQUIRE(min_index[0] == 6);
+  REQUIRE(max_out[0] == 8);
+  REQUIRE(max_index[0] == 0);
+}
+
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles zero-length input", "[reduce][arg_minmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<int>{};
@@ -120,6 +162,25 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles zero-length input", "[reduce
 
   // For zero-length inputs, no output is written; just verify it does not crash.
   auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+  REQUIRE(error == cudaSuccess);
+}
+
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax handles zero-length input", "[reduce][arg_minlastmax]", CUB_SMALL)
+{
+  auto input     = thrust::device_vector<int>{};
+  auto min_out   = thrust::device_vector<int>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<int>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  // For zero-length inputs, no output is written; just verify it does not crash.
+  auto error = cub::DeviceReduce::ArgMinLastMax(
     input.begin(),
     min_out.begin(),
     min_index.begin(),
@@ -142,6 +203,34 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax accepts run_to_run determinism requi
   auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
 
   auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()),
+    env);
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}
+
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax accepts run_to_run determinism requirements",
+              "[reduce][arg_minlastmax]",
+              CUB_SMALL)
+{
+  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = thrust::device_vector<float>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<float>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
+
+  auto error = cub::DeviceReduce::ArgMinLastMax(
     input.begin(),
     min_out.begin(),
     min_index.begin(),
@@ -185,6 +274,34 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax accepts stream", "[reduce][arg_minma
   REQUIRE(max_index[0] == 2);
 }
 
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax accepts stream", "[reduce][arg_minlastmax]", CUB_SMALL)
+{
+  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = thrust::device_vector<float>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<float>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceReduce::ArgMinLastMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()),
+    stream_ref);
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}
+
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles single element", "[reduce][arg_minmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<int>{42};
@@ -194,6 +311,29 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles single element", "[reduce][a
   auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
 
   auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == 42);
+  REQUIRE(min_index[0] == 0);
+  REQUIRE(max_out[0] == 42);
+  REQUIRE(max_index[0] == 0);
+}
+
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax handles single element", "[reduce][arg_minlastmax]", CUB_SMALL)
+{
+  auto input     = thrust::device_vector<int>{42};
+  auto min_out   = thrust::device_vector<int>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<int>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  auto error = cub::DeviceReduce::ArgMinLastMax(
     input.begin(),
     min_out.begin(),
     min_index.begin(),
@@ -232,8 +372,32 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax with compare_op", "[reduce][arg_minm
   REQUIRE(max_index[0] == 2);
 }
 
-// All-same values: first minimum at index 0, last maximum at last index
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax tie-breaking: first min and last max", "[reduce][arg_minmax]", CUB_SMALL)
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax with compare_op", "[reduce][arg_minlastmax]", CUB_SMALL)
+{
+  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = thrust::device_vector<float>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<float>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  auto error = cub::DeviceReduce::ArgMinLastMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()),
+    cuda::std::less{});
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}
+
+// All-same values: first minimum at index 0, first maximum at index 0
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax tie-breaking: first min and first max", "[reduce][arg_minmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<int>{5, 5, 5, 5, 5};
   auto min_out   = thrust::device_vector<int>(1);
@@ -253,10 +417,39 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax tie-breaking: first min and last max
   REQUIRE(min_out[0] == 5);
   REQUIRE(min_index[0] == 0); // first minimum: smallest index on tie
   REQUIRE(max_out[0] == 5);
+  REQUIRE(max_index[0] == 0); // first maximum: smallest index on tie
+}
+
+// All-same values: first minimum at index 0, last maximum at last index
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax tie-breaking: first min and last max",
+              "[reduce][arg_minlastmax]",
+              CUB_SMALL)
+{
+  auto input     = thrust::device_vector<int>{5, 5, 5, 5, 5};
+  auto min_out   = thrust::device_vector<int>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<int>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  auto error = cub::DeviceReduce::ArgMinLastMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == 5);
+  REQUIRE(min_index[0] == 0); // first minimum: smallest index on tie
+  REQUIRE(max_out[0] == 5);
   REQUIRE(max_index[0] == 4); // last maximum: largest index on tie
 }
 
-CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][arg_minmax]", CUB_SMALL, full_type_list)
+CUB_TEST("Device ArgMinMax and ArgMinLastMax work with all device interfaces",
+         "[reduce][device][arg_minmax][arg_minlastmax]",
+         CUB_SMALL,
+         full_type_list)
 {
   using params   = params_t<TestType>;
   using item_t   = typename params::item_t;
@@ -294,36 +487,52 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
 
   constexpr int num_segments = 1;
 
+  // Precompute reference values shared by both sections
+  c2h::host_vector<item_t> host_items(in_items);
+
+  auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend());
+  const auto expected_min       = static_cast<output_t>(*expected_min_it);
+  const auto expected_min_index = static_cast<cuda::std::int64_t>(expected_min_it - host_items.cbegin());
+
+  // First maximum: standard max_element returns the first occurrence
+  auto expected_first_max_it          = cuda::std::max_element(host_items.cbegin(), host_items.cend());
+  const auto expected_first_max       = static_cast<output_t>(*expected_first_max_it);
+  const auto expected_first_max_index = static_cast<cuda::std::int64_t>(expected_first_max_it - host_items.cbegin());
+
+  // Last maximum: max_element on the reversed range finds the last occurrence in the forward range
+  auto expected_last_max_it          = cuda::std::max_element(host_items.crbegin(), host_items.crend());
+  const auto expected_last_max       = static_cast<output_t>(*expected_last_max_it);
+  const auto expected_last_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
+                                     - static_cast<cuda::std::int64_t>(expected_last_max_it - host_items.crbegin());
+
+  using unwrapped_t = unwrap_value_t<output_t>;
+  c2h::device_vector<unwrapped_t> d_min_out(num_segments), d_max_out(num_segments);
+  c2h::device_vector<cuda::std::int64_t> d_min_index(num_segments), d_max_index(num_segments);
+
   SECTION("argminmax")
   {
-    // Prepare verification data
-    c2h::host_vector<item_t> host_items(in_items);
-
-    // First minimum: standard min_element returns the first occurrence
-    auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend());
-    const auto expected_min       = static_cast<output_t>(*expected_min_it);
-    const auto expected_min_index = static_cast<cuda::std::int64_t>(expected_min_it - host_items.cbegin());
-
-    // Last maximum: max_element on the reversed range finds the last occurrence in the forward range
-    auto expected_last_max_it     = cuda::std::max_element(host_items.crbegin(), host_items.crend());
-    const auto expected_max       = static_cast<output_t>(*expected_last_max_it);
-    const auto expected_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
-                                  - static_cast<cuda::std::int64_t>(expected_last_max_it - host_items.crbegin());
-
-    // Run test
-    using unwrapped_t = unwrap_value_t<output_t>;
-    c2h::device_vector<unwrapped_t> d_min_out(num_segments), d_max_out(num_segments);
-    c2h::device_vector<cuda::std::int64_t> d_min_index(num_segments), d_max_index(num_segments);
     device_arg_minmax(
       unwrap_it(d_in_it), d_min_out.data(), d_min_index.data(), d_max_out.data(), d_max_index.data(), num_items);
 
-    // Verify
     output_t gpu_min = static_cast<output_t>(d_min_out[0]);
     output_t gpu_max = static_cast<output_t>(d_max_out[0]);
     REQUIRE(expected_min == gpu_min);
     REQUIRE(expected_min_index == d_min_index[0]);
-    REQUIRE(expected_max == gpu_max);
-    REQUIRE(expected_max_index == d_max_index[0]);
+    REQUIRE(expected_first_max == gpu_max);
+    REQUIRE(expected_first_max_index == d_max_index[0]);
+  }
+
+  SECTION("argminlastmax")
+  {
+    device_arg_minlastmax(
+      unwrap_it(d_in_it), d_min_out.data(), d_min_index.data(), d_max_out.data(), d_max_index.data(), num_items);
+
+    output_t gpu_min = static_cast<output_t>(d_min_out[0]);
+    output_t gpu_max = static_cast<output_t>(d_max_out[0]);
+    REQUIRE(expected_min == gpu_min);
+    REQUIRE(expected_min_index == d_min_index[0]);
+    REQUIRE(expected_last_max == gpu_max);
+    REQUIRE(expected_last_max_index == d_max_index[0]);
   }
 
   // GCC7 ICEs (finish_member_declaration, cp/semantics.c:3029) on the generic lambda used below to
@@ -332,23 +541,6 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
 #if !_CCCL_COMPILER(GCC, <, 8)
   SECTION("argminmax with user provided memory and environment")
   {
-    // Prepare verification data
-    c2h::host_vector<item_t> host_items(in_items);
-
-    auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend());
-    const auto expected_min       = static_cast<output_t>(*expected_min_it);
-    const auto expected_min_index = static_cast<cuda::std::int64_t>(expected_min_it - host_items.cbegin());
-
-    auto expected_last_max_it     = cuda::std::max_element(host_items.crbegin(), host_items.crend());
-    const auto expected_max       = static_cast<output_t>(*expected_last_max_it);
-    const auto expected_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
-                                  - static_cast<cuda::std::int64_t>(expected_last_max_it - host_items.crbegin());
-
-    // Run test
-    using unwrapped_t = unwrap_value_t<output_t>;
-    c2h::device_vector<unwrapped_t> d_min_out(num_segments), d_max_out(num_segments);
-    c2h::device_vector<cuda::std::int64_t> d_min_index(num_segments), d_max_index(num_segments);
-
     const auto num_items_i64 = static_cast<cuda::std::int64_t>(num_items);
 
     size_t expected_allocation_size = 0;
@@ -403,8 +595,8 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
       output_t gpu_max = static_cast<output_t>(d_max_out[0]);
       REQUIRE(expected_min == gpu_min);
       REQUIRE(expected_min_index == d_min_index[0]);
-      REQUIRE(expected_max == gpu_max);
-      REQUIRE(expected_max_index == d_max_index[0]);
+      REQUIRE(expected_first_max == gpu_max);
+      REQUIRE(expected_first_max_index == d_max_index[0]);
     };
 
     int current_device;
@@ -449,6 +641,109 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
       test_argminmax(policy);
     }
   }
+
+  SECTION("argminlastmax with user provided memory and environment")
+  {
+    const auto num_items_i64 = static_cast<cuda::std::int64_t>(num_items);
+
+    size_t expected_allocation_size = 0;
+    auto error                      = cub::DeviceReduce::ArgMinLastMax(
+      static_cast<void*>(nullptr),
+      expected_allocation_size,
+      unwrap_it(d_in_it),
+      d_min_out.data(),
+      d_min_index.data(),
+      d_max_out.data(),
+      d_max_index.data(),
+      num_items_i64);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+    void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+    auto test_argminlastmax = [&](const auto& env) {
+      size_t num_bytes = 0;
+      error            = cub::DeviceReduce::ArgMinLastMax(
+        static_cast<void*>(nullptr),
+        num_bytes,
+        unwrap_it(d_in_it),
+        d_min_out.data(),
+        d_min_index.data(),
+        d_max_out.data(),
+        d_max_index.data(),
+        num_items_i64,
+        env);
+      REQUIRE(error == cudaSuccess);
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+      REQUIRE(expected_allocation_size == num_bytes);
+
+      error = cub::DeviceReduce::ArgMinLastMax(
+        temp_storage,
+        num_bytes,
+        unwrap_it(d_in_it),
+        d_min_out.data(),
+        d_min_index.data(),
+        d_max_out.data(),
+        d_max_index.data(),
+        num_items_i64,
+        env);
+      REQUIRE(error == cudaSuccess);
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+      output_t gpu_min = static_cast<output_t>(d_min_out[0]);
+      output_t gpu_max = static_cast<output_t>(d_max_out[0]);
+      REQUIRE(expected_min == gpu_min);
+      REQUIRE(expected_min_index == d_min_index[0]);
+      REQUIRE(expected_last_max == gpu_max);
+      REQUIRE(expected_last_max_index == d_max_index[0]);
+    };
+
+    int current_device;
+    error = cudaGetDevice(&current_device);
+    REQUIRE(error == cudaSuccess);
+
+    SECTION("DeviceReduce::ArgMinLastMax works with cudaStream_t")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      test_argminlastmax(stream.get());
+    }
+
+    SECTION("DeviceReduce::ArgMinLastMax works with cuda::stream")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      test_argminlastmax(stream);
+    }
+
+    SECTION("DeviceReduce::ArgMinLastMax works with cuda::stream_ref")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      cuda::stream_ref stream_ref{stream};
+      test_argminlastmax(stream_ref);
+    }
+
+    SECTION("DeviceReduce::ArgMinLastMax works with cuda::std::execution::env")
+    {
+      cuda::std::execution::env env{};
+      test_argminlastmax(env);
+    }
+
+    SECTION("DeviceReduce::ArgMinLastMax works with cuda::execution::gpu")
+    {
+      const auto policy = cuda::execution::gpu;
+      test_argminlastmax(policy);
+    }
+
+    SECTION("DeviceReduce::ArgMinLastMax works with cuda::execution::gpu with stream")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+      test_argminlastmax(policy);
+    }
+  }
 #endif // !_CCCL_COMPILER(GCC, <, 8)
 
   // abs comparison via cuda::uabs only compiles for integral scalar types
@@ -459,23 +754,18 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
       abs_less_t compare_op;
 
       // Prepare verification data
-      c2h::host_vector<item_t> host_items(in_items);
+      c2h::host_vector<item_t> host_items_abs(in_items);
 
       // First minimum by abs value: first element with smallest |value|
-      auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend(), compare_op);
-      const auto expected_min       = static_cast<output_t>(*expected_min_it);
-      const auto expected_min_index = static_cast<cuda::std::int64_t>(expected_min_it - host_items.cbegin());
+      auto exp_min_it          = cuda::std::min_element(host_items_abs.cbegin(), host_items_abs.cend(), compare_op);
+      const auto exp_min       = static_cast<output_t>(*exp_min_it);
+      const auto exp_min_index = static_cast<cuda::std::int64_t>(exp_min_it - host_items_abs.cbegin());
 
-      // Last maximum by abs value: last element with largest |value|
-      auto expected_last_max_it     = cuda::std::max_element(host_items.crbegin(), host_items.crend(), compare_op);
-      const auto expected_max       = static_cast<output_t>(*expected_last_max_it);
-      const auto expected_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
-                                    - static_cast<cuda::std::int64_t>(expected_last_max_it - host_items.crbegin());
+      // First maximum by abs value: first element with largest |value|
+      auto exp_first_max_it    = cuda::std::max_element(host_items_abs.cbegin(), host_items_abs.cend(), compare_op);
+      const auto exp_first_max = static_cast<output_t>(*exp_first_max_it);
+      const auto exp_first_max_index = static_cast<cuda::std::int64_t>(exp_first_max_it - host_items_abs.cbegin());
 
-      // Run test
-      using unwrapped_t = unwrap_value_t<output_t>;
-      c2h::device_vector<unwrapped_t> d_min_out(num_segments), d_max_out(num_segments);
-      c2h::device_vector<cuda::std::int64_t> d_min_index(num_segments), d_max_index(num_segments);
       device_arg_minmax(
         unwrap_it(d_in_it),
         d_min_out.data(),
@@ -485,13 +775,47 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
         num_items,
         compare_op);
 
-      // Verify
       output_t gpu_min = static_cast<output_t>(d_min_out[0]);
       output_t gpu_max = static_cast<output_t>(d_max_out[0]);
-      REQUIRE(expected_min == gpu_min);
-      REQUIRE(expected_min_index == d_min_index[0]);
-      REQUIRE(expected_max == gpu_max);
-      REQUIRE(expected_max_index == d_max_index[0]);
+      REQUIRE(exp_min == gpu_min);
+      REQUIRE(exp_min_index == d_min_index[0]);
+      REQUIRE(exp_first_max == gpu_max);
+      REQUIRE(exp_first_max_index == d_max_index[0]);
+    }
+
+    SECTION("argminlastmax-abs_less_t")
+    {
+      abs_less_t compare_op;
+
+      // Prepare verification data
+      c2h::host_vector<item_t> host_items_abs(in_items);
+
+      // First minimum by abs value: first element with smallest |value|
+      auto exp_min_it          = cuda::std::min_element(host_items_abs.cbegin(), host_items_abs.cend(), compare_op);
+      const auto exp_min       = static_cast<output_t>(*exp_min_it);
+      const auto exp_min_index = static_cast<cuda::std::int64_t>(exp_min_it - host_items_abs.cbegin());
+
+      // Last maximum by abs value: last element with largest |value|
+      auto exp_last_max_it    = cuda::std::max_element(host_items_abs.crbegin(), host_items_abs.crend(), compare_op);
+      const auto exp_last_max = static_cast<output_t>(*exp_last_max_it);
+      const auto exp_last_max_index = static_cast<cuda::std::int64_t>(host_items_abs.size()) - 1
+                                    - static_cast<cuda::std::int64_t>(exp_last_max_it - host_items_abs.crbegin());
+
+      device_arg_minlastmax(
+        unwrap_it(d_in_it),
+        d_min_out.data(),
+        d_min_index.data(),
+        d_max_out.data(),
+        d_max_index.data(),
+        num_items,
+        compare_op);
+
+      output_t gpu_min = static_cast<output_t>(d_min_out[0]);
+      output_t gpu_max = static_cast<output_t>(d_max_out[0]);
+      REQUIRE(exp_min == gpu_min);
+      REQUIRE(exp_min_index == d_min_index[0]);
+      REQUIRE(exp_last_max == gpu_max);
+      REQUIRE(exp_last_max_index == d_max_index[0]);
     }
   }
 }

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -71,10 +71,10 @@ struct abs_less_t
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax basic correctness", "[reduce][arg_minmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<int>{8, 6, -7, 5, 3, 1, -9};
-  auto min_out   = thrust::device_vector<int>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<int>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -112,10 +112,10 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax basic correctness", "[reduce][arg_mi
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax basic correctness", "[reduce][arg_minlastmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<int>{8, 6, -7, 5, 3, 1, -9};
-  auto min_out   = thrust::device_vector<int>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<int>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
@@ -153,10 +153,10 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax basic correctness", "[reduce][ar
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles zero-length input", "[reduce][arg_minmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<int>{};
-  auto min_out   = thrust::device_vector<int>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<int>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   // For zero-length inputs, no output is written; just verify it does not crash.
   auto error = cub::DeviceReduce::ArgMinMax(
@@ -172,10 +172,10 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles zero-length input", "[reduce
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax handles zero-length input", "[reduce][arg_minlastmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<int>{};
-  auto min_out   = thrust::device_vector<int>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<int>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   // For zero-length inputs, no output is written; just verify it does not crash.
   auto error = cub::DeviceReduce::ArgMinLastMax(
@@ -191,10 +191,10 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax handles zero-length input", "[re
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax accepts stream", "[reduce][arg_minmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = thrust::device_vector<float>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<float>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = thrust::device_vector<float>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<float>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
@@ -219,10 +219,10 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax accepts stream", "[reduce][arg_minma
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax accepts stream", "[reduce][arg_minlastmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = thrust::device_vector<float>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<float>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = thrust::device_vector<float>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<float>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
@@ -247,10 +247,10 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax accepts stream", "[reduce][arg_m
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles single element", "[reduce][arg_minmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<int>{42};
-  auto min_out   = thrust::device_vector<int>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<int>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   auto error = cub::DeviceReduce::ArgMinMax(
     input.begin(),
@@ -270,10 +270,10 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles single element", "[reduce][a
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax handles single element", "[reduce][arg_minlastmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<int>{42};
-  auto min_out   = thrust::device_vector<int>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<int>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   auto error = cub::DeviceReduce::ArgMinLastMax(
     input.begin(),
@@ -293,10 +293,10 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax handles single element", "[reduc
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax with compare_op", "[reduce][arg_minmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = thrust::device_vector<float>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<float>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = thrust::device_vector<float>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<float>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   auto error = cub::DeviceReduce::ArgMinMax(
     input.begin(),
@@ -317,10 +317,10 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax with compare_op", "[reduce][arg_minm
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax with compare_op", "[reduce][arg_minlastmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = thrust::device_vector<float>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<float>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = thrust::device_vector<float>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<float>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   auto error = cub::DeviceReduce::ArgMinLastMax(
     input.begin(),
@@ -342,10 +342,10 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax with compare_op", "[reduce][arg_
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax tie-breaking: first min and first max", "[reduce][arg_minmax]", CUB_SMALL)
 {
   auto input     = thrust::device_vector<int>{5, 5, 5, 5, 5};
-  auto min_out   = thrust::device_vector<int>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<int>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   auto error = cub::DeviceReduce::ArgMinMax(
     input.begin(),
@@ -368,10 +368,10 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax tie-breaking: first min and last
               CUB_SMALL)
 {
   auto input     = thrust::device_vector<int>{5, 5, 5, 5, 5};
-  auto min_out   = thrust::device_vector<int>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<int>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   auto error = cub::DeviceReduce::ArgMinLastMax(
     input.begin(),

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -9,8 +9,6 @@
 #include <thrust/fill.h>
 
 #include <cuda/__cmath/uabs.h>
-#include <cuda/__execution/determinism.h>
-#include <cuda/__execution/require.h>
 #include <cuda/devices>
 #include <cuda/std/__algorithm/max_element.h>
 #include <cuda/std/__algorithm/min_element.h>
@@ -188,62 +186,6 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax handles zero-length input", "[re
     max_index.begin(),
     static_cast<::cuda::std::int64_t>(input.size()));
   REQUIRE(error == cudaSuccess);
-}
-
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax accepts run_to_run determinism requirements",
-              "[reduce][arg_minmax]",
-              CUB_SMALL)
-{
-  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = thrust::device_vector<float>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<float>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
-
-  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
-
-  auto error = cub::DeviceReduce::ArgMinMax(
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()),
-    env);
-
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(min_out[0] == 0.0f);
-  REQUIRE(min_index[0] == 3);
-  REQUIRE(max_out[0] == 4.0f);
-  REQUIRE(max_index[0] == 2);
-}
-
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax accepts run_to_run determinism requirements",
-              "[reduce][arg_minlastmax]",
-              CUB_SMALL)
-{
-  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = thrust::device_vector<float>(1);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = thrust::device_vector<float>(1);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
-
-  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
-
-  auto error = cub::DeviceReduce::ArgMinLastMax(
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()),
-    env);
-
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(min_out[0] == 0.0f);
-  REQUIRE(min_index[0] == 3);
-  REQUIRE(max_out[0] == 4.0f);
-  REQUIRE(max_index[0] == 2);
 }
 
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax accepts stream", "[reduce][arg_minmax]", CUB_SMALL)

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -129,6 +129,25 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax basic correctness", "[reduce][arg_mi
   REQUIRE(max_index[0] == 0);
 }
 
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles zero-length input", "[reduce][arg_minmax]", CUB_SMALL)
+{
+  auto input     = thrust::device_vector<int>{};
+  auto min_out   = thrust::device_vector<int>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<int>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  // For zero-length inputs, no output is written; just verify it does not crash.
+  auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+  REQUIRE(error == cudaSuccess);
+}
+
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax accepts run_to_run determinism requirements",
               "[reduce][arg_minmax]",
               CUB_SMALL)

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -8,6 +8,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/fill.h>
 
+#include <cuda/__cmath/uabs.h>
 #include <cuda/__execution/determinism.h>
 #include <cuda/__execution/require.h>
 #include <cuda/devices>
@@ -74,6 +75,15 @@ enum class gen_data_t : int
   GEN_TYPE_RANDOM,
   /// Constant value as input data
   GEN_TYPE_CONST
+};
+
+struct abs_less_t
+{
+  template <typename T>
+  _CCCL_HOST_DEVICE_API auto operator()(const T& a, const T& b) const -> bool
+  {
+    return cuda::uabs(a) < cuda::uabs(b);
+  }
 };
 
 #if TEST_TYPES == 0
@@ -196,6 +206,30 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles single element", "[reduce][a
   REQUIRE(min_index[0] == 0);
   REQUIRE(max_out[0] == 42);
   REQUIRE(max_index[0] == 0);
+}
+
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax with compare_op", "[reduce][arg_minmax]", CUB_SMALL)
+{
+  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = thrust::device_vector<float>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<float>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()),
+    cuda::std::less{});
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
 }
 
 // All-same values: first minimum at index 0, last maximum at last index
@@ -415,5 +449,47 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
       test_argminmax(policy);
     }
   }
+
+#  if TEST_TYPES < 2
+  SECTION("argminmax-abs_less_t")
+  {
+    abs_less_t compare_op;
+
+    // Prepare verification data
+    c2h::host_vector<item_t> host_items(in_items);
+
+    // First minimum by abs value: first element with smallest |value|
+    auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend(), compare_op);
+    const auto expected_min       = *expected_min_it;
+    const auto expected_min_index = static_cast<cuda::std::int64_t>(expected_min_it - host_items.cbegin());
+
+    // Last maximum by abs value: last element with largest |value|
+    auto expected_last_max_it     = cuda::std::max_element(host_items.crbegin(), host_items.crend(), compare_op);
+    const auto expected_max       = *expected_last_max_it;
+    const auto expected_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
+                                  - static_cast<cuda::std::int64_t>(expected_last_max_it - host_items.crbegin());
+
+    // Run test
+    using unwrapped_t = unwrap_value_t<output_t>;
+    c2h::device_vector<unwrapped_t> d_min_out(num_segments), d_max_out(num_segments);
+    c2h::device_vector<cuda::std::int64_t> d_min_index(num_segments), d_max_index(num_segments);
+    device_arg_minmax(
+      unwrap_it(d_in_it),
+      d_min_out.data(),
+      d_min_index.data(),
+      d_max_out.data(),
+      d_max_index.data(),
+      num_items,
+      compare_op);
+
+    // Verify
+    output_t gpu_min = static_cast<output_t>(d_min_out[0]);
+    output_t gpu_max = static_cast<output_t>(d_max_out[0]);
+    REQUIRE(expected_min == gpu_min);
+    REQUIRE(expected_min_index == d_min_index[0]);
+    REQUIRE(expected_max == gpu_max);
+    REQUIRE(expected_max_index == d_max_index[0]);
+  }
+#  endif
 #endif // TEST_TYPES != 4
 }

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -326,6 +326,10 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
     REQUIRE(expected_max_index == d_max_index[0]);
   }
 
+  // GCC7 ICEs (finish_member_declaration, cp/semantics.c:3029) on the generic lambda used below to
+  // exercise the various environment/stream argument types, so skip this section there. The behavior
+  // is compiler-independent and remains covered by newer compilers and the *_env test files.
+#if !_CCCL_COMPILER(GCC, <, 8)
   SECTION("argminmax with user provided memory and environment")
   {
     // Prepare verification data
@@ -445,6 +449,7 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
       test_argminmax(policy);
     }
   }
+#endif // !_CCCL_COMPILER(GCC, <, 8)
 
   // abs comparison via cuda::uabs only compiles for integral scalar types
   if constexpr (cuda::std::is_integral_v<item_t>)

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -301,12 +301,12 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
 
     // First minimum: standard min_element returns the first occurrence
     auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend());
-    const auto expected_min       = *expected_min_it;
+    const auto expected_min       = static_cast<output_t>(*expected_min_it);
     const auto expected_min_index = static_cast<cuda::std::int64_t>(expected_min_it - host_items.cbegin());
 
     // Last maximum: max_element on the reversed range finds the last occurrence in the forward range
     auto expected_last_max_it     = cuda::std::max_element(host_items.crbegin(), host_items.crend());
-    const auto expected_max       = *expected_last_max_it;
+    const auto expected_max       = static_cast<output_t>(*expected_last_max_it);
     const auto expected_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
                                   - static_cast<cuda::std::int64_t>(expected_last_max_it - host_items.crbegin());
 
@@ -332,11 +332,11 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
     c2h::host_vector<item_t> host_items(in_items);
 
     auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend());
-    const auto expected_min       = *expected_min_it;
+    const auto expected_min       = static_cast<output_t>(*expected_min_it);
     const auto expected_min_index = static_cast<cuda::std::int64_t>(expected_min_it - host_items.cbegin());
 
     auto expected_last_max_it     = cuda::std::max_element(host_items.crbegin(), host_items.crend());
-    const auto expected_max       = *expected_last_max_it;
+    const auto expected_max       = static_cast<output_t>(*expected_last_max_it);
     const auto expected_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
                                   - static_cast<cuda::std::int64_t>(expected_last_max_it - host_items.crbegin());
 
@@ -458,12 +458,12 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
 
       // First minimum by abs value: first element with smallest |value|
       auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend(), compare_op);
-      const auto expected_min       = *expected_min_it;
+      const auto expected_min       = static_cast<output_t>(*expected_min_it);
       const auto expected_min_index = static_cast<cuda::std::int64_t>(expected_min_it - host_items.cbegin());
 
       // Last maximum by abs value: last element with largest |value|
       auto expected_last_max_it     = cuda::std::max_element(host_items.crbegin(), host_items.crend(), compare_op);
-      const auto expected_max       = *expected_last_max_it;
+      const auto expected_max       = static_cast<output_t>(*expected_last_max_it);
       const auto expected_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
                                     - static_cast<cuda::std::int64_t>(expected_last_max_it - host_items.crbegin());
 

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -282,7 +282,6 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
   using params   = params_t<TestType>;
   using item_t   = typename params::item_t;
   using output_t = typename params::output_t;
-  using offset_t = int32_t;
 
   constexpr int max_items = 5000000;
   constexpr int min_items = 1;

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -15,6 +15,7 @@
 #include <cuda/std/__algorithm/max_element.h>
 #include <cuda/std/__algorithm/min_element.h>
 #include <cuda/std/execution>
+#include <cuda/std/type_traits>
 #include <cuda/stream>
 
 #include "catch2_test_device_reduce.cuh"
@@ -26,7 +27,6 @@
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMinMax, device_arg_minmax);
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
-// %PARAM% TEST_TYPES types 0:1:2:3:4
 
 // List of types to test
 using custom_t =
@@ -35,36 +35,19 @@ using custom_t =
                      c2h::lexicographical_less_comparable_t,
                      c2h::lexicographical_greater_comparable_t>;
 
-#if TEST_TYPES == 0
-using full_type_list = c2h::type_list<type_pair<std::uint8_t>, type_pair<std::int8_t, std::int32_t>>;
-#elif TEST_TYPES == 1
-using full_type_list = c2h::type_list<type_pair<std::int32_t>, type_pair<std::int64_t>>;
-#elif TEST_TYPES == 2
-using full_type_list =
-  c2h::type_list<type_pair<uchar3>,
-                 type_pair<
-#  if _CCCL_CTK_AT_LEAST(13, 0)
-                   ulonglong4_16a
-#  else // _CCCL_CTK_AT_LEAST(13, 0)
-                   ulonglong4
-#  endif // _CCCL_CTK_AT_LEAST(13, 0)
-                   >>;
-#elif TEST_TYPES == 3
 // clang-format off
 using full_type_list = c2h::type_list<
-type_pair<custom_t>
+  type_pair<std::uint8_t>,
+  type_pair<std::int16_t, std::int32_t>, // DPX SIMD instructions and different (larger) output type
+  type_pair<std::int32_t>,
+  type_pair<std::int64_t, std::int32_t>, // different (smaller) output type
+  type_pair<uchar3>,
+  type_pair<custom_t>
 #if TEST_HALF_T()
 , type_pair<half_t>
 #endif // TEST_HALF_T()
-#if TEST_BF_T()
-, type_pair<bfloat16_t>
-#endif // TEST_BF_T()
 >;
 // clang-format on
-#elif TEST_TYPES == 4
-// DPX SIMD instructions
-using full_type_list = c2h::type_list<type_pair<std::uint16_t>, type_pair<std::int16_t>>;
-#endif
 
 /**
  * @brief Input data generation mode
@@ -85,8 +68,6 @@ struct abs_less_t
     return cuda::uabs(a) < cuda::uabs(b);
   }
 };
-
-#if TEST_TYPES == 0
 
 CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax basic correctness", "[reduce][arg_minmax]", CUB_SMALL)
 {
@@ -275,8 +256,6 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax tie-breaking: first min and last max
   REQUIRE(max_index[0] == 4); // last maximum: largest index on tie
 }
 
-#endif // TEST_TYPES == 0
-
 CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][arg_minmax]", CUB_SMALL, full_type_list)
 {
   using params   = params_t<TestType>;
@@ -313,7 +292,6 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
 
   CAPTURE(c2h::type_name<item_t>(), c2h::type_name<output_t>(), num_items);
 
-#if TEST_TYPES != 4
   constexpr int num_segments = 1;
 
   SECTION("argminmax")
@@ -468,46 +446,47 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
     }
   }
 
-#  if TEST_TYPES < 2
-  SECTION("argminmax-abs_less_t")
+  // abs comparison via cuda::uabs only compiles for integral scalar types
+  if constexpr (cuda::std::is_integral_v<item_t>)
   {
-    abs_less_t compare_op;
+    SECTION("argminmax-abs_less_t")
+    {
+      abs_less_t compare_op;
 
-    // Prepare verification data
-    c2h::host_vector<item_t> host_items(in_items);
+      // Prepare verification data
+      c2h::host_vector<item_t> host_items(in_items);
 
-    // First minimum by abs value: first element with smallest |value|
-    auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend(), compare_op);
-    const auto expected_min       = *expected_min_it;
-    const auto expected_min_index = static_cast<cuda::std::int64_t>(expected_min_it - host_items.cbegin());
+      // First minimum by abs value: first element with smallest |value|
+      auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend(), compare_op);
+      const auto expected_min       = *expected_min_it;
+      const auto expected_min_index = static_cast<cuda::std::int64_t>(expected_min_it - host_items.cbegin());
 
-    // Last maximum by abs value: last element with largest |value|
-    auto expected_last_max_it     = cuda::std::max_element(host_items.crbegin(), host_items.crend(), compare_op);
-    const auto expected_max       = *expected_last_max_it;
-    const auto expected_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
-                                  - static_cast<cuda::std::int64_t>(expected_last_max_it - host_items.crbegin());
+      // Last maximum by abs value: last element with largest |value|
+      auto expected_last_max_it     = cuda::std::max_element(host_items.crbegin(), host_items.crend(), compare_op);
+      const auto expected_max       = *expected_last_max_it;
+      const auto expected_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
+                                    - static_cast<cuda::std::int64_t>(expected_last_max_it - host_items.crbegin());
 
-    // Run test
-    using unwrapped_t = unwrap_value_t<output_t>;
-    c2h::device_vector<unwrapped_t> d_min_out(num_segments), d_max_out(num_segments);
-    c2h::device_vector<cuda::std::int64_t> d_min_index(num_segments), d_max_index(num_segments);
-    device_arg_minmax(
-      unwrap_it(d_in_it),
-      d_min_out.data(),
-      d_min_index.data(),
-      d_max_out.data(),
-      d_max_index.data(),
-      num_items,
-      compare_op);
+      // Run test
+      using unwrapped_t = unwrap_value_t<output_t>;
+      c2h::device_vector<unwrapped_t> d_min_out(num_segments), d_max_out(num_segments);
+      c2h::device_vector<cuda::std::int64_t> d_min_index(num_segments), d_max_index(num_segments);
+      device_arg_minmax(
+        unwrap_it(d_in_it),
+        d_min_out.data(),
+        d_min_index.data(),
+        d_max_out.data(),
+        d_max_index.data(),
+        num_items,
+        compare_op);
 
-    // Verify
-    output_t gpu_min = static_cast<output_t>(d_min_out[0]);
-    output_t gpu_max = static_cast<output_t>(d_max_out[0]);
-    REQUIRE(expected_min == gpu_min);
-    REQUIRE(expected_min_index == d_min_index[0]);
-    REQUIRE(expected_max == gpu_max);
-    REQUIRE(expected_max_index == d_max_index[0]);
+      // Verify
+      output_t gpu_min = static_cast<output_t>(d_min_out[0]);
+      output_t gpu_max = static_cast<output_t>(d_max_out[0]);
+      REQUIRE(expected_min == gpu_min);
+      REQUIRE(expected_min_index == d_min_index[0]);
+      REQUIRE(expected_max == gpu_max);
+      REQUIRE(expected_max_index == d_max_index[0]);
+    }
   }
-#  endif
-#endif // TEST_TYPES != 4
 }

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -231,9 +231,8 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
   using output_t = typename params::output_t;
   using offset_t = int32_t;
 
-  constexpr int max_items    = 5000000;
-  constexpr int min_items    = 1;
-  constexpr int num_segments = 1;
+  constexpr int max_items = 5000000;
+  constexpr int min_items = 1;
 
   // Generate the input sizes to test for
   const int num_items = GENERATE_COPY(
@@ -263,6 +262,8 @@ CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][
   CAPTURE(c2h::type_name<item_t>(), c2h::type_name<output_t>(), num_items);
 
 #if TEST_TYPES != 4
+  constexpr int num_segments = 1;
+
   SECTION("argminmax")
   {
     // Prepare verification data

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -1,0 +1,418 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_reduce.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/fill.h>
+
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/require.h>
+#include <cuda/devices>
+#include <cuda/std/__algorithm/max_element.h>
+#include <cuda/std/__algorithm/min_element.h>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include "catch2_test_device_reduce.cuh"
+#include "catch2_test_launch_helper.h"
+#include "cub_test_macros.h"
+#include <c2h/custom_type.h>
+#include <c2h/extended_types.h>
+
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMinMax, device_arg_minmax);
+
+// %PARAM% TEST_LAUNCH lid 0:1:2
+// %PARAM% TEST_TYPES types 0:1:2:3:4
+
+// List of types to test
+using custom_t =
+  c2h::custom_type_t<c2h::accumulateable_t,
+                     c2h::equal_comparable_t,
+                     c2h::lexicographical_less_comparable_t,
+                     c2h::lexicographical_greater_comparable_t>;
+
+#if TEST_TYPES == 0
+using full_type_list = c2h::type_list<type_pair<std::uint8_t>, type_pair<std::int8_t, std::int32_t>>;
+#elif TEST_TYPES == 1
+using full_type_list = c2h::type_list<type_pair<std::int32_t>, type_pair<std::int64_t>>;
+#elif TEST_TYPES == 2
+using full_type_list =
+  c2h::type_list<type_pair<uchar3>,
+                 type_pair<
+#  if _CCCL_CTK_AT_LEAST(13, 0)
+                   ulonglong4_16a
+#  else // _CCCL_CTK_AT_LEAST(13, 0)
+                   ulonglong4
+#  endif // _CCCL_CTK_AT_LEAST(13, 0)
+                   >>;
+#elif TEST_TYPES == 3
+// clang-format off
+using full_type_list = c2h::type_list<
+type_pair<custom_t>
+#if TEST_HALF_T()
+, type_pair<half_t>
+#endif // TEST_HALF_T()
+#if TEST_BF_T()
+, type_pair<bfloat16_t>
+#endif // TEST_BF_T()
+>;
+// clang-format on
+#elif TEST_TYPES == 4
+// DPX SIMD instructions
+using full_type_list = c2h::type_list<type_pair<std::uint16_t>, type_pair<std::int16_t>>;
+#endif
+
+/**
+ * @brief Input data generation mode
+ */
+enum class gen_data_t : int
+{
+  /// Uniform random data generation
+  GEN_TYPE_RANDOM,
+  /// Constant value as input data
+  GEN_TYPE_CONST
+};
+
+#if TEST_TYPES == 0
+
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax basic correctness", "[reduce][arg_minmax]", CUB_SMALL)
+{
+  auto input     = thrust::device_vector<int>{8, 6, -7, 5, 3, 1, -9};
+  auto min_out   = thrust::device_vector<int>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<int>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+
+  auto error = cub::DeviceReduce::ArgMinMax(
+    d_temp_storage,
+    temp_storage_bytes,
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+  REQUIRE(error == cudaSuccess);
+
+  thrust::device_vector<char> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  error = cub::DeviceReduce::ArgMinMax(
+    d_temp_storage,
+    temp_storage_bytes,
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == -9);
+  REQUIRE(min_index[0] == 6);
+  REQUIRE(max_out[0] == 8);
+  REQUIRE(max_index[0] == 0);
+}
+
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax accepts run_to_run determinism requirements",
+              "[reduce][arg_minmax]",
+              CUB_SMALL)
+{
+  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = thrust::device_vector<float>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<float>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
+
+  auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()),
+    env);
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}
+
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax accepts stream", "[reduce][arg_minmax]", CUB_SMALL)
+{
+  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = thrust::device_vector<float>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<float>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()),
+    stream_ref);
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}
+
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles single element", "[reduce][arg_minmax]", CUB_SMALL)
+{
+  auto input     = thrust::device_vector<int>{42};
+  auto min_out   = thrust::device_vector<int>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<int>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == 42);
+  REQUIRE(min_index[0] == 0);
+  REQUIRE(max_out[0] == 42);
+  REQUIRE(max_index[0] == 0);
+}
+
+// All-same values: first minimum at index 0, last maximum at last index
+CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax tie-breaking: first min and last max", "[reduce][arg_minmax]", CUB_SMALL)
+{
+  auto input     = thrust::device_vector<int>{5, 5, 5, 5, 5};
+  auto min_out   = thrust::device_vector<int>(1);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = thrust::device_vector<int>(1);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1);
+
+  auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == 5);
+  REQUIRE(min_index[0] == 0); // first minimum: smallest index on tie
+  REQUIRE(max_out[0] == 5);
+  REQUIRE(max_index[0] == 4); // last maximum: largest index on tie
+}
+
+#endif // TEST_TYPES == 0
+
+CUB_TEST("Device ArgMinMax works with all device interfaces", "[reduce][device][arg_minmax]", CUB_SMALL, full_type_list)
+{
+  using params   = params_t<TestType>;
+  using item_t   = typename params::item_t;
+  using output_t = typename params::output_t;
+  using offset_t = int32_t;
+
+  constexpr int max_items    = 5000000;
+  constexpr int min_items    = 1;
+  constexpr int num_segments = 1;
+
+  // Generate the input sizes to test for
+  const int num_items = GENERATE_COPY(
+    take(3, random(min_items, max_items)),
+    values({
+      min_items,
+      max_items,
+    }));
+
+  // Input data generation to test
+  const gen_data_t data_gen_mode = GENERATE_COPY(gen_data_t::GEN_TYPE_RANDOM, gen_data_t::GEN_TYPE_CONST);
+
+  // Generate input data
+  c2h::device_vector<item_t> in_items(num_items);
+  if (data_gen_mode == gen_data_t::GEN_TYPE_RANDOM)
+  {
+    c2h::gen(C2H_SEED(2), in_items);
+  }
+  else
+  {
+    item_t default_constant{};
+    init_default_constant(default_constant);
+    thrust::fill(c2h::device_policy, in_items.begin(), in_items.end(), default_constant);
+  }
+  auto d_in_it = thrust::raw_pointer_cast(in_items.data());
+
+  CAPTURE(c2h::type_name<item_t>(), c2h::type_name<output_t>(), num_items);
+
+#if TEST_TYPES != 4
+  SECTION("argminmax")
+  {
+    // Prepare verification data
+    c2h::host_vector<item_t> host_items(in_items);
+
+    // First minimum: standard min_element returns the first occurrence
+    auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend());
+    const auto expected_min       = *expected_min_it;
+    const auto expected_min_index = static_cast<cuda::std::int64_t>(expected_min_it - host_items.cbegin());
+
+    // Last maximum: max_element on the reversed range finds the last occurrence in the forward range
+    auto expected_last_max_it     = cuda::std::max_element(host_items.crbegin(), host_items.crend());
+    const auto expected_max       = *expected_last_max_it;
+    const auto expected_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
+                                  - static_cast<cuda::std::int64_t>(expected_last_max_it - host_items.crbegin());
+
+    // Run test
+    using unwrapped_t = unwrap_value_t<output_t>;
+    c2h::device_vector<unwrapped_t> d_min_out(num_segments), d_max_out(num_segments);
+    c2h::device_vector<cuda::std::int64_t> d_min_index(num_segments), d_max_index(num_segments);
+    device_arg_minmax(
+      unwrap_it(d_in_it), d_min_out.data(), d_min_index.data(), d_max_out.data(), d_max_index.data(), num_items);
+
+    // Verify
+    output_t gpu_min = static_cast<output_t>(d_min_out[0]);
+    output_t gpu_max = static_cast<output_t>(d_max_out[0]);
+    REQUIRE(expected_min == gpu_min);
+    REQUIRE(expected_min_index == d_min_index[0]);
+    REQUIRE(expected_max == gpu_max);
+    REQUIRE(expected_max_index == d_max_index[0]);
+  }
+
+  SECTION("argminmax with user provided memory and environment")
+  {
+    // Prepare verification data
+    c2h::host_vector<item_t> host_items(in_items);
+
+    auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend());
+    const auto expected_min       = *expected_min_it;
+    const auto expected_min_index = static_cast<cuda::std::int64_t>(expected_min_it - host_items.cbegin());
+
+    auto expected_last_max_it     = cuda::std::max_element(host_items.crbegin(), host_items.crend());
+    const auto expected_max       = *expected_last_max_it;
+    const auto expected_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
+                                  - static_cast<cuda::std::int64_t>(expected_last_max_it - host_items.crbegin());
+
+    // Run test
+    using unwrapped_t = unwrap_value_t<output_t>;
+    c2h::device_vector<unwrapped_t> d_min_out(num_segments), d_max_out(num_segments);
+    c2h::device_vector<cuda::std::int64_t> d_min_index(num_segments), d_max_index(num_segments);
+
+    const auto num_items_i64 = static_cast<cuda::std::int64_t>(num_items);
+
+    size_t expected_allocation_size = 0;
+    auto error                      = cub::DeviceReduce::ArgMinMax(
+      static_cast<void*>(nullptr),
+      expected_allocation_size,
+      unwrap_it(d_in_it),
+      d_min_out.data(),
+      d_min_index.data(),
+      d_max_out.data(),
+      d_max_index.data(),
+      num_items_i64);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+    void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+    auto test_argminmax = [&](const auto& env) {
+      size_t num_bytes = 0;
+      error            = cub::DeviceReduce::ArgMinMax(
+        static_cast<void*>(nullptr),
+        num_bytes,
+        unwrap_it(d_in_it),
+        d_min_out.data(),
+        d_min_index.data(),
+        d_max_out.data(),
+        d_max_index.data(),
+        num_items_i64,
+        env);
+      REQUIRE(error == cudaSuccess);
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+      REQUIRE(expected_allocation_size == num_bytes);
+
+      error = cub::DeviceReduce::ArgMinMax(
+        temp_storage,
+        num_bytes,
+        unwrap_it(d_in_it),
+        d_min_out.data(),
+        d_min_index.data(),
+        d_max_out.data(),
+        d_max_index.data(),
+        num_items_i64,
+        env);
+      REQUIRE(error == cudaSuccess);
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+      output_t gpu_min = static_cast<output_t>(d_min_out[0]);
+      output_t gpu_max = static_cast<output_t>(d_max_out[0]);
+      REQUIRE(expected_min == gpu_min);
+      REQUIRE(expected_min_index == d_min_index[0]);
+      REQUIRE(expected_max == gpu_max);
+      REQUIRE(expected_max_index == d_max_index[0]);
+    };
+
+    int current_device;
+    error = cudaGetDevice(&current_device);
+    REQUIRE(error == cudaSuccess);
+
+    SECTION("DeviceReduce::ArgMinMax works with cudaStream_t")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      test_argminmax(stream.get());
+    }
+
+    SECTION("DeviceReduce::ArgMinMax works with cuda::stream")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      test_argminmax(stream);
+    }
+
+    SECTION("DeviceReduce::ArgMinMax works with cuda::stream_ref")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      cuda::stream_ref stream_ref{stream};
+      test_argminmax(stream_ref);
+    }
+
+    SECTION("DeviceReduce::ArgMinMax works with cuda::std::execution::env")
+    {
+      cuda::std::execution::env env{};
+      test_argminmax(env);
+    }
+
+    SECTION("DeviceReduce::ArgMinMax works with cuda::execution::gpu")
+    {
+      const auto policy = cuda::execution::gpu;
+      test_argminmax(policy);
+    }
+
+    SECTION("DeviceReduce::ArgMinMax works with cuda::execution::gpu with stream")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+      test_argminmax(policy);
+    }
+  }
+#endif // TEST_TYPES != 4
+}

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -14,6 +14,7 @@
 #include <cuda/std/__algorithm/min_element.h>
 #include <cuda/std/execution>
 #include <cuda/std/type_traits>
+#include <cuda/std/utility>
 #include <cuda/stream>
 
 #include "catch2_test_device_reduce.cuh"
@@ -68,330 +69,148 @@ struct abs_less_t
   }
 };
 
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax basic correctness", "[reduce][arg_minmax]", CUB_SMALL)
+template <typename... Args>
+cudaError_t call_argminmax_api(bool last_max, Args&&... args)
 {
+  return last_max ? cub::DeviceReduce::ArgMinLastMax(::cuda::std::forward<Args>(args)...)
+                  : cub::DeviceReduce::ArgMinMax(::cuda::std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+void call_argminmax_launch_wrapper(bool last_max, Args&&... args)
+{
+  if (last_max)
+  {
+    device_arg_minlastmax(::cuda::std::forward<Args>(args)...);
+  }
+  else
+  {
+    device_arg_minmax(::cuda::std::forward<Args>(args)...);
+  }
+}
+
+CUB_TEST_CASE("cub::DeviceReduce::ArgMin[Last]Max basic correctness", "[reduce][arg_minmax][arg_minlastmax]", CUB_SMALL)
+{
+  const bool last_max = GENERATE(false, true);
+
   auto input     = thrust::device_vector<int>{8, 6, -7, 5, 3, 1, -9};
   auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
   auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
   auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
   auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  void* d_temp_storage      = nullptr;
-  size_t temp_storage_bytes = 0;
-
-  auto error = cub::DeviceReduce::ArgMinMax(
-    d_temp_storage,
-    temp_storage_bytes,
+  call_argminmax_launch_wrapper(
+    last_max,
     input.begin(),
     min_out.begin(),
     min_index.begin(),
     max_out.begin(),
     max_index.begin(),
     static_cast<::cuda::std::int64_t>(input.size()));
-  REQUIRE(error == cudaSuccess);
-
-  thrust::device_vector<char> temp_storage(temp_storage_bytes, thrust::no_init);
-  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
-
-  error = cub::DeviceReduce::ArgMinMax(
-    d_temp_storage,
-    temp_storage_bytes,
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()));
-  REQUIRE(error == cudaSuccess);
   REQUIRE(min_out[0] == -9);
   REQUIRE(min_index[0] == 6);
   REQUIRE(max_out[0] == 8);
   REQUIRE(max_index[0] == 0);
 }
 
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax basic correctness", "[reduce][arg_minlastmax]", CUB_SMALL)
-{
-  auto input     = thrust::device_vector<int>{8, 6, -7, 5, 3, 1, -9};
-  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  void* d_temp_storage      = nullptr;
-  size_t temp_storage_bytes = 0;
-
-  auto error = cub::DeviceReduce::ArgMinLastMax(
-    d_temp_storage,
-    temp_storage_bytes,
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()));
-  REQUIRE(error == cudaSuccess);
-
-  thrust::device_vector<char> temp_storage(temp_storage_bytes, thrust::no_init);
-  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
-
-  error = cub::DeviceReduce::ArgMinLastMax(
-    d_temp_storage,
-    temp_storage_bytes,
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()));
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(min_out[0] == -9);
-  REQUIRE(min_index[0] == 6);
-  REQUIRE(max_out[0] == 8);
-  REQUIRE(max_index[0] == 0);
-}
-
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles zero-length input", "[reduce][arg_minmax]", CUB_SMALL)
-{
-  auto input     = thrust::device_vector<int>{};
-  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  // For zero-length inputs, no output is written; just verify it does not crash.
-  auto error = cub::DeviceReduce::ArgMinMax(
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()));
-  REQUIRE(error == cudaSuccess);
-}
-
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax handles zero-length input", "[reduce][arg_minlastmax]", CUB_SMALL)
-{
-  auto input     = thrust::device_vector<int>{};
-  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  // For zero-length inputs, no output is written; just verify it does not crash.
-  auto error = cub::DeviceReduce::ArgMinLastMax(
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()));
-  REQUIRE(error == cudaSuccess);
-}
-
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax accepts stream", "[reduce][arg_minmax]", CUB_SMALL)
-{
-  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = thrust::device_vector<float>(1, thrust::no_init);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = thrust::device_vector<float>(1, thrust::no_init);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
-
-  auto error = cub::DeviceReduce::ArgMinMax(
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()),
-    stream_ref);
-  stream.sync();
-
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(min_out[0] == 0.0f);
-  REQUIRE(min_index[0] == 3);
-  REQUIRE(max_out[0] == 4.0f);
-  REQUIRE(max_index[0] == 2);
-}
-
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax accepts stream", "[reduce][arg_minlastmax]", CUB_SMALL)
-{
-  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = thrust::device_vector<float>(1, thrust::no_init);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = thrust::device_vector<float>(1, thrust::no_init);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
-
-  auto error = cub::DeviceReduce::ArgMinLastMax(
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()),
-    stream_ref);
-  stream.sync();
-
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(min_out[0] == 0.0f);
-  REQUIRE(min_index[0] == 3);
-  REQUIRE(max_out[0] == 4.0f);
-  REQUIRE(max_index[0] == 2);
-}
-
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax handles single element", "[reduce][arg_minmax]", CUB_SMALL)
-{
-  auto input     = thrust::device_vector<int>{42};
-  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  auto error = cub::DeviceReduce::ArgMinMax(
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()));
-
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(min_out[0] == 42);
-  REQUIRE(min_index[0] == 0);
-  REQUIRE(max_out[0] == 42);
-  REQUIRE(max_index[0] == 0);
-}
-
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax handles single element", "[reduce][arg_minlastmax]", CUB_SMALL)
-{
-  auto input     = thrust::device_vector<int>{42};
-  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  auto error = cub::DeviceReduce::ArgMinLastMax(
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()));
-
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(min_out[0] == 42);
-  REQUIRE(min_index[0] == 0);
-  REQUIRE(max_out[0] == 42);
-  REQUIRE(max_index[0] == 0);
-}
-
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax with compare_op", "[reduce][arg_minmax]", CUB_SMALL)
-{
-  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = thrust::device_vector<float>(1, thrust::no_init);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = thrust::device_vector<float>(1, thrust::no_init);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  auto error = cub::DeviceReduce::ArgMinMax(
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()),
-    cuda::std::less{});
-
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(min_out[0] == 0.0f);
-  REQUIRE(min_index[0] == 3);
-  REQUIRE(max_out[0] == 4.0f);
-  REQUIRE(max_index[0] == 2);
-}
-
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax with compare_op", "[reduce][arg_minlastmax]", CUB_SMALL)
-{
-  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = thrust::device_vector<float>(1, thrust::no_init);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = thrust::device_vector<float>(1, thrust::no_init);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  auto error = cub::DeviceReduce::ArgMinLastMax(
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()),
-    cuda::std::less{});
-
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(min_out[0] == 0.0f);
-  REQUIRE(min_index[0] == 3);
-  REQUIRE(max_out[0] == 4.0f);
-  REQUIRE(max_index[0] == 2);
-}
-
-// All-same values: first minimum at index 0, first maximum at index 0
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax tie-breaking: first min and first max", "[reduce][arg_minmax]", CUB_SMALL)
-{
-  auto input     = thrust::device_vector<int>{5, 5, 5, 5, 5};
-  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
-  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
-  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  auto error = cub::DeviceReduce::ArgMinMax(
-    input.begin(),
-    min_out.begin(),
-    min_index.begin(),
-    max_out.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()));
-
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(min_out[0] == 5);
-  REQUIRE(min_index[0] == 0); // first minimum: smallest index on tie
-  REQUIRE(max_out[0] == 5);
-  REQUIRE(max_index[0] == 0); // first maximum: smallest index on tie
-}
-
-// All-same values: first minimum at index 0, last maximum at last index
-CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax tie-breaking: first min and last max",
-              "[reduce][arg_minlastmax]",
+CUB_TEST_CASE("cub::DeviceReduce::ArgMin[Last]Max handles zero-length input",
+              "[reduce][arg_minmax][arg_minlastmax]",
               CUB_SMALL)
 {
-  auto input     = thrust::device_vector<int>{5, 5, 5, 5, 5};
+  const bool last_max = GENERATE(false, true);
+
+  auto input     = thrust::device_vector<int>{};
   auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
   auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
   auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
   auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
-  auto error = cub::DeviceReduce::ArgMinLastMax(
+  // For zero-length inputs, no output is written; just verify it does not crash.
+  call_argminmax_launch_wrapper(
+    last_max,
     input.begin(),
     min_out.begin(),
     min_index.begin(),
     max_out.begin(),
     max_index.begin(),
     static_cast<::cuda::std::int64_t>(input.size()));
+}
 
-  REQUIRE(error == cudaSuccess);
+CUB_TEST_CASE("cub::DeviceReduce::ArgMin[Last]Max handles single element",
+              "[reduce][arg_minmax][arg_minlastmax]",
+              CUB_SMALL)
+{
+  const bool last_max = GENERATE(false, true);
+
+  auto input     = thrust::device_vector<int>{42};
+  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  call_argminmax_launch_wrapper(
+    last_max,
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+  REQUIRE(min_out[0] == 42);
+  REQUIRE(min_index[0] == 0);
+  REQUIRE(max_out[0] == 42);
+  REQUIRE(max_index[0] == 0);
+}
+
+CUB_TEST_CASE("cub::DeviceReduce::ArgMin[Last]Max with compare_op", "[reduce][arg_minmax][arg_minlastmax]", CUB_SMALL)
+{
+  const bool last_max = GENERATE(false, true);
+
+  auto input     = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = thrust::device_vector<float>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<float>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  call_argminmax_launch_wrapper(
+    last_max,
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()),
+    cuda::std::less{});
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}
+
+// All-same values: first minimum at index 0. The maximum is the first occurrence (index 0) for ArgMinMax and the last
+// occurrence (last index) for ArgMinLastMax.
+CUB_TEST_CASE("cub::DeviceReduce::ArgMin[Last]Max tie-breaking", "[reduce][arg_minmax][arg_minlastmax]", CUB_SMALL)
+{
+  const bool last_max = GENERATE(false, true);
+
+  auto input     = thrust::device_vector<int>{5, 5, 5, 5, 5};
+  auto min_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto min_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = thrust::device_vector<int>(1, thrust::no_init);
+  auto max_index = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  call_argminmax_launch_wrapper(
+    last_max,
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
   REQUIRE(min_out[0] == 5);
   REQUIRE(min_index[0] == 0); // first minimum: smallest index on tie
   REQUIRE(max_out[0] == 5);
-  REQUIRE(max_index[0] == 4); // last maximum: largest index on tie
+  REQUIRE(max_index[0] == (last_max ? 4 : 0));
 }
 
-CUB_TEST("Device ArgMinMax and ArgMinLastMax work with all device interfaces",
-         "[reduce][device][arg_minmax][arg_minlastmax]",
-         CUB_SMALL,
-         full_type_list)
+CUB_TEST(
+  "Device ArgMinMax and ArgMinLastMax works", "[reduce][device][arg_minmax][arg_minlastmax]", CUB_SMALL, full_type_list)
 {
   using params   = params_t<TestType>;
   using item_t   = typename params::item_t;
@@ -429,7 +248,7 @@ CUB_TEST("Device ArgMinMax and ArgMinLastMax work with all device interfaces",
 
   constexpr int num_segments = 1;
 
-  // Precompute reference values shared by both sections
+  // Precompute reference values shared by both APIs
   c2h::host_vector<item_t> host_items(in_items);
 
   auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend());
@@ -451,248 +270,35 @@ CUB_TEST("Device ArgMinMax and ArgMinLastMax work with all device interfaces",
   c2h::device_vector<unwrapped_t> d_min_out(num_segments), d_max_out(num_segments);
   c2h::device_vector<cuda::std::int64_t> d_min_index(num_segments), d_max_index(num_segments);
 
-  SECTION("argminmax")
+  SECTION("default")
   {
-    device_arg_minmax(
-      unwrap_it(d_in_it), d_min_out.data(), d_min_index.data(), d_max_out.data(), d_max_index.data(), num_items);
+    const bool last_max           = GENERATE(false, true);
+    const auto expected_max       = last_max ? expected_last_max : expected_first_max;
+    const auto expected_max_index = last_max ? expected_last_max_index : expected_first_max_index;
 
-    output_t gpu_min = static_cast<output_t>(d_min_out[0]);
-    output_t gpu_max = static_cast<output_t>(d_max_out[0]);
-    REQUIRE(expected_min == gpu_min);
-    REQUIRE(expected_min_index == d_min_index[0]);
-    REQUIRE(expected_first_max == gpu_max);
-    REQUIRE(expected_first_max_index == d_max_index[0]);
-  }
-
-  SECTION("argminlastmax")
-  {
-    device_arg_minlastmax(
-      unwrap_it(d_in_it), d_min_out.data(), d_min_index.data(), d_max_out.data(), d_max_index.data(), num_items);
-
-    output_t gpu_min = static_cast<output_t>(d_min_out[0]);
-    output_t gpu_max = static_cast<output_t>(d_max_out[0]);
-    REQUIRE(expected_min == gpu_min);
-    REQUIRE(expected_min_index == d_min_index[0]);
-    REQUIRE(expected_last_max == gpu_max);
-    REQUIRE(expected_last_max_index == d_max_index[0]);
-  }
-
-  // GCC7 ICEs (finish_member_declaration, cp/semantics.c:3029) on the generic lambda used below to
-  // exercise the various environment/stream argument types, so skip this section there. The behavior
-  // is compiler-independent and remains covered by newer compilers and the *_env test files.
-#if !_CCCL_COMPILER(GCC, <, 8)
-  SECTION("argminmax with user provided memory and environment")
-  {
-    const auto num_items_i64 = static_cast<cuda::std::int64_t>(num_items);
-
-    size_t expected_allocation_size = 0;
-    auto error                      = cub::DeviceReduce::ArgMinMax(
-      static_cast<void*>(nullptr),
-      expected_allocation_size,
+    call_argminmax_launch_wrapper(
+      last_max,
       unwrap_it(d_in_it),
       d_min_out.data(),
       d_min_index.data(),
       d_max_out.data(),
       d_max_index.data(),
-      num_items_i64);
-    REQUIRE(error == cudaSuccess);
-    REQUIRE(cudaSuccess == cudaPeekAtLastError());
-    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+      num_items);
 
-    auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
-    void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
-
-    auto test_argminmax = [&](const auto& env) {
-      size_t num_bytes = 0;
-      error            = cub::DeviceReduce::ArgMinMax(
-        static_cast<void*>(nullptr),
-        num_bytes,
-        unwrap_it(d_in_it),
-        d_min_out.data(),
-        d_min_index.data(),
-        d_max_out.data(),
-        d_max_index.data(),
-        num_items_i64,
-        env);
-      REQUIRE(error == cudaSuccess);
-      REQUIRE(cudaSuccess == cudaPeekAtLastError());
-      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
-      REQUIRE(expected_allocation_size == num_bytes);
-
-      error = cub::DeviceReduce::ArgMinMax(
-        temp_storage,
-        num_bytes,
-        unwrap_it(d_in_it),
-        d_min_out.data(),
-        d_min_index.data(),
-        d_max_out.data(),
-        d_max_index.data(),
-        num_items_i64,
-        env);
-      REQUIRE(error == cudaSuccess);
-      REQUIRE(cudaSuccess == cudaPeekAtLastError());
-      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
-
-      output_t gpu_min = static_cast<output_t>(d_min_out[0]);
-      output_t gpu_max = static_cast<output_t>(d_max_out[0]);
-      REQUIRE(expected_min == gpu_min);
-      REQUIRE(expected_min_index == d_min_index[0]);
-      REQUIRE(expected_first_max == gpu_max);
-      REQUIRE(expected_first_max_index == d_max_index[0]);
-    };
-
-    int current_device;
-    error = cudaGetDevice(&current_device);
-    REQUIRE(error == cudaSuccess);
-
-    SECTION("DeviceReduce::ArgMinMax works with cudaStream_t")
-    {
-      cuda::stream stream{cuda::devices[current_device]};
-      test_argminmax(stream.get());
-    }
-
-    SECTION("DeviceReduce::ArgMinMax works with cuda::stream")
-    {
-      cuda::stream stream{cuda::devices[current_device]};
-      test_argminmax(stream);
-    }
-
-    SECTION("DeviceReduce::ArgMinMax works with cuda::stream_ref")
-    {
-      cuda::stream stream{cuda::devices[current_device]};
-      cuda::stream_ref stream_ref{stream};
-      test_argminmax(stream_ref);
-    }
-
-    SECTION("DeviceReduce::ArgMinMax works with cuda::std::execution::env")
-    {
-      cuda::std::execution::env env{};
-      test_argminmax(env);
-    }
-
-    SECTION("DeviceReduce::ArgMinMax works with cuda::execution::gpu")
-    {
-      const auto policy = cuda::execution::gpu;
-      test_argminmax(policy);
-    }
-
-    SECTION("DeviceReduce::ArgMinMax works with cuda::execution::gpu with stream")
-    {
-      cuda::stream stream{cuda::devices[current_device]};
-      const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
-      test_argminmax(policy);
-    }
+    output_t gpu_min = static_cast<output_t>(d_min_out[0]);
+    output_t gpu_max = static_cast<output_t>(d_max_out[0]);
+    REQUIRE(expected_min == gpu_min);
+    REQUIRE(expected_min_index == d_min_index[0]);
+    REQUIRE(expected_max == gpu_max);
+    REQUIRE(expected_max_index == d_max_index[0]);
   }
-
-  SECTION("argminlastmax with user provided memory and environment")
-  {
-    const auto num_items_i64 = static_cast<cuda::std::int64_t>(num_items);
-
-    size_t expected_allocation_size = 0;
-    auto error                      = cub::DeviceReduce::ArgMinLastMax(
-      static_cast<void*>(nullptr),
-      expected_allocation_size,
-      unwrap_it(d_in_it),
-      d_min_out.data(),
-      d_min_index.data(),
-      d_max_out.data(),
-      d_max_index.data(),
-      num_items_i64);
-    REQUIRE(error == cudaSuccess);
-    REQUIRE(cudaSuccess == cudaPeekAtLastError());
-    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
-
-    auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
-    void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
-
-    auto test_argminlastmax = [&](const auto& env) {
-      size_t num_bytes = 0;
-      error            = cub::DeviceReduce::ArgMinLastMax(
-        static_cast<void*>(nullptr),
-        num_bytes,
-        unwrap_it(d_in_it),
-        d_min_out.data(),
-        d_min_index.data(),
-        d_max_out.data(),
-        d_max_index.data(),
-        num_items_i64,
-        env);
-      REQUIRE(error == cudaSuccess);
-      REQUIRE(cudaSuccess == cudaPeekAtLastError());
-      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
-      REQUIRE(expected_allocation_size == num_bytes);
-
-      error = cub::DeviceReduce::ArgMinLastMax(
-        temp_storage,
-        num_bytes,
-        unwrap_it(d_in_it),
-        d_min_out.data(),
-        d_min_index.data(),
-        d_max_out.data(),
-        d_max_index.data(),
-        num_items_i64,
-        env);
-      REQUIRE(error == cudaSuccess);
-      REQUIRE(cudaSuccess == cudaPeekAtLastError());
-      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
-
-      output_t gpu_min = static_cast<output_t>(d_min_out[0]);
-      output_t gpu_max = static_cast<output_t>(d_max_out[0]);
-      REQUIRE(expected_min == gpu_min);
-      REQUIRE(expected_min_index == d_min_index[0]);
-      REQUIRE(expected_last_max == gpu_max);
-      REQUIRE(expected_last_max_index == d_max_index[0]);
-    };
-
-    int current_device;
-    error = cudaGetDevice(&current_device);
-    REQUIRE(error == cudaSuccess);
-
-    SECTION("DeviceReduce::ArgMinLastMax works with cudaStream_t")
-    {
-      cuda::stream stream{cuda::devices[current_device]};
-      test_argminlastmax(stream.get());
-    }
-
-    SECTION("DeviceReduce::ArgMinLastMax works with cuda::stream")
-    {
-      cuda::stream stream{cuda::devices[current_device]};
-      test_argminlastmax(stream);
-    }
-
-    SECTION("DeviceReduce::ArgMinLastMax works with cuda::stream_ref")
-    {
-      cuda::stream stream{cuda::devices[current_device]};
-      cuda::stream_ref stream_ref{stream};
-      test_argminlastmax(stream_ref);
-    }
-
-    SECTION("DeviceReduce::ArgMinLastMax works with cuda::std::execution::env")
-    {
-      cuda::std::execution::env env{};
-      test_argminlastmax(env);
-    }
-
-    SECTION("DeviceReduce::ArgMinLastMax works with cuda::execution::gpu")
-    {
-      const auto policy = cuda::execution::gpu;
-      test_argminlastmax(policy);
-    }
-
-    SECTION("DeviceReduce::ArgMinLastMax works with cuda::execution::gpu with stream")
-    {
-      cuda::stream stream{cuda::devices[current_device]};
-      const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
-      test_argminlastmax(policy);
-    }
-  }
-#endif // !_CCCL_COMPILER(GCC, <, 8)
 
   // abs comparison via cuda::uabs only compiles for integral scalar types
   if constexpr (cuda::std::is_integral_v<item_t>)
   {
-    SECTION("argminmax-abs_less_t")
+    SECTION("abs_less_t")
     {
+      const bool last_max = GENERATE(false, true);
       abs_less_t compare_op;
 
       // First minimum by abs value: first element with smallest |value|
@@ -705,39 +311,17 @@ CUB_TEST("Device ArgMinMax and ArgMinLastMax work with all device interfaces",
       const auto exp_first_max       = static_cast<output_t>(*exp_first_max_it);
       const auto exp_first_max_index = static_cast<cuda::std::int64_t>(exp_first_max_it - host_items.cbegin());
 
-      device_arg_minmax(
-        unwrap_it(d_in_it),
-        d_min_out.data(),
-        d_min_index.data(),
-        d_max_out.data(),
-        d_max_index.data(),
-        num_items,
-        compare_op);
-
-      output_t gpu_min = static_cast<output_t>(d_min_out[0]);
-      output_t gpu_max = static_cast<output_t>(d_max_out[0]);
-      REQUIRE(exp_min == gpu_min);
-      REQUIRE(exp_min_index == d_min_index[0]);
-      REQUIRE(exp_first_max == gpu_max);
-      REQUIRE(exp_first_max_index == d_max_index[0]);
-    }
-
-    SECTION("argminlastmax-abs_less_t")
-    {
-      abs_less_t compare_op;
-
-      // First minimum by abs value: first element with smallest |value|
-      auto exp_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend(), compare_op);
-      const auto exp_min       = static_cast<output_t>(*exp_min_it);
-      const auto exp_min_index = static_cast<cuda::std::int64_t>(exp_min_it - host_items.cbegin());
-
       // Last maximum by abs value: last element with largest |value|
       auto exp_last_max_it          = cuda::std::max_element(host_items.crbegin(), host_items.crend(), compare_op);
       const auto exp_last_max       = static_cast<output_t>(*exp_last_max_it);
       const auto exp_last_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
                                     - static_cast<cuda::std::int64_t>(exp_last_max_it - host_items.crbegin());
 
-      device_arg_minlastmax(
+      const auto exp_max       = last_max ? exp_last_max : exp_first_max;
+      const auto exp_max_index = last_max ? exp_last_max_index : exp_first_max_index;
+
+      call_argminmax_launch_wrapper(
+        last_max,
         unwrap_it(d_in_it),
         d_min_out.data(),
         d_min_index.data(),
@@ -750,8 +334,8 @@ CUB_TEST("Device ArgMinMax and ArgMinLastMax work with all device interfaces",
       output_t gpu_max = static_cast<output_t>(d_max_out[0]);
       REQUIRE(exp_min == gpu_min);
       REQUIRE(exp_min_index == d_min_index[0]);
-      REQUIRE(exp_last_max == gpu_max);
-      REQUIRE(exp_last_max_index == d_max_index[0]);
+      REQUIRE(exp_max == gpu_max);
+      REQUIRE(exp_max_index == d_max_index[0]);
     }
   }
 }

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -90,7 +90,7 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinMax basic correctness", "[reduce][arg_mi
     static_cast<::cuda::std::int64_t>(input.size()));
   REQUIRE(error == cudaSuccess);
 
-  thrust::device_vector<char> temp_storage(temp_storage_bytes);
+  thrust::device_vector<char> temp_storage(temp_storage_bytes, thrust::no_init);
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
   error = cub::DeviceReduce::ArgMinMax(
@@ -131,7 +131,7 @@ CUB_TEST_CASE("cub::DeviceReduce::ArgMinLastMax basic correctness", "[reduce][ar
     static_cast<::cuda::std::int64_t>(input.size()));
   REQUIRE(error == cudaSuccess);
 
-  thrust::device_vector<char> temp_storage(temp_storage_bytes);
+  thrust::device_vector<char> temp_storage(temp_storage_bytes, thrust::no_init);
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
   error = cub::DeviceReduce::ArgMinLastMax(
@@ -695,18 +695,15 @@ CUB_TEST("Device ArgMinMax and ArgMinLastMax work with all device interfaces",
     {
       abs_less_t compare_op;
 
-      // Prepare verification data
-      c2h::host_vector<item_t> host_items_abs(in_items);
-
       // First minimum by abs value: first element with smallest |value|
-      auto exp_min_it          = cuda::std::min_element(host_items_abs.cbegin(), host_items_abs.cend(), compare_op);
+      auto exp_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend(), compare_op);
       const auto exp_min       = static_cast<output_t>(*exp_min_it);
-      const auto exp_min_index = static_cast<cuda::std::int64_t>(exp_min_it - host_items_abs.cbegin());
+      const auto exp_min_index = static_cast<cuda::std::int64_t>(exp_min_it - host_items.cbegin());
 
       // First maximum by abs value: first element with largest |value|
-      auto exp_first_max_it    = cuda::std::max_element(host_items_abs.cbegin(), host_items_abs.cend(), compare_op);
-      const auto exp_first_max = static_cast<output_t>(*exp_first_max_it);
-      const auto exp_first_max_index = static_cast<cuda::std::int64_t>(exp_first_max_it - host_items_abs.cbegin());
+      auto exp_first_max_it          = cuda::std::max_element(host_items.cbegin(), host_items.cend(), compare_op);
+      const auto exp_first_max       = static_cast<output_t>(*exp_first_max_it);
+      const auto exp_first_max_index = static_cast<cuda::std::int64_t>(exp_first_max_it - host_items.cbegin());
 
       device_arg_minmax(
         unwrap_it(d_in_it),
@@ -729,19 +726,16 @@ CUB_TEST("Device ArgMinMax and ArgMinLastMax work with all device interfaces",
     {
       abs_less_t compare_op;
 
-      // Prepare verification data
-      c2h::host_vector<item_t> host_items_abs(in_items);
-
       // First minimum by abs value: first element with smallest |value|
-      auto exp_min_it          = cuda::std::min_element(host_items_abs.cbegin(), host_items_abs.cend(), compare_op);
+      auto exp_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend(), compare_op);
       const auto exp_min       = static_cast<output_t>(*exp_min_it);
-      const auto exp_min_index = static_cast<cuda::std::int64_t>(exp_min_it - host_items_abs.cbegin());
+      const auto exp_min_index = static_cast<cuda::std::int64_t>(exp_min_it - host_items.cbegin());
 
       // Last maximum by abs value: last element with largest |value|
-      auto exp_last_max_it    = cuda::std::max_element(host_items_abs.crbegin(), host_items_abs.crend(), compare_op);
-      const auto exp_last_max = static_cast<output_t>(*exp_last_max_it);
-      const auto exp_last_max_index = static_cast<cuda::std::int64_t>(host_items_abs.size()) - 1
-                                    - static_cast<cuda::std::int64_t>(exp_last_max_it - host_items_abs.crbegin());
+      auto exp_last_max_it          = cuda::std::max_element(host_items.crbegin(), host_items.crend(), compare_op);
+      const auto exp_last_max       = static_cast<output_t>(*exp_last_max_it);
+      const auto exp_last_max_index = static_cast<cuda::std::int64_t>(host_items.size()) - 1
+                                    - static_cast<cuda::std::int64_t>(exp_last_max_it - host_items.crbegin());
 
       device_arg_minlastmax(
         unwrap_it(d_in_it),

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // Should precede any includes
 struct stream_registry_factory_t;

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
@@ -31,10 +31,10 @@ namespace stdexec = cuda::std::execution;
 CUB_TEST_CASE("Device ArgMinMax works with default environment", "[reduce][device]", CUB_SMALL)
 {
   auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = c2h::device_vector<float>(1);
-  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = c2h::device_vector<float>(1);
-  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   auto error = cub::DeviceReduce::ArgMinMax(
     input.begin(),
@@ -53,10 +53,10 @@ CUB_TEST_CASE("Device ArgMinMax works with default environment", "[reduce][devic
 CUB_TEST_CASE("Device ArgMinLastMax works with default environment", "[reduce][device]", CUB_SMALL)
 {
   auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = c2h::device_vector<float>(1);
-  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = c2h::device_vector<float>(1);
-  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   auto error = cub::DeviceReduce::ArgMinLastMax(
     input.begin(),
@@ -77,10 +77,10 @@ CUB_TEST_CASE("Device ArgMinLastMax works with default environment", "[reduce][d
 CUB_TEST("Device ArgMinMax uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = c2h::device_vector<float>(1);
-  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = c2h::device_vector<float>(1);
-  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   const auto n = static_cast<::cuda::std::int64_t>(input.size());
 
@@ -110,10 +110,10 @@ CUB_TEST("Device ArgMinMax uses environment", "[reduce][device]", CUB_SMALL)
 CUB_TEST("Device ArgMinLastMax uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = c2h::device_vector<float>(1);
-  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = c2h::device_vector<float>(1);
-  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   const auto n = static_cast<::cuda::std::int64_t>(input.size());
 
@@ -143,10 +143,10 @@ CUB_TEST("Device ArgMinLastMax uses environment", "[reduce][device]", CUB_SMALL)
 CUB_TEST("Device ArgMinMax with compare_op uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = c2h::device_vector<float>(1);
-  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = c2h::device_vector<float>(1);
-  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   const auto n = static_cast<::cuda::std::int64_t>(input.size());
 
@@ -178,10 +178,10 @@ CUB_TEST("Device ArgMinMax with compare_op uses environment", "[reduce][device]"
 CUB_TEST("Device ArgMinLastMax with compare_op uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = c2h::device_vector<float>(1);
-  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
-  auto max_out   = c2h::device_vector<float>(1);
-  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   const auto n = static_cast<::cuda::std::int64_t>(input.size());
 

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
@@ -18,6 +18,7 @@ struct stream_registry_factory_t;
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMinMax, device_arg_minmax);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMinLastMax, device_arg_minlastmax);
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -39,6 +40,28 @@ CUB_TEST_CASE("Device ArgMinMax works with default environment", "[reduce][devic
   auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
 
   auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}
+
+CUB_TEST_CASE("Device ArgMinLastMax works with default environment", "[reduce][device]", CUB_SMALL)
+{
+  auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = c2h::device_vector<float>(1);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = c2h::device_vector<float>(1);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
+
+  auto error = cub::DeviceReduce::ArgMinLastMax(
     input.begin(),
     min_out.begin(),
     min_index.begin(),
@@ -87,6 +110,39 @@ CUB_TEST("Device ArgMinMax uses environment", "[reduce][device]", CUB_SMALL)
   REQUIRE(max_index[0] == 2);
 }
 
+CUB_TEST("Device ArgMinLastMax uses environment", "[reduce][device]", CUB_SMALL)
+{
+  auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = c2h::device_vector<float>(1);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = c2h::device_vector<float>(1);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
+
+  const auto n = static_cast<::cuda::std::int64_t>(input.size());
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceReduce::ArgMinLastMax(
+      nullptr,
+      expected_bytes_allocated,
+      input.begin(),
+      min_out.begin(),
+      min_index.begin(),
+      max_out.begin(),
+      max_index.begin(),
+      n));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_arg_minlastmax(input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, env);
+
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}
+
 CUB_TEST("Device ArgMinMax with compare_op uses environment", "[reduce][device]", CUB_SMALL)
 {
   auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
@@ -114,6 +170,41 @@ CUB_TEST("Device ArgMinMax with compare_op uses environment", "[reduce][device]"
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
   device_arg_minmax(
+    input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, cuda::std::less{}, env);
+
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}
+
+CUB_TEST("Device ArgMinLastMax with compare_op uses environment", "[reduce][device]", CUB_SMALL)
+{
+  auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = c2h::device_vector<float>(1);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = c2h::device_vector<float>(1);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
+
+  const auto n = static_cast<::cuda::std::int64_t>(input.size());
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceReduce::ArgMinLastMax(
+      nullptr,
+      expected_bytes_allocated,
+      input.begin(),
+      min_out.begin(),
+      min_index.begin(),
+      max_out.begin(),
+      max_index.begin(),
+      n,
+      cuda::std::less{}));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_arg_minlastmax(
     input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, cuda::std::less{}, env);
 
   REQUIRE(min_out[0] == 0.0f);

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
@@ -22,9 +22,6 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMinLastMax, device_arg_minlastmax);
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
-#include <cuda/__execution/determinism.h>
-#include <cuda/__execution/require.h>
-
 #include "cub_test_macros.h"
 
 namespace stdexec = cuda::std::execution;

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Should precede any includes
+struct stream_registry_factory_t;
+#define CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY stream_registry_factory_t
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_reduce.cuh>
+
+#include <thrust/device_vector.h>
+
+#include <cuda/devices>
+#include <cuda/iterator>
+#include <cuda/stream>
+
+#include "catch2_test_env_launch_helper.h"
+
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMinMax, device_arg_minmax);
+
+// %PARAM% TEST_LAUNCH lid 0:1:2
+
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/require.h>
+
+#include "cub_test_macros.h"
+
+namespace stdexec = cuda::std::execution;
+
+#if TEST_LAUNCH == 0
+
+CUB_TEST_CASE("Device ArgMinMax works with default environment", "[reduce][device]", CUB_SMALL)
+{
+  auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = c2h::device_vector<float>(1);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = c2h::device_vector<float>(1);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
+
+  auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_out.begin(),
+    min_index.begin(),
+    max_out.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()));
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}
+
+#endif
+
+CUB_TEST("Device ArgMinMax uses environment", "[reduce][device]", CUB_SMALL)
+{
+  auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = c2h::device_vector<float>(1);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = c2h::device_vector<float>(1);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
+
+  const auto n = static_cast<::cuda::std::int64_t>(input.size());
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceReduce::ArgMinMax(
+      nullptr,
+      expected_bytes_allocated,
+      input.begin(),
+      min_out.begin(),
+      min_index.begin(),
+      max_out.begin(),
+      max_index.begin(),
+      n));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_arg_minmax(input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, env);
+
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
@@ -86,3 +86,38 @@ CUB_TEST("Device ArgMinMax uses environment", "[reduce][device]", CUB_SMALL)
   REQUIRE(max_out[0] == 4.0f);
   REQUIRE(max_index[0] == 2);
 }
+
+CUB_TEST("Device ArgMinMax with compare_op uses environment", "[reduce][device]", CUB_SMALL)
+{
+  auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = c2h::device_vector<float>(1);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = c2h::device_vector<float>(1);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
+
+  const auto n = static_cast<::cuda::std::int64_t>(input.size());
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceReduce::ArgMinMax(
+      nullptr,
+      expected_bytes_allocated,
+      input.begin(),
+      min_out.begin(),
+      min_index.begin(),
+      max_out.begin(),
+      max_index.begin(),
+      n,
+      cuda::std::less{}));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_arg_minmax(
+    input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, cuda::std::less{}, env);
+
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
@@ -12,7 +12,10 @@ struct stream_registry_factory_t;
 #include <thrust/device_vector.h>
 
 #include <cuda/devices>
+#include <cuda/execution>
 #include <cuda/iterator>
+#include <cuda/std/execution>
+#include <cuda/std/utility>
 #include <cuda/stream>
 
 #include "catch2_test_env_launch_helper.h"
@@ -26,17 +29,55 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMinLastMax, device_arg_minlastmax);
 
 namespace stdexec = cuda::std::execution;
 
+template <typename... Args>
+cudaError_t call_argminmax_api(bool last_max, Args&&... args)
+{
+  return last_max ? cub::DeviceReduce::ArgMinLastMax(::cuda::std::forward<Args>(args)...)
+                  : cub::DeviceReduce::ArgMinMax(::cuda::std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+void call_argminmax_launch_wrapper(bool last_max, Args&&... args)
+{
+  if (last_max)
+  {
+    device_arg_minlastmax(::cuda::std::forward<Args>(args)...);
+  }
+  else
+  {
+    device_arg_minmax(::cuda::std::forward<Args>(args)...);
+  }
+}
+
+// Custom tuning that forces a specific block size, used to verify a tuning environment reaches the kernel.
+template <int ThreadsPerBlock>
+struct reduce_tuning
+{
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::ReducePolicy
+  {
+    const auto policy =
+      cub::ReducePassPolicy{ThreadsPerBlock, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
+    return {policy, policy};
+  }
+};
+
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 32>, cuda::std::integral_constant<unsigned int, 64>>;
+
 #if TEST_LAUNCH == 0
 
-CUB_TEST_CASE("Device ArgMinMax works with default environment", "[reduce][device]", CUB_SMALL)
+CUB_TEST_CASE("Device ArgMin[Last]Max works with default environment", "[reduce][device]", CUB_SMALL)
 {
+  const bool last_max = GENERATE(false, true);
+
   auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
   auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
   auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
   auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
-  auto error = cub::DeviceReduce::ArgMinMax(
+  auto error = call_argminmax_api(
+    last_max,
     input.begin(),
     min_out.begin(),
     min_index.begin(),
@@ -50,162 +91,149 @@ CUB_TEST_CASE("Device ArgMinMax works with default environment", "[reduce][devic
   REQUIRE(max_index[0] == 2);
 }
 
-CUB_TEST_CASE("Device ArgMinLastMax works with default environment", "[reduce][device]", CUB_SMALL)
+#endif // TEST_LAUNCH == 0
+
+CUB_TEST("Device ArgMin[Last]Max uses environment", "[reduce][device]", CUB_SMALL)
 {
+  const bool last_max = GENERATE(false, true);
+
   auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
   auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
   auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
   auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
-  auto error = cub::DeviceReduce::ArgMinLastMax(
+  const auto n = static_cast<::cuda::std::int64_t>(input.size());
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == call_argminmax_api(
+      last_max,
+      nullptr,
+      expected_bytes_allocated,
+      input.begin(),
+      min_out.begin(),
+      min_index.begin(),
+      max_out.begin(),
+      max_index.begin(),
+      n));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  call_argminmax_launch_wrapper(
+    last_max, input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, env);
+
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}
+
+CUB_TEST("Device ArgMin[Last]Max with compare_op uses environment", "[reduce][device]", CUB_SMALL)
+{
+  const bool last_max = GENERATE(false, true);
+
+  auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+
+  const auto n = static_cast<::cuda::std::int64_t>(input.size());
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == call_argminmax_api(
+      last_max,
+      nullptr,
+      expected_bytes_allocated,
+      input.begin(),
+      min_out.begin(),
+      min_index.begin(),
+      max_out.begin(),
+      max_index.begin(),
+      n,
+      cuda::std::less{}));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  call_argminmax_launch_wrapper(
+    last_max,
     input.begin(),
     min_out.begin(),
     min_index.begin(),
     max_out.begin(),
     max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()));
+    n,
+    cuda::std::less{},
+    env);
+
+  REQUIRE(min_out[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_out[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
+}
+
+#if TEST_LAUNCH == 0
+CUB_TEST("Device ArgMin[Last]Max uses custom stream", "[reduce][device]", CUB_SMALL)
+{
+  const bool last_max = GENERATE(false, true);
+
+  // The maximum value 4 appears twice, so first-max and last-max disagree on the reported index.
+  auto input     = c2h::device_vector<float>{3.0f, 4.0f, 4.0f, 0.0f, 2.0f};
+  auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+
+  const auto n                                = static_cast<::cuda::std::int64_t>(input.size());
+  const cuda::std::int64_t expected_max_index = last_max ? 2 : 1;
+
+  cuda::stream stream{cuda::devices[0]};
+  const auto error = call_argminmax_api(
+    last_max, input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, stream);
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(min_out[0] == 0.0f);
   REQUIRE(min_index[0] == 3);
   REQUIRE(max_out[0] == 4.0f);
-  REQUIRE(max_index[0] == 2);
+  REQUIRE(max_index[0] == expected_max_index);
 }
+#endif // TEST_LAUNCH == 0
 
-#endif
-
-CUB_TEST("Device ArgMinMax uses environment", "[reduce][device]", CUB_SMALL)
+// Device-side (CDP) launch cannot apply a host-provided tuning environment, so skip it there (matches the other
+// tuning tests in catch2_test_device_reduce_env.cu).
+#if TEST_LAUNCH != 1
+CUB_TEST("Device ArgMin[Last]Max can be tuned", "[reduce][device]", CUB_SMALL, block_sizes)
 {
-  auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
-  auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
-  auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  const bool last_max                      = GENERATE(false, true);
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  const auto n = static_cast<::cuda::std::int64_t>(input.size());
+  c2h::device_vector<unsigned int> d_block_size(1);
+  using compare_t = block_size_extracting_op<cuda::std::less<>>;
+  compare_t compare_op{thrust::raw_pointer_cast(d_block_size.data())};
 
-  size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::ArgMinMax(
-      nullptr,
-      expected_bytes_allocated,
-      input.begin(),
-      min_out.begin(),
-      min_index.begin(),
-      max_out.begin(),
-      max_index.begin(),
-      n));
+  // The maximum value 4 appears twice, so first-max and last-max disagree on the reported index.
+  auto input     = c2h::device_vector<int>{3, 4, 4, 0, 2};
+  auto min_out   = c2h::device_vector<int>(1);
+  auto min_index = c2h::device_vector<cuda::std::int64_t>(1);
+  auto max_out   = c2h::device_vector<int>(1);
+  auto max_index = c2h::device_vector<cuda::std::int64_t>(1);
 
-  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+  const auto n                                = static_cast<int>(input.size());
+  const cuda::std::int64_t expected_max_index = last_max ? 2 : 1;
 
-  device_arg_minmax(input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, env);
+  auto env = cuda::execution::tune(reduce_tuning<target_block_size>{});
 
-  REQUIRE(min_out[0] == 0.0f);
+  call_argminmax_launch_wrapper(
+    last_max, input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, compare_op, env);
+
+  REQUIRE(min_out[0] == 0);
   REQUIRE(min_index[0] == 3);
-  REQUIRE(max_out[0] == 4.0f);
-  REQUIRE(max_index[0] == 2);
+  REQUIRE(max_out[0] == 4);
+  REQUIRE(max_index[0] == expected_max_index);
+  REQUIRE(d_block_size[0] == target_block_size);
 }
-
-CUB_TEST("Device ArgMinLastMax uses environment", "[reduce][device]", CUB_SMALL)
-{
-  auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
-  auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
-  auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  const auto n = static_cast<::cuda::std::int64_t>(input.size());
-
-  size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::ArgMinLastMax(
-      nullptr,
-      expected_bytes_allocated,
-      input.begin(),
-      min_out.begin(),
-      min_index.begin(),
-      max_out.begin(),
-      max_index.begin(),
-      n));
-
-  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
-
-  device_arg_minlastmax(input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, env);
-
-  REQUIRE(min_out[0] == 0.0f);
-  REQUIRE(min_index[0] == 3);
-  REQUIRE(max_out[0] == 4.0f);
-  REQUIRE(max_index[0] == 2);
-}
-
-CUB_TEST("Device ArgMinMax with compare_op uses environment", "[reduce][device]", CUB_SMALL)
-{
-  auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
-  auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
-  auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  const auto n = static_cast<::cuda::std::int64_t>(input.size());
-
-  size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::ArgMinMax(
-      nullptr,
-      expected_bytes_allocated,
-      input.begin(),
-      min_out.begin(),
-      min_index.begin(),
-      max_out.begin(),
-      max_index.begin(),
-      n,
-      cuda::std::less{}));
-
-  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
-
-  device_arg_minmax(
-    input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, cuda::std::less{}, env);
-
-  REQUIRE(min_out[0] == 0.0f);
-  REQUIRE(min_index[0] == 3);
-  REQUIRE(max_out[0] == 4.0f);
-  REQUIRE(max_index[0] == 2);
-}
-
-CUB_TEST("Device ArgMinLastMax with compare_op uses environment", "[reduce][device]", CUB_SMALL)
-{
-  auto input     = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_out   = c2h::device_vector<float>(1, thrust::no_init);
-  auto min_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-  auto max_out   = c2h::device_vector<float>(1, thrust::no_init);
-  auto max_index = c2h::device_vector<cuda::std::int64_t>(1, thrust::no_init);
-
-  const auto n = static_cast<::cuda::std::int64_t>(input.size());
-
-  size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::ArgMinLastMax(
-      nullptr,
-      expected_bytes_allocated,
-      input.begin(),
-      min_out.begin(),
-      min_index.begin(),
-      max_out.begin(),
-      max_index.begin(),
-      n,
-      cuda::std::less{}));
-
-  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
-
-  device_arg_minlastmax(
-    input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, cuda::std::less{}, env);
-
-  REQUIRE(min_out[0] == 0.0f);
-  REQUIRE(min_index[0] == 3);
-  REQUIRE(max_out[0] == 4.0f);
-  REQUIRE(max_index[0] == 2);
-}
+#endif // TEST_LAUNCH != 1

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
@@ -18,10 +18,10 @@ CUB_TEST("cub::DeviceReduce::ArgMinMax API example", "[reduce][env]", CUB_SMALL)
 {
   // example-begin argminmax-env
   auto input      = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_output = thrust::device_vector<float>(1);
-  auto min_index  = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_output = thrust::device_vector<float>(1);
-  auto max_index  = thrust::device_vector<cuda::std::int64_t>(1);
+  auto min_output = thrust::device_vector<float>(1, thrust::no_init);
+  auto min_index  = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
+  auto max_output = thrust::device_vector<float>(1, thrust::no_init);
+  auto max_index  = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
   cuda::stream stream{cuda::devices[0]};
 

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "insert_nested_NVTX_range_guard.h"
 
@@ -13,6 +13,8 @@
 #include <cuda/devices>
 #include <cuda/std/__execution/env.h>
 #include <cuda/stream>
+
+#include <iostream>
 
 #include "cub_test_macros.h"
 

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
@@ -7,27 +7,23 @@
 
 #include <thrust/device_vector.h>
 
-#include <cuda/__execution/determinism.h>
-#include <cuda/__execution/require.h>
-#include <cuda/__execution/tune.h>
 #include <cuda/devices>
-#include <cuda/std/__execution/env.h>
 #include <cuda/stream>
 
 #include <iostream>
 
 #include "cub_test_macros.h"
 
-CUB_TEST("cub::DeviceReduce::ArgMinMax accepts determinism requirements", "[reduce][env]", CUB_SMALL)
+CUB_TEST("cub::DeviceReduce::ArgMinMax API example", "[reduce][env]", CUB_SMALL)
 {
-  // example-begin argminmax-env-determinism
+  // example-begin argminmax-env
   auto input      = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto min_output = thrust::device_vector<float>(1);
   auto min_index  = thrust::device_vector<cuda::std::int64_t>(1);
   auto max_output = thrust::device_vector<float>(1);
   auto max_index  = thrust::device_vector<cuda::std::int64_t>(1);
 
-  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
+  cuda::stream stream{cuda::devices[0]};
 
   auto error = cub::DeviceReduce::ArgMinMax(
     input.begin(),
@@ -36,7 +32,7 @@ CUB_TEST("cub::DeviceReduce::ArgMinMax accepts determinism requirements", "[redu
     max_output.begin(),
     max_index.begin(),
     static_cast<::cuda::std::int64_t>(input.size()),
-    env);
+    stream);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceReduce::ArgMinMax failed with status: " << error << '\n';
@@ -46,42 +42,12 @@ CUB_TEST("cub::DeviceReduce::ArgMinMax accepts determinism requirements", "[redu
   thrust::device_vector<cuda::std::int64_t> expected_min_index{3};
   thrust::device_vector<float> expected_max{4.0f};
   thrust::device_vector<cuda::std::int64_t> expected_max_index{2};
-  // example-end argminmax-env-determinism
+  // example-end argminmax-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(min_output == expected_min);
   REQUIRE(min_index == expected_min_index);
   REQUIRE(max_output == expected_max);
   REQUIRE(max_index == expected_max_index);
-}
-
-CUB_TEST("cub::DeviceReduce::ArgMinMax with compare_op accepts determinism requirements", "[reduce][env]", CUB_SMALL)
-{
-  auto input      = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
-  auto min_output = thrust::device_vector<float>(1);
-  auto min_index  = thrust::device_vector<cuda::std::int64_t>(1);
-  auto max_output = thrust::device_vector<float>(1);
-  auto max_index  = thrust::device_vector<cuda::std::int64_t>(1);
-
-  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
-
-  auto error = cub::DeviceReduce::ArgMinMax(
-    input.begin(),
-    min_output.begin(),
-    min_index.begin(),
-    max_output.begin(),
-    max_index.begin(),
-    static_cast<::cuda::std::int64_t>(input.size()),
-    cuda::std::less{},
-    env);
-  if (error != cudaSuccess)
-  {
-    std::cerr << "cub::DeviceReduce::ArgMinMax failed with status: " << error << '\n';
-  }
-
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(min_output[0] == 0.0f);
-  REQUIRE(min_index[0] == 3);
-  REQUIRE(max_output[0] == 4.0f);
-  REQUIRE(max_index[0] == 2);
 }

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
@@ -53,17 +53,15 @@ CUB_TEST("cub::DeviceReduce::ArgMinMax accepts determinism requirements", "[redu
   REQUIRE(max_index == expected_max_index);
 }
 
-CUB_TEST("cub::DeviceReduce::ArgMinMax accepts stream", "[reduce][env]", CUB_SMALL)
+CUB_TEST("cub::DeviceReduce::ArgMinMax with compare_op accepts determinism requirements", "[reduce][env]", CUB_SMALL)
 {
-  // example-begin argminmax-env-stream
   auto input      = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto min_output = thrust::device_vector<float>(1);
   auto min_index  = thrust::device_vector<cuda::std::int64_t>(1);
   auto max_output = thrust::device_vector<float>(1);
   auto max_index  = thrust::device_vector<cuda::std::int64_t>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
 
   auto error = cub::DeviceReduce::ArgMinMax(
     input.begin(),
@@ -72,22 +70,16 @@ CUB_TEST("cub::DeviceReduce::ArgMinMax accepts stream", "[reduce][env]", CUB_SMA
     max_output.begin(),
     max_index.begin(),
     static_cast<::cuda::std::int64_t>(input.size()),
-    stream_ref);
+    cuda::std::less{},
+    env);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceReduce::ArgMinMax failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected_min{0.0f};
-  thrust::device_vector<cuda::std::int64_t> expected_min_index{3};
-  thrust::device_vector<float> expected_max{4.0f};
-  thrust::device_vector<cuda::std::int64_t> expected_max_index{2};
-  // example-end argminmax-env-stream
-  stream.sync();
-
   REQUIRE(error == cudaSuccess);
-  REQUIRE(min_output == expected_min);
-  REQUIRE(min_index == expected_min_index);
-  REQUIRE(max_output == expected_max);
-  REQUIRE(max_index == expected_max_index);
+  REQUIRE(min_output[0] == 0.0f);
+  REQUIRE(min_index[0] == 3);
+  REQUIRE(max_output[0] == 4.0f);
+  REQUIRE(max_index[0] == 2);
 }

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_reduce.cuh>
+
+#include <thrust/device_vector.h>
+
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/require.h>
+#include <cuda/__execution/tune.h>
+#include <cuda/devices>
+#include <cuda/std/__execution/env.h>
+#include <cuda/stream>
+
+#include "cub_test_macros.h"
+
+CUB_TEST("cub::DeviceReduce::ArgMinMax accepts determinism requirements", "[reduce][env]", CUB_SMALL)
+{
+  // example-begin argminmax-env-determinism
+  auto input      = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_output = thrust::device_vector<float>(1);
+  auto min_index  = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_output = thrust::device_vector<float>(1);
+  auto max_index  = thrust::device_vector<cuda::std::int64_t>(1);
+
+  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
+
+  auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_output.begin(),
+    min_index.begin(),
+    max_output.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()),
+    env);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceReduce::ArgMinMax failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<float> expected_min{0.0f};
+  thrust::device_vector<cuda::std::int64_t> expected_min_index{3};
+  thrust::device_vector<float> expected_max{4.0f};
+  thrust::device_vector<cuda::std::int64_t> expected_max_index{2};
+  // example-end argminmax-env-determinism
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_output == expected_min);
+  REQUIRE(min_index == expected_min_index);
+  REQUIRE(max_output == expected_max);
+  REQUIRE(max_index == expected_max_index);
+}
+
+CUB_TEST("cub::DeviceReduce::ArgMinMax accepts stream", "[reduce][env]", CUB_SMALL)
+{
+  // example-begin argminmax-env-stream
+  auto input      = thrust::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_output = thrust::device_vector<float>(1);
+  auto min_index  = thrust::device_vector<cuda::std::int64_t>(1);
+  auto max_output = thrust::device_vector<float>(1);
+  auto max_index  = thrust::device_vector<cuda::std::int64_t>(1);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceReduce::ArgMinMax(
+    input.begin(),
+    min_output.begin(),
+    min_index.begin(),
+    max_output.begin(),
+    max_index.begin(),
+    static_cast<::cuda::std::int64_t>(input.size()),
+    stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceReduce::ArgMinMax failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<float> expected_min{0.0f};
+  thrust::device_vector<cuda::std::int64_t> expected_min_index{3};
+  thrust::device_vector<float> expected_max{4.0f};
+  thrust::device_vector<cuda::std::int64_t> expected_max_index{2};
+  // example-end argminmax-env-stream
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_output == expected_min);
+  REQUIRE(min_index == expected_min_index);
+  REQUIRE(max_output == expected_max);
+  REQUIRE(max_index == expected_max_index);
+}

--- a/cub/test/catch2_test_device_reduce_arg_minmax_large_offsets.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_large_offsets.cu
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_reduce.cuh>
+
+#include <cuda/iterator>
+
+#include <cstdint>
+
+#include "catch2_large_problem_helper.cuh"
+#include "catch2_test_device_reduce.cuh"
+#include "catch2_test_launch_helper.h"
+#include "cub_test_macros.h"
+
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMinMax, device_arg_minmax);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMinLastMax, device_arg_minlastmax);
+
+// %PARAM% TEST_LAUNCH lid 0:1:2
+
+// List of offset types to test
+using offset_types = c2h::type_list<std::int32_t, std::uint32_t, std::uint64_t>;
+
+// Dispatches to ArgMinMax (first maximum) or ArgMinLastMax (last maximum) so a single test body covers both APIs.
+template <typename... Args>
+void call_argminmax_launch_wrapper(bool last_max, Args... args)
+{
+  if (last_max)
+  {
+    device_arg_minlastmax(args...);
+  }
+  else
+  {
+    device_arg_minmax(args...);
+  }
+}
+
+// Maps an index to a value that is the global minimum (0) at two positions, the global maximum (2) at two other
+// positions, and a filler (1) everywhere else. Repeating the extrema lets us place one occurrence near the start and
+// one near the end of the input, so for large offset types they land in different streaming partitions.
+template <typename ItemT>
+struct repeated_extrema_op
+{
+  uint64_t min_pos_first;
+  uint64_t min_pos_last;
+  uint64_t max_pos_first;
+  uint64_t max_pos_last;
+
+  __host__ __device__ _CCCL_FORCEINLINE ItemT operator()(const uint64_t index) const
+  {
+    if (index == min_pos_first || index == min_pos_last)
+    {
+      return ItemT{0};
+    }
+    if (index == max_pos_first || index == max_pos_last)
+    {
+      return ItemT{2};
+    }
+    return ItemT{1};
+  }
+};
+
+CUB_TEST(
+  "Device ArgMin[Last]Max reports first/last extremum across partitions", "[reduce][device]", CUB_SMALL, offset_types)
+{
+  using index_t  = uint64_t;
+  using offset_t = typename c2h::get<0, TestType>;
+  using item_t   = int;
+
+  CAPTURE(c2h::type_name<offset_t>());
+
+  const bool last_max = GENERATE(false, true);
+
+  // Large enough that 32/64-bit offset types span more than one streaming partition.
+  const offset_t num_items = detail::make_large_offset<offset_t>();
+  const index_t n          = static_cast<index_t>(num_items);
+
+  // Place the repeated minimum (0) and maximum (2) once near the start and once near the end of the input, so their two
+  // occurrences fall into different partitions. This verifies that, across the partition boundary, the minimum and
+  // ArgMinMax's maximum resolve to the first occurrence while ArgMinLastMax's maximum resolves to the last.
+  const index_t min_pos_first = 0;
+  const index_t min_pos_last  = n - 2;
+  const index_t max_pos_first = 1;
+  const index_t max_pos_last  = n - 1;
+
+  const auto d_in_it = cuda::transform_iterator(
+    cuda::counting_iterator(index_t{}),
+    repeated_extrema_op<item_t>{min_pos_first, min_pos_last, max_pos_first, max_pos_last});
+
+  c2h::device_vector<item_t> min_out(1, thrust::no_init);
+  c2h::device_vector<item_t> max_out(1, thrust::no_init);
+  c2h::device_vector<cuda::std::int64_t> min_index(1, thrust::no_init);
+  c2h::device_vector<cuda::std::int64_t> max_index(1, thrust::no_init);
+
+  call_argminmax_launch_wrapper(
+    last_max,
+    d_in_it,
+    thrust::raw_pointer_cast(min_out.data()),
+    thrust::raw_pointer_cast(min_index.data()),
+    thrust::raw_pointer_cast(max_out.data()),
+    thrust::raw_pointer_cast(max_index.data()),
+    num_items);
+
+  const auto expected_max_index = static_cast<cuda::std::int64_t>(last_max ? max_pos_last : max_pos_first);
+
+  REQUIRE(min_out[0] == item_t{0});
+  REQUIRE(min_index[0] == static_cast<cuda::std::int64_t>(min_pos_first));
+  REQUIRE(max_out[0] == item_t{2});
+  REQUIRE(max_index[0] == expected_max_index);
+}


### PR DESCRIPTION
- [x] No SASS changes to `cub.bench.reduce.arg_extrema.base` on SM120

Perf on B200:
```
### [0] NVIDIA B200

| T{ct} |   Elements{io}   |    Size     | Samples |  CPU Time  | Noise |  GPU Time  | Noise |  Elem/s  | GlobalMem BW | BWUtil |
|-------|------------------|-------------|---------|------------|-------|------------|-------|----------|--------------|--------|
|    I8 |     2^16 = 65536 |  64.000 KiB |    412x |  41.515 us | 4.83% |  10.667 us | 8.64% |   6.144G |   6.146 GB/s |  0.08% |
|    I8 |   2^20 = 1048576 |   1.000 MiB |    458x |  44.318 us | 3.61% |  13.443 us | 3.94% |  78.000G |  78.001 GB/s |  1.02% |
|    I8 |  2^24 = 16777216 |  16.000 MiB |    388x |  72.837 us | 1.84% |  41.983 us | 0.14% | 399.622G | 399.622 GB/s |  5.21% |
|    I8 | 2^28 = 268435456 | 256.000 MiB |    404x | 315.061 us | 0.46% | 283.819 us | 0.24% | 945.797G | 945.798 GB/s | 12.33% |
|   I16 |     2^16 = 65536 | 128.000 KiB |    376x |  40.070 us | 3.74% |   9.315 us | 3.72% |   7.035G |  14.073 GB/s |  0.18% |
|   I16 |   2^20 = 1048576 |   2.000 MiB |    444x |  44.397 us | 3.33% |  13.226 us | 1.44% |  79.282G | 158.566 GB/s |  2.07% |
|   I16 |  2^24 = 16777216 |  32.000 MiB |    376x |  64.082 us | 2.12% |  33.492 us | 1.38% | 500.927G |   1.002 TB/s | 13.06% |
|   I16 | 2^28 = 268435456 | 512.000 MiB |    370x | 241.831 us | 0.90% | 211.444 us | 0.74% |   1.270T |   2.539 TB/s | 33.09% |
|   I32 |     2^16 = 65536 | 256.000 KiB |    406x |  39.381 us | 3.19% |   9.217 us | 1.21% |   7.110G |  28.443 GB/s |  0.37% |
|   I32 |   2^20 = 1048576 |   4.000 MiB |    374x |  41.453 us | 3.95% |  11.263 us | 0.43% |  93.102G | 372.408 GB/s |  4.85% |
|   I32 |  2^24 = 16777216 |  64.000 MiB |    542x |  63.297 us | 2.03% |  33.446 us | 2.27% | 501.621G |   2.006 TB/s | 26.15% |
|   I32 | 2^28 = 268435456 |   1.000 GiB |    342x | 235.277 us | 0.73% | 204.983 us | 0.51% |   1.310T |   5.238 TB/s | 68.27% |
|   I64 |     2^16 = 65536 | 512.000 KiB |    372x |  39.413 us | 3.12% |   9.469 us | 5.78% |   6.921G |  55.371 GB/s |  0.72% |
|   I64 |   2^20 = 1048576 |   8.000 MiB |    424x |  45.779 us | 3.37% |  15.513 us | 2.56% |  67.594G | 540.755 GB/s |  7.05% |
|   I64 |  2^24 = 16777216 | 128.000 MiB |    456x |  82.051 us | 1.86% |  52.005 us | 1.21% | 322.606G |   2.581 TB/s | 33.64% |
|   I64 | 2^28 = 268435456 |   2.000 GiB |    408x | 398.546 us | 0.45% | 368.180 us | 0.30% | 729.087G |   5.833 TB/s | 76.02% |
|  I128 |     2^16 = 65536 |   1.000 MiB |    366x |  42.939 us | 3.42% |  13.139 us | 2.92% |   4.988G |  79.813 GB/s |  1.04% |
|  I128 |   2^20 = 1048576 |  16.000 MiB |    450x |  63.765 us | 2.11% |  33.629 us | 1.12% |  31.181G | 498.891 GB/s |  6.50% |
|  I128 |  2^24 = 16777216 | 256.000 MiB |    422x | 125.478 us | 1.15% |  95.520 us | 0.75% | 175.641G |   2.810 TB/s | 36.63% |
|  I128 | 2^28 = 268435456 |   4.000 GiB |    394x | 775.130 us | 0.25% | 744.927 us | 0.21% | 360.351G |   5.766 TB/s | 75.15% |
|   F32 |     2^16 = 65536 | 256.000 KiB |    332x |  39.544 us | 4.04% |   9.214 us | 0.51% |   7.112G |  28.452 GB/s |  0.37% |
|   F32 |   2^20 = 1048576 |   4.000 MiB |    462x |  41.638 us | 3.34% |  11.267 us | 0.99% |  93.069G | 372.279 GB/s |  4.85% |
|   F32 |  2^24 = 16777216 |  64.000 MiB |    304x |  63.185 us | 3.07% |  33.126 us | 2.86% | 506.465G |   2.026 TB/s | 26.40% |
|   F32 | 2^28 = 268435456 |   1.000 GiB |    426x | 235.411 us | 0.81% | 205.053 us | 0.52% |   1.309T |   5.236 TB/s | 68.25% |
|   F64 |     2^16 = 65536 | 512.000 KiB |    466x |  39.665 us | 3.43% |   9.214 us | 1.24% |   7.113G |  56.906 GB/s |  0.74% |
|   F64 |   2^20 = 1048576 |   8.000 MiB |    312x |  45.869 us | 3.14% |  15.366 us | 0.34% |  68.239G | 545.913 GB/s |  7.12% |
|   F64 |  2^24 = 16777216 | 128.000 MiB |    358x |  79.554 us | 2.20% |  49.389 us | 2.02% | 339.695G |   2.718 TB/s | 35.42% |
|   F64 | 2^28 = 268435456 |   2.000 GiB |    372x | 387.349 us | 0.46% | 356.944 us | 0.36% | 752.037G |   6.016 TB/s | 78.42% |
```

For the curious, I started with just using `TransformReduce` and that was slower in all regards. Here is `TransformReduce` vs. the streaming approach implemented in this PR:
```
## [0] NVIDIA B200

|  T{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      2^16      |  11.163 us |       3.93% |  10.667 us |       8.64% |   -0.496 us |  -4.44% |  🟢 FAST  |
|   I8    |      2^20      |  17.421 us |       1.57% |  13.443 us |       3.94% |   -3.977 us | -22.83% |  🟢 FAST  |
|   I8    |      2^24      |  58.418 us |       0.55% |  41.983 us |       0.14% |  -16.435 us | -28.13% |  🟢 FAST  |
|   I8    |      2^28      | 457.626 us |       0.13% | 283.819 us |       0.24% | -173.806 us | -37.98% |  🟢 FAST  |
|   I16   |      2^16      |   9.396 us |       5.01% |   9.315 us |       3.72% |   -0.081 us |  -0.86% |  🔵 SAME  |
|   I16   |      2^20      |  15.984 us |       5.52% |  13.226 us |       1.44% |   -2.758 us | -17.26% |  🟢 FAST  |
|   I16   |      2^24      |  48.341 us |       1.26% |  33.492 us |       1.38% |  -14.849 us | -30.72% |  🟢 FAST  |
|   I16   |      2^28      | 360.044 us |       0.27% | 211.444 us |       0.74% | -148.600 us | -41.27% |  🟢 FAST  |
|   I32   |      2^16      |   9.212 us |       0.53% |   9.217 us |       1.21% |    0.005 us |   0.06% |  🔵 SAME  |
|   I32   |      2^20      |  15.348 us |       1.13% |  11.263 us |       0.43% |   -4.086 us | -26.62% |  🟢 FAST  |
|   I32   |      2^24      |  44.035 us |       0.27% |  33.446 us |       2.27% |  -10.589 us | -24.05% |  🟢 FAST  |
|   I32   |      2^28      | 332.335 us |       0.29% | 204.983 us |       0.51% | -127.352 us | -38.32% |  🟢 FAST  |
|   I64   |      2^16      |   9.650 us |       6.87% |   9.469 us |       5.78% |   -0.181 us |  -1.87% |  🔵 SAME  |
|   I64   |      2^20      |  17.145 us |       2.67% |  15.513 us |       2.56% |   -1.632 us |  -9.52% |  🟢 FAST  |
|   I64   |      2^24      |  56.240 us |       0.98% |  52.005 us |       1.21% |   -4.235 us |  -7.53% |  🟢 FAST  |
|   I64   |      2^28      | 472.469 us |       0.23% | 368.180 us |       0.30% | -104.289 us | -22.07% |  🟢 FAST  |
|  I128   |      2^16      |  13.315 us |       0.36% |  13.139 us |       2.92% |   -0.177 us |  -1.33% |  🟢 FAST  |
|  I128   |      2^20      |  35.840 us |       0.00% |  33.629 us |       1.12% |   -2.211 us |  -6.17% |  🟡 ????  |
|  I128   |      2^24      | 101.062 us |       0.60% |  95.520 us |       0.75% |   -5.542 us |  -5.48% |  🟢 FAST  |
|  I128   |      2^28      | 911.910 us |       0.16% | 744.927 us |       0.21% | -166.983 us | -18.31% |  🟢 FAST  |
|   F32   |      2^16      |   9.219 us |       0.77% |   9.214 us |       0.51% |   -0.004 us |  -0.05% |  🔵 SAME  |
|   F32   |      2^20      |  15.359 us |       0.35% |  11.267 us |       0.99% |   -4.092 us | -26.64% |  🟢 FAST  |
|   F32   |      2^24      |  43.742 us |       1.31% |  33.126 us |       2.86% |  -10.615 us | -24.27% |  🟢 FAST  |
|   F32   |      2^28      | 332.245 us |       0.28% | 205.053 us |       0.52% | -127.192 us | -38.28% |  🟢 FAST  |
|   F64   |      2^16      |   9.246 us |       2.65% |   9.214 us |       1.24% |   -0.032 us |  -0.35% |  🔵 SAME  |
|   F64   |      2^20      |  17.176 us |       3.77% |  15.366 us |       0.34% |   -1.810 us | -10.54% |  🟢 FAST  |
|   F64   |      2^24      |  54.272 us |       0.00% |  49.389 us |       2.02% |   -4.883 us |  -9.00% |  🟡 ????  |
|   F64   |      2^28      | 441.550 us |       0.24% | 356.944 us |       0.36% |  -84.606 us | -19.16% |  🟢 FAST  |
```

Fixes: #6124