### PR TITLE
Fix nightly lldb printers

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -65,7 +65,6 @@ workflows:
   #
   # IMPORTANT: Do NOT delete or remove the `override:` key below, even when it is empty.
   override:
-    - {jobs: ['test'], project: 'libcudacxx', ctk: '12.X', std: 'max', cxx: ['gcc14', 'clang19', 'msvc2022'], gpu: 't4'}
 
   pull_request:
     # Old CTK: Oldest/newest supported host compilers:

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -65,6 +65,7 @@ workflows:
   #
   # IMPORTANT: Do NOT delete or remove the `override:` key below, even when it is empty.
   override:
+    - {jobs: ['test'], project: 'libcudacxx', ctk: '12.X', std: 'max', cxx: ['gcc14', 'clang19', 'msvc2022'], gpu: 't4'}
 
   pull_request:
     # Old CTK: Oldest/newest supported host compilers:

--- a/libcudacxx/share/libcudacxx/lldb/mdspan.py
+++ b/libcudacxx/share/libcudacxx/lldb/mdspan.py
@@ -350,8 +350,11 @@ def _mdspan_info(value: lldb.SBValue) -> MdspanInfo | None:
 
 
 def mdspan_summary(value: lldb.SBValue, _internal_dict: InternalDict) -> str | None:
-    stripped = cccl_common.strip_reference_value(value)
-    info = _mdspan_info(stripped)
+    # Report metadata only (mirrors buffer_summary). Whether the data is
+    # readable is already visible in the element list the synthetic provider
+    # supplies, so do not stage a throwaway host copy to find out: that costs
+    # three inferior calls per print and scales with the element count.
+    info = _mdspan_info(cccl_common.strip_reference_value(value))
     if info is None:
         return None
     details = []
@@ -360,22 +363,7 @@ def mdspan_summary(value: lldb.SBValue, _internal_dict: InternalDict) -> str | N
         details.append(f"rank={len(info.extents)}")
         details.append(f"extents=[{extents_text}]")
     if info.data is not None:
-        data_address = info.data.GetValueAsUnsigned(0)
-        data_text = f"data={data_address:#x}"
-        span = _required_span_size(info.layout, info.extents, info.strides)
-        if span > 0:
-            frame = stripped.GetFrame()
-            element_type = info.data.GetType().GetPointeeType()
-            byte_count = span * element_type.GetByteSize()
-            host_copy = _stage_host_copy(frame, data_address, byte_count)
-            if host_copy is None:
-                # Mirrors GDB's own wording for an unreadable pointee.
-                data_text += (
-                    f" <error: Cannot access memory at address {data_address:#x}>"
-                )
-            else:
-                _release_host_copy(frame, host_copy.GetValueAsUnsigned(0))
-        details.append(data_text)
+        details.append(f"data={info.data.GetValueAsUnsigned(0):#x}")
     if not details:
         return None
     return ", ".join(details)

--- a/libcudacxx/share/libcudacxx/lldb/std_array.py
+++ b/libcudacxx/share/libcudacxx/lldb/std_array.py
@@ -52,9 +52,6 @@ class ArraySyntheticProvider:
     def has_children(self) -> bool:
         return self.size != 0
 
-    def get_type_name(self) -> str:
-        return self.type_name
-
     def get_child_index(self, name: str) -> int:
         if name.startswith("[") and name.endswith("]"):
             try:

--- a/libcudacxx/test/debugging/array/lldb.expected
+++ b/libcudacxx/test/debugging/array/lldb.expected
@@ -1,21 +1,21 @@
 =============== array.normal begin ===============
-(cuda::std::array<int, 3>) <address> ([0] = -7, [1] = 0, [2] = 42)
+(const cuda::std::array<int, 3> &) <address> ([0] = -7, [1] = 0, [2] = 42)
 =============== array.normal end ===============
 =============== array.empty begin ===============
-(cuda::std::array<int, 0>) <address>
+(const cuda::std::array<int, 0> &) <address>
 =============== array.empty end ===============
 =============== array.nested begin ===============
-(cuda::std::array<cuda::std::array<int, 2>, 2>) <address>: {
+(const cuda::std::array<cuda::std::array<int, 2>, 2> &) <address>: {
   [0] = ([0] = 13, [1] = -5)
   [1] = ([0] = 0, [1] = 88)
 }
 =============== array.nested end ===============
 =============== array.alias begin ===============
-(cuda::std::array<int, 4>) <address> ([0] = -31, [1] = 17, [2] = 8, [3] = -64)
+(const array_alias &) <address> ([0] = -31, [1] = 17, [2] = 8, [3] = -64)
 =============== array.alias end ===============
 =============== array.update.before begin ===============
-(cuda::std::array<int, 3>) <address> ([0] = 6, [1] = -91, [2] = 52)
+(const cuda::std::array<int, 3> &) <address> ([0] = 6, [1] = -91, [2] = 52)
 =============== array.update.before end ===============
 =============== array.update.after begin ===============
-(cuda::std::array<int, 3>) <address> ([0] = 3, [1] = 85, [2] = -12)
+(const cuda::std::array<int, 3> &) <address> ([0] = 3, [1] = 85, [2] = -12)
 =============== array.update.after end ===============

--- a/libcudacxx/test/debugging/atomic/lldb.expected
+++ b/libcudacxx/test/debugging/atomic/lldb.expected
@@ -26,7 +26,7 @@
 (cuda::std::atomic<long long>) <address> (value = -31)
 =============== atomic.alias end ===============
 =============== atomic.nested begin ===============
-(cuda::std::array<cuda::std::atomic<int>, 2>) <address>: {
+(const cuda::std::array<cuda::std::atomic<int>, 2> &) <address>: {
   [0] = (value = 17)
   [1] = (value = -64)
 }

--- a/libcudacxx/test/debugging/complex/lldb.expected
+++ b/libcudacxx/test/debugging/complex/lldb.expected
@@ -11,7 +11,7 @@
 (cuda::std::complex<float>) <address> (real = -3.5, imag = 0.25)
 =============== complex.alias end ===============
 =============== complex.nested begin ===============
-(cuda::std::array<cuda::std::complex<float>, 2>) <address>: {
+(const cuda::std::array<cuda::std::complex<float>, 2> &) <address>: {
   [0] = (real = 13.5, imag = -5.5)
   [1] = (real = 0.25, imag = 88.5)
 }

--- a/libcudacxx/test/debugging/event/lldb.expected
+++ b/libcudacxx/test/debugging/event/lldb.expected
@@ -20,7 +20,7 @@
 (cuda::timed_event) <address> (handle = 0x0000000000000000)
 =============== event.timed_no_init end ===============
 =============== event.nested begin ===============
-(cuda::std::array<cuda::event_ref, 2>) <address>: {
+(const cuda::std::array<cuda::event_ref, 2> &) <address>: {
   [0] = (handle = <address>)
   [1] = (handle = 0x0000000000000000)
 }

--- a/libcudacxx/test/debugging/mdspan/lldb.expected
+++ b/libcudacxx/test/debugging/mdspan/lldb.expected
@@ -153,7 +153,7 @@
 }
 =============== mdspan.device_backed end ===============
 =============== mdspan.copy_failure begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, 1>>) <address> rank=1, extents=[1], data=0x0 <error: Cannot access memory at address 0x0>
+(cuda::std::mdspan<int, cuda::std::extents<int, 1>>) <address> rank=1, extents=[1], data=0x0
 =============== mdspan.copy_failure end ===============
 =============== mdspan.managed_mdspan begin ===============
 (cuda::managed_mdspan<int, cuda::std::extents<int, 2>>) <address> rank=1, extents=[2], data=<address>: {
@@ -168,7 +168,7 @@
 }
 =============== mdspan.restrict_mdspan end ===============
 =============== mdspan.array begin ===============
-(cuda::std::array<cuda::std::mdspan<int, cuda::std::extents<int, 2>>, 2>) <address>: {
+(const cuda::std::array<cuda::std::mdspan<int, cuda::std::extents<int, 2>>, 2> &) <address>: {
   [0] = rank=1, extents=[2], data=<address> {
     [0] = -2
     [1] = 4

--- a/libcudacxx/test/debugging/mdspan/source.cu
+++ b/libcudacxx/test/debugging/mdspan/source.cu
@@ -156,6 +156,15 @@ inspect_array(const cuda::std::array<cuda::std::mdspan<int, cuda::std::extents<i
 
 int main()
 {
+  // Build the CUDA context before the first breakpoint. The printer copies elements
+  // with an inferior cudaMemcpy call; if that call is the first CUDA call in the
+  // process, a breakpoint hit during context setup interrupts it, LLDB unwinds it,
+  // and every later copy fails with cudaErrorContextIsDestroyed.
+  if (cudaFree(nullptr) != cudaSuccess)
+  {
+    return 1;
+  }
+
   int rank1_dynamic_data[4] = {10, -3, 7, 42};
   const cuda::std::mdspan<int, cuda::std::dextents<int, 1>> rank1_dynamic(rank1_dynamic_data, 4);
   inspect_rank1_dynamic(rank1_dynamic);

--- a/libcudacxx/test/debugging/stream/gdb.expected
+++ b/libcudacxx/test/debugging/stream/gdb.expected
@@ -61,17 +61,21 @@ cuda::stream_ref handle=invalid, unique_id=unavailable
 cuda::stream handle=invalid, unique_id=unavailable
 =============== stream.moved_from end ===============
 =============== stream.summary begin ===============
-std::vector of length 3, capacity 3 = {[0] = cuda::stream_ref handle=<address>, unique_id=<id> = {
+cuda::std::array<cuda::stream_ref, 3> = {
+  [0] = cuda::stream_ref handle=<address>, unique_id=<id> = {
     device = 0,
     priority = 0,
     is_capturing = false,
     flags = 1
-  }, [1] = cuda::stream_ref handle=default, unique_id=<id> = {
+  },
+  [1] = cuda::stream_ref handle=default, unique_id=<id> = {
     device = 0,
     priority = 0,
     is_capturing = false,
     flags = 0
-  }, [2] = cuda::stream_ref handle=invalid, unique_id=unavailable}
+  },
+  [2] = cuda::stream_ref handle=invalid, unique_id=unavailable
+}
 =============== stream.summary end ===============
 =============== stream.update.before begin ===============
 cuda::stream_ref handle=default, unique_id=<id> = {

--- a/libcudacxx/test/debugging/stream/lldb.expected
+++ b/libcudacxx/test/debugging/stream/lldb.expected
@@ -61,7 +61,7 @@
 (const cuda::stream &) <address> handle=invalid, unique_id=unavailable
 =============== stream.moved_from end ===============
 =============== stream.summary begin ===============
-(const std::vector<cuda::stream_ref> &) <address> size=3: {
+(const cuda::std::array<cuda::stream_ref, 3> &) <address>: {
   [0] = handle=<address>, unique_id=<id> {
     device = 0
     priority = 0

--- a/libcudacxx/test/debugging/stream/source.cu
+++ b/libcudacxx/test/debugging/stream/source.cu
@@ -2,10 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cuda/std/array>
 #include <cuda/std/utility>
 #include <cuda/stream>
-
-#include <vector>
 
 #include <cuda.h>
 #include <cuda_runtime_api.h>
@@ -62,7 +61,10 @@ using stream_ref_alias = cuda::stream_ref;
   KEEP_FOR_DEBUGGER(value);
 }
 
-[[gnu::noinline]] void inspect_summary(const std::vector<cuda::stream_ref>& values)
+// cuda::std::array keeps this case on a CCCL formatter. A std::vector would use the
+// system libc++ or libstdc++ container formatter, whose output is not stable across
+// toolchain versions.
+[[gnu::noinline]] void inspect_summary(const cuda::std::array<cuda::stream_ref, 3>& values)
 {
   KEEP_FOR_DEBUGGER(values);
 }
@@ -99,7 +101,7 @@ int main()
   const cuda::stream_ref invalid_stream{cuda::invalid_stream};
   cuda::stream moved_from_stream{device};
   const cuda::stream moved_to_stream{cuda::std::move(moved_from_stream)};
-  const std::vector<cuda::stream_ref> summarized_streams{stream_reference, default_stream, invalid_stream};
+  const cuda::std::array<cuda::stream_ref, 3> summarized_streams{stream_reference, default_stream, invalid_stream};
   cuda::stream_ref updated_stream{default_stream};
   const cuda::stream capture_stream{device};
 

--- a/libcudacxx/test/debugging/stream/source.cu
+++ b/libcudacxx/test/debugging/stream/source.cu
@@ -130,6 +130,7 @@ int main()
   inspect_invalid(invalid_stream);
   inspect_moved_from(moved_from_stream);
   inspect_summary(summarized_streams);
+  KEEP_FOR_DEBUGGER(summarized_streams);
   inspect_before_update(updated_stream);
   updated_stream = owning_stream;
   inspect_after_update(updated_stream);


### PR DESCRIPTION


## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Use `array` instead of builtin printers for which we have more control over.

Also optimize the `mdspan` printers. They previously tried to copy the entire array from device to host just to check if they could access the pointer. This is pointless.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
