### PR TITLE
convert some ::value to _v

### DIFF
--- a/libcudacxx/include/cuda/__functional/address_stability.h
+++ b/libcudacxx/include/cuda/__functional/address_stability.h
@@ -65,7 +65,7 @@ struct proclaims_copyable_arguments<__callable_permitting_copied_arguments<F>> :
 template <typename F>
 [[nodiscard]] _CCCL_API constexpr auto proclaim_copyable_arguments(F&& f)
 {
-  if constexpr (proclaims_copyable_arguments<F>::value)
+  if constexpr (proclaims_copyable_arguments_v<F>)
   { // If F is already marked then we do not need to wrap it
     return f;
   }

--- a/libcudacxx/include/cuda/std/__algorithm/equal_range.h
+++ b/libcudacxx/include/cuda/std/__algorithm/equal_range.h
@@ -77,7 +77,7 @@ template <class _ForwardIterator, class _Tp, class _Compare>
 [[nodiscard]] _CCCL_API constexpr pair<_ForwardIterator, _ForwardIterator>
 equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp)
 {
-  static_assert(__is_callable<_Compare, decltype(*__first), const _Tp&>::value, "The comparator has to be callable");
+  static_assert(__is_callable_v<_Compare, decltype(*__first), const _Tp&>, "The comparator has to be callable");
   static_assert(is_copy_constructible_v<_ForwardIterator>, "Iterator has to be copy constructible");
   return ::cuda::std::__equal_range<_ClassicAlgPolicy>(
     ::cuda::std::move(__first),

--- a/libcudacxx/include/cuda/std/__algorithm/includes.h
+++ b/libcudacxx/include/cuda/std/__algorithm/includes.h
@@ -57,8 +57,7 @@ template <class _InputIterator1, class _InputIterator2, class _Compare>
 [[nodiscard]] _CCCL_API constexpr bool includes(
   _InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2, _Compare __comp)
 {
-  static_assert(__is_callable<_Compare, decltype(*__first1), decltype(*__first2)>::value,
-                "Comparator has to be callable");
+  static_assert(__is_callable_v<_Compare, decltype(*__first1), decltype(*__first2)>, "Comparator has to be callable");
 
   return ::cuda::std::__includes(
     ::cuda::std::move(__first1),

--- a/libcudacxx/include/cuda/std/__algorithm/lower_bound.h
+++ b/libcudacxx/include/cuda/std/__algorithm/lower_bound.h
@@ -63,7 +63,7 @@ template <class _ForwardIterator, class _Tp, class _Compare>
 [[nodiscard]] _CCCL_API constexpr _ForwardIterator
 lower_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp)
 {
-  static_assert(__is_callable<_Compare, decltype(*__first), const _Tp&>::value, "The comparator has to be callable");
+  static_assert(__is_callable_v<_Compare, decltype(*__first), const _Tp&>, "The comparator has to be callable");
   auto __proj = ::cuda::std::identity();
   return ::cuda::std::__lower_bound<_ClassicAlgPolicy>(__first, __last, __value, __comp, __proj);
 }

--- a/libcudacxx/include/cuda/std/__algorithm/min_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/min_element.h
@@ -67,8 +67,7 @@ template <class _ForwardIterator, class _Compare>
 min_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
 {
   static_assert(__has_forward_traversal<_ForwardIterator>, "std::min_element requires a ForwardIterator");
-  static_assert(__is_callable<_Compare, decltype(*__first), decltype(*__first)>::value,
-                "The comparator has to be callable");
+  static_assert(__is_callable_v<_Compare, decltype(*__first), decltype(*__first)>, "The comparator has to be callable");
 
   return ::cuda::std::__min_element<__comp_ref_type<_Compare>>(
     ::cuda::std::move(__first), ::cuda::std::move(__last), __comp);

--- a/libcudacxx/include/cuda/std/__algorithm/minmax.h
+++ b/libcudacxx/include/cuda/std/__algorithm/minmax.h
@@ -47,7 +47,7 @@ template <class _Tp>
 template <class _Tp, class _Compare>
 [[nodiscard]] _CCCL_API constexpr pair<_Tp, _Tp> minmax(initializer_list<_Tp> __t, _Compare __comp)
 {
-  static_assert(__is_callable<_Compare, _Tp, _Tp>::value, "The comparator has to be callable");
+  static_assert(__is_callable_v<_Compare, _Tp, _Tp>, "The comparator has to be callable");
   identity __proj{};
   auto __ret = ::cuda::std::__minmax_element_impl(__t.begin(), __t.end(), __comp, __proj);
   return pair<_Tp, _Tp>(*__ret.first, *__ret.second);

--- a/libcudacxx/include/cuda/std/__algorithm/minmax_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/minmax_element.h
@@ -125,8 +125,7 @@ template <class _ForwardIterator, class _Compare>
 minmax_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
 {
   static_assert(__has_forward_traversal<_ForwardIterator>, "::cuda::std::minmax_element requires a ForwardIterator");
-  static_assert(__is_callable<_Compare, decltype(*__first), decltype(*__first)>::value,
-                "The comparator has to be callable");
+  static_assert(__is_callable_v<_Compare, decltype(*__first), decltype(*__first)>, "The comparator has to be callable");
   auto __proj = identity();
   return ::cuda::std::__minmax_element_impl(__first, __last, __comp, __proj);
 }

--- a/libcudacxx/include/cuda/std/__algorithm/stable_sort.h
+++ b/libcudacxx/include/cuda/std/__algorithm/stable_sort.h
@@ -230,10 +230,10 @@ _CCCL_API void __stable_sort_move(
 }
 
 template <class _Tp>
-struct __stable_sort_switch
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL unsigned __stable_sort_switch() noexcept
 {
-  static const unsigned value = 128 * is_trivially_copy_assignable_v<_Tp>;
-};
+  return 128 * is_trivially_copy_assignable_v<_Tp>;
+}
 
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
 _CCCL_API void __stable_sort(
@@ -258,7 +258,7 @@ _CCCL_API void __stable_sort(
       }
       return;
   }
-  if (__len <= static_cast<difference_type>(__stable_sort_switch<value_type>::value))
+  if (__len <= static_cast<difference_type>(::cuda::std::__stable_sort_switch<value_type>()))
   {
     ::cuda::std::__insertion_sort<_AlgPolicy, _Compare>(__first, __last, __comp);
     return;
@@ -292,7 +292,7 @@ _CCCL_API void __stable_sort_impl(_RandomAccessIterator __first, _RandomAccessIt
   difference_type __len = __last - __first;
   pair<value_type*, ptrdiff_t> __buf(0, 0);
   unique_ptr<value_type, __return_temporary_buffer> __h;
-  if (__len > static_cast<difference_type>(__stable_sort_switch<value_type>::value))
+  if (__len > static_cast<difference_type>(::cuda::std::__stable_sort_switch<value_type>()))
   {
     __buf = ::cuda::std::get_temporary_buffer<value_type>(__len);
     __h.reset(__buf.first);

--- a/libcudacxx/include/cuda/std/__concepts/referenceable.h
+++ b/libcudacxx/include/cuda/std/__concepts/referenceable.h
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_STD___TYPE_TRAITS_IS_REFERENCEABLE_H
-#define _CUDA_STD___TYPE_TRAITS_IS_REFERENCEABLE_H
+#ifndef _CUDA_STD___CONCEPTS_REFERENCEABLE_H
+#define _CUDA_STD___CONCEPTS_REFERENCEABLE_H
 
 #include <cuda/std/detail/__config>
 
@@ -28,16 +28,16 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp, class = void>
-inline constexpr bool __is_referenceable_v = false;
+inline constexpr bool __is_referenceable_impl = false;
 
 template <class _Tp>
-inline constexpr bool __is_referenceable_v<_Tp, void_t<_Tp&>> = true;
+inline constexpr bool __is_referenceable_impl<_Tp, void_t<_Tp&>> = true;
 
 template <class _Tp>
-_CCCL_CONCEPT __referenceable = __is_referenceable_v<_Tp>;
+_CCCL_CONCEPT __referenceable = __is_referenceable_impl<_Tp>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_STD___TYPE_TRAITS_IS_REFERENCEABLE_H
+#endif // _CUDA_STD___CONCEPTS_REFERENCEABLE_H

--- a/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
@@ -25,6 +25,7 @@
 #include <cuda/std/__fwd/reference_wrapper.h>
 #include <cuda/std/__memory/addressof.h>
 #include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__utility/declval.h>
 #include <cuda/std/__utility/forward.h>

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -27,6 +27,7 @@
 #include <cuda/std/__concepts/convertible_to.h>
 #include <cuda/std/__concepts/copyable.h>
 #include <cuda/std/__concepts/equality_comparable.h>
+#include <cuda/std/__concepts/referenceable.h>
 #include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__concepts/totally_ordered.h>
 #include <cuda/std/__fwd/iterator.h>

--- a/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
@@ -20,7 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__type_traits/is_referenceable.h>
+#include <cuda/std/__concepts/referenceable.h>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -52,7 +52,7 @@ using add_lvalue_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_LVALUE_REFE
 
 #else // ^^^ _CCCL_BUILTIN_ADD_LVALUE_REFERENCE ^^^ / vvv !_CCCL_BUILTIN_ADD_LVALUE_REFERENCE vvv
 
-template <class _Tp, bool = __is_referenceable_v<_Tp>>
+template <class _Tp, bool = __referenceable<_Tp>>
 struct __add_lvalue_reference_impl
 {
   using type _CCCL_NODEBUG_ALIAS = _Tp;

--- a/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
@@ -20,7 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__type_traits/is_referenceable.h>
+#include <cuda/std/__concepts/referenceable.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_void.h>
 #include <cuda/std/__type_traits/remove_cv.h>
@@ -55,7 +55,7 @@ using add_pointer_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_POINTER(_Tp);
 #  endif // !_CCCL_COMPILER(GCC)
 
 #else // ^^^ _CCCL_BUILTIN_ADD_POINTER ^^^ / vvv !_CCCL_BUILTIN_ADD_POINTER vvv
-template <class _Tp, bool = __is_referenceable_v<_Tp> || is_void_v<_Tp>>
+template <class _Tp, bool = __referenceable<_Tp> || is_void_v<_Tp>>
 struct __add_pointer_impl
 {
   using type _CCCL_NODEBUG_ALIAS = remove_reference_t<_Tp>*;

--- a/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
@@ -20,7 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__type_traits/is_referenceable.h>
+#include <cuda/std/__concepts/referenceable.h>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -52,7 +52,7 @@ using add_rvalue_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_RVALUE_REFE
 
 #else // ^^^ _CCCL_BUILTIN_ADD_RVALUE_REFERENCE ^^^ / vvv !_CCCL_BUILTIN_ADD_RVALUE_REFERENCE vvv
 
-template <class _Tp, bool = __is_referenceable_v<_Tp>>
+template <class _Tp, bool = __referenceable<_Tp>>
 struct __add_rvalue_reference_impl
 {
   using type _CCCL_NODEBUG_ALIAS = _Tp;

--- a/libcudacxx/include/cuda/std/__type_traits/decay.h
+++ b/libcudacxx/include/cuda/std/__type_traits/decay.h
@@ -20,11 +20,11 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__concepts/referenceable.h>
 #include <cuda/std/__type_traits/add_pointer.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/is_array.h>
 #include <cuda/std/__type_traits/is_function.h>
-#include <cuda/std/__type_traits/is_referenceable.h>
 #include <cuda/std/__type_traits/remove_cv.h>
 #include <cuda/std/__type_traits/remove_extent.h>
 #include <cuda/std/__type_traits/remove_reference.h>
@@ -81,7 +81,7 @@ private:
   using _Up _CCCL_NODEBUG_ALIAS = remove_reference_t<_Tp>;
 
 public:
-  using type _CCCL_NODEBUG_ALIAS = typename __decay_impl<_Up, __is_referenceable_v<_Up>>::type;
+  using type _CCCL_NODEBUG_ALIAS = typename __decay_impl<_Up, __referenceable<_Up>>::type;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_copy_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_copy_assignable.h
@@ -49,7 +49,7 @@ is_copy_assignable : public is_assignable<add_lvalue_reference_t<_Tp>, add_lvalu
 
 template <class _Tp>
 inline constexpr bool is_copy_assignable_v =
-  is_assignable<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<add_const_t<_Tp>>>::value;
+  is_assignable_v<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<add_const_t<_Tp>>>;
 
 #endif // No builtin
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_copy_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_copy_constructible.h
@@ -47,7 +47,7 @@ is_copy_constructible : public is_constructible<_Tp, add_lvalue_reference_t<add_
 {};
 
 template <class _Tp>
-inline constexpr bool is_copy_constructible_v = is_constructible<_Tp, add_lvalue_reference_t<add_const_t<_Tp>>>::value;
+inline constexpr bool is_copy_constructible_v = is_constructible_v<_Tp, add_lvalue_reference_t<add_const_t<_Tp>>>;
 
 #endif // No builtin
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_destructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_destructible.h
@@ -84,7 +84,7 @@ template <class _Tp, bool>
 struct __destructible_false;
 
 template <class _Tp>
-struct __destructible_false<_Tp, false> : public __destructible_imp<_Tp, is_reference<_Tp>::value>
+struct __destructible_false<_Tp, false> : public __destructible_imp<_Tp, is_reference_v<_Tp>>
 {};
 
 template <class _Tp>
@@ -92,7 +92,7 @@ struct __destructible_false<_Tp, true> : public false_type
 {};
 
 template <class _Tp>
-struct is_destructible : public __destructible_false<_Tp, is_function<_Tp>::value>
+struct is_destructible : public __destructible_false<_Tp, is_function_v<_Tp>>
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_move_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_move_constructible.h
@@ -45,7 +45,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT is_move_constructible : public is_construct
 {};
 
 template <class _Tp>
-inline constexpr bool is_move_constructible_v = is_constructible<_Tp, add_rvalue_reference_t<_Tp>>::value;
+inline constexpr bool is_move_constructible_v = is_constructible_v<_Tp, add_rvalue_reference_t<_Tp>>;
 
 #endif // No builtin
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_destructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_destructible.h
@@ -45,7 +45,7 @@ inline constexpr bool is_nothrow_destructible_v = _CCCL_BUILTIN_IS_NOTHROW_DESTR
 
 #else // ^^^ _CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE ^^^ / vvv !_CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE vvv
 
-template <class _Tp, bool = is_destructible<_Tp>::value>
+template <class _Tp, bool = is_destructible_v<_Tp>>
 struct __cccl_is_nothrow_destructible : false_type
 {};
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_swappable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_swappable.h
@@ -20,6 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__concepts/referenceable.h>
 #include <cuda/std/__type_traits/add_lvalue_reference.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/disjunction.h>
@@ -30,7 +31,6 @@
 #include <cuda/std/__type_traits/is_move_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_move_assignable.h>
 #include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
-#include <cuda/std/__type_traits/is_referenceable.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_void.h>
 #include <cuda/std/__type_traits/nat.h>
@@ -161,7 +161,7 @@ struct __is_nothrow_swappable : public integral_constant<bool, __detail::__nothr
 template <class _Tp, class _Up>
 inline constexpr bool is_swappable_with_v = __detail::__swappable_with<_Tp, _Up>::value;
 
-template <class _Tp, bool = __is_referenceable_v<_Tp>>
+template <class _Tp, bool = __referenceable<_Tp>>
 inline constexpr bool is_swappable_v = false;
 
 template <class _Tp>
@@ -171,7 +171,7 @@ inline constexpr bool is_swappable_v<_Tp, true> =
 template <class _Tp, class _Up>
 inline constexpr bool is_nothrow_swappable_with_v = __detail::__nothrow_swappable_with<_Tp, _Up>::value;
 
-template <class _Tp, bool = __is_referenceable_v<_Tp>>
+template <class _Tp, bool = __referenceable<_Tp>>
 inline constexpr bool is_nothrow_swappable_v = false;
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/remove_cvref.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_cvref.h
@@ -20,7 +20,6 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/remove_cv.h>
 #include <cuda/std/__type_traits/remove_reference.h>
 

--- a/libcudacxx/include/cuda/std/type_traits
+++ b/libcudacxx/include/cuda/std/type_traits
@@ -112,7 +112,6 @@
 #include <cuda/std/__type_traits/is_polymorphic.h>
 #include <cuda/std/__type_traits/is_primary_template.h>
 #include <cuda/std/__type_traits/is_reference.h>
-#include <cuda/std/__type_traits/is_referenceable.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_scalar.h>
 #include <cuda/std/__type_traits/is_scoped_enum.h>

--- a/libcudacxx/test/libcudacxx/libcxx/utilities/meta/is_referenceable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/utilities/meta/is_referenceable.pass.cpp
@@ -12,149 +12,149 @@
 //    or a ref-qualifier, or a reference type.
 //
 
+#include <cuda/std/__concepts/referenceable.h>
 #include <cuda/std/cassert>
-#include <cuda/std/type_traits>
 
 #include "test_macros.h"
 
 struct Foo
 {};
 
-static_assert((!cuda::std::__is_referenceable_v<void>) );
-static_assert((cuda::std::__is_referenceable_v<int>) );
-static_assert((cuda::std::__is_referenceable_v<int[3]>) );
-static_assert((cuda::std::__is_referenceable_v<int[]>) );
-static_assert((cuda::std::__is_referenceable_v<int&>) );
-static_assert((cuda::std::__is_referenceable_v<const int&>) );
-static_assert((cuda::std::__is_referenceable_v<int*>) );
-static_assert((cuda::std::__is_referenceable_v<const int*>) );
-static_assert((cuda::std::__is_referenceable_v<Foo>) );
-static_assert((cuda::std::__is_referenceable_v<const Foo>) );
-static_assert((cuda::std::__is_referenceable_v<Foo&>) );
-static_assert((cuda::std::__is_referenceable_v<const Foo&>) );
-static_assert((cuda::std::__is_referenceable_v<Foo&&>) );
-static_assert((cuda::std::__is_referenceable_v<const Foo&&>) );
+static_assert(!cuda::std::__referenceable<void>);
+static_assert(cuda::std::__referenceable<int>);
+static_assert(cuda::std::__referenceable<int[3]>);
+static_assert(cuda::std::__referenceable<int[]>);
+static_assert(cuda::std::__referenceable<int&>);
+static_assert(cuda::std::__referenceable<const int&>);
+static_assert(cuda::std::__referenceable<int*>);
+static_assert(cuda::std::__referenceable<const int*>);
+static_assert(cuda::std::__referenceable<Foo>);
+static_assert(cuda::std::__referenceable<const Foo>);
+static_assert(cuda::std::__referenceable<Foo&>);
+static_assert(cuda::std::__referenceable<const Foo&>);
+static_assert(cuda::std::__referenceable<Foo&&>);
+static_assert(cuda::std::__referenceable<const Foo&&>);
 
 #if !TEST_COMPILER(MSVC)
-static_assert((cuda::std::__is_referenceable_v<int __attribute__((__vector_size__(8)))>) );
-static_assert((cuda::std::__is_referenceable_v<const int __attribute__((__vector_size__(8)))>) );
-static_assert((cuda::std::__is_referenceable_v<float __attribute__((__vector_size__(16)))>) );
-static_assert((cuda::std::__is_referenceable_v<const float __attribute__((__vector_size__(16)))>) );
+static_assert(cuda::std::__referenceable<int __attribute__((__vector_size__(8)))>);
+static_assert(cuda::std::__referenceable<const int __attribute__((__vector_size__(8)))>);
+static_assert(cuda::std::__referenceable<float __attribute__((__vector_size__(16)))>);
+static_assert(cuda::std::__referenceable<const float __attribute__((__vector_size__(16)))>);
 #endif // !TEST_COMPILER(MSVC)
 
 // Functions without cv-qualifiers are referenceable
-static_assert((cuda::std::__is_referenceable_v<void()>) );
-static_assert((!cuda::std::__is_referenceable_v<void() const>) );
-static_assert((!cuda::std::__is_referenceable_v<void() &>) );
-static_assert((!cuda::std::__is_referenceable_v<void() const&>) );
-static_assert((!cuda::std::__is_referenceable_v<void() &&>) );
-static_assert((!cuda::std::__is_referenceable_v<void() const&&>) );
+static_assert(cuda::std::__referenceable<void()>);
+static_assert(!cuda::std::__referenceable<void() const>);
+static_assert(!cuda::std::__referenceable<void() &>);
+static_assert(!cuda::std::__referenceable<void() const&>);
+static_assert(!cuda::std::__referenceable<void() &&>);
+static_assert(!cuda::std::__referenceable<void() const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void(int)>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int) const>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int) &>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int) const&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int) &&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int) const&&>) );
+static_assert(cuda::std::__referenceable<void(int)>);
+static_assert(!cuda::std::__referenceable<void(int) const>);
+static_assert(!cuda::std::__referenceable<void(int) &>);
+static_assert(!cuda::std::__referenceable<void(int) const&>);
+static_assert(!cuda::std::__referenceable<void(int) &&>);
+static_assert(!cuda::std::__referenceable<void(int) const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void(int, float)>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float) const>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float) &>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float) const&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float) &&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float) const&&>) );
+static_assert(cuda::std::__referenceable<void(int, float)>);
+static_assert(!cuda::std::__referenceable<void(int, float) const>);
+static_assert(!cuda::std::__referenceable<void(int, float) &>);
+static_assert(!cuda::std::__referenceable<void(int, float) const&>);
+static_assert(!cuda::std::__referenceable<void(int, float) &&>);
+static_assert(!cuda::std::__referenceable<void(int, float) const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void(int, float, Foo&)>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&) const>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&) &>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&) const&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&) &&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&) const&&>) );
+static_assert(cuda::std::__referenceable<void(int, float, Foo&)>);
+static_assert(!cuda::std::__referenceable<void(int, float, Foo&) const>);
+static_assert(!cuda::std::__referenceable<void(int, float, Foo&) &>);
+static_assert(!cuda::std::__referenceable<void(int, float, Foo&) const&>);
+static_assert(!cuda::std::__referenceable<void(int, float, Foo&) &&>);
+static_assert(!cuda::std::__referenceable<void(int, float, Foo&) const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void(...)>) );
-static_assert((!cuda::std::__is_referenceable_v<void(...) const>) );
-static_assert((!cuda::std::__is_referenceable_v<void(...) &>) );
-static_assert((!cuda::std::__is_referenceable_v<void(...) const&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(...) &&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(...) const&&>) );
+static_assert(cuda::std::__referenceable<void(...)>);
+static_assert(!cuda::std::__referenceable<void(...) const>);
+static_assert(!cuda::std::__referenceable<void(...) &>);
+static_assert(!cuda::std::__referenceable<void(...) const&>);
+static_assert(!cuda::std::__referenceable<void(...) &&>);
+static_assert(!cuda::std::__referenceable<void(...) const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void(int, ...)>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, ...) const>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, ...) &>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, ...) const&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, ...) &&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, ...) const&&>) );
+static_assert(cuda::std::__referenceable<void(int, ...)>);
+static_assert(!cuda::std::__referenceable<void(int, ...) const>);
+static_assert(!cuda::std::__referenceable<void(int, ...) &>);
+static_assert(!cuda::std::__referenceable<void(int, ...) const&>);
+static_assert(!cuda::std::__referenceable<void(int, ...) &&>);
+static_assert(!cuda::std::__referenceable<void(int, ...) const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void(int, float, ...)>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, ...) const>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, ...) &>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, ...) const&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, ...) &&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, ...) const&&>) );
+static_assert(cuda::std::__referenceable<void(int, float, ...)>);
+static_assert(!cuda::std::__referenceable<void(int, float, ...) const>);
+static_assert(!cuda::std::__referenceable<void(int, float, ...) &>);
+static_assert(!cuda::std::__referenceable<void(int, float, ...) const&>);
+static_assert(!cuda::std::__referenceable<void(int, float, ...) &&>);
+static_assert(!cuda::std::__referenceable<void(int, float, ...) const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void(int, float, Foo&, ...)>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&, ...) const>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&, ...) &>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&, ...) const&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&, ...) &&>) );
-static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&, ...) const&&>) );
+static_assert(cuda::std::__referenceable<void(int, float, Foo&, ...)>);
+static_assert(!cuda::std::__referenceable<void(int, float, Foo&, ...) const>);
+static_assert(!cuda::std::__referenceable<void(int, float, Foo&, ...) &>);
+static_assert(!cuda::std::__referenceable<void(int, float, Foo&, ...) const&>);
+static_assert(!cuda::std::__referenceable<void(int, float, Foo&, ...) &&>);
+static_assert(!cuda::std::__referenceable<void(int, float, Foo&, ...) const&&>);
 
 // member functions with or without cv-qualifiers are referenceable
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)()>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)() const>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)() &>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)() const&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)() &&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)() const&&>) );
+static_assert(cuda::std::__referenceable<void (Foo::*)()>);
+static_assert(cuda::std::__referenceable<void (Foo::*)() const>);
+static_assert(cuda::std::__referenceable<void (Foo::*)() &>);
+static_assert(cuda::std::__referenceable<void (Foo::*)() const&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)() &&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)() const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int)>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int) const>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int) &>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int) const&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int) &&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int) const&&>) );
+static_assert(cuda::std::__referenceable<void (Foo::*)(int)>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int) const>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int) &>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int) const&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int) &&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int) const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float)>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float) const>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float) &>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float) const&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float) &&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float) const&&>) );
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float)>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float) const>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float) &>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float) const&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float) &&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float) const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&)>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&) const>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&) &>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&) const&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&) &&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&) const&&>) );
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, Foo&)>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, Foo&) const>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, Foo&) &>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, Foo&) const&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, Foo&) &&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, Foo&) const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(...)>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(...) const>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(...) &>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(...) const&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(...) &&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(...) const&&>) );
+static_assert(cuda::std::__referenceable<void (Foo::*)(...)>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(...) const>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(...) &>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(...) const&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(...) &&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(...) const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, ...)>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, ...) const>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, ...) &>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, ...) const&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, ...) &&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, ...) const&&>) );
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, ...)>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, ...) const>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, ...) &>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, ...) const&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, ...) &&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, ...) const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, ...)>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, ...) const>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, ...) &>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, ...) const&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, ...) &&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, ...) const&&>) );
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, ...)>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, ...) const>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, ...) &>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, ...) const&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, ...) &&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, ...) const&&>);
 
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&, ...)>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&, ...) const>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&, ...) &>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&, ...) const&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&, ...) &&>) );
-static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&, ...) const&&>) );
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, Foo&, ...)>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, Foo&, ...) const>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, Foo&, ...) &>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, Foo&, ...) const&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, Foo&, ...) &&>);
+static_assert(cuda::std::__referenceable<void (Foo::*)(int, float, Foo&, ...) const&&>);
 
 int main(int, char**)
 {


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Convert many instances of `meow<...>::value` to `meow_v<...>`.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
