### PR TITLE
libcu++: atomics SASS FileCheck suite for arithmetic atomic operations

### DIFF
--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_apis.cu
@@ -32,9 +32,9 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; ADD-NOT: {{.*}}{{(IADD3|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
-; SUB-DAG: {{.*}}{{(IADD3|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; SUB-DAG: {{.*}}{{(IADD3|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
 ; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_apis.cu
@@ -45,7 +45,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; ADD_NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; SUB_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
 ; SUB_NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_apis.cu
@@ -11,27 +11,43 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
 // %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE add,block
+// %FILECHECK% PREFIX_COMBINE add,non_block
+// %FILECHECK% PREFIX_COMBINE sub,block
+// %FILECHECK% PREFIX_COMBINE sub,non_block
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_arithmetic(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
 {
   return atom.OP(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; ADD-NOT: {{.*}}{{(IADD3|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-R6{{.*}}
-; SUB-DAG: {{.*}}{{(IADD3|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-R6{{.*}}
+; ADD-NOT: {{.*}}{{(IADD3|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
+; SUB-DAG: {{.*}}{{(IADD3|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; ADD_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; ADD_NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SUB_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
+; SUB_NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_apis.cu
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
+// %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_arithmetic(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+{
+  return atom.OP(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; ADD-NOT: {{.*}}{{(IADD3|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-R6{{.*}}
+; SUB-DAG: {{.*}}{{(IADD3|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-R6{{.*}}
+; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_apis.cu
@@ -31,10 +31,10 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; ADD-NOT: {{.*}}{{(IADD3|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
+; ADD-NOT: {{.*}}{{(IADD3|IADD|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SUB-DAG: {{.*}}{{(IADD3|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
+; SUB-DAG: {{.*}}{{(IADD3|IADD|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
 ; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_floating_types.cu
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
+// %PARAM% TYPE,SASS_TYPE type f32=float,.F32.FTZ.RN:f64=double,.F64.RN
+// %PARAM% OP op fetch_add:fetch_sub
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// Generic-address floating-point atomics contain a separate CAS fallback for
+// local memory. The native path must still use the floating-point add opcode.
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_floating_types.cu
@@ -38,7 +38,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_floating_types.cu
@@ -12,12 +12,14 @@
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
 // %PARAM% TYPE,SASS_TYPE type f32=float,.F32.FTZ.RN:f64=double,.F64.RN
 // %PARAM% OP op fetch_add:fetch_sub
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -26,11 +28,19 @@ __device__ auto atomic_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 // local memory. The native path must still use the floating-point add opcode.
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_apis.cu
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block
+// %PARAM% OP,SASS_OP op min=fetch_min,MIN:max=fetch_max,MAX
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_minmax(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+{
+  return atom.OP(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.[[SASS_OP]].S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]].S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_apis.cu
@@ -37,7 +37,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.[[SASS_OP]].S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]].S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_apis.cu
@@ -11,25 +11,35 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block
 // %PARAM% OP,SASS_OP op min=fetch_min,MIN:max=fetch_max,MAX
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_minmax(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
 {
   return atom.OP(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.[[SASS_OP]].S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]].S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_floating_types.cu
@@ -43,12 +43,17 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[CAS_RESULT_PRED:P[0-9]+]],{{.*}}
+; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; SMXX: {{.*}}@{{!?}}[[CAS_RESULT_PRED]] BRA{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_floating_types.cu
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block
+// %PARAM% TYPE,SASS_SIZE,SASS_CALC type f32=float,,FSETP:f64=double,.64,DSETP
+// %PARAM% OP op fetch_min:fetch_max
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_minmax(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; BLOCK-DAG: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
+; NON_BLOCK-DAG: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
+; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; SMXX: {{.*}}ISETP.NE{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_floating_types.cu
@@ -43,7 +43,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_floating_types.cu
@@ -12,12 +12,14 @@
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block
 // %PARAM% TYPE,SASS_SIZE,SASS_CALC type f32=float,,FSETP:f64=double,.64,DSETP
 // %PARAM% OP op fetch_min:fetch_max
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_minmax(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -25,17 +27,25 @@ __device__ auto atomic_minmax(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_floating_types.cu
@@ -29,11 +29,11 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types.cu
@@ -39,7 +39,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types.cu
@@ -12,12 +12,14 @@
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block
 // %PARAM% TYPE,SASS_TYPE type i32=int32_t,.S32:u32=uint32_t,:i64=int64_t,.S64:u64=uint64_t,.64
 // %PARAM% OP,SASS_OP op min=fetch_min,MIN:max=fetch_max,MAX
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_minmax(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -25,13 +27,21 @@ __device__ auto atomic_minmax(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types.cu
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block
+// %PARAM% TYPE,SASS_TYPE type i32=int32_t,.S32:u32=uint32_t,:i64=int64_t,.S64:u64=uint64_t,.64
+// %PARAM% OP,SASS_OP op min=fetch_min,MIN:max=fetch_max,MAX
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_minmax(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic.cu
@@ -12,7 +12,9 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE,SASS_CALC type f16=f16,HSETP2:bf16=bf16,HSETP2
 // %PARAM% OP op fetch_min:fetch_max
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -20,7 +22,7 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_minmax(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -30,12 +32,17 @@ __device__ auto atomic_minmax(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
@@ -43,6 +50,9 @@ __device__ auto atomic_minmax(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic.cu
@@ -10,9 +10,13 @@
 
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
-// %PARAM% TYPE,SASS_CALC type f16=f16,HSETP2:bf16=bf16,HSETP2
+// %PARAM% TYPE,FILECHECK_PREFIX_TYPE type f16=f16,f16:bf16=bf16,bf16
 // %PARAM% OP op fetch_min:fetch_max
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm75,f16
+// %FILECHECK% PREFIX_COMBINE sm75,bf16
+// %FILECHECK% PREFIX_COMBINE sm80,f16
+// %FILECHECK% PREFIX_COMBINE sm80,bf16
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
@@ -38,7 +42,11 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
-; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; SM75_F16-DAG: {{.*}}HSETP2{{.*}}
+; SM75_BF16-DAG: {{.*}}FSETP{{.*}}
+; SM80_F16-DAG: {{.*}}HSETP2{{.*}}
+; SM80_BF16-DAG: {{.*}}FSETP{{.*}}
+; SM90-PLUS-DAG: {{.*}}HSETP2{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -50,10 +58,12 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic.cu
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE,SASS_CALC type f16=f16,HSETP2:bf16=bf16,HSETP2
+// %PARAM% OP op fetch_min:fetch_max
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_minmax(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// Owning 16-bit extended floating-point atomics use 32-bit storage, so min/max
+// must compare the decoded value and update the storage through a 32-bit CAS.
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
+; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
+; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
+; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic.cu
@@ -34,11 +34,11 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic.cu
@@ -50,7 +50,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
@@ -33,12 +33,12 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
@@ -12,7 +12,9 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE,SASS_CALC type f16=f16,HSETP2:bf16=bf16,HSETP2
 // %PARAM% OP op fetch_min:fetch_max
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -20,7 +22,7 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_minmax(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -28,7 +30,7 @@ __device__ auto atomic_minmax(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.U16.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
@@ -37,12 +39,20 @@ __device__ auto atomic_minmax(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
@@ -48,7 +48,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE,SASS_CALC type f16=f16,HSETP2:bf16=bf16,HSETP2
+// %PARAM% OP op fetch_min:fetch_max
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_minmax(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-DAG: {{.*}}LD.E.U16.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK-DAG: {{.*}}LD.E.U16.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
@@ -33,8 +33,6 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
-; BLOCK-DAG: {{.*}}LD.E.U16.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
-; NON_BLOCK-DAG: {{.*}}LD.E.U16.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
@@ -10,9 +10,13 @@
 
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
-// %PARAM% TYPE,SASS_CALC type f16=f16,HSETP2:bf16=bf16,HSETP2
+// %PARAM% TYPE,FILECHECK_PREFIX_TYPE type f16=f16,f16:bf16=bf16,bf16
 // %PARAM% OP op fetch_min:fetch_max
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm75,f16
+// %FILECHECK% PREFIX_COMBINE sm75,bf16
+// %FILECHECK% PREFIX_COMBINE sm80,f16
+// %FILECHECK% PREFIX_COMBINE sm80,bf16
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
@@ -36,7 +40,11 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
-; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; SM75_F16-DAG: {{.*}}HSETP2{{.*}}
+; SM75_BF16-DAG: {{.*}}FSETP{{.*}}
+; SM80_F16-DAG: {{.*}}HSETP2{{.*}}
+; SM80_BF16-DAG: {{.*}}FSETP{{.*}}
+; SM90-PLUS-DAG: {{.*}}HSETP2{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
@@ -48,10 +56,12 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_apis.cu
@@ -39,7 +39,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]].S32{{.*}}
 ; BLOCK: {{.*}}ATOM.E.[[SASS_OP]].S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]].S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_apis.cu
@@ -11,27 +11,37 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block
 // %PARAM% OP,SASS_OP op min=fetch_min,MIN:max=fetch_max,MAX
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_minmax(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
 {
   return atom.OP(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]].S32{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]].S32{{.*}}
 ; BLOCK: {{.*}}ATOM.E.[[SASS_OP]].S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]].S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]].S32{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_apis.cu
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block
+// %PARAM% OP,SASS_OP op min=fetch_min,MIN:max=fetch_max,MAX
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_minmax(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+{
+  return atom.OP(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]].S32{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]].S32{{.*}}
+; BLOCK: {{.*}}ATOM.E.[[SASS_OP]].S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]].S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]].S32{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_floating_types.cu
@@ -44,12 +44,17 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.E.CAS[[SASS_SIZE]]{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS[[SASS_SIZE]]{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[CAS_RESULT_PRED:P[0-9]+]],{{.*}}
+; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS[[SASS_SIZE]]{{.*}}
+; SMXX: {{.*}}@{{!?}}[[CAS_RESULT_PRED]] BRA{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_floating_types.cu
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
+// %PARAM% TYPE,SASS_SIZE,SASS_CALC type f32=float,,FSETP:f64=double,.64,DSETP
+// %PARAM% OP op fetch_min:fetch_max
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_minmax(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; BLOCK-DAG: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
+; NON_BLOCK-DAG: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
+; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS[[SASS_SIZE]]{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; SMXX: {{.*}}ISETP.NE{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS[[SASS_SIZE]]{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_floating_types.cu
@@ -12,12 +12,14 @@
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
 // %PARAM% TYPE,SASS_SIZE,SASS_CALC type f32=float,,FSETP:f64=double,.64,DSETP
 // %PARAM% OP op fetch_min:fetch_max
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_minmax(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -25,18 +27,26 @@ __device__ auto atomic_minmax(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS[[SASS_SIZE]]{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS[[SASS_SIZE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_floating_types.cu
@@ -44,7 +44,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.E.CAS[[SASS_SIZE]]{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_floating_types.cu
@@ -29,11 +29,11 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E[[SASS_SIZE]].STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E[[SASS_SIZE]].STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types.cu
@@ -12,12 +12,14 @@
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
 // %PARAM% TYPE,SASS_TYPE type i32=int32_t,.S32:u32=uint32_t,:i64=int64_t,.S64:u64=uint64_t,.64
 // %PARAM% OP,SASS_OP op min=fetch_min,MIN:max=fetch_max,MAX
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_minmax(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -25,15 +27,23 @@ __device__ auto atomic_minmax(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
 ; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types.cu
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
+// %PARAM% TYPE,SASS_TYPE type i32=int32_t,.S32:u32=uint32_t,:i64=int64_t,.S64:u64=uint64_t,.64
+// %PARAM% OP,SASS_OP op min=fetch_min,MIN:max=fetch_max,MAX
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_minmax(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
+; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types.cu
@@ -41,7 +41,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
 ; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic.cu
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
+// %PARAM% TYPE,SASS_CALC type f16=f16,HSETP2:bf16=bf16,HSETP2
+// %PARAM% OP op fetch_min:fetch_max
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_minmax(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// Owning 16-bit extended floating-point atomics use 32-bit storage, so min/max
+// must compare the decoded value and update the storage through a 32-bit CAS.
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
+; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
+; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
+; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic.cu
@@ -10,9 +10,13 @@
 
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
-// %PARAM% TYPE,SASS_CALC type f16=f16,HSETP2:bf16=bf16,HSETP2
+// %PARAM% TYPE,FILECHECK_PREFIX_TYPE type f16=f16,f16:bf16=bf16,bf16
 // %PARAM% OP op fetch_min:fetch_max
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm75,f16
+// %FILECHECK% PREFIX_COMBINE sm75,bf16
+// %FILECHECK% PREFIX_COMBINE sm80,f16
+// %FILECHECK% PREFIX_COMBINE sm80,bf16
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
@@ -38,7 +42,11 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
-; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; SM75_F16-DAG: {{.*}}HSETP2{{.*}}
+; SM75_BF16-DAG: {{.*}}FSETP{{.*}}
+; SM80_F16-DAG: {{.*}}HSETP2{{.*}}
+; SM80_BF16-DAG: {{.*}}FSETP{{.*}}
+; SM90-PLUS-DAG: {{.*}}HSETP2{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -50,10 +58,12 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic.cu
@@ -34,11 +34,11 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic.cu
@@ -50,7 +50,7 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic.cu
@@ -12,7 +12,9 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE,SASS_CALC type f16=f16,HSETP2:bf16=bf16,HSETP2
 // %PARAM% OP op fetch_min:fetch_max
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -20,7 +22,7 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_minmax(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -30,12 +32,17 @@ __device__ auto atomic_minmax(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE val
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
@@ -43,6 +50,9 @@ __device__ auto atomic_minmax(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE val
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
@@ -33,12 +33,12 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
@@ -10,9 +10,13 @@
 
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
-// %PARAM% TYPE,SASS_CALC type f16=f16,HSETP2:bf16=bf16,HSETP2
+// %PARAM% TYPE,FILECHECK_PREFIX_TYPE type f16=f16,f16:bf16=bf16,bf16
 // %PARAM% OP op fetch_min:fetch_max
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm75,f16
+// %FILECHECK% PREFIX_COMBINE sm75,bf16
+// %FILECHECK% PREFIX_COMBINE sm80,f16
+// %FILECHECK% PREFIX_COMBINE sm80,bf16
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
@@ -36,7 +40,11 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
-; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; SM75_F16-DAG: {{.*}}HSETP2{{.*}}
+; SM75_BF16-DAG: {{.*}}FSETP{{.*}}
+; SM80_F16-DAG: {{.*}}HSETP2{{.*}}
+; SM80_BF16-DAG: {{.*}}FSETP{{.*}}
+; SM90-PLUS-DAG: {{.*}}HSETP2{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
@@ -49,10 +57,12 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
@@ -12,7 +12,9 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE,SASS_CALC type f16=f16,HSETP2:bf16=bf16,HSETP2
 // %PARAM% OP op fetch_min:fetch_max
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -20,7 +22,7 @@
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_minmax(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -28,7 +30,7 @@ __device__ auto atomic_minmax(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.U16.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
@@ -37,13 +39,21 @@ __device__ auto atomic_minmax(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
@@ -49,7 +49,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
@@ -33,8 +33,6 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
-; BLOCK-DAG: {{.*}}LD.E.U16.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
-; NON_BLOCK-DAG: {{.*}}LD.E.U16.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
+// %PARAM% TYPE,SASS_CALC type f16=f16,HSETP2:bf16=bf16,HSETP2
+// %PARAM% OP op fetch_min:fetch_max
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_minmax(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_minmax.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK-DAG: {{.*}}LD.E.U16.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK-DAG: {{.*}}LD.E.U16.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; SMXX-DAG: {{.*}}[[SASS_CALC]]{{.*}}
+; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_apis.cu
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
+// %PARAM% OP,DELTA,FILECHECK_PREFIX_RESULT op post_inc=post_increment,0x1,post_inc:post_dec=post_decrement,0xffffffff,post_dec:pre_inc=pre_increment,0x1,pre_inc:pre_dec=pre_decrement,0xffffffff,pre_dec
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+template <class Atomic>
+__device__ auto post_increment(Atomic& atom)
+{
+  return atom++;
+}
+
+template <class Atomic>
+__device__ auto post_decrement(Atomic& atom)
+{
+  return atom--;
+}
+
+template <class Atomic>
+__device__ auto pre_increment(Atomic& atom)
+{
+  return ++atom;
+}
+
+template <class Atomic>
+__device__ auto pre_decrement(Atomic& atom)
+{
+  return --atom;
+}
+
+__device__ auto atomic_increment_decrement(TEMPLATE<int32_t, SCOPE>& atom)
+{
+  return OP(atom);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_increment_decrement.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SMXX: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}[[DELTA]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
+; POST_INC-NOT: {{.*}}{{(VIADD|IADD3)}}{{.*}}[[OLD]]{{.*}}
+; POST_DEC-NOT: {{.*}}{{(VIADD|IADD3)}}{{.*}}[[OLD]]{{.*}}
+; PRE_INC: {{.*}}{{(VIADD|IADD3)}} R4, [[OLD]], 0x1{{.*}}
+; PRE_DEC: {{.*}}{{(VIADD|IADD3)}} R4, [[OLD]], {{-0x1|0xffffffff}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_apis.cu
@@ -44,6 +44,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
   return OP(atom);
 }
 
+// clang-format off
 /*
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
@@ -51,7 +52,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
-; INC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?|HFMA2(\.MMA)?}} [[OPERAND:R[0-9]+]], {{.*}}{{0x1|5\.9604644775390625e-08}}{{.*}}
+; INC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?|HFMA2(\.MMA)?}} [[OPERAND:R[0-9]+]], {{.*}}{{(0x1|5\.9604644775390625e-08)([,;[:space:]]|$)}}{{.*}}
 ; DEC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}0xffffffff{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
@@ -61,9 +62,10 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; POST_INC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
 ; POST_DEC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
-; PRE_INC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], 0x1{{.*}}
-; PRE_DEC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], {{-0x1|0xffffffff}}{{.*}}
+; PRE_INC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], 0x1{{([,;[:space:]]|$)}}{{.*}}
+; PRE_DEC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], {{(-0x1|0xffffffff)([,;[:space:]]|$)}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_apis.cu
@@ -10,7 +10,7 @@
 
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
-// %PARAM% OP,DELTA,FILECHECK_PREFIX_RESULT op post_inc=post_increment,0x1,post_inc:post_dec=post_decrement,0xffffffff,post_dec:pre_inc=pre_increment,0x1,pre_inc:pre_dec=pre_decrement,0xffffffff,pre_dec
+// %PARAM% OP,FILECHECK_PREFIX_RESULT,FILECHECK_PREFIX_OPERAND op post_inc=post_increment,post_inc,inc:post_dec=post_decrement,post_dec,dec:pre_inc=pre_increment,pre_inc,inc:pre_dec=pre_decrement,pre_dec,dec
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -49,19 +49,20 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK: {{.*}}CCTL.IVALL{{.*}}
+; SMXX-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
+; INC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?|HFMA2}} [[OPERAND:R[0-9]+]], {{.*}}{{0x1|5\.9604644775390625e-08}}{{.*}}
+; DEC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}0xffffffff{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}[[DELTA]]{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
 ; NON_BLOCK-NEXT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; POST_INC-NOT: {{.*}}{{(VIADD|IADD3)}}{{.*}}[[OLD]]{{.*}}
-; POST_DEC-NOT: {{.*}}{{(VIADD|IADD3)}}{{.*}}[[OLD]]{{.*}}
-; PRE_INC: {{.*}}{{(VIADD|IADD3)}} {{R[0-9]+}}, [[OLD]], 0x1{{.*}}
-; PRE_DEC: {{.*}}{{(VIADD|IADD3)}} {{R[0-9]+}}, [[OLD]], {{-0x1|0xffffffff}}{{.*}}
+; POST_INC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
+; POST_DEC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
+; PRE_INC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, [[OLD]], 0x1{{.*}}
+; PRE_DEC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, [[OLD]], {{-0x1|0xffffffff}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_apis.cu
@@ -39,24 +39,29 @@ __device__ auto pre_decrement(Atomic& atom)
   return --atom;
 }
 
-__device__ auto atomic_increment_decrement(TEMPLATE<int32_t, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 {
   return OP(atom);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_increment_decrement.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}[[DELTA]]{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
+; NON_BLOCK-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; POST_INC-NOT: {{.*}}{{(VIADD|IADD3)}}{{.*}}[[OLD]]{{.*}}
 ; POST_DEC-NOT: {{.*}}{{(VIADD|IADD3)}}{{.*}}[[OLD]]{{.*}}
-; PRE_INC: {{.*}}{{(VIADD|IADD3)}} R4, [[OLD]], 0x1{{.*}}
-; PRE_DEC: {{.*}}{{(VIADD|IADD3)}} R4, [[OLD]], {{-0x1|0xffffffff}}{{.*}}
+; PRE_INC: {{.*}}{{(VIADD|IADD3)}} {{R[0-9]+}}, [[OLD]], 0x1{{.*}}
+; PRE_DEC: {{.*}}{{(VIADD|IADD3)}} {{R[0-9]+}}, [[OLD]], {{-0x1|0xffffffff}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_apis.cu
@@ -51,7 +51,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
-; INC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?|HFMA2}} [[OPERAND:R[0-9]+]], {{.*}}{{0x1|5\.9604644775390625e-08}}{{.*}}
+; INC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?|HFMA2(\.MMA)?}} [[OPERAND:R[0-9]+]], {{.*}}{{0x1|5\.9604644775390625e-08}}{{.*}}
 ; DEC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}0xffffffff{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
@@ -61,8 +61,8 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; POST_INC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
 ; POST_DEC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
-; PRE_INC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, [[OLD]], 0x1{{.*}}
-; PRE_DEC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, [[OLD]], {{-0x1|0xffffffff}}{{.*}}
+; PRE_INC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], 0x1{{.*}}
+; PRE_DEC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], {{-0x1|0xffffffff}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_volatile_apis.cu
@@ -10,7 +10,7 @@
 
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
-// %PARAM% OP,DELTA,FILECHECK_PREFIX_RESULT op post_inc=post_increment,0x1,post_inc:post_dec=post_decrement,0xffffffff,post_dec:pre_inc=pre_increment,0x1,pre_inc:pre_dec=pre_decrement,0xffffffff,pre_dec
+// %PARAM% OP,FILECHECK_PREFIX_RESULT,FILECHECK_PREFIX_OPERAND op post_inc=post_increment,post_inc,inc:post_dec=post_decrement,post_dec,dec:pre_inc=pre_increment,pre_inc,inc:pre_dec=pre_decrement,pre_dec,dec
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -50,20 +50,21 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK: {{.*}}CCTL.IVALL{{.*}}
+; SMXX-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
+; INC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?|HFMA2}} [[OPERAND:R[0-9]+]], {{.*}}{{0x1|5\.9604644775390625e-08}}{{.*}}
+; DEC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}0xffffffff{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}[[DELTA]]{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
 ; NON_BLOCK-NEXT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; POST_INC-NOT: {{.*}}{{(VIADD|IADD3)}}{{.*}}[[OLD]]{{.*}}
-; POST_DEC-NOT: {{.*}}{{(VIADD|IADD3)}}{{.*}}[[OLD]]{{.*}}
-; PRE_INC: {{.*}}{{(VIADD|IADD3)}} {{R[0-9]+}}, [[OLD]], 0x1{{.*}}
-; PRE_DEC: {{.*}}{{(VIADD|IADD3)}} {{R[0-9]+}}, [[OLD]], {{-0x1|0xffffffff}}{{.*}}
+; POST_INC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
+; POST_DEC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
+; PRE_INC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, [[OLD]], 0x1{{.*}}
+; PRE_DEC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, [[OLD]], {{-0x1|0xffffffff}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_volatile_apis.cu
@@ -44,6 +44,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
   return OP(atom);
 }
 
+// clang-format off
 /*
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
@@ -52,7 +53,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
-; INC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?|HFMA2(\.MMA)?}} [[OPERAND:R[0-9]+]], {{.*}}{{0x1|5\.9604644775390625e-08}}{{.*}}
+; INC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?|HFMA2(\.MMA)?}} [[OPERAND:R[0-9]+]], {{.*}}{{(0x1|5\.9604644775390625e-08)([,;[:space:]]|$)}}{{.*}}
 ; DEC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}0xffffffff{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
@@ -63,10 +64,11 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; POST_INC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
 ; POST_DEC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
-; PRE_INC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], 0x1{{.*}}
-; PRE_DEC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], {{-0x1|0xffffffff}}{{.*}}
+; PRE_INC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], 0x1{{([,;[:space:]]|$)}}{{.*}}
+; PRE_DEC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], {{(-0x1|0xffffffff)([,;[:space:]]|$)}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_volatile_apis.cu
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
+// %PARAM% OP,DELTA,FILECHECK_PREFIX_RESULT op post_inc=post_increment,0x1,post_inc:post_dec=post_decrement,0xffffffff,post_dec:pre_inc=pre_increment,0x1,pre_inc:pre_dec=pre_decrement,0xffffffff,pre_dec
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+template <class Atomic>
+__device__ auto post_increment(Atomic& atom)
+{
+  return atom++;
+}
+
+template <class Atomic>
+__device__ auto post_decrement(Atomic& atom)
+{
+  return atom--;
+}
+
+template <class Atomic>
+__device__ auto pre_increment(Atomic& atom)
+{
+  return ++atom;
+}
+
+template <class Atomic>
+__device__ auto pre_decrement(Atomic& atom)
+{
+  return --atom;
+}
+
+__device__ auto atomic_increment_decrement(TEMPLATE<int32_t, SCOPE>& atom)
+{
+  return OP(atom);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_increment_decrement.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
+; SMXX: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SMXX: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}[[DELTA]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
+; BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
+; POST_INC-NOT: {{.*}}{{(VIADD|IADD3)}}{{.*}}[[OLD]]{{.*}}
+; POST_DEC-NOT: {{.*}}{{(VIADD|IADD3)}}{{.*}}[[OLD]]{{.*}}
+; PRE_INC: {{.*}}{{(VIADD|IADD3)}} R4, [[OLD]], 0x1{{.*}}
+; PRE_DEC: {{.*}}{{(VIADD|IADD3)}} R4, [[OLD]], {{-0x1|0xffffffff}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_volatile_apis.cu
@@ -39,26 +39,31 @@ __device__ auto pre_decrement(Atomic& atom)
   return --atom;
 }
 
-__device__ auto atomic_increment_decrement(TEMPLATE<int32_t, SCOPE>& atom)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 {
   return OP(atom);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_increment_decrement.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}[[DELTA]]{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
+; NON_BLOCK-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; POST_INC-NOT: {{.*}}{{(VIADD|IADD3)}}{{.*}}[[OLD]]{{.*}}
 ; POST_DEC-NOT: {{.*}}{{(VIADD|IADD3)}}{{.*}}[[OLD]]{{.*}}
-; PRE_INC: {{.*}}{{(VIADD|IADD3)}} R4, [[OLD]], 0x1{{.*}}
-; PRE_DEC: {{.*}}{{(VIADD|IADD3)}} R4, [[OLD]], {{-0x1|0xffffffff}}{{.*}}
+; PRE_INC: {{.*}}{{(VIADD|IADD3)}} {{R[0-9]+}}, [[OLD]], 0x1{{.*}}
+; PRE_DEC: {{.*}}{{(VIADD|IADD3)}} {{R[0-9]+}}, [[OLD]], {{-0x1|0xffffffff}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_volatile_apis.cu
@@ -52,7 +52,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
-; INC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?|HFMA2}} [[OPERAND:R[0-9]+]], {{.*}}{{0x1|5\.9604644775390625e-08}}{{.*}}
+; INC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?|HFMA2(\.MMA)?}} [[OPERAND:R[0-9]+]], {{.*}}{{0x1|5\.9604644775390625e-08}}{{.*}}
 ; DEC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}0xffffffff{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
@@ -63,8 +63,8 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; POST_INC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
 ; POST_DEC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
-; PRE_INC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, [[OLD]], 0x1{{.*}}
-; PRE_DEC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, [[OLD]], {{-0x1|0xffffffff}}{{.*}}
+; PRE_INC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], 0x1{{.*}}
+; PRE_DEC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], {{-0x1|0xffffffff}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_pointer_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_pointer_types.cu
@@ -40,7 +40,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, cuda
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_pointer_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_pointer_types.cu
@@ -12,27 +12,37 @@
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
 // %PARAM% TYPE,FILECHECK_PREFIX_TYPE type ptr1=char*,unscaled:ptr4=int32_t*,scaled
 // %PARAM% OP op fetch_add:fetch_sub
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_pointer_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, cuda::std::ptrdiff_t value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, cuda::std::ptrdiff_t value)
 {
   return atom.OP(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_pointer_arithmetic.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; UNSCALED-NOT: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
 ; SCALED: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; UNSCALED: {{.*}}RET.ABS.NODEC{{.*}}
 ; SCALED: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_pointer_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_pointer_types.cu
@@ -11,8 +11,12 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
 // %PARAM% TYPE,FILECHECK_PREFIX_TYPE type ptr1=char*,unscaled:ptr4=int32_t*,scaled
-// %PARAM% OP op fetch_add:fetch_sub
+// %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub
 // %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE add,block
+// %FILECHECK% PREFIX_COMBINE add,non_block
+// %FILECHECK% PREFIX_COMBINE sub,block
+// %FILECHECK% PREFIX_COMBINE sub,non_block
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
@@ -24,22 +28,27 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, cuda
   return atom.OP(value, ORDER);
 }
 
+// clang-format off
 /*
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; ADD-NOT: {{.*}}{{(IADD3|IADD(\.64)?|LEA)}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
 ; UNSCALED-NOT: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
 ; SCALED: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; SUB-DAG: {{.*}}{{(IADD3|IADD(\.64)?|LEA)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; ADD_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; ADD_NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SUB_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
+; SUB_NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -48,3 +57,4 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, cuda
 ; SCALED: {{.*}}RET.ABS.NODEC{{.*}}
 
 */
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_pointer_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_pointer_types.cu
@@ -38,9 +38,9 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, cuda
 ; SCALED: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; SUB-DAG: {{.*}}{{(IADD3|IADD(\.64)?|LEA)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
-; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_pointer_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_pointer_types.cu
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:cad=ca,tsd,GPU,non_block:cas=ca,tss,SYS,non_block:carb=car,tsb,CTA,block:card=car,tsd,GPU,non_block:cars=car,tss,SYS,non_block:csa=csa,tss,SYS,non_block:csar=csar,tss,SYS,non_block
+// %PARAM% TYPE,FILECHECK_PREFIX_TYPE type ptr1=char*,unscaled:ptr4=int32_t*,scaled
+// %PARAM% OP op fetch_add:fetch_sub
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_pointer_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, cuda::std::ptrdiff_t value)
+{
+  return atom.OP(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_pointer_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; UNSCALED-NOT: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
+; SCALED: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; UNSCALED: {{.*}}RET.ABS.NODEC{{.*}}
+; SCALED: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types.cu
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
+// %PARAM% TYPE,SASS_TYPE type i32=int32_t,.S32:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64
+// %PARAM% OP op fetch_add:fetch_sub
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types.cu
@@ -38,7 +38,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types.cu
@@ -12,25 +12,35 @@
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
 // %PARAM% TYPE,SASS_TYPE type i32=int32_t,.S32:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64
 // %PARAM% OP op fetch_add:fetch_sub
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
@@ -12,12 +12,14 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type i128:u128
 // %PARAM% OP,SASS_CALC op add=fetch_add,IADD3:sub=fetch_sub,IADD3:min=fetch_min,ISETP:max=fetch_max,ISETP
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_arithmetic(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -25,19 +27,27 @@ __device__ auto atomic_arithmetic(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE valu
 // clang-format off
 /*
 
-; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; BLOCK: {{.*}}LD.E.128.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.128.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX: {{.*}}[[SASS_CALC]]{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% OP,SASS_CALC op add=fetch_add,IADD3:sub=fetch_sub,IADD3:min=fetch_min,ISETP:max=fetch_max,ISETP
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_arithmetic(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// clang-format off
+/*
+
+; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; BLOCK: {{.*}}LD.E.128.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}LD.E.128.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX: {{.*}}[[SASS_CALC]]{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
+; SMXX: {{.*}}ISETP.NE{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
@@ -45,7 +45,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
@@ -11,8 +11,11 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type i128:u128
-// %PARAM% OP,SASS_CALC op add=fetch_add,IADD3:sub=fetch_sub,IADD3:min=fetch_min,ISETP:max=fetch_max,ISETP
+// %PARAM% OP,FILECHECK_PREFIX_CALC op add=fetch_add,add_sub:sub=fetch_sub,add_sub:min=fetch_min,minmax:max=fetch_max,minmax
 // %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE sm90,add_sub
+// %FILECHECK% PREFIX_COMBINE sm100,add_sub
+// %FILECHECK% PREFIX_COMBINE sm120,add_sub
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
@@ -33,7 +36,12 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; BLOCK: {{.*}}LD.E.128.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.128.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
-; SMXX: {{.*}}[[SASS_CALC]]{{.*}}
+; SM90_ADD_SUB: {{.*}}IADD3{{.*}}
+; SM100_ADD_SUB: {{.*}}IADD3{{.*}}
+; SM120_ADD_SUB-DAG: {{.*}}IADD.64 RZ, [[CARRY:P[0-9]+]], {{.*}}
+; SM120_ADD_SUB-DAG: {{.*}}IADD.64 [[LOW:R[0-9]+]], {{.*}}
+; SM120_ADD_SUB: {{.*}}IADD.64.X [[HIGH:R[0-9]+]], {{.*}}, [[CARRY]]{{.*}}
+; MINMAX: {{.*}}ISETP{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
@@ -45,12 +53,17 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{.*}}
+; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}@{{!?P[0-9]+}} BRA{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic.cu
@@ -38,7 +38,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic.cu
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE,SASS_TYPE type i8=int8_t,.S32:u8=uint8_t,:i16=int16_t,.S32:u16=uint16_t,
+// %PARAM% OP,SASS_OP op add=fetch_add,ADD:sub=fetch_sub,ADD:min=fetch_min,MIN:max=fetch_max,MAX
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_arithmetic(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic.cu
@@ -12,25 +12,35 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE,SASS_TYPE type i8=int8_t,.S32:u8=uint8_t,:i16=int16_t,.S32:u16=uint16_t,
 // %PARAM% OP,SASS_OP op add=fetch_add,ADD:sub=fetch_sub,ADD:min=fetch_min,MIN:max=fetch_max,MAX
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_arithmetic(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
@@ -30,9 +30,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
-; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
@@ -12,12 +12,14 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t
 // %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub:min=fetch_min,min:max=fetch_max,max
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_arithmetic(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -25,11 +27,16 @@ __device__ auto atomic_arithmetic(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE valu
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; ADD: {{.*}}{{IADD3|IMAD\.IADD}}{{.*}}
@@ -41,6 +48,9 @@ __device__ auto atomic_arithmetic(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE valu
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
@@ -39,8 +39,8 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; ADD: {{.*}}{{IADD3|IMAD\.IADD}}{{.*}}
-; SUB: {{.*}}{{IADD3|IMAD\.IADD}}{{.*}}
+; ADD: {{.*}}{{IADD3|IADD|IMAD\.IADD}}{{.*}}
+; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD}}{{.*}}
 ; MIN: {{.*}}IMNMX{{.*}}
 ; MAX: {{.*}}IMNMX{{.*}}
 ; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
@@ -48,10 +48,12 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
@@ -48,7 +48,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t
+// %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub:min=fetch_min,min:max=fetch_max,max
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_arithmetic(cuda::atomic_ref<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; ADD: {{.*}}{{IADD3|IMAD\.IADD}}{{.*}}
+; SUB: {{.*}}{{IADD3|IMAD\.IADD}}{{.*}}
+; MIN: {{.*}}IMNMX{{.*}}
+; MAX: {{.*}}IMNMX{{.*}}
+; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
@@ -39,9 +39,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; ADD-NOT: {{.*}}{{IADD3|IADD|IMAD\.IADD}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
+; ADD-NOT: {{.*}}{{IADD3|IADD|IMAD\.IADD|IMAD\.MOV}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
 ; ADD: {{.*}}{{IADD3|IADD|IMAD\.IADD}}{{.*}}
-; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD}} [[SUB_VALUE:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
+; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD|IMAD\.MOV}} [[SUB_VALUE:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
 ; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD|PRMT|LOP3\.LUT}} {{R[0-9]+}}, {{.*}}[[SUB_VALUE]]{{.*}}
 ; MIN: {{.*}}IMNMX{{.*}}
 ; MAX: {{.*}}IMNMX{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
@@ -39,8 +39,10 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; ADD-NOT: {{.*}}{{IADD3|IADD|IMAD\.IADD}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
 ; ADD: {{.*}}{{IADD3|IADD|IMAD\.IADD}}{{.*}}
-; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD}}{{.*}}
+; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD}} [[SUB_VALUE:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
+; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD|PRMT|LOP3\.LUT}} {{R[0-9]+}}, {{.*}}[[SUB_VALUE]]{{.*}}
 ; MIN: {{.*}}IMNMX{{.*}}
 ; MAX: {{.*}}IMNMX{{.*}}
 ; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_apis.cu
@@ -47,7 +47,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; ADD_NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; SUB_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
 ; SUB_NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_apis.cu
@@ -32,10 +32,10 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
-; ADD-NOT: {{.*}}{{(IADD3|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
+; ADD-NOT: {{.*}}{{(IADD3|IADD|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SUB-DAG: {{.*}}{{(IADD3|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
+; SUB-DAG: {{.*}}{{(IADD3|IADD|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
 ; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_apis.cu
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
+// %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_arithmetic(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+{
+  return atom.OP(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
+; ADD-NOT: {{.*}}{{(IADD3|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-R6{{.*}}
+; SUB-DAG: {{.*}}{{(IADD3|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-R6{{.*}}
+; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
+; BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_apis.cu
@@ -11,29 +11,45 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcab=vca,tsb,CTA,block:vcad=vca,tsd,GPU,non_block:vcas=vca,tss,SYS,non_block:vcarb=vcar,tsb,CTA,block:vcard=vcar,tsd,GPU,non_block:vcars=vcar,tss,SYS,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
 // %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE add,block
+// %FILECHECK% PREFIX_COMBINE add,non_block
+// %FILECHECK% PREFIX_COMBINE sub,block
+// %FILECHECK% PREFIX_COMBINE sub,non_block
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_arithmetic(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, int32_t value)
 {
   return atom.OP(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
-; ADD-NOT: {{.*}}{{(IADD3|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-R6{{.*}}
-; SUB-DAG: {{.*}}{{(IADD3|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-R6{{.*}}
+; ADD-NOT: {{.*}}{{(IADD3|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
+; SUB-DAG: {{.*}}{{(IADD3|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
-; BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; ADD_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; ADD_NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SUB_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
+; SUB_NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_apis.cu
@@ -33,9 +33,9 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
 ; ADD-NOT: {{.*}}{{(IADD3|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
-; SUB-DAG: {{.*}}{{(IADD3|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; SUB-DAG: {{.*}}{{(IADD3|IMAD\.MOV)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
 ; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_floating_types.cu
@@ -12,12 +12,14 @@
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
 // %PARAM% TYPE,SASS_TYPE type f32=float,.F32.FTZ.RN:f64=double,.F64.RN
 // %PARAM% OP op fetch_add:fetch_sub
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -26,13 +28,21 @@ __device__ auto atomic_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 // local memory. The native path must still contain exactly one add opcode.
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_floating_types.cu
@@ -40,7 +40,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_floating_types.cu
@@ -30,18 +30,14 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
-; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_floating_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_floating_types.cu
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
+// %PARAM% TYPE,SASS_TYPE type f32=float,.F32.FTZ.RN:f64=double,.F64.RN
+// %PARAM% OP op fetch_add:fetch_sub
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// Generic-address floating-point atomics contain a separate CAS fallback for
+// local memory. The native path must still contain exactly one add opcode.
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
+; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_pointer_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_pointer_types.cu
@@ -12,29 +12,39 @@
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
 // %PARAM% TYPE,FILECHECK_PREFIX_TYPE type ptr1=char*,unscaled:ptr4=int32_t*,scaled
 // %PARAM% OP op fetch_add:fetch_sub
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_pointer_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, cuda::std::ptrdiff_t value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, cuda::std::ptrdiff_t value)
 {
   return atom.OP(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_pointer_arithmetic.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.64{{.*}}
 ; UNSCALED-NOT: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
 ; SCALED: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.64{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.64{{.*}}
 ; UNSCALED: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_pointer_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_pointer_types.cu
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
+// %PARAM% TYPE,FILECHECK_PREFIX_TYPE type ptr1=char*,unscaled:ptr4=int32_t*,scaled
+// %PARAM% OP op fetch_add:fetch_sub
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_pointer_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, cuda::std::ptrdiff_t value)
+{
+  return atom.OP(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_pointer_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD.64{{.*}}
+; UNSCALED-NOT: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
+; SCALED: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD.64{{.*}}
+; BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD.64{{.*}}
+; UNSCALED: {{.*}}RET.ABS.NODEC{{.*}}
+; SCALED: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_pointer_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_pointer_types.cu
@@ -42,7 +42,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, cuda
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.64{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_pointer_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_pointer_types.cu
@@ -11,8 +11,12 @@
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block:vcsa=vcsa,tss,SYS,non_block:vcsar=vcsar,tss,SYS,non_block
 // %PARAM% TYPE,FILECHECK_PREFIX_TYPE type ptr1=char*,unscaled:ptr4=int32_t*,scaled
-// %PARAM% OP op fetch_add:fetch_sub
+// %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub
 // %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE add,block
+// %FILECHECK% PREFIX_COMBINE add,non_block
+// %FILECHECK% PREFIX_COMBINE sub,block
+// %FILECHECK% PREFIX_COMBINE sub,non_block
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
@@ -24,15 +28,18 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, cuda
   return atom.OP(value, ORDER);
 }
 
+// clang-format off
 /*
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.64{{.*}}
+; ADD-NOT: {{.*}}{{(IADD3|IADD(\.64)?|LEA)}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
 ; UNSCALED-NOT: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
 ; SCALED: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; SUB-DAG: {{.*}}{{(IADD3|IADD(\.64)?|LEA)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -40,8 +47,10 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, cuda
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD.64{{.*}}
-; BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; ADD_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; ADD_NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SUB_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
+; SUB_NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -51,3 +60,4 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, cuda
 ; SCALED: {{.*}}RET.ABS.NODEC{{.*}}
 
 */
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_pointer_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_pointer_types.cu
@@ -39,9 +39,9 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, cuda
 ; SCALED: {{.*}}SHF.L.U64{{.*}}, {{R[0-9]+}}{{(\.reuse)?}}, 0x2{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; MEMBAR-DAG: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; SUB-DAG: {{.*}}{{(IADD3|IADD(\.64)?|LEA)}} [[OPERAND:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
-; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types.cu
@@ -29,19 +29,15 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
-; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types.cu
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
+// %PARAM% TYPE,SASS_TYPE type i32=int32_t,.S32:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64
+// %PARAM% OP op fetch_add:fetch_sub
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
+; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types.cu
@@ -40,7 +40,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types.cu
@@ -12,27 +12,37 @@
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
 // %PARAM% TYPE,SASS_TYPE type i32=int32_t,.S32:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64
 // %PARAM% OP op fetch_add:fetch_sub
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_arithmetic(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
 ; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_128_atomic_ref.cu
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% TYPE type i128:u128
+// %PARAM% OP,SASS_CALC op add=fetch_add,IADD3:sub=fetch_sub,IADD3:min=fetch_min,ISETP:max=fetch_max,ISETP
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_arithmetic(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// clang-format off
+/*
+
+; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SMXX-NOT: {{.*}}LD.E.128{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; BLOCK: {{.*}}LD.E.128.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}LD.E.128.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}LD.E.128{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX: {{.*}}[[SASS_CALC]]{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
+; SMXX: {{.*}}ISETP.NE{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_128_atomic_ref.cu
@@ -11,8 +11,11 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type i128:u128
-// %PARAM% OP,SASS_CALC op add=fetch_add,IADD3:sub=fetch_sub,IADD3:min=fetch_min,ISETP:max=fetch_max,ISETP
+// %PARAM% OP,FILECHECK_PREFIX_CALC op add=fetch_add,add_sub:sub=fetch_sub,add_sub:min=fetch_min,minmax:max=fetch_max,minmax
 // %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE sm90,add_sub
+// %FILECHECK% PREFIX_COMBINE sm100,add_sub
+// %FILECHECK% PREFIX_COMBINE sm120,add_sub
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
@@ -35,7 +38,12 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; BLOCK: {{.*}}LD.E.128.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.128.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX-NOT: {{.*}}LD.E.128{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
-; SMXX: {{.*}}[[SASS_CALC]]{{.*}}
+; SM90_ADD_SUB: {{.*}}IADD3{{.*}}
+; SM100_ADD_SUB: {{.*}}IADD3{{.*}}
+; SM120_ADD_SUB-DAG: {{.*}}IADD.64 RZ, [[CARRY:P[0-9]+]], {{.*}}
+; SM120_ADD_SUB-DAG: {{.*}}IADD.64 [[LOW:R[0-9]+]], {{.*}}
+; SM120_ADD_SUB: {{.*}}IADD.64.X [[HIGH:R[0-9]+]], {{.*}}, [[CARRY]]{{.*}}
+; MINMAX: {{.*}}ISETP{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
@@ -47,11 +55,16 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{.*}}
+; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; SMXX: {{.*}}@{{!?P[0-9]+}} BRA{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_128_atomic_ref.cu
@@ -12,12 +12,14 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type i128:u128
 // %PARAM% OP,SASS_CALC op add=fetch_add,IADD3:sub=fetch_sub,IADD3:min=fetch_min,ISETP:max=fetch_max,ISETP
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_arithmetic(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -25,7 +27,7 @@ __device__ auto atomic_arithmetic(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, 
 // clang-format off
 /*
 
-; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SM90-PLUS-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
@@ -34,12 +36,20 @@ __device__ auto atomic_arithmetic(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, 
 ; NON_BLOCK: {{.*}}LD.E.128.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX-NOT: {{.*}}LD.E.128{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX: {{.*}}[[SASS_CALC]]{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_128_atomic_ref.cu
@@ -47,7 +47,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic.cu
@@ -40,7 +40,7 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
 ; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic.cu
@@ -12,27 +12,37 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE,SASS_TYPE type i8=int8_t,.S32:u8=uint8_t,:i16=int16_t,.S32:u16=uint16_t,
 // %PARAM% OP,SASS_OP op add=fetch_add,ADD:sub=fetch_sub,ADD:min=fetch_min,MIN:max=fetch_max,MAX
-// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_arithmetic(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
 
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
 ; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic.cu
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
+// %PARAM% TYPE,SASS_TYPE type i8=int8_t,.S32:u8=uint8_t,:i16=int16_t,.S32:u16=uint16_t,
+// %PARAM% OP,SASS_OP op add=fetch_add,ADD:sub=fetch_sub,ADD:min=fetch_min,MIN:max=fetch_max,MAX
+// %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_ORDER order relaxed=mor,,no_membar:acquire=moa,,no_membar:release=more,ALL,membar:acq_rel=moar,ALL,membar:seq_cst=mosc,SC,membar
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_arithmetic(volatile cuda::atomic<TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
+; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
@@ -39,9 +39,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; ADD-NOT: {{.*}}{{IADD3|IADD|IMAD\.IADD}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
+; ADD-NOT: {{.*}}{{IADD3|IADD|IMAD\.IADD|IMAD\.MOV}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
 ; ADD: {{.*}}{{IADD3|IADD|IMAD\.IADD}}{{.*}}
-; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD}} [[SUB_VALUE:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
+; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD|IMAD\.MOV}} [[SUB_VALUE:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
 ; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD|PRMT|LOP3\.LUT}} {{R[0-9]+}}, {{.*}}[[SUB_VALUE]]{{.*}}
 ; MIN: {{.*}}IMNMX{{.*}}
 ; MAX: {{.*}}IMNMX{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
@@ -12,12 +12,14 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t
 // %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub:min=fetch_min,min:max=fetch_max,max
-// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
 
-__device__ auto atomic_arithmetic(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
 {
   return atom.OP(value, ORDER);
 }
@@ -25,11 +27,16 @@ __device__ auto atomic_arithmetic(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, 
 // clang-format off
 /*
 
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; ADD: {{.*}}{{IADD3|IMAD\.IADD}}{{.*}}
@@ -42,6 +49,9 @@ __device__ auto atomic_arithmetic(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, 
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
@@ -30,9 +30,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
-; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
@@ -49,7 +49,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE-NEXT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
+// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t
+// %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub:min=fetch_min,min:max=fetch_max,max
+// %PARAM% ORDER,FILECHECK_PREFIX_ORDER order relaxed=mor,no_membar:acquire=moa,no_membar:release=more,release:acq_rel=moar,release:seq_cst=mosc,seq_cst
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+__device__ auto atomic_arithmetic(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE value)
+{
+  return atom.OP(value, ORDER);
+}
+
+// clang-format off
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*atomic_arithmetic.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; ADD: {{.*}}{{IADD3|IMAD\.IADD}}{{.*}}
+; SUB: {{.*}}{{IADD3|IMAD\.IADD}}{{.*}}
+; MIN: {{.*}}IMNMX{{.*}}
+; MAX: {{.*}}IMNMX{{.*}}
+; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
@@ -39,8 +39,10 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; ADD-NOT: {{.*}}{{IADD3|IADD|IMAD\.IADD}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
 ; ADD: {{.*}}{{IADD3|IADD|IMAD\.IADD}}{{.*}}
-; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD}}{{.*}}
+; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD}} [[SUB_VALUE:R[0-9]+]], {{.*}}-{{R[0-9]+}}{{.*}}
+; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD|PRMT|LOP3\.LUT}} {{R[0-9]+}}, {{.*}}[[SUB_VALUE]]{{.*}}
 ; MIN: {{.*}}IMNMX{{.*}}
 ; MAX: {{.*}}IMNMX{{.*}}
 ; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
@@ -39,8 +39,8 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; ADD: {{.*}}{{IADD3|IMAD\.IADD}}{{.*}}
-; SUB: {{.*}}{{IADD3|IMAD\.IADD}}{{.*}}
+; ADD: {{.*}}{{IADD3|IADD|IMAD\.IADD}}{{.*}}
+; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD}}{{.*}}
 ; MIN: {{.*}}IMNMX{{.*}}
 ; MAX: {{.*}}IMNMX{{.*}}
 ; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
@@ -49,10 +49,12 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}


### PR DESCRIPTION
## Description

Resolves #10666.

This PR introduces the third SASS FileCheck suite for the atomic codegen, which includes a wide coverage of volatile and non-volatile codegen results for arithmetic operations: fetch_add, fetch_sub, increment/decrement operators, fetch_min, and fetch_max.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
