### PR TITLE
[STF] torch.localized: localized tensor factories for PyTorch (stack 3/4)

### DIFF
--- a/docs/python/stf.rst
+++ b/docs/python/stf.rst
@@ -151,6 +151,14 @@ are complementary and a consumer picks the semantics by construction:
   consumer's stream after the allocation stream with an event wait (nothing
   blocks on the host).
 
+The localized-allocation surface (``interop.pytorch.localized_empty``)
+exposes the same choice as ``lifetime="pinned"`` (CAI import; the metadata
+registry pins the pages until :func:`release`) versus ``lifetime="gc"``
+(DLPack import; the tensor -- typically an ``nn.Parameter``, where it is the
+default -- owns the pages, so unloading the module frees the VMM and the
+placement metadata). See ``tests/stf/test_device_array_dlpack.py`` and
+``tests/stf/interop/test_localized_weights_example.py``.
+
 Interop adapters
 ----------------
 

--- a/python/cuda_stf/README.md
+++ b/python/cuda_stf/README.md
@@ -83,6 +83,101 @@ borrowed = numba.cuda.as_cuda_array(arr)   # CAI: arr must stay alive
 owned    = torch.from_dlpack(arr)          # DLPack: the tensor keeps it alive
 ```
 
+For pytorch-flavored code, an optional convenience attaches the factory
+family as a `torch.localized` namespace (an attribute plus a `sys.modules`
+entry -- purely additive, nothing about torch's own behavior changes, and
+`uninstall()` reverses it):
+
+```python
+import torch
+import cuda.stf._experimental as stf
+
+stf.interop.pytorch.install()      # adds torch.localized
+stf.machine_init()
+grid = stf.exec_place_grid.from_devices([0, 1])
+
+w = torch.localized.parameter((4096, 4096), torch.bfloat16, grid,
+                              spec=(("blocked", 0), None))
+# no spec => the default: blocked along dim 0 (here: batch rows split
+# across the grid). Placement granularity is the 2 MiB VMM page, so give
+# the split something to work with -- a tensor smaller than one page lands
+# on a single place no matter the spec.
+x = torch.localized.zeros((8192, 4096), torch.float32, grid)
+b = torch.localized.zeros_like(x)  # reuses x's placement verbatim
+torch.localized.placement_report(x)  # dry-run: bytes per grid position
+```
+
+Compute follows the same model: `torch.localized.map(fn, *tensors)` applies
+a map expression (eager, or a stock `torch.compile` artifact — fusion stays
+torch's job) once per die, each over a strided view of exactly the die's
+elements, forked/joined with events so the whole thing is CUDA-graph
+capturable. The iteration split is inferred from the operands' placement
+(all localized operands must share one spec; replicated ones pass whole).
+Valid bodies are maps w.r.t. the split axes: pointwise always, dim-wise ops
+along unsplit dims (softmax/LayerNorm over hidden with a batch split) too;
+reductions over a split dim are per-die partials over
+`torch.localized.views(t)` plus a fold. The runnable spectrum — including
+graph capture and an `nn.Module` — lives in
+`tests/stf/test_localized_map_examples.py`.
+
+`from torch.localized import zeros` works too. For codebases that prefer
+explicit imports over patching, `stf.interop.pytorch.namespace()` returns
+the identical object without touching torch. `install()` refuses to clobber a
+`torch.localized` that is not ours.
+
+The localized-allocation surface (`interop.pytorch.localized_empty`, plus
+the factory family `localized_zeros/ones/full` and the placement-reusing
+`*_like` variants) exposes
+this as `lifetime="pinned"` (CAI + registry, freed by `release()`) versus
+`lifetime="gc"` (DLPack; the tensor — typically an `nn.Parameter`, where it
+is the default — owns the pages, freed when the module is unloaded). See
+`tests/stf/test_device_array_dlpack.py` and
+`tests/stf/interop/test_localized_weights_example.py`.
+
+Its sibling `interop.pytorch.replicated_empty` covers the other half of the
+placement vocabulary: one canonical copy, read by tasks at
+`replicated_dplace(t)` (= `data_place.replicated(grid)`, read-only) so the
+runtime materializes one replica per grid member — the
+write-once-read-replicated shape of model weights. Partition specs express
+partial replication with
+`cute_partition.from_spec(..., replicate_over=(axis,...))` — the poster
+child is a weight sharded over one grid axis with one copy per coordinate
+of the other (tensor-parallel shards replicated across the remaining axis):
+
+```python
+# (P, Q) grid: blocked over axis 0, one copy per coordinate of axis 1
+part = stf.cute_partition.from_spec((K,), (("blocked", 0),), (P, Q), replicate_over=(1,))
+```
+
+(End-to-end shaped-grid execution from Python arrives with the grid-reshape
+bindings; the descriptor, `placement_evaluate` and the C/C++ layers handle
+it today.) In general:
+
+**Pointer model.** Sharding and replication differ in one fundamental way:
+a localized allocation keeps the single-base-pointer illusion because page
+translation is many-to-one (one VA range, pages physically striped), while
+replication is one-to-many per page, which no single translation can
+express. Consumers therefore fall into three tiers: *naive* code (loaders,
+plain torch kernels) uses the one canonical pointer -- always correct, no
+locality win; *STF tasks* still see a plain tensor, rebased to their
+shard's replica at dispatch (replicas are layout-homogeneous, so only the
+base differs); *placement-aware* code detects `ReplicatedMeta` via
+`get_meta` and obtains per-replica bases with freeze + `get(member)`. This
+is also why direct allocation on a replicated place is rejected: "give me
+the pointer" has no answer when there are several. Consequently
+`replicated_empty` is a *primitive*, not a drop-in weight abstraction: it
+returns the canonical copy (plus registry metadata), and a consumer that
+wants per-replica access needs both a multi-tensor wrapper (the
+single-process analog of DTensor's ``Replicate()`` placement) and sharded
+execution -- a whole-device kernel takes one pointer per argument and
+cannot read "the right replica per domain". That wrapper belongs to the
+consuming framework layer, where the execution sharding lives.
+`placement_evaluate` reports the per-member copies
+(`stats.replication_factor`, `stats.resident_bytes`), and a composite data
+place built from such a partition is itself replicated (read-only) — through
+a logical data it resolves to one composite VMM allocation per replicated
+coordinate, each striped over its fiber's places.
+
 ## Documentation
 
 For complete documentation, examples, and API reference, visit:

--- a/python/cuda_stf/README.md
+++ b/python/cuda_stf/README.md
@@ -112,7 +112,8 @@ a map expression (eager, or a stock `torch.compile` artifact — fusion stays
 torch's job) once per die, each over a strided view of exactly the die's
 elements, forked/joined with events so the whole thing is CUDA-graph
 capturable. The iteration split is inferred from the operands' placement
-(all localized operands must share one spec; replicated ones pass whole).
+(all localized operands must share one spec; ordinary broadcast scalars
+pass whole).
 Valid bodies are maps w.r.t. the split axes: pointwise always, dim-wise ops
 along unsplit dims (softmax/LayerNorm over hidden with a batch split) too;
 reductions over a split dim are per-die partials over
@@ -133,50 +134,6 @@ this as `lifetime="pinned"` (CAI + registry, freed by `release()`) versus
 is the default — owns the pages, freed when the module is unloaded). See
 `tests/stf/test_device_array_dlpack.py` and
 `tests/stf/interop/test_localized_weights_example.py`.
-
-Its sibling `interop.pytorch.replicated_empty` covers the other half of the
-placement vocabulary: one canonical copy, read by tasks at
-`replicated_dplace(t)` (= `data_place.replicated(grid)`, read-only) so the
-runtime materializes one replica per grid member — the
-write-once-read-replicated shape of model weights. Partition specs express
-partial replication with
-`cute_partition.from_spec(..., replicate_over=(axis,...))` — the poster
-child is a weight sharded over one grid axis with one copy per coordinate
-of the other (tensor-parallel shards replicated across the remaining axis):
-
-```python
-# (P, Q) grid: blocked over axis 0, one copy per coordinate of axis 1
-part = stf.cute_partition.from_spec((K,), (("blocked", 0),), (P, Q), replicate_over=(1,))
-```
-
-(End-to-end shaped-grid execution from Python arrives with the grid-reshape
-bindings; the descriptor, `placement_evaluate` and the C/C++ layers handle
-it today.) In general:
-
-**Pointer model.** Sharding and replication differ in one fundamental way:
-a localized allocation keeps the single-base-pointer illusion because page
-translation is many-to-one (one VA range, pages physically striped), while
-replication is one-to-many per page, which no single translation can
-express. Consumers therefore fall into three tiers: *naive* code (loaders,
-plain torch kernels) uses the one canonical pointer -- always correct, no
-locality win; *STF tasks* still see a plain tensor, rebased to their
-shard's replica at dispatch (replicas are layout-homogeneous, so only the
-base differs); *placement-aware* code detects `ReplicatedMeta` via
-`get_meta` and obtains per-replica bases with freeze + `get(member)`. This
-is also why direct allocation on a replicated place is rejected: "give me
-the pointer" has no answer when there are several. Consequently
-`replicated_empty` is a *primitive*, not a drop-in weight abstraction: it
-returns the canonical copy (plus registry metadata), and a consumer that
-wants per-replica access needs both a multi-tensor wrapper (the
-single-process analog of DTensor's ``Replicate()`` placement) and sharded
-execution -- a whole-device kernel takes one pointer per argument and
-cannot read "the right replica per domain". That wrapper belongs to the
-consuming framework layer, where the execution sharding lives.
-`placement_evaluate` reports the per-member copies
-(`stats.replication_factor`, `stats.resident_bytes`), and a composite data
-place built from such a partition is itself replicated (read-only) — through
-a logical data it resolves to one composite VMM allocation per replicated
-coordinate, each striped over its fiber's places.
 
 ## Documentation
 

--- a/python/cuda_stf/cuda/stf/_experimental/__init__.py
+++ b/python/cuda_stf/cuda/stf/_experimental/__init__.py
@@ -56,6 +56,11 @@ _LAZY_SYMBOLS = {
     "task_graph": ".task_graph",
 }
 
+#: Lazily imported SUBPACKAGES (the attribute is the module itself). The
+#: interop adapters stay opt-in: accessing ``interop`` imports only the
+#: subpackage; each adapter imports its optional runtime at first call.
+_LAZY_MODULES = frozenset({"interop"})
+
 if TYPE_CHECKING:
     from ._stf_bindings import (
         AccessMode,
@@ -85,6 +90,10 @@ if TYPE_CHECKING:
 
 
 def __getattr__(name: str) -> Any:
+    if name in _LAZY_MODULES:
+        value = importlib.import_module(f".{name}", __name__)
+        globals()[name] = value
+        return value
     module_name = _LAZY_SYMBOLS.get(name)
     if module_name is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
@@ -96,7 +105,7 @@ def __getattr__(name: str) -> Any:
 
 
 def __dir__() -> list[str]:
-    return sorted(set(globals()) | set(__all__))
+    return sorted(set(globals()) | set(__all__) | set(_LAZY_MODULES))
 
 
 __all__ = [

--- a/python/cuda_stf/cuda/stf/_experimental/interop/__init__.py
+++ b/python/cuda_stf/cuda/stf/_experimental/interop/__init__.py
@@ -14,3 +14,20 @@ import the adapter they need, for example::
 The optional runtime is imported lazily inside the adapter functions; a missing
 dependency raises a clear ``ImportError`` at first call.
 """
+
+
+_SUBMODULES = frozenset({"numba", "pytorch"})
+
+
+def __getattr__(name):
+    if name in _SUBMODULES:
+        import importlib
+
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | _SUBMODULES)

--- a/python/cuda_stf/cuda/stf/_experimental/interop/pytorch.py
+++ b/python/cuda_stf/cuda/stf/_experimental/interop/pytorch.py
@@ -135,3 +135,698 @@ def pytorch_task(ctx, *args):
 
 
 __all__ = ["pytorch_task", "tensor_arg", "tensor_arguments"]
+
+
+# ---------------------------------------------------------------------------
+# Localized allocation: torch tensors backed by composite VMM data places.
+#
+# Lifted from the two consumer prototypes that predicted this surface
+# (vllm localization/phase0/localized_torch.py and pytorch
+# torch/cuda/_localized/_alloc.py — same lineage): one ordinary contiguous
+# torch.Tensor whose PHYSICAL pages are striped over the grid's places by a
+# partition. Checkpoint loaders and kernels see a plain tensor.
+#
+# Two tiers:
+#   * structured (preferred): a cute-partition SPEC — hashable, carries its
+#     own extents, drives placement_evaluate and downstream splitting.
+#   * callback (escape hatch): a Python mapper over the flat byte domain —
+#     opaque to caching and compilation; for assignments the spec grammar
+#     cannot express (e.g. permuted expert->place tables).
+#
+# Two lifetimes (the interchange protocol picks it):
+#   * "pinned" — CAI import (torch.as_tensor): CAI describes memory but
+#     transfers no ownership, so the registry pins the allocation for the
+#     process and release() evicts explicitly.
+#   * "gc" — DLPack import (torch.from_dlpack): the tensor's STORAGE owns
+#     the allocation (module -> parameter -> storage -> deleter), freed when
+#     the last view dies; the registry holds metadata only, evicted by a
+#     finalizer that is reachable precisely because nothing pins the buffer.
+#     This is the idiomatic lifetime for nn.Parameter weights: unload paths
+#     (model swap, sleep mode) free the VMM with the module.
+#
+# Metadata is keyed by BASE STORAGE POINTER in a module registry so it
+# survives views, reshapes, and nn.Parameter wrapping (tensor attributes do
+# not) — the enabler for compiler-side detection in consumers.
+# ---------------------------------------------------------------------------
+
+import sys as _sys
+import weakref as _weakref
+from dataclasses import dataclass as _dataclass, field as _field
+from typing import Any as _Any
+
+
+def _np_dtype_tables():
+    import numpy as np  # noqa: PLC0415
+    torch = _import_torch()
+
+    direct = {
+        torch.float64: np.float64,
+        torch.float32: np.float32,
+        torch.float16: np.float16,
+        torch.int64: np.int64,
+        torch.int32: np.int32,
+        torch.int16: np.int16,
+        torch.int8: np.int8,
+        torch.uint8: np.uint8,
+        torch.bool: np.bool_,
+    }
+    # numpy has no native bfloat16/fp8: allocate same-size storage and
+    # view() the torch tensor back to the requested dtype.
+    storage = {
+        torch.bfloat16: np.uint16,
+        getattr(torch, "float8_e4m3fn", None): np.uint8,
+        getattr(torch, "float8_e5m2", None): np.uint8,
+    }
+    storage.pop(None, None)
+    return direct, storage
+
+
+def _np_dtype(dtype):
+    import numpy as np  # noqa: PLC0415
+
+    direct, storage = _np_dtype_tables()
+    if dtype in direct:
+        return np.dtype(direct[dtype])
+    if dtype in storage:
+        return np.dtype(storage[dtype])
+    try:
+        return np.dtype(dtype)
+    except TypeError:
+        supported = sorted(str(k) for k in (*direct, *storage))
+        raise TypeError(
+            f"unsupported dtype {dtype!r} for localized allocation; "
+            f"supported torch dtypes: {supported}"
+        ) from None
+
+
+@_dataclass
+class LocalizedMeta:
+    """Placement metadata for one localized allocation."""
+
+    shape: tuple
+    dtype: _Any
+    grid: _Any
+    partition: _Any = None  # structured tier: the cute_partition
+    mapper: _Any = None  # callback tier: the Python mapper
+    lifetime: str = "pinned"  # "pinned" (CAI + registry) | "gc" (DLPack)
+    _keepalive: list = _field(default_factory=list, repr=False)
+
+
+@_dataclass
+class ReplicatedMeta:
+    """Placement metadata for one replicated allocation.
+
+    One canonical physical copy backs the tensor; the grid names the places
+    that hold their own copy when the tensor is READ at
+    ``data_place.replicated(grid)`` (the runtime broadcasts on first use and
+    reuses the replicas afterwards). The write-once-read-replicated shape of
+    model weights.
+    """
+
+    shape: tuple
+    dtype: _Any
+    grid: _Any
+    lifetime: str = "pinned"  # "pinned" (CAI + registry) | "gc" (DLPack)
+    _keepalive: list = _field(default_factory=list, repr=False)
+
+
+#: base storage pointer -> LocalizedMeta | ReplicatedMeta (guarded by the
+#: GIL; allocation and lookup are host-side).
+_REGISTRY: dict = {}
+
+
+def _evict(base, meta):
+    """Registry eviction for gc-lifetime allocations (finalizer target).
+
+    Guarded on identity so a recycled base address can never evict a
+    successor's entry.
+    """
+    if _REGISTRY.get(base) is meta:
+        del _REGISTRY[base]
+
+
+def localized_empty(shape, dtype, grid, *, spec=None, mapper=None, lifetime="pinned"):
+    """Allocate a ``torch.Tensor`` whose pages are placed by *grid*.
+
+    Exactly one of ``spec`` (structured tier; defaults to blocked along
+    axis 0 when both are ``None``) or ``mapper`` (callback tier over the
+    flat byte domain) selects the placement policy.
+
+    ``lifetime`` selects the interchange protocol and with it who owns the
+    allocation:
+
+    * ``"pinned"`` (default): CAI import. CAI transfers no ownership, so
+      the registry pins the allocation for the process; free explicitly
+      with :func:`release`.
+    * ``"gc"``: DLPack import. The tensor's storage OWNS the allocation
+      (freed when the last view dies — the idiomatic lifetime for
+      ``nn.Parameter`` weights, where unloading the module frees the VMM);
+      the registry holds metadata only and self-evicts.
+    """
+    from .. import DeviceArray, cute_partition, data_place  # noqa: PLC0415
+
+    torch = _import_torch()
+    if isinstance(shape, int):
+        shape = (shape,)
+    shape = tuple(int(s) for s in shape)
+    if spec is not None and mapper is not None:
+        raise ValueError("pass either spec= or mapper=, not both")
+    if lifetime not in ("pinned", "gc"):
+        raise ValueError(f'lifetime must be "pinned" or "gc", got {lifetime!r}')
+
+    np_dtype = _np_dtype(dtype)
+    meta = LocalizedMeta(shape=shape, dtype=dtype, grid=grid, lifetime=lifetime)
+
+    if mapper is not None:
+        numel = 1
+        for s in shape:
+            numel *= s
+        nbytes = numel * np_dtype.itemsize
+        dplace = data_place.composite(grid, mapper, data_rank=1)
+        buf = DeviceArray(numel, np_dtype, dplace, dims=(nbytes,), elemsize=1)
+        meta.mapper = mapper
+    else:
+        if spec is None:
+            spec = (("blocked", 0),) + (None,) * (len(shape) - 1)
+        if isinstance(spec, cute_partition):
+            # Prebuilt partition (e.g. reused from another allocation's meta
+            # by the *_like factories): its extents are the contract.
+            if tuple(spec.true_dims) != shape:
+                raise ValueError(
+                    f"partition true_dims {tuple(spec.true_dims)} do not match shape {shape}"
+                )
+            part = spec
+        else:
+            gd = grid.dims() if callable(getattr(grid, "dims", None)) else grid.dims
+            part = cute_partition.from_spec(shape, spec, tuple(int(e) for e in gd))
+        dplace = data_place.composite_cute(grid, part)
+        buf = DeviceArray(shape, np_dtype, dplace)
+        meta.partition = part
+
+    if lifetime == "gc":
+        # DLPack: the tensor's storage takes ownership (the capsule holds
+        # the DeviceArray, which holds the data place). Nothing pins the
+        # buffer, so a finalizer on it is REACHABLE and evicts the
+        # metadata when the storage dies.
+        t = torch.from_dlpack(buf)
+    else:
+        t = torch.as_tensor(buf)
+    _, storage_dtypes = _np_dtype_tables()
+    if isinstance(dtype, torch.dtype) and dtype in storage_dtypes:
+        t = t.view(dtype)
+    t = t.view(shape)
+
+    base = t.untyped_storage().data_ptr()
+    if lifetime == "gc":
+        _weakref.finalize(buf, _evict, base, meta)
+    else:
+        # CAI carries no ownership: the DeviceArray owns the VMM allocation
+        # and the data place's mapper trampoline must outlive the buffer.
+        meta._keepalive.extend((buf, dplace))
+    _REGISTRY[base] = meta
+    return t
+
+
+def localized_parameter(
+    shape, dtype, grid, *, spec=None, mapper=None, requires_grad=False, lifetime="gc"
+):
+    """:func:`localized_empty` wrapped as ``torch.nn.Parameter``.
+
+    ``requires_grad`` defaults to ``False`` (the inference /
+    ``create_weights`` target). ``lifetime`` defaults to ``"gc"`` here —
+    a parameter registered on a module IS the idiomatic owner (module ->
+    parameter -> storage -> allocation), so unloading the module frees the
+    VMM; pass ``lifetime="pinned"`` for the registry-pinned behavior.
+    """
+    torch = _import_torch()
+    return torch.nn.Parameter(
+        localized_empty(shape, dtype, grid, spec=spec, mapper=mapper, lifetime=lifetime),
+        requires_grad=requires_grad,
+    )
+
+
+def localized_zeros(shape, dtype, grid, *, spec=None, mapper=None, lifetime="pinned"):
+    """:func:`localized_empty` filled with zeros.
+
+    The fill is an ordinary in-place torch write through the tensor's single
+    base pointer. Unlike NUMA first-touch, VMM placement is fixed at
+    allocation by the partition -- the fill has no effect on locality (this
+    holds for any in-place initializer: ``normal_()``, ``nn.init.*``, ...).
+    """
+    t = localized_empty(shape, dtype, grid, spec=spec, mapper=mapper, lifetime=lifetime)
+    t.zero_()
+    return t
+
+
+def localized_ones(shape, dtype, grid, *, spec=None, mapper=None, lifetime="pinned"):
+    """:func:`localized_empty` filled with ones (see :func:`localized_zeros`)."""
+    t = localized_empty(shape, dtype, grid, spec=spec, mapper=mapper, lifetime=lifetime)
+    t.fill_(1)
+    return t
+
+
+def localized_full(shape, fill_value, dtype, grid, *, spec=None, mapper=None, lifetime="pinned"):
+    """:func:`localized_empty` filled with ``fill_value`` (see :func:`localized_zeros`)."""
+    t = localized_empty(shape, dtype, grid, spec=spec, mapper=mapper, lifetime=lifetime)
+    t.fill_(fill_value)
+    return t
+
+
+def _localized_like(tensor, dtype, lifetime):
+    meta = get_meta(tensor)
+    if meta is None or not isinstance(meta, LocalizedMeta):
+        raise ValueError("tensor is not a localized allocation")
+    return localized_empty(
+        meta.shape,
+        meta.dtype if dtype is None else dtype,
+        meta.grid,
+        spec=meta.partition if meta.partition is not None else None,
+        mapper=meta.mapper,
+        lifetime=meta.lifetime if lifetime is None else lifetime,
+    )
+
+
+def localized_empty_like(tensor, *, dtype=None, lifetime=None):
+    """New localized allocation with *tensor*'s placement (same grid and
+    partition object -- or mapper -- same shape; ``dtype``/``lifetime``
+    overridable)."""
+    return _localized_like(tensor, dtype, lifetime)
+
+
+def localized_zeros_like(tensor, *, dtype=None, lifetime=None):
+    """:func:`localized_empty_like` filled with zeros."""
+    t = _localized_like(tensor, dtype, lifetime)
+    t.zero_()
+    return t
+
+
+def localized_ones_like(tensor, *, dtype=None, lifetime=None):
+    """:func:`localized_empty_like` filled with ones."""
+    t = _localized_like(tensor, dtype, lifetime)
+    t.fill_(1)
+    return t
+
+
+def localized_full_like(tensor, fill_value, *, dtype=None, lifetime=None):
+    """:func:`localized_empty_like` filled with ``fill_value``."""
+    t = _localized_like(tensor, dtype, lifetime)
+    t.fill_(fill_value)
+    return t
+
+
+def replicated_empty(shape, dtype, grid, *, device=0, canonical=None, lifetime="pinned"):
+    """Allocate a ``torch.Tensor`` intended to be replicated over *grid*.
+
+    The sibling of :func:`localized_empty` for the other half of the
+    placement vocabulary: instead of striping one allocation over the grid,
+    the tensor is a single canonical copy (plain device memory on
+    ``device``) that tasks READ at ``data_place.replicated(grid)`` — the
+    runtime materializes one replica per grid member on first use. Write the
+    tensor at its canonical place (weight loading), read it replicated:
+    replicated places are read-only by contract.
+
+    Use :func:`replicated_dplace` to obtain the read-side data place for
+    task dependencies. ``lifetime`` follows :func:`localized_empty`:
+    ``"pinned"`` (CAI import, freed via :func:`release`) or ``"gc"``
+    (DLPack import, storage owns the allocation).
+
+    ``canonical`` optionally names the data place of the canonical copy
+    (overriding ``device``). Pass the first member's place (e.g. a
+    locality-domain place on a domain grid) so the canonical copy IS
+    replica 0: the runtime then materializes only N-1 broadcast copies
+    instead of leaving an extra never-read build copy behind (N+1 total).
+    """
+    from .. import DeviceArray, data_place  # noqa: PLC0415
+
+    torch = _import_torch()
+    if isinstance(shape, int):
+        shape = (shape,)
+    shape = tuple(int(s) for s in shape)
+    if lifetime not in ("pinned", "gc"):
+        raise ValueError(f'lifetime must be "pinned" or "gc", got {lifetime!r}')
+
+    np_dtype = _np_dtype(dtype)
+    meta = ReplicatedMeta(shape=shape, dtype=dtype, grid=grid, lifetime=lifetime)
+
+    dplace = canonical if canonical is not None else data_place.device(int(device))
+    buf = DeviceArray(shape, np_dtype, dplace)
+
+    if lifetime == "gc":
+        t = torch.from_dlpack(buf)
+    else:
+        t = torch.as_tensor(buf)
+    _, storage_dtypes = _np_dtype_tables()
+    if isinstance(dtype, torch.dtype) and dtype in storage_dtypes:
+        t = t.view(dtype)
+    t = t.view(shape)
+
+    base = t.untyped_storage().data_ptr()
+    if lifetime == "gc":
+        _weakref.finalize(buf, _evict, base, meta)
+    else:
+        meta._keepalive.extend((buf, dplace))
+    _REGISTRY[base] = meta
+    return t
+
+
+def replicated_dplace(tensor):
+    """Read-side data place for a :func:`replicated_empty` tensor.
+
+    Returns ``data_place.replicated(meta.grid)`` for use in read
+    dependencies (write access at a replicated place raises at dependency
+    construction).
+    """
+    from .. import data_place  # noqa: PLC0415
+
+    meta = get_meta(tensor)
+    if meta is None:
+        raise ValueError("tensor is not a registered STF allocation")
+    if not isinstance(meta, ReplicatedMeta):
+        raise TypeError("tensor is a localized allocation, not a replicated one")
+    return data_place.replicated(meta.grid)
+
+
+def release(tensor):
+    """Explicitly release *tensor*'s localized allocation.
+
+    For ``lifetime="pinned"`` allocations the registry owns the keepalive
+    (DeviceArray + data place): ``release`` evicts the entry and the VMM
+    mapping is freed once no tensor view references the storage either.
+    (A garbage-collected lifetime tied to "the last view" is not
+    expressible with CAI imports — the consumer prototypes'
+    ``weakref.finalize(buf, ...)`` was unreachable for exactly this
+    reason: the registry itself kept the buffer alive. That is what
+    ``lifetime="gc"`` exists for.)
+
+    For ``lifetime="gc"`` allocations the storage already owns the
+    buffer; ``release`` merely drops the metadata early (harmless — it
+    would self-evict when the storage dies).
+    """
+    base = tensor.untyped_storage().data_ptr()
+    meta = _REGISTRY.pop(base, None)
+    if meta is None:
+        raise ValueError("tensor is not a live localized allocation")
+    meta._keepalive.clear()
+
+
+def get_meta(tensor):
+    """Metadata for *tensor* if its storage is a localized allocation.
+
+    Survives views, reshapes, and ``nn.Parameter`` wrapping (keyed by base
+    storage pointer). Returns ``None`` for ordinary tensors.
+    """
+    try:
+        base = tensor.untyped_storage().data_ptr()
+    except (AttributeError, RuntimeError):
+        return None
+    return _REGISTRY.get(base)
+
+
+def spec_of(tensor):
+    """Placement spec of a registered allocation: the ``cute_partition``
+    (structured tier), the mapper (callback tier), or ``None`` for a
+    replicated allocation. Looked up by base storage pointer, so views,
+    reshapes and ``nn.Parameter`` wrapping all resolve to their root
+    allocation (tensor attributes would not survive those)."""
+    meta = get_meta(tensor)
+    if meta is None:
+        raise ValueError("tensor is not a registered STF allocation")
+    if isinstance(meta, ReplicatedMeta):
+        return None
+    return meta.partition if meta.partition is not None else meta.mapper
+
+
+def grid_of(tensor):
+    """Execution grid of a registered allocation (see :func:`spec_of`)."""
+    meta = get_meta(tensor)
+    if meta is None:
+        raise ValueError("tensor is not a registered STF allocation")
+    return meta.grid
+
+
+def live_metas():
+    """Snapshot of metadata for all live localized allocations."""
+    return list(_REGISTRY.values())
+
+
+def placement_report(tensor, probes: int = 4096):
+    """Dry-run the block-owner decision for *tensor*'s allocation.
+
+    Returns the ``placement_evaluate`` stats (bytes per grid index and a
+    sampling-fidelity ``accuracy``; ~1.0 means page granularity matches
+    the partition exactly).
+    """
+    from .. import placement_evaluate  # noqa: PLC0415
+
+    meta = get_meta(tensor)
+    if meta is None:
+        raise ValueError("tensor is not a localized allocation")
+    np_dtype = _np_dtype(meta.dtype)
+    if isinstance(meta, ReplicatedMeta):
+        raise ValueError(
+            "tensor is a replicated allocation: one full copy per grid "
+            "member by construction (no block-owner decision to report)"
+        )
+    if meta.partition is not None:
+        return placement_evaluate(meta.grid, meta.partition, None, np_dtype.itemsize)
+    numel = 1
+    for s in meta.shape:
+        numel *= s
+    return placement_evaluate(meta.grid, meta.mapper, (numel * np_dtype.itemsize,), 1)
+
+# ---------------------------------------------------------------------------
+# map: per-die execution of a map expression over localized operands.
+# ---------------------------------------------------------------------------
+
+
+def _partitions_equal(a, b):
+    if a is b:
+        return True
+    return (
+        tuple(a.true_dims) == tuple(b.true_dims)
+        and tuple(a.grid_dims) == tuple(b.grid_dims)
+        and a.place_leaves == b.place_leaves
+        and a.local_leaves == b.local_leaves
+        and a.replicate_over == b.replicate_over
+    )
+
+
+#: per-grid-size stream pools for the fork/join (created once, reused)
+_MAP_STREAMS: dict = {}
+
+
+def _map_streams(nplaces):
+    torch = _import_torch()
+    pool = _MAP_STREAMS.get(nplaces)
+    if pool is None:
+        pool = [torch.cuda.Stream() for _ in range(nplaces)]
+        _MAP_STREAMS[nplaces] = pool
+    return pool
+
+
+def _die_view(torch, tensor, part, die):
+    """Strided view selecting exactly die's owned elements (padded space).
+
+    The local leaves are the die-local iteration shape; the grid place
+    offset rebases it. Die identity lives entirely in the storage offset,
+    so all dies' views are shape/stride identical -- one torch.compile
+    artifact (guards on shape/stride) serves every die.
+    """
+    leaves = part.local_leaves
+    sizes = tuple(int(e) for e, _ in leaves)
+    strides = tuple(int(st) for _, st in leaves)
+    offset = int(part.grid_place_offset(die)) + tensor.storage_offset()
+    return torch.as_strided(tensor, sizes, strides, offset)
+
+
+def views(tensor, spec=None):
+    """The per-die strided views of a localized tensor (one per grid
+    position, exactly the die's owned elements, padded space).
+
+    The escape hatch for constructs beyond :func:`map` -- e.g. reductions
+    over a SPLIT dim, done as per-die partials over these views followed by
+    a fold of the P partials (the write-dual pattern).
+    """
+    torch = _import_torch()
+    part = spec if spec is not None else spec_of(tensor)
+    if part is None or callable(part):
+        raise ValueError("views requires the structured (spec) tier")
+    gd = 1
+    for e in tuple(part.grid_dims):
+        gd *= int(e)
+    return [_die_view(torch, tensor, part, d) for d in range(gd)]
+
+
+def map(fn, *tensors, spec=None, streams=None):  # noqa: A001 - namespace attribute
+    """Apply a MAP expression per die, each die over its owned elements.
+
+    ``fn`` is any callable -- eager, or a (stock) ``torch.compile`` artifact
+    -- whose dataflow respects the split axes: pointwise always; dim-wise
+    ops along UNSPLIT dims (softmax/LayerNorm over an unsplit hidden dim
+    with batch-blocked operands) are valid; reductions or stencils touching
+    a split dim are not (those need per-die partials + a fold). ``fn`` must
+    write IN-PLACE (or into localized operands passed to it): out-of-place
+    results would come from the ordinary torch allocator, unlocalized.
+
+    The iteration spec is inferred from the operands: all localized
+    operands must share one partition (validated eagerly from the
+    registry); replicated allocations and ordinary broadcast scalars pass
+    through whole. ``spec=`` overrides only when no localized operand
+    carries one.
+
+    Execution forks one launch per die on a cached per-die stream (the
+    event-based fork/join idiom, which stream capture follows), each over
+    a strided view of exactly the die's elements -- restriction by
+    re-indexing, not predication. Confinement to SM partitions can be
+    layered by passing explicit ``streams=`` (e.g. green-context streams).
+
+    Views cover the PADDED space: split dims are padded to divisibility,
+    so ``fn`` may compute on padding elements; they are never observed
+    through the tensor's true extents.
+    """
+    torch = _import_torch()
+
+    part = spec
+    view_args = []  # per operand: partition or None (pass-through)
+    for t in tensors:
+        meta = get_meta(t) if isinstance(t, torch.Tensor) else None
+        if meta is None or isinstance(meta, ReplicatedMeta):
+            view_args.append(None)  # scalars, plain tensors, replicated: whole
+            continue
+        if meta.partition is None:
+            raise ValueError(
+                "map requires the structured (spec) tier; a mapper-tier "
+                "allocation has no leaves to build per-die views from"
+            )
+        if part is None:
+            part = meta.partition
+        elif not _partitions_equal(part, meta.partition):
+            raise ValueError(
+                "misaligned operands: all localized operands of map must "
+                "share one partition (or be replicated)"
+            )
+        view_args.append(meta.partition)
+    if part is None:
+        raise ValueError(
+            "no localized operand carries a partition; pass spec= explicitly"
+        )
+
+    gd = 1
+    for e in tuple(part.grid_dims):
+        gd *= int(e)
+
+    if streams is None:
+        streams = _map_streams(gd)
+    if len(streams) < gd:
+        raise ValueError(f"need {gd} streams, got {len(streams)}")
+
+    current = torch.cuda.current_stream()
+    fork = torch.cuda.Event()
+    fork.record(current)
+    join_events = []
+    for die in range(gd):
+        s = streams[die]
+        s.wait_event(fork)
+        with torch.cuda.stream(s):
+            args = tuple(
+                _die_view(torch, t, p, die) if p is not None else t
+                for t, p in zip(tensors, view_args)
+            )
+            fn(*args)
+        e = torch.cuda.Event()
+        e.record(s)
+        join_events.append(e)
+    for e in join_events:
+        current.wait_event(e)
+
+
+# ---------------------------------------------------------------------------
+# Optional convenience: a `torch.localized` namespace.
+#
+# Purely additive sugar -- an attribute (and sys.modules entry) on the torch
+# module, nothing about torch's own behavior changes. The names mirror the
+# torch factory family; placement arguments are ours.
+# ---------------------------------------------------------------------------
+
+
+def _build_namespace(qualname):
+    import types  # noqa: PLC0415
+
+    ns = types.ModuleType(qualname)
+    ns.__doc__ = (
+        "Localized tensor factories attached by cuda.stf "
+        "(see cuda.stf._experimental.interop.pytorch.install)."
+    )
+    ns.empty = localized_empty
+    ns.zeros = localized_zeros
+    ns.ones = localized_ones
+    ns.full = localized_full
+    ns.parameter = localized_parameter
+    ns.empty_like = localized_empty_like
+    ns.zeros_like = localized_zeros_like
+    ns.ones_like = localized_ones_like
+    ns.full_like = localized_full_like
+    ns.release = release
+    ns.get_meta = get_meta
+    ns.spec_of = spec_of
+    ns.grid_of = grid_of
+    ns.map = map
+    ns.views = views
+    ns.live_metas = live_metas
+    ns.placement_report = placement_report
+    ns._cuda_stf_localized = True
+    return ns
+
+
+def install(name="localized"):
+    """Attach the localized factory namespace to torch as ``torch.<name>``.
+
+    After ``install()``, pytorch-style code reads naturally::
+
+        import torch
+        import cuda.stf._experimental as stf
+
+        stf.interop.pytorch.install()
+        stf.machine_init()
+        grid = stf.exec_place_grid.from_devices([0, 1])
+
+        w = torch.localized.parameter((4096, 4096), torch.bfloat16, grid,
+                                      spec=(("blocked", 0), None))
+        x = torch.localized.zeros((8, 4096), torch.float32, grid)
+        torch.localized.placement_report(w)
+
+    ``from torch.localized import zeros`` also works (a ``sys.modules``
+    entry is registered). Idempotent; refuses to clobber a ``torch.<name>``
+    attribute that is not ours; reversible with :func:`uninstall`. Returns
+    the namespace. For codebases that prefer no patching, :func:`namespace`
+    returns the same object without touching torch.
+    """
+    torch = _import_torch()
+    existing = getattr(torch, name, None)
+    if existing is not None and not getattr(existing, "_cuda_stf_localized", False):
+        raise RuntimeError(
+            f"torch.{name} already exists and does not belong to cuda.stf; "
+            f"pick another name: install(name=...)"
+        )
+    ns = _build_namespace(f"torch.{name}")
+    setattr(torch, name, ns)
+    _sys.modules[f"torch.{name}"] = ns
+    return ns
+
+
+def namespace():
+    """The localized factory namespace WITHOUT patching torch (for users or
+    codebases that prefer explicit imports over convenience patching)."""
+    return _build_namespace("cuda.stf.localized")
+
+
+def uninstall(name="localized"):
+    """Remove a namespace previously attached by :func:`install`."""
+    torch = _import_torch()
+    existing = getattr(torch, name, None)
+    if existing is None:
+        return
+    if not getattr(existing, "_cuda_stf_localized", False):
+        raise RuntimeError(f"torch.{name} does not belong to cuda.stf; not removing it")
+    delattr(torch, name)
+    _sys.modules.pop(f"torch.{name}", None)

--- a/python/cuda_stf/cuda/stf/_experimental/interop/pytorch.py
+++ b/python/cuda_stf/cuda/stf/_experimental/interop/pytorch.py
@@ -302,6 +302,10 @@ def localized_empty(shape, dtype, grid, *, spec=None, mapper=None, lifetime="pin
         for s in shape:
             numel *= s
         nbytes = numel * np_dtype.itemsize
+        # The buffer below is allocated flat (dims=(nbytes,), elemsize=1), so
+        # the mapper's contract on this path is byte space: data_rank=1 with
+        # data_dims == (nbytes,) and byte-offset coordinates, matching the
+        # documented task-path behavior of data_place.composite.
         dplace = data_place.composite(grid, mapper, data_rank=1)
         buf = DeviceArray(numel, np_dtype, dplace, dims=(nbytes,), elemsize=1)
         meta.mapper = mapper

--- a/python/cuda_stf/cuda/stf/_experimental/interop/pytorch.py
+++ b/python/cuda_stf/cuda/stf/_experimental/interop/pytorch.py
@@ -169,14 +169,16 @@ __all__ = ["pytorch_task", "tensor_arg", "tensor_arguments"]
 # not) — the enabler for compiler-side detection in consumers.
 # ---------------------------------------------------------------------------
 
-import sys as _sys
-import weakref as _weakref
-from dataclasses import dataclass as _dataclass, field as _field
-from typing import Any as _Any
+import sys as _sys  # noqa: E402
+import weakref as _weakref  # noqa: E402
+from dataclasses import dataclass as _dataclass  # noqa: E402
+from dataclasses import field as _field  # noqa: E402
+from typing import Any as _Any  # noqa: E402
 
 
 def _np_dtype_tables():
     import numpy as np  # noqa: PLC0415
+
     torch = _import_torch()
 
     direct = {
@@ -232,25 +234,7 @@ class LocalizedMeta:
     _keepalive: list = _field(default_factory=list, repr=False)
 
 
-@_dataclass
-class ReplicatedMeta:
-    """Placement metadata for one replicated allocation.
-
-    One canonical physical copy backs the tensor; the grid names the places
-    that hold their own copy when the tensor is READ at
-    ``data_place.replicated(grid)`` (the runtime broadcasts on first use and
-    reuses the replicas afterwards). The write-once-read-replicated shape of
-    model weights.
-    """
-
-    shape: tuple
-    dtype: _Any
-    grid: _Any
-    lifetime: str = "pinned"  # "pinned" (CAI + registry) | "gc" (DLPack)
-    _keepalive: list = _field(default_factory=list, repr=False)
-
-
-#: base storage pointer -> LocalizedMeta | ReplicatedMeta (guarded by the
+#: base storage pointer -> LocalizedMeta (guarded by the
 #: GIL; allocation and lookup are host-side).
 _REGISTRY: dict = {}
 
@@ -364,7 +348,9 @@ def localized_parameter(
     """
     torch = _import_torch()
     return torch.nn.Parameter(
-        localized_empty(shape, dtype, grid, spec=spec, mapper=mapper, lifetime=lifetime),
+        localized_empty(
+            shape, dtype, grid, spec=spec, mapper=mapper, lifetime=lifetime
+        ),
         requires_grad=requires_grad,
     )
 
@@ -389,7 +375,9 @@ def localized_ones(shape, dtype, grid, *, spec=None, mapper=None, lifetime="pinn
     return t
 
 
-def localized_full(shape, fill_value, dtype, grid, *, spec=None, mapper=None, lifetime="pinned"):
+def localized_full(
+    shape, fill_value, dtype, grid, *, spec=None, mapper=None, lifetime="pinned"
+):
     """:func:`localized_empty` filled with ``fill_value`` (see :func:`localized_zeros`)."""
     t = localized_empty(shape, dtype, grid, spec=spec, mapper=mapper, lifetime=lifetime)
     t.fill_(fill_value)
@@ -438,78 +426,6 @@ def localized_full_like(tensor, fill_value, *, dtype=None, lifetime=None):
     return t
 
 
-def replicated_empty(shape, dtype, grid, *, device=0, canonical=None, lifetime="pinned"):
-    """Allocate a ``torch.Tensor`` intended to be replicated over *grid*.
-
-    The sibling of :func:`localized_empty` for the other half of the
-    placement vocabulary: instead of striping one allocation over the grid,
-    the tensor is a single canonical copy (plain device memory on
-    ``device``) that tasks READ at ``data_place.replicated(grid)`` — the
-    runtime materializes one replica per grid member on first use. Write the
-    tensor at its canonical place (weight loading), read it replicated:
-    replicated places are read-only by contract.
-
-    Use :func:`replicated_dplace` to obtain the read-side data place for
-    task dependencies. ``lifetime`` follows :func:`localized_empty`:
-    ``"pinned"`` (CAI import, freed via :func:`release`) or ``"gc"``
-    (DLPack import, storage owns the allocation).
-
-    ``canonical`` optionally names the data place of the canonical copy
-    (overriding ``device``). Pass the first member's place (e.g. a
-    locality-domain place on a domain grid) so the canonical copy IS
-    replica 0: the runtime then materializes only N-1 broadcast copies
-    instead of leaving an extra never-read build copy behind (N+1 total).
-    """
-    from .. import DeviceArray, data_place  # noqa: PLC0415
-
-    torch = _import_torch()
-    if isinstance(shape, int):
-        shape = (shape,)
-    shape = tuple(int(s) for s in shape)
-    if lifetime not in ("pinned", "gc"):
-        raise ValueError(f'lifetime must be "pinned" or "gc", got {lifetime!r}')
-
-    np_dtype = _np_dtype(dtype)
-    meta = ReplicatedMeta(shape=shape, dtype=dtype, grid=grid, lifetime=lifetime)
-
-    dplace = canonical if canonical is not None else data_place.device(int(device))
-    buf = DeviceArray(shape, np_dtype, dplace)
-
-    if lifetime == "gc":
-        t = torch.from_dlpack(buf)
-    else:
-        t = torch.as_tensor(buf)
-    _, storage_dtypes = _np_dtype_tables()
-    if isinstance(dtype, torch.dtype) and dtype in storage_dtypes:
-        t = t.view(dtype)
-    t = t.view(shape)
-
-    base = t.untyped_storage().data_ptr()
-    if lifetime == "gc":
-        _weakref.finalize(buf, _evict, base, meta)
-    else:
-        meta._keepalive.extend((buf, dplace))
-    _REGISTRY[base] = meta
-    return t
-
-
-def replicated_dplace(tensor):
-    """Read-side data place for a :func:`replicated_empty` tensor.
-
-    Returns ``data_place.replicated(meta.grid)`` for use in read
-    dependencies (write access at a replicated place raises at dependency
-    construction).
-    """
-    from .. import data_place  # noqa: PLC0415
-
-    meta = get_meta(tensor)
-    if meta is None:
-        raise ValueError("tensor is not a registered STF allocation")
-    if not isinstance(meta, ReplicatedMeta):
-        raise TypeError("tensor is a localized allocation, not a replicated one")
-    return data_place.replicated(meta.grid)
-
-
 def release(tensor):
     """Explicitly release *tensor*'s localized allocation.
 
@@ -548,15 +464,13 @@ def get_meta(tensor):
 
 def spec_of(tensor):
     """Placement spec of a registered allocation: the ``cute_partition``
-    (structured tier), the mapper (callback tier), or ``None`` for a
-    replicated allocation. Looked up by base storage pointer, so views,
-    reshapes and ``nn.Parameter`` wrapping all resolve to their root
-    allocation (tensor attributes would not survive those)."""
+    (structured tier) or the mapper (callback tier). Looked up by base
+    storage pointer, so views, reshapes and ``nn.Parameter`` wrapping all
+    resolve to their root allocation (tensor attributes would not survive
+    those)."""
     meta = get_meta(tensor)
     if meta is None:
         raise ValueError("tensor is not a registered STF allocation")
-    if isinstance(meta, ReplicatedMeta):
-        return None
     return meta.partition if meta.partition is not None else meta.mapper
 
 
@@ -586,17 +500,13 @@ def placement_report(tensor, probes: int = 4096):
     if meta is None:
         raise ValueError("tensor is not a localized allocation")
     np_dtype = _np_dtype(meta.dtype)
-    if isinstance(meta, ReplicatedMeta):
-        raise ValueError(
-            "tensor is a replicated allocation: one full copy per grid "
-            "member by construction (no block-owner decision to report)"
-        )
     if meta.partition is not None:
         return placement_evaluate(meta.grid, meta.partition, None, np_dtype.itemsize)
     numel = 1
     for s in meta.shape:
         numel *= s
     return placement_evaluate(meta.grid, meta.mapper, (numel * np_dtype.itemsize,), 1)
+
 
 # ---------------------------------------------------------------------------
 # map: per-die execution of a map expression over localized operands.
@@ -611,7 +521,6 @@ def _partitions_equal(a, b):
         and tuple(a.grid_dims) == tuple(b.grid_dims)
         and a.place_leaves == b.place_leaves
         and a.local_leaves == b.local_leaves
-        and a.replicate_over == b.replicate_over
     )
 
 
@@ -674,9 +583,8 @@ def map(fn, *tensors, spec=None, streams=None):  # noqa: A001 - namespace attrib
 
     The iteration spec is inferred from the operands: all localized
     operands must share one partition (validated eagerly from the
-    registry); replicated allocations and ordinary broadcast scalars pass
-    through whole. ``spec=`` overrides only when no localized operand
-    carries one.
+    registry); ordinary broadcast scalars pass through whole. ``spec=``
+    overrides only when no localized operand carries one.
 
     Execution forks one launch per die on a cached per-die stream (the
     event-based fork/join idiom, which stream capture follows), each over
@@ -694,8 +602,8 @@ def map(fn, *tensors, spec=None, streams=None):  # noqa: A001 - namespace attrib
     view_args = []  # per operand: partition or None (pass-through)
     for t in tensors:
         meta = get_meta(t) if isinstance(t, torch.Tensor) else None
-        if meta is None or isinstance(meta, ReplicatedMeta):
-            view_args.append(None)  # scalars, plain tensors, replicated: whole
+        if meta is None:
+            view_args.append(None)  # scalars and plain tensors: whole
             continue
         if meta.partition is None:
             raise ValueError(
@@ -707,7 +615,7 @@ def map(fn, *tensors, spec=None, streams=None):  # noqa: A001 - namespace attrib
         elif not _partitions_equal(part, meta.partition):
             raise ValueError(
                 "misaligned operands: all localized operands of map must "
-                "share one partition (or be replicated)"
+                "share one partition"
             )
         view_args.append(meta.partition)
     if part is None:

--- a/python/cuda_stf/tests/stf/interop/test_localized_weights_example.py
+++ b/python/cuda_stf/tests/stf/interop/test_localized_weights_example.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""EXAMPLE: localized model weights with module-owned lifetime.
+
+The end-to-end idiom this package recommends for framework weights, in
+one screen:
+
+1. Build a place grid (here two views of one device; on multi-domain
+   parts, one place per locality domain).
+2. Allocate each weight with :func:`localized_parameter`: ONE ordinary
+   ``torch.nn.Parameter`` whose physical pages are striped over the
+   grid's places by a cute-partition spec. Checkpoint loaders, views,
+   and every torch op see a plain tensor.
+3. Ownership is the module's, via DLPack (``lifetime="gc"``, the
+   default for parameters): module -> parameter -> storage ->
+   allocation. Dropping the module frees the VMM and the placement
+   metadata — no registry pin, no explicit release, no leak on model
+   swap/unload.
+4. Compiler-side passes read the placement through :func:`get_meta`
+   (keyed by storage, so it survives views and Parameter wrapping).
+"""
+
+import gc
+import weakref
+
+import pytest
+
+pytest.importorskip("cuda.stf._experimental._stf_bindings")
+torch = pytest.importorskip("torch")
+
+import cuda.stf._experimental as stf  # noqa: E402
+from cuda.stf._experimental.interop import pytorch as tp  # noqa: E402
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires a CUDA device"
+)
+
+
+class LocalizedMLP(torch.nn.Module):
+    """Two matmul weights, each blocked over the grid's places along the
+    outermost axis (rows land whole on one place)."""
+
+    def __init__(self, grid, d_in=64, d_hidden=16384, d_out=64):
+        super().__init__()
+        self.w1 = tp.localized_parameter((d_hidden, d_in), torch.float32, grid)
+        self.w2 = tp.localized_parameter((d_out, d_hidden), torch.float32, grid)
+
+    def forward(self, x):
+        return torch.relu(x @ self.w1.T) @ self.w2.T
+
+
+@requires_cuda
+def test_localized_weights_lifecycle_example():
+    stf.machine_init()
+    grid = stf.exec_place_grid.create([stf.exec_place.device(0)] * 2)
+
+    model = LocalizedMLP(grid).eval()
+    with torch.no_grad():
+        for p in model.parameters():
+            p.normal_(0, 0.02)
+
+    # ordinary tensors to every consumer: checkpoint-style copy, forward
+    x = torch.randn(8, 64, device="cuda")
+    with torch.no_grad():
+        y = model(x)
+    assert y.shape == (8, 64)
+
+    # the structured channel a compiler pass reads
+    meta = tp.get_meta(model.w1)
+    assert meta.partition is not None and meta.lifetime == "gc"
+    report = tp.placement_report(model.w1)
+    assert report.accuracy == 1.0  # page-aligned rows: exact placement
+
+    # module-owned lifetime: unloading the model frees pages AND metadata
+    w1_meta = weakref.ref(meta)
+    del meta, model
+    gc.collect()
+    torch.cuda.synchronize()
+    assert w1_meta() is None

--- a/python/cuda_stf/tests/stf/test_localized_map_examples.py
+++ b/python/cuda_stf/tests/stf/test_localized_map_examples.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""The localized programming model for pytorch users, as runnable examples.
+
+The premise: allocate with a placement (``torch.localized.*`` factories),
+compute with ``torch.localized.map`` -- one fused expression (eager, or a
+stock ``torch.compile`` artifact) applied per die over exactly the elements
+that die owns. Placement lives with the tensors; ``map`` infers it.
+
+The examples walk the validity spectrum deliberately:
+  1. trivially independent (fused pointwise chains) -- always valid;
+  2. dim-wise ops along UNSPLIT dims (softmax over hidden with the batch
+     split) -- valid, and the transformer inner-loop shape;
+  3. reductions over SPLIT dims -- NOT a map: shown done right with
+     per-die partials + a fold (the write-dual boundary, made explicit);
+  4. misalignment -- rejected eagerly from registry metadata;
+  5. CUDA-graph capture of the whole fork/join -- the "works in real
+     life" requirement;
+  6. an ``nn.Module`` with localized parameters end to end.
+"""
+
+import pytest
+
+pytest.importorskip("cuda.stf._experimental._stf_bindings")
+torch = pytest.importorskip("torch")
+
+import cuda.stf._experimental as stf  # noqa: E402
+from cuda.stf._experimental.interop import pytorch as tp  # noqa: E402
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires a CUDA device"
+)
+
+N_PLACES = 2
+SHAPE = (4096, 1024)  # rows split across dies; big enough for real striping
+
+
+@pytest.fixture(params=["devices", "locality_domains"])
+def grid(request):
+    """Every example runs at two granularities: a device grid (repeat), and
+    the machine's locality domains -- the substrate the placement work is
+    for. The domain flavor skips cleanly where the locality-domain
+    bindings (PR #10703) are not in the build."""
+    stf.machine_init()
+    if request.param == "devices":
+        return stf.exec_place_grid.from_devices([0] * N_PLACES)
+    eg = stf.exec_place_grid
+    if hasattr(eg, "machine"):
+        return eg.machine(granularity="locality_domain")
+    if hasattr(eg, "locality_domains"):
+        return eg.locality_domains(0)
+    pytest.skip("locality-domain bindings not available (PR #10703)")
+
+
+def _compiled(fn):
+    """Stock torch.compile when triton is available, eager otherwise --
+    map treats both identically (any callable)."""
+    try:
+        import triton  # noqa: F401, PLC0415
+
+        return torch.compile(fn)
+    except ImportError:
+        return fn
+
+
+# -- 1. trivially independent: a fused pointwise chain ----------------------
+
+
+@requires_cuda
+def test_map_pointwise_chain(grid):
+    def body(x, y):
+        # several pointwise ops; inductor fuses them into one kernel
+        x.mul_(2.0).add_(y).relu_().sub_(0.5)
+
+    x = tp.localized_empty(SHAPE, torch.float32, grid)
+    y = tp.localized_empty(SHAPE, torch.float32, grid)
+    x.normal_()
+    y.normal_()
+    ref_x = x.clone()  # plain tensor: the whole-device reference
+    ref_y = y.clone()
+
+    tp.map(_compiled(body), x, y)
+    body(ref_x, ref_y)
+    torch.cuda.synchronize()
+    assert torch.equal(x, ref_x)
+
+    tp.release(x)
+    tp.release(y)
+
+
+# -- 2. dim-wise ops along the UNSPLIT dim -----------------------------------
+
+
+@requires_cuda
+def test_map_softmax_over_unsplit_dim(grid):
+    def body(x):
+        # softmax over the hidden (unsplit) dim: every row lives whole
+        # inside one die, so this is a valid map despite the reduction
+        x.copy_(torch.softmax(x, dim=-1))
+
+    x = tp.localized_empty(SHAPE, torch.float32, grid)
+    x.normal_()
+    ref = x.clone()
+
+    tp.map(_compiled(body), x)
+    body(ref)
+    torch.cuda.synchronize()
+    assert torch.allclose(x, ref, atol=1e-6)
+    tp.release(x)
+
+
+# -- 3. the boundary: reductions over the SPLIT dim --------------------------
+
+
+@requires_cuda
+def test_split_dim_reduction_is_partials_plus_fold(grid):
+    # A global sum reduces OVER the split dim: not a map. The correct
+    # construct is per-die partials (each die reduces its own elements
+    # into its own slot) followed by a fold of the P partials.
+    x = tp.localized_ones(SHAPE, torch.float32, grid)
+
+    # per-die partials over the public per-die views ...
+    partials = torch.stack([v.sum() for v in tp.views(x)])
+    # ... then the fold of the P partials
+    total = partials.sum()
+    torch.cuda.synchronize()
+    assert total.item() == SHAPE[0] * SHAPE[1]
+    assert partials.numel() == len(tp.views(x))  # one partial per grid place
+    tp.release(x)
+
+
+# -- 4. misalignment is rejected eagerly -------------------------------------
+
+
+@requires_cuda
+def test_map_rejects_misaligned_operands(grid):
+    x = tp.localized_empty(SHAPE, torch.float32, grid)  # default: blocked dim 0
+    y = tp.localized_empty(
+        SHAPE, torch.float32, grid, spec=(None, ("cyclic", 0))
+    )
+    with pytest.raises(ValueError, match="misaligned"):
+        tp.map(lambda a, b: a.add_(b), x, y)
+    with pytest.raises(ValueError, match="spec="):
+        tp.map(lambda a: a.zero_(), torch.zeros(4, device="cuda"))
+    tp.release(x)
+    tp.release(y)
+
+
+# -- 5. the whole fork/join is CUDA-graph capturable --------------------------
+
+
+@requires_cuda
+def test_map_captures_into_cuda_graph(grid):
+    def body(x):
+        x.mul_(3.0).add_(1.0)
+
+    x = tp.localized_ones(SHAPE, torch.float32, grid)
+    torch.cuda.synchronize()
+
+    # warm-up outside capture (streams, lazy state)
+    tp.map(body, x)
+    torch.cuda.synchronize()
+    x.fill_(1.0)
+    torch.cuda.synchronize()
+
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        # the event-based fork/join is exactly the shape stream capture
+        # follows: side streams fork from and join back into the capture
+        # stream
+        tp.map(body, x)
+    x.fill_(1.0)
+    torch.cuda.synchronize()
+    g.replay()
+    torch.cuda.synchronize()
+    assert torch.all(x == 4.0)
+    g.replay()
+    torch.cuda.synchronize()
+    assert torch.all(x == 13.0)  # replays compose: (1*3+1)*3+1
+    tp.release(x)
+
+
+# -- 6. the motivator: an nn.Module with localized parameters ----------------
+
+
+@requires_cuda
+def test_localized_mlp_module(grid):
+    """A pytorch-user-shaped module: weights are localized parameters,
+    the forward is ordinary pytorch (placement-transparent tier), the
+    in-place activation stage additionally shows the map tier."""
+
+    BATCH, D_IN, D_H = 64, 256, 512
+
+    class TinyMLP(torch.nn.Module):
+        # Sizes are kept small for test speed: placement *physics* needs
+        # tensors past the 2 MiB block (see the README); the mechanism --
+        # placed parameters, localized activations, map for the pointwise
+        # stage, plain matmuls for the rest -- is what this shows.
+        def __init__(self, grid):
+            super().__init__()
+            self.w1 = tp.localized_parameter((D_H, D_IN), torch.float32, grid)
+            self.w2 = tp.localized_parameter((D_IN, D_H), torch.float32, grid)
+            # the activation buffer is placed too (batch-blocked), so the
+            # activation stage is a real map over aligned operands
+            self.h = tp.localized_empty((BATCH, D_H), torch.float32, grid)
+            with torch.no_grad():
+                self.w1.normal_(std=0.02)
+                self.w2.normal_(std=0.02)
+
+        def forward(self, x):
+            # matmuls are NOT maps (contraction over a split dim): they run
+            # as ordinary whole-device pytorch -- localized tensors are
+            # plain tensors -- writing into the placed buffer via out=
+            torch.matmul(x, self.w1.t(), out=self.h)
+            # the pointwise stage IS a map: per-die over the batch split
+            tp.map(lambda t: t.relu_(), self.h)
+            return self.h @ self.w2.t()
+
+    m = TinyMLP(grid)
+    x = torch.randn(BATCH, D_IN, device="cuda")
+    with torch.no_grad():
+        out = m(x)
+        ref = ((x @ m.w1.t()).relu_()) @ m.w2.t()
+    torch.cuda.synchronize()
+    assert torch.allclose(out, ref, atol=1e-5)
+    # placement is discoverable on every placed piece
+    assert tp.spec_of(m.w1) is not None
+    assert tp.grid_of(m.h) is grid

--- a/python/cuda_stf/tests/stf/test_pytorch_interop_alloc.py
+++ b/python/cuda_stf/tests/stf/test_pytorch_interop_alloc.py
@@ -1,0 +1,401 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Localized allocation through ``interop.pytorch``: torch tensors backed by
+composite VMM data places (structured spec tier + callback escape hatch)."""
+
+import pytest
+
+pytest.importorskip("cuda.stf._experimental._stf_bindings")
+torch = pytest.importorskip("torch")
+pytest.importorskip("numpy")
+
+import cuda.stf._experimental as stf  # noqa: E402
+from cuda.stf._experimental.interop import pytorch as tp  # noqa: E402
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires a CUDA device"
+)
+
+N_PLACES = 2
+# page-aligned outer rows so placement fidelity is exact at 2 MiB VMM pages
+SHAPE = (8, 64, 16384)  # row = 64*16384*2B = 2 MiB (bf16/f16)
+
+
+@pytest.fixture()
+def grid():
+    stf.machine_init()
+    places = [stf.exec_place.device(0)] * N_PLACES
+    return stf.exec_place_grid.create(places)
+
+
+@requires_cuda
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_structured_alloc_roundtrip(grid, dtype):
+    t = tp.localized_empty(SHAPE, dtype, grid)
+    src = torch.randn(SHAPE, dtype=dtype, device="cuda")
+    t.copy_(src)
+    torch.cuda.synchronize()
+    assert torch.equal(t, src)
+    assert t.dtype == dtype and tuple(t.shape) == SHAPE
+
+
+@requires_cuda
+def test_meta_survives_views_and_parameter(grid):
+    t = tp.localized_empty(SHAPE, torch.float16, grid)
+    meta = tp.get_meta(t)
+    assert meta is not None and meta.partition is not None
+    # views, reshapes, and Parameter wrapping keep the same storage
+    assert tp.get_meta(t.view(-1)) is meta
+    assert tp.get_meta(t.reshape(SHAPE[0], -1)) is meta
+    assert tp.get_meta(torch.nn.Parameter(t, requires_grad=False)) is meta
+    # plain tensors carry no meta
+    assert tp.get_meta(torch.zeros(4, device="cuda")) is None
+
+
+@requires_cuda
+def test_registry_pinned_until_release(grid):
+    """Allocations are registry-pinned (weights lifetime); release() evicts.
+    NB: this test exposed that the consumer prototypes' finalize-on-buffer
+    was unreachable (the registry kept the buffer alive) — pinning +
+    explicit release are the honest semantics for CAI-imported storage."""
+    before = len(tp.live_metas())
+    t = tp.localized_empty((4, 64, 16384), torch.float16, grid)
+    assert len(tp.live_metas()) == before + 1
+    tp.release(t)
+    assert len(tp.live_metas()) == before
+    with pytest.raises(ValueError):
+        tp.release(t)
+
+
+@requires_cuda
+def test_placement_report_and_tier_parity(grid):
+    """Structured tier and the callback escape hatch place identically for
+    the blocked policy (the localization-lab parity claim, upstreamed)."""
+    t_spec = tp.localized_empty(SHAPE, torch.float16, grid)
+    row_bytes = SHAPE[1] * SHAPE[2] * 2
+
+    def blocked_rows(data_coords, data_dims, grid_dims):
+        n = grid_dims[0]
+        rows = data_dims[0] // row_bytes
+        r = data_coords[0] // row_bytes
+        chunk = -(-rows // n)
+        return (min(r // chunk, n - 1),)
+
+    t_map = tp.localized_empty(SHAPE, torch.float16, grid, mapper=blocked_rows)
+    s1 = tp.placement_report(t_spec)
+    s2 = tp.placement_report(t_map)
+    assert list(s1.bytes_per_grid_index) == list(s2.bytes_per_grid_index)
+    assert s1.accuracy == s2.accuracy == 1.0
+
+
+@requires_cuda
+def test_parameter_and_spec_mapper_exclusive(grid):
+    p = tp.localized_parameter((4, 64, 16384), torch.float16, grid)
+    assert isinstance(p, torch.nn.Parameter) and not p.requires_grad
+    with pytest.raises(ValueError, match="not both"):
+        tp.localized_empty(SHAPE, torch.float16, grid,
+                           spec=(("blocked", 0), None, None),
+                           mapper=lambda c, d, g: (0,))
+
+
+# -- gc lifetime (DLPack tier) -------------------------------------------------
+
+
+@requires_cuda
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_gc_structured_roundtrip(grid, dtype):
+    """lifetime="gc" allocates through DLPack; the view chain (storage-dtype
+    for bf16, then shape) works identically to the pinned tier."""
+    t = tp.localized_empty(SHAPE, dtype, grid, lifetime="gc")
+    src = torch.randn(SHAPE, dtype=dtype, device="cuda")
+    t.copy_(src)
+    torch.cuda.synchronize()
+    assert torch.equal(t, src)
+    meta = tp.get_meta(t)
+    assert meta is not None and meta.lifetime == "gc" and meta.partition is not None
+    assert not meta._keepalive  # nothing pinned: the storage owns the buffer
+    tp.release(t)  # early metadata drop is allowed and harmless
+
+
+@requires_cuda
+def test_gc_callback_roundtrip(grid):
+    t = tp.localized_empty(
+        (4, 64, 16384), torch.float16, grid,
+        mapper=lambda c, d, g: (0,), lifetime="gc",
+    )
+    t.fill_(3.0)
+    torch.cuda.synchronize()
+    assert float(t.sum(dtype=torch.float64)) == 3.0 * t.numel()
+
+
+@requires_cuda
+def test_gc_registry_self_evicts(grid):
+    """The gc tier's registry finalizer is REACHABLE (nothing pins the
+    buffer): when the last tensor view dies, the storage frees the VMM and
+    the metadata evicts itself — no release() call, no leak on unload."""
+    import gc
+    import weakref
+
+    t = tp.localized_empty((4, 64, 16384), torch.float16, grid, lifetime="gc")
+    p = torch.nn.Parameter(t, requires_grad=False)
+    meta_ref = weakref.ref(tp.get_meta(t))
+    assert meta_ref() is not None and tp.get_meta(p) is meta_ref()
+    assert meta_ref() in tp.live_metas()
+    del t, p
+    gc.collect()
+    # the registry entry (the meta's only strong holder) is gone
+    assert meta_ref() is None
+
+
+@requires_cuda
+def test_gc_and_pinned_place_identically(grid):
+    """The lifetime choice is orthogonal to placement: both tiers produce
+    the same bytes-per-place decision."""
+    t_pin = tp.localized_empty(SHAPE, torch.float16, grid)
+    t_gc = tp.localized_empty(SHAPE, torch.float16, grid, lifetime="gc")
+    s1, s2 = tp.placement_report(t_pin), tp.placement_report(t_gc)
+    assert list(s1.bytes_per_grid_index) == list(s2.bytes_per_grid_index)
+    assert s1.accuracy == s2.accuracy == 1.0
+    tp.release(t_pin)
+
+
+@requires_cuda
+def test_localized_parameter_defaults_to_gc(grid):
+    """A parameter registered on a module is the idiomatic owner: dropping
+    the module frees the allocation and the metadata."""
+    import gc
+    import weakref
+
+    m = torch.nn.Module()
+    m.w = tp.localized_parameter((4, 64, 16384), torch.float16, grid)
+    meta_ref = weakref.ref(tp.get_meta(m.w))
+    assert meta_ref().lifetime == "gc"
+    m.w.data.fill_(1.0)
+    torch.cuda.synchronize()
+    del m
+    gc.collect()
+    assert meta_ref() is None  # module unload freed everything
+
+
+@requires_cuda
+def test_invalid_lifetime_rejected(grid):
+    with pytest.raises(ValueError, match="lifetime"):
+        tp.localized_empty(SHAPE, torch.float16, grid, lifetime="forever")
+
+
+# ---------------------------------------------------------------------------
+# replicated_empty: the other half of the placement vocabulary — one
+# canonical copy, read replicated over the grid.
+# ---------------------------------------------------------------------------
+
+
+@requires_cuda
+def test_replicated_empty_roundtrip(grid):
+    t = tp.replicated_empty(SHAPE, torch.float32, grid)
+    src = torch.randn(SHAPE, dtype=torch.float32, device="cuda")
+    t.copy_(src)
+    torch.cuda.synchronize()
+    assert torch.equal(t, src)
+    assert t.dtype == torch.float32 and tuple(t.shape) == SHAPE
+
+
+@requires_cuda
+def test_replicated_empty_meta_and_dplace(grid):
+    t = tp.replicated_empty((64,), torch.float32, grid)
+    meta = tp.get_meta(t)
+    assert isinstance(meta, tp.ReplicatedMeta)
+    assert meta.grid is grid
+    # meta survives views and Parameter wrapping (same storage)
+    assert tp.get_meta(t.view(8, 8)) is meta
+
+    dplace = tp.replicated_dplace(t)
+    assert dplace is not None
+
+    # The read-side place is read-only by contract: a write dep at it is
+    # rejected at dependency construction
+    import numpy as np
+
+    ctx = stf.context()
+    lX = ctx.logical_data(np.zeros(8, dtype=np.float32))
+    with pytest.raises(ValueError, match="read"):
+        lX.write(dplace)
+    ctx.finalize()
+
+
+@requires_cuda
+def test_replicated_dplace_rejects_localized(grid):
+    t = tp.localized_empty(SHAPE, torch.float16, grid)
+    with pytest.raises(TypeError, match="localized"):
+        tp.replicated_dplace(t)
+    tp.release(t)
+
+
+@requires_cuda
+def test_replicated_empty_gc_lifetime(grid):
+    t = tp.replicated_empty((128,), torch.float32, grid, lifetime="gc")
+    meta = tp.get_meta(t)
+    assert meta is not None and meta.lifetime == "gc"
+    base = t.untyped_storage().data_ptr()
+    del t
+    import gc
+
+    gc.collect()
+    # storage died -> finalizer evicted the metadata
+    del base
+    assert all(m is not meta for m in tp.live_metas())
+
+
+@requires_cuda
+def test_replicated_empty_release_pinned(grid):
+    t = tp.replicated_empty((128,), torch.float32, grid)
+    assert tp.get_meta(t) is not None
+    tp.release(t)
+    assert tp.get_meta(t) is None
+
+
+@requires_cuda
+def test_replicated_empty_canonical_place(grid):
+    # The canonical copy can be placed explicitly (e.g. at replica 0's
+    # place) so the built copy IS a replica: N copies total, not N+1.
+    t = tp.replicated_empty((64,), torch.float32, grid, canonical=stf.data_place.device(0))
+    meta = tp.get_meta(t)
+    assert isinstance(meta, tp.ReplicatedMeta)
+    tp.release(t)
+
+
+@requires_cuda
+def test_replicated_empty_invalid_lifetime(grid):
+    with pytest.raises(ValueError, match="lifetime"):
+        tp.replicated_empty((8,), torch.float32, grid, lifetime="forever")
+
+
+# ---------------------------------------------------------------------------
+# Factory family: zeros / ones / full and the *_like variants
+# ---------------------------------------------------------------------------
+
+
+@requires_cuda
+def test_localized_factories_values(grid):
+    z = tp.localized_zeros((64, 32), torch.float32, grid)
+    o = tp.localized_ones((64, 32), torch.float32, grid)
+    f = tp.localized_full((64, 32), 3.5, torch.float32, grid)
+    torch.cuda.synchronize()
+    assert torch.all(z == 0) and torch.all(o == 1) and torch.all(f == 3.5)
+    for t in (z, o, f):
+        assert tp.get_meta(t) is not None
+        tp.release(t)
+
+
+@requires_cuda
+def test_localized_like_reuses_placement(grid):
+    t = tp.localized_empty(SHAPE, torch.float16, grid, spec=(None, ("blocked", 0), None))
+    meta = tp.get_meta(t)
+
+    z = tp.localized_zeros_like(t)
+    zmeta = tp.get_meta(z)
+    # the partition OBJECT is reused, not rebuilt
+    assert zmeta.partition is meta.partition
+    assert zmeta.shape == meta.shape and zmeta.dtype == meta.dtype
+    torch.cuda.synchronize()
+    assert torch.all(z == 0)
+
+    # dtype override keeps the placement (partition is element-indexed)
+    h = tp.localized_empty_like(t, dtype=torch.float32)
+    assert tp.get_meta(h).partition is meta.partition
+    assert h.dtype == torch.float32
+
+    # in-place torch init works on any localized tensor (no first-touch
+    # placement semantics: pages are placed at allocation)
+    h.normal_()
+    torch.cuda.synchronize()
+
+    for x in (t, z, h):
+        tp.release(x)
+
+
+@requires_cuda
+def test_localized_like_rejects_non_localized(grid):
+    plain = torch.zeros(8, device="cuda")
+    with pytest.raises(ValueError, match="localized"):
+        tp.localized_empty_like(plain)
+    r = tp.replicated_empty((8,), torch.float32, grid)
+    with pytest.raises(ValueError, match="localized"):
+        tp.localized_zeros_like(r)
+    tp.release(r)
+
+
+@requires_cuda
+def test_localized_empty_accepts_prebuilt_partition(grid):
+    part = stf.cute_partition.from_spec((256,), (("blocked", 0),), (N_PLACES,))
+    t = tp.localized_empty((256,), torch.float32, grid, spec=part)
+    assert tp.get_meta(t).partition is part
+    with pytest.raises(ValueError, match="true_dims"):
+        tp.localized_empty((128,), torch.float32, grid, spec=part)
+    tp.release(t)
+
+
+# ---------------------------------------------------------------------------
+# torch.localized convenience namespace (no GPU needed: pure patching)
+# ---------------------------------------------------------------------------
+
+
+def test_install_uninstall_torch_localized():
+    ns = tp.install()
+    try:
+        assert torch.localized is ns
+        assert torch.localized.empty is tp.localized_empty
+        assert torch.localized.zeros_like is tp.localized_zeros_like
+        # import machinery works through the sys.modules entry
+        from torch.localized import zeros  # noqa: PLC0415
+
+        assert zeros is tp.localized_zeros
+        # idempotent
+        assert tp.install() is not None
+    finally:
+        tp.uninstall()
+    assert not hasattr(torch, "localized")
+
+
+def test_install_refuses_foreign_attribute():
+    torch.localized = object()
+    try:
+        with pytest.raises(RuntimeError, match="does not belong"):
+            tp.install()
+        with pytest.raises(RuntimeError, match="not removing"):
+            tp.uninstall()
+    finally:
+        del torch.localized
+
+
+def test_namespace_without_patching():
+    ns = tp.namespace()
+    assert ns.full is tp.localized_full
+    assert not hasattr(torch, "localized")
+
+
+def test_attribute_chain_and_laziness():
+    import sys
+
+    # one import is enough: stf.interop.pytorch resolves lazily
+    assert stf.interop.pytorch.install is tp.install
+    assert stf.interop.pytorch.localized_zeros is tp.localized_zeros
+    # sibling adapters are NOT imported by touching the chain
+    assert "cuda.stf._experimental.interop.numba" not in sys.modules
+
+
+@requires_cuda
+def test_spec_and_grid_accessors(grid):
+    t = tp.localized_empty(SHAPE, torch.float16, grid)
+    assert tp.grid_of(t) is grid
+    assert tp.spec_of(t) is tp.get_meta(t).partition
+    # resolves through views and Parameter wrapping (storage-keyed)
+    assert tp.spec_of(t.view(-1)) is tp.spec_of(t)
+    assert tp.grid_of(torch.nn.Parameter(t, requires_grad=False)) is grid
+    r = tp.replicated_empty((8,), torch.float32, grid)
+    assert tp.spec_of(r) is None and tp.grid_of(r) is grid
+    with pytest.raises(ValueError, match="registered"):
+        tp.spec_of(torch.zeros(4, device="cuda"))
+    tp.release(t)
+    tp.release(r)

--- a/python/cuda_stf/tests/stf/test_pytorch_interop_alloc.py
+++ b/python/cuda_stf/tests/stf/test_pytorch_interop_alloc.py
@@ -95,9 +95,13 @@ def test_parameter_and_spec_mapper_exclusive(grid):
     p = tp.localized_parameter((4, 64, 16384), torch.float16, grid)
     assert isinstance(p, torch.nn.Parameter) and not p.requires_grad
     with pytest.raises(ValueError, match="not both"):
-        tp.localized_empty(SHAPE, torch.float16, grid,
-                           spec=(("blocked", 0), None, None),
-                           mapper=lambda c, d, g: (0,))
+        tp.localized_empty(
+            SHAPE,
+            torch.float16,
+            grid,
+            spec=(("blocked", 0), None, None),
+            mapper=lambda c, d, g: (0,),
+        )
 
 
 # -- gc lifetime (DLPack tier) -------------------------------------------------
@@ -122,8 +126,11 @@ def test_gc_structured_roundtrip(grid, dtype):
 @requires_cuda
 def test_gc_callback_roundtrip(grid):
     t = tp.localized_empty(
-        (4, 64, 16384), torch.float16, grid,
-        mapper=lambda c, d, g: (0,), lifetime="gc",
+        (4, 64, 16384),
+        torch.float16,
+        grid,
+        mapper=lambda c, d, g: (0,),
+        lifetime="gc",
     )
     t.fill_(3.0)
     torch.cuda.synchronize()
@@ -186,92 +193,6 @@ def test_invalid_lifetime_rejected(grid):
 
 
 # ---------------------------------------------------------------------------
-# replicated_empty: the other half of the placement vocabulary — one
-# canonical copy, read replicated over the grid.
-# ---------------------------------------------------------------------------
-
-
-@requires_cuda
-def test_replicated_empty_roundtrip(grid):
-    t = tp.replicated_empty(SHAPE, torch.float32, grid)
-    src = torch.randn(SHAPE, dtype=torch.float32, device="cuda")
-    t.copy_(src)
-    torch.cuda.synchronize()
-    assert torch.equal(t, src)
-    assert t.dtype == torch.float32 and tuple(t.shape) == SHAPE
-
-
-@requires_cuda
-def test_replicated_empty_meta_and_dplace(grid):
-    t = tp.replicated_empty((64,), torch.float32, grid)
-    meta = tp.get_meta(t)
-    assert isinstance(meta, tp.ReplicatedMeta)
-    assert meta.grid is grid
-    # meta survives views and Parameter wrapping (same storage)
-    assert tp.get_meta(t.view(8, 8)) is meta
-
-    dplace = tp.replicated_dplace(t)
-    assert dplace is not None
-
-    # The read-side place is read-only by contract: a write dep at it is
-    # rejected at dependency construction
-    import numpy as np
-
-    ctx = stf.context()
-    lX = ctx.logical_data(np.zeros(8, dtype=np.float32))
-    with pytest.raises(ValueError, match="read"):
-        lX.write(dplace)
-    ctx.finalize()
-
-
-@requires_cuda
-def test_replicated_dplace_rejects_localized(grid):
-    t = tp.localized_empty(SHAPE, torch.float16, grid)
-    with pytest.raises(TypeError, match="localized"):
-        tp.replicated_dplace(t)
-    tp.release(t)
-
-
-@requires_cuda
-def test_replicated_empty_gc_lifetime(grid):
-    t = tp.replicated_empty((128,), torch.float32, grid, lifetime="gc")
-    meta = tp.get_meta(t)
-    assert meta is not None and meta.lifetime == "gc"
-    base = t.untyped_storage().data_ptr()
-    del t
-    import gc
-
-    gc.collect()
-    # storage died -> finalizer evicted the metadata
-    del base
-    assert all(m is not meta for m in tp.live_metas())
-
-
-@requires_cuda
-def test_replicated_empty_release_pinned(grid):
-    t = tp.replicated_empty((128,), torch.float32, grid)
-    assert tp.get_meta(t) is not None
-    tp.release(t)
-    assert tp.get_meta(t) is None
-
-
-@requires_cuda
-def test_replicated_empty_canonical_place(grid):
-    # The canonical copy can be placed explicitly (e.g. at replica 0's
-    # place) so the built copy IS a replica: N copies total, not N+1.
-    t = tp.replicated_empty((64,), torch.float32, grid, canonical=stf.data_place.device(0))
-    meta = tp.get_meta(t)
-    assert isinstance(meta, tp.ReplicatedMeta)
-    tp.release(t)
-
-
-@requires_cuda
-def test_replicated_empty_invalid_lifetime(grid):
-    with pytest.raises(ValueError, match="lifetime"):
-        tp.replicated_empty((8,), torch.float32, grid, lifetime="forever")
-
-
-# ---------------------------------------------------------------------------
 # Factory family: zeros / ones / full and the *_like variants
 # ---------------------------------------------------------------------------
 
@@ -290,7 +211,9 @@ def test_localized_factories_values(grid):
 
 @requires_cuda
 def test_localized_like_reuses_placement(grid):
-    t = tp.localized_empty(SHAPE, torch.float16, grid, spec=(None, ("blocked", 0), None))
+    t = tp.localized_empty(
+        SHAPE, torch.float16, grid, spec=(None, ("blocked", 0), None)
+    )
     meta = tp.get_meta(t)
 
     z = tp.localized_zeros_like(t)
@@ -320,10 +243,6 @@ def test_localized_like_rejects_non_localized(grid):
     plain = torch.zeros(8, device="cuda")
     with pytest.raises(ValueError, match="localized"):
         tp.localized_empty_like(plain)
-    r = tp.replicated_empty((8,), torch.float32, grid)
-    with pytest.raises(ValueError, match="localized"):
-        tp.localized_zeros_like(r)
-    tp.release(r)
 
 
 @requires_cuda
@@ -393,9 +312,6 @@ def test_spec_and_grid_accessors(grid):
     # resolves through views and Parameter wrapping (storage-keyed)
     assert tp.spec_of(t.view(-1)) is tp.spec_of(t)
     assert tp.grid_of(torch.nn.Parameter(t, requires_grad=False)) is grid
-    r = tp.replicated_empty((8,), torch.float32, grid)
-    assert tp.spec_of(r) is None and tp.grid_of(r) is grid
     with pytest.raises(ValueError, match="registered"):
         tp.spec_of(torch.zeros(4, device="cuda"))
     tp.release(t)
-    tp.release(r)


### PR DESCRIPTION
## Description

**Part 3/4 of the split of #9892** — stacks on #10769 (structured partitions) and #10770 (placement evaluation). Until those merge, the Files view shows the union; this PR's own delta is **8 files, +1322/−1** (tip of #10770 → tip of this).

- **`interop.pytorch`**: `localized_empty/zeros/ones/full` (+`_like`), `localized_parameter`, lifetime tiers (`pinned` = CAI borrow, `gc` = DLPack ownership), `spec_of`/`grid_of`, `placement_report`, and per-die `views()` (one plain strided view per grid position, the placement-aware `chunk`, over which users write ordinary per-die torch loops).
- **Optional `torch.localized` namespace**: `install()`/`uninstall()`/`namespace()` — purely additive attribute + `sys.modules` entry, refuses to clobber.
- `stf.interop` resolves lazily from the top-level import.
- **Tests**: the allocation surface, the localized-weights example, the runnable localized-views example spectrum (per-die AXPY, split-dim reduction as partials + fold, an `nn.Module`); README walkthrough + docs.

**Replication note**: `replicated_empty`/`replicated_dplace`/`ReplicatedMeta` and the README replication and pointer-model sections moved to the replication PR at the top of the stack (4/4).

## Checklist
- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

