### PR TITLE
Add missing `_CCCL_DEDUCTION_GUIDE_ATTRIBUTES` to deduction guides

### DIFF
--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -139,7 +139,7 @@ struct arg_reduce_op : ValueLessThen
 };
 
 template <typename ValueLessThen>
-arg_reduce_op(ValueLessThen) -> arg_reduce_op<ValueLessThen>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES arg_reduce_op(ValueLessThen) -> arg_reduce_op<ValueLessThen>;
 
 /// @brief Arg min functor (keeps the value and offset of the first occurrence of the smallest item)
 using arg_min = arg_reduce_op<::cuda::std::less<>>;
@@ -156,7 +156,7 @@ struct swap_args : Predicate
 };
 
 template <typename Predicate>
-swap_args(Predicate) -> swap_args<Predicate>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES swap_args(Predicate) -> swap_args<Predicate>;
 
 /// @brief Arg max functor (keeps the value and offset of the first occurrence of the larger item)
 using arg_max = arg_reduce_op<swap_args<::cuda::std::less<>>>;

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -245,7 +245,7 @@ private:
 };
 
 template <typename IterT>
-FutureValue(IterT) -> FutureValue<detail::it_value_t<IterT>, IterT>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES FutureValue(IterT) -> FutureValue<detail::it_value_t<IterT>, IterT>;
 
 namespace detail
 {

--- a/cub/test/catch2_test_device_segmented_topk_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_topk_pairs.cu
@@ -49,7 +49,8 @@ struct flag_intra_segment_duplicates
 };
 
 template <typename ItemItT, typename SegIdItT>
-flag_intra_segment_duplicates(ItemItT, SegIdItT) -> flag_intra_segment_duplicates<ItemItT, SegIdItT>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES flag_intra_segment_duplicates(ItemItT, SegIdItT)
+  -> flag_intra_segment_duplicates<ItemItT, SegIdItT>;
 
 template <cub::detail::topk::select SelectDirection,
           typename KeyInputItItT,

--- a/cub/test/catch2_test_device_topk_common.cuh
+++ b/cub/test/catch2_test_device_topk_common.cuh
@@ -79,7 +79,8 @@ struct get_output_size_op
 };
 
 template <typename OffsetItT, typename KSizesItT>
-get_output_size_op(OffsetItT, KSizesItT, cuda::std::int64_t) -> get_output_size_op<OffsetItT, KSizesItT>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES get_output_size_op(OffsetItT, KSizesItT, cuda::std::int64_t)
+  -> get_output_size_op<OffsetItT, KSizesItT>;
 
 template <typename IteratorT, typename OffsetItT>
 struct offset_iterator_op

--- a/cudax/include/cuda/experimental/__cuco/detail/open_addressing/kernels.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/open_addressing/kernels.cuh
@@ -61,7 +61,8 @@ struct __insert_if_fn
 };
 
 template <class _InputIt, class _StencilIt, class _Predicate, class _Ref>
-__insert_if_fn(_InputIt, _StencilIt, _Predicate, _Ref) -> __insert_if_fn<_InputIt, _StencilIt, _Predicate, _Ref>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __insert_if_fn(_InputIt, _StencilIt, _Predicate, _Ref)
+  -> __insert_if_fn<_InputIt, _StencilIt, _Predicate, _Ref>;
 
 //! @brief Scalar (cooperative-group size 1) functor writing `pred(stencil[i]) ? contains(first[i]) : false`.
 template <class _InputIt, class _StencilIt, class _Predicate, class _OutputIt, class _Ref>
@@ -80,7 +81,7 @@ struct __contains_if_fn
 };
 
 template <class _InputIt, class _StencilIt, class _Predicate, class _OutputIt, class _Ref>
-__contains_if_fn(_InputIt, _StencilIt, _Predicate, _OutputIt, _Ref)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __contains_if_fn(_InputIt, _StencilIt, _Predicate, _OutputIt, _Ref)
   -> __contains_if_fn<_InputIt, _StencilIt, _Predicate, _OutputIt, _Ref>;
 
 //! @brief Inserts all elements in the range `[first, first + n)` and returns the number of

--- a/cudax/include/cuda/experimental/__execution/transform_completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/transform_completion_signatures.cuh
@@ -166,7 +166,7 @@ struct __transform_all_fn
 };
 
 template <class _TransformOne>
-__transform_all_fn(_TransformOne) -> __transform_all_fn<_TransformOne>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __transform_all_fn(_TransformOne) -> __transform_all_fn<_TransformOne>;
 
 template <class _Completions,
           class _ValueFn   = __default_transform_fn<set_value_t>,

--- a/cudax/include/cuda/experimental/__stf/utility/dimensions.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/dimensions.cuh
@@ -524,11 +524,11 @@ private:
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 // Deduction guides
 template <typename... Int>
-box(Int...) -> box<sizeof...(Int)>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES box(Int...) -> box<sizeof...(Int)>;
 template <typename... E>
-box(::std::initializer_list<E>...) -> box<sizeof...(E)>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES box(::std::initializer_list<E>...) -> box<sizeof...(E)>;
 template <typename E, size_t dimensions>
-box(::std::array<E, dimensions>) -> box<dimensions>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES box(::std::array<E, dimensions>) -> box<dimensions>;
 #endif // !_CCCL_DOXYGEN_INVOKED
 
 #ifdef UNITTESTED_FILE

--- a/libcudacxx/include/cuda/__argument/argument.h
+++ b/libcudacxx/include/cuda/__argument/argument.h
@@ -297,7 +297,7 @@ public:
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <class _Arg, auto _Lowest, auto _Highest>
-_CCCL_HOST_DEVICE immediate(_Arg, static_bounds<_Lowest, _Highest>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES immediate(_Arg, static_bounds<_Lowest, _Highest>)
   -> immediate<_Arg, static_bounds<_Lowest, _Highest>>;
 
 #endif // _CCCL_DOXYGEN_INVOKED
@@ -393,15 +393,15 @@ public:
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <class _Arg, auto _Lowest, auto _Highest>
-_CCCL_HOST_DEVICE __immediate_sequence(_Arg, static_bounds<_Lowest, _Highest>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __immediate_sequence(_Arg, static_bounds<_Lowest, _Highest>)
   -> __immediate_sequence<_Arg, static_bounds<_Lowest, _Highest>>;
 
 template <class _Arg, auto _Lowest, auto _Highest, class _Tp>
-_CCCL_HOST_DEVICE __immediate_sequence(_Arg, static_bounds<_Lowest, _Highest>, runtime_bounds<_Tp>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __immediate_sequence(_Arg, static_bounds<_Lowest, _Highest>, runtime_bounds<_Tp>)
   -> __immediate_sequence<_Arg, static_bounds<_Lowest, _Highest>>;
 
 template <class _Arg, class _Tp, auto _Lowest, auto _Highest>
-_CCCL_HOST_DEVICE __immediate_sequence(_Arg, runtime_bounds<_Tp>, static_bounds<_Lowest, _Highest>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __immediate_sequence(_Arg, runtime_bounds<_Tp>, static_bounds<_Lowest, _Highest>)
   -> __immediate_sequence<_Arg, static_bounds<_Lowest, _Highest>>;
 #endif // _CCCL_DOXYGEN_INVOKED
 
@@ -474,20 +474,21 @@ public:
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <class _Arg>
-_CCCL_HOST_DEVICE deferred(_Arg) -> deferred<_Arg>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES deferred(_Arg) -> deferred<_Arg>;
 
 template <class _Arg, auto _Lowest, auto _Highest>
-_CCCL_HOST_DEVICE deferred(_Arg, static_bounds<_Lowest, _Highest>) -> deferred<_Arg, static_bounds<_Lowest, _Highest>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES deferred(_Arg, static_bounds<_Lowest, _Highest>)
+  -> deferred<_Arg, static_bounds<_Lowest, _Highest>>;
 
 template <class _Arg, class _Tp>
-_CCCL_HOST_DEVICE deferred(_Arg, runtime_bounds<_Tp>) -> deferred<_Arg>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES deferred(_Arg, runtime_bounds<_Tp>) -> deferred<_Arg>;
 
 template <class _Arg, auto _Lowest, auto _Highest, class _Tp>
-_CCCL_HOST_DEVICE deferred(_Arg, static_bounds<_Lowest, _Highest>, runtime_bounds<_Tp>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES deferred(_Arg, static_bounds<_Lowest, _Highest>, runtime_bounds<_Tp>)
   -> deferred<_Arg, static_bounds<_Lowest, _Highest>>;
 
 template <class _Arg, class _Tp, auto _Lowest, auto _Highest>
-_CCCL_HOST_DEVICE deferred(_Arg, runtime_bounds<_Tp>, static_bounds<_Lowest, _Highest>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES deferred(_Arg, runtime_bounds<_Tp>, static_bounds<_Lowest, _Highest>)
   -> deferred<_Arg, static_bounds<_Lowest, _Highest>>;
 #endif // _CCCL_DOXYGEN_INVOKED
 
@@ -504,21 +505,21 @@ public:
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <class _Arg>
-_CCCL_HOST_DEVICE deferred_sequence(_Arg) -> deferred_sequence<_Arg>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES deferred_sequence(_Arg) -> deferred_sequence<_Arg>;
 
 template <class _Arg, auto _Lowest, auto _Highest>
-_CCCL_HOST_DEVICE deferred_sequence(_Arg, static_bounds<_Lowest, _Highest>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES deferred_sequence(_Arg, static_bounds<_Lowest, _Highest>)
   -> deferred_sequence<_Arg, static_bounds<_Lowest, _Highest>>;
 
 template <class _Arg, class _Tp>
-_CCCL_HOST_DEVICE deferred_sequence(_Arg, runtime_bounds<_Tp>) -> deferred_sequence<_Arg>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES deferred_sequence(_Arg, runtime_bounds<_Tp>) -> deferred_sequence<_Arg>;
 
 template <class _Arg, auto _Lowest, auto _Highest, class _Tp>
-_CCCL_HOST_DEVICE deferred_sequence(_Arg, static_bounds<_Lowest, _Highest>, runtime_bounds<_Tp>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES deferred_sequence(_Arg, static_bounds<_Lowest, _Highest>, runtime_bounds<_Tp>)
   -> deferred_sequence<_Arg, static_bounds<_Lowest, _Highest>>;
 
 template <class _Arg, class _Tp, auto _Lowest, auto _Highest>
-_CCCL_HOST_DEVICE deferred_sequence(_Arg, runtime_bounds<_Tp>, static_bounds<_Lowest, _Highest>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES deferred_sequence(_Arg, runtime_bounds<_Tp>, static_bounds<_Lowest, _Highest>)
   -> deferred_sequence<_Arg, static_bounds<_Lowest, _Highest>>;
 #endif // _CCCL_DOXYGEN_INVOKED
 

--- a/libcudacxx/include/cuda/__argument/argument_bounds.h
+++ b/libcudacxx/include/cuda/__argument/argument_bounds.h
@@ -147,7 +147,7 @@ public:
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <class _Tp>
-_CCCL_HOST_DEVICE runtime_bounds(_Tp, _Tp) -> runtime_bounds<_Tp>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES runtime_bounds(_Tp, _Tp) -> runtime_bounds<_Tp>;
 #endif // _CCCL_DOXYGEN_INVOKED
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__expected/unexpected.h
+++ b/libcudacxx/include/cuda/std/__expected/unexpected.h
@@ -157,7 +157,7 @@ private:
 };
 
 template <class _Err>
-unexpected(_Err) -> unexpected<_Err>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES unexpected(_Err) -> unexpected<_Err>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__functional/function.h
+++ b/libcudacxx/include/cuda/std/__functional/function.h
@@ -1055,7 +1055,7 @@ public:
 };
 
 template <class _Rp, class... _Ap>
-function(_Rp (*)(_Ap...)) -> function<_Rp(_Ap...)>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES function(_Rp (*)(_Ap...)) -> function<_Rp(_Ap...)>;
 
 template <class _Fp>
 struct __strip_signature;
@@ -1145,7 +1145,7 @@ struct __strip_signature<_Rp (_Gp::*)(_Ap...) const volatile & noexcept>
 };
 
 template <class _Fp, class _Stripped = typename __strip_signature<decltype(&_Fp::operator())>::type>
-function(_Fp) -> function<_Stripped>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES function(_Fp) -> function<_Stripped>;
 
 template <class _Rp, class... _ArgTypes>
 function<_Rp(_ArgTypes...)>::function(const function& __f)

--- a/libcudacxx/include/cuda/std/__utility/ctad_support.h
+++ b/libcudacxx/include/cuda/std/__utility/ctad_support.h
@@ -22,6 +22,6 @@
 
 #define _CCCL_CTAD_SUPPORTED_FOR_TYPE(_ClassName) \
   template <class... _Tag>                        \
-  _ClassName(typename _Tag::__allow_ctad...)->_ClassName<_Tag...>
+  _CCCL_DEDUCTION_GUIDE_ATTRIBUTES _ClassName(typename _Tag::__allow_ctad...) -> _ClassName<_Tag...>
 
 #endif // _CUDA_STD___UTILITY_CTAD_SUPPORT_H

--- a/libcudacxx/test/support/counting_predicates.h
+++ b/libcudacxx/test/support/counting_predicates.h
@@ -106,6 +106,6 @@ public:
 };
 
 template <class Predicate>
-counting_predicate(Predicate pred, int& count) -> counting_predicate<Predicate>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES counting_predicate(Predicate pred, int& count) -> counting_predicate<Predicate>;
 
 #endif // TEST_SUPPORT_COUNTING_PREDICATES_H

--- a/libcudacxx/test/support/test_iterators.h
+++ b/libcudacxx/test/support/test_iterators.h
@@ -2080,7 +2080,7 @@ struct ProxyRange
 
 template <cuda::std::ranges::input_range R>
   requires cuda::std::ranges::viewable_range<R&&>
-ProxyRange(R&&) -> ProxyRange<cuda::std::views::all_t<R&&>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES ProxyRange(R&&) -> ProxyRange<cuda::std::views::all_t<R&&>>;
 #endif // !defined(_LIBCUDACXX_HAS_NO_INCOMPLETE_RANGES)
 
 namespace types

--- a/libcudacxx/test/support/type_algorithms.h
+++ b/libcudacxx/test/support/type_algorithms.h
@@ -89,7 +89,7 @@ struct apply_type_identity
 };
 
 template <class T>
-apply_type_identity(T) -> apply_type_identity<T>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES apply_type_identity(T) -> apply_type_identity<T>;
 
 template <template <class...> class T, class... Args>
 struct partial_instantiation


### PR DESCRIPTION
There are clang-cuda 22 jobs failing due to missing `_CCCL_DEDUCTION_GUIDE_ATTRIBUTES` on deduction guides. I've also added to some other relevant places