### PR TITLE
Unpack launch()'s kernel arguments with cuda::std::apply

### DIFF
--- a/cudax/include/cuda/experimental/__stf/internal/launch.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/launch.cuh
@@ -20,6 +20,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__tuple_dir/apply.h>
+#include <cuda/std/__tuple_dir/tuple.h>
+
 #include <cuda/experimental/__stf/internal/execution_policy.cuh> // launch_impl() uses execution_policy
 #include <cuda/experimental/__stf/internal/interpreted_execution_policy_impl.cuh>
 #include <cuda/experimental/__stf/internal/task_dep.cuh>
@@ -38,10 +41,30 @@ class stream_task;
 
 namespace reserved
 {
+//! @brief Builds the argument tuple that `launch_kernel` receives by value.
+//!
+//! @param[in] __prefix Value to place first, in practice the thread hierarchy.
+//! @param[in] __tuple Data instances that follow it.
+//! @return A `cuda::std::tuple` holding `__prefix` ahead of the elements of `__tuple`.
+//!
+//! The result is deliberately not a `std::tuple`: the kernel unpacks it in device code, and
+//! libstdc++'s `std::apply` is host-only. nvcc accepts calling it from device code because
+//! `--expt-relaxed-constexpr` admits host `constexpr` functions there, but clang-cuda has no
+//! such escape hatch and rejects it.
+template <typename _Prefix, typename... _Ts>
+[[nodiscard]] auto __make_kernel_args(_Prefix __prefix, ::std::tuple<_Ts...> __tuple)
+{
+  return ::std::apply(
+    [&](auto&&... __elements) {
+      return ::cuda::std::tuple<_Prefix, _Ts...>(mv(__prefix), ::std::forward<decltype(__elements)>(__elements)...);
+    },
+    mv(__tuple));
+}
+
 template <typename Fun, typename Arg>
 __global__ void launch_kernel(Fun f, Arg arg)
 {
-  ::std::apply(mv(f), mv(arg));
+  ::cuda::std::apply(mv(f), mv(arg));
 }
 
 template <typename interpreted_spec, typename Fun, typename Stream_t>
@@ -136,7 +159,7 @@ void launch_impl(interpreted_spec interpreted_policy, exec_place& p, Fun f, Arg 
       th.set_device_tmp(th_dev_tmp_ptr);
     }
 
-    auto kernel_args = tuple_prepend(mv(th), mv(arg));
+    auto kernel_args = __make_kernel_args(mv(th), mv(arg));
     using args_type  = decltype(kernel_args);
     void* all_args[] = {&f, &kernel_args};
 
@@ -149,7 +172,7 @@ void graph_launch_impl(task_t& t, interpreted_spec interpreted_policy, exec_plac
 {
   _CCCL_ASSERT(p.size() == 1, "Expected scalar exec_place");
 
-  auto kernel_args = tuple_prepend(thread_hierarchy(static_cast<int>(rank), interpreted_policy), mv(arg));
+  auto kernel_args = __make_kernel_args(thread_hierarchy(static_cast<int>(rank), interpreted_policy), mv(arg));
   using args_type  = decltype(kernel_args);
   void* all_args[] = {&f, &kernel_args};
 
@@ -209,7 +232,7 @@ public:
     const size_t grid_size = e_place.size();
 
     using th_t     = typename spec_t::thread_hierarchy_t;
-    using arg_type = decltype(tuple_prepend(th_t(), arg));
+    using arg_type = decltype(__make_kernel_args(th_t(), arg));
 
     auto interpreted_policy = interpreted_execution_policy(spec, e_place, reserved::launch_kernel<Fun, arg_type>);
 
@@ -392,7 +415,7 @@ public:
     // not leave a started task without teardown guards. args_type only needs the
     // unevaluated return type of data2inst, so get() is not invoked here.
     using th_t      = typename thread_hierarchy_spec_t::thread_hierarchy_t;
-    using args_type = decltype(tuple_prepend(th_t(), data2inst<decltype(t), Deps...>(t)));
+    using args_type = decltype(__make_kernel_args(th_t(), data2inst<decltype(t), Deps...>(t)));
 
     auto interpreted_policy = interpreted_execution_policy(spec, e_place, reserved::launch_kernel<Fun, args_type>);
 


### PR DESCRIPTION
Second step toward building STF with clang-cuda, so that `bugprone-exception-escape` can eventually run over STF (`ci/build_tidy.sh` still sets `-Dcudax_ENABLE_CUDASTF=OFF`). Follows [#10793](https://github.com/NVIDIA/cccl/pull/10793), which fixed portability slips in the tests; this one is in the library.

`launch_kernel` took a `std::tuple` by value and unpacked it with `std::apply`. libstdc++ declares `std::apply` host-only, so device code has no business calling it. nvcc lets it pass because `--expt-relaxed-constexpr` admits host `constexpr` functions in device code; clang-cuda has no such escape hatch and rejects every `ctx.launch` in the tree.

The kernel now receives a `cuda::std::tuple` and unpacks it with `cuda::std::apply`. A small `reserved::__make_kernel_args` helper builds it at the two launch sites (`launch_impl` and `graph_launch_impl`) and is named by the two occupancy queries, so the instantiation whose occupancy is queried stays the one that gets launched. `data2inst` keeps producing a `std::tuple`: the helper is precisely the boundary where host plumbing turns into a kernel argument, so nothing else has to change.

## Validation

A clang-cuda `-fsyntax-only` sweep (clang 21, CTK 12, `sm_75`) over all 283 STF tests and examples goes from 50 failures to 33, with no regressions. The 17 that flip are every `ctx.launch` user plus the standalone `reserved::launch`, across both the stream and graph backends.

nvcc 13.2 still compiles the launch path (C++17, `sm_90`), and four representative tests covering `launch_impl` and `graph_launch_impl` build and run correctly on an RTX 3070: `01-axpy-launch`, `launch_sum`, `standalone-launches`, and `graph/many`. `pre-commit` passes.

## What the remaining 33 are

Only five still need real work, so this is close to the end of the road for the source fixes:

* 8 are fixed by [#10793](https://github.com/NVIDIA/cccl/pull/10793) (missing `<unistd.h>`, unqualified `min`).
* 9 are artifacts of my local toolkit, which has no cuBLAS, cuSOLVER, or NVTX headers.
* 6 exercise `algorithm.cuh`, whose include in `stf.cuh` is commented out, so they do not compile with nvcc either.
* 5 are the `static_error_checks` xfail tests, which are supposed to fail to compile. Two of them fail on the wrong diagnostic under clang (a deleted copy constructor rather than the expected `static_assert`), which the xfail regex would need to accommodate.
* 5 are genuine: `launch_scan.cu` reaches `core.cuh`'s `tuple_prepend` from device code through `thread_hierarchy::apply_partition`, which needs the same treatment as this PR one level down; `parallel_for_2D.cu`, `parallel_for_host.cu`, and `test2_parallel_for_context.cu` call a host `operator()` from host-device code; and `frozen_data_init.cu` does the same with `operator->*`.
