### PR TITLE
MGMN Determinism

### DIFF
--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -187,6 +187,15 @@ std::vector<T> to_vec(std::vector<T> const& vec)
 {
   return vec;
 }
+
+template <class T, class... Props>
+std::vector<T> to_vec(cuda::buffer<T, Props...> const& buf)
+{
+  const auto host = cuda::make_buffer(buf.stream(), cuda::mr::legacy_pinned_memory_resource{}, buf);
+
+  buf.stream().sync();
+  return std::vector<T>{host.begin(), host.end()};
+}
 } // namespace detail
 
 #define REQUIRE_APPROX_EQ(ref, out)                          \

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/common.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/common.h
@@ -24,6 +24,9 @@
 
 #include <cuda/__container/buffer.h>
 #include <cuda/__device/logical_device_ref.h>
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/require.h>
+#include <cuda/__functional/call_or.h>
 #include <cuda/__functional/lazy_call_or.h>
 #include <cuda/__memory_pool/locality_domain_memory_pool.h>
 #include <cuda/__memory_resource/get_memory_resource.h>
@@ -118,6 +121,12 @@ struct __in_range_out_it_properties
   using __buffer_type _CCCL_NODEBUG =
     ::cuda::__buffer_type_for_props<__output_type, typename __resource_type::default_queries>;
 };
+
+template <class _Env>
+using __determinism_of_t _CCCL_NODEBUG = ::cuda::__call_result_or_t<
+  ::cuda::execution::determinism::__get_determinism_t,
+  ::cuda::execution::determinism::run_to_run_t,
+  ::cuda::__call_result_or_t<::cuda::execution::__get_requirements_t, ::cuda::std::execution::env<>, _Env>>;
 
 template <class _RangeOfIters>
 _CCCL_CONCEPT __range_of_random_access_iterators = _CCCL_REQUIRES_EXPR((_RangeOfIters), )(

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h
@@ -238,6 +238,31 @@ _CCCL_HOST_API void reduce(
   static_assert(::cuda::std::__is_callable_v<::cuda::get_stream_t, typename __properties::__env_type>,
                 "Environment must contain a stream");
 
+  // TODO(jfaibussowit):
+  //
+  // Determinism is a tricky problem. In addition to CUB it also depends on the communicator so
+  // we need some way of asking the communicator whether they can satisfy it. But should it
+  // expose a query() member? A default_properties? And what should the default be, to assume
+  // it can only handle not_guaranteed? Also, it's relatively obvious that you can ask the
+  // question about reductions, but should you be able to ask it about other methods like
+  // gather/allgather?
+  //
+  // There is an additional wrinkle that determinism for comms is usually tied to the
+  // topology as well. If you run the same program but with different number of ranks, you
+  // probably get different results. We can't ensure this at compile time.
+  //
+  // So all this is to say, I will punt this until a user has a need for it, which may help us
+  // decide these things.
+  {
+    using __determinism _CCCL_NODEBUG =
+      ::cuda::experimental::mgmn::__detail::__determinism_of_t<typename __properties::__env_type>;
+
+    static_assert(::cuda::std::same_as<__determinism, ::cuda::execution::determinism::run_to_run_t>
+                    || ::cuda::std::same_as<__determinism, ::cuda::execution::determinism::not_guaranteed_t>,
+                  "Only run_to_run and not_guaranteed reductions are currently supported. Please open an issue at "
+                  "github.com/NVIDIA/cccl/issue requesting support for stronger determinism");
+  }
+
   const auto __num_local = ::cuda::std::ranges::size(__comms);
 
   if (!__num_local)

--- a/cudax/test/multi_gpu/CMakeLists.txt
+++ b/cudax/test/multi_gpu/CMakeLists.txt
@@ -18,6 +18,117 @@ function(cudax_add_multi_gpu_test sub_prefix target_name_var source)
   set("${target_name_var}" "${${target_name_var}}" PARENT_SCOPE)
 endfunction()
 
+#[=======================================================================[.rst:
+cudax_split_multi_gpu_tests
+---------------------------
+
+Split a list of test sources into the ones that are expected to compile and the ones that
+are expected to fail to compile.
+
+A source is expected to fail to compile if its file name ends in ``_fail``. The two kinds
+need different registration, because a fail test is not a Catch2 test and must not be built
+as part of ``all``. So pass the first result to :command:`cudax_add_multi_gpu_test` and the
+second to :command:`cudax_add_multi_gpu_fail_test`.
+
+Arguments
+^^^^^^^^^
+
+``srcs``
+  The list of test sources to split. Pass the list variable by name, not by value.
+
+``pass_srcs_var``
+  The variable in which to store the sources that are expected to compile, in the parent
+  scope.
+
+``fail_srcs_var``
+  The variable in which to store the sources that are expected to fail to compile, in the
+  parent scope.
+
+#]=======================================================================]
+function(cudax_split_multi_gpu_tests srcs pass_srcs_var fail_srcs_var)
+  set(pass_srcs)
+  set(fail_srcs)
+
+  foreach (src IN LISTS ${srcs})
+    cmake_path(GET src STEM filename)
+    if ("${filename}" MATCHES "_fail$")
+      list(APPEND fail_srcs "${src}")
+    else()
+      list(APPEND pass_srcs "${src}")
+    endif()
+  endforeach()
+
+  set("${pass_srcs_var}" "${pass_srcs}" PARENT_SCOPE)
+  set("${fail_srcs_var}" "${fail_srcs}" PARENT_SCOPE)
+endfunction()
+
+#[=======================================================================[.rst:
+cudax_add_multi_gpu_fail_test
+-----------------------------
+
+Add a multi-GPU test that is expected to fail to compile, and register it with ctest. Use
+this for sources that follow the ``_fail.cu`` naming convention.
+
+The created target is excluded from ``all``, because building it is the failure the test
+looks for. The test itself builds the target and passes only if the compiler output matches
+the expected error. So the source must declare the error it expects with a comment of the
+form:
+
+.. code-block:: c++
+
+  // expected-error {{"the diagnostic text to match"}}
+
+The target is never linked or run, so it needs no Catch2 main.
+
+The created target is named ``cudax.test.multi_gpu.<sub_prefix>.error.<source stem>``.
+
+Arguments
+^^^^^^^^^
+
+``sub_prefix``
+  The dotted name of the group the test belongs to, for example ``algorithms.reduce``. Use
+  the same value as for the corresponding :command:`cudax_add_multi_gpu_test` calls.
+
+``target_name_var``
+  The variable in which to store the created target name, in the parent scope. Useful for
+  modifying the target after creation, for example to link an extra library.
+
+``source``
+  The source file that implements the test.
+
+#]=======================================================================]
+function(cudax_add_multi_gpu_fail_test sub_prefix target_name_var source)
+  cmake_path(GET source STEM filename)
+
+  set(test_target "cudax.test.multi_gpu.${sub_prefix}.error.${filename}")
+
+  # The test never links or runs, so it needs no Catch2 main. NO_METATARGETS keeps it out of
+  # the aggregate build targets, since it is expected to fail to compile.
+  cccl_add_executable(
+    ${test_target}
+    SOURCES "${source}"
+    NO_METATARGETS
+    NO_CLANG_TIDY
+  )
+  target_include_directories(
+    ${test_target}
+    PRIVATE "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/include"
+  )
+  target_link_libraries(
+    ${test_target}
+    PRIVATE #
+      cudax.compiler_interface
+      CUDA::cudart_static
+  )
+  cccl_add_xfail_compile_target_test(
+    ${test_target}
+    SOURCE_FILE "${source}"
+    ERROR_REGEX_LABEL "expected-error"
+  )
+
+  set("${target_name_var}" "${test_target}" PARENT_SCOPE)
+endfunction()
+
 add_subdirectory(algorithms)
 add_subdirectory(communicators)
 add_subdirectory(concepts)

--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_determinism.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_determinism.cu
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/require.h>
+#include <cuda/buffer>
+#include <cuda/functional>
+#include <cuda/memory_resource>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/std/limits>
+#include <cuda/std/span>
+#include <cuda/std/type_traits>
+
+#include <cuda/experimental/__multi_gpu/algorithm/scan/scan.h>
+
+#include <vector>
+
+#include <algorithm_common.h>
+#include <determinism_common.h>
+#include <nccl_test_common.h>
+#include <testing.cuh>
+
+namespace
+{
+// `exclusive_scan` forwards the environment to `cub::DeviceScan::ExclusiveScan` and to the two
+// `cub::DeviceReduce::Reduce` calls that build the per-rank prefix. A requirement is supported
+// only where both CUB algorithms support it. Every other combination is a compile-time error, so
+// it cannot appear here.
+using supported_cases =
+  c2h::type_list<c2h::type_list<cuda::std::int32_t, cuda::std::plus<>, cuda::execution::determinism::run_to_run_t>,
+                 c2h::type_list<cuda::std::int32_t, cuda::std::plus<>, cuda::execution::determinism::gpu_to_gpu_t>,
+                 c2h::type_list<cuda::std::int32_t, cuda::maximum<>, cuda::execution::determinism::run_to_run_t>,
+                 c2h::type_list<cuda::std::int32_t, cuda::maximum<>, cuda::execution::determinism::gpu_to_gpu_t>,
+                 // `gpu_to_gpu` does not support a floating-point type.
+                 c2h::type_list<float, cuda::std::plus<>, cuda::execution::determinism::run_to_run_t>>;
+} // namespace
+
+// Each rank runs on its own thread, because the per-rank calls must rendezvous in their
+// collectives. Catch2 assertions stay on the main thread after the join.
+MULTI_GPU_TEST("exclusive_scan single-comm, supported determinism requirements", supported_cases)
+{
+  using Case        = c2h::get<0, TestType>;
+  using T           = c2h::get<0, Case>;
+  using Op          = c2h::get<1, Case>;
+  using Determinism = c2h::get<2, Case>;
+
+  const T init     = static_cast<T>(GENERATE(0, 1, -1, 5));
+  const auto ident = get_identity<T, Op>();
+  constexpr Op op{};
+
+  auto comms = this->communicators();
+  auto rng   = make_rng(C2H_SEED(2));
+
+  std::vector<std::vector<T>> inputs_by_rank(static_cast<cuda::std::size_t>(comms.front().size()));
+
+  const auto total_count = inputs_by_rank.size() * large_values_per_rank;
+  for (auto& values : inputs_by_rank)
+  {
+    values = make_random_values<T>(large_values_per_rank, total_count, rng);
+  }
+
+  auto streams = nccl_test_util::make_streams();
+
+  const auto make_env = [](cuda::stream_ref stream) {
+    return ::cuda::std::execution::env{stream, ::cuda::execution::require(Determinism{})};
+  };
+
+  std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<T>> out;
+  std::vector<decltype(make_env(streams[0]))> envs;
+
+  in.reserve(comms.size());
+  out.reserve(comms.size());
+  envs.reserve(comms.size());
+  for (cuda::std::size_t i = 0; i < comms.size(); ++i)
+  {
+    const auto& values = inputs_by_rank[static_cast<cuda::std::size_t>(comms[i].rank())];
+
+    in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
+    out.emplace_back(cuda::make_device_buffer<T>(
+      streams[i], comms[i].logical_device().underlying_device(), values.size(), cuda::no_init));
+    envs.emplace_back(make_env(streams[i]));
+  }
+
+  INFO("init = " << init);
+  INFO("ident = " << ident);
+
+  run_threaded(comms.size(), [&](cuda::std::size_t i) {
+    cudax::mgmn::exclusive_scan(
+      cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
+  });
+
+  // Keep an independent snapshot because each launch overwrites the output buffers.
+  std::vector<std::vector<T>> first_results;
+  for (const auto& buf : out)
+  {
+    first_results.push_back(::detail::to_vec(buf));
+  }
+
+  constexpr int num_runs = 4;
+  for (int run = 0; run < num_runs; ++run)
+  {
+    INFO("run = " << run);
+
+    run_threaded(comms.size(), [&](cuda::std::size_t i) {
+      cudax::mgmn::exclusive_scan(
+        cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
+    });
+
+    for (cuda::std::size_t i = 0; i < out.size(); ++i)
+    {
+      INFO("device = " << i);
+
+      const auto actual = ::detail::to_vec(out[i]);
+      REQUIRE(actual.size() == first_results[i].size());
+      REQUIRE_THAT(actual, ::detail::BitwiseEqualsRange(first_results[i]));
+    }
+  }
+}

--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_determinism.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_determinism.cu
@@ -102,6 +102,8 @@ MULTI_GPU_TEST("exclusive_scan single-comm, supported determinism requirements",
 
   // Keep an independent snapshot because each launch overwrites the output buffers.
   std::vector<std::vector<T>> first_results;
+
+  first_results.reserve(out.size());
   for (const auto& buf : out)
   {
     first_results.push_back(::detail::to_vec(buf));

--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_determinism.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_determinism.cu
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/require.h>
+#include <cuda/buffer>
+#include <cuda/functional>
+#include <cuda/memory_resource>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/std/limits>
+#include <cuda/std/span>
+#include <cuda/std/type_traits>
+
+#include <cuda/experimental/__multi_gpu/algorithm/scan/scan.h>
+
+#include <vector>
+
+#include <algorithm_common.h>
+#include <determinism_common.h>
+#include <nccl_test_common.h>
+#include <testing.cuh>
+
+namespace
+{
+// `inclusive_scan` forwards the environment to `cub::DeviceScan::InclusiveScanInit` and to the
+// two `cub::DeviceReduce::Reduce` calls that build the per-rank prefix. A requirement is supported
+// only where both CUB algorithms support it. Every other combination is a compile-time error, so
+// it cannot appear here.
+using supported_cases =
+  c2h::type_list<c2h::type_list<cuda::std::int32_t, cuda::std::plus<>, cuda::execution::determinism::run_to_run_t>,
+                 c2h::type_list<cuda::std::int32_t, cuda::std::plus<>, cuda::execution::determinism::gpu_to_gpu_t>,
+                 c2h::type_list<cuda::std::int32_t, cuda::maximum<>, cuda::execution::determinism::run_to_run_t>,
+                 c2h::type_list<cuda::std::int32_t, cuda::maximum<>, cuda::execution::determinism::gpu_to_gpu_t>,
+                 // `gpu_to_gpu` does not support a floating-point type.
+                 c2h::type_list<float, cuda::std::plus<>, cuda::execution::determinism::run_to_run_t>>;
+} // namespace
+
+// Each rank runs on its own thread, because the per-rank calls must rendezvous in their
+// collectives. Catch2 assertions stay on the main thread after the join.
+MULTI_GPU_TEST("inclusive_scan single-comm, supported determinism requirements", supported_cases)
+{
+  using Case        = c2h::get<0, TestType>;
+  using T           = c2h::get<0, Case>;
+  using Op          = c2h::get<1, Case>;
+  using Determinism = c2h::get<2, Case>;
+
+  const T init     = static_cast<T>(GENERATE(0, 1, -1, 5));
+  const auto ident = get_identity<T, Op>();
+  constexpr Op op{};
+
+  auto comms = this->communicators();
+  auto rng   = make_rng(C2H_SEED(2));
+
+  std::vector<std::vector<T>> inputs_by_rank(static_cast<cuda::std::size_t>(comms.front().size()));
+
+  const auto total_count = inputs_by_rank.size() * large_values_per_rank;
+  for (auto& values : inputs_by_rank)
+  {
+    values = make_random_values<T>(large_values_per_rank, total_count, rng);
+  }
+
+  auto streams = nccl_test_util::make_streams();
+
+  const auto make_env = [](cuda::stream_ref stream) {
+    return ::cuda::std::execution::env{stream, ::cuda::execution::require(Determinism{})};
+  };
+
+  std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<T>> out;
+  std::vector<decltype(make_env(streams[0]))> envs;
+
+  in.reserve(comms.size());
+  out.reserve(comms.size());
+  envs.reserve(comms.size());
+  for (cuda::std::size_t i = 0; i < comms.size(); ++i)
+  {
+    const auto& values = inputs_by_rank[static_cast<cuda::std::size_t>(comms[i].rank())];
+
+    in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
+    out.emplace_back(cuda::make_device_buffer<T>(
+      streams[i], comms[i].logical_device().underlying_device(), values.size(), cuda::no_init));
+    envs.emplace_back(make_env(streams[i]));
+  }
+
+  INFO("init = " << init);
+  INFO("ident = " << ident);
+
+  run_threaded(comms.size(), [&](cuda::std::size_t i) {
+    cudax::mgmn::inclusive_scan(
+      cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
+  });
+
+  // Keep an independent snapshot because each launch overwrites the output buffers.
+  std::vector<std::vector<T>> first_results;
+  for (const auto& buf : out)
+  {
+    first_results.push_back(::detail::to_vec(buf));
+  }
+
+  constexpr int num_runs = 4;
+  for (int run = 0; run < num_runs; ++run)
+  {
+    INFO("run = " << run);
+
+    run_threaded(comms.size(), [&](cuda::std::size_t i) {
+      cudax::mgmn::inclusive_scan(
+        cudax::distributed, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
+    });
+
+    for (cuda::std::size_t i = 0; i < out.size(); ++i)
+    {
+      INFO("device = " << i);
+
+      const auto actual = ::detail::to_vec(out[i]);
+      REQUIRE(actual.size() == first_results[i].size());
+      REQUIRE_THAT(actual, ::detail::BitwiseEqualsRange(first_results[i]));
+    }
+  }
+}

--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_determinism.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_determinism.cu
@@ -102,6 +102,8 @@ MULTI_GPU_TEST("inclusive_scan single-comm, supported determinism requirements",
 
   // Keep an independent snapshot because each launch overwrites the output buffers.
   std::vector<std::vector<T>> first_results;
+
+  first_results.reserve(out.size());
   for (const auto& buf : out)
   {
     first_results.push_back(::detail::to_vec(buf));

--- a/cudax/test/multi_gpu/algorithms/reduce/CMakeLists.txt
+++ b/cudax/test/multi_gpu/algorithms/reduce/CMakeLists.txt
@@ -14,7 +14,14 @@ endif()
 
 file(GLOB test_srcs LIST_DIRECTORIES FALSE CONFIGURE_DEPENDS *.cu *.cpp)
 
+cudax_split_multi_gpu_tests(test_srcs test_srcs fail_test_srcs)
+
 foreach (src IN LISTS test_srcs)
   cudax_add_multi_gpu_test("algorithms.reduce" test_target "${src}")
+  target_link_libraries(${test_target} PRIVATE NCCL::nccl)
+endforeach()
+
+foreach (src IN LISTS fail_test_srcs)
+  cudax_add_multi_gpu_fail_test("algorithms.reduce" test_target "${src}")
   target_link_libraries(${test_target} PRIVATE NCCL::nccl)
 endforeach()

--- a/cudax/test/multi_gpu/algorithms/reduce/reduce_determinism_fail_common.cuh
+++ b/cudax/test/multi_gpu/algorithms/reduce/reduce_determinism_fail_common.cuh
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CUDAX_TEST_MULTI_GPU_ALGORITHMS_REDUCE_REDUCE_DETERMINISM_FAIL_COMMON_CUH
+#define CUDAX_TEST_MULTI_GPU_ALGORITHMS_REDUCE_REDUCE_DETERMINISM_FAIL_COMMON_CUH
+
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/require.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/execution>
+
+#include <cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h>
+#include <cuda/experimental/__multi_gpu/nccl_communicator_ref.h>
+
+namespace cudax = ::cuda::experimental;
+
+// Calls `reduce` with an environment that carries `determinism`. Nothing here runs. A null
+// communicator, a null stream and null iterators only have to satisfy the constraints on `reduce`,
+// so that the body is instantiated and the static_assert fires.
+template <class Determinism>
+void reduce_with_determinism(Determinism determinism)
+{
+  cudax::nccl_communicator_ref comm{::ncclComm_t{}};
+  auto env = ::cuda::std::execution::env{::cuda::stream_ref{::cudaStream_t{}}, ::cuda::execution::require(determinism)};
+  int* ptr{};
+
+  cudax::mgmn::reduce(cudax::broadcasted, comm, env, ptr, ::cuda::std::size_t{0}, ptr);
+}
+
+#endif // CUDAX_TEST_MULTI_GPU_ALGORITHMS_REDUCE_REDUCE_DETERMINISM_FAIL_COMMON_CUH

--- a/cudax/test/multi_gpu/algorithms/reduce/reduce_determinism_fail_common.cuh
+++ b/cudax/test/multi_gpu/algorithms/reduce/reduce_determinism_fail_common.cuh
@@ -27,7 +27,7 @@ namespace cudax = ::cuda::experimental;
 template <class Determinism>
 void reduce_with_determinism(Determinism determinism)
 {
-  cudax::nccl_communicator_ref comm{::ncclComm_t{}};
+  cudax::mgmn::nccl_communicator_ref comm{::ncclComm_t{}};
   auto env = ::cuda::std::execution::env{::cuda::stream_ref{::cudaStream_t{}}, ::cuda::execution::require(determinism)};
   int* ptr{};
 

--- a/cudax/test/multi_gpu/algorithms/reduce/single_comm_determinism.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/single_comm_determinism.cu
@@ -1,0 +1,295 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/require.h>
+#include <cuda/buffer>
+#include <cuda/functional>
+#include <cuda/memory_resource>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/std/type_traits>
+
+#include <cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h>
+
+#include <numeric>
+#include <vector>
+
+#include <algorithm_common.h>
+#include <determinism_common.h>
+#include <nccl_test_common.h>
+#include <testing.cuh>
+
+namespace
+{
+// `gpu_to_gpu` is a compile-time error, covered by the `*_determinism_fail.cu` test.
+using run_to_run_cases =
+  c2h::type_list<c2h::type_list<cuda::std::int32_t, cuda::std::plus<>, cuda::execution::determinism::run_to_run_t>,
+                 c2h::type_list<cuda::std::int32_t, cuda::maximum<>, cuda::execution::determinism::run_to_run_t>,
+                 c2h::type_list<float, cuda::std::plus<>, cuda::execution::determinism::run_to_run_t>>;
+
+// `make_random_values` draws from a numeric distribution, so `custom_value` cannot be an input
+// here.
+using arithmetic_value_types = c2h::remove<value_types, custom_value>;
+
+using nondeterministic_cases =
+  c2h::type_list<c2h::type_list<cuda::std::int32_t, cuda::std::plus<>, cuda::execution::determinism::not_guaranteed_t>,
+                 c2h::type_list<cuda::std::int32_t, cuda::maximum<>, cuda::execution::determinism::not_guaranteed_t>,
+                 c2h::type_list<float, cuda::std::plus<>, cuda::execution::determinism::not_guaranteed_t>>;
+} // namespace
+
+// Each rank runs on its own thread, because the per-rank calls must rendezvous in their
+// collectives. Catch2 assertions stay on the main thread after the join.
+MULTI_GPU_TEST("reduce single-comm, run_to_run determinism", run_to_run_cases)
+{
+  using Case        = c2h::get<0, TestType>;
+  using T           = c2h::get<0, Case>;
+  using Op          = c2h::get<1, Case>;
+  using Determinism = c2h::get<2, Case>;
+
+  const T init     = make_value<T>(GENERATE(0, 1, 5));
+  const auto ident = get_identity<T, Op>();
+  constexpr Op op{};
+
+  auto comms = this->communicators();
+  auto rng   = make_rng(C2H_SEED(2));
+
+  std::vector<std::vector<T>> inputs_by_rank(static_cast<cuda::std::size_t>(comms.front().size()));
+
+  const auto total_count = inputs_by_rank.size() * large_values_per_rank;
+  for (auto& values : inputs_by_rank)
+  {
+    values = make_random_values<T>(large_values_per_rank, total_count, rng);
+  }
+
+  auto streams = nccl_test_util::make_streams();
+
+  const auto make_env = [](cuda::stream_ref stream) {
+    return ::cuda::std::execution::env{stream, ::cuda::execution::require(Determinism{})};
+  };
+
+  std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<T>> out;
+  std::vector<decltype(make_env(streams[0]))> envs;
+
+  in.reserve(comms.size());
+  out.reserve(comms.size());
+  envs.reserve(comms.size());
+  for (cuda::std::size_t i = 0; i < comms.size(); ++i)
+  {
+    const auto& values = inputs_by_rank[static_cast<cuda::std::size_t>(comms[i].rank())];
+
+    in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
+    out.emplace_back(
+      cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
+    envs.emplace_back(make_env(streams[i]));
+  }
+
+  INFO("init = " << init);
+  INFO("ident = " << ident);
+
+  run_threaded(comms.size(), [&](cuda::std::size_t i) {
+    cudax::mgmn::reduce(
+      cudax::broadcasted, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
+  });
+
+  // Keep an independent snapshot because each launch overwrites the output buffers.
+  std::vector<std::vector<T>> first_results;
+  for (const auto& buf : out)
+  {
+    first_results.push_back(::detail::to_vec(buf));
+  }
+
+  constexpr int num_runs = 4;
+  for (int run = 0; run < num_runs; ++run)
+  {
+    INFO("run = " << run);
+
+    run_threaded(comms.size(), [&](cuda::std::size_t i) {
+      cudax::mgmn::reduce(
+        cudax::broadcasted, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
+    });
+
+    for (cuda::std::size_t i = 0; i < out.size(); ++i)
+    {
+      INFO("device = " << i);
+
+      const auto actual = ::detail::to_vec(out[i]);
+      REQUIRE(actual.size() == first_results[i].size());
+      REQUIRE_THAT(actual, ::detail::BitwiseEqualsRange(first_results[i]));
+    }
+  }
+}
+
+// `run_to_run` is the default, so an environment that carries no requirement at all must give the
+// same guarantee as one that asks for `run_to_run` explicitly.
+MULTI_GPU_TEST("reduce single-comm, default determinism requirement", arithmetic_value_types, operators)
+{
+  using T  = c2h::get<0, TestType>;
+  using Op = c2h::get<1, TestType>;
+
+  const T init     = make_value<T>(GENERATE(0, 1, 5));
+  const auto ident = get_identity<T, Op>();
+  constexpr Op op{};
+
+  auto comms = this->communicators();
+  auto rng   = make_rng(C2H_SEED(2));
+
+  std::vector<std::vector<T>> inputs_by_rank(static_cast<cuda::std::size_t>(comms.front().size()));
+
+  const auto total_count = inputs_by_rank.size() * large_values_per_rank;
+  for (auto& values : inputs_by_rank)
+  {
+    values = make_random_values<T>(large_values_per_rank, total_count, rng);
+  }
+
+  auto streams = nccl_test_util::make_streams();
+
+  const auto make_env = [](cuda::stream_ref stream) {
+    return ::cuda::std::execution::env{stream};
+  };
+
+  std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<T>> out;
+  std::vector<decltype(make_env(streams[0]))> envs;
+
+  in.reserve(comms.size());
+  out.reserve(comms.size());
+  envs.reserve(comms.size());
+  for (cuda::std::size_t i = 0; i < comms.size(); ++i)
+  {
+    const auto& values = inputs_by_rank[static_cast<cuda::std::size_t>(comms[i].rank())];
+
+    in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
+    out.emplace_back(
+      cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
+    envs.emplace_back(make_env(streams[i]));
+  }
+
+  INFO("init = " << init);
+  INFO("ident = " << ident);
+
+  run_threaded(comms.size(), [&](cuda::std::size_t i) {
+    cudax::mgmn::reduce(
+      cudax::broadcasted, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
+  });
+
+  // Keep an independent snapshot because each launch overwrites the output buffers.
+  std::vector<std::vector<T>> first_results;
+  for (const auto& buf : out)
+  {
+    first_results.push_back(::detail::to_vec(buf));
+  }
+
+  constexpr int num_runs = 4;
+  for (int run = 0; run < num_runs; ++run)
+  {
+    INFO("run = " << run);
+
+    run_threaded(comms.size(), [&](cuda::std::size_t i) {
+      cudax::mgmn::reduce(
+        cudax::broadcasted, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
+    });
+
+    for (cuda::std::size_t i = 0; i < out.size(); ++i)
+    {
+      INFO("device = " << i);
+
+      const auto actual = ::detail::to_vec(out[i]);
+      REQUIRE(actual.size() == first_results[i].size());
+      REQUIRE_THAT(actual, ::detail::BitwiseEqualsRange(first_results[i]));
+    }
+  }
+}
+
+MULTI_GPU_TEST("reduce single-comm, not_guaranteed correctness", nondeterministic_cases)
+{
+  using Case        = c2h::get<0, TestType>;
+  using T           = c2h::get<0, Case>;
+  using Op          = c2h::get<1, Case>;
+  using Determinism = c2h::get<2, Case>;
+
+  const T init     = make_value<T>(GENERATE(0, 1, 5));
+  const auto ident = get_identity<T, Op>();
+  constexpr Op op{};
+
+  auto comms = this->communicators();
+  auto rng   = make_rng(C2H_SEED(2));
+
+  std::vector<std::vector<T>> inputs_by_rank(static_cast<cuda::std::size_t>(comms.front().size()));
+
+  const auto total_count = inputs_by_rank.size() * large_values_per_rank;
+  for (auto& values : inputs_by_rank)
+  {
+    values = make_random_values<T>(large_values_per_rank, total_count, rng);
+  }
+
+  auto streams = nccl_test_util::make_streams();
+
+  const auto make_env = [](cuda::stream_ref stream) {
+    return ::cuda::std::execution::env{stream, ::cuda::execution::require(Determinism{})};
+  };
+
+  std::vector<cuda::device_buffer<T>> in;
+  std::vector<cuda::device_buffer<T>> out;
+  std::vector<decltype(make_env(streams[0]))> envs;
+
+  in.reserve(comms.size());
+  out.reserve(comms.size());
+  envs.reserve(comms.size());
+  for (cuda::std::size_t i = 0; i < comms.size(); ++i)
+  {
+    const auto& values = inputs_by_rank[static_cast<cuda::std::size_t>(comms[i].rank())];
+
+    in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
+    out.emplace_back(
+      cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), 1, cuda::no_init));
+    envs.emplace_back(make_env(streams[i]));
+  }
+
+  INFO("init = " << init);
+  INFO("ident = " << ident);
+
+  T expected = init;
+  for (const auto& values : inputs_by_rank)
+  {
+    expected = std::accumulate(values.begin(), values.end(), expected, op);
+  }
+
+  constexpr int num_runs = 4;
+
+  for (int run = 0; run < num_runs; ++run)
+  {
+    INFO("run = " << run);
+
+    run_threaded(comms.size(), [&](cuda::std::size_t i) {
+      cudax::mgmn::reduce(
+        cudax::broadcasted, comms[i], envs[i], in[i].begin(), in[i].size(), out[i].begin(), init, op, ident);
+    });
+
+    for (cuda::std::size_t i = 0; i < out.size(); ++i)
+    {
+      INFO("device = " << i);
+
+      const auto actual = ::detail::to_vec(out[i]);
+      REQUIRE(actual.size() == 1);
+      if constexpr (cuda::std::is_floating_point_v<T>)
+      {
+        REQUIRE_APPROX_EQ_EPSILON(std::vector<T>{expected}, actual, 0.001);
+      }
+      else
+      {
+        REQUIRE(actual[0] == expected);
+      }
+    }
+  }
+}

--- a/cudax/test/multi_gpu/algorithms/reduce/single_comm_determinism.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/single_comm_determinism.cu
@@ -104,6 +104,8 @@ MULTI_GPU_TEST("reduce single-comm, run_to_run determinism", run_to_run_cases)
 
   // Keep an independent snapshot because each launch overwrites the output buffers.
   std::vector<std::vector<T>> first_results;
+
+  first_results.reserve(out.size());
   for (const auto& buf : out)
   {
     first_results.push_back(::detail::to_vec(buf));
@@ -185,6 +187,8 @@ MULTI_GPU_TEST("reduce single-comm, default determinism requirement", arithmetic
 
   // Keep an independent snapshot because each launch overwrites the output buffers.
   std::vector<std::vector<T>> first_results;
+
+  first_results.reserve(out.size());
   for (const auto& buf : out)
   {
     first_results.push_back(::detail::to_vec(buf));

--- a/cudax/test/multi_gpu/algorithms/reduce/single_comm_gpu_to_gpu_determinism_fail.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/single_comm_gpu_to_gpu_determinism_fail.cu
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include "reduce_determinism_fail_common.cuh"
+
+int main()
+{
+  // expected-error {{"Only run_to_run and not_guaranteed reductions are currently supported"}}
+  reduce_with_determinism(::cuda::execution::determinism::gpu_to_gpu);
+
+  return EXIT_FAILURE;
+}

--- a/cudax/test/multi_gpu/include/determinism_common.h
+++ b/cudax/test/multi_gpu/include/determinism_common.h
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cuda/std/cstddef>
+#include <cuda/std/limits>
+#include <cuda/std/random>
+#include <cuda/std/type_traits>
+
+#include <algorithm>
+#include <vector>
+
+#include <c2h/catch2_test_helper.h>
+
+// Large enough to force a multi-block, multi-pass device fold. A single-block fold would agree
+// with itself for a trivial reason and would not exercise the determinism guarantee.
+inline constexpr cuda::std::size_t large_values_per_rank = 100'000;
+
+// Integer inputs cannot overflow. Fractional inputs expose changes in floating-point addition order.
+template <class T, class RNG>
+[[nodiscard]] std::vector<T> make_random_values(cuda::std::size_t count, cuda::std::size_t total_count, RNG& rng)
+{
+  static_assert(cuda::std::is_arithmetic_v<T>);
+  std::vector<T> values(count);
+
+  if (count == 0 || total_count == 0)
+  {
+    return values;
+  }
+
+  if constexpr (cuda::std::is_floating_point_v<T>)
+  {
+    cuda::std::uniform_real_distribution<T> dist{T{0.5}, T{1.5}};
+
+    std::generate(values.begin(), values.end(), [&] {
+      return static_cast<T>(dist(rng));
+    });
+  }
+  else
+  {
+    // The division stays in `size_t` so that a narrow `T` cannot wrap the denominator.
+    const auto bound =
+      static_cast<T>(static_cast<cuda::std::size_t>(cuda::std::numeric_limits<T>::max()) / (2 * total_count));
+
+    // The input is too large to fold exactly in this integer type
+    REQUIRE(bound > 0);
+
+    // An unsigned type has no negative values to draw from.
+    const T lower = cuda::std::is_signed_v<T> ? static_cast<T>(-bound) : static_cast<T>(0);
+    cuda::std::uniform_int_distribution<T> dist{lower, bound};
+
+    std::generate(values.begin(), values.end(), [&] {
+      return dist(rng);
+    });
+  }
+  return values;
+}


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Test all of the existing reduction algorithms for determinism support.

`cudax::reduce()` currently can only support non-deterministic reductions since the determinism of the reduction depends on the communicator. This is a solvable problem, but I'm not quite sure how I want to structure the API for asking the communicator, so I punt it and require non-determinism (even if we could ask, the default NCCL communicator would answer "non deterministic" always anyway).

The various scans dont use the comms for reductions, so their determinism is entirely based on CUB; we can just pass through and support all of the available options.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
