### PR TITLE
[libcu++] Guard against overflows in async buffer

### DIFF
--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -32,6 +32,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
 #include <catch2/matchers/catch_matchers_templated.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
 

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -783,7 +783,7 @@ public:
   }
 
 #  ifndef _CCCL_DOXYGEN_INVOKED
-  _CCCL_HOST_API constexpr void __set_size_unsynchronized(size_type __size) noexcept
+  _CCCL_HOST_API constexpr void __set_size_unsynchronized(size_type __size)
   {
     __buf_.__set_size(__size);
   }

--- a/libcudacxx/include/cuda/__container/resizable_buffer.h
+++ b/libcudacxx/include/cuda/__container/resizable_buffer.h
@@ -127,7 +127,7 @@ public:
   _CCCL_HOST_API __resizable_buffer& operator=(__resizable_buffer&& __other) noexcept
   {
     if (this != ::cuda::std::addressof(__other))
-    {
+    { // This cannot throw because in other we already checked that capacity is sufficient
       __base_t::__set_size_unsynchronized(__capacity_);
       __base_t::operator=(::cuda::std::move(__other));
       __capacity_ = ::cuda::std::exchange(__other.__capacity_, 0);

--- a/libcudacxx/include/cuda/__container/uninitialized_async_buffer.h
+++ b/libcudacxx/include/cuda/__container/uninitialized_async_buffer.h
@@ -220,7 +220,7 @@ private:
     return __a;
   }
 
-  static size_t __validate_element_count(const size_t __count, const size_t __alignment)
+  [[nodiscard]] static size_t __validate_element_count(const size_t __count, const size_t __alignment)
   {
     constexpr size_t __max_element_count = static_cast<size_t>(-1) / sizeof(_Tp);
     if (__count > __max_element_count)
@@ -228,8 +228,8 @@ private:
       _CCCL_THROW(::std::invalid_argument, "cuda::__uninitialized_async_buffer: Input size overflow");
     }
 
-    const size_t __count_bytes = __count * sizeof(_Tp);
-    if (__count_bytes > __max_element_count - (__alignment - 1))
+    const size_t __count_elements = __count * sizeof(_Tp);
+    if (__count_elements > __max_element_count - (__alignment - 1))
     {
       _CCCL_THROW(::std::invalid_argument, "cuda::__uninitialized_async_buffer: Input size overflow");
     }
@@ -466,6 +466,8 @@ public:
   _CCCL_HOST_API void
   __replace_allocation_discard(::cuda::stream_ref __stream, const size_t __count, const size_t __old_capacity)
   {
+    __validate_element_count(__count, __alignment_);
+
     if (__buf_)
     {
       __mr_.deallocate(__stream_, __buf_, __get_allocation_size(__old_capacity), __alignment_);
@@ -476,7 +478,6 @@ public:
     __stream_ = __stream;
     if (__count != 0)
     {
-      __validate_element_count(__count, __alignment_);
       __buf_ = __mr_.allocate(__stream_, __get_allocation_size(__count), __alignment_);
     }
     __count_ = __count;

--- a/libcudacxx/include/cuda/__container/uninitialized_async_buffer.h
+++ b/libcudacxx/include/cuda/__container/uninitialized_async_buffer.h
@@ -27,6 +27,7 @@
 #  include <cuda/__memory_resource/any_resource.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/__stream/stream_ref.h>
+#  include <cuda/std/__host_stdlib/stdexcept>
 #  include <cuda/std/__memory/addressof.h>
 #  include <cuda/std/__memory/align.h>
 #  include <cuda/std/__new/launder.h>
@@ -207,7 +208,7 @@ public:
     const size_t __alignment = alignof(_Tp))
       : __mr_(::cuda::std::move(__mr))
       , __stream_(__stream)
-      , __count_(__count)
+      , __count_(__validate_element_count(__count, __alignment))
       , __alignment_(__validate_alignment_param(__alignment))
       , __buf_(__count_ == 0 ? nullptr : __mr_.allocate(__stream_, __get_allocation_size(__count_), __alignment_))
   {}
@@ -217,6 +218,22 @@ private:
   {
     ::cuda::__validate_allocation_alignment(__a, alignof(_Tp));
     return __a;
+  }
+
+  static size_t __validate_element_count(const size_t __count, const size_t __alignment)
+  {
+    constexpr size_t __max_element_count = static_cast<size_t>(-1) / sizeof(_Tp);
+    if (__count > __max_element_count)
+    {
+      _CCCL_THROW(::std::invalid_argument, "cuda::__uninitialized_async_buffer: Input size overflow");
+    }
+
+    const size_t __count_bytes = __count * sizeof(_Tp);
+    if (__count_bytes > __max_element_count - (__alignment - 1))
+    {
+      _CCCL_THROW(::std::invalid_argument, "cuda::__uninitialized_async_buffer: Input size overflow");
+    }
+    return __count;
   }
 
 public:
@@ -303,9 +320,9 @@ public:
   }
 
 #  ifndef _CCCL_DOXYGEN_INVOKED
-  _CCCL_HOST_API constexpr void __set_size(const size_t __count) noexcept
+  _CCCL_HOST_API constexpr void __set_size(const size_t __count)
   {
-    __count_ = __count;
+    __count_ = __validate_element_count(__count, __alignment_);
   }
 #  endif // _CCCL_DOXYGEN_INVOKED
 
@@ -459,6 +476,7 @@ public:
     __stream_ = __stream;
     if (__count != 0)
     {
+      __validate_element_count(__count, __alignment_);
       __buf_ = __mr_.allocate(__stream_, __get_allocation_size(__count), __alignment_);
     }
     __count_ = __count;

--- a/libcudacxx/include/cuda/__container/uninitialized_async_buffer.h
+++ b/libcudacxx/include/cuda/__container/uninitialized_async_buffer.h
@@ -214,13 +214,13 @@ public:
   {}
 
 private:
-  static size_t __validate_alignment_param(size_t __a)
+  _CCCL_HOST_API static size_t __validate_alignment_param(size_t __a)
   {
     ::cuda::__validate_allocation_alignment(__a, alignof(_Tp));
     return __a;
   }
 
-  [[nodiscard]] static size_t __validate_element_count(const size_t __count, const size_t __alignment)
+  _CCCL_HOST_API static size_t __validate_element_count(const size_t __count, const size_t __alignment)
   {
     constexpr size_t __max_element_count = static_cast<size_t>(-1) / sizeof(_Tp);
     if (__count > __max_element_count)

--- a/libcudacxx/test/libcudacxx/cuda/containers/uninitialized_async_buffer.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/uninitialized_async_buffer.cu
@@ -95,6 +95,29 @@ C2H_TEST_LIST(
       CCCLRT_CHECK(input.size() == 0);
       CCCLRT_CHECK(input.stream() == cuda::stream_ref{cudaStream_t{}});
     }
+
+    if constexpr (sizeof(TestType) != 1)
+    { // Ensure that we properly fail to allocate data that would overflow
+      constexpr size_t max_element_count = static_cast<size_t>(-1) / sizeof(TestType);
+
+      try
+      { // Multiplication for byte count would overflow
+        __uninitialized_async_buffer input{resource, stream, max_element_count + 1};
+      }
+      catch (const ::std::invalid_argument& e)
+      {
+        CHECK(e.what() == ::std::string("cuda::__uninitialized_async_buffer: Input size overflow"));
+      }
+
+      try
+      { // Adding alignment would overflow
+        __uninitialized_async_buffer input{resource, stream, max_element_count, 4};
+      }
+      catch (const ::std::invalid_argument& e)
+      {
+        CHECK(e.what() == ::std::string("cuda::__uninitialized_async_buffer: Input size overflow"));
+      }
+    }
   }
 
   SECTION("conversion")
@@ -217,6 +240,20 @@ C2H_TEST_LIST(
       CCCLRT_CHECK(old_buf.size() == old_size);
 
       CCCLRT_CHECK(buf.stream() == old_buf.stream());
+    }
+
+    if constexpr (sizeof(TestType) != 1)
+    {
+      constexpr size_t max_element_count = static_cast<size_t>(-1) / sizeof(TestType);
+
+      try
+      { // Multiplication for byte count would overflow
+        const __uninitialized_async_buffer old_buf = buf.__replace_allocation(max_element_count + 1);
+      }
+      catch (const ::std::invalid_argument& e)
+      {
+        CHECK(e.what() == ::std::string("cuda::__uninitialized_async_buffer: Input size overflow"));
+      }
     }
   }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/uninitialized_async_buffer.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/uninitialized_async_buffer.cu
@@ -100,23 +100,17 @@ C2H_TEST_LIST(
     { // Ensure that we properly fail to allocate data that would overflow
       constexpr size_t max_element_count = static_cast<size_t>(-1) / sizeof(TestType);
 
-      try
-      { // Multiplication for byte count would overflow
-        __uninitialized_async_buffer input{resource, stream, max_element_count + 1};
-      }
-      catch (const ::std::invalid_argument& e)
-      {
-        CHECK(e.what() == ::std::string("cuda::__uninitialized_async_buffer: Input size overflow"));
-      }
+      // Multiplication for byte count would overflow
+      REQUIRE_THROWS_MATCHES(
+        __uninitialized_async_buffer(resource, stream, max_element_count + 1),
+        ::std::invalid_argument,
+        Catch::Matchers::ExceptionMessageMatcher("cuda::__uninitialized_async_buffer: Input size overflow"));
 
-      try
-      { // Adding alignment would overflow
-        __uninitialized_async_buffer input{resource, stream, max_element_count, 4};
-      }
-      catch (const ::std::invalid_argument& e)
-      {
-        CHECK(e.what() == ::std::string("cuda::__uninitialized_async_buffer: Input size overflow"));
-      }
+      // Adding alignment would overflow
+      REQUIRE_THROWS_MATCHES(
+        __uninitialized_async_buffer(resource, stream, max_element_count, 4),
+        ::std::invalid_argument,
+        Catch::Matchers::ExceptionMessageMatcher("cuda::__uninitialized_async_buffer: Input size overflow"));
     }
   }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/uninitialized_async_buffer.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/uninitialized_async_buffer.cu
@@ -225,6 +225,21 @@ C2H_TEST_LIST(
     const TestType* old_ptr = buf.data();
     const size_t old_size   = buf.size();
 
+    if constexpr (sizeof(TestType) != 1)
+    {
+      constexpr size_t max_element_count = static_cast<size_t>(-1) / sizeof(TestType);
+      cuda::stream new_stream{cuda::device_ref{0}};
+
+      REQUIRE_THROWS_MATCHES(
+        (buf.__replace_allocation(new_stream, max_element_count + 1)),
+        ::std::invalid_argument,
+        Catch::Matchers::ExceptionMessageMatcher("cuda::__uninitialized_async_buffer: Input size overflow"));
+
+      CCCLRT_CHECK(buf.data() == old_ptr);
+      CCCLRT_CHECK(buf.size() == old_size);
+      CCCLRT_CHECK(buf.stream() == stream);
+    }
+
     {
       const __uninitialized_async_buffer old_buf = buf.__replace_allocation(1337);
       CCCLRT_CHECK(buf.data() != old_ptr);
@@ -232,22 +247,7 @@ C2H_TEST_LIST(
 
       CCCLRT_CHECK(old_buf.data() == old_ptr);
       CCCLRT_CHECK(old_buf.size() == old_size);
-
       CCCLRT_CHECK(buf.stream() == old_buf.stream());
-    }
-
-    if constexpr (sizeof(TestType) != 1)
-    {
-      constexpr size_t max_element_count = static_cast<size_t>(-1) / sizeof(TestType);
-
-      try
-      { // Multiplication for byte count would overflow
-        const __uninitialized_async_buffer old_buf = buf.__replace_allocation(max_element_count + 1);
-      }
-      catch (const ::std::invalid_argument& e)
-      {
-        CHECK(e.what() == ::std::string("cuda::__uninitialized_async_buffer: Input size overflow"));
-      }
     }
   }
 


### PR DESCRIPTION
We are determining the size of the allocation through some calculations that can potentially overflow.

Guard against those cases with a clear error message

Fixes nvbug6511332