### PR TITLE
[STF] Formalize that parallel_for on the host requires nvcc or nvc++

### DIFF
--- a/cudax/examples/stf/frozen_data_init.cu
+++ b/cudax/examples/stf/frozen_data_init.cu
@@ -47,8 +47,8 @@ int main()
             EXPECT(fabs(x(i, j) - h_buf(i, j)) < 0.0001);
           };
 #else
-  CUDASTF_UNSUPPORTED(parallel_for_on_the_host_requires_nvcc_or_nvcpp,
-                      "parallel_for on exec_place::host() requires nvcc or nvc++");
+  _CCCL_UNSUPPORTED(parallel_for_on_the_host_requires_nvcc_or_nvcpp,
+                    "parallel_for on exec_place::host() requires nvcc or nvc++");
 #endif
 
   // Make sure all tasks are done before unfreezing

--- a/cudax/examples/stf/frozen_data_init.cu
+++ b/cudax/examples/stf/frozen_data_init.cu
@@ -47,19 +47,8 @@ int main()
             EXPECT(fabs(x(i, j) - h_buf(i, j)) < 0.0001);
           };
 #else
-  // parallel_for on the host requires nvcc or nvc++, which alone can classify lambdas for
-  // host/device execution; state that limitation instead of letting the kernel instantiation
-  // explain it. The call below is declared but never defined, and its 'error' attribute fires
-  // only at codegen: clang-tidy and -fsyntax-only sweeps analyze this file cleanly, while an
-  // actual build fails at compile time with the message (or at link time, with the name as
-  // the message, on compilers without the attribute). The noexcept is load-bearing: with a
-  // nontrivial destructor in scope the call would otherwise be emitted as an invoke, whose
-  // error-attribute diagnostic clang silently skips.
-#  if _CCCL_HAS_ATTRIBUTE(error)
-  __attribute__((error("parallel_for on exec_place::host() requires nvcc or nvc++")))
-#  endif
-  void parallel_for_on_the_host_requires_nvcc_or_nvcpp() noexcept;
-  parallel_for_on_the_host_requires_nvcc_or_nvcpp();
+  CUDASTF_UNSUPPORTED(parallel_for_on_the_host_requires_nvcc_or_nvcpp,
+                      "parallel_for on exec_place::host() requires nvcc or nvc++");
 #endif
 
   // Make sure all tasks are done before unfreezing

--- a/cudax/examples/stf/frozen_data_init.cu
+++ b/cudax/examples/stf/frozen_data_init.cu
@@ -41,10 +41,26 @@ int main()
     x(i, j) = d_buf(i, j);
   };
 
+#if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_CUDA_COMPILER(NVHPC)
   ctx.parallel_for(exec_place::host(), lX.shape(), lX.read()).set_symbol("check buf")
       ->*[h_buf](size_t i, size_t j, auto x) {
             EXPECT(fabs(x(i, j) - h_buf(i, j)) < 0.0001);
           };
+#else
+  // parallel_for on the host requires nvcc or nvc++, which alone can classify lambdas for
+  // host/device execution; state that limitation instead of letting the kernel instantiation
+  // explain it. The call below is declared but never defined, and its 'error' attribute fires
+  // only at codegen: clang-tidy and -fsyntax-only sweeps analyze this file cleanly, while an
+  // actual build fails at compile time with the message (or at link time, with the name as
+  // the message, on compilers without the attribute). The noexcept is load-bearing: with a
+  // nontrivial destructor in scope the call would otherwise be emitted as an invoke, whose
+  // error-attribute diagnostic clang silently skips.
+#  if _CCCL_HAS_ATTRIBUTE(error)
+  __attribute__((error("parallel_for on exec_place::host() requires nvcc or nvc++")))
+#  endif
+  void parallel_for_on_the_host_requires_nvcc_or_nvcpp() noexcept;
+  parallel_for_on_the_host_requires_nvcc_or_nvcpp();
+#endif
 
   // Make sure all tasks are done before unfreezing
   frozen_buffer.unfreeze(ctx.fence());

--- a/cudax/examples/stf/parallel_for_2D.cu
+++ b/cudax/examples/stf/parallel_for_2D.cu
@@ -53,6 +53,7 @@ int main()
     }
   };
 
+#if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_CUDA_COMPILER(NVHPC)
   ctx.parallel_for(exec_place::host(), ly.shape(), ly.read())
       ->*[=] __host__(size_t i, size_t j, slice<const double, 2> sy) {
             double expected = y0(i, j);
@@ -69,6 +70,21 @@ int main()
               printf("sy(%zu, %zu) %f expect %f\n", i, j, sy(i, j), expected);
             }
           };
+#else
+  // parallel_for on the host requires nvcc or nvc++, which alone can classify lambdas for
+  // host/device execution; state that limitation instead of letting the kernel instantiation
+  // explain it. The call below is declared but never defined, and its 'error' attribute fires
+  // only at codegen: clang-tidy and -fsyntax-only sweeps analyze this file cleanly, while an
+  // actual build fails at compile time with the message (or at link time, with the name as
+  // the message, on compilers without the attribute). The noexcept is load-bearing: with a
+  // nontrivial destructor in scope the call would otherwise be emitted as an invoke, whose
+  // error-attribute diagnostic clang silently skips.
+#  if _CCCL_HAS_ATTRIBUTE(error)
+  __attribute__((error("parallel_for on exec_place::host() requires nvcc or nvc++")))
+#  endif
+  void parallel_for_on_the_host_requires_nvcc_or_nvcpp() noexcept;
+  parallel_for_on_the_host_requires_nvcc_or_nvcpp();
+#endif
 
   ctx.finalize();
 }

--- a/cudax/examples/stf/parallel_for_2D.cu
+++ b/cudax/examples/stf/parallel_for_2D.cu
@@ -71,8 +71,8 @@ int main()
             }
           };
 #else
-  CUDASTF_UNSUPPORTED(parallel_for_on_the_host_requires_nvcc_or_nvcpp,
-                      "parallel_for on exec_place::host() requires nvcc or nvc++");
+  _CCCL_UNSUPPORTED(parallel_for_on_the_host_requires_nvcc_or_nvcpp,
+                    "parallel_for on exec_place::host() requires nvcc or nvc++");
 #endif
 
   ctx.finalize();

--- a/cudax/examples/stf/parallel_for_2D.cu
+++ b/cudax/examples/stf/parallel_for_2D.cu
@@ -71,19 +71,8 @@ int main()
             }
           };
 #else
-  // parallel_for on the host requires nvcc or nvc++, which alone can classify lambdas for
-  // host/device execution; state that limitation instead of letting the kernel instantiation
-  // explain it. The call below is declared but never defined, and its 'error' attribute fires
-  // only at codegen: clang-tidy and -fsyntax-only sweeps analyze this file cleanly, while an
-  // actual build fails at compile time with the message (or at link time, with the name as
-  // the message, on compilers without the attribute). The noexcept is load-bearing: with a
-  // nontrivial destructor in scope the call would otherwise be emitted as an invoke, whose
-  // error-attribute diagnostic clang silently skips.
-#  if _CCCL_HAS_ATTRIBUTE(error)
-  __attribute__((error("parallel_for on exec_place::host() requires nvcc or nvc++")))
-#  endif
-  void parallel_for_on_the_host_requires_nvcc_or_nvcpp() noexcept;
-  parallel_for_on_the_host_requires_nvcc_or_nvcpp();
+  CUDASTF_UNSUPPORTED(parallel_for_on_the_host_requires_nvcc_or_nvcpp,
+                      "parallel_for on exec_place::host() requires nvcc or nvc++");
 #endif
 
   ctx.finalize();

--- a/cudax/include/cuda/experimental/__stf/utility/core.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/core.cuh
@@ -48,9 +48,9 @@
  */
 #if _CCCL_HAS_ATTRIBUTE(error)
 #  define _CUDASTF_UNSUPPORTED_ATTRIBUTE(_msg) __attribute__((error(_msg)))
-#else // ^^^ _CCCL_HAS_ATTRIBUTE(error) ^^^ / vvv !_CCCL_HAS_ATTRIBUTE(error) vvv
+#else // _CCCL_HAS_ATTRIBUTE(error)
 #  define _CUDASTF_UNSUPPORTED_ATTRIBUTE(_msg)
-#endif // ^^^ !_CCCL_HAS_ATTRIBUTE(error) ^^^
+#endif // _CCCL_HAS_ATTRIBUTE(error)
 #define CUDASTF_UNSUPPORTED(_name, _msg)                \
   do                                                    \
   {                                                     \

--- a/cudax/include/cuda/experimental/__stf/utility/core.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/core.cuh
@@ -33,7 +33,7 @@
 
 /**
  * @brief Formalizes, at a statement position, that the enclosing code is not supported with
- * the current compiler: `CUDASTF_UNSUPPORTED(name_that_reads_as_a_message, "message")`.
+ * the current compiler: `_CCCL_UNSUPPORTED(name_that_reads_as_a_message, "message")`.
  *
  * Expands to a call to `name_that_reads_as_a_message`, declared on the spot but never defined
  * anywhere, carrying the GNU `error` attribute. The attribute's diagnostic fires only at
@@ -47,14 +47,14 @@
  * (observed with clang 21, plain C++ and CUDA alike).
  */
 #if _CCCL_HAS_ATTRIBUTE(error)
-#  define _CUDASTF_UNSUPPORTED_ATTRIBUTE(_msg) __attribute__((error(_msg)))
+#  define _CCCL_UNSUPPORTED_ATTRIBUTE(_msg) __attribute__((error(_msg)))
 #else // _CCCL_HAS_ATTRIBUTE(error)
-#  define _CUDASTF_UNSUPPORTED_ATTRIBUTE(_msg)
+#  define _CCCL_UNSUPPORTED_ATTRIBUTE(_msg)
 #endif // _CCCL_HAS_ATTRIBUTE(error)
-#define CUDASTF_UNSUPPORTED(_name, _msg)                \
+#define _CCCL_UNSUPPORTED(_name, _msg)                  \
   do                                                    \
   {                                                     \
-    _CUDASTF_UNSUPPORTED_ATTRIBUTE(_msg)                \
+    _CCCL_UNSUPPORTED_ATTRIBUTE(_msg)                   \
     void _name() noexcept; /* deliberately undefined */ \
     _name();                                            \
   } while (0)

--- a/cudax/include/cuda/experimental/__stf/utility/core.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/core.cuh
@@ -31,6 +31,34 @@
 #include <type_traits>
 #include <utility>
 
+/**
+ * @brief Formalizes, at a statement position, that the enclosing code is not supported with
+ * the current compiler: `CUDASTF_UNSUPPORTED(name_that_reads_as_a_message, "message")`.
+ *
+ * Expands to a call to `name_that_reads_as_a_message`, declared on the spot but never defined
+ * anywhere, carrying the GNU `error` attribute. The attribute's diagnostic fires only at
+ * codegen, which yields the intended split: clang-tidy and `-fsyntax-only` sweeps analyze the
+ * enclosing file cleanly, an actual build fails at compile time with the message, compilers
+ * without the attribute fail at link with the function name as the message, and nothing
+ * anywhere compiles into wrong runtime behavior.
+ *
+ * The `noexcept` is load-bearing: with a nontrivial destructor in scope the call would
+ * otherwise be emitted as an invoke, whose error-attribute diagnostic clang silently skips
+ * (observed with clang 21, plain C++ and CUDA alike).
+ */
+#if _CCCL_HAS_ATTRIBUTE(error)
+#  define _CUDASTF_UNSUPPORTED_ATTRIBUTE(_msg) __attribute__((error(_msg)))
+#else // ^^^ _CCCL_HAS_ATTRIBUTE(error) ^^^ / vvv !_CCCL_HAS_ATTRIBUTE(error) vvv
+#  define _CUDASTF_UNSUPPORTED_ATTRIBUTE(_msg)
+#endif // ^^^ !_CCCL_HAS_ATTRIBUTE(error) ^^^
+#define CUDASTF_UNSUPPORTED(_name, _msg)                \
+  do                                                    \
+  {                                                     \
+    _CUDASTF_UNSUPPORTED_ATTRIBUTE(_msg)                \
+    void _name() noexcept; /* deliberately undefined */ \
+    _name();                                            \
+  } while (0)
+
 namespace cuda::experimental::stf
 {
 #ifndef _CCCL_DOXYGEN_INVOKED // FIXME Doxygen is lost with decltype(auto)

--- a/cudax/test/stf/parallel_for/parallel_for_host.cu
+++ b/cudax/test/stf/parallel_for/parallel_for_host.cu
@@ -19,9 +19,25 @@ int main()
   int nqpoints = 3;
   auto ltoken  = ctx.token();
 
+#if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_CUDA_COMPILER(NVHPC)
   ctx.parallel_for(exec_place::host(), box(5), ltoken.read())->*[nqpoints] __host__(size_t) {
     _CCCL_ASSERT(nqpoints == 3, "invalid value");
   };
+#else
+  // parallel_for on the host requires nvcc or nvc++, which alone can classify lambdas for
+  // host/device execution; state that limitation instead of letting the kernel instantiation
+  // explain it. The call below is declared but never defined, and its 'error' attribute fires
+  // only at codegen: clang-tidy and -fsyntax-only sweeps analyze this file cleanly, while an
+  // actual build fails at compile time with the message (or at link time, with the name as
+  // the message, on compilers without the attribute). The noexcept is load-bearing: with a
+  // nontrivial destructor in scope the call would otherwise be emitted as an invoke, whose
+  // error-attribute diagnostic clang silently skips.
+#  if _CCCL_HAS_ATTRIBUTE(error)
+  __attribute__((error("parallel_for on exec_place::host() requires nvcc or nvc++")))
+#  endif
+  void parallel_for_on_the_host_requires_nvcc_or_nvcpp() noexcept;
+  parallel_for_on_the_host_requires_nvcc_or_nvcpp();
+#endif
 
   ctx.finalize();
 }

--- a/cudax/test/stf/parallel_for/parallel_for_host.cu
+++ b/cudax/test/stf/parallel_for/parallel_for_host.cu
@@ -24,8 +24,8 @@ int main()
     _CCCL_ASSERT(nqpoints == 3, "invalid value");
   };
 #else
-  CUDASTF_UNSUPPORTED(parallel_for_on_the_host_requires_nvcc_or_nvcpp,
-                      "parallel_for on exec_place::host() requires nvcc or nvc++");
+  _CCCL_UNSUPPORTED(parallel_for_on_the_host_requires_nvcc_or_nvcpp,
+                    "parallel_for on exec_place::host() requires nvcc or nvc++");
 #endif
 
   ctx.finalize();

--- a/cudax/test/stf/parallel_for/parallel_for_host.cu
+++ b/cudax/test/stf/parallel_for/parallel_for_host.cu
@@ -24,19 +24,8 @@ int main()
     _CCCL_ASSERT(nqpoints == 3, "invalid value");
   };
 #else
-  // parallel_for on the host requires nvcc or nvc++, which alone can classify lambdas for
-  // host/device execution; state that limitation instead of letting the kernel instantiation
-  // explain it. The call below is declared but never defined, and its 'error' attribute fires
-  // only at codegen: clang-tidy and -fsyntax-only sweeps analyze this file cleanly, while an
-  // actual build fails at compile time with the message (or at link time, with the name as
-  // the message, on compilers without the attribute). The noexcept is load-bearing: with a
-  // nontrivial destructor in scope the call would otherwise be emitted as an invoke, whose
-  // error-attribute diagnostic clang silently skips.
-#  if _CCCL_HAS_ATTRIBUTE(error)
-  __attribute__((error("parallel_for on exec_place::host() requires nvcc or nvc++")))
-#  endif
-  void parallel_for_on_the_host_requires_nvcc_or_nvcpp() noexcept;
-  parallel_for_on_the_host_requires_nvcc_or_nvcpp();
+  CUDASTF_UNSUPPORTED(parallel_for_on_the_host_requires_nvcc_or_nvcpp,
+                      "parallel_for on exec_place::host() requires nvcc or nvc++");
 #endif
 
   ctx.finalize();

--- a/cudax/test/stf/parallel_for/test2_parallel_for_context.cu
+++ b/cudax/test/stf/parallel_for/test2_parallel_for_context.cu
@@ -71,19 +71,8 @@ int main()
             //    assert(fabs(sy(i, j) - expected) < 0.001);
           };
 #else
-  // parallel_for on the host requires nvcc or nvc++, which alone can classify lambdas for
-  // host/device execution; state that limitation instead of letting the kernel instantiation
-  // explain it. The call below is declared but never defined, and its 'error' attribute fires
-  // only at codegen: clang-tidy and -fsyntax-only sweeps analyze this file cleanly, while an
-  // actual build fails at compile time with the message (or at link time, with the name as
-  // the message, on compilers without the attribute). The noexcept is load-bearing: with a
-  // nontrivial destructor in scope the call would otherwise be emitted as an invoke, whose
-  // error-attribute diagnostic clang silently skips.
-#  if _CCCL_HAS_ATTRIBUTE(error)
-  __attribute__((error("parallel_for on exec_place::host() requires nvcc or nvc++")))
-#  endif
-  void parallel_for_on_the_host_requires_nvcc_or_nvcpp() noexcept;
-  parallel_for_on_the_host_requires_nvcc_or_nvcpp();
+  CUDASTF_UNSUPPORTED(parallel_for_on_the_host_requires_nvcc_or_nvcpp,
+                      "parallel_for on exec_place::host() requires nvcc or nvc++");
 #endif
 
   ctx.finalize();

--- a/cudax/test/stf/parallel_for/test2_parallel_for_context.cu
+++ b/cudax/test/stf/parallel_for/test2_parallel_for_context.cu
@@ -71,8 +71,8 @@ int main()
             //    assert(fabs(sy(i, j) - expected) < 0.001);
           };
 #else
-  CUDASTF_UNSUPPORTED(parallel_for_on_the_host_requires_nvcc_or_nvcpp,
-                      "parallel_for on exec_place::host() requires nvcc or nvc++");
+  _CCCL_UNSUPPORTED(parallel_for_on_the_host_requires_nvcc_or_nvcpp,
+                    "parallel_for on exec_place::host() requires nvcc or nvc++");
 #endif
 
   ctx.finalize();

--- a/cudax/test/stf/parallel_for/test2_parallel_for_context.cu
+++ b/cudax/test/stf/parallel_for/test2_parallel_for_context.cu
@@ -53,6 +53,7 @@ int main()
     }
   };
 
+#if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_CUDA_COMPILER(NVHPC)
   ctx.parallel_for(exec_place::host(), ly.shape(), ly.read())
       ->*[=] __host__(size_t i, size_t j, slice<const double, 2> sy) {
             double expected = y0(i, j);
@@ -69,6 +70,21 @@ int main()
             }
             //    assert(fabs(sy(i, j) - expected) < 0.001);
           };
+#else
+  // parallel_for on the host requires nvcc or nvc++, which alone can classify lambdas for
+  // host/device execution; state that limitation instead of letting the kernel instantiation
+  // explain it. The call below is declared but never defined, and its 'error' attribute fires
+  // only at codegen: clang-tidy and -fsyntax-only sweeps analyze this file cleanly, while an
+  // actual build fails at compile time with the message (or at link time, with the name as
+  // the message, on compilers without the attribute). The noexcept is load-bearing: with a
+  // nontrivial destructor in scope the call would otherwise be emitted as an invoke, whose
+  // error-attribute diagnostic clang silently skips.
+#  if _CCCL_HAS_ATTRIBUTE(error)
+  __attribute__((error("parallel_for on exec_place::host() requires nvcc or nvc++")))
+#  endif
+  void parallel_for_on_the_host_requires_nvcc_or_nvcpp() noexcept;
+  parallel_for_on_the_host_requires_nvcc_or_nvcpp();
+#endif
 
   ctx.finalize();
 }


### PR DESCRIPTION
## Description

The tactical third option alongside #10814 and #10815, agreed with @caugonnet: the codebase does not support clang-cuda today, and the current failure mode for `parallel_for(exec_place::host(), ...)` is an explosion several template levels deep inside the device kernel. This PR **formalizes the limitation** instead of letting the instantiation explain it — a step forward regardless of how the #10814/#10815 design discussion resolves, and severable from both (#10815 would delete these guards; #10814 rewrites these stanzas anyway).

### Mechanism

The four affected tests/examples guard the host-`parallel_for` stanza for nvcc/nvc++. The other branch holds a call that is **declared but never defined**, carrying the GNU `error` attribute — the Linux kernel's `__compiletime_error` idiom. The attribute's diagnostic fires only at **codegen**, which produces exactly the desired split:

- **clang-tidy and `-fsyntax-only` sweeps** (the consumers the exception-escape series needs, #10793 #10796 #10801 #10805) analyze the TU cleanly — verified with clang-tidy 21 running `bugprone-exception-escape` under `--cuda-host-only`;
- **an actual build** fails at compile time with one line: `call to 'parallel_for_on_the_host_requires_nvcc_or_nvcpp()' declared with 'error' attribute: parallel_for on exec_place::host() requires nvcc or nvc++`;
- **compilers without the attribute** fail at link, with the function name as the message;
- **nothing anywhere** compiles into wrong runtime behavior.

### A subtlety worth its comment

The `noexcept` on the poison declaration is load-bearing, and its absence was a bug during development: with a nontrivial destructor in scope (a `context`, say), the call is emitted as an *invoke*, and clang silently skips the error-attribute diagnostic on invokes (observed with clang 21, plain C++ and CUDA alike — arguably a clang bug worth reporting upstream). `noexcept` removes the landing pad and restores the diagnostic.

Note `tiled_loops.cu` also runs `parallel_for` on the host but needs no guard: its unannotated lambda is implicitly `__host__ __device__` under clang and its body is device-legal, so it compiles and dispatches dynamically — supported semantics on every compiler. The guard marks exactly the unsupported combination (a host-only callable), nothing more.

### Effect on the clang-cuda sweep

With this, `-fsyntax-only` over all 283 STF tests and examples fails only on the six TUs of the upstream-disabled `algorithm` construct (#4403) and the five deliberately-failing `static_error_checks` — i.e., the tree is clean for the clang-tidy work.

## Testing

- `-fsyntax-only` (clang-cuda 21): clean on all four TUs.
- Real clang build: fails with the poison message on all four (verified per-TU).
- clang-tidy 21, `bugprone-exception-escape`, `--cuda-host-only`: analyzes cleanly (only the known pre-LLVM-22 `CheckMain` artifact, see #10805).
- nvcc 13.2: compiles unchanged; tests run green on an RTX 3070 (sm_86).
- pre-commit passes.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)