### PR TITLE
Fix infinite bin levels in DeviceHistogram tests and re-enable float

### DIFF
--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -168,6 +168,38 @@ auto compute_reference_result(
   return h_histogram;
 }
 
+// Computes the [lower_level, upper_level] sample range for a channel with `num_bins` bins, laid out inside
+// [0:max_level]. The range gets narrower the fewer bins a channel uses. Example:
+//    max_level = 256
+//   num_levels = { 257, 129,  65 }
+//  lower_level = {   0,  64,  96 }
+//  upper_level = { 256, 192, 160 }
+//
+// The bounds are derived by shrinking [0:max_level] by the bins the channel does not use, instead of growing
+// `num_bins * min_bin_width` around the center. The latter rounds up beyond max_level and thus yields infinity when
+// max_level is the maximum of a floating point LevelT, see NVIDIA/cccl#1793.
+template <typename LevelT>
+auto compute_bin_range(int num_bins, LevelT max_level, int max_level_count) -> array<LevelT, 2>
+{
+  const auto min_bin_width = max_level / (max_level_count - 1);
+  REQUIRE(min_bin_width > 0);
+
+  const int unused_bins       = (max_level_count - 1) - num_bins;
+  const int unused_bins_below = unused_bins / 2;
+  const int unused_bins_above = unused_bins - unused_bins_below;
+
+  const auto lower_level = static_cast<LevelT>(unused_bins_below * min_bin_width);
+  const auto upper_level = static_cast<LevelT>(max_level - unused_bins_above * min_bin_width);
+  // `lower_level < upper_level` alone does not catch an overflow to +/-infinity, which is how #1793 went unnoticed
+  if constexpr (!cs::is_unsigned_v<LevelT>)
+  {
+    REQUIRE(lower_level >= LevelT{});
+  }
+  REQUIRE(upper_level <= max_level);
+  REQUIRE(lower_level < upper_level);
+  return {lower_level, upper_level};
+}
+
 template <size_t ActiveChannels, typename LevelT>
 auto setup_bin_levels_for_even(const array<int, ActiveChannels>& num_levels, LevelT max_level, int max_level_count)
   -> array<array<LevelT, ActiveChannels>, 2>
@@ -176,25 +208,14 @@ auto setup_bin_levels_for_even(const array<int, ActiveChannels>& num_levels, Lev
   auto& lower_level = levels[0];
   auto& upper_level = levels[1];
 
-  // Create upper and lower levels between between [0:max_level], getting narrower with each channel. Example:
-  //    max_level = 256
-  //   num_levels = { 257, 129,  65 }
-  //  lower_level = {   0,  64,  96 }
-  //  upper_level = { 256, 192, 160 }
-
   // TODO(bgruber): eventually, we could just pick a random lower/upper bound for each channel
-
-  const auto min_bin_width = max_level / (max_level_count - 1);
-  REQUIRE(min_bin_width > 0);
 
   for (size_t c = 0; c < ActiveChannels; ++c)
   {
-    const int num_bins        = num_levels[c] - 1;
-    const auto min_hist_width = num_bins * min_bin_width;
-    lower_level[c]            = static_cast<LevelT>(max_level / 2 - min_hist_width / 2);
-    upper_level[c]            = static_cast<LevelT>(max_level / 2 + min_hist_width / 2);
     CAPTURE(c, num_levels[c]);
-    REQUIRE(lower_level[c] < upper_level[c]);
+    const auto [lower, upper] = compute_bin_range(num_levels[c] - 1, max_level, max_level_count);
+    lower_level[c]            = lower;
+    upper_level[c]            = upper;
   }
   return levels;
 }
@@ -206,18 +227,20 @@ auto setup_bin_levels_for_range(const array<int, ActiveChannels>& num_levels, Le
   // TODO(bgruber): eventually, we could just pick random levels for each channel
 
   const auto min_bin_width = max_level / (max_level_count - 1);
-  REQUIRE(min_bin_width > 0);
 
   array<c2h::host_vector<LevelT>, ActiveChannels> levels;
   for (size_t c = 0; c < ActiveChannels; ++c)
   {
+    CAPTURE(c, num_levels[c]);
     levels[c].resize(num_levels[c]);
     const int num_bins        = num_levels[c] - 1;
-    const auto min_hist_width = num_bins * min_bin_width;
-    const auto lower_level    = (max_level / 2 - min_hist_width / 2);
+    const auto [lower, upper] = compute_bin_range(num_bins, max_level, max_level_count);
     for (int l = 0; l < num_levels[c]; ++l)
     {
-      levels[c][l] = static_cast<LevelT>(lower_level + l * min_bin_width);
+      // The last level is taken from the range instead of being computed, because `lower + num_bins * min_bin_width`
+      // rounds up beyond max_level and thus yields infinity when max_level is the maximum of a floating point LevelT,
+      // see NVIDIA/cccl#1793.
+      levels[c][l] = (l == num_bins) ? upper : static_cast<LevelT>(lower + l * min_bin_width);
       if (l > 0)
       {
         REQUIRE(levels[c][l - 1] < levels[c][l]);
@@ -523,9 +546,8 @@ CUB_TEST("DeviceHistogram::Histogram* basic use", "[histogram][device]", CUB_SMA
   test_even_and_range<sample_t, 4, 3, int>(max_level, max_level_count, 1920, 1080);
 }
 
-// TODO(bgruber): float produces INFs in the HistogramRange test setup AND the HistogramEven implementation
 // This test covers int32 and int64 arithmetic for bin computation
-CUB_TEST("DeviceHistogram::Histogram* large levels", "[histogram][device]", CUB_SMALL, c2h::remove<types, float>)
+CUB_TEST("DeviceHistogram::Histogram* large levels", "[histogram][device]", CUB_SMALL, types)
 {
   using sample_t             = c2h::get<0, TestType>;
   using level_t              = sample_t;


### PR DESCRIPTION
## Problem

The `DeviceHistogram::Histogram* large levels` test excludes `float`, with a `TODO` noting that it produces INFs. Re-enabling it fails immediately:

```
catch2_test_device_histogram.cu(223): FAILED:
  CATCH_REQUIRE( levels[c][l - 1] < levels[c][l] )
with expansion:
  -inff < -inff

lower_level := { -inff, 8.44e37f, 1.27e38f }
upper_level := {  inff, 2.55e38f, 2.13e38f }
```

The level setup computes `min_bin_width = max_level / (max_level_count - 1)`, which rounds up for floating point types. `num_bins * min_bin_width` therefore exceeds `max_level` and overflows to infinity when `max_level` is the maximum of the type, and centering the range as `max_level / 2 +/- inf / 2` yields `lower_level = -inf`, `upper_level = +inf` for the channel that uses all bins. Channels using fewer bins stay finite, which is why only the first channel is affected.

Two things follow from that:

- The overflow is not specific to `float`. `double` is affected as well and only escapes because the test divides `max_level` by `max_level_count - 1` for types wider than `int`.
- The `HistogramEven` failure mentioned in the `TODO` is a downstream effect, not a separate bug in the implementation. `MayOverflow` returns `false` for floating point, and the reference bin index in the test uses the same formula as `ScaleTransform`; both just evaluate to NaN once the levels are infinite. No change to `dispatch_histogram.cuh` is needed.

## Fix

Derive the sample range by shrinking `[0:max_level]` by the bins a channel does not use, instead of growing `num_bins * min_bin_width` around the center:

```cpp
const int unused_bins       = (max_level_count - 1) - num_bins;
const int unused_bins_below = unused_bins / 2;
const int unused_bins_above = unused_bins - unused_bins_below;

const auto lower_level = static_cast<LevelT>(unused_bins_below * min_bin_width);
const auto upper_level = static_cast<LevelT>(max_level - unused_bins_above * min_bin_width);
```

The bins removed from the range are always fewer than the bins a channel uses, so every intermediate value stays within `[0:max_level]` and cannot overflow, for any `LevelT` and any `max_level_count`. `HistogramRange` takes its last level from that range for the same reason, rather than computing `lower + num_bins * min_bin_width`.

`lower_level < upper_level` does not reject `-inf < +inf`, which is how this went unnoticed, so the helper also checks that the range stays within `[0:max_level]`. Restoring the old arithmetic makes that assertion fire with `-inff >= 0.0f` instead of failing later somewhere else.

The ranges of the example in the comment are unchanged. For integral types the range now extends to the maximum of the type instead of stopping one bin short, so coverage widens slightly.

## Verification

Local runs on Windows, MSVC 14.50, CTK 13.3, RTX 5070 (sm_120):

- `cub.test.device.histogram.lid_0`: 40 test cases, 55511 assertions, all passing
- `cub.test.device.histogram.lid_2`: 33 test cases, 56274 assertions, all passing
- `large levels` re-run 20 times with 20 distinct seeds, no failures

Sweeping the old and new arithmetic over `max_level_count = 2..4096` and every `num_bins`, with `max_level = numeric_limits<T>::max()`:

| formula | float violations | double violations |
| --- | --- | --- |
| old | 610 (first at `max_level_count = 26`) | 748 (first at `max_level_count = 4`) |
| new | 0 | 0 |

A violation is a non-finite bound, a bound outside `[0:max_level]`, or `lower >= upper`. Checking the full level sequences of the range path over `max_level_count = 2..512` gives 22500352 levels per type with no violations.

Fixes #1793
