### PR TITLE
[cudax] Require synchronizers to provide a view

### DIFF
--- a/cudax/include/cuda/experimental/__group/group.cuh
+++ b/cudax/include/cuda/experimental/__group/group.cuh
@@ -159,6 +159,22 @@ public:
       , __synchronizer_instance_{__make_synchronizer_instance(__unit, __synchronizer_, __parent, __mapping_result_)}
   {}
 
+  // todo(dabayer): Delete copy constructor.
+  // group(const group&) = delete;
+
+  _CCCL_DEVICE_API ~group()
+  {
+    // Skip the synchronization for threads that are not part of this group.
+    if constexpr (!_MappingResult::is_always_exhaustive())
+    {
+      if (!__mapping_result_.is_valid())
+      {
+        return;
+      }
+    }
+    __synchronizer_instance_.deinit(__mapping_result_, __hier_);
+  }
+
   [[nodiscard]] _CCCL_DEVICE_API const hierarchy_type& hierarchy() const noexcept
   {
     return __hier_;
@@ -187,7 +203,7 @@ public:
         return;
       }
     }
-    __synchronizer_instance_.do_sync(__mapping_result_, __synchronizer_, __hier_);
+    __synchronizer_instance_.do_sync(__mapping_result_, __hier_);
   }
 
   _CCCL_DEVICE_API void sync_aligned() const noexcept
@@ -200,7 +216,7 @@ public:
         return;
       }
     }
-    __synchronizer_instance_.do_sync_aligned(__mapping_result_, __synchronizer_, __hier_);
+    __synchronizer_instance_.do_sync_aligned(__mapping_result_, __hier_);
   }
 
   _CCCL_TEMPLATE(class _Tp, class _InLevel)

--- a/cudax/include/cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh
@@ -24,6 +24,7 @@
 #include <cuda/barrier>
 #include <cuda/hierarchy>
 #include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__memory/construct_at.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__utility/declval.h>
 #include <cuda/std/span>
@@ -64,6 +65,67 @@ inline constexpr thread_scope __barrier_scope_v = thread_scope_system;
 template <thread_scope _Sco, class _ComplFn>
 inline constexpr thread_scope __barrier_scope_v<barrier<_Sco, _ComplFn>> = _Sco;
 
+template <class _Barrier, class _Unit, bool _Owning = true>
+class __barrier_synchronizer_instance
+{
+  _Barrier* __barrier_;
+
+public:
+  [[nodiscard]] _CCCL_DEVICE_API static __barrier_synchronizer_instance invalid() noexcept
+  {
+    return __barrier_synchronizer_instance{nullptr};
+  }
+
+  _CCCL_DEVICE_API explicit __barrier_synchronizer_instance(_Barrier* __barrier) noexcept
+      : __barrier_{__barrier}
+  {}
+
+  // todo(dabayer): Delete copy constructor for owning variant and provide only move constructor.
+  // __barrier_synchronizer_instance(const __barrier_synchronizer_instance&) = delete;
+
+  // _CCCL_DEVICE_API __barrier_synchronizer_instance(__barrier_synchronizer_instance&& __other) noexcept
+  //    : __barrier_{::cuda::std::exchange(__other.__barrier_, )}
+  // {}
+
+  template <class _MappingResult, class _Hierarchy>
+  _CCCL_DEVICE_API void do_sync(const _MappingResult&, const _Hierarchy&) const noexcept
+  {
+    __barrier_->arrive_and_wait();
+  }
+
+  template <class _MappingResult, class _Hierarchy>
+  _CCCL_DEVICE_API void do_sync_aligned(const _MappingResult&, const _Hierarchy&) const noexcept
+  {
+    __barrier_->arrive_and_wait();
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API auto view() const noexcept
+  {
+    return __barrier_synchronizer_instance<_Barrier, _Unit, /*is-owning*/ false>{__barrier_};
+  }
+
+  template <class _MappingResult, class _Hierarchy>
+  _CCCL_DEVICE_API void deinit(const _MappingResult& __mapping_result, const _Hierarchy& __hier) noexcept
+  {
+    if constexpr (_Owning)
+    {
+      if (__barrier_ != nullptr)
+      {
+        ::cuda::std::size_t __thread_rank_in_unit = 0u;
+        if constexpr (!::cuda::std::is_same_v<_Unit, thread_level>)
+        {
+          __thread_rank_in_unit = gpu_thread.rank(_Unit{}, __hier);
+        }
+
+        if (__mapping_result.unit_rank() == 0 && __thread_rank_in_unit == 0)
+        {
+          ::cuda::std::destroy_at(__barrier_);
+        }
+      }
+    }
+  }
+};
+
 template <class _Barrier, ::cuda::std::size_t _Np>
 class barrier_synchronizer
 {
@@ -74,24 +136,8 @@ class barrier_synchronizer
 public:
   using barrier_type = _Barrier;
 
-  struct __synchronizer_instance
-  {
-    template <class _MappingResult, class _Hierarchy>
-    _CCCL_DEVICE_API void do_sync(const _MappingResult& __mapping_result,
-                                  const barrier_synchronizer& __synchronizer,
-                                  const _Hierarchy&) const noexcept
-    {
-      __synchronizer.__barriers_[__mapping_result.group_rank()].arrive_and_wait();
-    }
-
-    template <class _MappingResult, class _Hierarchy>
-    _CCCL_DEVICE_API void do_sync_aligned(const _MappingResult& __mapping_result,
-                                          const barrier_synchronizer& __synchronizer,
-                                          const _Hierarchy&) const noexcept
-    {
-      __synchronizer.__barriers_[__mapping_result.group_rank()].arrive_and_wait();
-    }
-  };
+  template <class _Unit>
+  using __synchronizer_instance = __barrier_synchronizer_instance<_Barrier, _Unit>;
 
   _CCCL_DEVICE_API barrier_synchronizer(::cuda::std::span<_Barrier, _Np> __barriers) noexcept
       : __barriers_(__barriers)
@@ -103,7 +149,7 @@ public:
   }
 
   template <class _Unit, class _ParentGroup, class _MappingResult>
-  [[nodiscard]] _CCCL_DEVICE_API __synchronizer_instance
+  [[nodiscard]] _CCCL_DEVICE_API __synchronizer_instance<_Unit>
   make_instance(const _Unit&, const _ParentGroup& __parent, const _MappingResult& __mapping_result) const noexcept
   {
     using _Level = typename _ParentGroup::level_type;
@@ -130,15 +176,20 @@ public:
       __thread_rank_in_unit = gpu_thread.rank(_Unit{}, __parent.hierarchy());
     }
 
-    if (__mapping_result.is_valid() && __mapping_result.unit_rank() == 0 && __thread_rank_in_unit == 0)
+    _Barrier* __group_barrier_ptr = nullptr;
+    if (__mapping_result.is_valid())
     {
-      init(&__barriers_[__mapping_result.group_rank()],
-           static_cast<::cuda::std::ptrdiff_t>(__mapping_result.unit_count() * __nthread_in_unit));
+      __group_barrier_ptr = __barriers_.data() + __mapping_result.group_rank();
+      if (__mapping_result.unit_rank() == 0 && __thread_rank_in_unit == 0)
+      {
+        init(__group_barrier_ptr,
+             static_cast<::cuda::std::ptrdiff_t>(__mapping_result.unit_count() * __nthread_in_unit));
+      }
     }
 
     // todo(dabayer): How we can expose making this aligned?
     __parent.sync();
-    return {};
+    return __synchronizer_instance<_Unit>{__group_barrier_ptr};
   }
 };
 

--- a/cudax/include/cuda/experimental/__group/synchronizer/lane_synchronizer.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizer/lane_synchronizer.cuh
@@ -55,18 +55,25 @@ public:
     }
 
     template <class _MappingResult, class _Hierarchy>
-    _CCCL_DEVICE_API void
-    do_sync(const _MappingResult& __mapping_result, const lane_synchronizer&, const _Hierarchy&) const noexcept
+    _CCCL_DEVICE_API void do_sync(const _MappingResult& __mapping_result, const _Hierarchy&) const noexcept
     {
       ::__syncwarp(__mapping_result.lane_mask().value());
     }
 
     template <class _MappingResult, class _Hierarchy>
-    _CCCL_DEVICE_API void
-    do_sync_aligned(const _MappingResult& __mapping_result, const lane_synchronizer&, const _Hierarchy&) const noexcept
+    _CCCL_DEVICE_API void do_sync_aligned(const _MappingResult& __mapping_result, const _Hierarchy&) const noexcept
     {
       ::__syncwarp(__mapping_result.lane_mask().value());
     }
+
+    [[nodiscard]] _CCCL_DEVICE_API __synchronizer_instance view() const noexcept
+    {
+      return *this;
+    }
+
+    template <class _MappingResult, class _Hierarchy>
+    _CCCL_DEVICE_API void deinit(const _MappingResult&, const _Hierarchy&) noexcept
+    {}
   };
 
   _CCCL_HIDE_FROM_ABI explicit lane_synchronizer() = default;

--- a/cudax/include/cuda/experimental/__group/synchronizer/level_synchronizer.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizer/level_synchronizer.cuh
@@ -61,77 +61,74 @@ _CCCL_DEVICE_API void __block_sync() noexcept
   }
 }
 
-template <>
-struct level_synchronizer::__synchronizer_instance<thread_level>
+template <class _Level>
+struct level_synchronizer::__synchronizer_instance
 {
   template <class _MappingResult, class _Hierarchy>
-  _CCCL_DEVICE_API void do_sync(const _MappingResult&, const level_synchronizer&, const _Hierarchy&) const noexcept
+  _CCCL_DEVICE_API void do_sync(const _MappingResult&, const _Hierarchy&) const noexcept
+  {
+    if constexpr (::cuda::std::is_same_v<_Level, thread_level>)
+    {
+    }
+    else if constexpr (::cuda::std::is_same_v<_Level, warp_level>)
+    {
+      ::__syncwarp();
+    }
+    else if constexpr (::cuda::std::is_same_v<_Level, block_level>)
+    {
+      ::cuda::experimental::__block_sync</*is-aligned*/ false>();
+    }
+    else if constexpr (::cuda::std::is_same_v<_Level, cluster_level>)
+    {
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,
+                        ({
+                          ::__cluster_barrier_arrive();
+                          ::__cluster_barrier_wait();
+                        }),
+                        ({ ::cuda::experimental::__block_sync</*is-aligned*/ false>(); }))
+    }
+    else
+    {
+      static_assert(::cuda::std::__always_false_v<_Level>, "Unsupported level");
+    }
+  }
+
+  template <class _MappingResult, class _Hierarchy>
+  _CCCL_DEVICE_API void do_sync_aligned(const _MappingResult&, const _Hierarchy&) const noexcept
+  {
+    if constexpr (::cuda::std::is_same_v<_Level, thread_level>)
+    {
+    }
+    else if constexpr (::cuda::std::is_same_v<_Level, warp_level>)
+    {
+      ::__syncwarp();
+    }
+    else if constexpr (::cuda::std::is_same_v<_Level, block_level>)
+    {
+      ::cuda::experimental::__block_sync</*is-aligned*/ true>();
+    }
+    else if constexpr (::cuda::std::is_same_v<_Level, cluster_level>)
+    {
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,
+                        ({
+                          asm volatile("barrier.cluster.arrive.aligned;");
+                          asm volatile("barrier.cluster.wait.aligned;");
+                        }),
+                        ({ ::cuda::experimental::__block_sync</*is-aligned*/ true>(); }))
+    }
+    else
+    {
+      static_assert(::cuda::std::__always_false_v<_Level>, "Unsupported level");
+    }
+  }
+
+  template <class _MappingResult, class _Hierarchy>
+  _CCCL_DEVICE_API void deinit(const _MappingResult&, const _Hierarchy&) noexcept
   {}
 
-  template <class _MappingResult, class _Hierarchy>
-  _CCCL_DEVICE_API void
-  do_sync_aligned(const _MappingResult&, const level_synchronizer&, const _Hierarchy&) const noexcept
-  {}
-};
-
-template <>
-struct level_synchronizer::__synchronizer_instance<warp_level>
-{
-  template <class _MappingResult, class _Hierarchy>
-  _CCCL_DEVICE_API void do_sync(const _MappingResult&, const level_synchronizer&, const _Hierarchy&) const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API __synchronizer_instance view() const noexcept
   {
-    ::__syncwarp();
-  }
-
-  template <class _MappingResult, class _Hierarchy>
-  _CCCL_DEVICE_API void
-  do_sync_aligned(const _MappingResult&, const level_synchronizer&, const _Hierarchy&) const noexcept
-  {
-    ::__syncwarp();
-  }
-};
-
-template <>
-struct level_synchronizer::__synchronizer_instance<block_level>
-{
-  template <class _MappingResult, class _Hierarchy>
-  _CCCL_DEVICE_API void do_sync(const _MappingResult&, const level_synchronizer&, const _Hierarchy&) const noexcept
-  {
-    ::cuda::experimental::__block_sync<false>();
-  }
-
-  template <class _MappingResult, class _Hierarchy>
-  _CCCL_DEVICE_API void
-  do_sync_aligned(const _MappingResult&, const level_synchronizer&, const _Hierarchy&) const noexcept
-  {
-    ::cuda::experimental::__block_sync<true>();
-  }
-};
-
-template <>
-struct level_synchronizer::__synchronizer_instance<cluster_level>
-{
-  template <class _MappingResult, class _Hierarchy>
-  _CCCL_DEVICE_API void do_sync(const _MappingResult&, const level_synchronizer&, const _Hierarchy&) const noexcept
-  {
-    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,
-                      ({
-                        ::__cluster_barrier_arrive();
-                        ::__cluster_barrier_wait();
-                      }),
-                      ({ ::cuda::experimental::__block_sync<false>(); }))
-  }
-
-  template <class _MappingResult, class _Hierarchy>
-  _CCCL_DEVICE_API void
-  do_sync_aligned(const _MappingResult&, const level_synchronizer&, const _Hierarchy&) const noexcept
-  {
-    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,
-                      ({
-                        asm volatile("barrier.cluster.arrive.aligned;");
-                        asm volatile("barrier.cluster.wait.aligned;");
-                      }),
-                      ({ ::cuda::experimental::__block_sync<true>(); }))
+    return *this;
   }
 };
 
@@ -141,17 +138,15 @@ template <>
 struct level_synchronizer::__synchronizer_instance<grid_level>
 {
   template <class _MappingResult, class _Hierarchy>
-  _CCCL_DEVICE_API void
-  do_sync(const _MappingResult&, const level_synchronizer&, const _Hierarchy& __hier) const noexcept
+  _CCCL_DEVICE_API void do_sync(const _MappingResult&, const _Hierarchy& __hier) const noexcept
   {
-    __sync_impl<false>(__hier);
+    __sync_impl</*is-aligned*/ false>(__hier);
   }
 
   template <class _MappingResult, class _Hierarchy>
-  _CCCL_DEVICE_API void
-  do_sync_aligned(const _MappingResult&, const level_synchronizer&, const _Hierarchy& __hier) const noexcept
+  _CCCL_DEVICE_API void do_sync_aligned(const _MappingResult&, const _Hierarchy& __hier) const noexcept
   {
-    __sync_impl<true>(__hier);
+    __sync_impl</*is-aligned*/ true>(__hier);
   }
 
   template <bool _Aligned, class _Hierarchy>
@@ -209,6 +204,15 @@ struct level_synchronizer::__synchronizer_instance<grid_level>
 
     // Wait for the thread 0 to finish the inter block synchronization.
     ::cuda::experimental::__block_sync<_Aligned>();
+  }
+
+  template <class _MappingResult, class _Hierarchy>
+  _CCCL_DEVICE_API void deinit(const _MappingResult&, const _Hierarchy&) noexcept
+  {}
+
+  [[nodiscard]] _CCCL_DEVICE_API __synchronizer_instance view() const noexcept
+  {
+    return *this;
   }
 };
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__group/this_group.cuh
+++ b/cudax/include/cuda/experimental/__group/this_group.cuh
@@ -157,12 +157,12 @@ public:
 
   _CCCL_DEVICE_API void sync() const noexcept
   {
-    __synchronizer_instance_.do_sync(__mapping_result_, __synchronizer_, __hier_);
+    __synchronizer_instance_.do_sync(__mapping_result_, __hier_);
   }
 
   _CCCL_DEVICE_API void sync_aligned() const noexcept
   {
-    __synchronizer_instance_.do_sync_aligned(__mapping_result_, __synchronizer_, __hier_);
+    __synchronizer_instance_.do_sync_aligned(__mapping_result_, __hier_);
   }
 
   _CCCL_TEMPLATE(class _Tp, class _InLevel)

--- a/cudax/test/group/synchronizer/barrier_synchronizer.cu
+++ b/cudax/test/group/synchronizer/barrier_synchronizer.cu
@@ -99,21 +99,36 @@ __device__ void test_barrier_synchronizer(const Level& level, Config config)
     const cudax::group_by mapping{4};
     const cudax::barrier_synchronizer synchronizer{barriers};
 
-    const auto mapping_result        = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
-    const auto synchronizer_instance = synchronizer.make_instance(cuda::gpu_thread, parent_group, mapping_result);
+    const auto mapping_result  = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
+    auto synchronizer_instance = synchronizer.make_instance(cuda::gpu_thread, parent_group, mapping_result);
 
     // Test do_sync(...).
-    static_assert(
-      cuda::std::is_same_v<void, decltype(synchronizer_instance.do_sync(mapping_result, synchronizer, hierarchy))>);
-    static_assert(noexcept(synchronizer_instance.do_sync(mapping_result, synchronizer, hierarchy)));
-    synchronizer_instance.do_sync(mapping_result, synchronizer, hierarchy);
+    static_assert(cuda::std::is_same_v<void, decltype(synchronizer_instance.do_sync(mapping_result, hierarchy))>);
+    static_assert(noexcept(synchronizer_instance.do_sync(mapping_result, hierarchy)));
+    synchronizer_instance.do_sync(mapping_result, hierarchy);
 
     // Test do_sync_aligned(...).
     static_assert(
-      cuda::std::is_same_v<void,
-                           decltype(synchronizer_instance.do_sync_aligned(mapping_result, synchronizer, hierarchy))>);
-    static_assert(noexcept(synchronizer_instance.do_sync_aligned(mapping_result, synchronizer, hierarchy)));
-    synchronizer_instance.do_sync_aligned(mapping_result, synchronizer, hierarchy);
+      cuda::std::is_same_v<void, decltype(synchronizer_instance.do_sync_aligned(mapping_result, hierarchy))>);
+    static_assert(noexcept(synchronizer_instance.do_sync_aligned(mapping_result, hierarchy)));
+    synchronizer_instance.do_sync_aligned(mapping_result, hierarchy);
+
+    // Test view().
+    static_assert(cuda::std::is_same_v<cudax::__barrier_synchronizer_instance<Barrier, cuda::thread_level, false>,
+                                       decltype(synchronizer_instance.view())>);
+    static_assert(noexcept(synchronizer_instance.view()));
+    auto synchronizer_instance_view = synchronizer_instance.view();
+    synchronizer_instance_view.do_sync(mapping_result, hierarchy);
+    synchronizer_instance_view.do_sync_aligned(mapping_result, hierarchy);
+    (void) synchronizer_instance_view.view();
+    static_assert(cuda::std::is_same_v<cudax::__barrier_synchronizer_instance<Barrier, cuda::thread_level, false>,
+                                       decltype(synchronizer_instance.view().view())>);
+    synchronizer_instance_view.deinit(mapping_result, hierarchy); // should be noop
+
+    // Test deinit(...);
+    static_assert(cuda::std::is_same_v<void, decltype(synchronizer_instance.deinit(mapping_result, hierarchy))>);
+    static_assert(noexcept(synchronizer_instance.deinit(mapping_result, hierarchy)));
+    synchronizer_instance.deinit(mapping_result, hierarchy);
   }
 }
 

--- a/cudax/test/group/synchronizer/lane_synchronizer.cu
+++ b/cudax/test/group/synchronizer/lane_synchronizer.cu
@@ -40,21 +40,33 @@ __device__ void test_lane_synchronizer(const Level& level, Config config)
     const cudax::group_by mapping{2};
     const Synchronizer synchronizer{};
 
-    const auto mapping_result        = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
-    const auto synchronizer_instance = synchronizer.make_instance(cuda::gpu_thread, parent_group, mapping_result);
+    const auto mapping_result  = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
+    auto synchronizer_instance = synchronizer.make_instance(cuda::gpu_thread, parent_group, mapping_result);
 
     // Test do_sync(...).
-    static_assert(
-      cuda::std::is_same_v<void, decltype(synchronizer_instance.do_sync(mapping_result, synchronizer, hierarchy))>);
-    static_assert(noexcept(synchronizer_instance.do_sync(mapping_result, synchronizer, hierarchy)));
-    synchronizer_instance.do_sync(mapping_result, synchronizer, hierarchy);
+    static_assert(cuda::std::is_same_v<void, decltype(synchronizer_instance.do_sync(mapping_result, hierarchy))>);
+    static_assert(noexcept(synchronizer_instance.do_sync(mapping_result, hierarchy)));
+    synchronizer_instance.do_sync(mapping_result, hierarchy);
 
     // Test do_sync_aligned(...).
     static_assert(
-      cuda::std::is_same_v<void,
-                           decltype(synchronizer_instance.do_sync_aligned(mapping_result, synchronizer, hierarchy))>);
-    static_assert(noexcept(synchronizer_instance.do_sync_aligned(mapping_result, synchronizer, hierarchy)));
-    synchronizer_instance.do_sync_aligned(mapping_result, synchronizer, hierarchy);
+      cuda::std::is_same_v<void, decltype(synchronizer_instance.do_sync_aligned(mapping_result, hierarchy))>);
+    static_assert(noexcept(synchronizer_instance.do_sync_aligned(mapping_result, hierarchy)));
+    synchronizer_instance.do_sync_aligned(mapping_result, hierarchy);
+
+    // Test view().
+    static_assert(cuda::std::is_same_v<decltype(synchronizer_instance), decltype(synchronizer_instance.view())>);
+    static_assert(noexcept(synchronizer_instance.view()));
+    auto synchronizer_instance_view = synchronizer_instance.view();
+    synchronizer_instance_view.do_sync(mapping_result, hierarchy);
+    synchronizer_instance_view.do_sync_aligned(mapping_result, hierarchy);
+    (void) synchronizer_instance_view.view();
+    synchronizer_instance_view.deinit(mapping_result, hierarchy); // should be noop
+
+    // Test deinit(...);
+    static_assert(cuda::std::is_same_v<void, decltype(synchronizer_instance.deinit(mapping_result, hierarchy))>);
+    static_assert(noexcept(synchronizer_instance.deinit(mapping_result, hierarchy)));
+    synchronizer_instance.deinit(mapping_result, hierarchy);
   }
 }
 

--- a/cudax/test/group/synchronizer/level_synchronizer.cu
+++ b/cudax/test/group/synchronizer/level_synchronizer.cu
@@ -39,24 +39,35 @@ __device__ void test_level_synchronizer(const Level& level, Config config)
     using SynchronizerInstance = typename Synchronizer::template __synchronizer_instance<Level>;
 
     MappingResult mapping_result{};
-    Synchronizer synchronizer{};
 
     // Test default constructor.
     static_assert(cuda::std::is_nothrow_default_constructible_v<SynchronizerInstance>);
     SynchronizerInstance synchronizer_instance{};
 
     // Test do_sync(...).
-    static_assert(
-      cuda::std::is_same_v<void, decltype(synchronizer_instance.do_sync(mapping_result, synchronizer, hierarchy))>);
-    static_assert(noexcept(synchronizer_instance.do_sync(mapping_result, synchronizer, hierarchy)));
-    synchronizer_instance.do_sync(mapping_result, synchronizer, hierarchy);
+    static_assert(cuda::std::is_same_v<void, decltype(synchronizer_instance.do_sync(mapping_result, hierarchy))>);
+    static_assert(noexcept(synchronizer_instance.do_sync(mapping_result, hierarchy)));
+    synchronizer_instance.do_sync(mapping_result, hierarchy);
 
     // Test do_sync_aligned(...).
     static_assert(
-      cuda::std::is_same_v<void,
-                           decltype(synchronizer_instance.do_sync_aligned(mapping_result, synchronizer, hierarchy))>);
-    static_assert(noexcept(synchronizer_instance.do_sync_aligned(mapping_result, synchronizer, hierarchy)));
-    synchronizer_instance.do_sync_aligned(mapping_result, synchronizer, hierarchy);
+      cuda::std::is_same_v<void, decltype(synchronizer_instance.do_sync_aligned(mapping_result, hierarchy))>);
+    static_assert(noexcept(synchronizer_instance.do_sync_aligned(mapping_result, hierarchy)));
+    synchronizer_instance.do_sync_aligned(mapping_result, hierarchy);
+
+    // Test view().
+    static_assert(cuda::std::is_same_v<decltype(synchronizer_instance), decltype(synchronizer_instance.view())>);
+    static_assert(noexcept(synchronizer_instance.view()));
+    auto synchronizer_instance_view = synchronizer_instance.view();
+    synchronizer_instance_view.do_sync(mapping_result, hierarchy);
+    synchronizer_instance_view.do_sync_aligned(mapping_result, hierarchy);
+    (void) synchronizer_instance_view.view();
+    synchronizer_instance_view.deinit(mapping_result, hierarchy); // should be noop
+
+    // Test deinit(...);
+    static_assert(cuda::std::is_same_v<void, decltype(synchronizer_instance.deinit(mapping_result, hierarchy))>);
+    static_assert(noexcept(synchronizer_instance.deinit(mapping_result, hierarchy)));
+    synchronizer_instance.deinit(mapping_result, hierarchy);
   }
 }
 


### PR DESCRIPTION
Up to this point, the synchronizer instance has always owned the synchronization resources. However, for a `group_view`, we need a non-owning view over the resource.

This PR changes the definition of the synchronizer instance to also implement `.view()` method that returns a non-owning view over the resource. The view returned view must satisfy the synchronizer instance concept, too.

I'm also trying to move towards removing the synchronizer instance dependency on the synchronizer object, because I'd like to remove the synchronizer from the `group`'s members, same as I did with mappings.

I've also added the `deinit(...)` function that should handle deinitialization of the synchronizer instance. It can't be done in the destructor, because it might need some more information like unit's rank for the operation.