### PR TITLE
Record that ~while_graph_scope_guard terminates on purpose

### DIFF
--- a/cudax/include/cuda/experimental/__stf/stackable/stackable_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/stackable/stackable_ctx.cuh
@@ -1315,6 +1315,9 @@ public:
     ctx_.push_while(&conditional_handle_, default_launch_value, flags, loc);
   }
 
+  // As with graph_scope_guard, a push_while() that cannot be matched by its pop() leaves the
+  // context stack inconsistent, so terminating is the intended outcome.
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~while_graph_scope_guard()
   {
     ctx_.pop();


### PR DESCRIPTION
Fourth step toward running `bugprone-exception-escape` over STF (`ci/build_tidy.sh` still sets `-Dcudax_ENABLE_CUDASTF=OFF`). Follows #10793, #10796, and #10801.

`graph_scope_guard`'s destructor calls `pop()` and carries a comment plus a `NOLINT` recording that an unmatched `pop()` leaves the context stack inconsistent, so terminating is the intended outcome. `while_graph_scope_guard` does exactly the same thing and was simply missed. This adds the same note.

That is a one-line change, but the reason it is worth its own PR is what it took to find, and what that says about enabling the check.

## The check is already enabled; STF just is not built

`bugprone-exception-escape` is not something we need to turn on. `.clang-tidy` enables `bugprone-*` and even configures the check. The only reason it does not cover STF is that `ci/build_tidy.sh` disables STF entirely, which is what this series has been chipping away at.

So I ran it over STF by hand: clang-tidy 21, all 283 STF tests and examples, `bugprone-exception-escape` alone. Across the whole subproject there is exactly **one** genuine finding, `~while_graph_scope_guard`, reported from 195 of the 283 translation units. With this change the sweep is clean. (Locally it also flags every `main`, because `bugprone-exception-escape.CheckMain`, which `.clang-tidy` sets to `false`, [was only added in LLVM 22](https://github.com/llvm/llvm-project/pull/164081) and my clang-tidy silently ignores it. Nothing to do here, but worth knowing if you sweep with clang 21 or older.)

## The finding that matters for the CI job

The sweep above passes `--cuda-host-only`. Without it the same sweep reports **twelve** findings per translation unit instead of one, and eleven of them are false:

```
scope_guard.cuh:178:16: error: an exception may be thrown in function
    'operator<<<void (&)() noexcept, (lambda at __places/data_place_impl.cuh:263:5) &>'
    which should not throw exceptions [bugprone-exception-escape]
  note: frame #2: function 'operator<<...' calls function 'operator()' here
        return ::cuda::std::forward<_Fn>(__fn)();     <-- this is inside _CCCL_TRY
```

The call it complains about sits inside a `_CCCL_TRY` with a `_CCCL_CATCH_ALL`, so nothing can escape. But:

```cpp
#if _CCCL_HAS_EXCEPTIONS() && _CCCL_HOST_COMPILATION()
#  define _CCCL_TRY       try
#  define _CCCL_CATCH_ALL catch (...)
```

Nothing in `.clang-tidy` or `run_clang_tidy.sh.in` restricts analysis to the host pass, so for a `.cu` file clang-tidy analyzes the device pass, where those macros correctly expand to nothing. Every host function that guards itself with `_CCCL_TRY` therefore looks like it leaks, and every instantiation is reported separately.

This does not affect the job today only because the code that uses those macros lives in STF and `__places` -- both disabled in `build_tidy.sh`, the second one right next to the first. It will start mattering the moment either is enabled, and no amount of source fixing will address it, since device code genuinely cannot have `try`/`catch`. Exception semantics only exist on the host, so analyzing the host pass is the right configuration for this check. I would rather raise that than fold an infra change into a `NOLINT` PR: @Jacobfaib, does adding `--cuda-host-only` to `ExtraArgs` (or to the runner script) sound right to you, or would you rather keep device-pass coverage for the other checks and scope this differently? Happy to send it either way.

## Validation

The host-pass sweep over all 283 STF translation units reports no non-`main` findings with this change, down from 195. `composite_conditional` and `graph_scope_test` build with nvcc 13.2 (C++17, `sm_86`) and run correctly on an RTX 3070. `pre-commit` passes.
