### PR TITLE
Minor maintenance on memory resource

### DIFF
--- a/cub/cub/detail/env_dispatch.cuh
+++ b/cub/cub/detail/env_dispatch.cuh
@@ -43,7 +43,7 @@ CUB_RUNTIME_FUNCTION static cudaError_t dispatch_with_env(const EnvT& env, Algor
   auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
 
   // Query memory resource from environment
-  auto mr = ::cuda::__call_or(::cuda::mr::__get_memory_resource, detail::device_memory_resource{}, env);
+  auto mr = ::cuda::__call_or(::cuda::mr::get_memory_resource, detail::device_memory_resource{}, env);
 
   // Query tuning from environment
   const auto tuning = ::cuda::__call_or(::cuda::execution::__get_tuning, ::cuda::std::execution::env<>{}, env);

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -311,10 +311,10 @@ void launch(ActionT action, Args... args)
   size_t bytes_allocated{};
   size_t bytes_deallocated{};
 
-  static_assert(!cuda::std::execution::__queryable_with<env_t, cuda::mr::__get_memory_resource_t>,
+  static_assert(!cuda::std::execution::__queryable_with<env_t, cuda::mr::get_memory_resource_t>,
                 "Don't specify memory resource for launch tests.");
   auto mr         = device_memory_resource{stream, &bytes_allocated, &bytes_deallocated};
-  auto mr_env     = cuda::std::execution::prop{cuda::mr::__get_memory_resource_t{}, mr};
+  auto mr_env     = cuda::std::execution::prop{cuda::mr::get_memory_resource_t{}, mr};
   auto stream_env = cuda::std::execution::prop{cuda::get_stream_t{}, cuda::stream_ref{stream}};
   auto fixed_env  = cuda::std::execution::env{mr_env, stream_env, env};
 
@@ -408,13 +408,13 @@ void launch(ActionT action, Args... args)
   // Host-side stream is unusable in device code, force it to be 0
   auto stream_env = cuda::std::execution::prop{cuda::get_stream_t{}, cuda::stream_ref{cudaStream_t{}}};
 
-  static_assert(!cuda::std::execution::__queryable_with<env_t, cuda::mr::__get_memory_resource_t>,
+  static_assert(!cuda::std::execution::__queryable_with<env_t, cuda::mr::get_memory_resource_t>,
                 "Don't specify memory resource for launch tests.");
   auto mr = device_side_memory_resource{
     thrust::raw_pointer_cast(d_temp_storage.data()),
     thrust::raw_pointer_cast(d_allocated.data()),
     thrust::raw_pointer_cast(d_deallocated.data())};
-  auto mr_env    = cuda::std::execution::prop{cuda::mr::__get_memory_resource_t{}, mr};
+  auto mr_env    = cuda::std::execution::prop{cuda::mr::get_memory_resource_t{}, mr};
   auto fixed_env = cuda::std::execution::env{mr_env, stream_env, env};
 
   auto fixed_args = replace_back(cuda::std::make_index_sequence<env_idx>{}, tuple, fixed_env);
@@ -463,12 +463,12 @@ void launch(ActionT action, Args... args)
   size_t bytes_allocated{};
   size_t bytes_deallocated{};
 
-  static_assert(!cuda::std::execution::__queryable_with<env_t, cuda::mr::__get_memory_resource_t>,
+  static_assert(!cuda::std::execution::__queryable_with<env_t, cuda::mr::get_memory_resource_t>,
                 "Don't specify memory resource for launch tests.");
 
   {
     auto mr         = throwing_memory_resource{};
-    auto mr_env     = cuda::std::execution::prop{cuda::mr::__get_memory_resource_t{}, mr};
+    auto mr_env     = cuda::std::execution::prop{cuda::mr::get_memory_resource_t{}, mr};
     auto fixed_env  = cuda::std::execution::env{mr_env, env};
     auto fixed_args = replace_back(cuda::std::make_index_sequence<env_idx>{}, tuple, fixed_env);
 
@@ -480,7 +480,7 @@ void launch(ActionT action, Args... args)
   }
 
   auto mr         = device_memory_resource{stream, &bytes_allocated, &bytes_deallocated};
-  auto mr_env     = cuda::std::execution::prop{cuda::mr::__get_memory_resource_t{}, mr};
+  auto mr_env     = cuda::std::execution::prop{cuda::mr::get_memory_resource_t{}, mr};
   auto stream_env = cuda::std::execution::prop{cuda::get_stream_t{}, cuda::stream_ref{stream}};
   auto fixed_env  = cuda::std::execution::env{mr_env, stream_env, env};
 

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -1019,7 +1019,7 @@ _CCCL_HOST_API buffer<_Tp, _FirstProperty, _RestProperties...> make_buffer(
 {
   auto __res =
     buffer<_Tp, _FirstProperty, _RestProperties...>{__stream, ::cuda::std::forward<_Resource>(__mr), __size, no_init};
-  __fill_n<_Tp, mr::__memory_accessibility_from_properties<_FirstProperty, _RestProperties...>::value>(
+  __fill_n<_Tp, mr::__memory_accessibility_from_properties_v<_FirstProperty, _RestProperties...>>(
     __stream, __res.__unwrapped_begin(), __size, __value);
   return __res;
 }

--- a/libcudacxx/include/cuda/__container/heterogeneous_iterator.h
+++ b/libcudacxx/include/cuda/__container/heterogeneous_iterator.h
@@ -208,12 +208,12 @@ class heterogeneous_iterator
     : public __heterogeneous_iterator_access<
         ::cuda::std::remove_const_t<_CvTp>,
         ::cuda::std::is_const_v<_CvTp> ? __is_heterogeneous_const_iter::__yes : __is_heterogeneous_const_iter::__no,
-        ::cuda::mr::__memory_accessibility_from_properties<_Properties...>::value>
+        ::cuda::mr::__memory_accessibility_from_properties_v<_Properties...>>
 {
   using __base = __heterogeneous_iterator_access<
     ::cuda::std::remove_const_t<_CvTp>,
     ::cuda::std::is_const_v<_CvTp> ? __is_heterogeneous_const_iter::__yes : __is_heterogeneous_const_iter::__no,
-    ::cuda::mr::__memory_accessibility_from_properties<_Properties...>::value>;
+    ::cuda::mr::__memory_accessibility_from_properties_v<_Properties...>>;
 
 public:
   using iterator_concept  = ::cuda::std::contiguous_iterator_tag;

--- a/libcudacxx/include/cuda/__fwd/get_memory_resource.h
+++ b/libcudacxx/include/cuda/__fwd/get_memory_resource.h
@@ -27,7 +27,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_MR
 
-struct __get_memory_resource_t;
+struct get_memory_resource_t;
 
 _CCCL_END_NAMESPACE_CUDA_MR
 

--- a/libcudacxx/include/cuda/__memory_resource/get_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/get_memory_resource.h
@@ -51,11 +51,11 @@ template <class _Env>
 _CCCL_CONCEPT __has_query_get_memory_resource = _CCCL_REQUIRES_EXPR((_Env))(
   requires(!__is_synchronous_resource_env<_Env>),
   requires(!__has_member_get_resource<_Env>),
-  requires(::cuda::std::execution::__queryable_with<const _Env&, __get_memory_resource_t>));
+  requires(::cuda::std::execution::__queryable_with<const _Env&, get_memory_resource_t>));
 
-//! @brief `__get_memory_resource_t` is a customization point object that queries a type `T` for an associated memory
-//! resource
-struct __get_memory_resource_t
+//! @brief `get_memory_resource_t` is a customization point object that queries a type `T` for
+//! an associated memory resource
+struct get_memory_resource_t
 {
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
@@ -79,16 +79,12 @@ struct __get_memory_resource_t
   _CCCL_REQUIRES(__has_query_get_memory_resource<_Env>)
   [[nodiscard]] _CCCL_API constexpr decltype(auto) _CCCL_STATIC_CALL_OPERATOR(const _Env& __env) noexcept
   {
-    static_assert(noexcept(__env.query(__get_memory_resource_t{})), "get_memory_resource_t query must be noexcept");
-    static_assert(resource<::cuda::std::remove_cvref_t<decltype(__env.query(__get_memory_resource_t{}))>>,
+    static_assert(noexcept(__env.query(get_memory_resource_t{})), "get_memory_resource_t query must be noexcept");
+    static_assert(resource<::cuda::std::remove_cvref_t<decltype(__env.query(get_memory_resource_t{}))>>,
                   "get_memory_resource_t query must return a cuda::mr::resource");
-    return __env.query(__get_memory_resource_t{});
+    return __env.query(get_memory_resource_t{});
   }
 };
-
-_CCCL_GLOBAL_CONSTANT auto __get_memory_resource = __get_memory_resource_t{};
-
-using get_memory_resource_t = __get_memory_resource_t;
 
 _CCCL_GLOBAL_CONSTANT auto get_memory_resource = get_memory_resource_t{};
 

--- a/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
@@ -44,9 +44,9 @@ _CCCL_BEGIN_NAMESPACE_CUDA_MR
 class legacy_managed_memory_resource : public memory_resource_base<legacy_managed_memory_resource>
 {
 private:
-  unsigned int __flags_ = cudaMemAttachGlobal;
+  unsigned int __flags_ = ::cudaMemAttachGlobal;
 
-  static constexpr unsigned int __available_flags = cudaMemAttachGlobal | cudaMemAttachHost;
+  static constexpr unsigned int __available_flags = ::cudaMemAttachGlobal | ::cudaMemAttachHost;
 
 public:
   //! @brief Construct a new legacy_managed_memory_resource.
@@ -55,7 +55,7 @@ public:
   //! for the resource. This association has the effect of initializing that device and the memory being implicitly
   //! freed if the device is reset.
   _CCCL_HOST_API constexpr legacy_managed_memory_resource(
-    const unsigned int __flags = cudaMemAttachGlobal, device_ref __device = {0}) noexcept
+    const unsigned int __flags = ::cudaMemAttachGlobal, ::cuda::device_ref __device = {0}) noexcept
       : __flags_(__flags & __available_flags)
       , __device_(__device)
   {
@@ -126,7 +126,7 @@ public:
   {}
 
   //! @brief Checks whether the passed in alignment is valid
-  _CCCL_HOST_API static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept
+  [[nodiscard]] _CCCL_HOST_API static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept
   {
     return __alignment <= ::cuda::mr::default_cuda_malloc_alignment
         && (::cuda::mr::default_cuda_malloc_alignment % __alignment == 0);
@@ -135,7 +135,7 @@ public:
   using default_queries = ::cuda::mr::properties_list<::cuda::mr::device_accessible, ::cuda::mr::host_accessible>;
 
 private:
-  device_ref __device_{0};
+  ::cuda::device_ref __device_{0};
 };
 static_assert(::cuda::mr::synchronous_resource_with<legacy_managed_memory_resource, ::cuda::mr::device_accessible>);
 static_assert(::cuda::mr::synchronous_resource_with<legacy_managed_memory_resource, ::cuda::mr::host_accessible>);

--- a/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
@@ -44,9 +44,9 @@ _CCCL_BEGIN_NAMESPACE_CUDA_MR
 class legacy_managed_memory_resource : public memory_resource_base<legacy_managed_memory_resource>
 {
 private:
-  unsigned int __flags_ = ::cudaMemAttachGlobal;
+  unsigned int __flags_ = cudaMemAttachGlobal;
 
-  static constexpr unsigned int __available_flags = ::cudaMemAttachGlobal | ::cudaMemAttachHost;
+  static constexpr unsigned int __available_flags = cudaMemAttachGlobal | cudaMemAttachHost;
 
 public:
   //! @brief Construct a new legacy_managed_memory_resource.

--- a/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
@@ -44,6 +44,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_MR
 class legacy_managed_memory_resource : public memory_resource_base<legacy_managed_memory_resource>
 {
 private:
+  // cudaMemAttach values are macros, so we cannot :: them.
   unsigned int __flags_ = cudaMemAttachGlobal;
 
   static constexpr unsigned int __available_flags = cudaMemAttachGlobal | cudaMemAttachHost;
@@ -55,7 +56,7 @@ public:
   //! for the resource. This association has the effect of initializing that device and the memory being implicitly
   //! freed if the device is reset.
   _CCCL_HOST_API constexpr legacy_managed_memory_resource(
-    const unsigned int __flags = ::cudaMemAttachGlobal, ::cuda::device_ref __device = {0}) noexcept
+    const unsigned int __flags = cudaMemAttachGlobal, ::cuda::device_ref __device = {0}) noexcept
       : __flags_(__flags & __available_flags)
       , __device_(__device)
   {

--- a/libcudacxx/include/cuda/__memory_resource/memory_resource_base.h
+++ b/libcudacxx/include/cuda/__memory_resource/memory_resource_base.h
@@ -38,7 +38,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_MR
 template <class _Derived>
 struct memory_resource_base
 {
-  [[nodiscard]] _CCCL_API constexpr const _Derived& query(const __get_memory_resource_t&) const noexcept
+  [[nodiscard]] _CCCL_API constexpr const _Derived& query(const get_memory_resource_t&) const noexcept
   {
     return static_cast<const _Derived&>(*this);
   }

--- a/libcudacxx/include/cuda/__memory_resource/properties.h
+++ b/libcudacxx/include/cuda/__memory_resource/properties.h
@@ -32,10 +32,10 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_MR
 
 //! @brief The default alignment by a cudaMalloc{...} call
-inline constexpr size_t default_cuda_malloc_alignment = 256;
+inline constexpr ::cuda::std::size_t default_cuda_malloc_alignment = 256;
 
 //! @brief The default alignment by a cudaMallocHost{...} call
-inline constexpr size_t default_cuda_malloc_host_alignment = alignof(::cuda::std::max_align_t);
+inline constexpr ::cuda::std::size_t default_cuda_malloc_host_alignment = alignof(::cuda::std::max_align_t);
 
 //! @brief The device_accessible property signals that the allocated memory is device accessible
 struct device_accessible
@@ -125,7 +125,7 @@ struct dynamic_accessibility_property
 };
 
 template <bool _HostAccessible, bool _DeviceAccessible>
-_CCCL_API constexpr __memory_accessibility __memory_accessibility_from_static_properties() noexcept
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __memory_accessibility __memory_accessibility_from_static_properties() noexcept
 {
   return _HostAccessible && _DeviceAccessible ? __memory_accessibility ::__host_device
        : _DeviceAccessible                    ? __memory_accessibility ::__device
@@ -134,11 +134,14 @@ _CCCL_API constexpr __memory_accessibility __memory_accessibility_from_static_pr
 }
 
 template <class... _Properties>
+inline constexpr __memory_accessibility __memory_accessibility_from_properties_v =
+  ::cuda::mr::__memory_accessibility_from_static_properties<::cuda::mr::__is_host_accessible<_Properties...>,
+                                                            ::cuda::mr::__is_device_accessible<_Properties...>>();
+
+template <class... _Properties>
 struct __memory_accessibility_from_properties
 {
-  static constexpr __memory_accessibility value =
-    __memory_accessibility_from_static_properties<::cuda::mr::__is_host_accessible<_Properties...>,
-                                                  ::cuda::mr::__is_device_accessible<_Properties...>>();
+  static constexpr __memory_accessibility value = ::cuda::mr::__memory_accessibility_from_properties_v<_Properties...>;
 };
 
 _CCCL_END_NAMESPACE_CUDA_MR

--- a/libcudacxx/include/cuda/__memory_resource/shared_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/shared_resource.h
@@ -254,7 +254,7 @@ private:
 //!
 //! @endrst
 template <class _Resource, class... _Args>
-_CCCL_HOST_API auto make_shared_resource(_Args&&... __args) -> shared_resource<_Resource>
+[[nodiscard]] _CCCL_HOST_API auto make_shared_resource(_Args&&... __args) -> shared_resource<_Resource>
 {
   static_assert(::cuda::mr::synchronous_resource<_Resource>,
                 "_Resource does not satisfy the cuda::mr::synchronous_resource concept");


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

- Remove the duplicated internal `__get_memory_resource_t` (and just use the public `get_memory_resource_t` name instead).
- Use an inline constexpr variable for `__memory_accessibility_from_properties` instead of a templated struct (this was being instantiated several times for every `cuda::buffer`)
- Some misc `[[nodiscard]]`

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
