### PR TITLE
[libcu++] Add missing `error_or` observer for `expected`

### DIFF
--- a/libcudacxx/include/cuda/std/__expected/expected.h
+++ b/libcudacxx/include/cuda/std/__expected/expected.h
@@ -570,7 +570,8 @@ public:
     return ::cuda::std::move(this->__union_.__unex_);
   }
 
-  template <class _Up>
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Up = remove_cv_t<_Tp>>
   _CCCL_API constexpr _Tp value_or(_Up&& __v) const&
   {
     static_assert(is_copy_constructible_v<_Tp>, "value_type has to be copy constructible");
@@ -578,7 +579,8 @@ public:
     return this->__has_val_ ? this->__union_.__val_ : static_cast<_Tp>(::cuda::std::forward<_Up>(__v));
   }
 
-  template <class _Up>
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Up = remove_cv_t<_Tp>>
   _CCCL_API constexpr _Tp value_or(_Up&& __v) &&
   {
     static_assert(is_move_constructible_v<_Tp>, "value_type has to be move constructible");
@@ -587,7 +589,28 @@ public:
                             : static_cast<_Tp>(::cuda::std::forward<_Up>(__v));
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Up = _Err>
+  [[nodiscard]] _CCCL_API constexpr _Err error_or(_Up&& __error) const&
+  {
+    static_assert(is_copy_constructible_v<_Err>, "error_type has to be copy constructible");
+    static_assert(is_convertible_v<_Up, _Err>, "argument has to be convertible to error_type");
+
+    return (this->__has_val_) ? ::cuda::std::forward<_Up>(__error) : this->__union_.__unex_;
+  }
+
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Up = _Err>
+  [[nodiscard]] _CCCL_API constexpr _Err error_or(_Up&& __error) &&
+  {
+    static_assert(is_move_constructible_v<_Err>, "error_type has to be move constructible");
+    static_assert(is_convertible_v<_Up, _Err>, "argument has to be convertible to error_type");
+
+    return (this->__has_val_) ? ::cuda::std::forward<_Up>(__error) : ::cuda::std::move(this->__union_.__unex_);
+  }
+
   // [expected.object.monadic]
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_constructible_v<_Err2, _Err2&>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) &
@@ -608,6 +631,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_copy_constructible_v<_Err2>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) const&
@@ -628,6 +652,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_move_constructible_v<_Err2>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) &&
@@ -648,6 +673,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_constructible_v<_Err2, const _Err2>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) const&&
@@ -668,6 +694,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_constructible_v<_Tp2, _Tp2&>)
   _CCCL_API constexpr auto or_else(_Fun&& __fun) &
@@ -689,6 +716,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_copy_constructible_v<_Tp2>)
   _CCCL_API constexpr auto or_else(_Fun&& __fun) const&
@@ -710,6 +738,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_move_constructible_v<_Tp2>)
   _CCCL_API constexpr auto or_else(_Fun&& __fun) &&
@@ -731,6 +760,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_constructible_v<_Tp2, const _Tp2>)
   _CCCL_API constexpr auto or_else(_Fun&& __fun) const&&
@@ -752,6 +782,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _CCCL_REQUIRES(is_constructible_v<_Err2, _Err2&> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun, _Tp2&>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) &
@@ -770,6 +801,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _CCCL_REQUIRES(
     is_constructible_v<_Err2, _Err2&> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun, _Tp2&>>, void>))
@@ -796,6 +828,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _CCCL_REQUIRES(
     is_copy_constructible_v<_Err2> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun, const _Tp2&>>, void>)
@@ -815,6 +848,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _CCCL_REQUIRES(
     is_copy_constructible_v<_Err2> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun, const _Tp2&>>, void>))
@@ -841,6 +875,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _CCCL_REQUIRES(is_move_constructible_v<_Err2> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun, _Tp2>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) &&
@@ -858,6 +893,8 @@ public:
       return expected<_Res, _Err>{unexpect, ::cuda::std::move(this->__union_.__unex_)};
     }
   }
+
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _CCCL_REQUIRES(is_move_constructible_v<_Err2> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun, _Tp2>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) &&
@@ -886,6 +923,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _CCCL_REQUIRES(
     is_constructible_v<_Err2, const _Err2> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun, const _Tp2>>, void>)
@@ -905,6 +943,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _CCCL_REQUIRES(
     is_constructible_v<_Err2, const _Err2> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun, const _Tp2>>, void>))
@@ -934,6 +973,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_constructible_v<_Tp2, _Tp2&>)
   _CCCL_API constexpr auto transform_error(_Fun&& __fun) &
@@ -959,6 +999,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_copy_constructible_v<_Tp2>)
   _CCCL_API constexpr auto transform_error(_Fun&& __fun) const&
@@ -985,6 +1026,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_move_constructible_v<_Tp2>)
   _CCCL_API constexpr auto transform_error(_Fun&& __fun) &&
@@ -1013,6 +1055,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_constructible_v<_Tp2, const _Tp2>)
   _CCCL_API constexpr auto transform_error(_Fun&& __fun) const&&
@@ -1453,7 +1496,28 @@ public:
     return ::cuda::std::move(this->__union_.__unex_);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Up = _Err>
+  [[nodiscard]] _CCCL_API constexpr _Err error_or(_Up&& __error) const&
+  {
+    static_assert(is_copy_constructible_v<_Err>, "error_type has to be copy constructible");
+    static_assert(is_convertible_v<_Up, _Err>, "argument has to be convertible to error_type");
+
+    return (this->__has_val_) ? ::cuda::std::forward<_Up>(__error) : this->__union_.__unex_;
+  }
+
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Up = _Err>
+  [[nodiscard]] _CCCL_API constexpr _Err error_or(_Up&& __error) &&
+  {
+    static_assert(is_move_constructible_v<_Err>, "error_type has to be move constructible");
+    static_assert(is_convertible_v<_Up, _Err>, "argument has to be convertible to error_type");
+
+    return (this->__has_val_) ? ::cuda::std::forward<_Up>(__error) : ::cuda::std::move(this->__union_.__unex_);
+  }
+
   // [expected.void.monadic]
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_constructible_v<_Err2, _Err2&>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) &
@@ -1474,6 +1538,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_copy_constructible_v<_Err2>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) const&
@@ -1494,6 +1559,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_move_constructible_v<_Err2>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) &&
@@ -1514,6 +1580,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_constructible_v<_Err2, const _Err2>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) const&&
@@ -1534,6 +1601,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Fun>
   _CCCL_API constexpr auto or_else(_Fun&& __fun) &
   {
@@ -1554,6 +1622,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Fun>
   _CCCL_API constexpr auto or_else(_Fun&& __fun) const&
   {
@@ -1574,6 +1643,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Fun>
   _CCCL_API constexpr auto or_else(_Fun&& __fun) &&
   {
@@ -1594,6 +1664,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Fun>
   _CCCL_API constexpr auto or_else(_Fun&& __fun) const&&
   {
@@ -1614,6 +1685,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_constructible_v<_Err2, _Err2&> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) &
@@ -1630,6 +1702,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_constructible_v<_Err2, _Err2&> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) &
@@ -1655,6 +1728,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_copy_constructible_v<_Err2> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) const&
@@ -1671,6 +1745,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_copy_constructible_v<_Err2> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) const&
@@ -1696,6 +1771,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_move_constructible_v<_Err2> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) &&
@@ -1711,6 +1787,8 @@ public:
       return expected<void, _Err>{unexpect, ::cuda::std::move(this->__union_.__unex_)};
     }
   }
+
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_move_constructible_v<_Err2> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) &&
@@ -1736,6 +1814,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_constructible_v<_Err2, const _Err2> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) const&&
@@ -1752,6 +1831,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
   _CCCL_REQUIRES(is_constructible_v<_Err2, const _Err2> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) const&&
@@ -1777,6 +1857,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Fun>
   _CCCL_API constexpr auto transform_error(_Fun&& __fun) &
   {
@@ -1801,6 +1882,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Fun>
   _CCCL_API constexpr auto transform_error(_Fun&& __fun) const&
   {
@@ -1826,6 +1908,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Fun>
   _CCCL_API constexpr auto transform_error(_Fun&& __fun) &&
   {
@@ -1853,6 +1936,7 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Fun>
   _CCCL_API constexpr auto transform_error(_Fun&& __fun) const&&
   {

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/observers/error_or.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/observers/error_or.pass.cpp
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class G = E> constexpr E error_or(G&& e) const &;
+// template<class G = E> constexpr E error_or(G&& e) &&;
+
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/expected>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+struct ConstructFromInt
+{
+  int value;
+  TEST_FUNC constexpr ConstructFromInt(int v)
+      : value(v)
+  {}
+};
+
+TEST_FUNC constexpr bool test_default_template_arg()
+{
+  // const &, has_value()
+  {
+    const cuda::std::expected<int, ConstructFromInt> e(5);
+    decltype(auto) x = e.error_or(10);
+    static_assert(cuda::std::same_as<ConstructFromInt, decltype(x)>);
+    assert(x.value == 10);
+  }
+
+  // const &, !has_value()
+  {
+    const cuda::std::expected<int, ConstructFromInt> e(cuda::std::unexpect, 5);
+    decltype(auto) x = e.error_or(10);
+    static_assert(cuda::std::same_as<ConstructFromInt, decltype(x)>);
+    assert(x.value == 5);
+  }
+
+  // &&, has_value()
+  {
+    cuda::std::expected<int, ConstructFromInt> e(5);
+    decltype(auto) x = cuda::std::move(e).error_or(10);
+    static_assert(cuda::std::same_as<ConstructFromInt, decltype(x)>);
+    assert(x.value == 10);
+  }
+
+  // &&, !has_value()
+  {
+    cuda::std::expected<int, ConstructFromInt> e(cuda::std::unexpect, 5);
+    decltype(auto) x = cuda::std::move(e).error_or(10);
+    static_assert(cuda::std::same_as<ConstructFromInt, decltype(x)>);
+    assert(x.value == 5);
+  }
+
+  return true;
+}
+
+TEST_FUNC constexpr bool test()
+{
+  // const &, has_value()
+  {
+    const cuda::std::expected<int, int> e(5);
+    decltype(auto) x = e.error_or(10);
+    static_assert(cuda::std::same_as<int, decltype(x)>);
+    assert(x == 10);
+  }
+
+  // const &, !has_value()
+  {
+    const cuda::std::expected<int, int> e(cuda::std::unexpect, 5);
+    decltype(auto) x = e.error_or(10);
+    static_assert(cuda::std::same_as<int, decltype(x)>);
+    assert(x == 5);
+  }
+
+  // &&, has_value()
+  {
+    cuda::std::expected<int, int> e(5);
+    decltype(auto) x = cuda::std::move(e).error_or(10);
+    static_assert(cuda::std::same_as<int, decltype(x)>);
+    assert(x == 10);
+  }
+
+  // &&, !has_value()
+  {
+    cuda::std::expected<int, int> e(cuda::std::unexpect, 5);
+    decltype(auto) x = cuda::std::move(e).error_or(10);
+    static_assert(cuda::std::same_as<int, decltype(x)>);
+    assert(x == 5);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  test_default_template_arg();
+  static_assert(test_default_template_arg());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.void/observers/error_or.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.void/observers/error_or.pass.cpp
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class G = E> constexpr E error_or(G&& e) const &;
+// template<class G = E> constexpr E error_or(G&& e) &&;
+
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/expected>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+struct ConstructFromInt
+{
+  int value;
+  TEST_FUNC constexpr ConstructFromInt(int v)
+      : value(v)
+  {}
+};
+
+TEST_FUNC constexpr bool test_default_template_arg()
+{
+  // const &, has_value()
+  {
+    const cuda::std::expected<void, ConstructFromInt> e;
+    decltype(auto) x = e.error_or(10);
+    static_assert(cuda::std::same_as<ConstructFromInt, decltype(x)>);
+    assert(x.value == 10);
+  }
+
+  // const &, !has_value()
+  {
+    const cuda::std::expected<void, ConstructFromInt> e(cuda::std::unexpect, 5);
+    decltype(auto) x = e.error_or(10);
+    static_assert(cuda::std::same_as<ConstructFromInt, decltype(x)>);
+    assert(x.value == 5);
+  }
+
+  // &&, has_value()
+  {
+    cuda::std::expected<void, ConstructFromInt> e;
+    decltype(auto) x = cuda::std::move(e).error_or(10);
+    static_assert(cuda::std::same_as<ConstructFromInt, decltype(x)>);
+    assert(x.value == 10);
+  }
+
+  // &&, !has_value()
+  {
+    cuda::std::expected<void, ConstructFromInt> e(cuda::std::unexpect, 5);
+    decltype(auto) x = cuda::std::move(e).error_or(10);
+    static_assert(cuda::std::same_as<ConstructFromInt, decltype(x)>);
+    assert(x.value == 5);
+  }
+
+  return true;
+}
+
+TEST_FUNC constexpr bool test()
+{
+  // const &, has_value()
+  {
+    const cuda::std::expected<void, int> e;
+    decltype(auto) x = e.error_or(10);
+    static_assert(cuda::std::same_as<int, decltype(x)>);
+    assert(x == 10);
+  }
+
+  // const &, !has_value()
+  {
+    const cuda::std::expected<void, int> e(cuda::std::unexpect, 5);
+    decltype(auto) x = e.error_or(10);
+    static_assert(cuda::std::same_as<int, decltype(x)>);
+    assert(x == 5);
+  }
+
+  // &&, has_value()
+  {
+    cuda::std::expected<void, int> e;
+    decltype(auto) x = cuda::std::move(e).error_or(10);
+    static_assert(cuda::std::same_as<int, decltype(x)>);
+    assert(x == 10);
+  }
+
+  // &&, !has_value()
+  {
+    cuda::std::expected<void, int> e(cuda::std::unexpect, 5);
+    decltype(auto) x = cuda::std::move(e).error_or(10);
+    static_assert(cuda::std::same_as<int, decltype(x)>);
+    assert(x == 5);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  test_default_template_arg();
+  static_assert(test_default_template_arg());
+
+  return 0;
+}


### PR DESCRIPTION
We were missing this observer for some reason.