### PR TITLE
[RFC][STF] Type the host execution place so parallel_for host-dispatches on every compiler

### DIFF
--- a/cudax/include/cuda/experimental/__places/places.cuh
+++ b/cudax/include/cuda/experimental/__places/places.cuh
@@ -73,6 +73,7 @@ template <typename T>
 struct hash;
 
 class exec_place;
+class exec_place_host;
 
 // Green contexts are only supported since CUDA 12.4
 
@@ -900,7 +901,7 @@ public:
   /* These helper methods provide convenient way to express execution places,
    * for example exec_place::host or exec_place::device(4).
    */
-  static exec_place host();
+  static exec_place_host host();
   static exec_place device_auto();
 
   static exec_place device(int devid);
@@ -1292,9 +1293,36 @@ public:
   }
 };
 
-inline exec_place exec_place::host()
+/**
+ * @brief The host execution place, as its own type.
+ *
+ * `exec_place::host()` returning this rather than an erased `exec_place` keeps host-ness in
+ * the type system, so constructs like `parallel_for` can select their host code path at
+ * compile time and never instantiate the device kernel. That static choice is the one
+ * classification available on every compiler: only nvcc has the extended-lambda builtins
+ * that tell a host lambda from a device one, so for clang-cuda a typed host place is what
+ * makes `parallel_for(exec_place::host(), ...)` with a plain host lambda compile at all.
+ */
+class exec_place_host : public exec_place
 {
-  return exec_place(make_static_instance<exec_place_host_impl>());
+public:
+  exec_place_host()
+      : exec_place(make_static_instance<exec_place_host_impl>())
+  {}
+
+  //! @brief The checked downcast: re-manufactures the static host-ness of a type-erased
+  //! place from a runtime check, for callers that erased a host place and need to hand a
+  //! host callable to a construct that dispatches on this type.
+  static exec_place_host from(const exec_place& __p)
+  {
+    _CCCL_ASSERT(__p.is_host(), "exec_place_host::from() requires a host execution place");
+    return exec_place_host();
+  }
+};
+
+inline exec_place_host exec_place::host()
+{
+  return exec_place_host();
 }
 
 // Implementation for device_auto placeholder

--- a/cudax/include/cuda/experimental/__stf/internal/parallel_for_scope.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/parallel_for_scope.cuh
@@ -774,14 +774,23 @@ public:
                           is_extended_device_lambda_closure_type = __nv_is_extended_device_lambda_closure_type(Fun);
 #  else // ^^^ _CCCL_CUDA_COMPILER(NVCC) ^^^ / vvv !_CCCL_CUDA_COMPILER(NVCC)
     // Only nvcc offers those traits. The claim below holds for nvc++, where every lambda can
-    // indeed run on host and device. For clang-cuda it is provisional: a device-only lambda
-    // takes the host branch, so classifying it correctly is part of supporting that compiler.
+    // indeed run on host and device. For clang-cuda it is a fallback: the statically-host
+    // branch below is the one that runs host lambdas there, and a host lambda handed an
+    // erased `exec_place` is diagnosed at the kernel it would not survive being compiled
+    // into. A device-only lambda taking the host branch remains to be classified.
     static constexpr bool is_extended_host_device_lambda_closure_type = true,
                           is_extended_device_lambda_closure_type      = false;
 #  endif // ^^^ !_CCCL_CUDA_COMPILER(NVCC) ^^^
 
-    // TODO redo cascade of tests
-    if constexpr (need_reduction)
+    // A place that is host by type: take the host path at compile time and never mention the
+    // device kernel. This is the one classification that works on every compiler; nvcc's
+    // lambda traits above refine the erased-place cases this cannot see.
+    if constexpr (::std::is_same_v<exec_place_t, exec_place_host>)
+    {
+      static_assert(!need_reduction, "Reduce access mode currently unimplemented on host.");
+      return do_parallel_for_host(::std::forward<Fun>(f), shape, t);
+    }
+    else if constexpr (need_reduction)
     {
       _CCCL_ASSERT(e_place != exec_place::host(), "Reduce access mode currently unimplemented on host.");
       _CCCL_ASSERT(e_place.size() == 1, "Reduce access mode currently unimplemented on grid of places.");
@@ -810,8 +819,11 @@ public:
       return do_parallel_for_host(::std::forward<Fun>(f), shape, t);
     }
 
-    // Device land. Must use the supplemental if constexpr below to avoid compilation errors.
-    if constexpr (is_extended_host_device_lambda_closure_type || is_extended_device_lambda_closure_type)
+    // Device land. This is a separate statement, not the else of the cascade above, so it
+    // instantiates regardless of which branch was taken; the statically-host case must be
+    // excluded here too or it would drag the device kernel back in.
+    if constexpr ((is_extended_host_device_lambda_closure_type || is_extended_device_lambda_closure_type)
+                  && !::std::is_same_v<exec_place_t, exec_place_host>)
     {
       if (e_place.size() == 1)
       {

--- a/cudax/include/cuda/experimental/__stf/internal/stf_places_into_stf_core.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/stf_places_into_stf_core.cuh
@@ -29,6 +29,7 @@ using ::cuda::experimental::places::augmented_stream;
 using ::cuda::experimental::places::data_place;
 using ::cuda::experimental::places::device_ordinal;
 using ::cuda::experimental::places::exec_place;
+using ::cuda::experimental::places::exec_place_host;
 using ::cuda::experimental::places::exec_place_scope;
 using ::cuda::experimental::places::from_index;
 using ::cuda::experimental::places::partition_cyclic;


### PR DESCRIPTION
## Description

One of two alternative resolutions to the last real clang-cuda blockers in STF (the other: #10814). **Exactly one of the two should merge.** Both clear the same four failures; they differ in what they believe `parallel_for` on the host *is*.

### The problem

`parallel_for` decides between its device kernel and its host path by classifying the callable with nvcc's `__nv_is_extended_*_lambda_closure_type` builtins. No other compiler has them, and clang-cuda *deliberately* keeps host/device attributes outside the type system: no trait, no SFINAE participation, wrong-side calls checked only when a kernel is emitted. Even an explicit `__host__` annotation on the lambda is recorded in clang's AST but exposed to the program nowhere. So a host lambda handed to `parallel_for` compiles on nvcc and breaks on clang-cuda — the fall-through device path instantiates the `loop<Fun>` kernel with it, and clang's deferred diagnostics correctly refuse. These are the last four real clang-cuda failures across all 283 STF tests and examples, blocking the `bugprone-exception-escape` series (#10793, #10796, #10801, #10805).

### The fix: carry the fact on the place, not the lambda

The compile-time fact clang cannot discover about the *callable* is instead carried by the *place*: `exec_place::host()` now returns `exec_place_host`, a stateless subclass that keeps host-ness visible to `if constexpr` while converting to the erased `exec_place` everywhere else. The dispatch takes the host path statically for a typed host place and **never mentions the kernel template** — which is the entire requirement, since clang's error is about instantiation, not execution.

- **Erasure is fully preserved.** `exec_place p = exec_place::host();` works exactly as before; the subclass is a compile-time annotation on the same pimpl, dropped harmlessly on first assignment (it carries no data). nvcc semantics are byte-for-byte unchanged: its lambda traits keep refining the erased-place cases the type cannot see.
- **`exec_place_host::from(p)`** is the checked downcast for the one residual corner: a caller who erased a host place and needs the static fact back to run a host lambda under clang-cuda. Runtime proof (assert `is_host()`), compile-time type.
- **Zero migration.** The four failing TUs compile under clang-cuda *with no changes to them*; no user-visible API or behavior changes anywhere.

### Why prefer this over #10814

#10814 resolves the same failures by declaring `parallel_for` device-only and deleting the host path (whose "parallelism" is today a serial loop in a CUDA callback). That is the bolder, simpler endpoint — but it is a breaking change, and it forecloses ever making the host path real (e.g., an actual parallel host loop dispatched off the callback thread), which this PR leaves open. This PR is the minimal, fully compatible fix: same clang-cuda outcome, nothing removed, nothing to migrate. If the project later decides host `parallel_for` should die, #10814's deletion applies on top of this cleanly — the typed place it introduces is even the vehicle #10814 uses for its compile-time rejection.

## Testing

- The four previously-failing TUs (`parallel_for_host`, `test2_parallel_for_context`, `parallel_for_2D`, `frozen_data_init`) pass `-fsyntax-only` with clang-cuda 21, unmodified.
- clang-cuda sweep over all 283 STF tests and examples: 272 pass; the 11 failures are pre-existing and out of scope (six TUs of the upstream-disabled `algorithm` construct (#4403), five deliberately-failing `static_error_checks`).
- Validated on hardware (RTX 3070, nvcc 13.2, sm_86): `parallel_for_host`, `frozen_data_init`, and the `stream_ctx.cuh` header unittests — including host `parallel_for` and the erased-place dynamic-dispatch test — compile and **run** green.
- Full `<cuda/experimental/stf.cuh>` TU compiles clean under nvcc 13.2.
- pre-commit (clang-format 22.1.5 et al.) passes.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)