### PR TITLE
[libcu++] Guard against zero alignment in memory pools

### DIFF
--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -32,6 +32,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
 #include <catch2/matchers/catch_matchers_templated.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
 

--- a/libcudacxx/include/cuda/__memory/is_valid_alignment.h
+++ b/libcudacxx/include/cuda/__memory/is_valid_alignment.h
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/__cmath/pow2.h>
+#include <cuda/__memory_resource/properties.h>
 #include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__type_traits/is_void.h>
 
@@ -39,6 +40,25 @@ template <class _Tp = void>
   else
   {
     return __alignment >= alignof(_Tp) && ::cuda::is_power_of_two(__alignment);
+  }
+}
+
+//! @brief Checks whether the passed in alignment is valid
+//! @param __alignment The user provided alignment
+//! @returns true if \p __alignment is less or equal than default_cuda_malloc_alignment and
+//! default_cuda_malloc_alignment is divisible by \p __alignment
+template <class _Tp = void>
+[[nodiscard]] _CCCL_API constexpr bool __is_valid_cuda_alignment(const size_t __alignment) noexcept
+{
+  if constexpr (::cuda::std::is_void_v<_Tp>)
+  {
+    return __alignment > 0 && __alignment <= ::cuda::mr::default_cuda_malloc_alignment
+        && (::cuda::mr::default_cuda_malloc_alignment % __alignment == 0);
+  }
+  else
+  {
+    return __alignment >= alignof(_Tp) && __alignment <= ::cuda::mr::default_cuda_malloc_alignment
+        && (::cuda::mr::default_cuda_malloc_alignment % __alignment == 0);
   }
 }
 

--- a/libcudacxx/include/cuda/__memory/is_valid_alignment.h
+++ b/libcudacxx/include/cuda/__memory/is_valid_alignment.h
@@ -43,6 +43,8 @@ template <class _Tp = void>
   }
 }
 
+#if _CCCL_HAS_CTK()
+
 //! @brief Checks whether the passed in alignment is valid
 //! @param __alignment The user provided alignment
 //! @returns true if \p __alignment is less or equal than default_cuda_malloc_alignment and
@@ -61,6 +63,8 @@ template <class _Tp = void>
         && (::cuda::mr::default_cuda_malloc_alignment % __alignment == 0);
   }
 }
+
+#endif // _CCCL_HAS_CTK()
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
+++ b/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
@@ -25,6 +25,7 @@
 
 #  include <cuda/__device/attributes.h>
 #  include <cuda/__device/device_ref.h>
+#  include <cuda/__memory/is_valid_alignment.h>
 #  include <cuda/__memory_resource/any_resource.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/__runtime/api_wrapper.h>
@@ -482,19 +483,6 @@ class __memory_pool_base
 protected:
   ::cudaMemPool_t __pool_;
 
-  //! @brief Checks whether the passed in alignment is valid.
-  //! @param __alignment the alignment to check.
-  //! @returns true if \p __alignment is valid.
-  [[nodiscard]] _CCCL_HOST_API static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept
-  {
-    if (__alignment == 0)
-    {
-      return false;
-    }
-    return __alignment <= ::cuda::mr::default_cuda_malloc_alignment
-        && (::cuda::mr::default_cuda_malloc_alignment % __alignment == 0);
-  }
-
 public:
   __memory_pool_base(::cuda::std::nullptr_t) = delete;
 
@@ -514,7 +502,7 @@ public:
   [[nodiscard]] _CCCL_HOST_API void*
   allocate_sync(const size_t __bytes, const size_t __alignment = ::cuda::mr::default_cuda_malloc_alignment)
   {
-    if (!__is_valid_alignment(__alignment))
+    if (!::cuda::__is_valid_cuda_alignment(__alignment))
     {
       _CCCL_THROW(::std::invalid_argument, "Invalid alignment passed to __memory_pool_base::allocate_sync.");
     }
@@ -540,7 +528,8 @@ public:
     const size_t,
     [[maybe_unused]] const size_t __alignment = ::cuda::mr::default_cuda_malloc_alignment) noexcept
   {
-    _CCCL_ASSERT(__is_valid_alignment(__alignment), "Invalid alignment passed to __memory_pool_base::deallocate_sync.");
+    _CCCL_ASSERT(::cuda::__is_valid_cuda_alignment(__alignment),
+                 "Invalid alignment passed to __memory_pool_base::deallocate_sync.");
     _CCCL_ASSERT_DRIVER_API(
       ::cuda::__driver::__freeAsyncNoThrow,
       "deallocate failed",
@@ -559,7 +548,7 @@ public:
   [[nodiscard]] _CCCL_HOST_API void*
   allocate(const ::cuda::stream_ref __stream, const size_t __bytes, const size_t __alignment)
   {
-    if (!__is_valid_alignment(__alignment))
+    if (!::cuda::__is_valid_cuda_alignment(__alignment))
     {
       _CCCL_THROW(::std::invalid_argument, "Invalid alignment passed to __memory_pool_base::allocate.");
     }
@@ -601,7 +590,8 @@ public:
   {
     // We need to ensure that the provided alignment matches the minimal
     // provided alignment
-    _CCCL_ASSERT(__is_valid_alignment(__alignment), "Invalid alignment passed to __memory_pool_base::deallocate.");
+    _CCCL_ASSERT(::cuda::__is_valid_cuda_alignment(__alignment),
+                 "Invalid alignment passed to __memory_pool_base::deallocate.");
     deallocate(__stream, __ptr, __bytes);
   }
 

--- a/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
+++ b/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
@@ -487,6 +487,10 @@ protected:
   //! @returns true if \p __alignment is valid.
   [[nodiscard]] _CCCL_HOST_API static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept
   {
+    if (__alignment == 0)
+    {
+      return false;
+    }
     return __alignment <= ::cuda::mr::default_cuda_malloc_alignment
         && (::cuda::mr::default_cuda_malloc_alignment % __alignment == 0);
   }

--- a/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
@@ -129,6 +129,10 @@ public:
   //! @brief Checks whether the passed in alignment is valid
   [[nodiscard]] _CCCL_HOST_API static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept
   {
+    if (__alignment == 0)
+    {
+      return false;
+    }
     return __alignment <= ::cuda::mr::default_cuda_malloc_alignment
         && (::cuda::mr::default_cuda_malloc_alignment % __alignment == 0);
   }

--- a/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
@@ -23,6 +23,7 @@
 
 #if _CCCL_HAS_CTK()
 
+#  include <cuda/__memory/is_valid_alignment.h>
 #  include <cuda/__memory_resource/any_resource.h>
 #  include <cuda/__memory_resource/get_property.h>
 #  include <cuda/__memory_resource/memory_resource_base.h>
@@ -72,7 +73,7 @@ public:
   allocate_sync(const size_t __bytes, const size_t __alignment = ::cuda::mr::default_cuda_malloc_alignment)
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
-    if (!__is_valid_alignment(__alignment))
+    if (!::cuda::__is_valid_cuda_alignment(__alignment))
     {
       _CCCL_THROW(::std::invalid_argument,
                   "Invalid alignment passed to legacy_managed_memory_resource::allocate_sync.");
@@ -93,7 +94,7 @@ public:
     [[maybe_unused]] const size_t __alignment = ::cuda::mr::default_cuda_malloc_alignment) noexcept
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
-    _CCCL_ASSERT(__is_valid_alignment(__alignment),
+    _CCCL_ASSERT(::cuda::__is_valid_cuda_alignment(__alignment),
                  "Invalid alignment passed to legacy_managed_memory_resource::deallocate_sync.");
     _CCCL_ASSERT_DRIVER_API(::cuda::__driver::__freeNoThrow,
                             "legacy_managed_memory_resource::deallocate_sync failed",
@@ -125,17 +126,6 @@ public:
   _CCCL_HOST_API friend constexpr void
   get_property(legacy_managed_memory_resource const&, ::cuda::mr::host_accessible) noexcept
   {}
-
-  //! @brief Checks whether the passed in alignment is valid
-  [[nodiscard]] _CCCL_HOST_API static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept
-  {
-    if (__alignment == 0)
-    {
-      return false;
-    }
-    return __alignment <= ::cuda::mr::default_cuda_malloc_alignment
-        && (::cuda::mr::default_cuda_malloc_alignment % __alignment == 0);
-  }
 
   using default_queries = ::cuda::mr::properties_list<::cuda::mr::device_accessible, ::cuda::mr::host_accessible>;
 

--- a/libcudacxx/include/cuda/__memory_resource/legacy_pinned_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_pinned_memory_resource.h
@@ -116,6 +116,10 @@ public:
   //! @brief Checks whether the passed in alignment is valid
   _CCCL_HOST_API static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept
   {
+    if (__alignment == 0)
+    {
+      return false;
+    }
     return __alignment <= ::cuda::mr::default_cuda_malloc_alignment
         && (::cuda::mr::default_cuda_malloc_alignment % __alignment == 0);
   }

--- a/libcudacxx/include/cuda/__memory_resource/legacy_pinned_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_pinned_memory_resource.h
@@ -24,6 +24,7 @@
 #if _CCCL_HAS_CTK()
 
 #  include <cuda/__device/device_ref.h>
+#  include <cuda/__memory/is_valid_alignment.h>
 #  include <cuda/__memory_resource/memory_resource_base.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/__memory_resource/resource.h>
@@ -63,7 +64,7 @@ public:
   allocate_sync(const size_t __bytes, const size_t __alignment = ::cuda::mr::default_cuda_malloc_alignment)
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
-    if (!__is_valid_alignment(__alignment))
+    if (!::cuda::__is_valid_cuda_alignment(__alignment))
     {
       _CCCL_THROW(::std::invalid_argument, "Invalid alignment passed to legacy_pinned_memory_resource::allocate_sync.");
     }
@@ -83,7 +84,7 @@ public:
     [[maybe_unused]] const size_t __alignment = ::cuda::mr::default_cuda_malloc_alignment) noexcept
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
-    _CCCL_ASSERT(__is_valid_alignment(__alignment),
+    _CCCL_ASSERT(::cuda::__is_valid_cuda_alignment(__alignment),
                  "Invalid alignment passed to legacy_pinned_memory_resource::deallocate_sync.");
     _CCCL_ASSERT_DRIVER_API(
       ::cuda::__driver::__freeHostNoThrow, "legacy_pinned_memory_resource::deallocate_sync failed", __ptr);
@@ -112,17 +113,6 @@ public:
   _CCCL_HOST_API friend constexpr void
   get_property(legacy_pinned_memory_resource const&, ::cuda::mr::host_accessible) noexcept
   {}
-
-  //! @brief Checks whether the passed in alignment is valid
-  _CCCL_HOST_API static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept
-  {
-    if (__alignment == 0)
-    {
-      return false;
-    }
-    return __alignment <= ::cuda::mr::default_cuda_malloc_alignment
-        && (::cuda::mr::default_cuda_malloc_alignment % __alignment == 0);
-  }
 
   using default_queries = ::cuda::mr::properties_list<::cuda::mr::device_accessible, ::cuda::mr::host_accessible>;
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
@@ -328,6 +328,21 @@ C2H_CCCLRT_TEST("device_memory_pool allocation", "[memory_resource]")
   }
 
 #if _CCCL_HAS_EXCEPTIONS()
+  { // allocate with zero alignment
+    while (true)
+    {
+      try
+      {
+        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 0);
+      }
+      catch (std::invalid_argument&)
+      {
+        break;
+      }
+      CHECK(false);
+    }
+  }
+
   { // allocate with too small alignment
     while (true)
     {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
@@ -329,77 +329,45 @@ C2H_CCCLRT_TEST("device_memory_pool allocation", "[memory_resource]")
 
 #if _CCCL_HAS_EXCEPTIONS()
   { // allocate with zero alignment
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 0);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
-    }
+    REQUIRE_THROWS_MATCHES(
+      res.allocate_sync(5, 0),
+      ::std::invalid_argument,
+      Catch::Matchers::ExceptionMessageMatcher("Invalid alignment passed to __memory_pool_base::allocate_sync."));
   }
 
   { // allocate with too small alignment
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 42);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
-    }
+    REQUIRE_THROWS_MATCHES(
+      res.allocate_sync(5, 42),
+      ::std::invalid_argument,
+      Catch::Matchers::ExceptionMessageMatcher("Invalid alignment passed to __memory_pool_base::allocate_sync."));
   }
 
   { // allocate with non matching alignment
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 1337);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
-    }
+    REQUIRE_THROWS_MATCHES(
+      res.allocate_sync(5, 1337),
+      ::std::invalid_argument,
+      Catch::Matchers::ExceptionMessageMatcher("Invalid alignment passed to __memory_pool_base::allocate_sync."));
   }
+
+  { // allocate with zero alignment
+    REQUIRE_THROWS_MATCHES(
+      res.allocate(raw_stream, 5, 0),
+      ::std::invalid_argument,
+      Catch::Matchers::ExceptionMessageMatcher("Invalid alignment passed to __memory_pool_base::allocate."));
+  }
+
   { // allocate with too small alignment
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate(raw_stream, 5, 42);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
-    }
+    REQUIRE_THROWS_MATCHES(
+      res.allocate(raw_stream, 5, 42),
+      ::std::invalid_argument,
+      Catch::Matchers::ExceptionMessageMatcher("Invalid alignment passed to __memory_pool_base::allocate."));
   }
 
   { // allocate with non matching alignment
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate(raw_stream, 5, 1337);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
-    }
+    REQUIRE_THROWS_MATCHES(
+      res.allocate(raw_stream, 5, 1337),
+      ::std::invalid_argument,
+      Catch::Matchers::ExceptionMessageMatcher("Invalid alignment passed to __memory_pool_base::allocate."));
   }
 #endif // _CCCL_HAS_EXCEPTIONS()
   {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/managed_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/managed_memory_resource.cu
@@ -139,49 +139,24 @@ C2H_CCCLRT_TEST_LIST("managed_memory_resource allocation", "[memory_resource]", 
   }
 
 #if _CCCL_HAS_EXCEPTIONS()
+  const char* error_msg =
+    cuda::std::is_same_v<managed_resource, cuda::mr::legacy_managed_memory_resource>
+      ? "Invalid alignment passed to legacy_managed_memory_resource::allocate_sync."
+      : "Invalid alignment passed to __memory_pool_base::allocate_sync.";
+
   { // allocate_sync with zero alignment
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 0);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
-    }
+    REQUIRE_THROWS_MATCHES(
+      res.allocate_sync(5, 0), ::std::invalid_argument, Catch::Matchers::ExceptionMessageMatcher(error_msg));
   }
 
   { // allocate_sync with too small alignment
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 42);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
-    }
+    REQUIRE_THROWS_MATCHES(
+      res.allocate_sync(5, 42), ::std::invalid_argument, Catch::Matchers::ExceptionMessageMatcher(error_msg));
   }
 
   { // allocate_sync with non matching alignment
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 1337);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
-    }
+    REQUIRE_THROWS_MATCHES(
+      res.allocate_sync(5, 1337), ::std::invalid_argument, Catch::Matchers::ExceptionMessageMatcher(error_msg));
   }
 #endif // _CCCL_HAS_EXCEPTIONS()
 }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/managed_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/managed_memory_resource.cu
@@ -139,6 +139,21 @@ C2H_CCCLRT_TEST_LIST("managed_memory_resource allocation", "[memory_resource]", 
   }
 
 #if _CCCL_HAS_EXCEPTIONS()
+  { // allocate_sync with zero alignment
+    while (true)
+    {
+      try
+      {
+        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 0);
+      }
+      catch (std::invalid_argument&)
+      {
+        break;
+      }
+      CHECK(false);
+    }
+  }
+
   { // allocate_sync with too small alignment
     while (true)
     {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/pinned_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/pinned_memory_resource.cu
@@ -171,9 +171,9 @@ C2H_CCCLRT_TEST_LIST("pinned_memory_resource allocation", "[memory_resource]", T
   if constexpr (cuda::mr::resource<pinned_resource>)
   {
     const char* error_msg =
-      cuda::std::is_same_v<pinned_resource, cuda::pinned_memory_pool_ref>
-        ? "Invalid alignment passed to __memory_pool_base::allocate."
-        : "Invalid alignment passed to legacy_pinned_memory_resource::allocate.";
+      cuda::std::is_same_v<pinned_resource, cuda::mr::legacy_pinned_memory_resource>
+        ? "Invalid alignment passed to legacy_pinned_memory_resource::allocate."
+        : "Invalid alignment passed to __memory_pool_base::allocate.";
 
     { // allocate_sync with zero alignment
       REQUIRE_THROWS_MATCHES(

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/pinned_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/pinned_memory_resource.cu
@@ -146,82 +146,48 @@ C2H_CCCLRT_TEST_LIST("pinned_memory_resource allocation", "[memory_resource]", T
   }
 
 #if _CCCL_HAS_EXCEPTIONS()
-  { // allocate_sync with zero
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 0);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
-    }
-  }
+  {
+    const char* error_msg =
+      cuda::std::is_same_v<pinned_resource, cuda::mr::legacy_pinned_memory_resource>
+        ? "Invalid alignment passed to legacy_pinned_memory_resource::allocate_sync."
+        : "Invalid alignment passed to __memory_pool_base::allocate_sync.";
 
-  { // allocate_sync with too small alignment
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 42);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
+    { // allocate_sync with zero alignment
+      REQUIRE_THROWS_MATCHES(
+        res.allocate_sync(5, 0), ::std::invalid_argument, Catch::Matchers::ExceptionMessageMatcher(error_msg));
     }
-  }
 
-  { // allocate_sync with non matching alignment
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 1337);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
+    { // allocate_sync with too small alignment
+      REQUIRE_THROWS_MATCHES(
+        res.allocate_sync(5, 42), ::std::invalid_argument, Catch::Matchers::ExceptionMessageMatcher(error_msg));
+    }
+
+    { // allocate_sync with non matching alignment
+      REQUIRE_THROWS_MATCHES(
+        res.allocate_sync(5, 1337), ::std::invalid_argument, Catch::Matchers::ExceptionMessageMatcher(error_msg));
     }
   }
 
   if constexpr (cuda::mr::resource<pinned_resource>)
   {
+    const char* error_msg =
+      cuda::std::is_same_v<pinned_resource, cuda::pinned_memory_pool_ref>
+        ? "Invalid alignment passed to __memory_pool_base::allocate."
+        : "Invalid alignment passed to legacy_pinned_memory_resource::allocate.";
+
+    { // allocate_sync with zero alignment
+      REQUIRE_THROWS_MATCHES(
+        res.allocate(stream, 5, 0), ::std::invalid_argument, Catch::Matchers::ExceptionMessageMatcher(error_msg));
+    }
+
     { // allocate with too small alignment
-      while (true)
-      {
-        try
-        {
-          [[maybe_unused]] auto* ptr = res.allocate(stream, 5, 42);
-        }
-        catch (std::invalid_argument&)
-        {
-          break;
-        }
-        CHECK(false);
-      }
+      REQUIRE_THROWS_MATCHES(
+        res.allocate(stream, 5, 42), ::std::invalid_argument, Catch::Matchers::ExceptionMessageMatcher(error_msg));
     }
 
     { // allocate with non matching alignment
-      while (true)
-      {
-        try
-        {
-          auto* ptr = res.allocate(stream, 5, 1337);
-          (void) ptr;
-        }
-        catch (std::invalid_argument&)
-        {
-          break;
-        }
-        CHECK(false);
-      }
+      REQUIRE_THROWS_MATCHES(
+        res.allocate(stream, 5, 1337), ::std::invalid_argument, Catch::Matchers::ExceptionMessageMatcher(error_msg));
     }
   }
 #endif // _CCCL_HAS_EXCEPTIONS()

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/pinned_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/pinned_memory_resource.cu
@@ -146,6 +146,21 @@ C2H_CCCLRT_TEST_LIST("pinned_memory_resource allocation", "[memory_resource]", T
   }
 
 #if _CCCL_HAS_EXCEPTIONS()
+  { // allocate_sync with zero
+    while (true)
+    {
+      try
+      {
+        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 0);
+      }
+      catch (std::invalid_argument&)
+      {
+        break;
+      }
+      CHECK(false);
+    }
+  }
+
   { // allocate_sync with too small alignment
     while (true)
     {


### PR DESCRIPTION
This could lead to division by zero errors.

Fixes nvbug6511351