### PR TITLE
Prepend to tuples without a deduction guide, so device code can too

### DIFF
--- a/cudax/include/cuda/experimental/__stf/utility/core.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/core.cuh
@@ -217,7 +217,10 @@ constexpr auto tuple_prepend(T&& prefix, ::std::tuple<P...> tuple)
 {
   return ::std::apply(
     [&](auto&&... p) {
-      return ::std::tuple(::std::forward<T>(prefix), ::std::forward<decltype(p)>(p)...);
+      // Spelling the type out rather than deducing it keeps this usable from device code: a
+      // deduction guide is not a constexpr function, so it stays host-only even where clang
+      // treats libstdc++'s constexpr tuple machinery as implicitly __host__ __device__.
+      return ::std::tuple<::std::decay_t<T>, P...>(::std::forward<T>(prefix), ::std::forward<decltype(p)>(p)...);
     },
     mv(tuple));
 }

--- a/cudax/include/cuda/experimental/__stf/utility/core.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/core.cuh
@@ -215,14 +215,10 @@ constexpr void unroll(F&& f, ::std::index_sequence<i...> = {})
 template <typename T, typename... P>
 constexpr auto tuple_prepend(T&& prefix, ::std::tuple<P...> tuple)
 {
-  return ::std::apply(
-    [&](auto&&... p) {
-      // Spelling the type out rather than deducing it keeps this usable from device code: a
-      // deduction guide is not a constexpr function, so it stays host-only even where clang
-      // treats libstdc++'s constexpr tuple machinery as implicitly __host__ __device__.
-      return ::std::tuple<::std::decay_t<T>, P...>(::std::forward<T>(prefix), ::std::forward<decltype(p)>(p)...);
-    },
-    mv(tuple));
+  // Spelling the prefix's type out rather than deducing it keeps this usable from device code: a
+  // deduction guide is not a constexpr function, so it stays host-only even where clang treats
+  // libstdc++'s constexpr tuple machinery as implicitly __host__ __device__.
+  return ::std::tuple_cat(::std::tuple<::std::decay_t<T>>(::std::forward<T>(prefix)), mv(tuple));
 }
 
 namespace reserved


### PR DESCRIPTION
Third step toward building STF with clang-cuda, so that `bugprone-exception-escape` can eventually run over STF (`ci/build_tidy.sh` still sets `-Dcudax_ENABLE_CUDASTF=OFF`). Follows #10793 (portability slips in the tests) and #10796 (`launch()`'s kernel arguments).

`reserved::tuple_prepend` built its result with CTAD. That was the one piece of the helper device code could not use: a deduction guide is not a constexpr function, so clang-cuda keeps it host-only, while it treats the rest of libstdc++'s constexpr tuple machinery -- `std::apply`, `std::get`, `std::make_tuple`, `std::tuple_cat` -- as implicitly `__host__ __device__`. Isolated, the diagnostic is exactly that:

```
error: reference to __host__ function '<deduction guide for tuple><int, double, char>' in
       __host__ __device__ function
```

`std::tuple_cat` avoids the guide, and it lets the `apply` and the lambda go too, so the body is now one line and the helper is usable from device code. That makes `thread_hierarchy::apply_partition` compile, and with it every `launch()` that partitions a shape.

Element types are preserved, which is what the documented return type `std::tuple<T, P...>` promises. `std::make_tuple` would also have fixed the build and read a little shorter, but it decays what it is handed: a tail holding `int&` comes back holding `int`, so writing through the result would quietly update a copy. Details in [the review thread](https://github.com/NVIDIA/cccl/pull/10801#discussion_r3779192216). Only the prefix has its type named, since that is where the guide was.

Worth noting what this replaces: my first instinct was to convert `tuple_prepend`, `reserved::make_tuple`, and `make_tuple_indexwise` to `cuda::std::tuple`, which would have rippled through `stream_task`, `graph_task`, `task_dep`, and `parallel_for`. None of that is needed -- the deduction guide was the only host-only element in the chain.

## Validation

`launch_scan.cu` is the only file in the tree that reaches `tuple_prepend` from device code, and it needs #10796 as well, so **on top of `main` alone this change flips nothing in the sweep**. With #10796 applied, a clang-cuda `-fsyntax-only` sweep (clang 21, CTK 12, `sm_75`) over all 283 STF tests and examples goes from 33 failures to 24, with no regressions: the eight #10793 fixes, plus `launch_scan.cu` for this one. I verified separately that the explicit-type, `make_tuple`, and `tuple_cat` spellings all instantiate from a `__global__` under clang-cuda, and that CTAD does not.

`tuple_prepend` is used by the stream, graph, host-launch, and launch paths, so nvcc 13.2 (C++17, `sm_86`) builds a representative spread of all four, and they run correctly on an RTX 3070: `01-axpy`, `02-axpy-host_launch`, `01-axpy-parallel_for`, `launch_scan`, `graph/many`, and `standalone-launches`. The header unit tests for `core.cuh`, `context.cuh` (which covers `make_tuple_indexwise`) and `thread_hierarchy.cuh` (which covers `apply_partition`) build and pass. `pre-commit` passes.

## What the remaining 24 are

The source fixes are done. Nothing left is mechanical:

* 9 are artifacts of my local toolkit, which has no cuBLAS, cuSOLVER, or NVTX headers.
* 6 exercise `algorithm.cuh`, whose include in `stf.cuh` is commented out, so they do not compile with nvcc either.
* 5 are the `static_error_checks` xfail tests, which are supposed to fail to compile. Two fail on the wrong diagnostic under clang (a deleted copy constructor rather than the expected `static_assert`), which the xfail regex would need to accommodate.
* 4 are one design question, not a bug: `parallel_for_2D.cu`, `parallel_for_host.cu`, `test2_parallel_for_context.cu`, and `frozen_data_init.cu` run `parallel_for` on `exec_place::host()` with lambdas that call host-only code such as `EXPECT`. `parallel_for` picks the host branch at run time, so the device branch is instantiated regardless, and clang compiles it. nvcc is spared because an unannotated lambda is host-only there, so `__nv_is_extended_host_device_lambda_closure_type` is false and the device branch is discarded. Clang has no equivalent trait and, per its maintainers, [treats every lambda as `__host__ __device__`](https://discourse.llvm.org/t/compiling-cuda-code-fails/61240) -- "all lambdas in clang are extended lambdas in NVCC's terms" -- so STF cannot tell a host-only lambda from a device-capable one. Making the device branch's instantiation depend on the execution place being known at compile time would fix it; short of that, those four are a documented limitation. I would rather settle that in its own PR than smuggle it in here.
