### PR TITLE
[STF] green_places(): initialize the driver on first use

### DIFF
--- a/python/cuda_stf/cuda/stf/_experimental/green_places.py
+++ b/python/cuda_stf/cuda/stf/_experimental/green_places.py
@@ -77,6 +77,14 @@ def green_places(
 
     from cuda.bindings import driver
 
+    # Lazy driver initialization: green_places() may be the first CUDA call
+    # in the process, and cuCtxGetCurrent reports CUDA_ERROR_NOT_INITIALIZED
+    # before cuInit. cuInit is idempotent, so no explicit setup is required
+    # of the caller.
+    (err,) = driver.cuInit(0)
+    if int(err) != 0:
+        raise RuntimeError(f"green_places(): cuInit failed with error code {int(err)}")
+
     # Save the caller's current context: Device.set_current() and
     # create_context() below both mutate the current context, and we must not
     # leak that side effect back to the caller. A NULL prev_ctx (no current


### PR DESCRIPTION
## Description

`green_places()` saves the caller's current context (`cuCtxGetCurrent`) before creating green-context views, so it can restore it and not leak the side effect. If `green_places()` is the **first CUDA call in the process**, the driver is not initialized yet and `cuCtxGetCurrent` fails with `CUDA_ERROR_NOT_INITIALIZED` — an opaque error nowhere near the user's actual code.

Repro (fresh process):
```python
from cuda.bindings import driver
err, ctx = driver.cuCtxGetCurrent()
# err == CUDA_ERROR_NOT_INITIALIZED
```

## Fix

Front-load an idempotent `cuInit(0)`. Callers that already initialized CUDA (`machine_init()`, any runtime API call) are unaffected; first-call users get working behavior instead of the misleading error. This matches the implicit-initialization convention of the runtime API and `cuda.core`'s `Device()`.

Extracted as a standalone fix from the structured-partitions branch (#9892), where it has been exercised since.

## Checklist
- [x] New or existing tests cover these changes — exercised by every green-context test path once the driver-init ordering applies
- [x] The documentation is up to date with these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)