### PR TITLE
[cuda.compute]: Bump numba-cuda floor version to 0.26.0

### DIFF
--- a/ci/windows/build_cuda_cccl_python.ps1
+++ b/ci/windows/build_cuda_cccl_python.ps1
@@ -276,8 +276,9 @@ function Build-CudaCcclWheel {
     # Run pip wheel to build the wheel.
     $pythonArgs = @(
         '-m', 'pip', 'wheel',
+        '--no-deps',
         '-w', $outDir,
-        ".[${extra}]",
+        '.',
         '-v'
     ) + $pipConfigArgs
 

--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -61,13 +61,13 @@ cu12 = [
   "cuda-cccl[minimal-cu12]",
   # numba-cuda currently expects numba.cuda.types.NPDatetime, removed in numba 0.66.
   "numba>=0.60.0,<0.66",
-  "numba-cuda[cu12]>=0.23.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0",
+  "numba-cuda[cu12]>=0.26.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0",
 ]
 cu13 = [
   "cuda-cccl[minimal-cu13]",
   # numba-cuda currently expects numba.cuda.types.NPDatetime, removed in numba 0.66.
   "numba>=0.60.0,<0.66",
-  "numba-cuda[cu13]>=0.23.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0"
+  "numba-cuda[cu13]>=0.26.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0"
 ]
 sysctk12 = [
   "cuda-cccl[minimal-sysctk12]",
@@ -75,7 +75,7 @@ sysctk12 = [
   "numba>=0.60.0,<0.66",
   # plain numba-cuda (no [cu12]) so it relies on the system-provided CUDA toolkit
   # instead of pulling the toolkit from pip -- the whole point of the sysctk extra.
-  "numba-cuda>=0.23.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0"
+  "numba-cuda>=0.26.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0"
 ]
 sysctk13 = [
   "cuda-cccl[minimal-sysctk13]",
@@ -83,7 +83,7 @@ sysctk13 = [
   "numba>=0.60.0,<0.66",
   # plain numba-cuda (no [cu13]) so it relies on the system-provided CUDA toolkit
   # instead of pulling the toolkit from pip -- the whole point of the sysctk extra.
-  "numba-cuda>=0.23.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0",
+  "numba-cuda>=0.26.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0",
 ]
 # The test extras do not include CuPy. The cuda.compute examples (run via
 # tests/test_examples.py) require it; install it separately (e.g.


### PR DESCRIPTION
This is in preparation for releasing a free threaded wheel. In its current form, we only support free threading for the minimal extra (i.e., without numba-cuda). Ideally, running `pip install cuda-cccl[cu12]` in a 3.14t env would fail because there is no numba-cuda 3.14t wheel, but numba-cuda versions older than 0.26.0 publish sdists, so they get resolved and the GIL gets re-enabled when we import cuda.compute.

By raising the floor, installation fails cleanly at resolution time