### PR TITLE
Give CUB's NVRTC test the 8 MiB stack it needs on MSVC

### DIFF
--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -251,6 +251,13 @@ function(
         ${test_target}
         PRIVATE "${CMAKE_CURRENT_BINARY_DIR}"
       )
+      # NVRTC's frontend recurses deeply while parsing the block-level primitives compiled by this
+      # test and overflows MSVC's 1 MiB default stack, see NVIDIA/cccl#9612. Give the main thread the
+      # 8 MiB that Linux provides by default, which is the size libnvcc's frontend worker uses for the
+      # same reason, see c/parallel.v2/src/hostjit/libnvcc/compiler.cpp.
+      if (MSVC)
+        target_link_options(${test_target} PRIVATE "/STACK:8388608") # 8 MiB
+      endif()
     endif()
 
     if ("${test_src}" MATCHES "test_iterator\\.cu$")


### PR DESCRIPTION
## Problem

`cub.test.nvrtc` crashes on MSVC:

```
catch2_test_nvrtc.cu(268): FAILED:
  {Unknown expression after the reported line}
due to a fatal error condition:
  SIGSEGV - Stack overflow

exit code -1073741571 (0xC00000FD = STATUS_STACK_OVERFLOW)
```

#9612 records the cause as unknown. Catch2 attributes a fatal SEH exception to the last completed assertion and prints `{Unknown expression after the reported line}`, so the reported line is `nvrtcCreateProgram` rather than the call that actually crashes, which is the `nvrtcCompileProgram` below it.

It is a plain stack exhaustion. NVRTC's frontend recurses deeply while parsing the block-level primitives this test compiles, and MSVC links executables with a 1 MiB default stack while Linux gives 8 MiB.

Rewriting the stack reserve of one already linked binary, with nothing else changed, is enough to flip the outcome:

| stack reserve | result |
| --- | --- |
| 1.0 MiB (MSVC default) | `SIGSEGV - Stack overflow` |
| 1.5 MiB | passes |
| 2 / 3 / 4 / 6 / 8 MiB | passes (538 assertions) |

## Fix

Request 8 MiB from the linker for this target on MSVC. Three things point at that number:

- It is what Linux provides by default, so the platforms stop differing.
- It is more than five times the measured requirement, which sits between 1.0 and 1.5 MiB.
- `libnvcc` already picks the same size for its frontend worker thread for exactly this reason, see `kFrontendStackSize` in `c/parallel.v2/src/hostjit/libnvcc/compiler.cpp`, whose comment reads "the frontend overflows on heavier kernels such as radix_sort / segmented_reduce; Linux's 8 MB default hides it".

A link option is enough here because this is an executable. `libnvcc` has to size a thread it creates itself, since as a library it cannot control how the application linking it is linked.

## Verification

Windows, MSVC 14.50, CTK 13.3, RTX 5070 (sm_120). Every configuration was verified in both directions: that the crash reproduces there, and that the fix resolves it. `all_stds` is `[17, 20]`, so the standard axis is covered rather than sampled.

| configuration | at 1 MiB | with the fix |
| --- | --- | --- |
| C++17 Release | `SIGSEGV - Stack overflow` | 10/10 runs pass |
| C++20 Release | `SIGSEGV - Stack overflow` | 10/10 runs pass |
| C++17 Debug | `SIGSEGV - Stack overflow` | 10/10 runs pass |
| C++20 Debug | `SIGSEGV - Stack overflow` | 10/10 runs pass |

Each build was configured from scratch. Of the 571 executable link edges in the generated `build.ninja`, exactly one carries `/STACK:8388608`, and it is `bin\cub.test.nvrtc.exe`.

Not covered locally, since I do not have the toolchains: non-MSVC hosts (the block does not execute there), MSVC older than 14.50, clang-cl, and CTK 12.x. The requirement comes from NVRTC rather than the host compiler, and the margin above is wide, but those axes rely on CI.

## Notes

This should let #5725 drop `MSVC` from `unsupported_nvrtc_host_compilers` and build the test on Windows.

The same in-process NVRTC pattern exists in `c/parallel/test/test_util.h` and `libcudacxx/test/utils/nvidia/nvrtc/nvrtcc_build.h`. I left those alone to keep this change scoped to #9612. For the `c/parallel` side, #10802 already reaches the same conclusion independently: "The working hypothesis is incomplete Windows stack protection [...] LLVM linking, optimization/codegen, nvJitLink, and LLD still execute on the caller's default 1 MiB stack." Happy to widen the fix if you would rather handle them together.

Fixes #9612
