### PR TITLE
[RFC][STF] parallel_for is a device construct: reject host execution places

### DIFF
--- a/cudax/examples/stf/frozen_data_init.cu
+++ b/cudax/examples/stf/frozen_data_init.cu
@@ -41,10 +41,17 @@ int main()
     x(i, j) = d_buf(i, j);
   };
 
-  ctx.parallel_for(exec_place::host(), lX.shape(), lX.read()).set_symbol("check buf")
-      ->*[h_buf](size_t i, size_t j, auto x) {
-            EXPECT(fabs(x(i, j) - h_buf(i, j)) < 0.0001);
-          };
+  // Host-side check: host work goes through host_launch with an explicit loop, parallel_for
+  // being a device-only construct.
+  ctx.host_launch(lX.read()).set_symbol("check buf")->*[h_buf](auto x) {
+    for (size_t i = 0; i < x.extent(0); i++)
+    {
+      for (size_t j = 0; j < x.extent(1); j++)
+      {
+        EXPECT(fabs(x(i, j) - h_buf(i, j)) < 0.0001);
+      }
+    }
+  };
 
   // Make sure all tasks are done before unfreezing
   frozen_buffer.unfreeze(ctx.fence());

--- a/cudax/examples/stf/parallel_for_2D.cu
+++ b/cudax/examples/stf/parallel_for_2D.cu
@@ -53,22 +53,29 @@ int main()
     }
   };
 
-  ctx.parallel_for(exec_place::host(), ly.shape(), ly.read())
-      ->*[=] __host__(size_t i, size_t j, slice<const double, 2> sy) {
-            double expected = y0(i, j);
-            for (size_t ii = 0; ii < 2; ii++)
-            {
-              for (size_t jj = 0; jj < 2; jj++)
-              {
-                expected += x0(2 * i + ii, 2 * j + jj);
-              }
-            }
+  // Check the result on the host: host work goes through host_launch with an explicit loop,
+  // parallel_for being a device-only construct.
+  ctx.host_launch(ly.read())->*[=](slice<const double, 2> sy) {
+    for (size_t i = 0; i < sy.extent(0); i++)
+    {
+      for (size_t j = 0; j < sy.extent(1); j++)
+      {
+        double expected = y0(i, j);
+        for (size_t ii = 0; ii < 2; ii++)
+        {
+          for (size_t jj = 0; jj < 2; jj++)
+          {
+            expected += x0(2 * i + ii, 2 * j + jj);
+          }
+        }
 
-            if (fabs(sy(i, j) - expected) > 0.001)
-            {
-              printf("sy(%zu, %zu) %f expect %f\n", i, j, sy(i, j), expected);
-            }
-          };
+        if (fabs(sy(i, j) - expected) > 0.001)
+        {
+          printf("sy(%zu, %zu) %f expect %f\n", i, j, sy(i, j), expected);
+        }
+      }
+    }
+  };
 
   ctx.finalize();
 }

--- a/cudax/include/cuda/experimental/__places/places.cuh
+++ b/cudax/include/cuda/experimental/__places/places.cuh
@@ -73,6 +73,7 @@ template <typename T>
 struct hash;
 
 class exec_place;
+class exec_place_host;
 
 // Green contexts are only supported since CUDA 12.4
 
@@ -900,7 +901,7 @@ public:
   /* These helper methods provide convenient way to express execution places,
    * for example exec_place::host or exec_place::device(4).
    */
-  static exec_place host();
+  static exec_place_host host();
   static exec_place device_auto();
 
   static exec_place device(int devid);
@@ -1292,9 +1293,27 @@ public:
   }
 };
 
-inline exec_place exec_place::host()
+/**
+ * @brief The host execution place, as its own type.
+ *
+ * `exec_place::host()` returning this rather than an erased `exec_place` keeps host-ness in
+ * the type system, so a construct that does not support host execution -- `parallel_for`,
+ * which builds CUDA kernels -- can reject the direct spelling
+ * `parallel_for(exec_place::host(), ...)` with a `static_assert` instead of a runtime
+ * failure. The type converts to `exec_place` and loses nothing in the process: host-ness
+ * remains queryable at runtime through `is_host()`, which is how erased places are checked.
+ */
+class exec_place_host : public exec_place
 {
-  return exec_place(make_static_instance<exec_place_host_impl>());
+public:
+  exec_place_host()
+      : exec_place(make_static_instance<exec_place_host_impl>())
+  {}
+};
+
+inline exec_place_host exec_place::host()
+{
+  return exec_place_host();
 }
 
 // Implementation for device_auto placeholder

--- a/cudax/include/cuda/experimental/__stf/internal/parallel_for_scope.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/parallel_for_scope.cuh
@@ -29,7 +29,6 @@
 
 #include <cuda/experimental/__stf/graph/internal/event_types.cuh>
 #include <cuda/experimental/__stf/internal/backend_ctx.cuh> // for null_partition
-#include <cuda/experimental/__stf/internal/ctx_resource.cuh>
 #include <cuda/experimental/__stf/internal/task_dep.cuh>
 #include <cuda/experimental/__stf/internal/task_statistics.cuh>
 #include <cuda/experimental/__stf/stream/internal/event_types.cuh>
@@ -447,34 +446,6 @@ loop_redux_finalize(tuple_args targs, redux_vars<tuple_args, tuple_ops>* redux_b
 }
 
 /**
- * @brief Resource wrapper for managing parallel_for host callback arguments
- *
- * This manages the memory allocated for parallel_for host callback arguments using the
- * ctx_resource system instead of manual delete in each callback.
- */
-template <typename ArgsType>
-class parallel_for_args_resource : public ctx_resource
-{
-public:
-  explicit parallel_for_args_resource(ArgsType* args)
-      : args_(args)
-  {}
-
-  bool can_release_in_callback() const noexcept override
-  {
-    return true;
-  }
-
-  void release_in_callback() noexcept override
-  {
-    delete args_;
-  }
-
-private:
-  ArgsType* args_;
-};
-
-/**
  * @brief Supporting class for the parallel_for construct
  *
  * This is used to implement operators such as ->* on the object produced by `ctx.parallel_for`
@@ -667,6 +638,15 @@ public:
   template <typename Fun>
   void operator->*(Fun&& f)
   {
+    // parallel_for builds CUDA kernels; it does not execute on the host, where it could only
+    // ever have offered a serial loop on a CUDA callback thread. Host work belongs to
+    // host_launch. The direct spelling `parallel_for(exec_place::host(), ...)` is rejected
+    // here at compile time; a type-erased place that turns out to be host is rejected at
+    // runtime below.
+    static_assert(!::std::is_same_v<exec_place_t, exec_place_host>,
+                  "parallel_for does not execute on the host; use host_launch instead");
+    EXPECT(!e_place.is_host(), "parallel_for does not execute on the host; use host_launch instead.");
+
     auto& dot        = *ctx.get_dot();
     auto& statistics = reserved::task_statistics::instance();
     auto t           = ctx.task(e_place);
@@ -768,86 +748,53 @@ public:
     static constexpr bool need_reduction = (deps_ops_t::does_work || ...);
 
 #  if _CCCL_CUDA_COMPILER(NVCC)
-    // With nvcc, dedicated traits tell how a lambda can be executed.
-    static constexpr bool is_extended_host_device_lambda_closure_type =
-                            __nv_is_extended_host_device_lambda_closure_type(Fun),
-                          is_extended_device_lambda_closure_type = __nv_is_extended_device_lambda_closure_type(Fun);
+    // With nvcc, dedicated traits tell whether the lambda can execute on the device.
+    static constexpr bool device_invocable =
+      __nv_is_extended_host_device_lambda_closure_type(Fun) || __nv_is_extended_device_lambda_closure_type(Fun);
 #  else // ^^^ _CCCL_CUDA_COMPILER(NVCC) ^^^ / vvv !_CCCL_CUDA_COMPILER(NVCC)
-    // Only nvcc offers those traits. The claim below holds for nvc++, where every lambda can
-    // indeed run on host and device. For clang-cuda it is provisional: a device-only lambda
-    // takes the host branch, so classifying it correctly is part of supporting that compiler.
-    static constexpr bool is_extended_host_device_lambda_closure_type = true,
-                          is_extended_device_lambda_closure_type      = false;
+    // Only nvcc offers those traits. nvc++ compiles every lambda for both sides, so the claim
+    // holds outright there. clang-cuda treats unannotated lambdas as implicitly
+    // __host__ __device__ and checks what a body actually calls only when the kernel is
+    // emitted, so a lambda that cannot really execute on the device is diagnosed at the
+    // kernel rather than here.
+    static constexpr bool device_invocable = true;
 #  endif // ^^^ !_CCCL_CUDA_COMPILER(NVCC) ^^^
+    static_assert(device_invocable,
+                  "parallel_for requires a callable invocable on the device (__device__ or "
+                  "__host__ __device__); for host execution use host_launch");
 
-    // TODO redo cascade of tests
-    if constexpr (need_reduction)
+    if constexpr (!device_invocable)
     {
-      _CCCL_ASSERT(e_place != exec_place::host(), "Reduce access mode currently unimplemented on host.");
+      // Discarded so the static_assert above stays the only diagnostic; instantiating the
+      // device path with a host callable would only bury it.
+    }
+    else if constexpr (need_reduction)
+    {
       _CCCL_ASSERT(e_place.size() == 1, "Reduce access mode currently unimplemented on grid of places.");
       do_parallel_for_redux(f, e_place, shape, t);
-      return;
     }
-    else if constexpr (is_extended_host_device_lambda_closure_type)
+    else if (e_place.size() == 1)
     {
-      // Can run on both - decide dynamically
-      if (e_place.is_host())
-      {
-        return do_parallel_for_host(::std::forward<Fun>(f), shape, t);
-      }
-      // Fall through for the device implementation
-    }
-    else if constexpr (is_extended_device_lambda_closure_type)
-    {
-      // Lambda can run only on device - make sure they're not trying it on the host
-      EXPECT(!e_place.is_host(), "Attempt to run a device function on the host.");
-      // Fall through for the device implementation
+      // Apply the parallel_for construct over the entire shape on the
+      // execution place of the task.
+      do_parallel_for(f, e_place, shape, t);
     }
     else
     {
-      // Lambda can run only on the host - make sure they're not trying it elsewhere
-      EXPECT(e_place.is_host(), "Attempt to run a host function on a device.");
-      return do_parallel_for_host(::std::forward<Fun>(f), shape, t);
-    }
-
-    // Device land. Must use the supplemental if constexpr below to avoid compilation errors.
-    if constexpr (is_extended_host_device_lambda_closure_type || is_extended_device_lambda_closure_type)
-    {
-      if (e_place.size() == 1)
+      if constexpr (::std::is_same_v<partitioner_t, null_partition>)
       {
-        // Apply the parallel_for construct over the entire shape on the
-        // execution place of the task.
-        if constexpr (need_reduction)
-        {
-          do_parallel_for_redux(f, e_place, shape, t);
-        }
-        else
-        {
-          do_parallel_for(f, e_place, shape, t);
-        }
+        fprintf(stderr, "Fatal: Grid execution requires a partitioner.\n");
+        abort();
       }
       else
       {
-        if constexpr (::std::is_same_v<partitioner_t, null_partition>)
+        for (size_t i = 0; i < e_place.size(); i++)
         {
-          fprintf(stderr, "Fatal: Grid execution requires a partitioner.\n");
-          abort();
-        }
-        else
-        {
-          for (size_t i = 0; i < e_place.size(); i++)
-          {
-            auto active          = t.activate_place(i);
-            const auto sub_shape = p_.apply(shape, pos4(i), e_place.get_dims());
-            do_parallel_for(f, active.place(), sub_shape, t, i);
-          }
+          auto active          = t.activate_place(i);
+          const auto sub_shape = p_.apply(shape, pos4(i), e_place.get_dims());
+          do_parallel_for(f, active.place(), sub_shape, t, i);
         }
       }
-    }
-    else
-    {
-      // This point is never reachable, but we can't prove that statically.
-      assert(!"Internal CUDASTF error.");
     }
   }
 
@@ -1126,99 +1073,6 @@ public:
 
       // fprintf(stderr, "KERNEL NODE => graph %p, gridDim %d blockDim %d (n %ld)\n", t.get_graph(),
       // kernel_params.gridDim.x, kernel_params.blockDim.x, n);
-    }
-    else
-    {
-      fprintf(stderr, "Internal error.\n");
-      abort();
-    }
-  }
-
-  // Executes loop on the host.
-  template <typename Fun, typename sub_shape_t>
-  void do_parallel_for_host(Fun&& f, const sub_shape_t& shape, typename context::task_type& t)
-  {
-    const size_t n = shape.size();
-
-    // Tuple <tuple<instances...>, size_t , fun, shape>
-    using args_t = ::std::tuple<deps_tup_t, size_t, Fun, sub_shape_t>;
-
-    // Create a tuple with all instances (eg. tuple<slice<double>, slice<int>>)
-    deps_tup_t instances = get_arg_instances(deps, t);
-
-    // Wrap this for_each_n call in a host callback launched in CUDA stream associated with that task
-    // To do so, we pack all argument in a dynamically allocated tuple
-    // that will be deleted by the resource system or immediately in callback
-    auto args = new args_t(mv(instances), n, mv(f), shape);
-
-    // For graph contexts, use deferred cleanup via ctx_resource (needed for graph replay)
-    // For stream contexts, delete immediately in callback (better memory efficiency)
-    if constexpr (::std::is_same_v<context, graph_ctx>)
-    {
-      auto resource = ::std::make_shared<parallel_for_args_resource<args_t>>(args);
-      ctx.add_resource(mv(resource));
-    }
-
-    // The function which the host callback will execute
-    auto host_func = [](void* untyped_args) {
-      // The CUDA runtime calls this back, so an exception thrown by the user code must not leave
-      // it.
-      on_throw(::std::abort) << [untyped_args] {
-        auto p = static_cast<decltype(args)>(untyped_args);
-
-        auto& data               = ::std::get<0>(*p);
-        const size_t n           = ::std::get<1>(*p);
-        Fun& f                   = ::std::get<2>(*p);
-        const sub_shape_t& shape = ::std::get<3>(*p);
-
-        // deps_ops_t are pairs of data instance type, and a reduction operator,
-        // this gets only the data instance types (eg. slice<double>)
-        auto explode_coords = [&](size_t i, auto&&... data) {
-          auto h = [&](auto&&... coords) {
-            f(::std::forward<decltype(coords)>(coords)..., ::std::forward<decltype(data)>(data)...);
-          };
-          auto coords = shape.index_to_coords(i);
-          if (!::cuda::experimental::stf::reserved::__shape_contains(shape, coords, 0))
-          {
-            return;
-          }
-          ::cuda::experimental::stf::reserved::__apply_coords(h, mv(coords));
-        };
-
-        // Finally we get to do the workload on every 1D item of the shape
-        for (size_t i = 0; i < n; ++i)
-        {
-          ::std::apply(explode_coords, ::std::tuple_cat(::std::make_tuple(i), data));
-        }
-
-        // For stream contexts, delete immediately (no replay risk)
-        // For graph contexts, resource system handles cleanup (avoid use-after-free on replay)
-        if constexpr (!::std::is_same_v<context, graph_ctx>)
-        {
-          delete p;
-        }
-      };
-    };
-
-    if constexpr (::std::is_same_v<context, stream_ctx>)
-    {
-      // Stream path: the callback owns `args` once the launch succeeds, so delete
-      // it if the enqueue throws. (Graph path hands ownership to a ctx resource
-      // above before the node is created, so it needs no guard here.)
-      SCOPE(fail)
-      {
-        delete args;
-      };
-      cuda_try<cudaLaunchHostFunc>(t.get_stream(), host_func, args);
-    }
-    else if constexpr (::std::is_same_v<context, graph_ctx>)
-    {
-      cudaHostNodeParams params;
-      params.userData = args;
-      params.fn       = host_func;
-
-      // Put this host node into the child graph that implements the graph_task<>
-      t.get_node() = cuda_try<cudaGraphAddHostNode>(t.get_ctx_graph(), nullptr, 0, &params);
     }
     else
     {

--- a/cudax/include/cuda/experimental/__stf/internal/stf_places_into_stf_core.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/stf_places_into_stf_core.cuh
@@ -29,6 +29,7 @@ using ::cuda::experimental::places::augmented_stream;
 using ::cuda::experimental::places::data_place;
 using ::cuda::experimental::places::device_ordinal;
 using ::cuda::experimental::places::exec_place;
+using ::cuda::experimental::places::exec_place_host;
 using ::cuda::experimental::places::exec_place_scope;
 using ::cuda::experimental::places::from_index;
 using ::cuda::experimental::places::partition_cyclic;

--- a/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
@@ -1178,10 +1178,16 @@ UNITTEST("parallel_for with integral shape")
 
 inline void unit_test_host_pfor()
 {
+  // parallel_for does not execute on the host (it builds CUDA kernels); host_launch is the
+  // host-side counterpart, and its explicit loop is the same serial loop the host path of
+  // parallel_for used to hide.
   stream_ctx ctx;
   auto lA = ctx.logical_data(shape_of<slice<size_t>>(64));
-  ctx.parallel_for(exec_place::host(), lA.shape(), lA.write())->*[](size_t i, slice<size_t> A) {
-    A(i) = 2 * i;
+  ctx.host_launch(lA.write())->*[](auto A) {
+    for (size_t i = 0; i < 64; i++)
+    {
+      A(i) = 2 * i;
+    }
   };
   ctx.host_launch(lA.read())->*[](auto A) {
     for (size_t i = 0; i < 64; i++)
@@ -1192,7 +1198,7 @@ inline void unit_test_host_pfor()
   ctx.finalize();
 }
 
-UNITTEST("basic parallel_for test on host")
+UNITTEST("host work written and checked through host_launch")
 {
   unit_test_host_pfor();
 };
@@ -1210,8 +1216,11 @@ inline void unit_test_pfor_mix_host_dev()
     sx(pos) = 17 * pos + 4;
   };
 
-  ctx.parallel_for(exec_place::host(), lx.shape(), lx.rw())->*[=](size_t pos, auto sx) {
-    sx(pos) = sx(pos) * sx(pos);
+  ctx.host_launch(lx.rw())->*[](auto sx) {
+    for (size_t pos = 0; pos < sx.size(); pos++)
+    {
+      sx(pos) = sx(pos) * sx(pos);
+    }
   };
 
   ctx.parallel_for(lx.shape(), lx.rw())->*[=] _CCCL_DEVICE(size_t pos, auto sx) {
@@ -1226,39 +1235,11 @@ inline void unit_test_pfor_mix_host_dev()
   }
 }
 
-/* This test ensures that parallel_for on exec_place::host are properly
- * interleaved with those on devices. */
-UNITTEST("parallel_for host and device")
+/* This test ensures that host work is properly interleaved with parallel_for
+ * on devices. */
+UNITTEST("host work interleaved with device parallel_for")
 {
   unit_test_pfor_mix_host_dev();
-};
-
-inline void unit_test_untyped_place_pfor()
-{
-  stream_ctx ctx;
-
-  exec_place where = exec_place::host();
-
-  auto lA = ctx.logical_data(shape_of<slice<size_t>>(64));
-  // We have to put both __host__ __device__ qualifiers as this is resolved
-  // dynamically and both host and device codes will be generated
-  ctx.parallel_for(where, lA.shape(), lA.write())->*[] _CCCL_HOST_DEVICE(size_t i, slice<size_t> A) {
-    // Even if we do have a __device__ qualifier, we are not supposed to call it
-    NV_IF_TARGET(NV_IS_DEVICE, (assert(0);))
-    A(i) = 2 * i;
-  };
-  ctx.host_launch(lA.read())->*[](auto A) {
-    for (size_t i = 0; i < 64; i++)
-    {
-      EXPECT(A(i) == 2 * i);
-    }
-  };
-  ctx.finalize();
-}
-
-UNITTEST("basic parallel_for test on host (untyped execution place)")
-{
-  unit_test_untyped_place_pfor();
 };
 
 inline void unit_test_pfor_grid()

--- a/cudax/test/stf/parallel_for/parallel_for_host.cu
+++ b/cudax/test/stf/parallel_for/parallel_for_host.cu
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// parallel_for does not execute on the host: `parallel_for(exec_place::host(), ...)` is a
+// compile-time error, and this test records the supported way to run the same host work,
+// which is host_launch with an explicit loop.
+
 #include <cuda/experimental/stf.cuh>
 
 using namespace cuda::experimental::stf;
@@ -19,8 +23,11 @@ int main()
   int nqpoints = 3;
   auto ltoken  = ctx.token();
 
-  ctx.parallel_for(exec_place::host(), box(5), ltoken.read())->*[nqpoints] __host__(size_t) {
-    _CCCL_ASSERT(nqpoints == 3, "invalid value");
+  ctx.host_launch(ltoken.read())->*[nqpoints](auto...) {
+    for (size_t i = 0; i < 5; i++)
+    {
+      _CCCL_ASSERT(nqpoints == 3, "invalid value");
+    }
   };
 
   ctx.finalize();

--- a/cudax/test/stf/parallel_for/test2_parallel_for_context.cu
+++ b/cudax/test/stf/parallel_for/test2_parallel_for_context.cu
@@ -53,22 +53,29 @@ int main()
     }
   };
 
-  ctx.parallel_for(exec_place::host(), ly.shape(), ly.read())
-      ->*[=] __host__(size_t i, size_t j, slice<const double, 2> sy) {
-            double expected = y0(i, j);
-            for (size_t ii = 0; ii < 2; ii++)
-            {
-              for (size_t jj = 0; jj < 2; jj++)
-              {
-                expected += x0(2 * i + ii, 2 * j + jj);
-              }
-            }
-            if (fabs(sy(i, j) - expected) > 0.001)
-            {
-              printf("sy(%zu, %zu) %f expect %f\n", i, j, sy(i, j), expected);
-            }
-            //    assert(fabs(sy(i, j) - expected) < 0.001);
-          };
+  // Check the result on the host: host work goes through host_launch with an explicit loop,
+  // parallel_for being a device-only construct.
+  ctx.host_launch(ly.read())->*[=](slice<const double, 2> sy) {
+    for (size_t i = 0; i < sy.extent(0); i++)
+    {
+      for (size_t j = 0; j < sy.extent(1); j++)
+      {
+        double expected = y0(i, j);
+        for (size_t ii = 0; ii < 2; ii++)
+        {
+          for (size_t jj = 0; jj < 2; jj++)
+          {
+            expected += x0(2 * i + ii, 2 * j + jj);
+          }
+        }
+        if (fabs(sy(i, j) - expected) > 0.001)
+        {
+          printf("sy(%zu, %zu) %f expect %f\n", i, j, sy(i, j), expected);
+        }
+        //    assert(fabs(sy(i, j) - expected) < 0.001);
+      }
+    }
+  };
 
   ctx.finalize();
 }

--- a/cudax/test/stf/parallel_for/tiled_loops.cu
+++ b/cudax/test/stf/parallel_for/tiled_loops.cu
@@ -65,15 +65,19 @@ int main()
   bool checked   = false;
   bool* pchecked = &checked;
 
-  /* Check the result on the host */
-  ctx.parallel_for(exec_place::host(), ly.shape(), ly.read())->*[=](size_t pos, slice<const double> sy) {
-    int expected = static_cast<int>(ref_tiling(pos, tile_size, nparts));
-    int value    = (int) sy(pos);
-    if (expected != value)
+  /* Check the result on the host: host work goes through host_launch, parallel_for being a
+   * device-only construct. */
+  ctx.host_launch(ly.read())->*[=](slice<const double> sy) {
+    for (size_t pos = 0; pos < sy.size(); pos++)
     {
-      printf("POS %zu -> %d (expected %d)\n", pos, value, expected);
+      int expected = static_cast<int>(ref_tiling(pos, tile_size, nparts));
+      int value    = (int) sy(pos);
+      if (expected != value)
+      {
+        printf("POS %zu -> %d (expected %d)\n", pos, value, expected);
+      }
+      assert(expected == value);
     }
-    assert(expected == value);
     *pchecked = true;
   };
 

--- a/docs/cudax/stf.rst
+++ b/docs/cudax/stf.rst
@@ -990,9 +990,10 @@ host memory from CUDA kernels, for example).
 ``parallel_for`` construct
 --------------------------
 
-CUDASTF provides a helper construct which creates CUDA kernels (or CPU
-kernels) which execute an operation over an index space described as a
-*shape*.
+CUDASTF provides a helper construct which creates CUDA kernels which
+execute an operation over an index space described as a *shape*.
+``parallel_for`` executes on device places only; work on the host
+belongs to ``host_launch``.
 
 Example with a 1-dimensional array
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

One of two alternative resolutions to the last real clang-cuda blockers in STF (the other: #10815). **Exactly one of the two should merge.** Both clear the same four failures; they differ in what they believe `parallel_for` on the host *is*.

### The claim

`parallel_for` builds CUDA kernels. Its host path never delivered what the name promises: it ran a **serial** loop inside a CUDA host callback — on a runtime thread where calling the CUDA API is illegal, and where a long loop stalls everything queued behind it. That is not a host backend; it is a false affordance. Host work already has a dedicated, honest construct — `host_launch` — whose explicit loop is the *same execution* the host path used to hide.

This PR removes the pretense:

- **Compile-time rejection of the direct spelling.** `exec_place::host()` now returns `exec_place_host`, a stateless subclass that keeps host-ness visible to a `static_assert` while converting to the erased `exec_place` everywhere else (nothing else in the places API changes; erased remains the universal currency).
- **Runtime rejection of the erased case.** A type-erased place that turns out to be host fails an `EXPECT` with the same message.
- **Host-only lambdas get their own `static_assert`** under nvcc ("parallel_for requires a callable invocable on the device; for host execution use host_launch"). clang-cuda, which cannot classify lambdas, diagnoses them at the kernel they cannot survive being compiled into.

### What falls out

- `do_parallel_for_host`, `parallel_for_args_resource`, and the serial-loop-in-a-callback wart are **deleted** (~150 lines).
- The three-way lambda-classification cascade collapses: with one execution target, device-invocability is the only question left. The clang-cuda classification problem does not get fixed — it **dissolves**, because there is no host/device fork left to pick.
- The clang-cuda sweep over all 283 STF tests and examples goes from 4 real failures to **zero** (remaining: six TUs of the upstream-disabled `algorithm` construct (#4403) and the five deliberately-failing `static_error_checks`). This unblocks `bugprone-exception-escape` over STF (#10793, #10796, #10801, #10805 series).

### Migration

Five tests/examples and two header unittests used the host path; all were host-side *validation loops*, and each now says what it does: `host_launch` with a loop. The "untyped execution place" unittest, whose entire purpose was dynamic host dispatch, is removed with the feature. In-tree migration is complete in this PR; external users get the `static_assert`/`EXPECT` message pointing at `host_launch`.

### Why prefer this over #10815

#10815 keeps host `parallel_for` working by preserving host-ness in the type system. It is the smaller, compatible change — but it perpetuates a construct that silently serializes, and it leaves the clang-cuda hole for host lambdas reached through erased places. This PR removes the case instead of encoding it: fewer concepts, less code, no false promise of parallelism. The cost is a breaking change in an experimental API, with a mechanical migration.

## Testing

- Validated on hardware (RTX 3070, nvcc 13.2, sm_86): all five migrated tests/examples and the `stream_ctx.cuh` header unittests compile and **run** green.
- Rejection verified both ways: the direct spelling fails with the `static_assert` message; the erased place fails at runtime with `expecter::failure` carrying the same guidance.
- clang-cuda 21 sweep: 272/283 pass; the 11 failures are all pre-existing and out of scope (disabled `algorithm` + negative-compile tests).
- Full `<cuda/experimental/stf.cuh>` TU compiles clean under nvcc 13.2.
- pre-commit (clang-format 22.1.5 et al.) passes.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
