### PR TITLE
[libcu++] Move `bit_reverse` implementation to `cuda::std::` namespace

### DIFF
--- a/libcudacxx/include/cuda/__bit/bit_reverse.h
+++ b/libcudacxx/include/cuda/__bit/bit_reverse.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -21,176 +21,19 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__bit/bit_reverse.h>
 #include <cuda/std/__type_traits/is_unsigned_integer.h>
-#include <cuda/std/cstdint>
 
 #include <cuda/std/__cccl/prologue.h>
 
-#if _CCCL_CHECK_BUILTIN(builtin_bitreverse8)
-#  define _CCCL_BUILTIN_BITREVERSE8(...) __builtin_bitreverse8(__VA_ARGS__)
-#endif
-
-#if _CCCL_CHECK_BUILTIN(builtin_bitreverse16)
-#  define _CCCL_BUILTIN_BITREVERSE16(...) __builtin_bitreverse16(__VA_ARGS__)
-#endif
-
-#if _CCCL_CHECK_BUILTIN(builtin_bitreverse32)
-#  define _CCCL_BUILTIN_BITREVERSE32(...) __builtin_bitreverse32(__VA_ARGS__)
-#endif
-
-#if _CCCL_CHECK_BUILTIN(builtin_bitreverse64)
-#  define _CCCL_BUILTIN_BITREVERSE64(...) __builtin_bitreverse64(__VA_ARGS__)
-#endif
-
-// nvcc doesn't allow clang's bitreverse builtin
-#if _CCCL_CUDA_COMPILER(NVCC)
-#  undef _CCCL_BUILTIN_BITREVERSE8
-#  undef _CCCL_BUILTIN_BITREVERSE16
-#  undef _CCCL_BUILTIN_BITREVERSE32
-#  undef _CCCL_BUILTIN_BITREVERSE64
-#endif // _CCCL_CUDA_COMPILER(NVCC)
-
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-#if defined(_CCCL_BUILTIN_BITREVERSE32)
-
-template <typename _Tp>
-[[nodiscard]] _CCCL_API constexpr _Tp __bit_reverse_builtin(_Tp __value) noexcept
-{
-#  if _CCCL_HAS_INT128()
-  if constexpr (sizeof(_Tp) == sizeof(__uint128_t))
-  {
-    auto __high = static_cast<__uint128_t>(_CCCL_BUILTIN_BITREVERSE64(static_cast<::cuda::std::uint64_t>(__value)))
-               << 64;
-    auto __low =
-      static_cast<__uint128_t>(_CCCL_BUILTIN_BITREVERSE64(static_cast<::cuda::std::uint64_t>(__value >> 64)));
-    return __high | __low;
-  }
-#  endif // _CCCL_HAS_INT128()
-  if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint64_t))
-  {
-    return _CCCL_BUILTIN_BITREVERSE64(__value);
-  }
-  else if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint32_t))
-  {
-    return _CCCL_BUILTIN_BITREVERSE32(__value);
-  }
-  else if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint16_t))
-  {
-    return _CCCL_BUILTIN_BITREVERSE16(__value);
-  }
-  else
-  {
-    return _CCCL_BUILTIN_BITREVERSE8(__value);
-  }
-}
-
-#endif // defined(_CCCL_BUILTIN_BITREVERSE32)
-
-#if _CCCL_CUDA_COMPILATION()
-
-template <typename _Tp>
-[[nodiscard]] _CCCL_DEVICE_API constexpr _Tp __bit_reverse_device(_Tp __value) noexcept
-{
-#  if _CCCL_HAS_INT128()
-  if constexpr (sizeof(_Tp) == sizeof(__uint128_t))
-  {
-    auto __high = static_cast<__uint128_t>(::cuda::__bit_reverse_device(static_cast<::cuda::std::uint64_t>(__value)))
-               << 64;
-    auto __low =
-      static_cast<__uint128_t>(::cuda::__bit_reverse_device(static_cast<::cuda::std::uint64_t>(__value >> 64)));
-    return __high | __low;
-  }
-#  endif // _CCCL_HAS_INT128()
-  if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint64_t))
-  {
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::__brevll(__value);))
-  }
-  else if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint32_t))
-  {
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::__brev(__value);))
-  }
-  else if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint16_t))
-  {
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::__brev(static_cast<::cuda::std::uint32_t>(__value) << 16);))
-  }
-  else
-  {
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::__brev(static_cast<::cuda::std::uint32_t>(__value) << 24);))
-  }
-  _CCCL_UNREACHABLE();
-}
-
-#endif // _CCCL_CUDA_COMPILATION()
-
-template <typename _Tp>
-[[nodiscard]] _CCCL_API constexpr _Tp __bit_reverse_generic(_Tp __value) noexcept
-{
-#if _CCCL_HAS_INT128()
-  if constexpr (sizeof(_Tp) == sizeof(__uint128_t))
-  {
-    constexpr auto __c1 = __uint128_t{0x5555555555555555} << 64 | ::cuda::std::uint64_t{0x5555555555555555};
-    constexpr auto __c2 = __uint128_t{0x3333333333333333} << 64 | ::cuda::std::uint64_t{0x3333333333333333};
-    constexpr auto __c3 = __uint128_t{0x0F0F0F0F0F0F0F0F} << 64 | ::cuda::std::uint64_t{0x0F0F0F0F0F0F0F0F};
-    constexpr auto __c4 = __uint128_t{0x00FF00FF00FF00FF} << 64 | ::cuda::std::uint64_t{0x00FF00FF00FF00FF};
-    constexpr auto __c5 = __uint128_t{0x0000FFFF0000FFFF} << 64 | ::cuda::std::uint64_t{0x0000FFFF0000FFFF};
-    constexpr auto __c6 = __uint128_t{0x00000000FFFFFFFF} << 64 | ::cuda::std::uint64_t{0x00000000FFFFFFFF};
-    __value             = ((__value >> 1) & __c1) | ((__value & __c1) << 1);
-    __value             = ((__value >> 2) & __c2) | ((__value & __c2) << 2);
-    __value             = ((__value >> 4) & __c3) | ((__value & __c3) << 4);
-    __value             = ((__value >> 8) & __c4) | ((__value & __c4) << 8);
-    __value             = ((__value >> 16) & __c5) | ((__value & __c5) << 16);
-    __value             = ((__value >> 32) & __c6) | ((__value & __c6) << 32);
-    return (__value >> 64) | (__value << 64);
-  }
-#endif // _CCCL_HAS_INT128()
-  if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint64_t))
-  {
-    __value = ((__value >> 1) & 0x5555555555555555) | ((__value & 0x5555555555555555) << 1);
-    __value = ((__value >> 2) & 0x3333333333333333) | ((__value & 0x3333333333333333) << 2);
-    __value = ((__value >> 4) & 0x0F0F0F0F0F0F0F0F) | ((__value & 0x0F0F0F0F0F0F0F0F) << 4);
-    __value = ((__value >> 8) & 0x00FF00FF00FF00FF) | ((__value & 0x00FF00FF00FF00FF) << 8);
-    __value = ((__value >> 16) & 0x0000FFFF0000FFFF) | ((__value & 0x0000FFFF0000FFFF) << 16);
-    return (__value >> 32) | (__value << 32);
-  }
-  else if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint32_t))
-  {
-    __value = ((__value >> 1) & 0x55555555) | ((__value & 0x55555555) << 1);
-    __value = ((__value >> 2) & 0x33333333) | ((__value & 0x33333333) << 2);
-    __value = ((__value >> 4) & 0x0F0F0F0F) | ((__value & 0x0F0F0F0F) << 4);
-    __value = ((__value >> 8) & 0x00FF00FF) | ((__value & 0x00FF00FF) << 8);
-    return (__value >> 16) | (__value << 16);
-  }
-  else if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint16_t))
-  {
-    __value = ((__value >> 1) & 0x5555) | ((__value & 0x5555) << 1);
-    __value = ((__value >> 2) & 0x3333) | ((__value & 0x3333) << 2);
-    __value = ((__value >> 4) & 0x0F0F) | ((__value & 0x0F0F) << 4);
-    return (__value >> 8) | (__value << 8);
-  }
-  else
-  {
-    __value = ((__value >> 1) & 0x55) | ((__value & 0x55) << 1);
-    __value = ((__value >> 2) & 0x33) | ((__value & 0x33) << 2);
-    return (__value >> 4) | (__value << 4);
-  }
-}
-
-template <typename _Tp>
-[[nodiscard]] _CCCL_API constexpr _Tp bit_reverse(_Tp __value) noexcept
+// todo(dabayer): Deprecate and remove this function in CCCL 4.0.
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp bit_reverse(_Tp __v) noexcept
 {
   static_assert(::cuda::std::__cccl_is_cv_unsigned_integer_v<_Tp>, "bit_reverse() requires unsigned integer types");
-#if !_CCCL_TILE_COMPILATION() // nvbug6085411: error: "call to non-tile function not supported!"
-  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
-  {
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::cuda::__bit_reverse_device(__value);))
-  }
-#endif // !_CCCL_TILE_COMPILATION()
-#if defined(_CCCL_BUILTIN_BITREVERSE32)
-  return ::cuda::__bit_reverse_builtin(__value);
-#else
-  return ::cuda::__bit_reverse_generic(__value);
-#endif
+  return ::cuda::std::bit_reverse(__v);
 }
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/std/__bit/bit_reverse.h
+++ b/libcudacxx/include/cuda/std/__bit/bit_reverse.h
@@ -21,19 +21,194 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__bit/bit_reverse.h>
 #include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__type_traits/always_false.h>
 #include <cuda/std/__type_traits/is_unsigned_integer.h>
+#include <cuda/std/cstdint>
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_HAS_BUILTIN(__builtin_bitreverse8)
+#  define _CCCL_BUILTIN_BITREVERSE8(...) __builtin_bitreverse8(__VA_ARGS__)
+#endif // has __builtin_bitreverse8
+
+#if _CCCL_HAS_BUILTIN(__builtin_bitreverse16)
+#  define _CCCL_BUILTIN_BITREVERSE16(...) __builtin_bitreverse16(__VA_ARGS__)
+#endif // has __builtin_bitreverse16
+
+#if _CCCL_HAS_BUILTIN(__builtin_bitreverse32)
+#  define _CCCL_BUILTIN_BITREVERSE32(...) __builtin_bitreverse32(__VA_ARGS__)
+#endif // has __builtin_bitreverse32
+
+#if _CCCL_HAS_BUILTIN(__builtin_bitreverse64)
+#  define _CCCL_BUILTIN_BITREVERSE64(...) __builtin_bitreverse64(__VA_ARGS__)
+#endif // has __builtin_bitreverse64
+
+#if _CCCL_HAS_BUILTIN(__builtin_bitreverse128)
+#  define _CCCL_BUILTIN_BITREVERSE128(...) __builtin_bitreverse128(__VA_ARGS__)
+#endif // has __builtin_bitreverse128
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __bit_reverse_impl_generic(_Tp __v) noexcept
+{
+  if constexpr (sizeof(_Tp) == sizeof(uint8_t))
+  {
+    __v = ((__v >> 1) & 0x55) | ((__v & 0x55) << 1);
+    __v = ((__v >> 2) & 0x33) | ((__v & 0x33) << 2);
+    return (__v >> 4) | (__v << 4);
+  }
+  else if constexpr (sizeof(_Tp) == sizeof(uint16_t))
+  {
+    __v = ((__v >> 1) & 0x5555) | ((__v & 0x5555) << 1);
+    __v = ((__v >> 2) & 0x3333) | ((__v & 0x3333) << 2);
+    __v = ((__v >> 4) & 0x0F0F) | ((__v & 0x0F0F) << 4);
+    return (__v >> 8) | (__v << 8);
+  }
+  else if constexpr (sizeof(_Tp) == sizeof(uint32_t))
+  {
+    __v = ((__v >> 1) & 0x55555555) | ((__v & 0x55555555) << 1);
+    __v = ((__v >> 2) & 0x33333333) | ((__v & 0x33333333) << 2);
+    __v = ((__v >> 4) & 0x0F0F0F0F) | ((__v & 0x0F0F0F0F) << 4);
+    __v = ((__v >> 8) & 0x00FF00FF) | ((__v & 0x00FF00FF) << 8);
+    return (__v >> 16) | (__v << 16);
+  }
+  else if constexpr (sizeof(_Tp) == sizeof(uint64_t))
+  {
+    __v = ((__v >> 1) & 0x5555555555555555ull) | ((__v & 0x5555555555555555ull) << 1);
+    __v = ((__v >> 2) & 0x3333333333333333ull) | ((__v & 0x3333333333333333ull) << 2);
+    __v = ((__v >> 4) & 0x0F0F0F0F0F0F0F0Full) | ((__v & 0x0F0F0F0F0F0F0F0Full) << 4);
+    __v = ((__v >> 8) & 0x00FF00FF00FF00FFull) | ((__v & 0x00FF00FF00FF00FFull) << 8);
+    __v = ((__v >> 16) & 0x0000FFFF0000FFFFull) | ((__v & 0x0000FFFF0000FFFFull) << 16);
+    return (__v >> 32) | (__v << 32);
+  }
+#if _CCCL_HAS_INT128()
+  else if constexpr (sizeof(_Tp) == sizeof(__uint128_t))
+  {
+    constexpr auto __c1 = __uint128_t{0x5555555555555555ull} << 64 | 0x5555555555555555ull;
+    constexpr auto __c2 = __uint128_t{0x3333333333333333ull} << 64 | 0x3333333333333333ull;
+    constexpr auto __c3 = __uint128_t{0x0F0F0F0F0F0F0F0Full} << 64 | 0x0F0F0F0F0F0F0F0Full;
+    constexpr auto __c4 = __uint128_t{0x00FF00FF00FF00FFull} << 64 | 0x00FF00FF00FF00FFull;
+    constexpr auto __c5 = __uint128_t{0x0000FFFF0000FFFFull} << 64 | 0x0000FFFF0000FFFFull;
+    constexpr auto __c6 = __uint128_t{0x00000000FFFFFFFFull} << 64 | 0x00000000FFFFFFFFull;
+    __v                 = ((__v >> 1) & __c1) | ((__v & __c1) << 1);
+    __v                 = ((__v >> 2) & __c2) | ((__v & __c2) << 2);
+    __v                 = ((__v >> 4) & __c3) | ((__v & __c3) << 4);
+    __v                 = ((__v >> 8) & __c4) | ((__v & __c4) << 8);
+    __v                 = ((__v >> 16) & __c5) | ((__v & __c5) << 16);
+    __v                 = ((__v >> 32) & __c6) | ((__v & __c6) << 32);
+    return (__v >> 64) | (__v << 64);
+  }
+#endif // _CCCL_HAS_INT128()
+  else
+  {
+    static_assert(__always_false_v<_Tp>, "Unsupported integer type");
+  }
+}
+
+#if _CCCL_HOST_COMPILATION()
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __bit_reverse_impl_host(_Tp __v) noexcept
+{
+  if constexpr (sizeof(_Tp) == sizeof(uint8_t))
+  {
+#  if defined(_CCCL_BUILTIN_BITREVERSE8)
+    return _CCCL_BUILTIN_BITREVERSE8(__v);
+#  else // ^^^ _CCCL_BUILTIN_BITREVERSE8 ^^^ / vvv !_CCCL_BUILTIN_BITREVERSE8 vvv
+    return ::cuda::std::__bit_reverse_impl_generic(__v);
+#  endif // ^^^ !_CCCL_BUILTIN_BITREVERSE8 ^^^
+  }
+  else if constexpr (sizeof(_Tp) == sizeof(uint16_t))
+  {
+#  if defined(_CCCL_BUILTIN_BITREVERSE16)
+    return _CCCL_BUILTIN_BITREVERSE16(__v);
+#  else // ^^^ _CCCL_BUILTIN_BITREVERSE16 ^^^ / vvv !_CCCL_BUILTIN_BITREVERSE16 vvv
+    return ::cuda::std::__bit_reverse_impl_generic(__v);
+#  endif // ^^^ !_CCCL_BUILTIN_BITREVERSE16 ^^^
+  }
+  else if constexpr (sizeof(_Tp) == sizeof(uint32_t))
+  {
+#  if defined(_CCCL_BUILTIN_BITREVERSE32)
+    return _CCCL_BUILTIN_BITREVERSE32(__v);
+#  else // ^^^ _CCCL_BUILTIN_BITREVERSE32 ^^^ / vvv !_CCCL_BUILTIN_BITREVERSE32 vvv
+    return ::cuda::std::__bit_reverse_impl_generic(__v);
+#  endif // ^^^ !_CCCL_BUILTIN_BITREVERSE32 ^^^
+  }
+  else if constexpr (sizeof(_Tp) == sizeof(uint64_t))
+  {
+#  if defined(_CCCL_BUILTIN_BITREVERSE64)
+    return _CCCL_BUILTIN_BITREVERSE64(__v);
+#  else // ^^^ _CCCL_BUILTIN_BITREVERSE64 ^^^ / vvv !_CCCL_BUILTIN_BITREVERSE64 vvv
+    return ::cuda::std::__bit_reverse_impl_generic(__v);
+#  endif // ^^^ !_CCCL_BUILTIN_BITREVERSE64 ^^^
+  }
+#  if _CCCL_HAS_INT128()
+  else if constexpr (sizeof(_Tp) == sizeof(__uint128_t))
+  {
+#    if defined(_CCCL_BUILTIN_BITREVERSE128)
+    return _CCCL_BUILTIN_BITREVERSE128(__v);
+#    elif defined(_CCCL_BUILTIN_BITREVERSE64)
+    return (__uint128_t{_CCCL_BUILTIN_BITREVERSE64(static_cast<uint64_t>(__v))} << 64)
+         | _CCCL_BUILTIN_BITREVERSE64(static_cast<uint64_t>(__v >> 64));
+#    else // ^^^ _CCCL_BUILTIN_BITREVERSE64 ^^^ / vvv !_CCCL_BUILTIN_BITREVERSE64 vvv
+    return ::cuda::std::__bit_reverse_impl_generic(__v);
+#    endif // ^^^ !_CCCL_BUILTIN_BITREVERSE64 ^^^
+  }
+#  endif // _CCCL_HAS_INT128()
+  else
+  {
+    return ::cuda::std::__bit_reverse_impl_generic(__v);
+  }
+}
+#endif // _CCCL_HOST_COMPILATION()
+
+#if _CCCL_DEVICE_COMPILATION()
+template <class _Tp>
+[[nodiscard]] _CCCL_DEVICE_API constexpr _Tp __bit_reverse_impl_device(_Tp __v) noexcept
+{
+  if constexpr (sizeof(_Tp) == sizeof(uint8_t))
+  {
+    return ::__brev(uint32_t{__v} << 24);
+  }
+  else if constexpr (sizeof(_Tp) == sizeof(uint16_t))
+  {
+    return ::__brev(uint32_t{__v} << 16);
+  }
+  else if constexpr (sizeof(_Tp) == sizeof(uint32_t))
+  {
+    return ::__brev(__v);
+  }
+  else if constexpr (sizeof(_Tp) == sizeof(uint64_t))
+  {
+    return ::__brevll(__v);
+  }
+#  if _CCCL_HAS_INT128()
+  else if constexpr (sizeof(_Tp) == sizeof(__uint128_t))
+  {
+    return (__uint128_t{::__brevll(static_cast<uint64_t>(__v))} << 64) | ::__brevll(static_cast<uint64_t>(__v >> 64));
+  }
+#  endif // _CCCL_HAS_INT128()
+  else
+  {
+    return ::cuda::std::__bit_reverse_impl_generic(__v);
+  }
+}
+#endif // _CCCL_DEVICE_COMPILATION()
 
 _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _Tp bit_reverse(_Tp __v) noexcept
 {
-  return ::cuda::bit_reverse(__v);
+#if !_CCCL_TILE_COMPILATION() // nvbug6085411: error: "call to non-tile function not supported!"
+  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+  {
+    NV_IF_ELSE_TARGET(NV_IS_HOST, ({ return ::cuda::std::__bit_reverse_impl_host(__v); }), ({
+                        return ::cuda::std::__bit_reverse_impl_device(__v);
+                      }))
+  }
+#endif // !_CCCL_TILE_COMPILATION()
+  return ::cuda::std::__bit_reverse_impl_generic(__v);
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__simd/bit/scalar.h
+++ b/libcudacxx/include/cuda/std/__simd/bit/scalar.h
@@ -21,7 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__bit/bit_reverse.h>
+#include <cuda/std/__bit/bit_reverse.h>
 #include <cuda/std/__bit/byteswap.h>
 #include <cuda/std/__bit/countl.h>
 #include <cuda/std/__bit/countr.h>
@@ -70,7 +70,7 @@ struct __simd_bit_reverse_generator
   template <typename _Idx>
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __result_t operator()(_Idx) const noexcept
   {
-    return ::cuda::bit_reverse(__v_[_Idx::value]);
+    return ::cuda::std::bit_reverse(__v_[_Idx::value]);
   }
 };
 


### PR DESCRIPTION
This PR enables host builtins for bit reverse and moves the implementation to `cuda::std::` namespace. We should deprecate and remove the `cuda::` version in CCCL 4.0.