### PR TITLE
[cudax][cuco] Organize test CMake files by directory

### DIFF
--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -110,74 +110,7 @@ cudax_add_catch2_test(test_target copy
     copy/copy_shared_memory.cu
 )
 
-cudax_add_catch2_test(test_target cuco.fixed_capacity_map.insert_and_contains ${cudax_target}
-    cuco/fixed_capacity_map/test_insert_and_contains.cu
-)
-
-cudax_add_catch2_test(test_target cuco.fixed_capacity_map.find ${cudax_target}
-    cuco/fixed_capacity_map/test_find.cu
-)
-
-cudax_add_catch2_test(test_target cuco.fixed_capacity_map.rebind ${cudax_target}
-    cuco/fixed_capacity_map/test_rebind.cu
-)
-
-cudax_add_catch2_test(test_target cuco.fixed_capacity_map.retrieve_all ${cudax_target}
-    cuco/fixed_capacity_map/test_retrieve_all.cu
-)
-
-cudax_add_catch2_test(test_target cuco.fixed_capacity_map.capacity ${cudax_target}
-    cuco/fixed_capacity_map/test_capacity.cu
-)
-
-cudax_add_catch2_test(test_target cuco.fixed_capacity_map.shared_memory ${cudax_target}
-    cuco/fixed_capacity_map/test_shared_memory.cu
-)
-
-cudax_add_catch2_test(test_target cuco.fixed_capacity_map.misaligned_storage ${cudax_target}
-    cuco/fixed_capacity_map/test_misaligned_storage.cu
-)
-
-cudax_add_catch2_test(test_target cuco.fixed_capacity_map.key_sentinel ${cudax_target}
-    cuco/fixed_capacity_map/test_key_sentinel.cu
-)
-
-cudax_add_catch2_test(test_target cuco.utility.capacity ${cudax_target}
-    cuco/utility/test_capacity.cu
-)
-
-cudax_add_catch2_test(test_target cuco.hyperloglog ${cudax_target}
-  cuco/hyperloglog/test_hyperloglog.cu
-)
-
-# cudax_add_cuco_fail_test
-function(cudax_add_cuco_fail_test target_name_var test_name source)
-  set(test_target cudax.test.${test_name})
-
-  cccl_add_executable(
-    ${test_target}
-    SOURCES ${source}
-    NO_METATARGETS
-    NO_CLANG_TIDY
-  )
-  target_link_libraries(${test_target} PRIVATE cudax.compiler_interface)
-  cccl_add_xfail_compile_target_test(
-    ${test_target}
-    SOURCE_FILE "${source}"
-    ERROR_REGEX_LABEL "expected-error"
-  )
-
-  set(${target_name_var} ${test_target} PARENT_SCOPE)
-endfunction()
-
-# Expected-failure compile tests (_fail.cu convention)
-cudax_add_cuco_fail_test(test_target cuco.fixed_capacity_map.key_size_fail
-  cuco/fixed_capacity_map/test_key_size_fail.cu
-)
-
-cudax_add_cuco_fail_test(test_target cuco.fixed_capacity_map.slot_size_fail
-  cuco/fixed_capacity_map/test_slot_size_fail.cu
-)
+add_subdirectory(cuco)
 
 cudax_add_catch2_test(test_target green_context
     green_context/green_ctx_smoke.cu

--- a/cudax/test/cuco/CMakeLists.txt
+++ b/cudax/test/cuco/CMakeLists.txt
@@ -1,0 +1,13 @@
+#===----------------------------------------------------------------------===##
+#
+# Part of CUDA Experimental in CUDA C++ Core Libraries,
+# under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+#
+#===----------------------------------------------------------------------===##
+
+add_subdirectory(fixed_capacity_map)
+add_subdirectory(hyperloglog)
+add_subdirectory(utility)

--- a/cudax/test/cuco/fixed_capacity_map/CMakeLists.txt
+++ b/cudax/test/cuco/fixed_capacity_map/CMakeLists.txt
@@ -1,0 +1,70 @@
+#===----------------------------------------------------------------------===##
+#
+# Part of CUDA Experimental in CUDA C++ Core Libraries,
+# under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+#
+#===----------------------------------------------------------------------===##
+
+cudax_add_catch2_test(test_target cuco.fixed_capacity_map.insert_and_contains ${cudax_target}
+  test_insert_and_contains.cu
+)
+
+cudax_add_catch2_test(test_target cuco.fixed_capacity_map.find ${cudax_target}
+  test_find.cu
+)
+
+cudax_add_catch2_test(test_target cuco.fixed_capacity_map.rebind ${cudax_target}
+  test_rebind.cu
+)
+
+cudax_add_catch2_test(test_target cuco.fixed_capacity_map.retrieve_all ${cudax_target}
+  test_retrieve_all.cu
+)
+
+cudax_add_catch2_test(test_target cuco.fixed_capacity_map.capacity ${cudax_target}
+  test_capacity.cu
+)
+
+cudax_add_catch2_test(test_target cuco.fixed_capacity_map.shared_memory ${cudax_target}
+  test_shared_memory.cu
+)
+
+cudax_add_catch2_test(test_target cuco.fixed_capacity_map.misaligned_storage ${cudax_target}
+  test_misaligned_storage.cu
+)
+
+cudax_add_catch2_test(test_target cuco.fixed_capacity_map.key_sentinel ${cudax_target}
+  test_key_sentinel.cu
+)
+
+# cudax_add_cuco_fail_test
+function(cudax_add_cuco_fail_test target_name_var test_name source)
+  set(test_target cudax.test.${test_name})
+
+  cccl_add_executable(
+    ${test_target}
+    SOURCES ${source}
+    NO_METATARGETS
+    NO_CLANG_TIDY
+  )
+  target_link_libraries(${test_target} PRIVATE cudax.compiler_interface)
+  cccl_add_xfail_compile_target_test(
+    ${test_target}
+    SOURCE_FILE "${source}"
+    ERROR_REGEX_LABEL "expected-error"
+  )
+
+  set(${target_name_var} ${test_target} PARENT_SCOPE)
+endfunction()
+
+# Expected-failure compile tests (_fail.cu convention)
+cudax_add_cuco_fail_test(test_target cuco.fixed_capacity_map.key_size_fail
+  test_key_size_fail.cu
+)
+
+cudax_add_cuco_fail_test(test_target cuco.fixed_capacity_map.slot_size_fail
+  test_slot_size_fail.cu
+)

--- a/cudax/test/cuco/hyperloglog/CMakeLists.txt
+++ b/cudax/test/cuco/hyperloglog/CMakeLists.txt
@@ -1,0 +1,13 @@
+#===----------------------------------------------------------------------===##
+#
+# Part of CUDA Experimental in CUDA C++ Core Libraries,
+# under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+#
+#===----------------------------------------------------------------------===##
+
+cudax_add_catch2_test(test_target cuco.hyperloglog ${cudax_target}
+  test_hyperloglog.cu
+)

--- a/cudax/test/cuco/utility/CMakeLists.txt
+++ b/cudax/test/cuco/utility/CMakeLists.txt
@@ -1,0 +1,13 @@
+#===----------------------------------------------------------------------===##
+#
+# Part of CUDA Experimental in CUDA C++ Core Libraries,
+# under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+#
+#===----------------------------------------------------------------------===##
+
+cudax_add_catch2_test(test_target cuco.utility.capacity ${cudax_target}
+  test_capacity.cu
+)


### PR DESCRIPTION
## Description

Follow-up to #10695 and https://github.com/NVIDIA/cccl/pull/10695#discussion_r3737955089.

During the review, @Jacobfaib suggested registering cuco tests through `add_subdirectory()` at each directory level instead of reaching into nested directories from `cudax/test/CMakeLists.txt`. This PR adds local CMake files for `cuco`, `fixed_capacity_map`, `hyperloglog`, and `utility` while preserving the existing test target names and sources.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.