### PR TITLE
Use native 8-bit PTX atomic loads and stores.

### DIFF
--- a/libcudacxx/codegen/generators/definitions.h
+++ b/libcudacxx/codegen/generators/definitions.h
@@ -107,7 +107,7 @@ inline std::string constraints(Operand op, size_t sz)
               }},
   };
 
-  if (sz == 16)
+  if (sz <= 16)
   {
     return {"h"};
   }

--- a/libcudacxx/codegen/generators/ld_st.h
+++ b/libcudacxx/codegen/generators/ld_st.h
@@ -97,8 +97,18 @@ template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, {3}, __atomic_cuda_operand_{0}{1}, {5}, {7})
 {{ asm volatile("ld{8}{4}{6}.{0}{1} %0,[%1];" : "={2}"(__dst) : "l"(__ptr) : "memory"); }})XXX";
+  constexpr auto asm_intrinsic_format_8   = R"XXX(
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, {3}, __atomic_cuda_operand_{0}{1}, {5}, {7})
+{{
+  uint16_t __tmp;
+  asm volatile("ld{8}{4}{6}.{0}{1} %0,[%1];" : "={2}"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}})XXX";
 
   constexpr size_t supported_sizes[] = {
+    8,
     16,
     32,
     64,
@@ -140,7 +150,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
         {
           for (auto mm : mmio_states)
           {
-            if (size == 16 && type == Operand::Floating)
+            if (size <= 16 && type == Operand::Floating)
             {
               continue;
             }
@@ -157,6 +167,20 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
             {
               out << std::format(
                 asm_intrinsic_format_128,
+                /* 0 */ operand(type),
+                /* 1 */ size,
+                /* 2 */ constraints(type, size),
+                /* 3 */ semantic_tag(sem),
+                /* 4 */ semantic_ld_st(sem),
+                /* 5 */ scope_tag(sco),
+                /* 6 */ scope_ld_st(sem, sco),
+                /* 7 */ mmio_tag(mm),
+                /* 8 */ mmio(mm));
+            }
+            else if (size == 8)
+            {
+              out << std::format(
+                asm_intrinsic_format_8,
                 /* 0 */ operand(type),
                 /* 1 */ size,
                 /* 2 */ constraints(type, size),
@@ -281,8 +305,17 @@ template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, {3}, __atomic_cuda_operand_{0}{1}, {5}, {7})
 {{ asm volatile("st{8}{4}{6}.{0}{1} [%0],%1;" :: "l"(__ptr), "{2}"(__val) : "memory"); }})XXX";
+  constexpr auto asm_intrinsic_format_8   = R"XXX(
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, {3}, __atomic_cuda_operand_{0}{1}, {5}, {7})
+{{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st{8}{4}{6}.{0}{1} [%0],%1;" :: "l"(__ptr), "{2}"(__tmp) : "memory");
+}})XXX";
 
   constexpr size_t supported_sizes[] = {
+    8,
     16,
     32,
     64,
@@ -338,6 +371,20 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
             {
               out << std::format(
                 asm_intrinsic_format_128,
+                /* 0 */ operand(type),
+                /* 1 */ size,
+                /* 2 */ constraints(type, size),
+                /* 3 */ semantic_tag(sem),
+                /* 4 */ semantic_ld_st(sem),
+                /* 5 */ scope_tag(sco),
+                /* 6 */ scope_ld_st(sem, sco),
+                /* 7 */ mmio_tag(mm),
+                /* 8 */ mmio(mm));
+            }
+            else if (size == 8)
+            {
+              out << std::format(
+                asm_intrinsic_format_8,
                 /* 0 */ operand(type),
                 /* 1 */ size,
                 /* 2 */ constraints(type, size),

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_derived.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_derived.h
@@ -44,26 +44,6 @@ using __cuda_atomic_enable_non_native_bitwise = enable_if_t<_Operand::__size <= 
 template <class _Operand>
 using __cuda_atomic_enable_native_bitwise = enable_if_t<_Operand::__size >= 32, bool>;
 
-template <class _Operand>
-using __cuda_atomic_enable_non_native_ld_st = enable_if_t<_Operand::__size <= 8, bool>;
-
-template <class _Operand>
-using __cuda_atomic_enable_native_ld_st = enable_if_t<_Operand::__size >= 16, bool>;
-
-template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_ld_st<_Operand> = 0>
-_CCCL_DEVICE static void
-__cuda_atomic_load(const _Type* __ptr, _Type& __dst, _Order, _Operand, _Sco, __atomic_cuda_mmio_disable)
-{
-  constexpr uint64_t __alignmask = (sizeof(uint16_t) - 1);
-  uint16_t* __aligned            = (uint16_t*) ((intptr_t) __ptr & (~__alignmask)); // NOLINT(performance-no-int-to-ptr)
-  const uint8_t __offset         = uint16_t((intptr_t) __ptr & __alignmask) * 8;
-
-  uint16_t __value = 0;
-  __cuda_atomic_load(__aligned, __value, _Order{}, __atomic_cuda_operand_b16{}, _Sco{}, __atomic_cuda_mmio_disable{});
-
-  __dst = static_cast<_Type>(__value >> __offset);
-}
-
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_bitwise<_Operand> = 0>
 _CCCL_DEVICE static bool
 __cuda_atomic_compare_exchange(_Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, _Order, _Operand, _Sco)
@@ -210,19 +190,6 @@ _CCCL_DEVICE_API _Type __cuda_atomic_fetch_update(_Type* __ptr, const _Fn& __op,
     __desired = __op(__expected);
   }
   return __expected;
-}
-
-template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_ld_st<_Operand> = 0>
-_CCCL_DEVICE static void
-__cuda_atomic_store(_Type* __ptr, _Type __val, _Order, _Operand, _Sco, __atomic_cuda_mmio_disable)
-{
-  // Store requires cas on 8/16b types
-  __cuda_atomic_fetch_update(
-    __ptr,
-    __cuda_atomic_op_bind<_Type, ::cuda::std::__cuda_atomic_op_store>{__val},
-    _Order{},
-    __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, _Operand::__size>{},
-    _Sco{});
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_arithmetic<_Operand> = 0>

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
@@ -124,6 +124,318 @@ static inline _CCCL_DEVICE void __cuda_atomic_load_memory_order_dispatch(_Fn &__
 
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.acquire.cta.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.acquire.cluster.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.acquire.gpu.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.acquire.sys.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.relaxed.cta.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.relaxed.cluster.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.relaxed.gpu.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.relaxed.sys.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.mmio.relaxed.sys.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.volatile.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.volatile.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.volatile.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.volatile.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.acquire.cta.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.acquire.cluster.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.acquire.gpu.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.acquire.sys.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.relaxed.cta.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.relaxed.cluster.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.relaxed.gpu.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.relaxed.sys.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u8, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.mmio.relaxed.sys.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.volatile.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.volatile.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.volatile.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.volatile.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.acquire.cta.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.acquire.cluster.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.acquire.gpu.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.acquire.sys.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.relaxed.cta.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.relaxed.cluster.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.relaxed.gpu.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.relaxed.sys.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s8, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.mmio.relaxed.sys.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.volatile.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.volatile.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.volatile.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
+  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+{
+  uint16_t __tmp;
+  asm volatile("ld.volatile.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
+  __dst = static_cast<_Type>(__tmp);
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
 { asm volatile("ld.acquire.cta.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
@@ -971,6 +1283,97 @@ static inline _CCCL_DEVICE void __cuda_atomic_store_memory_order_dispatch(_Fn &_
   )
 }
 
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.release.cta.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.release.cluster.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.release.gpu.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.release.sys.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.relaxed.cta.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.relaxed.cluster.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.relaxed.gpu.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.relaxed.sys.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.mmio.relaxed.sys.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.volatile.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.volatile.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.volatile.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
+template <class _Type>
+static inline _CCCL_DEVICE void __cuda_atomic_store(
+  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+{
+  const uint16_t __tmp = static_cast<uint16_t>(__val);
+  asm volatile("st.volatile.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
+}
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)


### PR DESCRIPTION
## Description

Resolves #10783.

This PR changes the PTX codegen of 8-bit atomics to directly load and store with the native 8 bit atomic load and store instructions.

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
