### PR TITLE
[libcu++] Suppress `static operator()`-related warnings globally

### DIFF
--- a/libcudacxx/codegen/generate_prologue_epilogue.py
+++ b/libcudacxx/codegen/generate_prologue_epilogue.py
@@ -171,6 +171,11 @@ _CCCL_DIAG_SUPPRESS_CLANG("-Wc++26-extensions")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wc++2b-extensions")
 #endif // ^^^ _CCCL_COMPILER(CLANG, <, 17) ^^^
 
+// Suppress `static operator()`-related warnings.
+_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
+
+_CCCL_DIAG_SUPPRESS_NVCC(342)
+
 // Suppress `if consteval`-related warnings.
 
 _CCCL_DIAG_SUPPRESS_NVHPC(if_consteval_nonstandard)

--- a/libcudacxx/include/cuda/__functional/always_true_false.h
+++ b/libcudacxx/include/cuda/__functional/always_true_false.h
@@ -25,11 +25,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 //! @brief Function object that always returns \c true regardless of the arguments passed.
 struct always_true
 {
@@ -49,10 +44,6 @@ struct always_false
     return false;
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__functional/call_or.h
+++ b/libcudacxx/include/cuda/__functional/call_or.h
@@ -29,11 +29,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 //! @brief `__call_or` is an higher-order function that accepts a function, a default
 //! value, and arguments to call the function with. If the function is callable with the
 //! provided arguments, it invokes the function and returns the result. Otherwise, it
@@ -64,10 +59,6 @@ _CCCL_GLOBAL_CONSTANT auto __call_or = __call_or_t{};
 
 template <class _Fn, class _Fallback, class... _Args>
 using __call_result_or_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__call_result_t<__call_or_t, _Fn, _Fallback, _Args...>;
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__functional/lazy_call_or.h
+++ b/libcudacxx/include/cuda/__functional/lazy_call_or.h
@@ -30,11 +30,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 _CCCL_BEGIN_NAMESPACE_CPO(__lazy_call_or_ns)
 //! @brief `__lazy_call_or` is like `__call_or` except that the fallback value is computed
 //! lazily.
@@ -63,10 +58,6 @@ struct __fn
   }
 };
 _CCCL_END_NAMESPACE_CPO
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 inline namespace __cpo
 {

--- a/libcudacxx/include/cuda/__functional/maximum.h
+++ b/libcudacxx/include/cuda/__functional/maximum.h
@@ -32,11 +32,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT maximum
 {
@@ -74,10 +69,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT maximum<void>
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__functional/minimum.h
+++ b/libcudacxx/include/cuda/__functional/minimum.h
@@ -32,11 +32,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT minimum
 {
@@ -74,10 +69,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT minimum<void>
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__iterator/zip_common.h
+++ b/libcudacxx/include/cuda/__iterator/zip_common.h
@@ -45,11 +45,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class... _Iterators>
 struct __zip_iter_constraints
 {
@@ -284,10 +279,6 @@ template <class _Iter>
 using __zip_maybe_proxy_reference_t = typename __zip_maybe_proxy_helper<_Iter>::reference;
 template <class _Iter>
 using __zip_maybe_proxy_value_type_t = typename __zip_maybe_proxy_helper<_Iter>::value_type;
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -50,11 +50,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 //! @addtogroup iterators
 //! @{
 
@@ -493,10 +488,6 @@ _CCCL_API constexpr zip_iterator<Iterators...> make_zip_iterator(Iterators... __
 }
 
 //! @}
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__memory_resource/get_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/get_memory_resource.h
@@ -53,11 +53,6 @@ _CCCL_CONCEPT __has_query_get_memory_resource = _CCCL_REQUIRES_EXPR((_Env))(
   requires(!__has_member_get_resource<_Env>),
   requires(::cuda::std::execution::__queryable_with<const _Env&, __get_memory_resource_t>));
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 //! @brief `__get_memory_resource_t` is a customization point object that queries a type `T` for an associated memory
 //! resource
 struct __get_memory_resource_t
@@ -96,10 +91,6 @@ _CCCL_GLOBAL_CONSTANT auto __get_memory_resource = __get_memory_resource_t{};
 using get_memory_resource_t = __get_memory_resource_t;
 
 _CCCL_GLOBAL_CONSTANT auto get_memory_resource = get_memory_resource_t{};
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_MR
 

--- a/libcudacxx/include/cuda/__stream/get_stream.h
+++ b/libcudacxx/include/cuda/__stream/get_stream.h
@@ -54,11 +54,6 @@ _CCCL_CONCEPT __has_query_get_stream = _CCCL_REQUIRES_EXPR((_Env), const _Env& _
   requires(!__has_member_stream<_Env>),
   requires(__convertible_to_stream_ref<decltype(__env.query(__cpo))>));
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 //! @brief `get_stream` is a customization point object that queries a type `T` for an associated stream
 struct get_stream_t
 {
@@ -108,10 +103,6 @@ struct get_stream_t
     return true;
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_GLOBAL_CONSTANT auto get_stream = get_stream_t{};
 

--- a/libcudacxx/include/cuda/std/__algorithm/comp.h
+++ b/libcudacxx/include/cuda/std/__algorithm/comp.h
@@ -29,11 +29,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __equal_to
 {
   _CCCL_EXEC_CHECK_DISABLE
@@ -55,10 +50,6 @@ struct __less
     return __lhs < __rhs;
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__algorithm/iter_swap.h
+++ b/libcudacxx/include/cuda/std/__algorithm/iter_swap.h
@@ -46,11 +46,6 @@ _CCCL_CONCEPT __readable_swappable =
   _CCCL_REQUIRES_EXPR((_ForwardIterator1, _ForwardIterator2), _ForwardIterator1 __a, _ForwardIterator2 __b)(
     requires(!__unqualified_iter_swap<_ForwardIterator1, _ForwardIterator2>), swap(*__a, *__b));
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   _CCCL_EXEC_CHECK_DISABLE
@@ -71,10 +66,6 @@ struct __fn
     swap(*__a, *__b);
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CPO
 

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_find_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_find_if.h
@@ -35,12 +35,6 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 _CCCL_BEGIN_NAMESPACE_CPO(__find_if)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   template <class _Ip, class _Sp, class _Pred, class _Proj>
@@ -73,11 +67,6 @@ struct __fn
     return __find_if_impl(::cuda::std::ranges::begin(__r), ::cuda::std::ranges::end(__r), __pred, __proj);
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_find_if_not.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_find_if_not.h
@@ -53,11 +53,6 @@ struct __not_pred
   }
 };
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   _CCCL_TEMPLATE(class _Ip, class _Sp, class _Pred, class _Proj = identity)
@@ -78,10 +73,6 @@ struct __fn
     return ::cuda::std::ranges::find_if(::cuda::std::forward<_Rp>(__r), __not_pred{__pred}, ::cuda::std::move(__proj));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CPO
 

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_for_each.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_for_each.h
@@ -37,11 +37,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 template <class _Iter, class _Func>
 using for_each_result = in_fun_result<_Iter, _Func>;
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 _CCCL_BEGIN_NAMESPACE_CPO(__for_each)
 struct __fn
 {
@@ -75,11 +70,6 @@ public:
     return __for_each_impl(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range), __func, __proj);
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_for_each_n.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_for_each_n.h
@@ -38,12 +38,6 @@ template <class _Iter, class _Func>
 using for_each_n_result = in_fun_result<_Iter, _Func>;
 
 _CCCL_BEGIN_NAMESPACE_CPO(__for_each_n)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   _CCCL_TEMPLATE(class _Iter, class _Func, class _Proj = identity)
@@ -59,11 +53,6 @@ struct __fn
     return {::cuda::std::move(__first), ::cuda::std::move(__func)};
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_min.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_min.h
@@ -34,13 +34,8 @@
 #include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
+
 _CCCL_BEGIN_NAMESPACE_CPO(__min)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   _CCCL_TEMPLATE(class _Tp, class _Proj = identity, class _Comp = ::cuda::std::ranges::less)
@@ -90,11 +85,6 @@ struct __fn
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_min_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_min_element.h
@@ -36,12 +36,6 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 _CCCL_BEGIN_NAMESPACE_CPO(__min_element)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   _CCCL_TEMPLATE(class _Ip, class _Sp, class _Proj = identity, class _Comp = ::cuda::std::ranges::less)
@@ -61,11 +55,6 @@ struct __fn
     return ::cuda::std::__min_element(::cuda::std::ranges::begin(__r), ::cuda::std::ranges::end(__r), __comp, __proj);
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__cccl/prologue.h
+++ b/libcudacxx/include/cuda/std/__cccl/prologue.h
@@ -334,6 +334,11 @@ _CCCL_DIAG_SUPPRESS_CLANG("-Wc++26-extensions")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wc++2b-extensions")
 #endif // ^^^ _CCCL_COMPILER(CLANG, <, 17) ^^^
 
+// Suppress `static operator()`-related warnings.
+_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
+
+_CCCL_DIAG_SUPPRESS_NVCC(342)
+
 // Suppress `if consteval`-related warnings.
 
 _CCCL_DIAG_SUPPRESS_NVHPC(if_consteval_nonstandard)

--- a/libcudacxx/include/cuda/std/__concepts/swappable.h
+++ b/libcudacxx/include/cuda/std/__concepts/swappable.h
@@ -100,11 +100,6 @@ inline constexpr bool __swappable_arrays = false;
 template <class _Tp, class _Up, class = void>
 inline constexpr bool __noexcept_swappable_arrays = false;
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   // 2.1   `S` is `(void)swap(E1, E2)`* if `E1` or `E2` has class or enumeration type and...
@@ -139,10 +134,6 @@ struct __fn
     __y = ::cuda::std::exchange(__x, ::cuda::std::move(__y));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 #if !_CCCL_HAS_CONCEPTS() || _CCCL_COMPILER(NVHPC)
 template <class _Tp, class _Up, class _Size>

--- a/libcudacxx/include/cuda/std/__format/format_spec_parser.h
+++ b/libcudacxx/include/cuda/std/__format/format_spec_parser.h
@@ -99,11 +99,6 @@ template <size_t _IdSize>
   ::cuda::std::__throw_format_error(__msg);
 }
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fmt_substitute_arg_id_visitor
 {
   template <class _Tp>
@@ -149,10 +144,6 @@ struct __fmt_substitute_arg_id_visitor
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <class _Context>
 [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr uint32_t __fmt_substitute_arg_id(basic_format_arg<_Context> __format_arg)

--- a/libcudacxx/include/cuda/std/__format/output_utils.h
+++ b/libcudacxx/include/cuda/std/__format/output_utils.h
@@ -35,11 +35,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 // Needs to be a functor for tile mode
 struct __fmt_hex_to_upper
 {
@@ -64,10 +59,6 @@ struct __fmt_hex_to_upper
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 struct __fmt_padding_size_result
 {

--- a/libcudacxx/include/cuda/std/__functional/bind_back.h
+++ b/libcudacxx/include/cuda/std/__functional/bind_back.h
@@ -42,11 +42,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <size_t _NBound, class = make_index_sequence<_NBound>>
 struct __bind_back_op;
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <size_t _NBound, size_t... _Ip>
 struct __bind_back_op<_NBound, index_sequence<_Ip...>>
 {
@@ -59,10 +54,6 @@ struct __bind_back_op<_NBound, index_sequence<_Ip...>>
   { return          ::cuda::std::invoke(::cuda::std::forward<_Fn>(__f), ::cuda::std::forward<_Args>(__args)..., ::cuda::std::get<_Ip>(::cuda::std::forward<_BoundArgs>(__bound_args))...); }
   // clang-format on
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <class _Fn, class _BoundArgs>
 struct __bind_back_t : __perfect_forward<__bind_back_op<tuple_size_v<_BoundArgs>>, _Fn, _BoundArgs>

--- a/libcudacxx/include/cuda/std/__functional/bind_front.h
+++ b/libcudacxx/include/cuda/std/__functional/bind_front.h
@@ -36,11 +36,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __bind_front_op
 {
   template <class... _Args>
@@ -51,10 +46,6 @@ struct __bind_front_op
     return ::cuda::std::invoke(::cuda::std::forward<_Args>(__args)...);
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <class _Fn, class... _BoundArgs>
 struct __bind_front_t : __perfect_forward<__bind_front_op, _Fn, _BoundArgs...>

--- a/libcudacxx/include/cuda/std/__functional/compose.h
+++ b/libcudacxx/include/cuda/std/__functional/compose.h
@@ -31,11 +31,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __compose_op
 {
   template <class _Fn1, class _Fn2, class... _Args>
@@ -51,10 +46,6 @@ struct __compose_op
       ::cuda::std::invoke(::cuda::std::forward<_Fn2>(__f2), ::cuda::std::forward<_Args>(__args)...));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <class _Fn1, class _Fn2>
 struct __compose_t : __perfect_forward<__compose_op, _Fn1, _Fn2>

--- a/libcudacxx/include/cuda/std/__functional/identity.h
+++ b/libcudacxx/include/cuda/std/__functional/identity.h
@@ -32,11 +32,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <class _Tp>
 inline constexpr bool __is_identity_v = false;
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct identity
 {
   template <class _Tp>
@@ -47,10 +42,6 @@ struct identity
 
   using is_transparent = void;
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <>
 inline constexpr bool __is_identity_v<identity> = true;

--- a/libcudacxx/include/cuda/std/__functional/operations.h
+++ b/libcudacxx/include/cuda/std/__functional/operations.h
@@ -30,11 +30,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 // Arithmetic operations
 
 template <class _Tp = void>
@@ -535,10 +530,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT logical_or<void>
   }
   using is_transparent = void;
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__functional/ranges_operations.h
+++ b/libcudacxx/include/cuda/std/__functional/ranges_operations.h
@@ -28,11 +28,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct equal_to
 {
   _CCCL_TEMPLATE(class _Tp, class _Up)
@@ -110,10 +105,6 @@ struct greater_equal
 
   using is_transparent = void;
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 

--- a/libcudacxx/include/cuda/std/__iterator/access.h
+++ b/libcudacxx/include/cuda/std/__iterator/access.h
@@ -27,11 +27,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 namespace __begin
 {
 struct __fn
@@ -131,10 +126,6 @@ inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cend = __cend::__fn{};
 } // namespace __cpo
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/advance.h
+++ b/libcudacxx/include/cuda/std/__iterator/advance.h
@@ -78,13 +78,8 @@ _CCCL_END_NAMESPACE_CUDA_STD
 // [range.iter.op.advance]
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
+
 _CCCL_BEGIN_NAMESPACE_CPO(__advance)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
 private:
@@ -220,11 +215,6 @@ public:
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__iterator/distance.h
+++ b/libcudacxx/include/cuda/std/__iterator/distance.h
@@ -66,13 +66,8 @@ _CCCL_END_NAMESPACE_CUDA_STD
 // [range.iter.op.distance]
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
+
 _CCCL_BEGIN_NAMESPACE_CPO(__distance)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   _CCCL_EXEC_CHECK_DISABLE
@@ -119,11 +114,6 @@ struct __fn
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__iterator/iter_move.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_move.h
@@ -87,11 +87,6 @@ template <class _Tp>
 _CCCL_CONCEPT __just_deref = _CCCL_FRAGMENT(__just_deref_, _Tp);
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 // [iterator.cust.move]
 
 struct __fn
@@ -126,15 +121,13 @@ struct __fn
   }
 };
 
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
+
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto iter_move = __iter_move::__fn{};
 } // namespace __cpo
+
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__iterator/iter_swap.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_swap.h
@@ -108,11 +108,6 @@ inline constexpr bool __noexcept_movable_storable<_T1, _T2, true> =
   && noexcept(*::cuda::std::declval<_T1>() = ::cuda::std::declval<iter_value_t<_T2>>());
 #endif // !_CCCL_HAS_NOEXCEPT_MANGLING()
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   _CCCL_EXEC_CHECK_DISABLE
@@ -143,10 +138,6 @@ struct __fn
     *::cuda::std::forward<_T1>(__x) = ::cuda::std::move(__old);
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CPO
 

--- a/libcudacxx/include/cuda/std/__iterator/next.h
+++ b/libcudacxx/include/cuda/std/__iterator/next.h
@@ -48,13 +48,8 @@ _CCCL_END_NAMESPACE_CUDA_STD
 // [range.iter.op.next]
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
+
 _CCCL_BEGIN_NAMESPACE_CPO(__next)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   _CCCL_EXEC_CHECK_DISABLE
@@ -94,11 +89,6 @@ struct __fn
     return __x;
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__iterator/prev.h
+++ b/libcudacxx/include/cuda/std/__iterator/prev.h
@@ -46,13 +46,8 @@ _CCCL_END_NAMESPACE_CUDA_STD
 // [range.iter.op.prev]
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
+
 _CCCL_BEGIN_NAMESPACE_CPO(__prev)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   _CCCL_EXEC_CHECK_DISABLE
@@ -82,11 +77,6 @@ struct __fn
     return __x;
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__iterator/reverse_access.h
+++ b/libcudacxx/include/cuda/std/__iterator/reverse_access.h
@@ -29,11 +29,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 namespace __rbegin
 {
 struct __fn
@@ -142,10 +137,6 @@ inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto crend = __crend::__fn{};
 } // namespace __cpo
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__linalg/conj_if_needed.h
+++ b/libcudacxx/include/cuda/std/__linalg/conj_if_needed.h
@@ -45,11 +45,6 @@ _CCCL_BEGIN_NAMESPACE_CPO(__conj_if_needed)
 template <class _Type>
 _CCCL_CONCEPT _HasConj = _CCCL_REQUIRES_EXPR((_Type), _Type __a)(static_cast<void>(::cuda::std::conj(__a)));
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   template <class _Type>
@@ -65,10 +60,6 @@ struct __fn
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CPO
 

--- a/libcudacxx/include/cuda/std/__memory/temporary_buffer.h
+++ b/libcudacxx/include/cuda/std/__memory/temporary_buffer.h
@@ -84,11 +84,6 @@ _CCCL_HOST_DEVICE_API inline void return_temporary_buffer(_Tp* __p) noexcept
   ::cuda::std::__cccl_deallocate_unsized((void*) __p, alignof(_Tp));
 }
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __return_temporary_buffer
 {
   template <class _Tp>
@@ -97,10 +92,6 @@ struct __return_temporary_buffer
     ::cuda::std::return_temporary_buffer(__p);
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
+++ b/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
@@ -52,11 +52,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __AlwaysFalse
 {
   template <class... _Args>
@@ -65,10 +60,6 @@ struct __AlwaysFalse
     return false;
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <class _ForwardIterator>
 struct __simple_rollback

--- a/libcudacxx/include/cuda/std/__memory/unique_ptr.h
+++ b/libcudacxx/include/cuda/std/__memory/unique_ptr.h
@@ -56,11 +56,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete
 {
@@ -103,10 +98,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete<_Tp[]>
     delete[] __ptr;
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <class _Deleter>
 struct __unique_ptr_deleter_sfinae
@@ -734,12 +725,6 @@ template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT hash;
 
 #ifndef __cuda_std__
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class _Tp, class _Dp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<unique_ptr<_Tp, _Dp>>
 {
@@ -754,9 +739,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<unique_ptr<_Tp, _Dp>>
     return hash<pointer>()(__ptr.get());
   }
 };
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 #endif // __cuda_std__
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__optional/hash.h
+++ b/libcudacxx/include/cuda/std/__optional/hash.h
@@ -29,12 +29,6 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #ifndef __cuda_std__
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<__enable_hash_helper<optional<_Tp>, remove_const_t<_Tp>>>
 {
@@ -48,11 +42,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<__enable_hash_helper<optional<_Tp>, re
     return static_cast<bool>(__opt) ? hash<remove_const_t<_Tp>>()(*__opt) : 0;
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 #endif // __cuda_std__
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
@@ -55,12 +55,6 @@ _CCCL_DIAG_POP
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__adjacent_difference, __execution_backend::__cuda>
 {
@@ -137,10 +131,6 @@ struct __pstl_dispatch<__pstl_algorithm::__adjacent_difference, __execution_back
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
@@ -59,11 +59,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
 {
@@ -166,10 +161,6 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
@@ -66,11 +66,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__copy_n, __execution_backend::__cuda>
 {
@@ -137,10 +132,6 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_n, __execution_backend::__cuda>
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
@@ -59,11 +59,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__exclusive_scan, __execution_backend::__cuda>
 {
@@ -145,10 +140,6 @@ struct __pstl_dispatch<__pstl_algorithm::__exclusive_scan, __execution_backend::
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
@@ -62,11 +62,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__find_if, __execution_backend::__cuda>
 {
@@ -156,10 +151,6 @@ struct __pstl_dispatch<__pstl_algorithm::__find_if, __execution_backend::__cuda>
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
@@ -62,11 +62,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__for_each_n, __execution_backend::__cuda>
 {
@@ -124,10 +119,6 @@ struct __pstl_dispatch<__pstl_algorithm::__for_each_n, __execution_backend::__cu
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
@@ -61,11 +61,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__generate_n, __execution_backend::__cuda>
 {
@@ -123,10 +118,6 @@ struct __pstl_dispatch<__pstl_algorithm::__generate_n, __execution_backend::__cu
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
@@ -59,11 +59,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::__cuda>
 {
@@ -215,10 +210,6 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/max_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/max_element.h
@@ -60,11 +60,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__max_element, __execution_backend::__cuda>
 {
@@ -155,10 +150,6 @@ struct __pstl_dispatch<__pstl_algorithm::__max_element, __execution_backend::__c
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
@@ -59,11 +59,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__merge, __execution_backend::__cuda>
 {
@@ -154,10 +149,6 @@ struct __pstl_dispatch<__pstl_algorithm::__merge, __execution_backend::__cuda>
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/min_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/min_element.h
@@ -60,11 +60,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__min_element, __execution_backend::__cuda>
 {
@@ -155,10 +150,6 @@ struct __pstl_dispatch<__pstl_algorithm::__min_element, __execution_backend::__c
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/partition.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/partition.h
@@ -59,11 +59,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__partition, __execution_backend::__cuda>
 {
@@ -167,10 +162,6 @@ struct __pstl_dispatch<__pstl_algorithm::__partition, __execution_backend::__cud
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/partition_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/partition_copy.h
@@ -58,11 +58,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__partition_copy, __execution_backend::__cuda>
 {
@@ -184,10 +179,6 @@ struct __pstl_dispatch<__pstl_algorithm::__partition_copy, __execution_backend::
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
@@ -67,11 +67,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
 {
@@ -174,10 +169,6 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
       __policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__init), ::cuda::std::move(__func));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
@@ -57,11 +57,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__remove_if, __execution_backend::__cuda>
 {
@@ -155,10 +150,6 @@ struct __pstl_dispatch<__pstl_algorithm::__remove_if, __execution_backend::__cud
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/rotate.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/rotate.h
@@ -71,11 +71,6 @@ struct __rotate_fn
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__rotate, __execution_backend::__cuda>
 {
@@ -176,10 +171,6 @@ struct __pstl_dispatch<__pstl_algorithm::__rotate, __execution_backend::__cuda>
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/rotate_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/rotate_copy.h
@@ -69,11 +69,6 @@ struct __rotate_copy_fn
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__rotate_copy, __execution_backend::__cuda>
 {
@@ -178,10 +173,6 @@ struct __pstl_dispatch<__pstl_algorithm::__rotate_copy, __execution_backend::__c
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/shift_left.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/shift_left.h
@@ -69,11 +69,6 @@ struct __shift_left_predicate
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__shift_left, __execution_backend::__cuda>
 {
@@ -161,10 +156,6 @@ struct __pstl_dispatch<__pstl_algorithm::__shift_left, __execution_backend::__cu
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/shift_right.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/shift_right.h
@@ -63,11 +63,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__shift_right, __execution_backend::__cuda>
 {
@@ -190,10 +185,6 @@ struct __pstl_dispatch<__pstl_algorithm::__shift_right, __execution_backend::__c
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/sort.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/sort.h
@@ -64,11 +64,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__sort, __execution_backend::__cuda>
 {
@@ -208,10 +203,6 @@ struct __pstl_dispatch<__pstl_algorithm::__sort, __execution_backend::__cuda>
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/stable_partition.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/stable_partition.h
@@ -60,11 +60,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__stable_partition, __execution_backend::__cuda>
 {
@@ -174,10 +169,6 @@ struct __pstl_dispatch<__pstl_algorithm::__stable_partition, __execution_backend
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
@@ -62,11 +62,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cuda>
 {
@@ -204,10 +199,6 @@ struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cud
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
@@ -61,11 +61,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__transform_reduce, __execution_backend::__cuda>
 {
@@ -183,10 +178,6 @@ struct __pstl_dispatch<__pstl_algorithm::__transform_reduce, __execution_backend
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/unique.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/unique.h
@@ -61,11 +61,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
 {
@@ -152,10 +147,6 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/unique_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/unique_copy.h
@@ -61,11 +61,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__unique_copy, __execution_backend::__cuda>
 {
@@ -170,10 +165,6 @@ struct __pstl_dispatch<__pstl_algorithm::__unique_copy, __execution_backend::__c
     }
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__pstl/swap_ranges.h
+++ b/libcudacxx/include/cuda/std/__pstl/swap_ranges.h
@@ -67,11 +67,6 @@ struct __swap_ranges_iter_swap_fn
   }
 };
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __swap_ranges_transform_fn
 {
   template <class _Tp, class _Up>
@@ -82,10 +77,6 @@ struct __swap_ranges_transform_fn
     return ::cuda::std::tuple{__lhs, __rhs};
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 

--- a/libcudacxx/include/cuda/std/__ranges/access.h
+++ b/libcudacxx/include/cuda/std/__ranges/access.h
@@ -35,11 +35,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class _Tp>
 _CCCL_CONCEPT __can_borrow = is_lvalue_reference_v<_Tp> || enable_borrowed_range<remove_cvref_t<_Tp>>;
 
@@ -304,10 +299,6 @@ inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cend = __cend::__fn{};
 } // namespace __cpo
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/all.h
+++ b/libcudacxx/include/cuda/std/__ranges/all.h
@@ -48,11 +48,6 @@ _CCCL_CONCEPT __to_owning_view = _CCCL_REQUIRES_EXPR((_Tp), _Tp&& __t)(
   requires(!__to_ref_view<_Tp>),
   (::cuda::std::ranges::owning_view{::cuda::std::forward<_Tp>(__t)}));
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn : __range_adaptor_closure<__fn>
 {
   _CCCL_TEMPLATE(class _Tp)
@@ -80,10 +75,6 @@ struct __fn : __range_adaptor_closure<__fn>
     return ::cuda::std::ranges::owning_view{::cuda::std::forward<_Tp>(__t)};
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CPO
 

--- a/libcudacxx/include/cuda/std/__ranges/common_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/common_view.h
@@ -163,13 +163,8 @@ inline constexpr bool enable_borrowed_range<common_view<_View>> = enable_borrowe
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_VIEWS
+
 _CCCL_BEGIN_NAMESPACE_CPO(__common)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn : __range_adaptor_closure<__fn>
 {
   _CCCL_TEMPLATE(class _Range)
@@ -188,11 +183,6 @@ struct __fn : __range_adaptor_closure<__fn>
     return common_view{::cuda::std::forward<_Range>(__range)};
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__ranges/counted.h
+++ b/libcudacxx/include/cuda/std/__ranges/counted.h
@@ -38,11 +38,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_VIEWS
 
 _CCCL_BEGIN_NAMESPACE_CPO(__counted)
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   _CCCL_TEMPLATE(class _It)
@@ -80,10 +75,6 @@ struct __fn
     return __go(::cuda::std::forward<_It>(__it), ::cuda::std::forward<_Diff>(__count));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CPO
 

--- a/libcudacxx/include/cuda/std/__ranges/data.h
+++ b/libcudacxx/include/cuda/std/__ranges/data.h
@@ -36,11 +36,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 // [range.prim.data]
 
 _CCCL_BEGIN_NAMESPACE_CPO(__data)
@@ -134,10 +129,6 @@ inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cdata = __cdata::__fn{};
 } // namespace __cpo
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/drop_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/drop_view.h
@@ -276,11 +276,6 @@ _CCCL_CONCEPT __use_generic = _CCCL_REQUIRES_EXPR((_Range, _Np))(
   requires(!__use_passthrough<_Range, _Np>),
   requires(!__use_subrange<_Range, _Np>));
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   // [range.drop.overview]: the `empty_view` case.
@@ -378,10 +373,6 @@ struct __fn
     return __pipeable(::cuda::std::__bind_back(__fn{}, ::cuda::std::forward<_Np>(__n)));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CPO
 

--- a/libcudacxx/include/cuda/std/__ranges/drop_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/drop_while_view.h
@@ -142,13 +142,8 @@ _CCCL_DEDUCTION_GUIDE_ATTRIBUTES drop_while_view(_Range&&, _Pred)
 _CCCL_END_NAMESPACE_CUDA_STD_VIEWS
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_VIEWS
+
 _CCCL_BEGIN_NAMESPACE_CPO(__drop_while)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   template <class _Range, class _Pred>
@@ -167,11 +162,6 @@ struct __fn
     return ::cuda::std::ranges::__pipeable{::cuda::std::__bind_back(__fn{}, ::cuda::std::forward<_Pred>(__pred))};
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__ranges/empty.h
+++ b/libcudacxx/include/cuda/std/__ranges/empty.h
@@ -71,11 +71,6 @@ template <class _Tp>
 _CCCL_CONCEPT __can_compare_begin_end = _CCCL_FRAGMENT(__can_compare_begin_end_, _Tp);
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   _CCCL_TEMPLATE(class _Tp)
@@ -101,10 +96,6 @@ struct __fn
     return ::cuda::std::ranges::begin(__t) == ::cuda::std::ranges::end(__t);
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CPO
 

--- a/libcudacxx/include/cuda/std/__ranges/filter_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/filter_view.h
@@ -360,13 +360,8 @@ _LIBCUDACXX_END_HIDDEN_FRIEND_NAMESPACE(filter_view)
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_VIEWS
+
 _CCCL_BEGIN_NAMESPACE_CPO(__filter)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   template <class _Range, class _Pred>
@@ -386,11 +381,6 @@ struct __fn
     return ::cuda::std::ranges::__pipeable{::cuda::std::__bind_back(__fn{}, ::cuda::std::forward<_Pred>(__pred))};
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__ranges/iota_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/iota_view.h
@@ -236,13 +236,8 @@ inline constexpr bool enable_borrowed_range<iota_view<_Start, _BoundSentinel>> =
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_VIEWS
+
 _CCCL_BEGIN_NAMESPACE_CPO(__iota)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   template <class _Start>
@@ -263,11 +258,6 @@ struct __fn
       ::cuda::std::forward<_Start>(__start), ::cuda::std::forward<_BoundSentinel>(__bound_sentinel));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__ranges/rbegin.h
+++ b/libcudacxx/include/cuda/std/__ranges/rbegin.h
@@ -35,11 +35,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 // [ranges.access.rbegin]
 
 _CCCL_BEGIN_NAMESPACE_CPO(__rbegin)
@@ -174,10 +169,6 @@ inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto crbegin = __crbegin::__fn{};
 } // namespace __cpo
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/rend.h
+++ b/libcudacxx/include/cuda/std/__ranges/rend.h
@@ -36,11 +36,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 // [range.access.rend]
 
 _CCCL_BEGIN_NAMESPACE_CPO(__rend)
@@ -180,10 +175,6 @@ inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto crend = __crend::__fn{};
 } // namespace __cpo
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/repeat_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/repeat_view.h
@@ -305,14 +305,9 @@ _CCCL_DEDUCTION_GUIDE_ATTRIBUTES repeat_view(_Tp, _Bound) -> repeat_view<_Tp, _B
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_VIEWS
-_CCCL_BEGIN_NAMESPACE_CPO(__repeat)
 
+_CCCL_BEGIN_NAMESPACE_CPO(__repeat)
 struct __fn
 {
   template <class _Tp>
@@ -331,18 +326,14 @@ struct __fn
     return ranges::repeat_view(::cuda::std::forward<_Tp>(__value), ::cuda::std::forward<_Bound>(__bound_sentinel));
   }
 };
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto repeat = __repeat::__fn{};
 } // namespace __cpo
+
 _CCCL_END_NAMESPACE_CUDA_STD_VIEWS
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/reverse_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/reverse_view.h
@@ -202,11 +202,6 @@ struct __unwrapped_reverse_subrange<
 template <class _Tp>
 using __unwrapped_reverse_subrange_t = typename __unwrapped_reverse_subrange<_Tp>::type;
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn : __range_adaptor_closure<__fn>
 {
   _CCCL_TEMPLATE(class _Range)
@@ -244,10 +239,6 @@ struct __fn : __range_adaptor_closure<__fn>
     return reverse_view{::cuda::std::forward<_Range>(__range)};
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CPO
 

--- a/libcudacxx/include/cuda/std/__ranges/single_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/single_view.h
@@ -131,11 +131,6 @@ _CCCL_BEGIN_NAMESPACE_CPO(__single_view)
 template <class _Tp>
 _CCCL_CONCEPT __can_single_view = _CCCL_REQUIRES_EXPR((_Tp))(typename(single_view<decay_t<_Tp>>));
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn : __range_adaptor_closure<__fn>
 {
   _CCCL_TEMPLATE(class _Tp)
@@ -147,10 +142,6 @@ struct __fn : __range_adaptor_closure<__fn>
     return single_view<decay_t<_Tp>>(::cuda::std::forward<_Tp>(__t));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CPO
 

--- a/libcudacxx/include/cuda/std/__ranges/size.h
+++ b/libcudacxx/include/cuda/std/__ranges/size.h
@@ -38,11 +38,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class>
 inline constexpr bool disable_sized_range = false;
 
@@ -199,10 +194,6 @@ inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto ssize = __ssize::__fn{};
 } // namespace __cpo
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/take_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_view.h
@@ -364,11 +364,6 @@ _CCCL_CONCEPT __use_generic = _CCCL_REQUIRES_EXPR((_Range, _Np))(
   requires(!__use_passthrough<_Range, _Np>),
   requires(!__use_iota<_Range, _Np>));
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   // [range.take.overview]: the `empty_view` case.
@@ -459,10 +454,6 @@ struct __fn
     return __pipeable(::cuda::std::__bind_back(__fn{}, ::cuda::std::forward<_Np>(__n)));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CPO
 

--- a/libcudacxx/include/cuda/std/__ranges/take_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_while_view.h
@@ -221,13 +221,8 @@ _CCCL_DEDUCTION_GUIDE_ATTRIBUTES take_while_view(_Range&&, _Pred)
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_VIEWS
+
 _CCCL_BEGIN_NAMESPACE_CPO(__take_while)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   template <class _Range, class _Pred>
@@ -246,11 +241,6 @@ struct __fn
     return __pipeable(::cuda::std::__bind_back(__fn{}, ::cuda::std::forward<_Pred>(__pred)));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__ranges/transform_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/transform_view.h
@@ -505,13 +505,8 @@ _CCCL_DEDUCTION_GUIDE_ATTRIBUTES transform_view(_Range&&, _Fn)
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_VIEWS
+
 _CCCL_BEGIN_NAMESPACE_CPO(__transform)
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 struct __fn
 {
   template <class _Range, class _Fn>
@@ -530,11 +525,6 @@ struct __fn
     return __pipeable(::cuda::std::__bind_back(__fn{}, ::cuda::std::forward<_Fn>(__f)));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
-
 _CCCL_END_NAMESPACE_CPO
 
 inline namespace __cpo

--- a/libcudacxx/include/cuda/std/__ranges/zip_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/zip_view.h
@@ -49,11 +49,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 _LIBCUDACXX_BEGIN_HIDDEN_FRIEND_NAMESPACE
 
 struct __zv_functors
@@ -397,10 +392,6 @@ inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto zip = __zip::__fn{};
 } // namespace __cpo
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD_VIEWS
 

--- a/libcudacxx/include/cuda/std/__simd/complex_math.h
+++ b/libcudacxx/include/cuda/std/__simd/complex_math.h
@@ -39,11 +39,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_SIMD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 // [simd.complex.math], helper functors for element-wise complex operations
 
 struct __fn_real
@@ -520,10 +515,6 @@ pow(const basic_vec<_Tp, _Abi>& __x, const basic_vec<_Tp, _Abi>& __y)
   using __vec_t = basic_vec<_Tp, _Abi>;
   return __vec_t{__gen_complex_apply_binary<__vec_t, __fn_pow_binary>{__x, __y}};
 }
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD_SIMD
 

--- a/libcudacxx/include/cuda/std/__string/helper_functions.h
+++ b/libcudacxx/include/cuda/std/__string/helper_functions.h
@@ -125,11 +125,6 @@ __cccl_str_find(const _CharT* __p, _SizeT __sz, const _CharT* __s, _SizeT __pos,
   return static_cast<_SizeT>(__r - __p);
 }
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 // In tile mode we cannot pass function pointers, but we can wrap the indirect call into the call operator
 template <class _Traits>
 struct _TraitsWrapperEq
@@ -140,10 +135,6 @@ struct _TraitsWrapperEq
     return _Traits::eq(__lhs, __rhs);
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 _CCCL_API constexpr _SizeT __cccl_str_rfind(const _CharT* __p, _SizeT __sz, _CharT __c, _SizeT __pos) noexcept

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_cat.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_cat.h
@@ -116,11 +116,6 @@ struct __tuple_cat_return_ref
 template <class _Types, class _I0, class _J0>
 struct __tuple_cat;
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class... _Types, size_t... _I0, size_t... _J0>
 struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J0...>>
 {
@@ -156,10 +151,6 @@ struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J
       ::cuda::std::forward<_Tuples>(__tpls)...);
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <class _Tuple0, class... _Tuples>
 _CCCL_API constexpr typename __tuple_cat_return<_Tuple0, _Tuples...>::type tuple_cat(_Tuple0&& __t0, _Tuples&&... __tpls)

--- a/libcudacxx/include/cuda/std/__type_traits/integral_constant.h
+++ b/libcudacxx/include/cuda/std/__type_traits/integral_constant.h
@@ -24,11 +24,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class _Tp, _Tp __v>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT integral_constant
 {
@@ -44,10 +39,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT integral_constant
     return value;
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 using true_type  = integral_constant<bool, true>;
 using false_type = integral_constant<bool, false>;

--- a/libcudacxx/include/cuda/std/__utility/monostate.h
+++ b/libcudacxx/include/cuda/std/__utility/monostate.h
@@ -79,12 +79,6 @@ _CCCL_API constexpr bool operator>=(monostate, monostate) noexcept
 #endif // !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 
 #ifndef __cuda_std__
-
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<monostate>
 {
@@ -96,10 +90,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<monostate>
     return 66740831; // return a fundamentally attractive random value.
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 #endif // __cuda_std__
 

--- a/libcudacxx/include/cuda/std/__variant/comparison.h
+++ b/libcudacxx/include/cuda/std/__variant/comparison.h
@@ -36,11 +36,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class _Operator>
 struct __convert_to_bool
 {
@@ -54,10 +49,6 @@ struct __convert_to_bool
     return _Operator{}(::cuda::std::forward<_T1>(__t1), ::cuda::std::forward<_T2>(__t2));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <class... _Types>
 [[nodiscard]] _CCCL_API constexpr bool operator==(const variant<_Types...>& __lhs, const variant<_Types...>& __rhs)

--- a/libcudacxx/include/cuda/std/__variant/hash.h
+++ b/libcudacxx/include/cuda/std/__variant/hash.h
@@ -35,11 +35,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class... _Types>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<__enable_hash_helper<variant<_Types...>, remove_const_t<_Types>...>>
 {
@@ -77,10 +72,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<__enable_hash_helper<variant<_Types...
     return ::cuda::std::__hash_combine(__res, hash<size_t>{}(__v.index()));
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__variant/variant_base.h
+++ b/libcudacxx/include/cuda/std/__variant/variant_base.h
@@ -216,11 +216,6 @@ protected:
   }
 };
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class... _Types>
 class _CCCL_TYPE_VISIBILITY_DEFAULT
 __dtor<__traits<_Types...>, _Trait::_Available> : public __base<_Trait::_Available, _Types...>
@@ -278,10 +273,6 @@ private:
     _CCCL_UNREACHABLE();
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <class... _Types>
 class _CCCL_TYPE_VISIBILITY_DEFAULT

--- a/libcudacxx/include/cuda/std/__variant/variant_match.h
+++ b/libcudacxx/include/cuda/std/__variant/variant_match.h
@@ -67,11 +67,6 @@ using __check_for_narrowing _CCCL_NODEBUG_ALIAS = typename conditional_t<
   __narrowing_check,
   __no_narrowing_check>::template _Apply<_Dest, _Source>;
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <class _Tp, size_t _Idx>
 struct __overload
 {
@@ -86,10 +81,6 @@ struct __overload_bool
   _CCCL_API inline auto _CCCL_STATIC_CALL_OPERATOR(bool, _Up&&)
     -> enable_if_t<is_same_v<_Ap, bool>, type_identity<_Tp>>;
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <size_t _Idx>
 struct __overload<bool, _Idx> : __overload_bool<bool, _Idx>

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -961,11 +961,6 @@ _CCCL_API constexpr bitset<_Size> operator^(const bitset<_Size>& __x, const bits
   return __r;
 }
 
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(342) // static call operator in earlier standard modes
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_NVHPC(static_member_operator_not_allowed)
-
 template <size_t _Size>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<bitset<_Size>> : public __unary_function<bitset<_Size>, size_t>
 {
@@ -974,10 +969,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<bitset<_Size>> : public __unary_functi
     return __bs.__hash_code();
   }
 };
-
-_CCCL_DIAG_POP
-
-_CCCL_END_NV_DIAG_SUPPRESS()
 
 template <class _CharT, class _Traits, size_t _Size>
 _CCCL_API inline basic_istream<_CharT, _Traits>& operator>>(basic_istream<_CharT, _Traits>& __is, bitset<_Size>& __x);


### PR DESCRIPTION
We suppress these warnings in a lot of places, I think it's better to suppress them globally.