### PR TITLE
[libcu++] Improve our to_address implementation

### DIFF
--- a/libcudacxx/include/cuda/std/__algorithm/unwrap_iter.h
+++ b/libcudacxx/include/cuda/std/__algorithm/unwrap_iter.h
@@ -60,18 +60,18 @@ struct __unwrap_iter_impl
 template <class _Iter>
 struct __unwrap_iter_impl<_Iter, true>
 {
-  using _ToAddressT = decltype(::cuda::std::__to_address(::cuda::std::declval<_Iter>()));
+  using _ToAddressT = decltype(::cuda::std::to_address(::cuda::std::declval<_Iter>()));
 
   _CCCL_EXEC_CHECK_DISABLE
   static _CCCL_API constexpr _Iter __rewrap(_Iter __orig_iter, _ToAddressT __unwrapped_iter)
   {
-    return __orig_iter + (__unwrapped_iter - ::cuda::std::__to_address(__orig_iter));
+    return __orig_iter + (__unwrapped_iter - ::cuda::std::to_address(__orig_iter));
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   static _CCCL_API constexpr _ToAddressT __unwrap(_Iter __i) noexcept
   {
-    return ::cuda::std::__to_address(__i);
+    return ::cuda::std::to_address(__i);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__bit/reference.h
+++ b/libcudacxx/include/cuda/std/__bit/reference.h
@@ -216,7 +216,7 @@ _CCCL_API constexpr void __fill_n_impl(__bit_iterator<_Cp, false> __first, typen
   }
   // do middle whole words
   __storage_type __nw = __n / __bits_per_word;
-  ::cuda::std::fill_n(::cuda::std::__to_address(__first.__seg_), __nw, _FillVal ? ~static_cast<__storage_type>(0) : 0);
+  ::cuda::std::fill_n(::cuda::std::to_address(__first.__seg_), __nw, _FillVal ? ~static_cast<__storage_type>(0) : 0);
   __n -= (__nw * __bits_per_word).__data;
   // do last partial word
   if (__n > 0)
@@ -290,8 +290,7 @@ _CCCL_API constexpr __bit_iterator<_Cp, false> __copy_aligned(
     // __first.__ctz_ == 0;
     // do middle words
     __storage_type __nw = __n / __bits_per_word;
-    ::cuda::std::copy_n(
-      ::cuda::std::__to_address(__first.__seg_), __nw.__data, ::cuda::std::__to_address(__result.__seg_));
+    ::cuda::std::copy_n(::cuda::std::to_address(__first.__seg_), __nw.__data, ::cuda::std::to_address(__result.__seg_));
     __result.__seg_ += __nw.__data;
     __n -= (__nw * __bits_per_word).__data;
     // do last word
@@ -434,8 +433,7 @@ _CCCL_API constexpr __bit_iterator<_Cp, false> __copy_backward_aligned(
     __storage_type __nw = __n / __bits_per_word;
     __result.__seg_ -= __nw.__data;
     __last.__seg_ -= __nw.__data;
-    ::cuda::std::copy_n(
-      ::cuda::std::__to_address(__last.__seg_), __nw.__data, ::cuda::std::__to_address(__result.__seg_));
+    ::cuda::std::copy_n(::cuda::std::to_address(__last.__seg_), __nw.__data, ::cuda::std::to_address(__result.__seg_));
     __n -= (__nw * __bits_per_word).__data;
     // do last word
     if (__n > 0)

--- a/libcudacxx/include/cuda/std/__iterator/bounded_iter.h
+++ b/libcudacxx/include/cuda/std/__iterator/bounded_iter.h
@@ -106,7 +106,7 @@ public:
   {
     _CCCL_ASSERT(__in_bounds(__current_),
                  "__bounded_iter::operator->: Attempt to dereference an out-of-range iterator");
-    return ::cuda::std::__to_address(__current_);
+    return ::cuda::std::to_address(__current_);
   }
 
   _CCCL_API constexpr reference operator[](difference_type __n) const noexcept
@@ -242,7 +242,7 @@ struct pointer_traits<__bounded_iter<_Iterator>>
 
   _CCCL_API constexpr static element_type* to_address(pointer __it) noexcept
   {
-    return ::cuda::std::__to_address(__it.__current_);
+    return ::cuda::std::to_address(__it.__current_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__iterator/wrap_iter.h
+++ b/libcudacxx/include/cuda/std/__iterator/wrap_iter.h
@@ -63,7 +63,7 @@ public:
   }
   _CCCL_API constexpr pointer operator->() const noexcept
   {
-    return ::cuda::std::__to_address(__i_);
+    return ::cuda::std::to_address(__i_);
   }
   _CCCL_API constexpr __wrap_iter& operator++() noexcept
   {
@@ -234,7 +234,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pointer_traits<__wrap_iter<_It>>
 
   _CCCL_API constexpr static element_type* to_address(pointer __w) noexcept
   {
-    return ::cuda::std::__to_address(__w.base());
+    return ::cuda::std::to_address(__w.base());
   }
 };
 

--- a/libcudacxx/include/cuda/std/__memory/pointer_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/pointer_traits.h
@@ -21,6 +21,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__concepts/derived_from.h>
+#include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__memory/addressof.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/conjunction.h>
@@ -29,6 +31,7 @@
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_class.h>
 #include <cuda/std/__type_traits/is_function.h>
+#include <cuda/std/__type_traits/is_pointer.h>
 #include <cuda/std/__type_traits/is_void.h>
 #include <cuda/std/__type_traits/void_t.h>
 #include <cuda/std/__utility/declval.h>
@@ -160,86 +163,40 @@ public:
 };
 
 // to_address
+template <class _Pointer>
+_CCCL_CONCEPT __has_cuda_std_to_address = _CCCL_REQUIRES_EXPR((_Pointer), const _Pointer& __ptr)(
+  typename(typename ::cuda::std::pointer_traits<_Pointer>), (::cuda::std::pointer_traits<_Pointer>::to_address(__ptr)));
 
-template <class _Pointer, class = void>
-struct __to_address_helper;
+template <class _Pointer>
+_CCCL_CONCEPT __has_const_operator_arrow = _CCCL_REQUIRES_EXPR((_Pointer), const _Pointer& __ptr)((__ptr.operator->()));
+
+template <class _Pointer>
+inline constexpr bool __is_fancy_pointer = __has_cuda_std_to_address<_Pointer> || __has_const_operator_arrow<_Pointer>;
 
 template <class _Tp>
-_CCCL_API constexpr _Tp* __to_address(_Tp* __p) noexcept
+[[nodiscard]] _CCCL_API constexpr auto to_address(_Tp* const __ptr) noexcept
 {
   static_assert(!is_function_v<_Tp>, "_Tp is a function type");
-  return __p;
+  return __ptr;
 }
 
-template <class _Pointer, class = void>
-inline constexpr bool __has_toaddress = false;
-
-template <class _Pointer>
-inline constexpr bool __has_toaddress<
-  _Pointer,
-  decltype((void) ::cuda::std::pointer_traits<_Pointer>::to_address(::cuda::std::declval<const _Pointer&>()))> = true;
-
-template <class _Pointer, class = void>
-inline constexpr bool __has_const_operator_arrow = false;
-
-template <class _Pointer>
-inline constexpr bool
-  __has_const_operator_arrow<_Pointer, decltype((void) ::cuda::std::declval<const _Pointer&>().operator->())> = true;
-
-template <class _Pointer>
-inline constexpr bool __is_fancy_pointer = __has_const_operator_arrow<_Pointer> || __has_toaddress<_Pointer>;
-
-// enable_if is needed here to avoid instantiating checks for fancy pointers on raw pointers
-template <class _Pointer, class = enable_if_t<is_class_v<_Pointer>>, class = enable_if_t<__is_fancy_pointer<_Pointer>>>
-_CCCL_API constexpr decay_t<decltype(__to_address_helper<_Pointer>::__call(::cuda::std::declval<const _Pointer&>()))>
-__to_address(const _Pointer& __p) noexcept
+_CCCL_EXEC_CHECK_DISABLE
+template <class _Pointer, enable_if_t<__is_fancy_pointer<_Pointer>, int> = 0>
+[[nodiscard]] _CCCL_API constexpr auto to_address(const _Pointer& __ptr) noexcept
 {
-  return __to_address_helper<_Pointer>::__call(__p);
-}
-
-template <class _Pointer, class>
-struct __to_address_helper
-{
-  _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API constexpr static decltype(::cuda::std::__to_address(::cuda::std::declval<const _Pointer&>().operator->()))
-  __call(const _Pointer& __p) noexcept
+  if constexpr (__has_cuda_std_to_address<_Pointer>)
   {
-    return ::cuda::std::__to_address(__p.operator->());
+    return ::cuda::std::pointer_traits<_Pointer>::to_address(__ptr);
   }
-};
-
-template <class _Pointer>
-struct __to_address_helper<
-  _Pointer,
-  decltype((void) ::cuda::std::pointer_traits<_Pointer>::to_address(::cuda::std::declval<const _Pointer&>()))>
-{
-  _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API constexpr static decltype(::cuda::std::pointer_traits<_Pointer>::to_address(
-    ::cuda::std::declval<const _Pointer&>()))
-  __call(const _Pointer& __p) noexcept
+  else
   {
-    return ::cuda::std::pointer_traits<_Pointer>::to_address(__p);
+    return ::cuda::std::to_address(__ptr.operator->());
   }
-};
-
-template <class _Tp>
-_CCCL_API constexpr auto to_address(_Tp* __p) noexcept
-{
-  return ::cuda::std::__to_address(__p);
 }
 
 template <class _Pointer>
-_CCCL_API constexpr auto to_address(const _Pointer& __p) noexcept -> decltype(::cuda::std::__to_address(__p))
-{
-  return ::cuda::std::__to_address(__p);
-}
-
-template <class _Iter, class = void>
-inline constexpr bool __can_to_address = false;
-
-template <class _Iter>
-inline constexpr bool
-  __can_to_address<_Iter, void_t<decltype(::cuda::std::to_address(::cuda::std::declval<_Iter&>()))>> = true;
+_CCCL_CONCEPT __can_to_address =
+  _CCCL_REQUIRES_EXPR((_Pointer), const _Pointer& __ptr)((::cuda::std::to_address(__ptr)));
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
+++ b/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
@@ -518,7 +518,7 @@ _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void __allocator_destroy(_Alloc& __alloc,
 {
   for (; __first != __last; ++__first)
   {
-    allocator_traits<_Alloc>::destroy(__alloc, ::cuda::std::__to_address(__first));
+    allocator_traits<_Alloc>::destroy(__alloc, ::cuda::std::to_address(__first));
   }
 }
 
@@ -557,7 +557,7 @@ __uninitialized_allocator_copy_impl(_Alloc& __alloc, _Iter1 __first1, _Sent1 __l
     _AllocatorDestroyRangeReverse<_Alloc, _Iter2>(__alloc, __destruct_first, __first2));
   while (__first1 != __last1)
   {
-    allocator_traits<_Alloc>::construct(__alloc, ::cuda::std::__to_address(__first2), *__first1);
+    allocator_traits<_Alloc>::construct(__alloc, ::cuda::std::to_address(__first2), *__first1);
     ++__first1;
     ++__first2;
   }
@@ -587,7 +587,7 @@ __uninitialized_allocator_copy_impl(_Alloc&, _In* __first1, _In* __last1, _Out* 
   {
     while (__first1 != __last1)
     {
-      ::cuda::std::__construct_at(::cuda::std::__to_address(__first2), *__first1);
+      ::cuda::std::__construct_at(::cuda::std::to_address(__first2), *__first1);
       ++__first1;
       ++__first2;
     }
@@ -627,9 +627,9 @@ __uninitialized_allocator_move_if_noexcept(_Alloc& __alloc, _Iter1 __first1, _Se
   {
 #if _CCCL_HAS_EXCEPTIONS()
     allocator_traits<_Alloc>::construct(
-      __alloc, ::cuda::std::__to_address(__first2), ::cuda::std::move_if_noexcept(*__first1));
+      __alloc, ::cuda::std::to_address(__first2), ::cuda::std::move_if_noexcept(*__first1));
 #else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
-    allocator_traits<_Alloc>::construct(__alloc, ::cuda::std::__to_address(__first2), ::cuda::std::move(*__first1));
+    allocator_traits<_Alloc>::construct(__alloc, ::cuda::std::to_address(__first2), ::cuda::std::move(*__first1));
 #endif // !_CCCL_HAS_EXCEPTIONS()
     ++__first1;
     ++__first2;
@@ -658,7 +658,7 @@ _Iter2 __uninitialized_allocator_move_if_noexcept(_Alloc&, _Iter1 __first1, _Ite
   {
     while (__first1 != __last1)
     {
-      ::cuda::std::__construct_at(::cuda::std::__to_address(__first2), ::cuda::std::move(*__first1));
+      ::cuda::std::__construct_at(::cuda::std::to_address(__first2), ::cuda::std::move(*__first1));
       ++__first1;
       ++__first2;
     }

--- a/libcudacxx/test/libcudacxx/libcxx/iterators/bounded_iter/pointer_traits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/iterators/bounded_iter/pointer_traits.pass.cpp
@@ -38,12 +38,8 @@ TEST_FUNC constexpr bool tests()
     int* e                                      = array + 5;
     cuda::std::__bounded_iter<Iter> const iter1 = cuda::std::__make_bounded_iter(Iter(b), Iter(b), Iter(e));
     cuda::std::__bounded_iter<Iter> const iter2 = cuda::std::__make_bounded_iter(Iter(e), Iter(b), Iter(e));
-    assert(cuda::std::__to_address(iter1) == b); // in-bounds iterator
-    assert(cuda::std::__to_address(iter2) == e); // out-of-bounds iterator
-#if TEST_STD_VER > 2017
     assert(cuda::std::to_address(iter1) == b); // in-bounds iterator
     assert(cuda::std::to_address(iter2) == e); // out-of-bounds iterator
-#endif // TEST_STD_VER > 2017
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.random.access/contiguous_iterator.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.random.access/contiguous_iterator.compile.pass.cpp
@@ -430,7 +430,10 @@ namespace cuda::std
 template <>
 struct pointer_traits<no_operator_arrow</*DisableArrow=*/true, /*DisableToAddress=*/false>>
 {
-  TEST_FUNC static constexpr int* to_address(const no_operator_arrow<true, false>&);
+  TEST_FUNC static constexpr int* to_address(const no_operator_arrow<true, false>&)
+  {
+    return nullptr;
+  }
 };
 } // namespace cuda::std
 

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/pointer.conversion/to_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/pointer.conversion/to_address.pass.cpp
@@ -1,0 +1,240 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <memory>
+
+// template <class T> constexpr T* to_address(T* p) noexcept;
+// template <class Ptr> constexpr auto to_address(const Ptr& p) noexcept;
+
+#include <cuda/std/cassert>
+#include <cuda/std/memory>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+struct Irrelevant;
+
+struct P1
+{
+  using element_type = Irrelevant;
+  TEST_FUNC constexpr explicit P1(int* p)
+      : p_(p)
+  {}
+  TEST_FUNC constexpr int* operator->() const
+  {
+    return p_;
+  }
+  int* p_;
+};
+
+struct P2
+{
+  using element_type = Irrelevant;
+  TEST_FUNC constexpr explicit P2(int* p)
+      : p_(p)
+  {}
+  TEST_FUNC constexpr P1 operator->() const
+  {
+    return p_;
+  }
+  P1 p_;
+};
+
+struct P3
+{
+  TEST_FUNC constexpr explicit P3(int* p)
+      : p_(p)
+  {}
+  int* p_;
+};
+
+template <>
+struct cuda::std::pointer_traits<P3>
+{
+  TEST_FUNC static constexpr int* to_address(const P3& p)
+  {
+    return p.p_;
+  }
+};
+
+struct P4
+{
+  TEST_FUNC constexpr explicit P4(int* p)
+      : p_(p)
+  {}
+  TEST_FUNC int* operator->() const; // should never be called
+  int* p_;
+};
+
+template <>
+struct cuda::std::pointer_traits<P4>
+{
+  TEST_FUNC static constexpr int* to_address(const P4& p)
+  {
+    return p.p_;
+  }
+};
+
+struct P5
+{
+  using element_type = Irrelevant;
+  TEST_FUNC int const* const& operator->() const;
+};
+
+struct P6
+{};
+
+template <>
+struct cuda::std::pointer_traits<P6>
+{
+  TEST_FUNC static int const* const& to_address(const P6&);
+};
+
+#if _CCCL_HAS_HOST_STD_LIB()
+struct STDP6
+{};
+
+template <>
+struct cuda::std::pointer_traits<STDP6>
+{
+  TEST_FUNC static int const* const& to_address(const STDP6&);
+};
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+// Taken from a build breakage caused in Clang
+namespace P7
+{
+template <typename T>
+struct CanProxy;
+template <typename T>
+struct CanQual
+{
+  TEST_FUNC CanProxy<T> operator->() const
+  {
+    return CanProxy<T>();
+  }
+};
+template <typename T>
+struct CanProxy
+{
+  TEST_FUNC const CanProxy<T>* operator->() const
+  {
+    return nullptr;
+  }
+};
+} // namespace P7
+
+namespace P8
+{
+template <class T>
+struct FancyPtrA
+{
+  using element_type = Irrelevant;
+  T* p_;
+  TEST_FUNC constexpr FancyPtrA(T* p)
+      : p_(p)
+  {}
+  TEST_FUNC T& operator*() const;
+  TEST_FUNC constexpr T* operator->() const
+  {
+    return p_;
+  }
+};
+template <class T>
+struct FancyPtrB
+{
+  T* p_;
+  TEST_FUNC constexpr FancyPtrB(T* p)
+      : p_(p)
+  {}
+  TEST_FUNC T& operator*() const;
+};
+} // namespace P8
+
+template <class T>
+struct cuda::std::pointer_traits<P8::FancyPtrB<T>>
+{
+  TEST_FUNC static constexpr T* to_address(const P8::FancyPtrB<T>& p)
+  {
+    return p.p_;
+  }
+};
+
+struct Incomplete;
+template <class T>
+struct Holder
+{
+  T t;
+};
+
+TEST_FUNC constexpr bool test()
+{
+  int i = 0;
+  static_assert(noexcept(cuda::std::to_address(&i)));
+  assert(cuda::std::to_address(&i) == &i);
+  P1 p1(&i);
+  static_assert(noexcept(cuda::std::to_address(p1)));
+  assert(cuda::std::to_address(p1) == &i);
+  P2 p2(&i);
+  static_assert(noexcept(cuda::std::to_address(p2)));
+  assert(cuda::std::to_address(p2) == &i);
+  P3 p3(&i);
+  static_assert(noexcept(cuda::std::to_address(p3)));
+  assert(cuda::std::to_address(p3) == &i);
+  P4 p4(&i);
+  static_assert(noexcept(cuda::std::to_address(p4)));
+  assert(cuda::std::to_address(p4) == &i);
+
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::to_address(cuda::std::declval<int const*>())), int const*>);
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::to_address(cuda::std::declval<P5>())), int const*>);
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::to_address(cuda::std::declval<P6>())), int const*>);
+
+  P7::CanQual<int>* p7 = nullptr;
+  assert(cuda::std::to_address(p7) == nullptr);
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::to_address(p7)), P7::CanQual<int>*>);
+
+  Holder<Incomplete>* p8_nil            = nullptr; // for C++03 compatibility
+  P8::FancyPtrA<Holder<Incomplete>> p8a = p8_nil;
+  assert(cuda::std::to_address(p8a) == p8_nil);
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::to_address(p8a)), decltype(p8_nil)>);
+
+  P8::FancyPtrB<Holder<Incomplete>> p8b = p8_nil;
+  assert(cuda::std::to_address(p8b) == p8_nil);
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::to_address(p8b)), decltype(p8_nil)>);
+
+  int p9[2] = {};
+  assert(cuda::std::to_address(p9) == p9);
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::to_address(p9)), int*>);
+
+  const int p10[2] = {};
+  assert(cuda::std::to_address(p10) == p10);
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::to_address(p10)), const int*>);
+
+  int (*p11)() = nullptr;
+  assert(cuda::std::to_address(&p11) == &p11);
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::to_address(&p11)), int (**)()>);
+
+  // See https://llvm.org/PR67449
+  {
+    struct S
+    {};
+    S* p = nullptr;
+    assert(cuda::std::to_address<S>(p) == p);
+    static_assert(cuda::std::is_same_v<decltype(cuda::std::to_address<S>(p)), S*>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/pointer.conversion/to_address_on_funcptr.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/pointer.conversion/to_address_on_funcptr.verify.cpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <memory>
+
+// template <class T> constexpr T* to_address(T* p) noexcept;
+//     Mandates: T is not a function type.
+
+#include <cuda/std/memory>
+
+#include "test_macros.h"
+
+int (*pf)();
+
+TEST_FUNC void test()
+{
+  (void) cuda::std::to_address(pf); // expected-error@*:* {{is a function type}}
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/pointer.conversion/to_address_on_function.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/pointer.conversion/to_address_on_function.verify.cpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <memory>
+
+// template <class T> constexpr T* to_address(T* p) noexcept;
+//     Mandates: T is not a function type.
+
+#include <cuda/std/memory>
+
+#include "test_macros.h"
+
+TEST_FUNC int f();
+
+TEST_FUNC void test()
+{
+  (void) cuda::std::to_address(f); // expected-error@*:* {{is a function type}}
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/pointer.conversion/to_address_std_iterators.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/pointer.conversion/to_address_std_iterators.pass.cpp
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <memory>
+
+// template <class T> constexpr T* to_address(T* p) noexcept;
+// template <class Ptr> constexpr auto to_address(const Ptr& p) noexcept;
+
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/memory>
+#include <cuda/std/span>
+#include <cuda/std/string_view>
+#include <cuda/std/utility>
+
+#if _CCCL_HAS_HOST_STD_LIB()
+#  include <array>
+#  include <string>
+#  include <string_view>
+#  include <vector>
+#  ifdef __cpp_lib_span
+#    include <span>
+#  endif // __cpp_lib_span
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+#include "test_macros.h"
+
+_CCCL_DIAG_SUPPRESS_NVCC(3215) // "if consteval" and "if not consteval" are not standard in this mode
+
+template <class C>
+TEST_FUNC constexpr void test_container_iterators(C c)
+{
+  assert(cuda::std::to_address(c.begin()) == c.data());
+  assert(cuda::std::to_address(c.end()) == c.data() + c.size());
+  assert(cuda::std::to_address(cuda::std::as_const(c).begin()) == cuda::std::as_const(c).data());
+  assert(cuda::std::to_address(cuda::std::as_const(c).end())
+         == cuda::std::as_const(c).data() + cuda::std::as_const(c).size());
+}
+
+TEST_FUNC constexpr bool test()
+{
+  test_container_iterators(cuda::std::array<int, 3>());
+  test_container_iterators(cuda::std::string_view("abc"));
+  test_container_iterators(cuda::std::span<const char>("abc"));
+
+#if _CCCL_HAS_HOST_STD_LIB()
+#  if defined(__cpp_lib_span)
+  NV_IF_TARGET(NV_IS_HOST, ({ test_container_iterators(std::span<const char>("abc")); }))
+#  endif //__cpp_lib_span
+  NV_IF_TARGET(NV_IS_HOST, ({
+                 test_container_iterators(std::array<int, 3>());
+                 test_container_iterators(std::string_view("abc"));
+               }))
+  if (!cuda::std::__cccl_default_is_constant_evaluated())
+  {
+    NV_IF_TARGET(NV_IS_HOST, ({
+                   test_container_iterators(std::vector<int>(3));
+                   test_container_iterators(std::string("abc"));
+                 }))
+  }
+#endif // _CCCL_HAS_HOST_STD_LIB()
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/pointer.conversion/to_address_without_pointer_traits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/pointer.conversion/to_address_without_pointer_traits.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <memory>
+
+// template <class Ptr> constexpr auto to_address(const Ptr& p) noexcept;
+//     Should not require a specialization of pointer_traits for Ptr.
+
+#include <cuda/std/cassert>
+#include <cuda/std/memory>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+struct IntPtr
+{
+  TEST_FUNC constexpr int* operator->() const
+  {
+    return ptr;
+  }
+
+  int* ptr;
+};
+
+template <class T, bool>
+struct TemplatedPtr
+{
+  TEST_FUNC constexpr T* operator->() const
+  {
+    return ptr;
+  }
+
+  T* ptr;
+};
+
+TEST_FUNC constexpr bool test()
+{
+  int i = 0;
+  assert(cuda::std::to_address(IntPtr{nullptr}) == nullptr);
+  assert(cuda::std::to_address(IntPtr{&i}) == &i);
+
+  bool b = false;
+  assert(cuda::std::to_address(TemplatedPtr<bool, true>{nullptr}) == nullptr);
+  assert(cuda::std::to_address(TemplatedPtr<bool, true>{&b}) == &b);
+
+  static_assert(!cuda::std::__can_to_address<int>);
+  static_assert(cuda::std::__can_to_address<IntPtr>);
+  static_assert(cuda::std::__can_to_address<TemplatedPtr<bool, true>>);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}


### PR DESCRIPTION
We found some issues with our current to_address implementation recently.

```
C:\msbuild\17\VC\Tools\MSVC\14.44.35207\include\xutility(550,46): error C2039: '->': is not a member of 'std::_Vb_iterator<std::_Wrap_alloc<std::allocator<unsigned int>>>'
            return _STD to_address(_Val.operator->()); // plain pointer overload must come first
```

The issue is that we used unqualified pointer_traits to check whether to_address is viable. However, we also need to respect overloads of std::pointer_traits, so bring that in too.

While we are at it we can significantly improve the implementation through our concept macros.

Also we did not test anything, so add some tests that this does the right thing.