### PR TITLE
Add opt-in fixed-width DeviceBatchedTopK output padding

### DIFF
--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -17,6 +17,7 @@
 #include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
 #include <cub/block/block_topk.cuh>
+#include <cub/detail/batched_topk_output_padding.cuh>
 #include <cub/detail/choose_offset.cuh>
 #include <cub/detail/segmented_params.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
@@ -31,22 +32,6 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
 {
-template <typename OutputSegmentsIteratorT, typename PaddingT>
-struct padded_output_segments_iterator;
-
-template <typename OutputSegmentsIteratorT>
-struct agent_batched_topk_output_segments_iterator_traits
-{
-  static constexpr bool is_padded = false;
-};
-
-template <typename OutputSegmentsIteratorT, typename PaddingT>
-struct agent_batched_topk_output_segments_iterator_traits<
-  padded_output_segments_iterator<OutputSegmentsIteratorT, PaddingT>>
-{
-  static constexpr bool is_padded = true;
-};
-
 // Atomic counters used by the small-segment kernel to (a) enqueue large segments into the large-segment work queue
 // and (b) elect the last block to run the epilogue scan over the queued tile counts. `alignas(128)` isolates each
 // counter on its own cache line for performance.
@@ -116,9 +101,8 @@ struct agent_batched_topk_worker_per_segment
 
   // Check if we are dealing with keys-only or key-value pairs
   static constexpr bool is_keys_only = ::cuda::std::is_same_v<value_t, cub::NullType>;
-  static constexpr bool pad_output   = agent_batched_topk_output_segments_iterator_traits<KeyOutputItItT>::is_padded;
-  static_assert(is_keys_only
-                  || pad_output == agent_batched_topk_output_segments_iterator_traits<ValueOutputItItT>::is_padded,
+  static constexpr bool pad_output   = is_padded_output_segments_iterator_v<KeyOutputItItT>;
+  static_assert(is_keys_only || pad_output == is_padded_output_segments_iterator_v<ValueOutputItItT>,
                 "key and value output padding must be enabled together");
 
   // -------------------------------------------------------------------------

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -25,11 +25,28 @@
 
 #include <cuda/__cmath/ceil_div.h>
 #include <cuda/argument>
+#include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
 {
+template <typename OutputSegmentsIteratorT, typename PaddingT>
+struct padded_output_segments_iterator;
+
+template <typename OutputSegmentsIteratorT>
+struct agent_batched_topk_output_segments_iterator_traits
+{
+  static constexpr bool is_padded = false;
+};
+
+template <typename OutputSegmentsIteratorT, typename PaddingT>
+struct agent_batched_topk_output_segments_iterator_traits<
+  padded_output_segments_iterator<OutputSegmentsIteratorT, PaddingT>>
+{
+  static constexpr bool is_padded = true;
+};
+
 // Atomic counters used by the small-segment kernel to (a) enqueue large segments into the large-segment work queue
 // and (b) elect the last block to run the epilogue scan over the queued tile counts. `alignas(128)` isolates each
 // counter on its own cache line for performance.
@@ -99,6 +116,10 @@ struct agent_batched_topk_worker_per_segment
 
   // Check if we are dealing with keys-only or key-value pairs
   static constexpr bool is_keys_only = ::cuda::std::is_same_v<value_t, cub::NullType>;
+  static constexpr bool pad_output   = agent_batched_topk_output_segments_iterator_traits<KeyOutputItItT>::is_padded;
+  static_assert(is_keys_only
+                  || pad_output == agent_batched_topk_output_segments_iterator_traits<ValueOutputItItT>::is_padded,
+                "key and value output padding must be enabled together");
 
   // -------------------------------------------------------------------------
   // Primitive Types
@@ -184,6 +205,36 @@ struct agent_batched_topk_worker_per_segment
       , d_large_segments_tile_offsets(d_large_segments_tile_offsets)
   {}
 
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  fill_output_tail(int segment_id, ::cuda::std::uint64_t num_selected, ::cuda::std::uint64_t output_size)
+  {
+    if constexpr (pad_output)
+    {
+      if (num_selected >= output_size)
+      {
+        return;
+      }
+
+      auto block_keys_out = d_key_segments_out_it[segment_id];
+      if constexpr (is_keys_only)
+      {
+        for (::cuda::std::uint64_t idx = num_selected + threadIdx.x; idx < output_size; idx += blockDim.x)
+        {
+          block_keys_out[idx] = d_key_segments_out_it.padding_value;
+        }
+      }
+      else
+      {
+        auto block_vals_out = d_value_segments_out_it[segment_id];
+        for (::cuda::std::uint64_t idx = num_selected + threadIdx.x; idx < output_size; idx += blockDim.x)
+        {
+          block_keys_out[idx] = d_key_segments_out_it.padding_value;
+          block_vals_out[idx] = d_value_segments_out_it.padding_value;
+        }
+      }
+    }
+  }
+
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void Process()
   {
     // Identify Segment
@@ -219,10 +270,10 @@ struct agent_batched_topk_worker_per_segment
     {
       // Process small segment. Clamp `k` (already floored to >= 0) to the segment size in a width holding both operands
       // so a `k` type narrower than the segment size cannot wrap; the result fits the segment-size type.
+      const auto output_size =
+        static_cast<::cuda::std::uint64_t>(params::__get_and_clamp_param_to_nonnegative(k_param, segment_id));
       const auto k = static_cast<decltype(segment_size)>(
-        (::cuda::std::min) (static_cast<::cuda::std::uint64_t>(
-                              params::__get_and_clamp_param_to_nonnegative(k_param, segment_id)),
-                            static_cast<::cuda::std::uint64_t>(segment_size)));
+        (::cuda::std::min) (output_size, static_cast<::cuda::std::uint64_t>(segment_size)));
       // Nothing to select for an empty segment (including a negative size or a negative `k`, both clamped to 0) or a
       // zero k: skip the block work, leaving its output untouched (also keeps the block primitive's `valid_items in
       // [1, tile_items]` precondition). We must not `return` here -- the large-segment epilogue below is unconditional
@@ -330,6 +381,8 @@ struct agent_batched_topk_worker_per_segment
           block_store_vals_t(temp_storage.store_vals).Store(block_vals_out, thread_values, k);
         }
       } // if (k != 0)
+
+      fill_output_tail(segment_id, static_cast<::cuda::std::uint64_t>(k), output_size);
     }
 
     // Epilogue: Scan queued large segment sizes (in tiles not elements) for load balancing search in the large segment

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -26,7 +26,6 @@
 
 #include <cuda/__cmath/ceil_div.h>
 #include <cuda/argument>
-#include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
 
@@ -252,16 +251,18 @@ struct agent_batched_topk_worker_per_segment
     }
     else
     {
-      // Process small segment. Clamp `k` (already floored to >= 0) to the segment size in a width holding both operands
-      // so a `k` type narrower than the segment size cannot wrap; the result fits the segment-size type.
-      const auto output_size =
+      // Process small segment. Keep the nonnegative requested k because selection clamps it to the segment size, while
+      // fixed-width padding ends at the requested k. Compare in a width holding both operands so a narrower k type
+      // cannot wrap; the selected count still fits the segment-size type.
+      const auto requested_k =
         static_cast<::cuda::std::uint64_t>(params::__get_and_clamp_param_to_nonnegative(k_param, segment_id));
       const auto k = static_cast<decltype(segment_size)>(
-        (::cuda::std::min) (output_size, static_cast<::cuda::std::uint64_t>(segment_size)));
+        (::cuda::std::min) (requested_k, static_cast<::cuda::std::uint64_t>(segment_size)));
+
       // Nothing to select for an empty segment (including a negative size or a negative `k`, both clamped to 0) or a
-      // zero k: skip the block work, leaving its output untouched (also keeps the block primitive's `valid_items in
-      // [1, tile_items]` precondition). We must not `return` here -- the large-segment epilogue below is unconditional
-      // participation, so bailing out would drop this block from the retirement count and stall the epilogue scan.
+      // zero k: skip the selection work (also keeps the block primitive's `valid_items in [1, tile_items]`
+      // precondition). We must not `return` here -- the large-segment epilogue below is unconditional participation, so
+      // bailing out would drop this block from the retirement count and stall the epilogue scan.
       if (k != 0)
       {
         const auto direction = select_directions.get_param(segment_id);
@@ -366,7 +367,7 @@ struct agent_batched_topk_worker_per_segment
         }
       } // if (k != 0)
 
-      fill_output_tail(segment_id, static_cast<::cuda::std::uint64_t>(k), output_size);
+      fill_output_tail(segment_id, static_cast<::cuda::std::uint64_t>(k), requested_k);
     }
 
     // Epilogue: Scan queued large segment sizes (in tiles not elements) for load balancing search in the large segment

--- a/cub/cub/agent/agent_batched_topk_cluster.cuh
+++ b/cub/cub/agent/agent_batched_topk_cluster.cuh
@@ -3377,12 +3377,13 @@ private:
       static_cast<::cuda::std::uint64_t>(segment_size_raw) <= ::cuda::std::numeric_limits<::cuda::std::uint32_t>::max(),
       "segment size must be non-negative and fit the 32-bit cluster offset type");
     segment_size = static_cast<segment_size_val_t>(segment_size_raw);
-    // Clamp `k` (already floored to >= 0) to the segment size in a 64-bit width holding both operands.
-    const auto output_size =
+    // Keep the nonnegative requested k because selection clamps it to the segment size, while fixed-width padding ends
+    // at the requested k. Compare in a 64-bit width holding both operands.
+    const auto requested_k =
       static_cast<::cuda::std::uint64_t>(detail::params::__get_and_clamp_param_to_nonnegative(k_param, segment_id));
-    const auto k_clamped = (::cuda::std::min) (output_size, static_cast<::cuda::std::uint64_t>(segment_size));
+    const auto k_clamped = (::cuda::std::min) (requested_k, static_cast<::cuda::std::uint64_t>(segment_size));
 
-    fill_output_tail(k_clamped, output_size);
+    fill_output_tail(k_clamped, requested_k);
 
     if (k_clamped == 0)
     {

--- a/cub/cub/agent/agent_batched_topk_cluster.cuh
+++ b/cub/cub/agent/agent_batched_topk_cluster.cuh
@@ -88,8 +88,29 @@
 
 CUB_NAMESPACE_BEGIN
 
+namespace detail::batched_topk
+{
+template <typename OutputSegmentsIteratorT, typename PaddingT>
+struct padded_output_segments_iterator;
+} // namespace detail::batched_topk
+
 namespace detail::batched_topk_cluster
 {
+template <typename OutputSegmentsIteratorT>
+struct agent_batched_topk_cluster_output_segments_iterator_traits
+{
+  static constexpr bool is_padded = false;
+  using iterator_type             = OutputSegmentsIteratorT;
+};
+
+template <typename OutputSegmentsIteratorT, typename PaddingT>
+struct agent_batched_topk_cluster_output_segments_iterator_traits<
+  detail::batched_topk::padded_output_segments_iterator<OutputSegmentsIteratorT, PaddingT>>
+{
+  static constexpr bool is_padded = true;
+  using iterator_type             = OutputSegmentsIteratorT;
+};
+
 // Dynamic-SMEM layout shared by dispatch and the agent. `max_block_resident_items` is the physical per-CTA resident
 // capacity. The unaligned head is staged as an edge in static SMEM (`edge_keys`), not a chunk slot, so the full
 // physical capacity is usable (no head reservation).
@@ -194,6 +215,12 @@ struct agent_batched_topk_cluster
   // Keys-only when the value payload type is `cub::NullType` (mirrors the baseline batched top-k agent). The value
   // iterators are then never dereferenced and the final filter's value writes are compiled out.
   static constexpr bool is_keys_only = ::cuda::std::is_same_v<value_t, cub::NullType>;
+  static constexpr bool pad_output =
+    agent_batched_topk_cluster_output_segments_iterator_traits<KeyOutputItItT>::is_padded;
+  static_assert(is_keys_only
+                  || pad_output
+                       == agent_batched_topk_cluster_output_segments_iterator_traits<ValueOutputItItT>::is_padded,
+                "key and value output padding must be enabled together");
 
   // Segment-size type: the smallest unsigned offset type (>= 32-bit) covering the parameter's declared upper bound. The
   // public entry caps that bound at 2^21, so this is always 32-bit.
@@ -741,6 +768,41 @@ struct agent_batched_topk_cluster
   }
 
 private:
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  fill_output_tail(::cuda::std::uint64_t num_selected, ::cuda::std::uint64_t output_size)
+  {
+    if constexpr (pad_output)
+    {
+      if (num_selected >= output_size)
+      {
+        return;
+      }
+
+      const auto cluster_tid = static_cast<::cuda::std::uint64_t>(cluster_block_rank) * policy.threads_per_block
+                             + static_cast<::cuda::std::uint64_t>(threadIdx.x);
+      const auto num_cluster_threads =
+        static_cast<::cuda::std::uint64_t>(num_full_cluster_blocks) * policy.threads_per_block;
+
+      auto keys_out = d_key_segments_out_it[segment_id];
+      if constexpr (is_keys_only)
+      {
+        for (auto idx = num_selected + cluster_tid; idx < output_size; idx += num_cluster_threads)
+        {
+          keys_out[idx] = d_key_segments_out_it.padding_value;
+        }
+      }
+      else
+      {
+        auto values_out = d_value_segments_out_it[segment_id];
+        for (auto idx = num_selected + cluster_tid; idx < output_size; idx += num_cluster_threads)
+        {
+          keys_out[idx]   = d_key_segments_out_it.padding_value;
+          values_out[idx] = d_value_segments_out_it.padding_value;
+        }
+      }
+    }
+  }
+
   _CCCL_DEVICE _CCCL_FORCEINLINE void reset_hist()
   {
     // The `num_buckets / policy.threads_per_block` full strided rounds are in range for every thread. The `<
@@ -1317,7 +1379,8 @@ private:
       detail::topk::identify_candidates_op_t<key_t, SelectDirection, policy.bits_per_pass, decomposer_t>;
 
     identify_op_t identify_op;
-    it_value_t<KeyOutputItItT> block_keys_out;
+    it_value_t<typename agent_batched_topk_cluster_output_segments_iterator_traits<KeyOutputItItT>::iterator_type>
+      block_keys_out;
     out_offset_t num_cluster_tie_winners;
     out_offset_t num_local_selected;
     offset_t selected_prefix;
@@ -3337,10 +3400,11 @@ private:
       "segment size must be non-negative and fit the 32-bit cluster offset type");
     segment_size = static_cast<segment_size_val_t>(segment_size_raw);
     // Clamp `k` (already floored to >= 0) to the segment size in a 64-bit width holding both operands.
-    const auto k_clamped =
-      (::cuda::std::min) (static_cast<::cuda::std::uint64_t>(
-                            detail::params::__get_and_clamp_param_to_nonnegative(k_param, segment_id)),
-                          static_cast<::cuda::std::uint64_t>(segment_size));
+    const auto output_size =
+      static_cast<::cuda::std::uint64_t>(detail::params::__get_and_clamp_param_to_nonnegative(k_param, segment_id));
+    const auto k_clamped = (::cuda::std::min) (output_size, static_cast<::cuda::std::uint64_t>(segment_size));
+
+    fill_output_tail(k_clamped, output_size);
 
     if (k_clamped == 0)
     {

--- a/cub/cub/agent/agent_batched_topk_cluster.cuh
+++ b/cub/cub/agent/agent_batched_topk_cluster.cuh
@@ -46,6 +46,7 @@
 #include <cub/agent/agent_topk.cuh>
 #include <cub/block/block_scan.cuh>
 #include <cub/block/radix_rank_sort_operations.cuh>
+#include <cub/detail/batched_topk_output_padding.cuh>
 #include <cub/detail/segmented_params.cuh>
 #include <cub/detail/warpspeed/optimize_smem_ptr.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
@@ -88,29 +89,8 @@
 
 CUB_NAMESPACE_BEGIN
 
-namespace detail::batched_topk
-{
-template <typename OutputSegmentsIteratorT, typename PaddingT>
-struct padded_output_segments_iterator;
-} // namespace detail::batched_topk
-
 namespace detail::batched_topk_cluster
 {
-template <typename OutputSegmentsIteratorT>
-struct agent_batched_topk_cluster_output_segments_iterator_traits
-{
-  static constexpr bool is_padded = false;
-  using iterator_type             = OutputSegmentsIteratorT;
-};
-
-template <typename OutputSegmentsIteratorT, typename PaddingT>
-struct agent_batched_topk_cluster_output_segments_iterator_traits<
-  detail::batched_topk::padded_output_segments_iterator<OutputSegmentsIteratorT, PaddingT>>
-{
-  static constexpr bool is_padded = true;
-  using iterator_type             = OutputSegmentsIteratorT;
-};
-
 // Dynamic-SMEM layout shared by dispatch and the agent. `max_block_resident_items` is the physical per-CTA resident
 // capacity. The unaligned head is staged as an edge in static SMEM (`edge_keys`), not a chunk slot, so the full
 // physical capacity is usable (no head reservation).
@@ -215,11 +195,9 @@ struct agent_batched_topk_cluster
   // Keys-only when the value payload type is `cub::NullType` (mirrors the baseline batched top-k agent). The value
   // iterators are then never dereferenced and the final filter's value writes are compiled out.
   static constexpr bool is_keys_only = ::cuda::std::is_same_v<value_t, cub::NullType>;
-  static constexpr bool pad_output =
-    agent_batched_topk_cluster_output_segments_iterator_traits<KeyOutputItItT>::is_padded;
+  static constexpr bool pad_output   = detail::batched_topk::is_padded_output_segments_iterator_v<KeyOutputItItT>;
   static_assert(is_keys_only
-                  || pad_output
-                       == agent_batched_topk_cluster_output_segments_iterator_traits<ValueOutputItItT>::is_padded,
+                  || pad_output == detail::batched_topk::is_padded_output_segments_iterator_v<ValueOutputItItT>,
                 "key and value output padding must be enabled together");
 
   // Segment-size type: the smallest unsigned offset type (>= 32-bit) covering the parameter's declared upper bound. The
@@ -1379,7 +1357,7 @@ private:
       detail::topk::identify_candidates_op_t<key_t, SelectDirection, policy.bits_per_pass, decomposer_t>;
 
     identify_op_t identify_op;
-    it_value_t<typename agent_batched_topk_cluster_output_segments_iterator_traits<KeyOutputItItT>::iterator_type>
+    it_value_t<typename detail::batched_topk::output_segments_iterator_traits<KeyOutputItItT>::iterator_type>
       block_keys_out;
     out_offset_t num_cluster_tie_winners;
     out_offset_t num_local_selected;

--- a/cub/cub/detail/batched_topk_output_padding.cuh
+++ b/cub/cub/detail/batched_topk_output_padding.cuh
@@ -20,9 +20,11 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
 {
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, bool HasValue>
 struct output_padding_values
 {
+  static constexpr bool has_value = HasValue;
+
   KeyT key;
   ValueT value;
 };

--- a/cub/cub/detail/batched_topk_output_padding.cuh
+++ b/cub/cub/detail/batched_topk_output_padding.cuh
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//! @file
+//! Internal output-padding types shared by DeviceBatchedTopK dispatch and agents.
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail::batched_topk
+{
+template <typename KeyT, typename ValueT>
+struct output_padding_values
+{
+  KeyT key;
+  ValueT value;
+};
+
+// Query tag for the optional, stateful padding property. Padding is deliberately not a cuda::execution requirement:
+// `require` accepts only stateless requirement types, while these values must survive in the environment until launch.
+struct get_output_padding_t
+{};
+
+// Carries an assignment-domain padding value alongside an output iterator-of-iterators while forwarding ordinary
+// segment access unchanged. Opt-in calls therefore instantiate a distinct kernel through the already-existing output
+// iterator template parameter; default calls retain their original kernel type and compile the padding path out.
+template <typename OutputSegmentsIteratorT, typename PaddingT>
+struct padded_output_segments_iterator
+{
+  OutputSegmentsIteratorT output_segments;
+  PaddingT padding_value;
+
+  template <typename SegmentIndexT>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE decltype(auto) operator[](SegmentIndexT segment_id)
+  {
+    return output_segments[segment_id];
+  }
+};
+
+template <typename OutputSegmentsIteratorT>
+struct output_segments_iterator_traits
+{
+  static constexpr bool is_padded = false;
+  using iterator_type             = OutputSegmentsIteratorT;
+};
+
+template <typename OutputSegmentsIteratorT, typename PaddingT>
+struct output_segments_iterator_traits<padded_output_segments_iterator<OutputSegmentsIteratorT, PaddingT>>
+{
+  static constexpr bool is_padded = true;
+  using iterator_type             = OutputSegmentsIteratorT;
+};
+
+template <typename OutputSegmentsIteratorT>
+inline constexpr bool is_padded_output_segments_iterator_v =
+  output_segments_iterator_traits<OutputSegmentsIteratorT>::is_padded;
+
+template <typename OutputSegmentsIteratorT, typename PaddingT>
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto
+make_padded_output_segments_iterator(OutputSegmentsIteratorT output_segments, PaddingT padding_value)
+{
+  return padded_output_segments_iterator<OutputSegmentsIteratorT, PaddingT>{output_segments, padding_value};
+}
+} // namespace detail::batched_topk
+
+CUB_NAMESPACE_END

--- a/cub/cub/device/device_batched_topk.cuh
+++ b/cub/cub/device/device_batched_topk.cuh
@@ -251,9 +251,9 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
     if constexpr (::cuda::std::execution::__queryable_with<EnvT, batched_topk::get_output_padding_t>)
     {
       const auto& padding         = env.query(batched_topk::get_output_padding_t{});
-      using value_padding_t       = ::cuda::std::remove_cvref_t<decltype(padding.value)>;
+      using padding_t             = ::cuda::std::remove_cvref_t<decltype(padding)>;
       constexpr bool is_keys_only = ::cuda::std::is_same_v<it_value_t<it_value_t<ValueInputIteratorItT>>, NullType>;
-      static_assert(is_keys_only == ::cuda::std::is_same_v<value_padding_t, NullType>,
+      static_assert(is_keys_only == !padding_t::has_value,
                     "cub::DeviceBatchedTopK::OutputPadding requires one value for Keys and two values for Pairs");
 
       const auto padded_keys_out = batched_topk::make_padded_output_segments_iterator(d_keys_out, padding.key);
@@ -277,7 +277,6 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
     return cudaErrorInvalidValue;
   }
 }
-
 //! @endcond
 } // namespace detail
 
@@ -473,7 +472,7 @@ struct DeviceBatchedTopK
   template <typename KeyT>
   [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr auto OutputPadding(KeyT key)
   {
-    using padding_t = detail::batched_topk::output_padding_values<KeyT, NullType>;
+    using padding_t = detail::batched_topk::output_padding_values<KeyT, NullType, false>;
     return ::cuda::std::execution::prop{detail::batched_topk::get_output_padding_t{}, padding_t{key, {}}};
   }
 
@@ -485,7 +484,7 @@ struct DeviceBatchedTopK
   template <typename KeyT, typename ValueT>
   [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr auto OutputPadding(KeyT key, ValueT value)
   {
-    using padding_t = detail::batched_topk::output_padding_values<KeyT, ValueT>;
+    using padding_t = detail::batched_topk::output_padding_values<KeyT, ValueT, true>;
     return ::cuda::std::execution::prop{detail::batched_topk::get_output_padding_t{}, padding_t{key, value}};
   }
 

--- a/cub/cub/device/device_batched_topk.cuh
+++ b/cub/cub/device/device_batched_topk.cuh
@@ -231,6 +231,23 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
     // conservative 64-bit upper bound here.
     constexpr auto total_num_items = ::cuda::args::immediate{::cuda::std::numeric_limits<::cuda::std::int64_t>::max()};
 
+    const auto dispatch_with_outputs = [&](auto d_keys_out_it, auto d_values_out_it) -> cudaError_t {
+      return batched_topk::dispatch<requested_determinism_t::value, requested_tie_break_t::value>(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_keys_in,
+        d_keys_out_it,
+        d_values_in,
+        d_values_out_it,
+        segment_sizes,
+        k,
+        ::cuda::args::constant<SelectDirection>{},
+        num_segments,
+        total_num_items,
+        stream,
+        tuning);
+    };
+
     if constexpr (::cuda::std::execution::__queryable_with<EnvT, batched_topk::get_output_padding_t>)
     {
       const auto& padding         = env.query(batched_topk::get_output_padding_t{});
@@ -242,56 +259,17 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
       const auto padded_keys_out = batched_topk::make_padded_output_segments_iterator(d_keys_out, padding.key);
       if constexpr (is_keys_only)
       {
-        return batched_topk::dispatch<requested_determinism_t::value, requested_tie_break_t::value>(
-          d_temp_storage,
-          temp_storage_bytes,
-          d_keys_in,
-          padded_keys_out,
-          d_values_in,
-          d_values_out,
-          segment_sizes,
-          k,
-          ::cuda::args::constant<SelectDirection>{},
-          num_segments,
-          total_num_items,
-          stream,
-          tuning);
+        return dispatch_with_outputs(padded_keys_out, d_values_out);
       }
       else
       {
         const auto padded_values_out = batched_topk::make_padded_output_segments_iterator(d_values_out, padding.value);
-        return batched_topk::dispatch<requested_determinism_t::value, requested_tie_break_t::value>(
-          d_temp_storage,
-          temp_storage_bytes,
-          d_keys_in,
-          padded_keys_out,
-          d_values_in,
-          padded_values_out,
-          segment_sizes,
-          k,
-          ::cuda::args::constant<SelectDirection>{},
-          num_segments,
-          total_num_items,
-          stream,
-          tuning);
+        return dispatch_with_outputs(padded_keys_out, padded_values_out);
       }
     }
     else
     {
-      return batched_topk::dispatch<requested_determinism_t::value, requested_tie_break_t::value>(
-        d_temp_storage,
-        temp_storage_bytes,
-        d_keys_in,
-        d_keys_out,
-        d_values_in,
-        d_values_out,
-        segment_sizes,
-        k,
-        ::cuda::args::constant<SelectDirection>{},
-        num_segments,
-        total_num_items,
-        stream,
-        tuning);
+      return dispatch_with_outputs(d_keys_out, d_values_out);
     }
   }
   else

--- a/cub/cub/device/device_batched_topk.cuh
+++ b/cub/cub/device/device_batched_topk.cuh
@@ -91,7 +91,7 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
   NumSegmentsParameterT num_segments,
   cudaStream_t stream,
   const TuningT& tuning,
-  [[maybe_unused]] const EnvT& env)
+  const EnvT& env)
 {
   // ---------------------------------------------------------------------------
   // Execution requirements.
@@ -231,26 +231,75 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
     // conservative 64-bit upper bound here.
     constexpr auto total_num_items = ::cuda::args::immediate{::cuda::std::numeric_limits<::cuda::std::int64_t>::max()};
 
-    return batched_topk::dispatch<requested_determinism_t::value, requested_tie_break_t::value>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_keys_in,
-      d_keys_out,
-      d_values_in,
-      d_values_out,
-      segment_sizes,
-      k,
-      ::cuda::args::constant<SelectDirection>{},
-      num_segments,
-      total_num_items,
-      stream,
-      tuning);
+    if constexpr (::cuda::std::execution::__queryable_with<EnvT, batched_topk::get_output_padding_t>)
+    {
+      const auto& padding         = env.query(batched_topk::get_output_padding_t{});
+      using value_padding_t       = ::cuda::std::remove_cvref_t<decltype(padding.value)>;
+      constexpr bool is_keys_only = ::cuda::std::is_same_v<it_value_t<it_value_t<ValueInputIteratorItT>>, NullType>;
+      static_assert(is_keys_only == ::cuda::std::is_same_v<value_padding_t, NullType>,
+                    "cub::DeviceBatchedTopK::OutputPadding requires one value for Keys and two values for Pairs");
+
+      const auto padded_keys_out = batched_topk::make_padded_output_segments_iterator(d_keys_out, padding.key);
+      if constexpr (is_keys_only)
+      {
+        return batched_topk::dispatch<requested_determinism_t::value, requested_tie_break_t::value>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_keys_in,
+          padded_keys_out,
+          d_values_in,
+          d_values_out,
+          segment_sizes,
+          k,
+          ::cuda::args::constant<SelectDirection>{},
+          num_segments,
+          total_num_items,
+          stream,
+          tuning);
+      }
+      else
+      {
+        const auto padded_values_out = batched_topk::make_padded_output_segments_iterator(d_values_out, padding.value);
+        return batched_topk::dispatch<requested_determinism_t::value, requested_tie_break_t::value>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_keys_in,
+          padded_keys_out,
+          d_values_in,
+          padded_values_out,
+          segment_sizes,
+          k,
+          ::cuda::args::constant<SelectDirection>{},
+          num_segments,
+          total_num_items,
+          stream,
+          tuning);
+      }
+    }
+    else
+    {
+      return batched_topk::dispatch<requested_determinism_t::value, requested_tie_break_t::value>(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_keys_in,
+        d_keys_out,
+        d_values_in,
+        d_values_out,
+        segment_sizes,
+        k,
+        ::cuda::args::constant<SelectDirection>{},
+        num_segments,
+        total_num_items,
+        stream,
+        tuning);
+    }
   }
   else
   {
     return cudaErrorInvalidValue;
   }
 }
+
 //! @endcond
 } // namespace detail
 
@@ -338,6 +387,31 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
 //! unspecified and may change across releases (temporary-storage handling is an implementation detail). Treat this
 //! purely as guidance for choosing bounds rather than as a guarantee.
 //!
+//! Fixed-width output padding
+//! +++++++++++++++++++++++++++++++++++++++++++++
+//!
+//! By default, each segment writes only its selected items and leaves any remaining output positions untouched. To
+//! request fixed-width output, compose ``DeviceBatchedTopK::OutputPadding`` into the existing execution environment:
+//!
+//! .. code-block:: c++
+//!
+//!     auto env = cuda::std::execution::env{
+//!       requirements,
+//!       cub::DeviceBatchedTopK::OutputPadding(key_pad, value_pad),
+//!       cuda::stream_ref{stream}};
+//!     cub::DeviceBatchedTopK::MaxPairs(
+//!       d_keys_in, d_keys_out, d_values_in, d_values_out, segment_sizes, k, num_segments, env);
+//!
+//! For segment ``i``, let ``width_i = max(k_i, 0)``, ``size_i = max(segment_sizes_i, 0)``, and
+//! ``selected_i = min(width_i, size_i)``. The algorithm writes selected items to ``[0, selected_i)`` and padding to
+//! ``[selected_i, width_i)``. The caller must provide at least ``width_i`` positions in each applicable per-segment
+//! output range. Use ``OutputPadding(key_pad)`` with the Keys APIs and ``OutputPadding(key_pad, value_pad)`` with the
+//! Pairs APIs.
+//!
+//! Padding values are copied into the execution environment and passed to device code as part of the kernel
+//! arguments. Each value's type must therefore be copyable and valid to pass to device code, and the value must be
+//! assignable through its corresponding output iterator.
+//!
 //! Current constraints (initial API surface)
 //! +++++++++++++++++++++++++++++++++++++++++++++
 //!
@@ -413,6 +487,30 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk(
 //! @endrst
 struct DeviceBatchedTopK
 {
+  //! @brief Creates an execution-environment property that pads unused keys in fixed-width output segments.
+  //!
+  //! Compose this property with the call's other properties via `cuda::std::execution::env`. See *Fixed-width output
+  //! padding* above for the exact per-segment selected and padded ranges, storage contract, and value-type
+  //! requirements.
+  template <typename KeyT>
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr auto OutputPadding(KeyT key)
+  {
+    using padding_t = detail::batched_topk::output_padding_values<KeyT, NullType>;
+    return ::cuda::std::execution::prop{detail::batched_topk::get_output_padding_t{}, padding_t{key, {}}};
+  }
+
+  //! @brief Creates an execution-environment property that pads unused key-value pairs in fixed-width output segments.
+  //!
+  //! Compose this property with the call's other properties via `cuda::std::execution::env`. See *Fixed-width output
+  //! padding* above for the exact per-segment selected and padded ranges, storage contract, and value-type
+  //! requirements.
+  template <typename KeyT, typename ValueT>
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr auto OutputPadding(KeyT key, ValueT value)
+  {
+    using padding_t = detail::batched_topk::output_padding_values<KeyT, ValueT>;
+    return ::cuda::std::execution::prop{detail::batched_topk::get_output_padding_t{}, padding_t{key, value}};
+  }
+
   //! @rst
   //! Overview
   //! +++++++++++++++++++++++++++++++++++++++++++++

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -65,6 +65,57 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
 {
+template <typename KeyT, typename ValueT>
+struct output_padding_values
+{
+  KeyT key;
+  ValueT value;
+};
+
+// Query tag for the optional, stateful padding property. Padding is deliberately not a cuda::execution requirement:
+// `require` accepts only stateless requirement types, while these values must survive in the environment until launch.
+struct get_output_padding_t
+{};
+
+// Carries an assignment-domain padding value alongside an output iterator-of-iterators while forwarding ordinary
+// segment access unchanged. Opt-in calls therefore instantiate a distinct kernel through the already-existing output
+// iterator template parameter; default calls retain their original kernel type and compile the padding path out.
+template <typename OutputSegmentsIteratorT, typename PaddingT>
+struct padded_output_segments_iterator
+{
+  OutputSegmentsIteratorT output_segments;
+  PaddingT padding_value;
+
+  template <typename SegmentIndexT>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE decltype(auto) operator[](SegmentIndexT segment_id)
+  {
+    return output_segments[segment_id];
+  }
+};
+
+template <typename OutputSegmentsIteratorT>
+struct output_segments_iterator_traits
+{
+  static constexpr bool is_padded = false;
+};
+
+template <typename OutputSegmentsIteratorT, typename PaddingT>
+struct output_segments_iterator_traits<padded_output_segments_iterator<OutputSegmentsIteratorT, PaddingT>>
+{
+  static constexpr bool is_padded = true;
+};
+
+template <typename OutputSegmentsIteratorT>
+inline constexpr bool is_padded_output_segments_iterator_v =
+  output_segments_iterator_traits<OutputSegmentsIteratorT>::is_padded;
+
+template <typename OutputSegmentsIteratorT, typename PaddingT>
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto
+make_padded_output_segments_iterator(OutputSegmentsIteratorT output_segments, PaddingT padding_value)
+{
+  return padded_output_segments_iterator<OutputSegmentsIteratorT, PaddingT>{output_segments, padding_value};
+}
+
 // -----------------------------------------------------------------------------
 // Internal: wrap the compile-time select direction into a discrete param for dispatch
 // -----------------------------------------------------------------------------
@@ -557,11 +608,19 @@ _CCCL_HOST_API cudaError_t launch_cluster_arm(
   static_assert(load_align_bytes % int{sizeof(key_t)} == 0);
 
   // Tightest upper bound the segment-size argument carries -- for a static-bounded per-segment sequence a loose type
-  // max, not the actual runtime maximum across segments.
-  const auto max_seg_size  = ::cuda::args::__highest_(segment_sizes);
+  // max, not the actual runtime maximum across segments. Preserve the original value for compact-output
+  // instantiations. For padded output only, an immediate/runtime bound may be negative even though its accepted static
+  // range has a non-negative upper bound; clamp in the bound's own type before widening so it cannot become a huge
+  // unsigned launch size.
+  auto max_seg_size = ::cuda::args::__highest_(segment_sizes);
+  if constexpr (detail::batched_topk::is_padded_output_segments_iterator_v<KeyOutputItItT>)
+  {
+    using max_seg_size_t = ::cuda::std::remove_cv_t<decltype(max_seg_size)>;
+    max_seg_size         = (::cuda::std::max) (max_seg_size, max_seg_size_t{0});
+  }
   using num_segments_val_t = typename ::cuda::args::__traits<NumSegmentsParameterT>::element_type;
-  // `num_segments > 0` and `max_seg_size > 0` here: the generic `dispatch` returns for the empty-batch cases (no
-  // segments, or a non-positive max segment size) before invoking this launch arm.
+  // `num_segments > 0` here: the generic `dispatch` returns for an empty batch. `max_seg_size` may be zero when output
+  // padding is enabled; the single-CTA launch shape then fills the whole positive-k output segment.
   const auto num_seg_val = detail::params::get_param(num_segments, num_segments_val_t{0});
 
   // Opt in to non-portable cluster blocks (>8 on Hopper).
@@ -815,8 +874,8 @@ _CCCL_HOST_API cudaError_t launch_baseline_arm(
       return cudaSuccess;
     }
 
-    // `num_segments > 0` and the max segment size > 0 here: the generic `dispatch` returns for the empty-batch cases
-    // (no segments, or a non-positive max segment size) before invoking this launch arm.
+    // `num_segments > 0` here: the generic `dispatch` returns for an empty batch. The max segment size may be zero when
+    // output padding is enabled; one baseline worker per segment then fills the whole positive-k output segment.
 
     if constexpr (any_small_segments)
     {
@@ -1057,14 +1116,18 @@ _CCCL_HOST_API cudaError_t dispatch(
     return cudaSuccess;
   }
 
-  // Empty batch = no work to launch: no segments, or a non-positive tightest max segment size (every segment empty,
-  // e.g. a uniform negative size clamped to 0). `== 0` suffices for `num_segments`: a negative count is already
-  // short-circuited as no work above. Consulted only on the launch (`d_temp_storage != nullptr`) of a *supported* arm
-  // below: the query pass falls through to size `temp_storage_bytes`, and the unsupported arm ignores it so an
-  // unavailable request still fails with cudaErrorNotSupported rather than being masked into success.
+  // Empty batch = no work to launch: no segments, or (for the default compact-output contract) a non-positive tightest
+  // max segment size (every segment empty, e.g. a uniform negative size clamped to 0). An output-padding request must
+  // still launch for empty segments because a positive k makes the entire output segment padding. `== 0` suffices for
+  // `num_segments`: a negative count is already short-circuited as no work above. Consulted only on the launch
+  // (`d_temp_storage != nullptr`) of a *supported* arm below: the query pass falls through to size
+  // `temp_storage_bytes`, and the unsupported arm ignores it so an unavailable request still fails with
+  // cudaErrorNotSupported rather than being masked into success.
   const auto empty_batch_no_launch = [&] {
     return d_temp_storage != nullptr
-        && (detail::params::get_param(num_segments, 0) == 0 || ::cuda::args::__highest_(segment_sizes) <= 0);
+        && (detail::params::get_param(num_segments, 0) == 0
+            || (!detail::batched_topk::is_padded_output_segments_iterator_v<KeyOutputItItT>
+                && ::cuda::args::__highest_(segment_sizes) <= 0));
   };
 
   return detail::dispatch_compute_cap(policy_selector_t{}, cc, [&](auto policy_getter) -> cudaError_t {

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -18,6 +18,7 @@
 #endif // no system header
 
 #include <cub/agent/agent_batched_topk_cluster.cuh>
+#include <cub/detail/batched_topk_output_padding.cuh>
 #include <cub/detail/cc_dispatch.cuh>
 #include <cub/detail/choose_offset.cuh>
 #include <cub/detail/launcher/cuda_runtime.cuh>
@@ -65,57 +66,6 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
 {
-template <typename KeyT, typename ValueT>
-struct output_padding_values
-{
-  KeyT key;
-  ValueT value;
-};
-
-// Query tag for the optional, stateful padding property. Padding is deliberately not a cuda::execution requirement:
-// `require` accepts only stateless requirement types, while these values must survive in the environment until launch.
-struct get_output_padding_t
-{};
-
-// Carries an assignment-domain padding value alongside an output iterator-of-iterators while forwarding ordinary
-// segment access unchanged. Opt-in calls therefore instantiate a distinct kernel through the already-existing output
-// iterator template parameter; default calls retain their original kernel type and compile the padding path out.
-template <typename OutputSegmentsIteratorT, typename PaddingT>
-struct padded_output_segments_iterator
-{
-  OutputSegmentsIteratorT output_segments;
-  PaddingT padding_value;
-
-  template <typename SegmentIndexT>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE decltype(auto) operator[](SegmentIndexT segment_id)
-  {
-    return output_segments[segment_id];
-  }
-};
-
-template <typename OutputSegmentsIteratorT>
-struct output_segments_iterator_traits
-{
-  static constexpr bool is_padded = false;
-};
-
-template <typename OutputSegmentsIteratorT, typename PaddingT>
-struct output_segments_iterator_traits<padded_output_segments_iterator<OutputSegmentsIteratorT, PaddingT>>
-{
-  static constexpr bool is_padded = true;
-};
-
-template <typename OutputSegmentsIteratorT>
-inline constexpr bool is_padded_output_segments_iterator_v =
-  output_segments_iterator_traits<OutputSegmentsIteratorT>::is_padded;
-
-template <typename OutputSegmentsIteratorT, typename PaddingT>
-[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto
-make_padded_output_segments_iterator(OutputSegmentsIteratorT output_segments, PaddingT padding_value)
-{
-  return padded_output_segments_iterator<OutputSegmentsIteratorT, PaddingT>{output_segments, padding_value};
-}
-
 // -----------------------------------------------------------------------------
 // Internal: wrap the compile-time select direction into a discrete param for dispatch
 // -----------------------------------------------------------------------------

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -1066,18 +1066,23 @@ _CCCL_HOST_API cudaError_t dispatch(
     return cudaSuccess;
   }
 
-  // Empty batch = no work to launch: no segments, or (for the default compact-output contract) a non-positive tightest
-  // max segment size (every segment empty, e.g. a uniform negative size clamped to 0). An output-padding request must
-  // still launch for empty segments because a positive k makes the entire output segment padding. `== 0` suffices for
-  // `num_segments`: a negative count is already short-circuited as no work above. Consulted only on the launch
-  // (`d_temp_storage != nullptr`) of a *supported* arm below: the query pass falls through to size
-  // `temp_storage_bytes`, and the unsupported arm ignores it so an unavailable request still fails with
-  // cudaErrorNotSupported rather than being masked into success.
+  // Empty batch = no work to launch: no segments; for compact output, a non-positive tightest max segment size; or for
+  // padded output, a non-positive tightest max k. Padded output must still launch for empty segments when k is positive
+  // because the entire output segment is padding. `== 0` suffices for `num_segments`: a negative count is already
+  // short-circuited as no work above. Consulted only on the launch (`d_temp_storage != nullptr`) of a *supported* arm
+  // below: the query pass falls through to size `temp_storage_bytes`, and the unsupported arm ignores it so an
+  // unavailable request still fails with cudaErrorNotSupported rather than being masked into success.
   const auto empty_batch_no_launch = [&] {
-    return d_temp_storage != nullptr
-        && (detail::params::get_param(num_segments, 0) == 0
-            || (!detail::batched_topk::is_padded_output_segments_iterator_v<KeyOutputItItT>
-                && ::cuda::args::__highest_(segment_sizes) <= 0));
+    if constexpr (detail::batched_topk::is_padded_output_segments_iterator_v<KeyOutputItItT>)
+    {
+      return d_temp_storage != nullptr
+          && (detail::params::get_param(num_segments, 0) == 0 || ::cuda::args::__highest_(k) <= 0);
+    }
+    else
+    {
+      return d_temp_storage != nullptr
+          && (detail::params::get_param(num_segments, 0) == 0 || ::cuda::args::__highest_(segment_sizes) <= 0);
+    }
   };
 
   return detail::dispatch_compute_cap(policy_selector_t{}, cc, [&](auto policy_getter) -> cudaError_t {

--- a/cub/test/catch2_test_device_batched_topk_env_api.cu
+++ b/cub/test/catch2_test_device_batched_topk_env_api.cu
@@ -22,6 +22,9 @@
 
 #include "cub_test_macros.h"
 
+void check_max_keys_env_output_padding();
+void check_min_pairs_env_output_padding();
+
 CUB_TEST("cub::DeviceBatchedTopK::MaxKeys env-alloc example", "[batched_topk][device][env]", CUB_SMALL)
 {
   // example-begin batched-topk-max-keys-env
@@ -63,6 +66,11 @@ CUB_TEST("cub::DeviceBatchedTopK::MaxKeys env-alloc example", "[batched_topk][de
   thrust::sort(keys_out.begin(), keys_out.begin() + k, cuda::std::greater<int>{});
   thrust::sort(keys_out.begin() + k, keys_out.begin() + 2 * k, cuda::std::greater<int>{});
   REQUIRE(keys_out == expected_result_set);
+
+  SECTION("the existing env overload composes the fixed-width output-padding property")
+  {
+    check_max_keys_env_output_padding();
+  }
 }
 
 CUB_TEST("cub::DeviceBatchedTopK::MinKeys env-alloc example", "[batched_topk][device][env]", CUB_SMALL)
@@ -237,4 +245,115 @@ CUB_TEST("cub::DeviceBatchedTopK::MinPairs env-alloc example", "[batched_topk][d
   thrust::sort(keys_out.begin(), keys_out.begin() + k);
   thrust::sort(keys_out.begin() + k, keys_out.begin() + 2 * k);
   REQUIRE(keys_out == expected_result_set);
+
+  SECTION("the existing env overload composes key and value output-padding properties")
+  {
+    check_min_pairs_env_output_padding();
+  }
+}
+
+void check_max_keys_env_output_padding()
+{
+  using seg_size_t           = cuda::std::int16_t;
+  constexpr int num_segments = 2;
+  constexpr int input_stride = 4;
+  constexpr int k            = 4;
+  constexpr int key_pad      = -1;
+  constexpr int sentinel     = -12345;
+
+  auto keys_in       = thrust::device_vector<int>{5, -3, 1, 7, /**/ 0, 9, 3, 2};
+  auto segment_sizes = thrust::device_vector<seg_size_t>{1, 3};
+  auto keys_out      = thrust::device_vector<int>(num_segments * k, sentinel);
+
+  auto d_keys_in =
+    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_in.data())), input_stride);
+  auto d_keys_out =
+    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_out.data())), k);
+
+  auto sizes_arg = cuda::args::deferred_sequence{
+    thrust::raw_pointer_cast(segment_sizes.data()), cuda::args::bounds<seg_size_t{0}, seg_size_t{4}>()};
+  constexpr auto k_arg = cuda::args::constant<k>{};
+  auto num_segs        = cuda::args::immediate{cuda::std::int64_t{num_segments}};
+
+  cuda::stream stream{cuda::devices[0]};
+  auto requirements = cuda::execution::require(
+    cuda::execution::determinism::not_guaranteed,
+    cuda::execution::tie_break::unspecified,
+    cuda::execution::output_ordering::unsorted);
+  auto env =
+    cuda::std::execution::env{requirements, cub::DeviceBatchedTopK::OutputPadding(key_pad), cuda::stream_ref{stream}};
+
+  REQUIRE(cudaSuccess == cub::DeviceBatchedTopK::MaxKeys(d_keys_in, d_keys_out, sizes_arg, k_arg, num_segs, env));
+  stream.sync();
+
+  thrust::sort(keys_out.begin(), keys_out.begin() + 1);
+  thrust::sort(keys_out.begin() + k, keys_out.begin() + k + 3);
+  REQUIRE(keys_out == thrust::device_vector<int>{5, -1, -1, -1, /**/ 0, 3, 9, -1});
+}
+
+void check_min_pairs_env_output_padding()
+{
+  using seg_size_t           = cuda::std::int16_t;
+  constexpr int num_segments = 2;
+  constexpr int input_stride = 4;
+  constexpr int k            = 4;
+  constexpr int key_pad      = -1;
+  constexpr int value_pad    = -2;
+
+  auto keys_in       = thrust::device_vector<int>{5, -3, 1, 7, /**/ 0, 9, 3, 2};
+  auto segment_sizes = thrust::device_vector<seg_size_t>{1, 3};
+  auto keys_out      = thrust::device_vector<int>(num_segments * k, /*canary=*/-12345);
+  auto values_out    = thrust::device_vector<int>(num_segments * k, /*canary=*/-23456);
+
+  auto d_keys_in =
+    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_in.data())), input_stride);
+  auto d_keys_out =
+    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_out.data())), k);
+  auto d_values_in = cuda::make_constant_iterator(cuda::make_counting_iterator(0));
+  auto d_values_out =
+    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(values_out.data())), k);
+
+  auto sizes_arg = cuda::args::deferred_sequence{
+    thrust::raw_pointer_cast(segment_sizes.data()), cuda::args::bounds<seg_size_t{0}, seg_size_t{4}>()};
+  constexpr auto k_arg = cuda::args::constant<k>{};
+  auto num_segs        = cuda::args::immediate{cuda::std::int64_t{num_segments}};
+
+  cuda::stream stream{cuda::devices[0]};
+  auto requirements = cuda::execution::require(
+    cuda::execution::determinism::not_guaranteed,
+    cuda::execution::tie_break::unspecified,
+    cuda::execution::output_ordering::unsorted);
+  auto env = cuda::std::execution::env{
+    requirements, cub::DeviceBatchedTopK::OutputPadding(key_pad, value_pad), cuda::stream_ref{stream}};
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceBatchedTopK::MinPairs(
+            d_keys_in, d_keys_out, d_values_in, d_values_out, sizes_arg, k_arg, num_segs, env));
+  stream.sync();
+
+  thrust::host_vector<int> h_keys_in    = keys_in;
+  thrust::host_vector<int> h_keys_out   = keys_out;
+  thrust::host_vector<int> h_values_out = values_out;
+  for (int segment = 0; segment < num_segments; ++segment)
+  {
+    const int valid       = segment == 0 ? 1 : 3;
+    const int output_base = segment * k;
+    const int input_base  = segment * input_stride;
+    for (int item = 0; item < valid; ++item)
+    {
+      const int value = h_values_out[output_base + item];
+      REQUIRE(value >= 0);
+      REQUIRE(value < valid);
+      REQUIRE(h_keys_out[output_base + item] == h_keys_in[input_base + value]);
+    }
+    for (int item = valid; item < k; ++item)
+    {
+      REQUIRE(h_keys_out[output_base + item] == key_pad);
+      REQUIRE(h_values_out[output_base + item] == value_pad);
+    }
+  }
+
+  thrust::sort(keys_out.begin(), keys_out.begin() + 1);
+  thrust::sort(keys_out.begin() + k, keys_out.begin() + k + 3);
+  REQUIRE(keys_out == thrust::device_vector<int>{5, -1, -1, -1, /**/ 0, 3, 9, -1});
 }

--- a/cub/test/catch2_test_device_batched_topk_env_api.cu
+++ b/cub/test/catch2_test_device_batched_topk_env_api.cu
@@ -22,9 +22,6 @@
 
 #include "cub_test_macros.h"
 
-void check_max_keys_env_output_padding();
-void check_min_pairs_env_output_padding();
-
 CUB_TEST("cub::DeviceBatchedTopK::MaxKeys env-alloc example", "[batched_topk][device][env]", CUB_SMALL)
 {
   // example-begin batched-topk-max-keys-env
@@ -66,11 +63,6 @@ CUB_TEST("cub::DeviceBatchedTopK::MaxKeys env-alloc example", "[batched_topk][de
   thrust::sort(keys_out.begin(), keys_out.begin() + k, cuda::std::greater<int>{});
   thrust::sort(keys_out.begin() + k, keys_out.begin() + 2 * k, cuda::std::greater<int>{});
   REQUIRE(keys_out == expected_result_set);
-
-  SECTION("the existing env overload composes the fixed-width output-padding property")
-  {
-    check_max_keys_env_output_padding();
-  }
 }
 
 CUB_TEST("cub::DeviceBatchedTopK::MinKeys env-alloc example", "[batched_topk][device][env]", CUB_SMALL)
@@ -245,115 +237,4 @@ CUB_TEST("cub::DeviceBatchedTopK::MinPairs env-alloc example", "[batched_topk][d
   thrust::sort(keys_out.begin(), keys_out.begin() + k);
   thrust::sort(keys_out.begin() + k, keys_out.begin() + 2 * k);
   REQUIRE(keys_out == expected_result_set);
-
-  SECTION("the existing env overload composes key and value output-padding properties")
-  {
-    check_min_pairs_env_output_padding();
-  }
-}
-
-void check_max_keys_env_output_padding()
-{
-  using seg_size_t           = cuda::std::int16_t;
-  constexpr int num_segments = 2;
-  constexpr int input_stride = 4;
-  constexpr int k            = 4;
-  constexpr int key_pad      = -1;
-  constexpr int sentinel     = -12345;
-
-  auto keys_in       = thrust::device_vector<int>{5, -3, 1, 7, /**/ 0, 9, 3, 2};
-  auto segment_sizes = thrust::device_vector<seg_size_t>{1, 3};
-  auto keys_out      = thrust::device_vector<int>(num_segments * k, sentinel);
-
-  auto d_keys_in =
-    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_in.data())), input_stride);
-  auto d_keys_out =
-    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_out.data())), k);
-
-  auto sizes_arg = cuda::args::deferred_sequence{
-    thrust::raw_pointer_cast(segment_sizes.data()), cuda::args::bounds<seg_size_t{0}, seg_size_t{4}>()};
-  constexpr auto k_arg = cuda::args::constant<k>{};
-  auto num_segs        = cuda::args::immediate{cuda::std::int64_t{num_segments}};
-
-  cuda::stream stream{cuda::devices[0]};
-  auto requirements = cuda::execution::require(
-    cuda::execution::determinism::not_guaranteed,
-    cuda::execution::tie_break::unspecified,
-    cuda::execution::output_ordering::unsorted);
-  auto env =
-    cuda::std::execution::env{requirements, cub::DeviceBatchedTopK::OutputPadding(key_pad), cuda::stream_ref{stream}};
-
-  REQUIRE(cudaSuccess == cub::DeviceBatchedTopK::MaxKeys(d_keys_in, d_keys_out, sizes_arg, k_arg, num_segs, env));
-  stream.sync();
-
-  thrust::sort(keys_out.begin(), keys_out.begin() + 1);
-  thrust::sort(keys_out.begin() + k, keys_out.begin() + k + 3);
-  REQUIRE(keys_out == thrust::device_vector<int>{5, -1, -1, -1, /**/ 0, 3, 9, -1});
-}
-
-void check_min_pairs_env_output_padding()
-{
-  using seg_size_t           = cuda::std::int16_t;
-  constexpr int num_segments = 2;
-  constexpr int input_stride = 4;
-  constexpr int k            = 4;
-  constexpr int key_pad      = -1;
-  constexpr int value_pad    = -2;
-
-  auto keys_in       = thrust::device_vector<int>{5, -3, 1, 7, /**/ 0, 9, 3, 2};
-  auto segment_sizes = thrust::device_vector<seg_size_t>{1, 3};
-  auto keys_out      = thrust::device_vector<int>(num_segments * k, /*canary=*/-12345);
-  auto values_out    = thrust::device_vector<int>(num_segments * k, /*canary=*/-23456);
-
-  auto d_keys_in =
-    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_in.data())), input_stride);
-  auto d_keys_out =
-    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_out.data())), k);
-  auto d_values_in = cuda::make_constant_iterator(cuda::make_counting_iterator(0));
-  auto d_values_out =
-    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(values_out.data())), k);
-
-  auto sizes_arg = cuda::args::deferred_sequence{
-    thrust::raw_pointer_cast(segment_sizes.data()), cuda::args::bounds<seg_size_t{0}, seg_size_t{4}>()};
-  constexpr auto k_arg = cuda::args::constant<k>{};
-  auto num_segs        = cuda::args::immediate{cuda::std::int64_t{num_segments}};
-
-  cuda::stream stream{cuda::devices[0]};
-  auto requirements = cuda::execution::require(
-    cuda::execution::determinism::not_guaranteed,
-    cuda::execution::tie_break::unspecified,
-    cuda::execution::output_ordering::unsorted);
-  auto env = cuda::std::execution::env{
-    requirements, cub::DeviceBatchedTopK::OutputPadding(key_pad, value_pad), cuda::stream_ref{stream}};
-
-  REQUIRE(cudaSuccess
-          == cub::DeviceBatchedTopK::MinPairs(
-            d_keys_in, d_keys_out, d_values_in, d_values_out, sizes_arg, k_arg, num_segs, env));
-  stream.sync();
-
-  thrust::host_vector<int> h_keys_in    = keys_in;
-  thrust::host_vector<int> h_keys_out   = keys_out;
-  thrust::host_vector<int> h_values_out = values_out;
-  for (int segment = 0; segment < num_segments; ++segment)
-  {
-    const int valid       = segment == 0 ? 1 : 3;
-    const int output_base = segment * k;
-    const int input_base  = segment * input_stride;
-    for (int item = 0; item < valid; ++item)
-    {
-      const int value = h_values_out[output_base + item];
-      REQUIRE(value >= 0);
-      REQUIRE(value < valid);
-      REQUIRE(h_keys_out[output_base + item] == h_keys_in[input_base + value]);
-    }
-    for (int item = valid; item < k; ++item)
-    {
-      REQUIRE(h_keys_out[output_base + item] == key_pad);
-      REQUIRE(h_values_out[output_base + item] == value_pad);
-    }
-  }
-
-  thrust::sort(keys_out.begin(), keys_out.begin() + 1);
-  thrust::sort(keys_out.begin() + k, keys_out.begin() + k + 3);
-  REQUIRE(keys_out == thrust::device_vector<int>{5, -1, -1, -1, /**/ 0, 3, 9, -1});
 }

--- a/cub/test/catch2_test_device_segmented_topk_keys.cu
+++ b/cub/test/catch2_test_device_segmented_topk_keys.cu
@@ -32,6 +32,9 @@
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/functional>
+#include <cuda/std/type_traits>
+
+#include <algorithm>
 
 #include "catch2_test_device_topk_common.cuh"
 #include "catch2_test_launch_helper.h"
@@ -103,6 +106,57 @@ _CCCL_HOST_API static cudaError_t dispatch_batched_topk_keys(
 DECLARE_TMPL_LAUNCH_WRAPPER(
   dispatch_batched_topk_keys,
   batched_topk_keys,
+  ESCAPE_LIST(
+    cub::detail::topk::select SelectDirection,
+    cuda::execution::determinism::__determinism_t Determinism =
+      cuda::execution::determinism::__determinism_t::__not_guaranteed,
+    cuda::execution::tie_break::__tie_break_t TieBreak = cuda::execution::tie_break::__tie_break_t::__unspecified),
+  ESCAPE_LIST(SelectDirection, Determinism, TieBreak));
+
+// Padding-property companion to dispatch_batched_topk_keys. The public algorithm signature is unchanged: the
+// stateful property is composed into EnvT alongside the existing requirements and stream.
+template <cub::detail::topk::select SelectDirection,
+          cuda::execution::determinism::__determinism_t Determinism =
+            cuda::execution::determinism::__determinism_t::__not_guaranteed,
+          cuda::execution::tie_break::__tie_break_t TieBreak = cuda::execution::tie_break::__tie_break_t::__unspecified,
+          typename KeyInputItItT,
+          typename KeyOutputItItT,
+          typename SegmentSizeParamT,
+          typename KParamT,
+          typename NumSegmentsParameterT,
+          typename PaddingPropertyT>
+_CCCL_HOST_API static cudaError_t dispatch_batched_topk_keys_with_padding(
+  void* d_temp_storage,
+  cuda::std::size_t& temp_storage_bytes,
+  KeyInputItItT d_key_segments_it,
+  KeyOutputItItT d_key_segments_out_it,
+  SegmentSizeParamT segment_sizes,
+  KParamT k,
+  NumSegmentsParameterT num_segments,
+  PaddingPropertyT padding,
+  cudaStream_t stream = nullptr)
+{
+  auto env = cuda::std::execution::env{
+    cuda::stream_ref{stream},
+    cuda::execution::require(cuda::execution::determinism::__determinism_holder_t<Determinism>{},
+                             cuda::execution::tie_break::__tie_break_holder_t<TieBreak>{},
+                             cuda::execution::output_ordering::unsorted),
+    padding};
+  if constexpr (SelectDirection == cub::detail::topk::select::max)
+  {
+    return cub::DeviceBatchedTopK::MaxKeys(
+      d_temp_storage, temp_storage_bytes, d_key_segments_it, d_key_segments_out_it, segment_sizes, k, num_segments, env);
+  }
+  else
+  {
+    return cub::DeviceBatchedTopK::MinKeys(
+      d_temp_storage, temp_storage_bytes, d_key_segments_it, d_key_segments_out_it, segment_sizes, k, num_segments, env);
+  }
+}
+
+DECLARE_TMPL_LAUNCH_WRAPPER(
+  dispatch_batched_topk_keys_with_padding,
+  batched_topk_keys_with_padding,
   ESCAPE_LIST(
     cub::detail::topk::select SelectDirection,
     cuda::execution::determinism::__determinism_t Determinism =
@@ -186,6 +240,121 @@ using det_tie_combos =
                          cuda::execution::tie_break::__tie_break_t::__prefer_smaller_index>,
                  det_tie<cuda::execution::determinism::__determinism_t::__gpu_to_gpu,
                          cuda::execution::tie_break::__tie_break_t::__prefer_larger_index>>;
+
+template <cub::detail::topk::select Direction,
+          cuda::execution::determinism::__determinism_t Determinism,
+          cuda::execution::tie_break::__tie_break_t TieBreak>
+void check_batched_topk_keys_output_padding()
+{
+  using key_t      = cuda::std::int32_t;
+  using seg_size_t = cuda::std::int16_t;
+
+  constexpr int num_segments = 9;
+  constexpr int input_stride = 5;
+  constexpr int output_width = 4;
+  constexpr int guard        = 3;
+  constexpr key_t sentinel   = -12345;
+  constexpr key_t pad        = -1;
+
+  // Segment sizes cover the clamped-negative, empty, short, exact-k, and longer-than-k paths. The last three rows use
+  // per-segment negative, zero, and smaller k values to pin the padding endpoint to max(k, 0), not the static bound.
+  const c2h::host_vector<seg_size_t> h_segment_sizes{-1, 0, 1, 3, 4, 5, 5, 5, 5};
+  const c2h::host_vector<seg_size_t> h_k{4, 4, 4, 4, 4, 4, -1, 0, 3};
+  c2h::device_vector<seg_size_t> d_segment_sizes = h_segment_sizes;
+  c2h::device_vector<seg_size_t> d_k             = h_k;
+
+  c2h::device_vector<key_t> keys_in(num_segments * input_stride, thrust::no_init);
+  thrust::sequence(keys_in.begin(), keys_in.end());
+  auto d_keys_in =
+    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_in.data())), input_stride);
+
+  const auto make_output = [=] {
+    return c2h::device_vector<key_t>(guard + num_segments * output_width + guard, sentinel);
+  };
+  auto compact_output = make_output();
+  auto padded_output  = make_output();
+
+  const auto make_output_it = [=](c2h::device_vector<key_t>& storage) {
+    auto output_ptr = thrust::raw_pointer_cast(storage.data()) + guard;
+    return cuda::make_strided_iterator(cuda::make_counting_iterator(output_ptr), output_width);
+  };
+  auto d_compact_output = make_output_it(compact_output);
+  auto d_padded_output  = make_output_it(padded_output);
+
+  auto segment_sizes = cuda::args::deferred_sequence{
+    thrust::raw_pointer_cast(d_segment_sizes.data()), cuda::args::bounds<seg_size_t{-1}, seg_size_t{5}>()};
+  auto k_arg = cuda::args::deferred_sequence{
+    thrust::raw_pointer_cast(d_k.data()), cuda::args::bounds<seg_size_t{-1}, seg_size_t{4}>()};
+  auto num_segs = cuda::args::immediate{cuda::std::int64_t{num_segments}};
+
+  CAPTURE(Direction, Determinism, TieBreak);
+
+  skip_unless_batched_topk_keys_supported<Direction, Determinism, TieBreak>(
+    /*static_max_segment_size=*/5, d_keys_in, d_compact_output, segment_sizes, k_arg, num_segs);
+
+  // The existing environment has compact semantics: unused slots remain untouched.
+  batched_topk_keys<Direction, Determinism, TieBreak>(d_keys_in, d_compact_output, segment_sizes, k_arg, num_segs);
+
+  // Adding the stateful property to the same EnvT materializes exactly [valid, max(k, 0)).
+  batched_topk_keys_with_padding<Direction, Determinism, TieBreak>(
+    d_keys_in, d_padded_output, segment_sizes, k_arg, num_segs, cub::DeviceBatchedTopK::OutputPadding(pad));
+
+  const auto verify = [&](const c2h::device_vector<key_t>& output, bool expect_padding) {
+    c2h::host_vector<key_t> h_output = output;
+
+    for (int i = 0; i < guard; ++i)
+    {
+      REQUIRE(h_output[i] == sentinel);
+      REQUIRE(h_output[guard + num_segments * output_width + i] == sentinel);
+    }
+
+    for (int segment = 0; segment < num_segments; ++segment)
+    {
+      const int segment_size = (std::max) (int{h_segment_sizes[segment]}, 0);
+      const int requested    = (std::max) (int{h_k[segment]}, 0);
+      const int valid        = (std::min) (requested, segment_size);
+      auto row_begin         = h_output.begin() + guard + segment * output_width;
+      std::sort(row_begin, row_begin + valid);
+
+      const int input_base = segment * input_stride;
+      const int first_key =
+        Direction == cub::detail::topk::select::min ? input_base : input_base + segment_size - valid;
+      for (int item = 0; item < valid; ++item)
+      {
+        REQUIRE(row_begin[item] == first_key + item);
+      }
+      for (int item = valid; item < requested; ++item)
+      {
+        REQUIRE(row_begin[item] == (expect_padding ? pad : sentinel));
+      }
+      for (int item = requested; item < output_width; ++item)
+      {
+        REQUIRE(row_begin[item] == sentinel);
+      }
+    }
+  };
+
+  verify(compact_output, false);
+  verify(padded_output, true);
+}
+
+// Exercise both implementation backends without multiplying the broad key-type/static-bound Cartesian product of the
+// existing variable-size/per-segment-k test. The deterministic case is only run where the cluster backend is available.
+template <cub::detail::topk::select Direction>
+void check_batched_topk_keys_output_padding_backends()
+{
+  check_batched_topk_keys_output_padding<Direction,
+                                         cuda::execution::determinism::__determinism_t::__not_guaranteed,
+                                         cuda::execution::tie_break::__tie_break_t::__unspecified>();
+
+  if (!batched_topk_backend_unavailable<cuda::execution::determinism::__determinism_t::__gpu_to_gpu,
+                                        cuda::execution::tie_break::__tie_break_t::__prefer_smaller_index>(5))
+  {
+    check_batched_topk_keys_output_padding<Direction,
+                                           cuda::execution::determinism::__determinism_t::__gpu_to_gpu,
+                                           cuda::execution::tie_break::__tie_break_t::__prefer_smaller_index>();
+  }
+}
 
 CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with small fixed-size segments",
          "[keys][segmented][topk][device]",
@@ -1588,6 +1757,18 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with variable-size segments and 
     keys_out_buffer, num_segments, compacted_offsets.cbegin(), compacted_offsets.cbegin() + 1, direction);
 
   REQUIRE(expected_keys == keys_out_buffer);
+
+#if TEST_TYPES == 0
+  // Extend this existing variable-size/per-segment-k test with fixed-width materialization. Restrict the focused
+  // contract matrix to one representative key/static-k instantiation; direction remains this test's Cartesian axis.
+  if constexpr (cuda::std::is_same_v<key_t, cuda::std::uint8_t> && static_max_k == 32)
+  {
+    SECTION("default output leaves the tail untouched; OutputPadding fills it through the requested per-row k")
+    {
+      check_batched_topk_keys_output_padding_backends<direction>();
+    }
+  }
+#endif // TEST_TYPES == 0
 }
 #if TEST_TYPES == 2
 // Heavy-tie stress/regression: collapse the keys to only a handful of distinct values so the k-th key's bucket holds a
@@ -2092,22 +2273,32 @@ CUB_TEST("DeviceBatchedTopK::MaxKeys treats a uniform negative segment size as n
   auto d_keys_out =
     cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_out.data())), k);
 
+  auto segment_sizes   = cuda::args::immediate{seg_size_t{-1}, cuda::args::bounds<-8, 100>()};
+  constexpr auto k_arg = cuda::args::constant<k>{};
+  auto num_segs        = cuda::args::immediate{cuda::std::int64_t{num_segments}};
+
   skip_unless_batched_topk_keys_supported<cub::detail::topk::select::max, determinism, tie_break>(
-    static_max_segment_size,
-    d_keys_in,
-    d_keys_out,
-    cuda::args::immediate{seg_size_t{-1}, cuda::args::bounds<-8, 100>()},
-    cuda::args::constant<k>{},
-    cuda::args::immediate{cuda::std::int64_t{num_segments}});
+    static_max_segment_size, d_keys_in, d_keys_out, segment_sizes, k_arg, num_segs);
   batched_topk_keys<cub::detail::topk::select::max, determinism, tie_break>(
-    d_keys_in,
-    d_keys_out,
-    cuda::args::immediate{seg_size_t{-1}, cuda::args::bounds<-8, 100>()},
-    cuda::args::constant<k>{},
-    cuda::args::immediate{cuda::std::int64_t{num_segments}});
+    d_keys_in, d_keys_out, segment_sizes, k_arg, num_segs);
 
   // No segment had any items, so the whole output is left untouched.
   REQUIRE(keys_out == thrust::device_vector<int>(num_segments * k, sentinel));
+
+  SECTION("OutputPadding fills every requested slot for the host-known empty segments")
+  {
+    constexpr int pad = -1;
+    auto padded_out   = thrust::device_vector<int>(num_segments * k, sentinel);
+    auto d_padded_out =
+      cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(padded_out.data())), k);
+
+    // The immediate negative value makes __highest_(segment_sizes) negative on the host. This specifically exercises
+    // deterministic cluster launch-shape sizing before the in-kernel empty-segment handling.
+    batched_topk_keys_with_padding<cub::detail::topk::select::max, determinism, tie_break>(
+      d_keys_in, d_padded_out, segment_sizes, k_arg, num_segs, cub::DeviceBatchedTopK::OutputPadding(pad));
+
+    REQUIRE(padded_out == thrust::device_vector<int>(num_segments * k, pad));
+  }
 }
 
 // Zero segments is a no-op, but with a positive segment-size bound the `max_seg_size <= 0` guard does not fire, so the

--- a/cub/test/catch2_test_device_segmented_topk_keys.cu
+++ b/cub/test/catch2_test_device_segmented_topk_keys.cu
@@ -289,9 +289,6 @@ void check_batched_topk_keys_output_padding()
 
   CAPTURE(Direction, Determinism, TieBreak);
 
-  skip_unless_batched_topk_keys_supported<Direction, Determinism, TieBreak>(
-    /*static_max_segment_size=*/5, d_keys_in, d_compact_output, segment_sizes, k_arg, num_segs);
-
   // The existing environment has compact semantics: unused slots remain untouched.
   batched_topk_keys<Direction, Determinism, TieBreak>(d_keys_in, d_compact_output, segment_sizes, k_arg, num_segs);
 
@@ -1760,10 +1757,10 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with variable-size segments and 
 
 #if TEST_TYPES == 0
   // Extend this existing variable-size/per-segment-k test with fixed-width materialization. Restrict the focused
-  // contract matrix to one representative key/static-k instantiation; direction remains this test's Cartesian axis.
+  // contract matrix to one representative key/static-k/runtime-size instantiation; direction remains an existing axis.
   if constexpr (cuda::std::is_same_v<key_t, cuda::std::uint8_t> && static_max_k == 32)
   {
-    SECTION("default output leaves the tail untouched; OutputPadding fills it through the requested per-row k")
+    if (num_items == min_items)
     {
       check_batched_topk_keys_output_padding_backends<direction>();
     }
@@ -2285,20 +2282,17 @@ CUB_TEST("DeviceBatchedTopK::MaxKeys treats a uniform negative segment size as n
   // No segment had any items, so the whole output is left untouched.
   REQUIRE(keys_out == thrust::device_vector<int>(num_segments * k, sentinel));
 
-  SECTION("OutputPadding fills every requested slot for the host-known empty segments")
-  {
-    constexpr int pad = -1;
-    auto padded_out   = thrust::device_vector<int>(num_segments * k, sentinel);
-    auto d_padded_out =
-      cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(padded_out.data())), k);
+  constexpr int pad = -1;
+  auto padded_out   = thrust::device_vector<int>(num_segments * k, sentinel);
+  auto d_padded_out =
+    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(padded_out.data())), k);
 
-    // The immediate negative value makes __highest_(segment_sizes) negative on the host. This specifically exercises
-    // deterministic cluster launch-shape sizing before the in-kernel empty-segment handling.
-    batched_topk_keys_with_padding<cub::detail::topk::select::max, determinism, tie_break>(
-      d_keys_in, d_padded_out, segment_sizes, k_arg, num_segs, cub::DeviceBatchedTopK::OutputPadding(pad));
+  // The immediate negative value makes __highest_(segment_sizes) negative on the host. This specifically exercises
+  // deterministic cluster launch-shape sizing before the in-kernel empty-segment handling.
+  batched_topk_keys_with_padding<cub::detail::topk::select::max, determinism, tie_break>(
+    d_keys_in, d_padded_out, segment_sizes, k_arg, num_segs, cub::DeviceBatchedTopK::OutputPadding(pad));
 
-    REQUIRE(padded_out == thrust::device_vector<int>(num_segments * k, pad));
-  }
+  REQUIRE(padded_out == thrust::device_vector<int>(num_segments * k, pad));
 }
 
 // Zero segments is a no-op, but with a positive segment-size bound the `max_seg_size <= 0` guard does not fire, so the

--- a/cub/test/catch2_test_device_segmented_topk_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_topk_pairs.cu
@@ -25,6 +25,7 @@
 #include <cuda/iterator>
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
+#include <cuda/std/type_traits>
 
 #include <algorithm>
 #include <functional>
@@ -140,6 +141,77 @@ DECLARE_TMPL_LAUNCH_WRAPPER(
     cuda::execution::tie_break::__tie_break_t TieBreak = cuda::execution::tie_break::__tie_break_t::__unspecified),
   ESCAPE_LIST(SelectDirection, Determinism, TieBreak));
 
+template <cub::detail::topk::select SelectDirection,
+          cuda::execution::determinism::__determinism_t Determinism =
+            cuda::execution::determinism::__determinism_t::__not_guaranteed,
+          cuda::execution::tie_break::__tie_break_t TieBreak = cuda::execution::tie_break::__tie_break_t::__unspecified,
+          typename KeyInputItItT,
+          typename KeyOutputItItT,
+          typename ValueInputItItT,
+          typename ValueOutputItItT,
+          typename SegmentSizeParameterT,
+          typename KParameterT,
+          typename NumSegmentsParameterT,
+          typename PaddingPropertyT>
+_CCCL_HOST_API static cudaError_t dispatch_batched_topk_pairs_with_padding(
+  void* d_temp_storage,
+  cuda::std::size_t& temp_storage_bytes,
+  KeyInputItItT d_key_segments_it,
+  KeyOutputItItT d_key_segments_out_it,
+  ValueInputItItT d_value_segments_it,
+  ValueOutputItItT d_value_segments_out_it,
+  SegmentSizeParameterT segment_sizes,
+  KParameterT k,
+  NumSegmentsParameterT num_segments,
+  PaddingPropertyT padding,
+  cudaStream_t stream = nullptr)
+{
+  auto env = cuda::std::execution::env{
+    cuda::stream_ref{stream},
+    cuda::execution::require(cuda::execution::determinism::__determinism_holder_t<Determinism>{},
+                             cuda::execution::tie_break::__tie_break_holder_t<TieBreak>{},
+                             cuda::execution::output_ordering::unsorted),
+    padding};
+  if constexpr (SelectDirection == cub::detail::topk::select::max)
+  {
+    return cub::DeviceBatchedTopK::MaxPairs(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_key_segments_it,
+      d_key_segments_out_it,
+      d_value_segments_it,
+      d_value_segments_out_it,
+      segment_sizes,
+      k,
+      num_segments,
+      env);
+  }
+  else
+  {
+    return cub::DeviceBatchedTopK::MinPairs(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_key_segments_it,
+      d_key_segments_out_it,
+      d_value_segments_it,
+      d_value_segments_out_it,
+      segment_sizes,
+      k,
+      num_segments,
+      env);
+  }
+}
+
+DECLARE_TMPL_LAUNCH_WRAPPER(
+  dispatch_batched_topk_pairs_with_padding,
+  batched_topk_pairs_with_padding,
+  ESCAPE_LIST(
+    cub::detail::topk::select SelectDirection,
+    cuda::execution::determinism::__determinism_t Determinism =
+      cuda::execution::determinism::__determinism_t::__not_guaranteed,
+    cuda::execution::tie_break::__tie_break_t TieBreak = cuda::execution::tie_break::__tie_break_t::__unspecified),
+  ESCAPE_LIST(SelectDirection, Determinism, TieBreak));
+
 // Wrapper-test companion to expect_batched_topk_unsupported_and_skip: when the request's backend is unavailable in this
 // build, dispatch it directly (host), verify the runtime cudaErrorNotSupported, and skip the correctness checks;
 // otherwise return so the caller runs its normal batched_topk_pairs<...> launch + checks. Pass the same trailing
@@ -214,6 +286,156 @@ using det_tie_pair_combos =
                               cuda::execution::tie_break::__tie_break_t::__prefer_smaller_index>,
                  det_tie_pair<cuda::execution::determinism::__determinism_t::__gpu_to_gpu,
                               cuda::execution::tie_break::__tie_break_t::__prefer_larger_index>>;
+
+template <cub::detail::topk::select Direction,
+          cuda::execution::determinism::__determinism_t Determinism,
+          cuda::execution::tie_break::__tie_break_t TieBreak>
+void check_batched_topk_pairs_output_padding()
+{
+  using key_t      = cuda::std::int32_t;
+  using value_t    = cuda::std::int32_t;
+  using seg_size_t = cuda::std::int16_t;
+
+  constexpr int num_segments     = 9;
+  constexpr int input_stride     = 5;
+  constexpr int output_width     = 4;
+  constexpr int guard            = 3;
+  constexpr key_t key_sentinel   = -12345;
+  constexpr value_t val_sentinel = -23456;
+  constexpr key_t key_pad        = -1;
+  constexpr value_t val_pad      = -2;
+
+  const c2h::host_vector<seg_size_t> h_segment_sizes{-1, 0, 1, 3, 4, 5, 5, 5, 5};
+  const c2h::host_vector<seg_size_t> h_k{4, 4, 4, 4, 4, 4, -1, 0, 3};
+  c2h::device_vector<seg_size_t> d_segment_sizes = h_segment_sizes;
+  c2h::device_vector<seg_size_t> d_k             = h_k;
+
+  c2h::device_vector<key_t> keys_in(num_segments * input_stride, thrust::no_init);
+  thrust::sequence(keys_in.begin(), keys_in.end());
+  auto d_keys_in =
+    cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_in.data())), input_stride);
+  auto d_values_in = cuda::make_constant_iterator(cuda::make_counting_iterator(value_t{0}));
+
+  const auto make_keys_output = [=] {
+    return c2h::device_vector<key_t>(guard + num_segments * output_width + guard, key_sentinel);
+  };
+  const auto make_values_output = [=] {
+    return c2h::device_vector<value_t>(guard + num_segments * output_width + guard, val_sentinel);
+  };
+  auto compact_keys = make_keys_output();
+  auto compact_vals = make_values_output();
+  auto padded_keys  = make_keys_output();
+  auto padded_vals  = make_values_output();
+
+  const auto make_output_it = [=](auto& storage) {
+    auto output_ptr = thrust::raw_pointer_cast(storage.data()) + guard;
+    return cuda::make_strided_iterator(cuda::make_counting_iterator(output_ptr), output_width);
+  };
+  auto d_compact_keys = make_output_it(compact_keys);
+  auto d_compact_vals = make_output_it(compact_vals);
+  auto d_padded_keys  = make_output_it(padded_keys);
+  auto d_padded_vals  = make_output_it(padded_vals);
+
+  auto segment_sizes = cuda::args::deferred_sequence{
+    thrust::raw_pointer_cast(d_segment_sizes.data()), cuda::args::bounds<seg_size_t{-1}, seg_size_t{5}>()};
+  auto k_arg = cuda::args::deferred_sequence{
+    thrust::raw_pointer_cast(d_k.data()), cuda::args::bounds<seg_size_t{-1}, seg_size_t{4}>()};
+  auto num_segs = cuda::args::immediate{cuda::std::int64_t{num_segments}};
+
+  CAPTURE(Direction, Determinism, TieBreak);
+
+  skip_unless_batched_topk_pairs_supported<Direction, Determinism, TieBreak>(
+    /*static_max_segment_size=*/5,
+    d_keys_in,
+    d_compact_keys,
+    d_values_in,
+    d_compact_vals,
+    segment_sizes,
+    k_arg,
+    num_segs);
+
+  batched_topk_pairs<Direction, Determinism, TieBreak>(
+    d_keys_in, d_compact_keys, d_values_in, d_compact_vals, segment_sizes, k_arg, num_segs);
+  batched_topk_pairs_with_padding<Direction, Determinism, TieBreak>(
+    d_keys_in,
+    d_padded_keys,
+    d_values_in,
+    d_padded_vals,
+    segment_sizes,
+    k_arg,
+    num_segs,
+    cub::DeviceBatchedTopK::OutputPadding(key_pad, val_pad));
+
+  const auto verify =
+    [&](const c2h::device_vector<key_t>& keys, const c2h::device_vector<value_t>& values, bool expect_padding) {
+      c2h::host_vector<key_t> h_keys     = keys;
+      c2h::host_vector<value_t> h_values = values;
+
+      for (int i = 0; i < guard; ++i)
+      {
+        REQUIRE(h_keys[i] == key_sentinel);
+        REQUIRE(h_keys[guard + num_segments * output_width + i] == key_sentinel);
+        REQUIRE(h_values[i] == val_sentinel);
+        REQUIRE(h_values[guard + num_segments * output_width + i] == val_sentinel);
+      }
+
+      for (int segment = 0; segment < num_segments; ++segment)
+      {
+        const int segment_size = (std::max) (int{h_segment_sizes[segment]}, 0);
+        const int requested    = (std::max) (int{h_k[segment]}, 0);
+        const int valid        = (std::min) (requested, segment_size);
+        const int output_base  = guard + segment * output_width;
+        const int input_base   = segment * input_stride;
+
+        std::vector<std::pair<key_t, value_t>> selected;
+        for (int item = 0; item < valid; ++item)
+        {
+          selected.emplace_back(h_keys[output_base + item], h_values[output_base + item]);
+        }
+        std::sort(selected.begin(), selected.end());
+
+        const int first_key =
+          Direction == cub::detail::topk::select::min ? input_base : input_base + segment_size - valid;
+        for (int item = 0; item < valid; ++item)
+        {
+          const key_t expected_key = first_key + item;
+          REQUIRE(selected[item].first == expected_key);
+          REQUIRE(selected[item].second == expected_key - input_base);
+        }
+        for (int item = valid; item < requested; ++item)
+        {
+          REQUIRE(h_keys[output_base + item] == (expect_padding ? key_pad : key_sentinel));
+          REQUIRE(h_values[output_base + item] == (expect_padding ? val_pad : val_sentinel));
+        }
+        for (int item = requested; item < output_width; ++item)
+        {
+          REQUIRE(h_keys[output_base + item] == key_sentinel);
+          REQUIRE(h_values[output_base + item] == val_sentinel);
+        }
+      }
+    };
+
+  verify(compact_keys, compact_vals, false);
+  verify(padded_keys, padded_vals, true);
+}
+
+// Exercise both implementation backends without multiplying the broad key-type/static-bound Cartesian product of the
+// existing variable-size/per-segment-k test. The deterministic case is only run where the cluster backend is available.
+template <cub::detail::topk::select Direction>
+void check_batched_topk_pairs_output_padding_backends()
+{
+  check_batched_topk_pairs_output_padding<Direction,
+                                          cuda::execution::determinism::__determinism_t::__not_guaranteed,
+                                          cuda::execution::tie_break::__tie_break_t::__unspecified>();
+
+  if (!batched_topk_backend_unavailable<cuda::execution::determinism::__determinism_t::__gpu_to_gpu,
+                                        cuda::execution::tie_break::__tie_break_t::__prefer_smaller_index>(5))
+  {
+    check_batched_topk_pairs_output_padding<Direction,
+                                            cuda::execution::determinism::__determinism_t::__gpu_to_gpu,
+                                            cuda::execution::tie_break::__tie_break_t::__prefer_smaller_index>();
+  }
+}
 
 // Consistency check: ensures values remain associated with their corresponding keys
 template <typename KeyT, typename ValueT>
@@ -2303,4 +2525,16 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with variable-size segments and
     keys_out_buffer, num_segments, compacted_offsets.cbegin(), compacted_offsets.cbegin() + 1, direction);
 
   REQUIRE(expected_keys == keys_out_buffer);
+
+#if TEST_TYPES == 0
+  // Extend this existing variable-size/per-segment-k test with fixed-width materialization. Restrict the focused
+  // contract matrix to one representative key/static-k instantiation; direction remains this test's Cartesian axis.
+  if constexpr (cuda::std::is_same_v<key_t, cuda::std::uint8_t> && static_max_k == 32)
+  {
+    SECTION("default output leaves both tails untouched; OutputPadding fills them through the requested per-row k")
+    {
+      check_batched_topk_pairs_output_padding_backends<direction>();
+    }
+  }
+#endif // TEST_TYPES == 0
 }

--- a/cub/test/catch2_test_device_segmented_topk_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_topk_pairs.cu
@@ -344,16 +344,6 @@ void check_batched_topk_pairs_output_padding()
 
   CAPTURE(Direction, Determinism, TieBreak);
 
-  skip_unless_batched_topk_pairs_supported<Direction, Determinism, TieBreak>(
-    /*static_max_segment_size=*/5,
-    d_keys_in,
-    d_compact_keys,
-    d_values_in,
-    d_compact_vals,
-    segment_sizes,
-    k_arg,
-    num_segs);
-
   batched_topk_pairs<Direction, Determinism, TieBreak>(
     d_keys_in, d_compact_keys, d_values_in, d_compact_vals, segment_sizes, k_arg, num_segs);
   batched_topk_pairs_with_padding<Direction, Determinism, TieBreak>(
@@ -2528,10 +2518,10 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with variable-size segments and
 
 #if TEST_TYPES == 0
   // Extend this existing variable-size/per-segment-k test with fixed-width materialization. Restrict the focused
-  // contract matrix to one representative key/static-k instantiation; direction remains this test's Cartesian axis.
+  // contract matrix to one representative key/static-k/runtime-size instantiation; direction remains an existing axis.
   if constexpr (cuda::std::is_same_v<key_t, cuda::std::uint8_t> && static_max_k == 32)
   {
-    SECTION("default output leaves both tails untouched; OutputPadding fills them through the requested per-row k")
+    if (num_items == min_items)
     {
       check_batched_topk_pairs_output_padding_backends<direction>();
     }


### PR DESCRIPTION
## Description

@humansand

closes #10833

Add opt-in fixed-width output padding to `cub::DeviceBatchedTopK` without changing its existing compact-output contract or any `Min`/`Max` function signature.

- **Contract:** for segment `i`, define `width_i = max(k_i, 0)`, `size_i = max(segment_size_i, 0)`, and `selected_i = min(width_i, size_i)`. Top-K writes selected items to `[0, selected_i)` and, only when requested, writes caller-provided padding values to `[selected_i, width_i)`.
- **Opt-in through existing API:** compose `DeviceBatchedTopK::OutputPadding(key_pad)` for Keys or `OutputPadding(key_pad, value_pad)` for Pairs into the existing `EnvT`, then call the unchanged `MinKeys`, `MaxKeys`, `MinPairs`, or `MaxPairs` signature.
- **Caller requirement:** opted-in output iterators expose at least `width_i` writable positions per segment. Calls without the property preserve the current behavior and may continue allocating only `selected_i` positions.
- **Implementation:** dispatch wraps only opted-in output iterators. The baseline and cluster agents assign the disjoint suffix from their existing Top-K launch; the common no-tail path performs no padding stores. Empty padded batches still launch because their positive-width output must be initialized.
- **Compatibility:** the default output iterator and kernel template types are unchanged. A direct SM100 code-generation comparison against `main` is byte-identical after normalized disassembly.
- **Tests:** padding coverage extends the existing variable-size/per-segment-`k` Keys and Pairs matrices and existing MaxKeys/MinPairs environment-allocation examples. It does not add standalone padding-only test cases.

I searched open issues and pull requests before implementing this. #10812 adds sorted segmented Top-K output through a separate post-processing kernel and explicitly leaves fusion out of scope; #9278 adds a maximum-total-items guarantee. Neither implements opt-in unused-tail materialization, and no matching open work was found.

### Reference consumer

The initial implementation and motivating integration is [flashinfer-ai/flashinfer#4442](https://github.com/flashinfer-ai/flashinfer/pull/4442), which adds the CUB `DeviceBatchedTopK` backend and its fused page-table and ragged transform APIs to FlashInfer.

The pushed FlashInfer branch [`zianglih:agent/cub-cccl-padding-reference`](https://github.com/zianglih/flashinfer/tree/agent/cub-cccl-padding-reference), specifically [commit `01af1b18`](https://github.com/zianglih/flashinfer/commit/01af1b185c58e180e55835b6288d8f380ff61968), is a concrete consumer of this candidate CCCL commit. It is based on the open FlashInfer CUB branch and:

- pins its CCCL submodule to this candidate commit;
- composes `OutputPadding(-1, -1)` into the existing `MaxPairs(..., env)` call for variable-length page-table and ragged transforms;
- preserves the `-1` sentinel before page-table lookup or ragged offset translation; and
- removes FlashInfer's separate post-Top-K tail kernel while leaving plain `top_k` on the unchanged unpadded specialization.

On the same CUDA 13.2 B200 system, a cold JIT build of that branch passed 6 focused forced-CUB tests and a 146-case transform/replay/workspace/tie suite. Three adjacent local-tail / CCCL-fused / local-tail sweeps at the GLM-5 shape (`fp32`, 16 rows, width 202752, `k=2048`, smaller-index tie break) showed median reductions of 1.4% for page-table/full, 1.8% for page-table/mixed, 5.1% for ragged/full, and 6.0% for ragged/mixed; short-row stress cases improved by 42–49%. The exact test commands and complete per-sweep medians are in the [FlashInfer integration evidence](https://gist.github.com/zianglih/b14833dba95bdfbcddbf677a22d6892f#file-flashinfer_cccl_integration_b200_results-md).

This branch is reference code only, not a requested integration target for this CCCL PR. The CCCL change has no FlashInfer dependency, no FlashInfer submodule update, and no downstream merge requirement. [NaderAlAwar/flashinfer#1](https://github.com/NaderAlAwar/flashinfer/pull/1) remains the independently mergeable two-kernel fallback until an upstream CCCL revision is available for a separate adoption change.

### Validation

Environment:

- `nvcr.io/nvidia/pytorch:26.05-py3`
- NVIDIA B200 (SM100), driver 580.126.09
- CUDA 13.2, `nvcc` 13.2.78
- GCC 13.3.0, C++/CUDA C++17
- Base commit `4a94f9f6445f47a5cf5978b1d0eed4ed524e5546`

Commands:

```bash
export CCCL_BUILD_INFIX=padding
cmake --preset cub-cpp17 -DCMAKE_CUDA_ARCHITECTURES=native
cmake --build --preset cub-cpp17 --target \
  cub.test.device.segmented_topk_keys \
  cub.test.device.segmented_topk_pairs \
  cub.test.device.batched_topk_api \
  cub.test.device.batched_topk_env_api -- -j8
ctest --preset cub-cpp17 \
  -R '^cub\.test\.device\.(segmented_topk_(keys|pairs)|batched_topk(_env)?_api)\.' \
  --output-on-failure -j8
pre-commit run --files \
  cub/cub/agent/agent_batched_topk.cuh \
  cub/cub/agent/agent_batched_topk_cluster.cuh \
  cub/cub/device/device_batched_topk.cuh \
  cub/cub/device/dispatch/dispatch_batched_topk.cuh \
  cub/test/catch2_test_device_batched_topk_env_api.cu \
  cub/test/catch2_test_device_segmented_topk_keys.cu \
  cub/test/catch2_test_device_segmented_topk_pairs.cu
```

The targeted build completed without errors. Complete CTest output:

```text
Test project /hai-workspace/cccl-padding/build/padding/cub-cpp17
      Start   1: generate_resource_spec
 1/15 Test   #1: generate_resource_spec ...............................   Passed    5.85 sec
      Start 530: cub.test.device.segmented_topk_keys.lid_0.types_2
      Start 533: cub.test.device.segmented_topk_keys.lid_2.types_2
      Start 528: cub.test.device.segmented_topk_keys.lid_0.types_0
      Start 531: cub.test.device.segmented_topk_keys.lid_2.types_0
      Start 529: cub.test.device.segmented_topk_keys.lid_0.types_1
      Start 532: cub.test.device.segmented_topk_keys.lid_2.types_1
      Start 535: cub.test.device.segmented_topk_pairs.lid_0.types_1
      Start 538: cub.test.device.segmented_topk_pairs.lid_2.types_1
 2/15 Test #532: cub.test.device.segmented_topk_keys.lid_2.types_1 ....   Passed   14.66 sec
      Start 536: cub.test.device.segmented_topk_pairs.lid_0.types_2
 3/15 Test #538: cub.test.device.segmented_topk_pairs.lid_2.types_1 ...   Passed   14.97 sec
      Start 537: cub.test.device.segmented_topk_pairs.lid_2.types_0
 4/15 Test #529: cub.test.device.segmented_topk_keys.lid_0.types_1 ....   Passed   16.27 sec
      Start 534: cub.test.device.segmented_topk_pairs.lid_0.types_0
 5/15 Test #535: cub.test.device.segmented_topk_pairs.lid_0.types_1 ...   Passed   17.38 sec
      Start 539: cub.test.device.segmented_topk_pairs.lid_2.types_2
 6/15 Test #528: cub.test.device.segmented_topk_keys.lid_0.types_0 ....   Passed   19.76 sec
      Start 121: cub.test.device.batched_topk_api.lid_0
 7/15 Test #121: cub.test.device.batched_topk_api.lid_0 ...............   Passed    1.45 sec
      Start 122: cub.test.device.batched_topk_env_api.lid_0
 8/15 Test #530: cub.test.device.segmented_topk_keys.lid_0.types_2 ....   Passed   22.52 sec
 9/15 Test #122: cub.test.device.batched_topk_env_api.lid_0 ...........   Passed    1.71 sec
10/15 Test #533: cub.test.device.segmented_topk_keys.lid_2.types_2 ....   Passed   23.29 sec
11/15 Test #531: cub.test.device.segmented_topk_keys.lid_2.types_0 ....   Passed   23.91 sec
12/15 Test #539: cub.test.device.segmented_topk_pairs.lid_2.types_2 ...   Passed    9.09 sec
13/15 Test #534: cub.test.device.segmented_topk_pairs.lid_0.types_0 ...   Passed   10.64 sec
14/15 Test #536: cub.test.device.segmented_topk_pairs.lid_0.types_2 ...   Passed   12.51 sec
15/15 Test #537: cub.test.device.segmented_topk_pairs.lid_2.types_0 ...   Passed   12.50 sec

100% tests passed, 0 tests failed out of 15

Total Test time (real) = 33.35 sec
```

The matrix covers default untouched tails and opt-in padding; negative, empty, short, exact-`k`, and longer-than-`k` segments; negative/zero/per-segment `k`; Min/Max; baseline and cluster backends; host and graph launch helpers; front/back canaries; pair association; and environment-managed allocation.

All scoped pre-commit hooks passed, including clang-format, codespell, leaked-secret detection, and CUB test memory classification.

### Default-path code generation

I compiled the same default-only deterministic SM100 `MaxPairs` specialization from upstream `main` and this candidate, normalized `cuobjdump --dump-sass`, and diffed the results:

The standalone benchmark, SASS helper, commands, and complete raw results are retained in [this reproducibility gist](https://gist.github.com/zianglih/b14833dba95bdfbcddbf677a22d6892f). From a CUDA 13.2 B200 environment:

```bash
gh gist clone b14833dba95bdfbcddbf677a22d6892f cccl-padding-validation
cd cccl-padding-validation
./compare_cccl_batched_topk_default_sass.sh \
  /path/to/candidate-cccl origin/main ./artifacts/sass
./run_cccl_batched_topk_padding_bench.sh \
  /path/to/candidate-cccl ./artifacts/perf
```

```text
738e1774d15aeae7cb210f08b26e4324fd8b6ea6b9dae19027c71f2fc2178817  baseline.sass
738e1774d15aeae7cb210f08b26e4324fd8b6ea6b9dae19027c71f2fc2178817  candidate.sass
PASS: default-only DeviceBatchedTopK SASS is byte-identical after normalization
```

### Performance

Focused operator benchmark:

- FP32 scores, int32 row-local indices, discarded key output
- 16 rows, width 202752, `k=2048` (GLM-5-shaped)
- `gpu_to_gpu`, `prefer_smaller_index`, unsorted output
- cold L2, with the cache flush synchronized before every timed interval
- 20 warmups and 100 CUDA-event samples per cell
- three same-GPU sweeps; each uses separate-tail A1 / fused B / separate-tail A2

`control` is the existing unpadded call. `separate` runs the existing call followed by a tail-only kernel. `fused` uses `OutputPadding` and emits the suffix in the existing Top-K launch. Complete median timings in microseconds:

| Sweep | Pattern | Control | A1 separate | B fused | A2 separate |
|---:|---|---:|---:|---:|---:|
| 1 | full | 42.832 | 44.288 | 43.696 | 44.448 |
| 1 | mixed | 42.528 | 43.984 | 43.056 | 44.096 |
| 1 | short | 19.776 | 21.200 | 20.448 | 21.264 |
| 2 | full | 43.392 | 44.576 | 44.096 | 44.512 |
| 2 | mixed | 42.720 | 44.432 | 43.328 | 44.096 |
| 2 | short | 19.936 | 21.472 | 20.512 | 21.024 |
| 3 | full | 42.816 | 44.224 | 43.792 | 44.272 |
| 3 | mixed | 42.272 | 43.920 | 42.944 | 43.808 |
| 3 | short | 19.648 | 20.928 | 20.288 | 20.816 |

- `full`: every segment length is 202752; padding performs no stores.
- `mixed`: lengths cycle through `[202752, 131072, 65536, 32768, 16384, 8192, 4096, 2048]`; padding performs no stores.
- `short`: lengths cycle through `[2047, 0, 2048, 1]`; partial and fully padded suffixes are written.

Using `(A1 + A2) / 2` as each sweep's paired separate-tail reference, the median paired result across the three sweeps is:

| Pattern | Fused vs separate tail | Fused overhead vs control | Separate overhead vs control |
|---|---:|---:|---:|
| full | 1.03% lower latency (1.010x) | +2.02% | +3.34% |
| mixed | 2.11% lower latency (1.022x) | +1.42% | +3.61% |
| short | 3.46% lower latency (1.036x) | +3.26% | +6.58% |

The gain is consistent but modest: fusing removes one launch and roughly halves the padding overhead for this shape, while Top-K selection remains the dominant cost.

Limitations:

- performance and SASS evidence are from one B200/SM100 system and one GLM-5-shaped `k=2048` workload;
- this is an operator-level benchmark, not end-to-end FlashInfer or SGLang throughput;
- the `full` and `mixed` cases measure the launch/control overhead when no suffix stores are needed; `short` exercises actual suffix writes;
- the linked FlashInfer consumer branch is reference code, while its current PR remains on the independently mergeable local tail-kernel fallback until an upstream CCCL revision is available.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
