### PR TITLE
libcu++: support subword extended floating-point atomic min and max.

### DIFF
--- a/libcudacxx/include/cuda/std/__atomic/types/small.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/small.h
@@ -80,12 +80,8 @@ _CCCL_DIAG_POP
 template <class _Tp>
 _CCCL_HOST_DEVICE_API bool __atomic_small_extended_floating_point_less(_Tp __lhs, _Tp __rhs)
 {
-  bool __result;
-  NV_DISPATCH_TARGET(NV_IS_DEVICE,
-                     (__result = __lhs < __rhs;),
-                     NV_IS_HOST,
-                     (__result = static_cast<float>(__lhs) < static_cast<float>(__rhs);))
-  return __result;
+  // Intentionally unqualified to avoid including <cuda_fp16.h> and <cuda_bf16.h>.
+  return __hlt(__lhs, __rhs);
 }
 
 template <typename _Tp>
@@ -227,9 +223,10 @@ template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<
 _CCCL_HOST_DEVICE_API auto __atomic_fetch_max_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
-  using _Tp = __atomic_underlying_t<_Sto>;
-  static_assert(is_integral_v<_Tp> || __is_extended_floating_point_v<_Tp>);
-  if constexpr (__is_extended_floating_point_v<_Tp>)
+  using _Tp                                             = __atomic_underlying_t<_Sto>;
+  constexpr bool __is_supported_extended_floating_point = __is_extended_floating_point_v<_Tp> && sizeof(_Tp) == 2;
+  static_assert(is_integral_v<_Tp> || __is_supported_extended_floating_point);
+  if constexpr (__is_supported_extended_floating_point)
   {
     auto __expected = __atomic_load_dispatch(&__a->__a_value, memory_order_relaxed, _Sco{});
     while (true)
@@ -254,9 +251,10 @@ template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<
 _CCCL_HOST_DEVICE_API auto __atomic_fetch_min_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
-  using _Tp = __atomic_underlying_t<_Sto>;
-  static_assert(is_integral_v<_Tp> || __is_extended_floating_point_v<_Tp>);
-  if constexpr (__is_extended_floating_point_v<_Tp>)
+  using _Tp                                             = __atomic_underlying_t<_Sto>;
+  constexpr bool __is_supported_extended_floating_point = __is_extended_floating_point_v<_Tp> && sizeof(_Tp) == 2;
+  static_assert(is_integral_v<_Tp> || __is_supported_extended_floating_point);
+  if constexpr (__is_supported_extended_floating_point)
   {
     auto __expected = __atomic_load_dispatch(&__a->__a_value, memory_order_relaxed, _Sco{});
     while (true)

--- a/libcudacxx/include/cuda/std/__atomic/types/small.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/small.h
@@ -28,6 +28,7 @@
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_extended_floating_point.h>
+#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_signed.h>
 #include <cuda/std/cstring>
 
@@ -80,8 +81,25 @@ _CCCL_DIAG_POP
 template <class _Tp>
 _CCCL_HOST_DEVICE_API bool __atomic_small_extended_floating_point_less(_Tp __lhs, _Tp __rhs)
 {
+#if _CCCL_HAS_CTK() && _CCCL_CTK_BELOW(12, 2)
+  // Before CTK 12.2, __hlt is device-only and its bfloat16 overload is unavailable before SM80.
+#  if _CCCL_HAS_NVBF16()
+  if constexpr (is_same_v<_Tp, __nv_bfloat16>)
+  {
+    // Intentionally unqualified to avoid including <cuda_bf16.h>.
+    NV_IF_ELSE_TARGET(
+      NV_PROVIDES_SM_80, (return __hlt(__lhs, __rhs);), (return __bfloat162float(__lhs) < __bfloat162float(__rhs);))
+  }
+  else
+#  endif // _CCCL_HAS_NVBF16()
+  {
+    // Intentionally unqualified to avoid including <cuda_fp16.h>.
+    NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return __hlt(__lhs, __rhs);), (return __half2float(__lhs) < __half2float(__rhs);))
+  }
+#else // ^^^ CTK below 12.2 ^^^ / vvv CTK 12.2 or newer vvv
   // Intentionally unqualified to avoid including <cuda_fp16.h> and <cuda_bf16.h>.
   return __hlt(__lhs, __rhs);
+#endif // CTK 12.2 or newer
 }
 
 template <typename _Tp>

--- a/libcudacxx/include/cuda/std/__atomic/types/small.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/small.h
@@ -27,6 +27,7 @@
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_arithmetic.h>
+#include <cuda/std/__type_traits/is_extended_floating_point.h>
 #include <cuda/std/__type_traits/is_signed.h>
 #include <cuda/std/cstring>
 
@@ -75,6 +76,17 @@ _CCCL_HOST_DEVICE_API _Tp __atomic_small_from_32(__atomic_small_proxy_t<_Tp> __v
 }
 
 _CCCL_DIAG_POP
+
+template <class _Tp>
+_CCCL_HOST_DEVICE_API bool __atomic_small_extended_floating_point_less(_Tp __lhs, _Tp __rhs)
+{
+  bool __result;
+  NV_DISPATCH_TARGET(NV_IS_DEVICE,
+                     (__result = __lhs < __rhs;),
+                     NV_IS_HOST,
+                     (__result = static_cast<float>(__lhs) < static_cast<float>(__rhs);))
+  return __result;
+}
 
 template <typename _Tp>
 struct __atomic_small_storage
@@ -215,20 +227,54 @@ template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<
 _CCCL_HOST_DEVICE_API auto __atomic_fetch_max_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
-  static_assert(is_floating_point_v<__atomic_underlying_t<_Sto>> || is_integral_v<__atomic_underlying_t<_Sto>>);
   using _Tp = __atomic_underlying_t<_Sto>;
-  return __atomic_small_from_32<_Tp>(
-    __atomic_fetch_max_dispatch(&__a->__a_value, __atomic_small_to_32(__val), __order, _Sco{}));
+  static_assert(is_integral_v<_Tp> || __is_extended_floating_point_v<_Tp>);
+  if constexpr (__is_extended_floating_point_v<_Tp>)
+  {
+    auto __expected = __atomic_load_dispatch(&__a->__a_value, memory_order_relaxed, _Sco{});
+    while (true)
+    {
+      const auto __old     = __atomic_small_from_32<_Tp>(__expected);
+      const auto __desired = __atomic_small_extended_floating_point_less(__old, _Tp(__val)) ? _Tp(__val) : __old;
+      if (__atomic_compare_exchange_strong_dispatch(
+            &__a->__a_value, &__expected, __atomic_small_to_32(__desired), __order, __order, _Sco{}))
+      {
+        return __old;
+      }
+    }
+  }
+  else
+  {
+    return __atomic_small_from_32<_Tp>(
+      __atomic_fetch_max_dispatch(&__a->__a_value, __atomic_small_to_32(__val), __order, _Sco{}));
+  }
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
 _CCCL_HOST_DEVICE_API auto __atomic_fetch_min_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
-  static_assert(is_floating_point_v<__atomic_underlying_t<_Sto>> || is_integral_v<__atomic_underlying_t<_Sto>>);
   using _Tp = __atomic_underlying_t<_Sto>;
-  return __atomic_small_from_32<_Tp>(
-    __atomic_fetch_min_dispatch(&__a->__a_value, __atomic_small_to_32(__val), __order, _Sco{}));
+  static_assert(is_integral_v<_Tp> || __is_extended_floating_point_v<_Tp>);
+  if constexpr (__is_extended_floating_point_v<_Tp>)
+  {
+    auto __expected = __atomic_load_dispatch(&__a->__a_value, memory_order_relaxed, _Sco{});
+    while (true)
+    {
+      const auto __old     = __atomic_small_from_32<_Tp>(__expected);
+      const auto __desired = __atomic_small_extended_floating_point_less(_Tp(__val), __old) ? _Tp(__val) : __old;
+      if (__atomic_compare_exchange_strong_dispatch(
+            &__a->__a_value, &__expected, __atomic_small_to_32(__desired), __order, __order, _Sco{}))
+      {
+        return __old;
+      }
+    }
+  }
+  else
+  {
+    return __atomic_small_from_32<_Tp>(
+      __atomic_fetch_min_dispatch(&__a->__a_value, __atomic_small_to_32(__val), __order, _Sco{}));
+  }
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_extended_floating_point.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_extended_floating_point.pass.cpp
@@ -8,14 +8,13 @@
 
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
-// UNSUPPORTED: nvcc-11, nvcc-12
-
 // UNSUPPORTED: force-tile
 // error: asm statement is unsupported in tile code
 
 // <cuda/atomic>
 
-// TODO: Add support for new half
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
 
 #include <cuda/atomic>
 #include <cuda/std/cassert>
@@ -24,6 +23,12 @@
 #include "atomic_helpers.h"
 #include "cuda_space_selector.h"
 #include "test_macros.h"
+
+template <class T>
+TEST_HOST_DEVICE_FUNC bool equal(T lhs, T rhs)
+{
+  return static_cast<float>(lhs) == static_cast<float>(rhs);
+}
 
 template <class T, template <typename, typename> class Selector, cuda::thread_scope ThreadScope>
 struct TestFn
@@ -35,76 +40,75 @@ struct TestFn
       using A = cuda::atomic<T, ThreadScope>;
       Selector<A, constructor_initializer> sel;
       A& t = *sel.construct();
-      t    = T(-1);
-      assert(t.fetch_min(T(-5)) == T(-1));
-      printf("%i == %i\n", (int) t.load(), (int) T(-5));
-      NV_IF_TARGET(NV_IS_HOST, (fflush(stdout);))
-      assert(t.load() == T(-5));
+      t    = T(-1.0f);
+      assert(equal(t.fetch_min(T(-5.0f)), T(-1.0f)));
+      assert(equal(t.load(), T(-5.0f)));
     }
     {
       using A = cuda::atomic<T, ThreadScope>;
       Selector<volatile A, constructor_initializer> sel;
       volatile A& t = *sel.construct();
-      t             = T(-1);
-      assert(t.fetch_min(T(-5)) == T(-1));
-      assert(t.load() == T(-5));
+      t             = T(-1.0f);
+      assert(equal(t.fetch_min(T(-5.0f)), T(-1.0f)));
+      assert(equal(t.load(), T(-5.0f)));
     }
     // Test not lesser
     {
       using A = cuda::atomic<T, ThreadScope>;
       Selector<A, constructor_initializer> sel;
       A& t = *sel.construct();
-      t    = T(-1);
-      assert(t.fetch_min(4) == T(-1));
-      assert(t.load() == T(-1));
+      t    = T(-1.0f);
+      assert(equal(t.fetch_min(T(4.0f)), T(-1.0f)));
+      assert(equal(t.load(), T(-1.0f)));
     }
     {
       using A = cuda::atomic<T, ThreadScope>;
       Selector<volatile A, constructor_initializer> sel;
       volatile A& t = *sel.construct();
-      t             = T(-1);
-      assert(t.fetch_min(4) == T(-1));
-      assert(t.load() == T(-1));
+      t             = T(-1.0f);
+      assert(equal(t.fetch_min(T(4.0f)), T(-1.0f)));
+      assert(equal(t.load(), T(-1.0f)));
     }
     // Fetch max
     {
       using A = cuda::atomic<T>;
       Selector<A, constructor_initializer> sel;
       A& t = *sel.construct();
-      t    = T(1);
-      assert(t.fetch_max(2) == T(1));
-      assert(t.load() == T(2));
+      t    = T(1.0f);
+      assert(equal(t.fetch_max(T(2.0f)), T(1.0f)));
+      assert(equal(t.load(), T(2.0f)));
     }
     {
       using A = cuda::atomic<T>;
       Selector<volatile A, constructor_initializer> sel;
       volatile A& t = *sel.construct();
-      t             = T(1);
-      assert(t.fetch_max(2) == T(1));
-      assert(t.load() == T(2));
+      t             = T(1.0f);
+      assert(equal(t.fetch_max(T(2.0f)), T(1.0f)));
+      assert(equal(t.load(), T(2.0f)));
     }
     // Test not greater
     {
       using A = cuda::atomic<T>;
       Selector<A, constructor_initializer> sel;
       A& t = *sel.construct();
-      t    = T(3);
-      assert(t.fetch_max(2) == T(3));
-      assert(t.load() == T(3));
+      t    = T(3.0f);
+      assert(equal(t.fetch_max(T(2.0f)), T(3.0f)));
+      assert(equal(t.load(), T(3.0f)));
     }
     {
       using A = cuda::atomic<T>;
       Selector<volatile A, constructor_initializer> sel;
       volatile A& t = *sel.construct();
-      t             = T(3);
-      assert(t.fetch_max(2) == T(3));
-      assert(t.load() == T(3));
+      t             = T(3.0f);
+      assert(equal(t.fetch_max(T(2.0f)), T(3.0f)));
+      assert(equal(t.load(), T(3.0f)));
     }
   }
 };
 
 int main(int, char**)
 {
+#if _CCCL_HAS_NVFP16()
   NV_DISPATCH_TARGET(NV_IS_HOST,
                      (TestFn<__half, local_memory_selector, cuda::thread_scope::thread_scope_thread>()();),
                      NV_PROVIDES_SM_70,
@@ -113,6 +117,18 @@ int main(int, char**)
   NV_IF_TARGET(NV_IS_DEVICE,
                (TestFn<__half, shared_memory_selector, cuda::thread_scope::thread_scope_thread>()();
                 TestFn<__half, global_memory_selector, cuda::thread_scope::thread_scope_thread>()();))
+#endif // _CCCL_HAS_NVFP16()
+
+#if _CCCL_HAS_NVBF16()
+  NV_DISPATCH_TARGET(NV_IS_HOST,
+                     (TestFn<__nv_bfloat16, local_memory_selector, cuda::thread_scope::thread_scope_thread>()();),
+                     NV_PROVIDES_SM_70,
+                     (TestFn<__nv_bfloat16, local_memory_selector, cuda::thread_scope::thread_scope_thread>()();))
+
+  NV_IF_TARGET(NV_IS_DEVICE,
+               (TestFn<__nv_bfloat16, shared_memory_selector, cuda::thread_scope::thread_scope_thread>()();
+                TestFn<__nv_bfloat16, global_memory_selector, cuda::thread_scope::thread_scope_thread>()();))
+#endif // _CCCL_HAS_NVBF16()
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_extended_floating_point.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_extended_floating_point.pass.cpp
@@ -13,10 +13,12 @@
 
 // <cuda/atomic>
 
-#include <cuda_bf16.h>
-#include <cuda_fp16.h>
+// clang-format off
+#include <disable_nvfp_conversions_and_operators.h>
+// clang-format on
 
 #include <cuda/atomic>
+#include <cuda/std/__floating_point/cast.h>
 #include <cuda/std/cassert>
 #include <cuda/std/type_traits>
 
@@ -27,7 +29,13 @@
 template <class T>
 TEST_HOST_DEVICE_FUNC bool equal(T lhs, T rhs)
 {
-  return static_cast<float>(lhs) == static_cast<float>(rhs);
+  return ::__heq(lhs, rhs);
+}
+
+template <class T>
+TEST_HOST_DEVICE_FUNC T value(float val)
+{
+  return cuda::std::__fp_cast<T>(val);
 }
 
 template <class T, template <typename, typename> class Selector, cuda::thread_scope ThreadScope>
@@ -40,68 +48,68 @@ struct TestFn
       using A = cuda::atomic<T, ThreadScope>;
       Selector<A, constructor_initializer> sel;
       A& t = *sel.construct();
-      t    = T(-1.0f);
-      assert(equal(t.fetch_min(T(-5.0f)), T(-1.0f)));
-      assert(equal(t.load(), T(-5.0f)));
+      t    = value<T>(-1.0f);
+      assert(equal(t.fetch_min(value<T>(-5.0f)), value<T>(-1.0f)));
+      assert(equal(t.load(), value<T>(-5.0f)));
     }
     {
       using A = cuda::atomic<T, ThreadScope>;
       Selector<volatile A, constructor_initializer> sel;
       volatile A& t = *sel.construct();
-      t             = T(-1.0f);
-      assert(equal(t.fetch_min(T(-5.0f)), T(-1.0f)));
-      assert(equal(t.load(), T(-5.0f)));
+      t             = value<T>(-1.0f);
+      assert(equal(t.fetch_min(value<T>(-5.0f)), value<T>(-1.0f)));
+      assert(equal(t.load(), value<T>(-5.0f)));
     }
     // Test not lesser
     {
       using A = cuda::atomic<T, ThreadScope>;
       Selector<A, constructor_initializer> sel;
       A& t = *sel.construct();
-      t    = T(-1.0f);
-      assert(equal(t.fetch_min(T(4.0f)), T(-1.0f)));
-      assert(equal(t.load(), T(-1.0f)));
+      t    = value<T>(-1.0f);
+      assert(equal(t.fetch_min(value<T>(4.0f)), value<T>(-1.0f)));
+      assert(equal(t.load(), value<T>(-1.0f)));
     }
     {
       using A = cuda::atomic<T, ThreadScope>;
       Selector<volatile A, constructor_initializer> sel;
       volatile A& t = *sel.construct();
-      t             = T(-1.0f);
-      assert(equal(t.fetch_min(T(4.0f)), T(-1.0f)));
-      assert(equal(t.load(), T(-1.0f)));
+      t             = value<T>(-1.0f);
+      assert(equal(t.fetch_min(value<T>(4.0f)), value<T>(-1.0f)));
+      assert(equal(t.load(), value<T>(-1.0f)));
     }
     // Fetch max
     {
       using A = cuda::atomic<T>;
       Selector<A, constructor_initializer> sel;
       A& t = *sel.construct();
-      t    = T(1.0f);
-      assert(equal(t.fetch_max(T(2.0f)), T(1.0f)));
-      assert(equal(t.load(), T(2.0f)));
+      t    = value<T>(1.0f);
+      assert(equal(t.fetch_max(value<T>(2.0f)), value<T>(1.0f)));
+      assert(equal(t.load(), value<T>(2.0f)));
     }
     {
       using A = cuda::atomic<T>;
       Selector<volatile A, constructor_initializer> sel;
       volatile A& t = *sel.construct();
-      t             = T(1.0f);
-      assert(equal(t.fetch_max(T(2.0f)), T(1.0f)));
-      assert(equal(t.load(), T(2.0f)));
+      t             = value<T>(1.0f);
+      assert(equal(t.fetch_max(value<T>(2.0f)), value<T>(1.0f)));
+      assert(equal(t.load(), value<T>(2.0f)));
     }
     // Test not greater
     {
       using A = cuda::atomic<T>;
       Selector<A, constructor_initializer> sel;
       A& t = *sel.construct();
-      t    = T(3.0f);
-      assert(equal(t.fetch_max(T(2.0f)), T(3.0f)));
-      assert(equal(t.load(), T(3.0f)));
+      t    = value<T>(3.0f);
+      assert(equal(t.fetch_max(value<T>(2.0f)), value<T>(3.0f)));
+      assert(equal(t.load(), value<T>(3.0f)));
     }
     {
       using A = cuda::atomic<T>;
       Selector<volatile A, constructor_initializer> sel;
       volatile A& t = *sel.construct();
-      t             = T(3.0f);
-      assert(equal(t.fetch_max(T(2.0f)), T(3.0f)));
-      assert(equal(t.load(), T(3.0f)));
+      t             = value<T>(3.0f);
+      assert(equal(t.fetch_max(value<T>(2.0f)), value<T>(3.0f)));
+      assert(equal(t.load(), value<T>(3.0f)));
     }
   }
 };

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_extended_floating_point.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_extended_floating_point.pass.cpp
@@ -29,7 +29,7 @@
 template <class T>
 TEST_HOST_DEVICE_FUNC bool equal(T lhs, T rhs)
 {
-  return ::__heq(lhs, rhs);
+  return cuda::std::__fp_cast<float>(lhs) == cuda::std::__fp_cast<float>(rhs);
 }
 
 template <class T>


### PR DESCRIPTION
## Description

Resolves #10810.

`cuda::atomic<__half>` and `cuda::atomic<__nv_bfloat16>` support basic atomic operations but currently reject `fetch_min` and `fetch_max` because the small-storage dispatch doesn't consider them to be floating point types. This PR changes the check to accept extended fp, and enables those operations using a widened CAS loop that decodes the stored value, performs a floating-point comparison, and writes the selected value back through the existing 32-bit representation.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
