### PR TITLE
Implement sorted outputs for segmented TopK

### DIFF
--- a/cub/cub/device/device_batched_topk.cuh
+++ b/cub/cub/device/device_batched_topk.cuh
@@ -103,8 +103,9 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
   //   1. determinism and tie_break must be acknowledged together (both specified, or both omitted default)
   //   2. an explicit tie_break of prefer_smaller_index / prefer_larger_index fully pins the result set across GPUs and
   //      therefore requires determinism::gpu_to_gpu (it cannot be paired with run_to_run or not_guaranteed)
-  //   3. `output_ordering::stable_sorted` is not implemented. `sorted` and `unsorted` support the five valid
-  //      (determinism, tie_break) combinations; the empty-env default remains rejected because it is stable-sorted.
+  //   3. `output_ordering::stable_sorted` is not implemented yet. `sorted` and `unsorted` support all five valid
+  //      (determinism, tie_break) combinations. The empty-env default is not yet available because it needs
+  //      `stable_sorted`.
   //
   // Backend routing implied by the request (exact rules in `policy_selector_from_types`, dispatch_batched_topk.cuh):
   // any request beyond fully non-deterministic -- determinism stronger than not_guaranteed (run_to_run/gpu_to_gpu), or
@@ -343,33 +344,36 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
 //!
 //! - **Host-only.** Unlike most CUB algorithms, ``DeviceBatchedTopK`` does not support CUDA dynamic parallelism: its
 //!   methods must be invoked from host code, not from device code.
-//! - **Segment size is architecture-dependent.** On pre-Hopper GPUs (compute capability < 9.0) every segment must be
-//!   processable by a single thread block (one worker per segment): the *statically-known maximum* segment size (the
-//!   upper bound of the ``segment_sizes`` annotation) must be small enough that such a block fits within the
-//!   shared-memory limit. On Hopper and newer GPUs (compute capability >= 9.0) the thread-block-cluster backend also
-//!   handles larger segments that exceed this per-block limit. Both uniform (fixed) and variable segment sizes are
-//!   supported. Independent of the architecture -- and independent of the integer type used for the ``segment_sizes``
-//!   argument (a wider type such as ``int64_t`` does not raise it) -- an individual segment is currently limited to a
-//!   maximum of ``2^21`` (about 2 million) items, enforced at compile time from the statically-known maximum segment
-//!   size. Larger segments are future work. A type whose maximum already lies within it (a narrow type such as
+//! - **Segment size support is architecture-dependent.** On pre-Hopper GPUs (compute capability < 9.0) every
+//!   segment must be processable by a single thread block (one worker per segment): the *statically-known maximum*
+//!   segment size (the upper bound of the ``segment_sizes`` annotation) must be small enough that such a block fits
+//!   within the shared-memory limit. On Hopper and newer GPUs (compute capability >= 9.0) the thread-block-cluster
+//!   backend also handles larger segments that exceed this per-block limit. Both uniform (fixed) and variable segment
+//!   sizes are supported. Independent of the architecture -- and independent of the integer type used for the
+//!   ``segment_sizes`` argument (a wider type such as ``int64_t`` does not raise it) -- an individual segment is
+//!   currently limited to a maximum of ``2^21`` (about 2 million) items, enforced at compile time from the
+//!   statically-known maximum segment size. Larger segments are future work. A type whose maximum already lies within
+//!   it (a narrow type such as
 //!   ``uint8_t``, ``int16_t``, or ``uint16_t``) is accepted un-annotated; a type whose maximum exceeds ``2^21`` (e.g.
 //!   ``int32_t``, ``uint32_t``, or ``int64_t``) must carry a compile-time ``cuda::args::bounds`` whose upper end does
 //!   not exceed ``2^21`` (see *Which form each parameter accepts* above for how the lower bound and out-of-bound values
 //!   are handled).
-//! - **k is at most 64 bits wide.** The element type of ``k`` may be no wider than 64 bits. The device clamps ``k`` to
+//! - **k is at most 64 bits wide.** The element type of ``k`` may be no wider than 64 bits. ``k`` is clamped to
 //!   the segment size through a 64-bit intermediate, so a wider integer type (e.g. ``__int128``) is rejected to avoid a
 //!   silent wrap. ``k`` itself has no algorithm-imposed maximum (see *Which form each parameter accepts* above).
 //! - **Uniform number of segments.** ``num_segments`` must be a single value (``constant``, ``immediate``, or a plain
 //!   integral) resolved on the host, and must not exceed ``2^31 - 1`` (it sizes the launch grid). A negative count is
 //!   treated as no work (an empty batch). A ``deferred`` (device-resident) count is not supported at this time.
-//! - **Sorted output is bounded.** ``cuda::execution::output_ordering::sorted`` is supported, while
-//!   ``stable_sorted`` (and therefore an empty, no-requirement environment) is rejected at compile time. Sorted output
-//!   requires ``min(k bound, segment-size bound)`` to fit one block-wide radix-sort tile and extra temporary storage
-//!   proportional to ``num_segments * min(k bound, segment-size bound)``. A ``k`` of at least 2048 is supported when
-//!   ``max(sizeof(key), sizeof(value)) <= 16``; larger key/value types may need a tighter ``k`` or segment-size bound.
-//!   The supported ``determinism`` / ``tie_break`` requirements depend on the architecture -- see the *Current support*
-//!   note below. ``determinism`` and ``tie_break`` must always be specified together, or both omitted to take the
-//!   default.
+//! - **Stable-sorted output is unsupported.** ``cuda::execution::output_ordering::stable_sorted`` is not
+//!   implemented yet, while
+//!   ``cuda::execution::output_ordering::unsorted`` and ``cuda::execution::output_ordering::sorted`` are supported.
+//! - **Sorted output requires small k.** When requiring ``cuda::execution::output_ordering::sorted``, every segment's
+//!   output must be processable by a single thread block. The *statically-known maximum* output size (the minimum of
+//!   the upper bounds of the ``segment_sizes`` and ``k``annotations) must be small enough that such a block fits within
+//!   the shared-memory limit. Larger key/value types may need a tighter ``k`` or segment-size bound.
+//! - **Determinism and tie-break requirements depend on the architecture.** The supported
+//!   ``determinism`` / ``tie_break`` requirements depend on the architecture -- see the *Current support* note below.
+//!   ``determinism`` and ``tie_break`` must always be specified together, or both omitted to take the default.
 //!
 //! Determinism, tie-breaking, and output ordering
 //! +++++++++++++++++++++++++++++++++++++++++++++++
@@ -391,8 +395,8 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
 //! .. note::
 //!
 //!    **Current support.** ``cuda::execution::output_ordering::unsorted`` and ``sorted`` are implemented.
-//!    ``stable_sorted`` and an empty environment (which requests it by default) are rejected at compile time. Sorted
-//!    output requires a bounded ``min(k bound, segment-size bound)`` and additional temporary storage; see *Current
+//!    ``stable_sorted`` (and an empty environment which requests ``stable_sorted`` by default) are rejected. Sorted
+//!    output requires a statically bounded per-segment output size and additional temporary storage; see *Current
 //!    constraints* above. The supported selection requirements and segment sizes differ by architecture:
 //!
 //!    - **Pre-Hopper (compute capability < 9.0):** only the fully non-deterministic request
@@ -487,11 +491,10 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
-  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
-  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
-  //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
-  //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
+  //!   **[optional]** Execution environment. See the *Current support* note above for the supported requirements and
+  //!   constraints. The default environment is not yet available because it needs `stable_sorted`.
+  //!
+  //!   So this is **not yet optional** in practice.
   //!   @endrst
   template <typename KeyInputIteratorItT,
             typename KeyOutputIteratorItT,
@@ -594,11 +597,10 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
-  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
-  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
-  //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
-  //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
+  //!   **[optional]** Execution environment. See the *Current support* note above for the supported requirements and
+  //!   constraints. The default environment is not yet available because it needs `stable_sorted`.
+  //!
+  //!   So this is **not yet optional** in practice.
   //!   @endrst
   template <typename KeyInputIteratorItT,
             typename KeyOutputIteratorItT,
@@ -704,11 +706,10 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
-  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
-  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
-  //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
-  //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
+  //!   **[optional]** Execution environment. See the *Current support* note above for the supported requirements and
+  //!   constraints. The default environment is not yet available because it needs `stable_sorted`.
+  //!
+  //!   So this is **not yet optional** in practice.
   //!   @endrst
   template <typename KeyInputIteratorItT,
             typename KeyOutputIteratorItT,
@@ -809,11 +810,10 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
-  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
-  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
-  //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
-  //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
+  //!   **[optional]** Execution environment. See the *Current support* note above for the supported requirements and
+  //!   constraints. The default environment is not yet available because it needs `stable_sorted`.
+  //!
+  //!   So this is **not yet optional** in practice.
   //!   @endrst
   template <typename KeyInputIteratorItT,
             typename KeyOutputIteratorItT,
@@ -936,11 +936,10 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
-  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
-  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
-  //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
-  //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
+  //!   **[optional]** Execution environment. See the *Current support* note above for the supported requirements and
+  //!   constraints. The default environment is not yet available because it needs `stable_sorted`.
+  //!
+  //!   So this is **not yet optional** in practice.
   //!   @endrst
   template <typename KeyInputIteratorItT,
             typename KeyOutputIteratorItT,
@@ -1053,11 +1052,10 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
-  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
-  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
-  //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
-  //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
+  //!   **[optional]** Execution environment. See the *Current support* note above for the supported requirements and
+  //!   constraints. The default environment is not yet available because it needs `stable_sorted`.
+  //!
+  //!   So this is **not yet optional** in practice.
   //!   @endrst
   template <typename KeyInputIteratorItT,
             typename KeyOutputIteratorItT,
@@ -1181,11 +1179,10 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
-  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
-  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
-  //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
-  //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
+  //!   **[optional]** Execution environment. See the *Current support* note above for the supported requirements and
+  //!   constraints. The default environment is not yet available because it needs `stable_sorted`.
+  //!
+  //!   So this is **not yet optional** in practice.
   //!   @endrst
   template <typename KeyInputIteratorItT,
             typename KeyOutputIteratorItT,
@@ -1298,11 +1295,10 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
-  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
-  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
-  //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
-  //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
+  //!   **[optional]** Execution environment. See the *Current support* note above for the supported requirements and
+  //!   constraints. The default environment is not yet available because it needs `stable_sorted`.
+  //!
+  //!   So this is **not yet optional** in practice.
   //!   @endrst
   template <typename KeyInputIteratorItT,
             typename KeyOutputIteratorItT,

--- a/cub/cub/device/device_batched_topk.cuh
+++ b/cub/cub/device/device_batched_topk.cuh
@@ -103,10 +103,8 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
   //   1. determinism and tie_break must be acknowledged together (both specified, or both omitted default)
   //   2. an explicit tie_break of prefer_smaller_index / prefer_larger_index fully pins the result set across GPUs and
   //      therefore requires determinism::gpu_to_gpu (it cannot be paired with run_to_run or not_guaranteed)
-  //   3. only `output_ordering::unsorted` is implemented. Given rules 1/2, this admits the five implemented
-  //      (determinism, tie_break) combinations -- (not_guaranteed, unspecified), (run_to_run, unspecified),
-  //      (gpu_to_gpu, {unspecified, prefer_smaller_index, prefer_larger_index}) -- while `sorted` / `stable_sorted`
-  //      (and therefore the empty-env default, which resolves to `stable_sorted`) remain rejected.
+  //   3. `output_ordering::stable_sorted` is not implemented. `sorted` and `unsorted` support the five valid
+  //      (determinism, tie_break) combinations; the empty-env default remains rejected because it is stable-sorted.
   //
   // Backend routing implied by the request (exact rules in `policy_selector_from_types`, dispatch_batched_topk.cuh):
   // any request beyond fully non-deterministic -- determinism stronger than not_guaranteed (run_to_run/gpu_to_gpu), or
@@ -148,8 +146,8 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
   constexpr bool tie_break_compatible_with_determinism =
     ::cuda::std::is_same_v<requested_tie_break_t, ::cuda::execution::tie_break::unspecified_t>
     || ::cuda::std::is_same_v<requested_determinism_t, ::cuda::execution::determinism::gpu_to_gpu_t>;
-  constexpr bool is_unsorted_output =
-    ::cuda::std::is_same_v<requested_order_t, ::cuda::execution::output_ordering::unsorted_t>;
+  constexpr bool is_stable_sorted_output =
+    ::cuda::std::is_same_v<requested_order_t, ::cuda::execution::output_ordering::stable_sorted_t>;
 
   static_assert(determinism_and_tie_break_paired,
                 "cub::DeviceBatchedTopK: determinism and tie_break requirements must be acknowledged together. Either "
@@ -161,11 +159,10 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
                 "prefer_larger_index pins the result set across GPUs and therefore requires "
                 "cuda::execution::determinism::gpu_to_gpu (it cannot be combined with run_to_run or not_guaranteed).");
   static_assert(
-    !determinism_and_tie_break_paired || !tie_break_compatible_with_determinism || is_unsorted_output,
-    "cub::DeviceBatchedTopK currently only implements cuda::execution::output_ordering::unsorted output "
-    "(cuda::execution::output_ordering::sorted and stable_sorted are not yet implemented). Because the default "
-    "output ordering is stable_sorted, an empty (no-requirement) environment is rejected: request unsorted output "
-    "explicitly, e.g. cuda::execution::require(cuda::execution::determinism::not_guaranteed, "
+    !determinism_and_tie_break_paired || !tie_break_compatible_with_determinism || !is_stable_sorted_output,
+    "cub::DeviceBatchedTopK does not yet implement cuda::execution::output_ordering::stable_sorted. Because the "
+    "default output ordering is stable_sorted, an empty (no-requirement) environment is rejected: request sorted or "
+    "unsorted output explicitly, e.g. cuda::execution::require(cuda::execution::determinism::not_guaranteed, "
     "cuda::execution::tie_break::unspecified, cuda::execution::output_ordering::unsorted).");
 
   // ---------------------------------------------------------------------------
@@ -231,7 +228,7 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
     // conservative 64-bit upper bound here.
     constexpr auto total_num_items = ::cuda::args::immediate{::cuda::std::numeric_limits<::cuda::std::int64_t>::max()};
 
-    return batched_topk::dispatch<requested_determinism_t::value, requested_tie_break_t::value>(
+    return batched_topk::dispatch<requested_determinism_t::value, requested_tie_break_t::value, requested_order_t::value>(
       d_temp_storage,
       temp_storage_bytes,
       d_keys_in,
@@ -365,10 +362,12 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
 //! - **Uniform number of segments.** ``num_segments`` must be a single value (``constant``, ``immediate``, or a plain
 //!   integral) resolved on the host, and must not exceed ``2^31 - 1`` (it sizes the launch grid). A negative count is
 //!   treated as no work (an empty batch). A ``deferred`` (device-resident) count is not supported at this time.
-//! - **Unsorted output required.** Only ``cuda::execution::output_ordering::unsorted`` is implemented; the sorted
-//!   orderings of the default contract described in *Determinism, tie-breaking, and output ordering* below (and hence
-//!   an empty, no-requirement environment, which defaults to ``stable_sorted``) are rejected at compile time. The
-//!   supported ``determinism`` / ``tie_break`` requirements depend on the architecture -- see the *Current support*
+//! - **Sorted output is bounded.** ``cuda::execution::output_ordering::sorted`` is supported, while
+//!   ``stable_sorted`` (and therefore an empty, no-requirement environment) is rejected at compile time. Sorted output
+//!   requires ``min(k bound, segment-size bound)`` to fit one block-wide radix-sort tile and extra temporary storage
+//!   proportional to ``num_segments * min(k bound, segment-size bound)``. A ``k`` of at least 2048 is supported when
+//!   ``max(sizeof(key), sizeof(value)) <= 16``; larger key/value types may need a tighter ``k`` or segment-size bound.
+//!   The supported ``determinism`` / ``tie_break`` requirements depend on the architecture -- see the *Current support*
 //!   note below. ``determinism`` and ``tie_break`` must always be specified together, or both omitted to take the
 //!   default.
 //!
@@ -391,10 +390,10 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
 //!
 //! .. note::
 //!
-//!    **Current support.** Only the unsorted output ordering is implemented;
-//!    ``cuda::execution::output_ordering::unsorted`` must be requested explicitly (``sorted`` / ``stable_sorted``, and
-//!    thus an empty, no-requirement environment, are rejected at compile time). The supported selection requirements
-//!    and segment sizes differ by architecture:
+//!    **Current support.** ``cuda::execution::output_ordering::unsorted`` and ``sorted`` are implemented.
+//!    ``stable_sorted`` and an empty environment (which requests it by default) are rejected at compile time. Sorted
+//!    output requires a bounded ``min(k bound, segment-size bound)`` and additional temporary storage; see *Current
+//!    constraints* above. The supported selection requirements and segment sizes differ by architecture:
 //!
 //!    - **Pre-Hopper (compute capability < 9.0):** only the fully non-deterministic request
 //!      ``(determinism::not_guaranteed, tie_break::unspecified)`` is supported, and every segment must fit a single
@@ -488,8 +487,9 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Must require `output_ordering::unsorted` (`sorted` / `stable_sorted`, and
-  //!   thus an empty environment, are not yet supported). The selection requirements may be any acknowledged
+  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
+  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
+  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
   //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
   //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
   //!   @endrst
@@ -594,8 +594,9 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Must require `output_ordering::unsorted` (`sorted` / `stable_sorted`, and
-  //!   thus an empty environment, are not yet supported). The selection requirements may be any acknowledged
+  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
+  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
+  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
   //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
   //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
   //!   @endrst
@@ -703,8 +704,9 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Must require `output_ordering::unsorted` (`sorted` / `stable_sorted`, and
-  //!   thus an empty environment, are not yet supported). The selection requirements may be any acknowledged
+  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
+  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
+  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
   //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
   //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
   //!   @endrst
@@ -807,8 +809,9 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Must require `output_ordering::unsorted` (`sorted` / `stable_sorted`, and
-  //!   thus an empty environment, are not yet supported). The selection requirements may be any acknowledged
+  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
+  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
+  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
   //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
   //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
   //!   @endrst
@@ -933,8 +936,9 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Must require `output_ordering::unsorted` (`sorted` / `stable_sorted`, and
-  //!   thus an empty environment, are not yet supported). The selection requirements may be any acknowledged
+  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
+  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
+  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
   //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
   //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
   //!   @endrst
@@ -1049,8 +1053,9 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Must require `output_ordering::unsorted` (`sorted` / `stable_sorted`, and
-  //!   thus an empty environment, are not yet supported). The selection requirements may be any acknowledged
+  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
+  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
+  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
   //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
   //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
   //!   @endrst
@@ -1176,8 +1181,9 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Must require `output_ordering::unsorted` (`sorted` / `stable_sorted`, and
-  //!   thus an empty environment, are not yet supported). The selection requirements may be any acknowledged
+  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
+  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
+  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
   //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
   //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
   //!   @endrst
@@ -1292,8 +1298,9 @@ struct DeviceBatchedTopK
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Must require `output_ordering::unsorted` (`sorted` / `stable_sorted`, and
-  //!   thus an empty environment, are not yet supported). The selection requirements may be any acknowledged
+  //!   **[optional]** Execution environment. Supports `output_ordering::unsorted` and `sorted`; `stable_sorted` (and
+  //!   thus an empty environment) is not yet supported. Sorted output needs a bounded `min(k bound, segment-size
+  //!   bound)` and additional temporary storage. The selection requirements may be any acknowledged
   //!   `(determinism, tie_break)` pair: `(not_guaranteed, unspecified)`, `(run_to_run, unspecified)`, or `gpu_to_gpu`
   //!   with `unspecified` / `prefer_smaller_index` / `prefer_larger_index`. Deterministic requests require SM 9.0+.
   //!   @endrst

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -22,6 +22,7 @@
 #include <cub/detail/choose_offset.cuh>
 #include <cub/detail/launcher/cuda_runtime.cuh>
 #include <cub/detail/segmented_params.cuh>
+#include <cub/detail/temporary_storage.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/device/dispatch/dispatch_scan.cuh>
 #include <cub/device/dispatch/kernels/kernel_batched_topk.cuh>
@@ -37,8 +38,10 @@
 #include <cuda/__cmath/ceil_div.h>
 #include <cuda/__cmath/round_up.h>
 #include <cuda/__execution/determinism.h>
+#include <cuda/__execution/output_ordering.h>
 #include <cuda/__execution/tie_break.h>
 #include <cuda/__iterator/counting_iterator.h>
+#include <cuda/__iterator/strided_iterator.h>
 #include <cuda/__iterator/transform_iterator.h>
 #include <cuda/__numeric/narrow.h>
 #include <cuda/argument>
@@ -929,7 +932,7 @@ template <
   typename TotalNumItemsGuaranteeT,
   typename TuningEnvT            = ::cuda::std::execution::env<>,
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-_CCCL_HOST_API cudaError_t dispatch(
+_CCCL_HOST_API cudaError_t dispatch_select(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
   KeyInputItItT d_key_segments_it,
@@ -1182,6 +1185,238 @@ _CCCL_HOST_API cudaError_t dispatch(
       return cudaErrorNotSupported;
     }
   });
+}
+
+template <typename KBoundT, typename SegmentSizeBoundT>
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr ::cuda::std::int64_t
+max_output_bound(KBoundT k_bound, SegmentSizeBoundT segment_size_bound)
+{
+  const ::cuda::std::int64_t min_bound =
+    ::cuda::std::cmp_less(+k_bound, +segment_size_bound)
+      ? static_cast<::cuda::std::int64_t>(k_bound)
+      : static_cast<::cuda::std::int64_t>(segment_size_bound);
+  return min_bound > 0 ? min_bound : 0;
+}
+
+template <
+  ::cuda::execution::determinism::__determinism_t Determinism =
+    ::cuda::execution::determinism::__determinism_t::__not_guaranteed,
+  ::cuda::execution::tie_break::__tie_break_t TieBreak = ::cuda::execution::tie_break::__tie_break_t::__unspecified,
+  ::cuda::execution::output_ordering::__output_ordering_t OutputOrdering =
+    ::cuda::execution::output_ordering::__output_ordering_t::__unsorted,
+  class KeyInputItItT,
+  class KeyOutputItItT,
+  class ValueInputItItT,
+  class ValueOutputItItT,
+  class SegmentSizeParameterT,
+  class KParameterT,
+  class SelectDirectionT,
+  class NumSegmentsParameterT,
+  class TotalNumItemsGuaranteeT,
+  class TuningEnvT            = ::cuda::std::execution::env<>,
+  class KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
+_CCCL_HOST_API cudaError_t dispatch(
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  KeyInputItItT d_key_segments_it,
+  KeyOutputItItT d_key_segments_out_it,
+  ValueInputItItT d_value_segments_it,
+  ValueOutputItItT d_value_segments_out_it,
+  SegmentSizeParameterT segment_sizes,
+  KParameterT k,
+  SelectDirectionT select_direction,
+  NumSegmentsParameterT num_segments,
+  TotalNumItemsGuaranteeT total_num_items_guarantee,
+  cudaStream_t stream,
+  const TuningEnvT& tuning_env           = {},
+  KernelLauncherFactory launcher_factory = {})
+{
+  constexpr ::cuda::std::int64_t static_max_out = max_output_bound(
+    ::cuda::args::__traits<KParameterT>::highest, ::cuda::args::__traits<SegmentSizeParameterT>::highest);
+
+  if constexpr (OutputOrdering == ::cuda::execution::output_ordering::__output_ordering_t::__unsorted
+                || static_max_out <= 1)
+  {
+    return dispatch_select<Determinism, TieBreak>(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_key_segments_it,
+      d_key_segments_out_it,
+      d_value_segments_it,
+      d_value_segments_out_it,
+      segment_sizes,
+      k,
+      select_direction,
+      num_segments,
+      total_num_items_guarantee,
+      stream,
+      tuning_env,
+      launcher_factory);
+  }
+  else
+  {
+    using key_t                   = it_value_t<it_value_t<KeyInputItItT>>;
+    using value_t                 = it_value_t<it_value_t<ValueInputItItT>>;
+    using num_segments_value_t    = typename ::cuda::args::__traits<NumSegmentsParameterT>::element_type;
+    constexpr bool is_keys_only   = ::cuda::std::is_same_v<value_t, NullType>;
+    constexpr bool sort_can_cover = sort_can_cover_v<key_t, value_t, static_max_out>;
+
+#if _CCCL_CUDA_COMPILATION() && !defined(CUB_DEFINE_RUNTIME_POLICIES) && !_CCCL_COMPILER(NVRTC) \
+  && !defined(CUB_DISABLE_TOPK_UNSUPPORTED_ARCH_ASSERT)
+    static_assert(
+      sort_can_cover,
+      "cub::DeviceBatchedTopK: sorted output cannot cover the statically-known maximum output size within the "
+      "shared-memory limit. Give k a tighter cuda::args::bounds or cuda::args::constant, tighten the segment-size "
+      "bound, or use narrower key/value types.");
+#endif // strict sorted-output coverage check
+
+    if constexpr (!sort_can_cover)
+    {
+      if (d_temp_storage == nullptr)
+      {
+        temp_storage_bytes = 1;
+        return cudaSuccess;
+      }
+      return cudaErrorNotSupported;
+    }
+    else
+    {
+      const num_segments_value_t num_segments_value = detail::params::get_param(num_segments, num_segments_value_t{0});
+      const ::cuda::std::int64_t max_out =
+        max_output_bound(::cuda::args::__highest_(k), ::cuda::args::__highest_(segment_sizes));
+
+      if (::cuda::std::cmp_greater(+num_segments_value, ::cuda::std::numeric_limits<int>::max())
+          || !::cuda::std::cmp_greater(+num_segments_value, 0) || max_out <= 0)
+      {
+        return dispatch_select<Determinism, TieBreak>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_key_segments_it,
+          d_key_segments_out_it,
+          d_value_segments_it,
+          d_value_segments_out_it,
+          segment_sizes,
+          k,
+          select_direction,
+          num_segments,
+          total_num_items_guarantee,
+          stream,
+          tuning_env,
+          launcher_factory);
+      }
+
+      const size_t num_segments_size = static_cast<size_t>(num_segments_value);
+      const size_t max_out_size      = static_cast<size_t>(max_out);
+      if (num_segments_size > ::cuda::std::numeric_limits<size_t>::max() / max_out_size)
+      {
+        return cudaErrorInvalidValue;
+      }
+
+      const size_t scratch_elements = num_segments_size * max_out_size;
+      if (scratch_elements > ::cuda::std::numeric_limits<size_t>::max() / sizeof(key_t)
+          || (!is_keys_only && scratch_elements > ::cuda::std::numeric_limits<size_t>::max() / sizeof(value_t)))
+      {
+        return cudaErrorInvalidValue;
+      }
+
+      temporary_storage::layout<3> temporary_storage_layout;
+      auto selection_storage = temporary_storage_layout.get_slot(0)->create_alias<::cuda::std::uint8_t>();
+      auto key_scratch       = temporary_storage_layout.get_slot(1)->create_alias<key_t>(scratch_elements);
+      auto value_scratch =
+        temporary_storage_layout.get_slot(2)->create_alias<value_t>(is_keys_only ? 0 : scratch_elements);
+
+      const auto query_key_segments_out_it =
+        ::cuda::make_strided_iterator(::cuda::make_counting_iterator(static_cast<key_t*>(nullptr)), max_out);
+      const auto query_value_segments_out_it =
+        ::cuda::make_strided_iterator(::cuda::make_counting_iterator(static_cast<value_t*>(nullptr)), max_out);
+
+      size_t selection_storage_bytes = 0;
+      if (const auto error = dispatch_select<Determinism, TieBreak>(
+            nullptr,
+            selection_storage_bytes,
+            d_key_segments_it,
+            query_key_segments_out_it,
+            d_value_segments_it,
+            query_value_segments_out_it,
+            segment_sizes,
+            k,
+            select_direction,
+            num_segments,
+            total_num_items_guarantee,
+            stream,
+            tuning_env,
+            launcher_factory))
+      {
+        return error;
+      }
+      selection_storage.grow(selection_storage_bytes);
+
+      if (d_temp_storage == nullptr)
+      {
+        temp_storage_bytes = temporary_storage_layout.get_size();
+        return cudaSuccess;
+      }
+
+      if (const auto error = temporary_storage_layout.map_to_buffer(d_temp_storage, temp_storage_bytes))
+      {
+        return error;
+      }
+
+      const auto launch_key_segments_out_it =
+        ::cuda::make_strided_iterator(::cuda::make_counting_iterator(key_scratch.get()), max_out);
+      const auto launch_value_segments_out_it =
+        ::cuda::make_strided_iterator(::cuda::make_counting_iterator(value_scratch.get()), max_out);
+
+      if (const auto error = dispatch_select<Determinism, TieBreak>(
+            selection_storage.get(),
+            selection_storage_bytes,
+            d_key_segments_it,
+            launch_key_segments_out_it,
+            d_value_segments_it,
+            launch_value_segments_out_it,
+            segment_sizes,
+            k,
+            select_direction,
+            num_segments,
+            total_num_items_guarantee,
+            stream,
+            tuning_env,
+            launcher_factory))
+      {
+        return error;
+      }
+
+      constexpr sort_policy sort = find_smallest_sort_policy<key_t, value_t, static_max_out>::policy;
+      const int grid_dim         = static_cast<int>(num_segments_value);
+      if (const auto error = CubDebug(
+            launcher_factory(grid_dim, sort.threads_per_block, 0, stream, /*dependent_launch=*/false)
+              .doit(device_batched_topk_sort_kernel<
+                      sort.threads_per_block,
+                      sort.items_per_thread,
+                      key_t,
+                      value_t,
+                      KeyOutputItItT,
+                      ValueOutputItItT,
+                      SegmentSizeParameterT,
+                      KParameterT,
+                      const decltype(wrap_select_direction(::cuda::std::declval<SelectDirectionT>())),
+                      NumSegmentsParameterT>,
+                    key_scratch.get(),
+                    value_scratch.get(),
+                    d_key_segments_out_it,
+                    d_value_segments_out_it,
+                    segment_sizes,
+                    k,
+                    wrap_select_direction(select_direction),
+                    num_segments,
+                    max_out)))
+      {
+        return error;
+      }
+
+      return CubDebug(detail::DebugSyncStream(stream));
+    }
+  }
 }
 } // namespace detail::batched_topk
 

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -625,6 +625,9 @@ _CCCL_HOST_API cudaError_t launch_cluster_arm(
   // `cluster_blocks` is far below the y-dimension limit). The device reads the segment id from clusterid.x (segments
   // stay the x-extent) and the CTA rank from cluster_ctarank (linearized across the cluster's dims), so this needs no
   // agent change.
+  _CCCL_ASSERT(::cuda::std::cmp_greater_equal(+num_seg_val, 0)
+                 && ::cuda::std::cmp_less_equal(+num_seg_val, ::cuda::std::numeric_limits<int>::max()),
+               "num_segments must be non-negative and fit a signed 32-bit grid dimension");
   const dim3 grid_dim{static_cast<unsigned>(num_seg_val), static_cast<unsigned>(cluster_blocks), 1u};
   const dim3 cluster_dim{1u, static_cast<unsigned>(cluster_blocks), 1u};
 
@@ -762,6 +765,7 @@ _CCCL_HOST_API cudaError_t launch_baseline_arm(
     using num_segments_val_t         = typename ::cuda::args::__traits<NumSegmentsParameterT>::element_type;
     using counters_t                 = batched_topk_counters<num_segments_val_t>;
     using segment_size_scan_offset_t = detail::choose_offset_t<num_segments_val_t>;
+    const auto num_segments_val      = params::get_param(num_segments, num_segments_val_t{0});
     using segment_size_scan_input_op_t =
       segment_size_to_tile_count_op<SegmentSizeParameterT, large_segment_tile_offset_t>;
     static constexpr auto multi_worker_per_segment_tile_size =
@@ -773,7 +777,6 @@ _CCCL_HOST_API cudaError_t launch_baseline_arm(
 
     if constexpr (!only_small_segments)
     {
-      const auto num_segments_val = params::get_param(num_segments, 0);
       // TODO(topk): the baseline large-segment (multi-CTA) path is WIP. Completing it requires: (1) guarding the
       // `num_segments_val * sizeof(...)` byte counts below against size_t overflow (safe today only because the entry
       // bounds num_segments_val to <= INT_MAX); (2) making the baseline tunable by populating its `epilogue` and
@@ -788,6 +791,10 @@ _CCCL_HOST_API cudaError_t launch_baseline_arm(
       else
       {
         // Query the temporary storage requirement of the segment-size transform-scan.
+        _CCCL_ASSERT(::cuda::std::cmp_greater_equal(+num_segments_val, 0)
+                       && ::cuda::std::cmp_less_equal(
+                         +num_segments_val, ::cuda::std::numeric_limits<segment_size_scan_offset_t>::max()),
+                     "num_segments must be non-negative and fit the segment-size scan offset type");
         if (const auto error = CubDebug(detail::scan::dispatch(
               nullptr,
               allocation_sizes[1],
@@ -831,7 +838,10 @@ _CCCL_HOST_API cudaError_t launch_baseline_arm(
           return error;
         }
       }
-      const int grid_dim      = static_cast<int>(params::get_param(num_segments, 0));
+      _CCCL_ASSERT(::cuda::std::cmp_greater_equal(+num_segments_val, 0)
+                     && ::cuda::std::cmp_less_equal(+num_segments_val, ::cuda::std::numeric_limits<int>::max()),
+                   "num_segments must be non-negative and fit a signed 32-bit grid dimension");
+      const int grid_dim      = static_cast<int>(num_segments_val);
       constexpr int block_dim = worker_per_segment_policy.threads_per_block;
       if (const auto error = CubDebug(
             launcher_factory(grid_dim, block_dim, 0, stream, /*dependent_launch=*/false)
@@ -869,6 +879,10 @@ _CCCL_HOST_API cudaError_t launch_baseline_arm(
     else
     {
       // No small segments: compute the per-segment tile offsets directly via a transform-scan over all segment sizes.
+      _CCCL_ASSERT(::cuda::std::cmp_greater_equal(+num_segments_val, 0)
+                     && ::cuda::std::cmp_less_equal(
+                       +num_segments_val, ::cuda::std::numeric_limits<segment_size_scan_offset_t>::max()),
+                   "num_segments must be non-negative and fit the segment-size scan offset type");
       if (const auto error = CubDebug(detail::scan::dispatch(
             allocations[1],
             allocation_sizes[1],
@@ -876,7 +890,7 @@ _CCCL_HOST_API cudaError_t launch_baseline_arm(
             static_cast<large_segment_tile_offset_t*>(allocations[0]),
             ::cuda::std::plus<>{},
             detail::InputValue<large_segment_tile_offset_t>(large_segment_tile_offset_t{0}),
-            static_cast<segment_size_scan_offset_t>(params::get_param(num_segments, 0)),
+            static_cast<segment_size_scan_offset_t>(num_segments_val),
             stream,
             {},
             {},
@@ -948,14 +962,6 @@ _CCCL_HOST_API cudaError_t dispatch_select(
   const TuningEnvT&                      = {},
   KernelLauncherFactory launcher_factory = {})
 {
-  // Both arms resolve `num_segments` on the host (allocation sizing, grid extent, empty-batch guard), so it must be a
-  // host-known single value; device-resident counts are future work. Defensive: the public entry checks this too, but
-  // `dispatch` is also called directly (tests / benchmarks).
-  static_assert(::cuda::args::__traits<NumSegmentsParameterT>::is_single_value
-                  && !::cuda::args::__traits<NumSegmentsParameterT>::is_deferred,
-                "cub::DeviceBatchedTopK requires a host-known uniform number of segments (constant, immediate, or a "
-                "plain integral value).");
-
   // The selection direction is a compile-time constant carried as `::cuda::args::constant<Dir>`. Wrap it into the
   // internal discrete param the kernel/agent expect (both host arms take the wrapped form).
   // Type derived from the parameter type rather than `decltype(select_directions)`: GCC 7 rejects the latter ("use of
@@ -1033,37 +1039,9 @@ _CCCL_HOST_API cudaError_t dispatch_select(
     return error;
   }
 
-  // `num_segments` maps to the grid's x-extent in both host launch arms (the baseline arm launches one block per
-  // segment; the cluster arm launches one cluster per segment, stacking the cluster's CTAs in the grid's y-dimension),
-  // so it must fit a positive 32-bit grid dimension. A count above INT_MAX cannot, so reject it as an out-of-contract
-  // value at this single host boundary: otherwise the baseline arm would silently narrow it to `int` and the cluster
-  // arm would build an out-of-range grid.x.
-  using num_segments_val_t                  = typename ::cuda::args::__traits<NumSegmentsParameterT>::element_type;
-  const num_segments_val_t num_segments_val = detail::params::get_param(num_segments, num_segments_val_t{0});
-  // Unary `+` integer-promotes the count to a standard integer type so the sign-safe `cmp_*` comparators accept it:
-  // they are constrained to `__cccl_is_integer_v`, which excludes the character count types the public API permits.
-  if (::cuda::std::cmp_greater(+num_segments_val, ::cuda::std::numeric_limits<int>::max()))
-  {
-    return cudaErrorInvalidValue;
-  }
-  // A negative count is no work (like a zero count), matching DeviceSegmentedReduce. Short-circuit here, before
-  // `dispatch_compute_cap`, so the query pass cannot fall into the baseline arm where `num_segments_val * sizeof(...)`
-  // would cast the negative count to a huge `size_t`. (Zero is handled by `empty_batch_no_launch` below, which keeps
-  // the arch-gated no-op semantics.) TODO(topk): file an issue to unify the negative-`num_segments` contract across
-  // CUB device algorithms.
-  if (::cuda::std::cmp_less(+num_segments_val, 0))
-  {
-    if (d_temp_storage == nullptr)
-    {
-      temp_storage_bytes = 1;
-    }
-    return cudaSuccess;
-  }
-
-  // Empty batch = no work to launch: no segments, or a non-positive tightest max segment size (every segment empty,
-  // e.g. a uniform negative size clamped to 0). `== 0` suffices for `num_segments`: a negative count is already
-  // short-circuited as no work above. Consulted only on the launch (`d_temp_storage != nullptr`) of a *supported* arm
-  // below: the query pass falls through to size `temp_storage_bytes`, and the unsupported arm ignores it so an
+  // Empty batch = no work: zero segments or a non-positive tightest max segment size.
+  // Consulted only on the launch (`d_temp_storage != nullptr`) of a *supported* arm below: the query pass falls
+  // through to size `temp_storage_bytes`, and the unsupported arm ignores it so an
   // unavailable request still fails with cudaErrorNotSupported rather than being masked into success.
   const auto empty_batch_no_launch = [&] {
     return d_temp_storage != nullptr
@@ -1231,8 +1209,32 @@ _CCCL_HOST_API cudaError_t dispatch(
   const TuningEnvT& tuning_env           = {},
   KernelLauncherFactory launcher_factory = {})
 {
+  // Both selection arms and the sort grid resolve `num_segments` on the host.
+  static_assert(::cuda::args::__traits<NumSegmentsParameterT>::is_single_value
+                  && !::cuda::args::__traits<NumSegmentsParameterT>::is_deferred,
+                "cub::DeviceBatchedTopK requires a host-known uniform number of segments (constant, immediate, or a "
+                "plain integral value).");
+
   constexpr ::cuda::std::int64_t static_max_out = max_output_bound(
     ::cuda::args::__traits<KParameterT>::highest, ::cuda::args::__traits<SegmentSizeParameterT>::highest);
+
+  // Both the selection and sort grids use one x-dimension entry per segment.
+  using num_segments_value_t                    = typename ::cuda::args::__traits<NumSegmentsParameterT>::element_type;
+  const num_segments_value_t num_segments_value = detail::params::get_param(num_segments, num_segments_value_t{0});
+  // Unary `+` integer-promotes the count to a standard integer type so the sign-safe `cmp_*` comparators accept it:
+  // they are constrained to `__cccl_is_integer_v`, which excludes the character count types the public API permits.
+  if (::cuda::std::cmp_greater(+num_segments_value, ::cuda::std::numeric_limits<int>::max()))
+  {
+    return cudaErrorInvalidValue;
+  }
+  if (::cuda::std::cmp_less(+num_segments_value, 0))
+  {
+    if (d_temp_storage == nullptr)
+    {
+      temp_storage_bytes = 1;
+    }
+    return cudaSuccess;
+  }
 
   if constexpr (OutputOrdering == ::cuda::execution::output_ordering::__output_ordering_t::__unsorted
                 || static_max_out <= 1)
@@ -1257,17 +1259,15 @@ _CCCL_HOST_API cudaError_t dispatch(
   {
     using key_t                   = it_value_t<it_value_t<KeyInputItItT>>;
     using value_t                 = it_value_t<it_value_t<ValueInputItItT>>;
-    using num_segments_value_t    = typename ::cuda::args::__traits<NumSegmentsParameterT>::element_type;
     constexpr bool is_keys_only   = ::cuda::std::is_same_v<value_t, NullType>;
     constexpr bool sort_can_cover = sort_can_cover_v<key_t, value_t, static_max_out>;
 
-#if _CCCL_CUDA_COMPILATION() && !defined(CUB_DEFINE_RUNTIME_POLICIES) && !_CCCL_COMPILER(NVRTC) \
-  && !defined(CUB_DISABLE_TOPK_UNSUPPORTED_ARCH_ASSERT)
+#if !defined(CUB_DEFINE_RUNTIME_POLICIES) && !_CCCL_COMPILER(NVRTC)
     static_assert(
       sort_can_cover,
       "cub::DeviceBatchedTopK: sorted output cannot cover the statically-known maximum output size within the "
-      "shared-memory limit. Give k a tighter cuda::args::bounds or cuda::args::constant, tighten the segment-size "
-      "bound, or use narrower key/value types.");
+      "shared-memory limit. Give k a tighter cuda::args::bounds or cuda::args::constant, or use narrower key/value "
+      "types.");
 #endif // strict sorted-output coverage check
 
     if constexpr (!sort_can_cover)
@@ -1281,42 +1281,27 @@ _CCCL_HOST_API cudaError_t dispatch(
     }
     else
     {
-      const num_segments_value_t num_segments_value = detail::params::get_param(num_segments, num_segments_value_t{0});
       const ::cuda::std::int64_t max_out =
         max_output_bound(::cuda::args::__highest_(k), ::cuda::args::__highest_(segment_sizes));
 
-      if (::cuda::std::cmp_greater(+num_segments_value, ::cuda::std::numeric_limits<int>::max())
-          || !::cuda::std::cmp_greater(+num_segments_value, 0) || max_out <= 0)
-      {
-        return dispatch_select<Determinism, TieBreak>(
-          d_temp_storage,
-          temp_storage_bytes,
-          d_key_segments_it,
-          d_key_segments_out_it,
-          d_value_segments_it,
-          d_value_segments_out_it,
-          segment_sizes,
-          k,
-          select_direction,
-          num_segments,
-          total_num_items_guarantee,
-          stream,
-          tuning_env,
-          launcher_factory);
-      }
+      const bool has_sort_work = ::cuda::std::cmp_greater(+num_segments_value, 0) && max_out > 0;
 
-      const size_t num_segments_size = static_cast<size_t>(num_segments_value);
-      const size_t max_out_size      = static_cast<size_t>(max_out);
-      if (num_segments_size > ::cuda::std::numeric_limits<size_t>::max() / max_out_size)
+      size_t scratch_elements = 0;
+      if (has_sort_work)
       {
-        return cudaErrorInvalidValue;
-      }
+        const size_t num_segments_size = static_cast<size_t>(num_segments_value);
+        const size_t max_out_size      = static_cast<size_t>(max_out);
+        if (num_segments_size > ::cuda::std::numeric_limits<size_t>::max() / max_out_size)
+        {
+          return cudaErrorInvalidValue;
+        }
 
-      const size_t scratch_elements = num_segments_size * max_out_size;
-      if (scratch_elements > ::cuda::std::numeric_limits<size_t>::max() / sizeof(key_t)
-          || (!is_keys_only && scratch_elements > ::cuda::std::numeric_limits<size_t>::max() / sizeof(value_t)))
-      {
-        return cudaErrorInvalidValue;
+        scratch_elements = num_segments_size * max_out_size;
+        if (scratch_elements > ::cuda::std::numeric_limits<size_t>::max() / sizeof(key_t)
+            || (!is_keys_only && scratch_elements > ::cuda::std::numeric_limits<size_t>::max() / sizeof(value_t)))
+        {
+          return cudaErrorInvalidValue;
+        }
       }
 
       temporary_storage::layout<3> temporary_storage_layout;
@@ -1325,9 +1310,10 @@ _CCCL_HOST_API cudaError_t dispatch(
       auto value_scratch =
         temporary_storage_layout.get_slot(2)->create_alias<value_t>(is_keys_only ? 0 : scratch_elements);
 
-      const auto query_key_segments_out_it =
+      // Null placeholders are used only to query the selection temporary-storage requirement.
+      const auto dummy_key_segments_out_it =
         ::cuda::make_strided_iterator(::cuda::make_counting_iterator(static_cast<key_t*>(nullptr)), max_out);
-      const auto query_value_segments_out_it =
+      const auto dummy_value_segments_out_it =
         ::cuda::make_strided_iterator(::cuda::make_counting_iterator(static_cast<value_t*>(nullptr)), max_out);
 
       size_t selection_storage_bytes = 0;
@@ -1335,9 +1321,9 @@ _CCCL_HOST_API cudaError_t dispatch(
             nullptr,
             selection_storage_bytes,
             d_key_segments_it,
-            query_key_segments_out_it,
+            dummy_key_segments_out_it,
             d_value_segments_it,
-            query_value_segments_out_it,
+            dummy_value_segments_out_it,
             segment_sizes,
             k,
             select_direction,
@@ -1362,18 +1348,18 @@ _CCCL_HOST_API cudaError_t dispatch(
         return error;
       }
 
-      const auto launch_key_segments_out_it =
+      const auto scratch_key_segments_out_it =
         ::cuda::make_strided_iterator(::cuda::make_counting_iterator(key_scratch.get()), max_out);
-      const auto launch_value_segments_out_it =
+      const auto scratch_value_segments_out_it =
         ::cuda::make_strided_iterator(::cuda::make_counting_iterator(value_scratch.get()), max_out);
 
       if (const auto error = dispatch_select<Determinism, TieBreak>(
             selection_storage.get(),
             selection_storage_bytes,
             d_key_segments_it,
-            launch_key_segments_out_it,
+            scratch_key_segments_out_it,
             d_value_segments_it,
-            launch_value_segments_out_it,
+            scratch_value_segments_out_it,
             segment_sizes,
             k,
             select_direction,
@@ -1386,8 +1372,16 @@ _CCCL_HOST_API cudaError_t dispatch(
         return error;
       }
 
+      if (!has_sort_work)
+      {
+        return cudaSuccess;
+      }
+
       constexpr sort_policy sort = find_smallest_sort_policy<key_t, value_t, static_max_out>::policy;
-      const int grid_dim         = static_cast<int>(num_segments_value);
+      _CCCL_ASSERT(::cuda::std::cmp_greater(+num_segments_value, 0)
+                     && ::cuda::std::cmp_less_equal(+num_segments_value, ::cuda::std::numeric_limits<int>::max()),
+                   "num_segments must be positive and fit a signed 32-bit grid dimension");
+      const int grid_dim = static_cast<int>(num_segments_value);
       if (const auto error = CubDebug(
             launcher_factory(grid_dim, sort.threads_per_block, 0, stream, /*dependent_launch=*/false)
               .doit(device_batched_topk_sort_kernel<

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -18,6 +18,8 @@
 
 #include <cub/agent/agent_batched_topk.cuh>
 #include <cub/agent/agent_batched_topk_cluster.cuh>
+#include <cub/block/block_load.cuh>
+#include <cub/block/block_radix_sort.cuh>
 #include <cub/device/dispatch/tuning/tuning_batched_topk.cuh>
 #include <cub/util_arch.cuh>
 #include <cub/util_device.cuh>
@@ -27,6 +29,8 @@
 #include <cuda/__execution/determinism.h>
 #include <cuda/__execution/tie_break.h>
 #include <cuda/argument>
+#include <cuda/std/__algorithm/min.h>
+#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cstdint>
 
 #include <nv/target>
@@ -35,6 +39,97 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
 {
+template <typename KeyT, typename ValueT, int ThreadsPerBlock, int ItemsPerThread>
+union sort_temp_storage
+{
+  typename BlockLoad<KeyT, ThreadsPerBlock, ItemsPerThread, BLOCK_LOAD_WARP_TRANSPOSE>::TempStorage load_keys;
+  typename BlockLoad<ValueT, ThreadsPerBlock, ItemsPerThread, BLOCK_LOAD_WARP_TRANSPOSE>::TempStorage load_values;
+  typename BlockRadixSort<KeyT, ThreadsPerBlock, ItemsPerThread, ValueT>::TempStorage sort;
+};
+
+template <typename KeyT, typename ValueT, ::cuda::std::int64_t StaticMaxOut>
+struct find_sort_policy_index
+{
+private:
+  template <int Index>
+  [[nodiscard]] static constexpr int find_index()
+  {
+    if constexpr (Index >= sorted_output_policy_count)
+    {
+      return -1;
+    }
+    else
+    {
+      constexpr sort_policy candidate = sorted_output_policies[Index];
+      constexpr ::cuda::std::int64_t tile_size =
+        ::cuda::std::int64_t{candidate.threads_per_block} * candidate.items_per_thread;
+      static_assert(tile_size <= 65535, "BlockRadixSort supports at most 65535 items per block.");
+      constexpr bool covers = tile_size >= StaticMaxOut;
+      constexpr bool fits_smem =
+        sizeof(sort_temp_storage<KeyT, ValueT, candidate.threads_per_block, candidate.items_per_thread>)
+        <= max_smem_per_block;
+      constexpr int next = find_index<Index + 1>();
+
+      if constexpr (covers && fits_smem)
+      {
+        return next >= 0 ? next : Index;
+      }
+      else
+      {
+        return next;
+      }
+    }
+  }
+
+public:
+  static constexpr int value = find_index<0>();
+};
+
+template <typename KeyT, typename ValueT, ::cuda::std::int64_t StaticMaxOut>
+inline constexpr bool sort_can_cover_v = find_sort_policy_index<KeyT, ValueT, StaticMaxOut>::value >= 0;
+
+template <typename KeyT, typename ValueT, ::cuda::std::int64_t StaticMaxOut>
+struct find_smallest_sort_policy
+{
+  static constexpr int index = find_sort_policy_index<KeyT, ValueT, StaticMaxOut>::value;
+  static_assert(index >= 0,
+                "cub::DeviceBatchedTopK: no sorted-output policy covers the statically-known maximum output size "
+                "within the shared-memory limit.");
+  static constexpr sort_policy policy = sorted_output_policies[index];
+};
+
+template <typename KeyT, typename ValueT, int Index = 0>
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr ::cuda::std::int64_t sort_covered_max()
+{
+  if constexpr (Index >= sorted_output_policy_count)
+  {
+    return 0;
+  }
+  else
+  {
+    constexpr sort_policy candidate = sorted_output_policies[Index];
+    constexpr ::cuda::std::int64_t tile_size =
+      ::cuda::std::int64_t{candidate.threads_per_block} * candidate.items_per_thread;
+    constexpr bool fits_smem =
+      sizeof(sort_temp_storage<KeyT, ValueT, candidate.threads_per_block, candidate.items_per_thread>)
+      <= max_smem_per_block;
+    constexpr ::cuda::std::int64_t next = sort_covered_max<KeyT, ValueT, Index + 1>();
+    return fits_smem && tile_size > next ? tile_size : next;
+  }
+}
+
+struct sixteen_byte_value
+{
+  ::cuda::std::int64_t first;
+  ::cuda::std::int64_t second;
+};
+
+static_assert(sort_covered_max<::cuda::std::int32_t, ::cuda::std::int32_t>() >= 2048);
+static_assert(sort_covered_max<::cuda::std::int64_t, ::cuda::std::int32_t>() >= 2048);
+static_assert(sort_covered_max<::cuda::std::int64_t, ::cuda::std::int64_t>() >= 2048);
+static_assert(sort_covered_max<float, ::cuda::std::int32_t>() >= 2048);
+static_assert(sort_covered_max<::cuda::std::int64_t, sixteen_byte_value>() >= 2048);
+
 // Assert-free search shared by `find_smallest_covering_policy_device` and the backend coverage predicate. Returns the
 // index of the smallest worker policy whose tile size still covers the upper bound on segment size AND whose
 // instantiated agent's shared memory usage fits within the static shared memory limit (max_smem_per_block), or -1 if
@@ -416,6 +511,96 @@ device_batched_topk_kernel(
     // runs.
     return;
   }
+}
+
+template <int ThreadsPerBlock,
+          int ItemsPerThread,
+          typename KeyT,
+          typename ValueT,
+          typename KeyOutputItItT,
+          typename ValueOutputItItT,
+          typename SegmentSizeParameterT,
+          typename KParameterT,
+          typename SelectDirectionParameterT,
+          typename NumSegmentsParameterT>
+_CCCL_LAUNCH_BOUNDS(ThreadsPerBlock) _CCCL_KERNEL_ATTRIBUTES void device_batched_topk_sort_kernel(
+  const KeyT* d_key_scratch,
+  const ValueT* d_value_scratch,
+  KeyOutputItItT d_key_segments_out_it,
+  ValueOutputItItT d_value_segments_out_it,
+  SegmentSizeParameterT segment_sizes,
+  KParameterT k_param,
+  SelectDirectionParameterT select_directions,
+  NumSegmentsParameterT num_segments,
+  ::cuda::std::int64_t max_out)
+{
+  constexpr bool is_keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
+  using block_radix_sort_t    = BlockRadixSort<KeyT, ThreadsPerBlock, ItemsPerThread, ValueT>;
+  using block_load_keys_t     = BlockLoad<KeyT, ThreadsPerBlock, ItemsPerThread, BLOCK_LOAD_WARP_TRANSPOSE>;
+  using block_load_values_t   = BlockLoad<ValueT, ThreadsPerBlock, ItemsPerThread, BLOCK_LOAD_WARP_TRANSPOSE>;
+  using traits                = detail::radix::traits_t<KeyT>;
+  using bit_ordered_type      = typename traits::bit_ordered_type;
+
+  const int segment_id = static_cast<int>(blockIdx.x);
+  if (segment_id >= params::get_param(num_segments, 0))
+  {
+    return;
+  }
+
+  const auto segment_size = params::__get_and_clamp_param_to_nonnegative(segment_sizes, segment_id);
+  const auto k_eff        = static_cast<decltype(segment_size)>(
+    (::cuda::std::min) (static_cast<::cuda::std::uint64_t>(
+                          params::__get_and_clamp_param_to_nonnegative(k_param, segment_id)),
+                        static_cast<::cuda::std::uint64_t>(segment_size)));
+  if (k_eff == 0)
+  {
+    return;
+  }
+
+  const int valid_items     = static_cast<int>(k_eff);
+  const auto scratch_offset = static_cast<::cuda::std::int64_t>(segment_id) * max_out;
+  const KeyT* const d_keys  = d_key_scratch + scratch_offset;
+
+  __shared__ sort_temp_storage<KeyT, ValueT, ThreadsPerBlock, ItemsPerThread> temp_storage;
+
+  KeyT keys[ItemsPerThread];
+  ValueT values[ItemsPerThread];
+
+  const bool is_successful_dispatch = params::dispatch_discrete(select_directions, segment_id, [&](auto direction_tag) {
+    constexpr bool descending         = decltype(direction_tag)::value == detail::topk::select::max;
+    bit_ordered_type default_key_bits = descending ? traits::min_raw_binary_key(detail::identity_decomposer_t{})
+                                                   : traits::max_raw_binary_key(detail::identity_decomposer_t{});
+    KeyT default_key                  = reinterpret_cast<KeyT&>(default_key_bits);
+
+    if constexpr (is_keys_only)
+    {
+      LoadDirectStriped<ThreadsPerBlock>(threadIdx.x, d_keys, keys, valid_items, default_key);
+    }
+    else
+    {
+      const ValueT* const d_values = d_value_scratch + scratch_offset;
+      block_load_keys_t(temp_storage.load_keys).Load(d_keys, keys, valid_items, default_key);
+      __syncthreads();
+      block_load_values_t(temp_storage.load_values).Load(d_values, values, valid_items, ValueT{});
+      __syncthreads();
+    }
+
+    if constexpr (descending)
+    {
+      block_radix_sort_t(temp_storage.sort).SortDescendingBlockedToStriped(keys, values);
+    }
+    else
+    {
+      block_radix_sort_t(temp_storage.sort).SortBlockedToStriped(keys, values);
+    }
+
+    StoreDirectStriped<ThreadsPerBlock>(threadIdx.x, d_key_segments_out_it[segment_id], keys, valid_items);
+    if constexpr (!is_keys_only)
+    {
+      StoreDirectStriped<ThreadsPerBlock>(threadIdx.x, d_value_segments_out_it[segment_id], values, valid_items);
+    }
+  });
+  _CCCL_ASSERT(is_successful_dispatch, "Error: Unsupported select direction");
 }
 } // namespace detail::batched_topk
 

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -572,6 +572,7 @@ _CCCL_LAUNCH_BOUNDS(ThreadsPerBlock) _CCCL_KERNEL_ATTRIBUTES void device_batched
                                                    : traits::max_raw_binary_key(detail::identity_decomposer_t{});
     KeyT default_key                  = reinterpret_cast<KeyT&>(default_key_bits);
 
+    // Unstable sorting permits this register-only striped load, avoiding a shared-memory transpose.
     if constexpr (is_keys_only)
     {
       LoadDirectStriped<ThreadsPerBlock>(threadIdx.x, d_keys, keys, valid_items, default_key);
@@ -585,6 +586,7 @@ _CCCL_LAUNCH_BOUNDS(ThreadsPerBlock) _CCCL_KERNEL_ATTRIBUTES void device_batched
       __syncthreads();
     }
 
+    // `NullType` selects BlockRadixSort's keys-only internal path, so this works for both keys and pairs.
     if constexpr (descending)
     {
       block_radix_sort_t(temp_storage.sort).SortDescendingBlockedToStriped(keys, values);

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -118,6 +118,29 @@ struct multi_worker_policy
 #endif // _CCCL_HOSTED()
 };
 
+//! Fixed launch geometry for the sorted-output epilogue.
+struct sort_policy
+{
+  int threads_per_block;
+  int items_per_thread;
+};
+
+inline constexpr sort_policy sorted_output_policies[] = {
+  {256, 64},
+  {256, 32},
+  {256, 16},
+  {256, 8},
+  {256, 4},
+  {256, 2},
+  {128, 2},
+  {128, 1},
+  {64, 1},
+  {32, 1},
+};
+
+inline constexpr int sorted_output_policy_count =
+  static_cast<int>(sizeof(sorted_output_policies) / sizeof(sorted_output_policies[0]));
+
 //! Sub-policy for the baseline (worker-per-segment) backend of @ref DeviceBatchedTopK.
 struct baseline_topk_policy
 {

--- a/cub/test/catch2_test_device_segmented_topk_keys.cu
+++ b/cub/test/catch2_test_device_segmented_topk_keys.cu
@@ -2220,6 +2220,49 @@ CUB_TEST("DeviceBatchedTopK::MaxKeys sorted output treats zero segments as no wo
   REQUIRE(keys_out == thrust::device_vector<int>(k, sentinel));
 }
 
+CUB_TEST("DeviceBatchedTopK::MaxKeys sorted output treats zero k as no work",
+         "[keys][segmented][topk][device]",
+         CUB_SMALL)
+{
+  constexpr int k_max        = 3;
+  constexpr int segment_size = 8;
+  constexpr int num_segments = 2;
+  constexpr int sentinel     = -12345;
+
+  auto keys_in  = thrust::device_vector<int>{0, 9, 3, 2, 1, 8, 7, 4, /**/ 5, 6, 1, 0, 3, 2, 8, 7};
+  auto keys_out = thrust::device_vector<int>(num_segments * k_max, sentinel);
+  auto d_keys_in =
+    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_in.data())), segment_size);
+  auto d_keys_out =
+    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_out.data())), k_max);
+
+  auto segment_sizes = cuda::args::immediate{cuda::std::int16_t{segment_size}, cuda::args::bounds<0, 100>()};
+  auto k_arg         = cuda::args::immediate{cuda::std::int16_t{0}, cuda::args::bounds<0, k_max>()};
+  auto num_segs      = cuda::args::immediate{cuda::std::int64_t{num_segments}};
+  auto env           = cuda::std::execution::env{cuda::execution::require(
+    cuda::execution::determinism::not_guaranteed,
+    cuda::execution::tie_break::unspecified,
+    cuda::execution::output_ordering::sorted)};
+
+  cuda::std::size_t temp_storage_bytes = 0;
+  auto error                           = cub::DeviceBatchedTopK::MaxKeys(
+    nullptr, temp_storage_bytes, d_keys_in, d_keys_out, segment_sizes, k_arg, num_segs, env);
+  REQUIRE(error == cudaSuccess);
+
+  thrust::device_vector<char> temp_storage(temp_storage_bytes, thrust::no_init);
+  error = cub::DeviceBatchedTopK::MaxKeys(
+    thrust::raw_pointer_cast(temp_storage.data()),
+    temp_storage_bytes,
+    d_keys_in,
+    d_keys_out,
+    segment_sizes,
+    k_arg,
+    num_segs,
+    env);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(keys_out == thrust::device_vector<int>(num_segments * k_max, sentinel));
+}
+
 // Deterministic-requirement counterpart: a gpu_to_gpu requirement routes to the SM90+ cluster backend. A positive size
 // bound means the `max_seg_size <= 0` guard does not apply, so the launch must be elided from `num_segments == 0`
 // alone -- by the dispatch's empty-batch guard, before the cluster arm launches. Where that backend is unavailable the

--- a/cub/test/catch2_test_device_segmented_topk_keys.cu
+++ b/cub/test/catch2_test_device_segmented_topk_keys.cu
@@ -67,6 +67,8 @@ template <cub::detail::topk::select SelectDirection,
           cuda::execution::determinism::__determinism_t Determinism =
             cuda::execution::determinism::__determinism_t::__not_guaranteed,
           cuda::execution::tie_break::__tie_break_t TieBreak = cuda::execution::tie_break::__tie_break_t::__unspecified,
+          cuda::execution::output_ordering::__output_ordering_t OutputOrdering =
+            cuda::execution::output_ordering::__output_ordering_t::__unsorted,
           typename KeyInputItItT,
           typename KeyOutputItItT,
           typename SegmentSizeParamT,
@@ -86,7 +88,7 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk_keys(
     cuda::stream_ref{stream},
     cuda::execution::require(cuda::execution::determinism::__determinism_holder_t<Determinism>{},
                              cuda::execution::tie_break::__tie_break_holder_t<TieBreak>{},
-                             cuda::execution::output_ordering::unsorted)};
+                             cuda::execution::output_ordering::__output_ordering_holder_t<OutputOrdering>{})};
   if constexpr (SelectDirection == cub::detail::topk::select::max)
   {
     return cub::DeviceBatchedTopK::MaxKeys(
@@ -107,8 +109,10 @@ DECLARE_TMPL_LAUNCH_WRAPPER(
     cub::detail::topk::select SelectDirection,
     cuda::execution::determinism::__determinism_t Determinism =
       cuda::execution::determinism::__determinism_t::__not_guaranteed,
-    cuda::execution::tie_break::__tie_break_t TieBreak = cuda::execution::tie_break::__tie_break_t::__unspecified),
-  ESCAPE_LIST(SelectDirection, Determinism, TieBreak));
+    cuda::execution::tie_break::__tie_break_t TieBreak = cuda::execution::tie_break::__tie_break_t::__unspecified,
+    cuda::execution::output_ordering::__output_ordering_t OutputOrdering =
+      cuda::execution::output_ordering::__output_ordering_t::__unsorted),
+  ESCAPE_LIST(SelectDirection, Determinism, TieBreak, OutputOrdering));
 
 // Wrapper-test companion to expect_batched_topk_unsupported_and_skip: when the request's backend is unavailable in this
 // build, dispatch it directly (host), verify the runtime cudaErrorNotSupported, and skip the correctness checks;
@@ -163,6 +167,8 @@ using key_types =
 using select_direction_list =
   c2h::enum_type_list<cub::detail::topk::select, cub::detail::topk::select::min, cub::detail::topk::select::max>;
 
+using sorted_key_types = c2h::type_list<cuda::std::int32_t, cuda::std::uint64_t>;
+
 // A (determinism, tie-break) requirement pair, used as a single compile-time test axis. Not a full cross product: a
 // tie-break preference is only meaningful with a deterministic requirement and is `gpu_to_gpu` by definition.
 template <cuda::execution::determinism::__determinism_t Determinism, cuda::execution::tie_break::__tie_break_t TieBreak>
@@ -186,6 +192,12 @@ using det_tie_combos =
                          cuda::execution::tie_break::__tie_break_t::__prefer_smaller_index>,
                  det_tie<cuda::execution::determinism::__determinism_t::__gpu_to_gpu,
                          cuda::execution::tie_break::__tie_break_t::__prefer_larger_index>>;
+
+using sorted_det_tie_combos =
+  c2h::type_list<det_tie<cuda::execution::determinism::__determinism_t::__not_guaranteed,
+                         cuda::execution::tie_break::__tie_break_t::__unspecified>,
+                 det_tie<cuda::execution::determinism::__determinism_t::__gpu_to_gpu,
+                         cuda::execution::tie_break::__tie_break_t::__unspecified>>;
 
 CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with small fixed-size segments",
          "[keys][segmented][topk][device]",
@@ -263,6 +275,58 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with small fixed-size segments",
 
   // Since the results of top-k are unordered, sort output segments before comparison.
   fixed_size_segmented_sort_keys(keys_out_buffer, num_segments, k, direction);
+
+  REQUIRE(expected_keys == keys_out_buffer);
+}
+
+CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys return ordered sorted output",
+         "[keys][segmented][topk][device]",
+         CUB_SMALL,
+         sorted_key_types,
+         select_direction_list,
+         sorted_det_tie_combos)
+{
+  using key_t           = c2h::get<0, TestType>;
+  using segment_size_t  = cuda::std::int64_t;
+  using segment_index_t = cuda::std::int64_t;
+
+  using combo                            = c2h::get<2, TestType>;
+  constexpr auto direction               = c2h::get<1, TestType>::value;
+  constexpr auto determinism             = combo::determinism;
+  constexpr auto tie_break               = combo::tie_break;
+  constexpr segment_size_t segment_size  = 2051;
+  constexpr segment_size_t static_max_k  = 2048;
+  constexpr segment_index_t num_segments = 3;
+  const segment_size_t k                 = GENERATE_COPY(values({segment_size_t{1}, static_max_k}));
+
+  c2h::device_vector<key_t> keys_in_buffer(num_segments * segment_size, thrust::no_init);
+  c2h::device_vector<key_t> keys_out_buffer(num_segments * k, thrust::no_init);
+  c2h::gen(C2H_SEED(1), keys_in_buffer);
+
+  auto d_keys_in_ptr  = thrust::raw_pointer_cast(keys_in_buffer.data());
+  auto d_keys_out_ptr = thrust::raw_pointer_cast(keys_out_buffer.data());
+  auto d_keys_in      = cuda::make_strided_iterator(cuda::make_counting_iterator(d_keys_in_ptr), segment_size);
+  auto d_keys_out     = cuda::make_strided_iterator(cuda::make_counting_iterator(d_keys_out_ptr), k);
+
+  c2h::device_vector<key_t> expected_keys(keys_in_buffer);
+
+  skip_unless_batched_topk_keys_supported<direction, determinism, tie_break>(
+    segment_size,
+    d_keys_in,
+    d_keys_out,
+    cuda::args::constant<segment_size>{},
+    cuda::args::immediate{k, cuda::args::bounds<segment_size_t{1}, static_max_k>()},
+    cuda::args::constant<num_segments>{});
+
+  batched_topk_keys<direction, determinism, tie_break, cuda::execution::output_ordering::__output_ordering_t::__sorted>(
+    d_keys_in,
+    d_keys_out,
+    cuda::args::constant<segment_size>{},
+    cuda::args::immediate{k, cuda::args::bounds<segment_size_t{1}, static_max_k>()},
+    cuda::args::constant<num_segments>{});
+
+  fixed_size_segmented_sort_keys(expected_keys, num_segments, segment_size, direction);
+  compact_sorted_keys_to_topk(expected_keys, segment_size, k);
 
   REQUIRE(expected_keys == keys_out_buffer);
 }
@@ -2114,7 +2178,7 @@ CUB_TEST("DeviceBatchedTopK::MaxKeys treats a uniform negative segment size as n
 // dispatch must elide the launch from `num_segments == 0` alone -- otherwise the grid would use `grid_dim == 0`, an
 // invalid launch configuration. A small size and no determinism requirement route this to the baseline backend; the
 // deterministic-requirement counterpart is below.
-CUB_TEST("DeviceBatchedTopK::MaxKeys treats zero segments as no work (no determinism requirement)",
+CUB_TEST("DeviceBatchedTopK::MaxKeys sorted output treats zero segments as no work",
          "[keys][segmented][topk][device]",
          CUB_SMALL)
 {
@@ -2135,7 +2199,7 @@ CUB_TEST("DeviceBatchedTopK::MaxKeys treats zero segments as no work (no determi
   auto env             = cuda::std::execution::env{cuda::execution::require(
     cuda::execution::determinism::not_guaranteed,
     cuda::execution::tie_break::unspecified,
-    cuda::execution::output_ordering::unsorted)};
+    cuda::execution::output_ordering::sorted)};
 
   cuda::std::size_t temp_storage_bytes = 0;
   auto error                           = cub::DeviceBatchedTopK::MaxKeys(

--- a/cub/test/catch2_test_device_segmented_topk_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_topk_pairs.cu
@@ -75,6 +75,8 @@ template <cub::detail::topk::select SelectDirection,
           cuda::execution::determinism::__determinism_t Determinism =
             cuda::execution::determinism::__determinism_t::__not_guaranteed,
           cuda::execution::tie_break::__tie_break_t TieBreak = cuda::execution::tie_break::__tie_break_t::__unspecified,
+          cuda::execution::output_ordering::__output_ordering_t OutputOrdering =
+            cuda::execution::output_ordering::__output_ordering_t::__unsorted,
           typename KeyInputItItT,
           typename KeyOutputItItT,
           typename ValueInputItItT,
@@ -98,7 +100,7 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk_pairs(
     cuda::stream_ref{stream},
     cuda::execution::require(cuda::execution::determinism::__determinism_holder_t<Determinism>{},
                              cuda::execution::tie_break::__tie_break_holder_t<TieBreak>{},
-                             cuda::execution::output_ordering::unsorted)};
+                             cuda::execution::output_ordering::__output_ordering_holder_t<OutputOrdering>{})};
   if constexpr (SelectDirection == cub::detail::topk::select::max)
   {
     return cub::DeviceBatchedTopK::MaxPairs(
@@ -137,8 +139,10 @@ DECLARE_TMPL_LAUNCH_WRAPPER(
     cub::detail::topk::select SelectDirection,
     cuda::execution::determinism::__determinism_t Determinism =
       cuda::execution::determinism::__determinism_t::__not_guaranteed,
-    cuda::execution::tie_break::__tie_break_t TieBreak = cuda::execution::tie_break::__tie_break_t::__unspecified),
-  ESCAPE_LIST(SelectDirection, Determinism, TieBreak));
+    cuda::execution::tie_break::__tie_break_t TieBreak = cuda::execution::tie_break::__tie_break_t::__unspecified,
+    cuda::execution::output_ordering::__output_ordering_t OutputOrdering =
+      cuda::execution::output_ordering::__output_ordering_t::__unsorted),
+  ESCAPE_LIST(SelectDirection, Determinism, TieBreak, OutputOrdering));
 
 // Wrapper-test companion to expect_batched_topk_unsupported_and_skip: when the request's backend is unavailable in this
 // build, dispatch it directly (host), verify the runtime cudaErrorNotSupported, and skip the correctness checks;
@@ -196,6 +200,8 @@ using uint_key_types = c2h::type_list<cuda::std::uint8_t, cuda::std::uint16_t, c
 using select_direction_list =
   c2h::enum_type_list<cub::detail::topk::select, cub::detail::topk::select::min, cub::detail::topk::select::max>;
 
+using sorted_pair_key_types = c2h::type_list<cuda::std::int32_t, cuda::std::uint64_t>;
+
 // Determinism/tie-break combinations used as a single compile-time axis by the determinism-aware pairs tests. The
 // selected multiset is invariant to the tie-break preference, so every combo is verified the same way; tie-break
 // preferences only pair with a deterministic requirement.
@@ -214,6 +220,12 @@ using det_tie_pair_combos =
                               cuda::execution::tie_break::__tie_break_t::__prefer_smaller_index>,
                  det_tie_pair<cuda::execution::determinism::__determinism_t::__gpu_to_gpu,
                               cuda::execution::tie_break::__tie_break_t::__prefer_larger_index>>;
+
+using sorted_det_tie_pair_combos =
+  c2h::type_list<det_tie_pair<cuda::execution::determinism::__determinism_t::__not_guaranteed,
+                              cuda::execution::tie_break::__tie_break_t::__unspecified>,
+                 det_tie_pair<cuda::execution::determinism::__determinism_t::__gpu_to_gpu,
+                              cuda::execution::tie_break::__tie_break_t::__unspecified>>;
 
 // Consistency check: ensures values remain associated with their corresponding keys
 template <typename KeyT, typename ValueT>
@@ -279,6 +291,13 @@ bool verify_unique_indices(const c2h::device_vector<ValueT>& values_compacted,
 
   return num_duplicates == 0;
 }
+
+struct sorted_wide_value
+{
+  cuda::std::int64_t first;
+  cuda::std::int64_t second;
+  cuda::std::int64_t third;
+};
 
 CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with small fixed-size segments",
          "[pairs][segmented][topk][device]",
@@ -374,6 +393,110 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with small fixed-size segments"
 
   // Since the results of top-k are unordered, sort output segments before comparison.
   fixed_size_segmented_sort_keys(keys_out_buffer, num_segments, k, direction);
+
+  REQUIRE(expected_keys == keys_out_buffer);
+}
+
+CUB_TEST("DeviceBatchedTopK sorted output reports unsupported wide values",
+         "[pairs][segmented][topk][device]",
+         CUB_SMALL)
+{
+  int** d_keys_in                  = nullptr;
+  int** d_keys_out                 = nullptr;
+  sorted_wide_value** d_values_in  = nullptr;
+  sorted_wide_value** d_values_out = nullptr;
+  auto segment_sizes               = cuda::args::constant<2048>{};
+  auto k                           = cuda::args::constant<2048>{};
+  auto num_segments                = cuda::args::constant<1>{};
+  auto env                         = cuda::std::execution::env{cuda::execution::require(
+    cuda::execution::determinism::not_guaranteed,
+    cuda::execution::tie_break::unspecified,
+    cuda::execution::output_ordering::sorted)};
+
+  cuda::std::size_t temp_storage_bytes = 0;
+  REQUIRE(
+    cub::DeviceBatchedTopK::MaxPairs(
+      nullptr, temp_storage_bytes, d_keys_in, d_keys_out, d_values_in, d_values_out, segment_sizes, k, num_segments, env)
+    == cudaSuccess);
+  REQUIRE(temp_storage_bytes == 1);
+
+  c2h::device_vector<cuda::std::uint8_t> temp_storage(temp_storage_bytes, thrust::no_init);
+  REQUIRE(
+    cub::DeviceBatchedTopK::MaxPairs(
+      thrust::raw_pointer_cast(temp_storage.data()),
+      temp_storage_bytes,
+      d_keys_in,
+      d_keys_out,
+      d_values_in,
+      d_values_out,
+      segment_sizes,
+      k,
+      num_segments,
+      env)
+    == cudaErrorNotSupported);
+}
+
+CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs return ordered sorted output",
+         "[pairs][segmented][topk][device]",
+         CUB_SMALL,
+         sorted_pair_key_types,
+         select_direction_list,
+         sorted_det_tie_pair_combos)
+{
+  using key_t           = c2h::get<0, TestType>;
+  using value_t         = cuda::std::int32_t;
+  using segment_size_t  = cuda::std::int64_t;
+  using segment_index_t = cuda::std::int64_t;
+
+  using combo                            = c2h::get<2, TestType>;
+  constexpr auto direction               = c2h::get<1, TestType>::value;
+  constexpr auto determinism             = combo::determinism;
+  constexpr auto tie_break               = combo::tie_break;
+  constexpr segment_size_t segment_size  = 2051;
+  constexpr segment_size_t static_max_k  = 2048;
+  constexpr segment_index_t num_segments = 3;
+  const segment_size_t k                 = GENERATE_COPY(values({segment_size_t{1}, static_max_k}));
+
+  c2h::device_vector<key_t> keys_in_buffer(num_segments * segment_size, thrust::no_init);
+  c2h::device_vector<key_t> keys_out_buffer(num_segments * k, thrust::no_init);
+  c2h::device_vector<value_t> values_out_buffer(num_segments * k, thrust::no_init);
+  c2h::gen(C2H_SEED(1), keys_in_buffer);
+
+  auto d_keys_in_ptr    = thrust::raw_pointer_cast(keys_in_buffer.data());
+  auto d_keys_out_ptr   = thrust::raw_pointer_cast(keys_out_buffer.data());
+  auto d_values_out_ptr = thrust::raw_pointer_cast(values_out_buffer.data());
+  auto values_in_it     = cuda::make_counting_iterator(value_t{0});
+  auto d_keys_in        = cuda::make_strided_iterator(cuda::make_counting_iterator(d_keys_in_ptr), segment_size);
+  auto d_keys_out       = cuda::make_strided_iterator(cuda::make_counting_iterator(d_keys_out_ptr), k);
+  auto d_values_in      = cuda::make_strided_iterator(cuda::make_counting_iterator(values_in_it), segment_size);
+  auto d_values_out     = cuda::make_strided_iterator(cuda::make_counting_iterator(d_values_out_ptr), k);
+
+  c2h::device_vector<key_t> expected_keys(keys_in_buffer);
+
+  skip_unless_batched_topk_pairs_supported<direction, determinism, tie_break>(
+    segment_size,
+    d_keys_in,
+    d_keys_out,
+    d_values_in,
+    d_values_out,
+    cuda::args::constant<segment_size>{},
+    cuda::args::immediate{k, cuda::args::bounds<segment_size_t{1}, static_max_k>()},
+    cuda::args::constant<num_segments>{});
+
+  batched_topk_pairs<direction, determinism, tie_break, cuda::execution::output_ordering::__output_ordering_t::__sorted>(
+    d_keys_in,
+    d_keys_out,
+    d_values_in,
+    d_values_out,
+    cuda::args::constant<segment_size>{},
+    cuda::args::immediate{k, cuda::args::bounds<segment_size_t{1}, static_max_k>()},
+    cuda::args::constant<num_segments>{});
+
+  REQUIRE(verify_pairs_consistency(keys_in_buffer, keys_out_buffer, values_out_buffer));
+  REQUIRE(verify_unique_indices(values_out_buffer, num_segments, k));
+
+  fixed_size_segmented_sort_keys(expected_keys, num_segments, segment_size, direction);
+  compact_sorted_keys_to_topk(expected_keys, segment_size, k);
 
   REQUIRE(expected_keys == keys_out_buffer);
 }

--- a/cub/test/catch2_test_device_segmented_topk_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_topk_pairs.cu
@@ -292,13 +292,6 @@ bool verify_unique_indices(const c2h::device_vector<ValueT>& values_compacted,
   return num_duplicates == 0;
 }
 
-struct sorted_wide_value
-{
-  cuda::std::int64_t first;
-  cuda::std::int64_t second;
-  cuda::std::int64_t third;
-};
-
 CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with small fixed-size segments",
          "[pairs][segmented][topk][device]",
          CUB_SMALL,
@@ -395,45 +388,6 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with small fixed-size segments"
   fixed_size_segmented_sort_keys(keys_out_buffer, num_segments, k, direction);
 
   REQUIRE(expected_keys == keys_out_buffer);
-}
-
-CUB_TEST("DeviceBatchedTopK sorted output reports unsupported wide values",
-         "[pairs][segmented][topk][device]",
-         CUB_SMALL)
-{
-  int** d_keys_in                  = nullptr;
-  int** d_keys_out                 = nullptr;
-  sorted_wide_value** d_values_in  = nullptr;
-  sorted_wide_value** d_values_out = nullptr;
-  auto segment_sizes               = cuda::args::constant<2048>{};
-  auto k                           = cuda::args::constant<2048>{};
-  auto num_segments                = cuda::args::constant<1>{};
-  auto env                         = cuda::std::execution::env{cuda::execution::require(
-    cuda::execution::determinism::not_guaranteed,
-    cuda::execution::tie_break::unspecified,
-    cuda::execution::output_ordering::sorted)};
-
-  cuda::std::size_t temp_storage_bytes = 0;
-  REQUIRE(
-    cub::DeviceBatchedTopK::MaxPairs(
-      nullptr, temp_storage_bytes, d_keys_in, d_keys_out, d_values_in, d_values_out, segment_sizes, k, num_segments, env)
-    == cudaSuccess);
-  REQUIRE(temp_storage_bytes == 1);
-
-  c2h::device_vector<cuda::std::uint8_t> temp_storage(temp_storage_bytes, thrust::no_init);
-  REQUIRE(
-    cub::DeviceBatchedTopK::MaxPairs(
-      thrust::raw_pointer_cast(temp_storage.data()),
-      temp_storage_bytes,
-      d_keys_in,
-      d_keys_out,
-      d_values_in,
-      d_values_out,
-      segment_sizes,
-      k,
-      num_segments,
-      env)
-    == cudaErrorNotSupported);
 }
 
 CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs return ordered sorted output",

--- a/cub/test/test_device_batched_topk_requirements_fail.cu
+++ b/cub/test/test_device_batched_topk_requirements_fail.cu
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// %PARAM% TEST_ERR err 0:1:2:3:4:5:6:7:8:9:10:11:12:13:14:15:16:17:18:19:20:21:22
+// %PARAM% TEST_ERR err 0:1:2:3:4:5:6:7:8:9:10:11:12:13:14:15:16:17:18:19:20:21:22:23:24
 
 // Defer the unsupported-architecture diagnosis to the dispatch's runtime check (not a compile-time static_assert)
 // so only the requirement static_asserts under test fire, regardless of which architectures this test is compiled for.
@@ -24,7 +24,7 @@
 // Verifies that cub::DeviceBatchedTopK rejects, at compile time, requests the public contract marks as ill-formed.
 // Each variant makes exactly one argument ill-formed (the others take valid defaults) and checks the single diagnostic:
 //
-//   * requirements (variants 0-5):
+//   * requirements (variants 0-5, 23-24):
 //       - determinism and tie_break must be acknowledged together, both specified or both omitted to take the default
 //       - an explicit tie_break of prefer_smaller_index / prefer_larger_index pins the result set across GPUs and so
 //         requires determinism::gpu_to_gpu (it cannot be paired with not_guaranteed or run_to_run)
@@ -159,11 +159,21 @@ int main()
   auto requirements =
     ex::require(ex::determinism::run_to_run, ex::tie_break::prefer_larger_index, ex::output_ordering::unsorted);
   // expected-error-5 {{"pins the result set across GPUs and therefore requires"}}
+#elif TEST_ERR == 23
+  auto requirements =
+    ex::require(ex::determinism::not_guaranteed, ex::tie_break::unspecified, ex::output_ordering::stable_sorted);
+  // expected-error-23 {{"does not yet implement cuda::execution::output_ordering::stable_sorted"}}
+#elif TEST_ERR == 24
+  // expected-error-24 {{"does not yet implement cuda::execution::output_ordering::stable_sorted"}}
 #else
   auto requirements = ex::require(ex::output_ordering::unsorted);
 #endif
 
-  auto env                  = cuda::std::execution::env{requirements};
+#if TEST_ERR == 24
+  auto env = cuda::std::execution::env{};
+#else
+  auto env = cuda::std::execution::env{requirements};
+#endif
   size_t temp_storage_bytes = 0;
   auto error                = cub::DeviceBatchedTopK::MaxKeys(
     nullptr, temp_storage_bytes, d_keys_in, d_keys_out, segment_sizes, k_arg, num_segments, env);

--- a/cub/test/test_device_batched_topk_sorted_coverage_fail.cu
+++ b/cub/test/test_device_batched_topk_sorted_coverage_fail.cu
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/device/device_batched_topk.cuh>
+
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/output_ordering.h>
+#include <cuda/__execution/require.h>
+#include <cuda/__execution/tie_break.h>
+#include <cuda/argument>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+#include <cuda/std/execution>
+
+#include <iostream>
+
+struct wide_value
+{
+  ::cuda::std::int64_t first;
+  ::cuda::std::int64_t second;
+  ::cuda::std::int64_t third;
+};
+
+int main()
+{
+  namespace ex = cuda::execution;
+
+  int** d_keys_in           = nullptr;
+  int** d_keys_out          = nullptr;
+  wide_value** d_values_in  = nullptr;
+  wide_value** d_values_out = nullptr;
+  auto segment_sizes        = cuda::args::constant<2048>{};
+  auto k_arg                = cuda::args::constant<2048>{};
+  auto num_segments         = cuda::args::immediate{cuda::std::int64_t{2}};
+  auto requirements =
+    ex::require(ex::determinism::not_guaranteed, ex::tie_break::unspecified, ex::output_ordering::sorted);
+  auto env = cuda::std::execution::env{requirements};
+
+  // expected-error {{"sorted output cannot cover the statically-known maximum output size"}}
+  cuda::std::size_t temp_storage_bytes = 0;
+  auto error                           = cub::DeviceBatchedTopK::MaxPairs(
+    nullptr,
+    temp_storage_bytes,
+    d_keys_in,
+    d_keys_out,
+    d_values_in,
+    d_values_out,
+    segment_sizes,
+    k_arg,
+    num_segments,
+    env);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceBatchedTopK::MaxPairs failed with status: " << error << '\n';
+  }
+}

--- a/docs/cub/device_topk_requirements.rst
+++ b/docs/cub/device_topk_requirements.rst
@@ -63,11 +63,15 @@ requires ``determinism::gpu_to_gpu``. See :ref:`cub-topk-set-membership` for the
 
 .. note::
 
-   **Current support.** Only the unsorted output ordering is implemented so far, so
-   ``cuda::execution::output_ordering::unsorted`` must be requested **explicitly**; ``sorted`` /
+   **Current support.** :cpp:struct:`cub::DeviceBatchedTopK` supports ``unsorted`` and ``sorted`` output.
    ``stable_sorted`` (and therefore an empty, no-requirement environment, which resolves to
-   ``stable_sorted``) ``static_assert`` at compile time. The supported *selection* requirements differ
-   by algorithm and, for :cpp:struct:`cub::DeviceBatchedTopK`, by architecture:
+   ``stable_sorted``) ``static_assert``s at compile time. Sorted batched output requires
+   ``min(k bound, segment-size bound)`` to fit a block-wide radix-sort tile and additional temporary
+   storage proportional to ``num_segments * min(k bound, segment-size bound)``. It supports a *k* of
+   at least 2048 whenever ``max(sizeof(key), sizeof(value)) <= 16``; a wider value may require a
+   tighter bound. As indicative common cases, 4-byte key/value pairs cover 8192 and an 8-byte key
+   with a 4-byte value covers 4096. The supported *selection* requirements differ by algorithm and, for
+   :cpp:struct:`cub::DeviceBatchedTopK`, by architecture:
 
    * :cpp:struct:`cub::DeviceBatchedTopK`:
 
@@ -83,9 +87,9 @@ requires ``determinism::gpu_to_gpu``. See :ref:`cub-topk-set-membership` for the
 
    * :cpp:struct:`cub::DeviceTopK` implements only the fully opted-out configuration
      (``cuda::execution::determinism::not_guaranteed`` with unsorted output) and has no tie-break
-     dimension yet, so it omits the ``tie_break`` token.
+     dimension yet, so it omits the ``tie_break`` token. Its sorted output remains unimplemented.
 
-   The remaining deterministic, tie-broken, and (stable-)sorted modes documented here define the
+   The remaining deterministic, tie-broken, and stable-sorted modes documented here define the
    committed long-term contract and will become available (including as the no-requirement default) as
    those code paths land.
 


### PR DESCRIPTION
- Only unstable-sorted output for now.
- Graph-capture-able.
- Single post-processing kernel.
- Kernel fusion out-of-scope for now.
- Same compile-time tile-size choice algorithm as the non-cluster batched TopK kernel but now dependent on static max k instead of static max segment size.
- Therefore support restricted to small k (big enough for the typical workloads with k<=2048).

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #10811

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
