### PR TITLE
Make eight STF tests and examples portable to clang-cuda

### DIFF
--- a/cudax/examples/stf/fdtd_mgpu.cu
+++ b/cudax/examples/stf/fdtd_mgpu.cu
@@ -16,6 +16,8 @@
 
 #include <cuda/experimental/stf.cuh>
 
+#include <algorithm>
+
 #include <stdlib.h>
 
 using namespace cuda::experimental::stf;
@@ -192,7 +194,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
   const double MU      = 1.256e-6; // Permeability of free space
 
   // CFL condition DT <= min(DX, DY, DZ) * sqrt(epsilon_max * mu_max)
-  double DT = 0.25 * min(min(DX, DY), DZ) * sqrt(EPSILON * MU);
+  double DT = 0.25 * std::min(std::min(DX, DY), DZ) * sqrt(EPSILON * MU);
 
   // Initialize E
   ctx.parallel_for(part, where, data_shape, lEx.write(), lEy.write(), lEz.write())

--- a/cudax/examples/stf/fdtd_repeat_n.cu
+++ b/cudax/examples/stf/fdtd_repeat_n.cu
@@ -19,6 +19,7 @@
 
 #include <cuda/experimental/stf.cuh>
 
+#include <algorithm>
 #include <iostream>
 
 #include <stdlib.h>
@@ -78,7 +79,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
   const double MU      = 1.256e-6; // Permeability of free space
 
   // CFL condition DT <= min(DX, DY, DZ) * sqrt(epsilon_max * mu_max)
-  double DT = 0.25 * min(min(DX, DY), DZ) * sqrt(EPSILON * MU);
+  double DT = 0.25 * std::min(std::min(DX, DY), DZ) * sqrt(EPSILON * MU);
 
   // Initialize E fields
   ctx.parallel_for(data_shape, lEx.write(), lEy.write(), lEz.write())

--- a/cudax/examples/stf/fdtd_while.cu
+++ b/cudax/examples/stf/fdtd_while.cu
@@ -16,6 +16,8 @@
 
 #include <cuda/experimental/stf.cuh>
 
+#include <algorithm>
+
 #include <stdlib.h>
 
 using namespace cuda::experimental::stf;
@@ -151,7 +153,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
   const double MU      = 1.256e-6; // Permeability of free space
 
   // CFL condition DT <= min(DX, DY, DZ) * sqrt(epsilon_max * mu_max)
-  double DT = 0.25 * min(min(DX, DY), DZ) * sqrt(EPSILON * MU);
+  double DT = 0.25 * std::min(std::min(DX, DY), DZ) * sqrt(EPSILON * MU);
 
   // Initialize E
   ctx.parallel_for(data_shape, lEx.write(), lEy.write(), lEz.write())

--- a/cudax/test/stf/dot/basic.cu
+++ b/cudax/test/stf/dot/basic.cu
@@ -15,6 +15,10 @@
 
 #include <cuda/experimental/stf.cuh>
 
+#if !_CCCL_COMPILER(MSVC)
+#  include <unistd.h> // access(), unlink()
+#endif // !_CCCL_COMPILER(MSVC)
+
 using namespace cuda::experimental::stf;
 
 int main()

--- a/cudax/test/stf/dot/graph_print_to_dot.cu
+++ b/cudax/test/stf/dot/graph_print_to_dot.cu
@@ -15,6 +15,10 @@
 
 #include <cuda/experimental/stf.cuh>
 
+#if !_CCCL_COMPILER(MSVC)
+#  include <unistd.h> // access(), unlink()
+#endif // !_CCCL_COMPILER(MSVC)
+
 using namespace cuda::experimental::stf;
 
 __global__ void dummy() {}

--- a/cudax/test/stf/dot/sections.cu
+++ b/cudax/test/stf/dot/sections.cu
@@ -15,6 +15,10 @@
 
 #include <cuda/experimental/stf.cuh>
 
+#if !_CCCL_COMPILER(MSVC)
+#  include <unistd.h> // access(), unlink()
+#endif // !_CCCL_COMPILER(MSVC)
+
 using namespace cuda::experimental::stf;
 
 int main()

--- a/cudax/test/stf/dot/with_events.cu
+++ b/cudax/test/stf/dot/with_events.cu
@@ -15,6 +15,10 @@
 
 #include <cuda/experimental/stf.cuh>
 
+#if !_CCCL_COMPILER(MSVC)
+#  include <unistd.h> // access(), unlink()
+#endif // !_CCCL_COMPILER(MSVC)
+
 using namespace cuda::experimental::stf;
 
 int main()

--- a/cudax/test/stf/parallel_for/fdtd.cu
+++ b/cudax/test/stf/parallel_for/fdtd.cu
@@ -11,6 +11,8 @@
 #include <cuda/experimental/__stf/stream/stream_ctx.cuh>
 #include <cuda/experimental/__stf/utility/dimensions.cuh>
 
+#include <algorithm>
+
 using namespace cuda::experimental::stf;
 
 // FIXME : MSVC has trouble with box constructors
@@ -126,7 +128,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
   const double MU      = 1.256e-6; // Permeability of free space
 
   // CFL condition DT <= min(DX, DY, DZ) * sqrt(epsilon_max * mu_max)
-  double DT = 0.25 * min(min(DX, DY), DZ) * sqrt(EPSILON * MU);
+  double DT = 0.25 * std::min(std::min(DX, DY), DZ) * sqrt(EPSILON * MU);
 
   // Initialize E
   ctx.parallel_for(data_shape, lEx.write(), lEy.write(), lEz.write())


### PR DESCRIPTION
First step toward building STF with clang-cuda, which is what [#10612](https://github.com/NVIDIA/cccl/pull/10612) was preparation for and what `bugprone-exception-escape` on STF ultimately needs. `ci/build_tidy.sh` still sets `-Dcudax_ENABLE_CUDASTF=OFF`; the goal is to delete that line once STF parses.

A clang-cuda sweep (clang 21, CTK 12, `-fsyntax-only`) over all 283 STF tests and examples on `main` leaves 50 failures, 35 of them real. This PR clears eight, all of which are portability slips in the tests rather than anything about STF itself:

* The four `dot` tests call `access()` and `unlink()` while relying on some other header to drag in `<unistd.h>`. They now include it directly, under the same `!_CCCL_COMPILER(MSVC)` guard that already wraps the bodies using those calls.
* The four FDTD sources compute `min(min(DX, DY), DZ)` on `double`s with an unqualified `min`. nvcc resolves that to CUDA's device-only overload even in host code; clang-cuda correctly refuses, since the only candidates are `__device__`. They now say `std::min` and include `<algorithm>`.

## Validation

All eight files pass `-fsyntax-only` with clang-cuda, where each previously failed, and all eight still compile with nvcc 13.2 (C++17, `sm_90`). `pre-commit` passes.

Remaining real failures, for context: 18 from `std::apply` in device code (all funnelling through `launch_kernel`, the next PR), 4 host functions called from `__host__ __device__`, 2 deleted copy constructors of `stream_task`, and 3 assorted `static_assert`s.
