### PR TITLE
[cub] Disable future arch test in compute sanitizer test mode

### DIFF
--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -339,6 +339,7 @@ function(
       "${test_src}" MATCHES "test_future_arch\\.cu$"
       AND "${CMAKE_CUDA_COMPILER_ID}" STREQUAL "NVIDIA"
       AND "${CMAKE_CUDA_COMPILER_VERSION}" VERSION_GREATER_EQUAL "13.0.0"
+      AND NOT "$ENV{CCCL_TEST_MODE}" MATCHES "^compute-sanitizer"
     )
       # In future arch test, we replace __CUDA_ARCH__ and __CUDA_ARCH_LIST__ with our own values. However, nvcc
       # preincludes <cuda_runtime.h> header, already working with __CUDA_ARCH__. So, we define the <cuda_runtime.h>'s


### PR DESCRIPTION
This test fails under compute sanitizer, but it's compile-only test anyway. I think it's fine to just skip the test when using  compute sanitizer test mode