### PR TITLE
[Thrust] Fix issue with tuple_of_iterator_references and swap

### DIFF
--- a/thrust/testing/reverse.cu
+++ b/thrust/testing/reverse.cu
@@ -169,3 +169,18 @@ struct TestReverseCopyToDiscardIterator
   }
 };
 VariableUnitTest<TestReverseCopyToDiscardIterator, ReverseTypes> TestReverseCopyToDiscardIteratorInstance;
+
+void TestReverseZippedHost()
+{
+  thrust::host_vector<int> a{1, 2, 3, 4};
+  thrust::host_vector<int> b{10, 20, 30, 40};
+  auto zip = thrust::zip_iterator{a.begin(), b.begin()};
+  thrust::reverse(zip, zip + 4);
+
+  const thrust::host_vector<int> expected_a{4, 3, 2, 1};
+  const thrust::host_vector<int> expected_b{40, 30, 20, 10};
+
+  ASSERT_EQUAL(a, expected_a);
+  ASSERT_EQUAL(b, expected_b);
+}
+DECLARE_UNITTEST(TestReverseZippedHost);

--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -174,6 +174,12 @@ public:
     return __to_tuple<Us...>(typename ::cuda::std::__make_tuple_indices<sizeof...(Ts)>::type{});
   }
 
+  template <class... Us>
+  _CCCL_HOST_DEVICE friend void swap(tuple_of_iterator_references& x, tuple_of_iterator_references<Us...>& y)
+  {
+    x.swap(y);
+  }
+
   // this overload of swap() permits swapping tuple_of_iterator_references returned as temporaries from
   // iterator dereferences
   template <class... Us>


### PR DESCRIPTION
Looks like that the `swap` overload from `cuda::std::tuple` was not picked up.

Fixes [BUG]: thrust::reverse over a zip_iterator range mirrors instead of reversing
Fixes #10684

For the amusement of @alliepiper