### PR TITLE
libcu++: respect atomic scopes in pointer arithmetic operations.

### DIFF
--- a/libcudacxx/include/cuda/std/__atomic/api/common.h
+++ b/libcudacxx/include/cuda/std/__atomic/api/common.h
@@ -163,12 +163,12 @@
   _CCCL_HOST_DEVICE_API inline _Tp fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) \
     _CONST _VOLATILE noexcept                                                                         \
   {                                                                                                   \
-    return __atomic_fetch_add_dispatch(&__a, __op, __m, __thread_scope_system_tag{});                 \
+    return __atomic_fetch_add_dispatch(&__a, __op, __m, _Sco{});                                      \
   }                                                                                                   \
   _CCCL_HOST_DEVICE_API inline _Tp fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) \
     _CONST _VOLATILE noexcept                                                                         \
   {                                                                                                   \
-    return __atomic_fetch_sub_dispatch(&__a, __op, __m, __thread_scope_system_tag{});                 \
+    return __atomic_fetch_sub_dispatch(&__a, __op, __m, _Sco{});                                      \
   }                                                                                                   \
   _CCCL_HOST_DEVICE_API inline _Tp operator++(int) _CONST _VOLATILE noexcept                          \
   {                                                                                                   \

--- a/libcudacxx/test/atomic_codegen/atomic_add_non_volatile.cu
+++ b/libcudacxx/test/atomic_codegen/atomic_add_non_volatile.cu
@@ -6,6 +6,24 @@ __global__ void add_relaxed_device_non_volatile(int* data, int* out, int n)
   *out     = ref.fetch_add(n, cuda::std::memory_order_relaxed);
 }
 
+__global__ void add_relaxed_block_pointer_non_volatile(int** data, int** out, int n)
+{
+  auto ref = cuda::atomic_ref<int*, cuda::thread_scope_block>{*data};
+  *out     = ref.fetch_add(n, cuda::std::memory_order_relaxed);
+}
+
+__global__ void add_relaxed_device_pointer_non_volatile(int** data, int** out, int n)
+{
+  auto ref = cuda::atomic_ref<int*, cuda::thread_scope_device>{*data};
+  *out     = ref.fetch_add(n, cuda::std::memory_order_relaxed);
+}
+
+__global__ void add_relaxed_system_pointer_non_volatile(int** data, int** out, int n)
+{
+  auto ref = cuda::atomic_ref<int*, cuda::thread_scope_system>{*data};
+  *out     = ref.fetch_add(n, cuda::std::memory_order_relaxed);
+}
+
 /*
 
 ; SM8X-LABEL: .target sm_80
@@ -17,5 +35,17 @@ __global__ void add_relaxed_device_non_volatile(int* data, int* out, int n)
 ; SM8X-NEXT: {{/*[[:space:]] *}}atom.add.relaxed.gpu.s32 %r[[#DEST:]],[%rd[[#ATOM]]],%r[[#INPUT]];{{[[:space:]]/*}}
 ; SM8X-NEXT: st.global.{{b|u}}32 [%rd[[#GOUT]]], %r[[#DEST]];
 ; SM8X-NEXT: ret;
+
+; SM8X-LABEL: .visible .entry {{_.*add_relaxed_block_pointer_non_volatile.*}}(
+; SM8X: {{.*}}atom.add.relaxed.cta.u64{{.*}}
+; SM8X: ret;
+
+; SM8X-LABEL: .visible .entry {{_.*add_relaxed_device_pointer_non_volatile.*}}(
+; SM8X: {{.*}}atom.add.relaxed.gpu.u64{{.*}}
+; SM8X: ret;
+
+; SM8X-LABEL: .visible .entry {{_.*add_relaxed_system_pointer_non_volatile.*}}(
+; SM8X: {{.*}}atom.add.relaxed.sys.u64{{.*}}
+; SM8X: ret;
 
 */

--- a/libcudacxx/test/atomic_codegen/atomic_sub_non_volatile.cu
+++ b/libcudacxx/test/atomic_codegen/atomic_sub_non_volatile.cu
@@ -6,6 +6,24 @@ __global__ void sub_relaxed_device_non_volatile(int* data, int* out, int n)
   *out     = ref.fetch_sub(n, cuda::std::memory_order_relaxed);
 }
 
+__global__ void sub_relaxed_block_pointer_non_volatile(int** data, int** out, int n)
+{
+  auto ref = cuda::atomic_ref<int*, cuda::thread_scope_block>{*data};
+  *out     = ref.fetch_sub(n, cuda::std::memory_order_relaxed);
+}
+
+__global__ void sub_relaxed_device_pointer_non_volatile(int** data, int** out, int n)
+{
+  auto ref = cuda::atomic_ref<int*, cuda::thread_scope_device>{*data};
+  *out     = ref.fetch_sub(n, cuda::std::memory_order_relaxed);
+}
+
+__global__ void sub_relaxed_system_pointer_non_volatile(int** data, int** out, int n)
+{
+  auto ref = cuda::atomic_ref<int*, cuda::thread_scope_system>{*data};
+  *out     = ref.fetch_sub(n, cuda::std::memory_order_relaxed);
+}
+
 /*
 
 ; SM8X-LABEL: .target sm_80
@@ -18,5 +36,17 @@ __global__ void sub_relaxed_device_non_volatile(int* data, int* out, int n)
 ; SM8X-NEXT: {{/*[[:space:]] *}}atom.add.relaxed.gpu.s32 %r[[#DEST:]],[%rd[[#ATOM]]],%r[[#NEG]];{{[[:space:]]/*}}
 ; SM8X-NEXT: st.global.{{b|u}}32 [%rd[[#GOUT]]], %r[[#DEST]];
 ; SM8X-NEXT: ret;
+
+; SM8X-LABEL: .visible .entry {{_.*sub_relaxed_block_pointer_non_volatile.*}}(
+; SM8X: {{.*}}atom.add.relaxed.cta.u64{{.*}}
+; SM8X: ret;
+
+; SM8X-LABEL: .visible .entry {{_.*sub_relaxed_device_pointer_non_volatile.*}}(
+; SM8X: {{.*}}atom.add.relaxed.gpu.u64{{.*}}
+; SM8X: ret;
+
+; SM8X-LABEL: .visible .entry {{_.*sub_relaxed_system_pointer_non_volatile.*}}(
+; SM8X: {{.*}}atom.add.relaxed.sys.u64{{.*}}
+; SM8X: ret;
 
 */


### PR DESCRIPTION
## Description

It seems that we've had pointer arithmetic go through the system scope. This PR fixes that.

Resolves #10808.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
