### PR TITLE
[libcudacxx] Implement ranges::find_last, find_last_if and find_last_if_not

### DIFF
--- a/docs/libcudacxx/standard_api/algorithms_library.rst
+++ b/docs/libcudacxx/standard_api/algorithms_library.rst
@@ -28,7 +28,18 @@ Extensions
 Restrictions
 ------------
 
-  - Algorithms in namespace `ranges` are not yet supported.
+  - Only a subset of the algorithms in namespace `ranges` is supported:
+
+    * ``find_if``
+    * ``find_if_not``
+    * ``find_last``
+    * ``find_last_if``
+    * ``find_last_if_not``
+    * ``for_each``
+    * ``for_each_n``
+    * ``min``
+    * ``min_element``
+
   - Some sorting algorithms are not yet supported:
 
     * ``inplace_merge``

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_find_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_find_if.h
@@ -37,8 +37,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 _CCCL_BEGIN_NAMESPACE_CPO(__find_if)
 struct __fn
 {
-  template <class _Ip, class _Sp, class _Pred, class _Proj>
-  _CCCL_API static constexpr _Ip __find_if_impl(_Ip __first, _Sp __last, _Pred& __pred, _Proj& __proj)
+  template <class _Iter, class _Sp, class _Pred, class _Proj>
+  _CCCL_API static constexpr _Iter __find_if_impl(_Iter __first, _Sp __last, _Pred& __pred, _Proj& __proj)
   {
     for (; __first != __last; ++__first)
     {
@@ -50,11 +50,11 @@ struct __fn
     return __first;
   }
 
-  _CCCL_TEMPLATE(class _Ip, class _Sp, class _Pred, class _Proj = identity)
-  _CCCL_REQUIRES(input_iterator<_Ip> _CCCL_AND sentinel_for<_Sp, _Ip> _CCCL_AND
-                   indirect_unary_predicate<_Pred, projected<_Ip, _Proj>>)
-  [[nodiscard]] _CCCL_API constexpr _Ip
-  _CCCL_STATIC_CALL_OPERATOR(_Ip __first, _Sp __last, _Pred __pred, _Proj __proj = {})
+  _CCCL_TEMPLATE(class _Iter, class _Sp, class _Pred, class _Proj = identity)
+  _CCCL_REQUIRES(input_iterator<_Iter> _CCCL_AND sentinel_for<_Sp, _Iter> _CCCL_AND
+                   indirect_unary_predicate<_Pred, projected<_Iter, _Proj>>)
+  [[nodiscard]] _CCCL_API constexpr _Iter
+  _CCCL_STATIC_CALL_OPERATOR(_Iter __first, _Sp __last, _Pred __pred, _Proj __proj = {})
   {
     return __find_if_impl(::cuda::std::move(__first), ::cuda::std::move(__last), __pred, __proj);
   }

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_find_if_not.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_find_if_not.h
@@ -37,29 +37,29 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 _CCCL_BEGIN_NAMESPACE_CPO(__find_if_not)
-template <class _Pred>
-struct __not_pred
-{
-  _CCCL_API constexpr __not_pred(_Pred& __pred) noexcept
-      : __pred_(__pred)
-  {}
-
-  _Pred& __pred_;
-
-  template <class _Tp>
-  _CCCL_API constexpr auto operator()(_Tp&& __e) const
-  {
-    return !::cuda::std::invoke(__pred_, ::cuda::std::forward<_Tp>(__e));
-  }
-};
-
 struct __fn
 {
-  _CCCL_TEMPLATE(class _Ip, class _Sp, class _Pred, class _Proj = identity)
-  _CCCL_REQUIRES(input_iterator<_Ip> _CCCL_AND sentinel_for<_Sp, _Ip> _CCCL_AND
-                   indirect_unary_predicate<_Pred, projected<_Ip, _Proj>>)
-  [[nodiscard]] _CCCL_API constexpr _Ip
-  _CCCL_STATIC_CALL_OPERATOR(_Ip __first, _Sp __last, _Pred __pred, _Proj __proj = {})
+  template <class _Pred>
+  struct __not_pred
+  {
+    _CCCL_API constexpr __not_pred(_Pred& __pred) noexcept
+        : __pred_(__pred)
+    {}
+
+    _Pred& __pred_;
+
+    template <class _Tp>
+    [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __e) const
+    {
+      return !::cuda::std::invoke(__pred_, ::cuda::std::forward<_Tp>(__e));
+    }
+  };
+
+  _CCCL_TEMPLATE(class _Iter, class _Sp, class _Pred, class _Proj = identity)
+  _CCCL_REQUIRES(input_iterator<_Iter> _CCCL_AND sentinel_for<_Sp, _Iter> _CCCL_AND
+                   indirect_unary_predicate<_Pred, projected<_Iter, _Proj>>)
+  [[nodiscard]] _CCCL_API constexpr _Iter
+  _CCCL_STATIC_CALL_OPERATOR(_Iter __first, _Sp __last, _Pred __pred, _Proj __proj = {})
   {
     return ::cuda::std::ranges::find_if(
       ::cuda::std::move(__first), ::cuda::std::move(__last), __not_pred{__pred}, ::cuda::std::move(__proj));

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_find_last.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_find_last.h
@@ -37,29 +37,29 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 _CCCL_BEGIN_NAMESPACE_CPO(__find_last)
-template <class _Tp>
-struct __equal_to_value
-{
-  _CCCL_API constexpr __equal_to_value(const _Tp& __value) noexcept
-      : __value_(__value)
-  {}
-
-  const _Tp& __value_;
-
-  template <class _Up>
-  _CCCL_API constexpr auto operator()(_Up&& __e) const
-  {
-    return ::cuda::std::forward<_Up>(__e) == __value_;
-  }
-};
-
 struct __fn
 {
-  _CCCL_TEMPLATE(class _Ip, class _Sp, class _Tp, class _Proj = identity)
-  _CCCL_REQUIRES(forward_iterator<_Ip> _CCCL_AND sentinel_for<_Sp, _Ip> _CCCL_AND
-                   indirect_binary_predicate<equal_to, projected<_Ip, _Proj>, const _Tp*>)
-  [[nodiscard]] _CCCL_API constexpr subrange<_Ip>
-  _CCCL_STATIC_CALL_OPERATOR(_Ip __first, _Sp __last, const _Tp& __value, _Proj __proj = {})
+  template <class _Tp>
+  struct __equal_to_value
+  {
+    _CCCL_API constexpr __equal_to_value(const _Tp& __value) noexcept
+        : __value_(__value)
+    {}
+
+    const _Tp& __value_;
+
+    template <class _Up>
+    [[nodiscard]] _CCCL_API constexpr auto operator()(_Up&& __e) const
+    {
+      return ::cuda::std::forward<_Up>(__e) == __value_;
+    }
+  };
+
+  _CCCL_TEMPLATE(class _Iter, class _Sp, class _Tp, class _Proj = identity)
+  _CCCL_REQUIRES(forward_iterator<_Iter> _CCCL_AND sentinel_for<_Sp, _Iter> _CCCL_AND
+                   indirect_binary_predicate<equal_to, projected<_Iter, _Proj>, const _Tp*>)
+  [[nodiscard]] _CCCL_API constexpr subrange<_Iter>
+  _CCCL_STATIC_CALL_OPERATOR(_Iter __first, _Sp __last, const _Tp& __value, _Proj __proj = {})
   {
     __equal_to_value<_Tp> __pred{__value};
     return __find_last_if::__fn::__find_last_if_impl(

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_find_last.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_find_last.h
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___ALGORITHM_RANGES_FIND_LAST_H
+#define _CUDA_STD___ALGORITHM_RANGES_FIND_LAST_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/ranges_find_last_if.h>
+#include <cuda/std/__functional/identity.h>
+#include <cuda/std/__functional/ranges_operations.h>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/projected.h>
+#include <cuda/std/__ranges/access.h>
+#include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/__ranges/dangling.h>
+#include <cuda/std/__ranges/subrange.h>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/move.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
+
+_CCCL_BEGIN_NAMESPACE_CPO(__find_last)
+template <class _Tp>
+struct __equal_to_value
+{
+  _CCCL_API constexpr __equal_to_value(const _Tp& __value) noexcept
+      : __value_(__value)
+  {}
+
+  const _Tp& __value_;
+
+  template <class _Up>
+  _CCCL_API constexpr auto operator()(_Up&& __e) const
+  {
+    return ::cuda::std::forward<_Up>(__e) == __value_;
+  }
+};
+
+struct __fn
+{
+  _CCCL_TEMPLATE(class _Ip, class _Sp, class _Tp, class _Proj = identity)
+  _CCCL_REQUIRES(forward_iterator<_Ip> _CCCL_AND sentinel_for<_Sp, _Ip> _CCCL_AND
+                   indirect_binary_predicate<equal_to, projected<_Ip, _Proj>, const _Tp*>)
+  [[nodiscard]] _CCCL_API constexpr subrange<_Ip>
+  _CCCL_STATIC_CALL_OPERATOR(_Ip __first, _Sp __last, const _Tp& __value, _Proj __proj = {})
+  {
+    __equal_to_value<_Tp> __pred{__value};
+    return __find_last_if::__fn::__find_last_if_impl(
+      ::cuda::std::move(__first), ::cuda::std::move(__last), __pred, __proj);
+  }
+
+  _CCCL_TEMPLATE(class _Rp, class _Tp, class _Proj = identity)
+  _CCCL_REQUIRES(
+    forward_range<_Rp> _CCCL_AND indirect_binary_predicate<equal_to, projected<iterator_t<_Rp>, _Proj>, const _Tp*>)
+  [[nodiscard]] _CCCL_API constexpr borrowed_subrange_t<_Rp>
+  _CCCL_STATIC_CALL_OPERATOR(_Rp&& __r, const _Tp& __value, _Proj __proj = {})
+  {
+    __equal_to_value<_Tp> __pred{__value};
+    return __find_last_if::__fn::__find_last_if_impl(
+      ::cuda::std::ranges::begin(__r), ::cuda::std::ranges::end(__r), __pred, __proj);
+  }
+};
+_CCCL_END_NAMESPACE_CPO
+
+inline namespace __cpo
+{
+_CCCL_GLOBAL_CONSTANT auto find_last = __find_last::__fn{};
+} // namespace __cpo
+
+_CCCL_END_NAMESPACE_CUDA_STD_RANGES
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___ALGORITHM_RANGES_FIND_LAST_H

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_find_last_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_find_last_if.h
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___ALGORITHM_RANGES_FIND_LAST_IF_H
+#define _CUDA_STD___ALGORITHM_RANGES_FIND_LAST_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__functional/identity.h>
+#include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/next.h>
+#include <cuda/std/__iterator/projected.h>
+#include <cuda/std/__ranges/access.h>
+#include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/__ranges/dangling.h>
+#include <cuda/std/__ranges/subrange.h>
+#include <cuda/std/__utility/move.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
+
+_CCCL_BEGIN_NAMESPACE_CPO(__find_last_if)
+struct __fn
+{
+  template <class _Ip, class _Sp, class _Pred, class _Proj>
+  _CCCL_API static constexpr subrange<_Ip> __find_last_if_impl(_Ip __first, _Sp __last, _Pred& __pred, _Proj& __proj)
+  {
+    // A bidirectional iterator can walk back from the end, so it stops at the first match it sees.
+    if constexpr (bidirectional_iterator<_Ip>)
+    {
+      auto __end = ::cuda::std::ranges::next(__first, __last);
+      for (auto __it = __end; __it != __first;)
+      {
+        if (::cuda::std::invoke(__pred, ::cuda::std::invoke(__proj, *--__it)))
+        {
+          return subrange<_Ip>{__it, __end};
+        }
+      }
+      return subrange<_Ip>{__end, __end};
+    }
+    else
+    {
+      // Otherwise the whole range has to be traversed, remembering the most recent match.
+      _Ip __result = __first;
+      bool __found = false;
+      for (; __first != __last; ++__first)
+      {
+        if (::cuda::std::invoke(__pred, ::cuda::std::invoke(__proj, *__first)))
+        {
+          __result = __first;
+          __found  = true;
+        }
+      }
+      if (!__found)
+      {
+        __result = __first;
+      }
+      return subrange<_Ip>{__result, __first};
+    }
+  }
+
+  _CCCL_TEMPLATE(class _Ip, class _Sp, class _Pred, class _Proj = identity)
+  _CCCL_REQUIRES(forward_iterator<_Ip> _CCCL_AND sentinel_for<_Sp, _Ip> _CCCL_AND
+                   indirect_unary_predicate<_Pred, projected<_Ip, _Proj>>)
+  [[nodiscard]] _CCCL_API constexpr subrange<_Ip>
+  _CCCL_STATIC_CALL_OPERATOR(_Ip __first, _Sp __last, _Pred __pred, _Proj __proj = {})
+  {
+    return __find_last_if_impl(::cuda::std::move(__first), ::cuda::std::move(__last), __pred, __proj);
+  }
+
+  _CCCL_TEMPLATE(class _Rp, class _Pred, class _Proj = identity)
+  _CCCL_REQUIRES(forward_range<_Rp> _CCCL_AND indirect_unary_predicate<_Pred, projected<iterator_t<_Rp>, _Proj>>)
+  [[nodiscard]] _CCCL_API constexpr borrowed_subrange_t<_Rp>
+  _CCCL_STATIC_CALL_OPERATOR(_Rp&& __r, _Pred __pred, _Proj __proj = {})
+  {
+    return __find_last_if_impl(::cuda::std::ranges::begin(__r), ::cuda::std::ranges::end(__r), __pred, __proj);
+  }
+};
+_CCCL_END_NAMESPACE_CPO
+
+inline namespace __cpo
+{
+_CCCL_GLOBAL_CONSTANT auto find_last_if = __find_last_if::__fn{};
+} // namespace __cpo
+
+_CCCL_END_NAMESPACE_CUDA_STD_RANGES
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___ALGORITHM_RANGES_FIND_LAST_IF_H

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_find_last_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_find_last_if.h
@@ -38,27 +38,32 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 _CCCL_BEGIN_NAMESPACE_CPO(__find_last_if)
 struct __fn
 {
-  template <class _Ip, class _Sp, class _Pred, class _Proj>
-  _CCCL_API static constexpr subrange<_Ip> __find_last_if_impl(_Ip __first, _Sp __last, _Pred& __pred, _Proj& __proj)
+  template <class _Iter, class _Sp, class _Pred, class _Proj>
+  [[nodiscard]] _CCCL_API static constexpr subrange<_Iter>
+  __find_last_if_impl(_Iter __first, _Sp __last, _Pred& __pred, _Proj& __proj)
   {
+    if (__first == __last)
+    {
+      return subrange<_Iter>{__first, ::cuda::std::move(__first)};
+    }
+
     // A bidirectional iterator can walk back from the end, so it stops at the first match it sees.
-    if constexpr (bidirectional_iterator<_Ip>)
+    if constexpr (bidirectional_iterator<_Iter>)
     {
       auto __end = ::cuda::std::ranges::next(__first, __last);
       for (auto __it = __end; __it != __first;)
       {
         if (::cuda::std::invoke(__pred, ::cuda::std::invoke(__proj, *--__it)))
         {
-          return subrange<_Ip>{__it, __end};
+          return subrange<_Iter>{::cuda::std::move(__it), ::cuda::std::move(__end)};
         }
       }
-      return subrange<_Ip>{__end, __end};
+      return subrange<_Iter>{__end, ::cuda::std::move(__end)};
     }
     else
-    {
-      // Otherwise the whole range has to be traversed, remembering the most recent match.
-      _Ip __result = __first;
-      bool __found = false;
+    { // Otherwise the whole range has to be traversed, remembering the most recent match.
+      _Iter __result = __first;
+      bool __found   = false;
       for (; __first != __last; ++__first)
       {
         if (::cuda::std::invoke(__pred, ::cuda::std::invoke(__proj, *__first)))
@@ -71,15 +76,15 @@ struct __fn
       {
         __result = __first;
       }
-      return subrange<_Ip>{__result, __first};
+      return subrange<_Iter>{::cuda::std::move(__result), ::cuda::std::move(__first)};
     }
   }
 
-  _CCCL_TEMPLATE(class _Ip, class _Sp, class _Pred, class _Proj = identity)
-  _CCCL_REQUIRES(forward_iterator<_Ip> _CCCL_AND sentinel_for<_Sp, _Ip> _CCCL_AND
-                   indirect_unary_predicate<_Pred, projected<_Ip, _Proj>>)
-  [[nodiscard]] _CCCL_API constexpr subrange<_Ip>
-  _CCCL_STATIC_CALL_OPERATOR(_Ip __first, _Sp __last, _Pred __pred, _Proj __proj = {})
+  _CCCL_TEMPLATE(class _Iter, class _Sp, class _Pred, class _Proj = identity)
+  _CCCL_REQUIRES(forward_iterator<_Iter> _CCCL_AND sentinel_for<_Sp, _Iter> _CCCL_AND
+                   indirect_unary_predicate<_Pred, projected<_Iter, _Proj>>)
+  [[nodiscard]] _CCCL_API constexpr subrange<_Iter>
+  _CCCL_STATIC_CALL_OPERATOR(_Iter __first, _Sp __last, _Pred __pred, _Proj __proj = {})
   {
     return __find_last_if_impl(::cuda::std::move(__first), ::cuda::std::move(__last), __pred, __proj);
   }

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_find_last_if_not.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_find_last_if_not.h
@@ -37,29 +37,29 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 _CCCL_BEGIN_NAMESPACE_CPO(__find_last_if_not)
-template <class _Pred>
-struct __not_pred
-{
-  _CCCL_API constexpr __not_pred(_Pred& __pred) noexcept
-      : __pred_(__pred)
-  {}
-
-  _Pred& __pred_;
-
-  template <class _Tp>
-  _CCCL_API constexpr auto operator()(_Tp&& __e) const
-  {
-    return !::cuda::std::invoke(__pred_, ::cuda::std::forward<_Tp>(__e));
-  }
-};
-
 struct __fn
 {
-  _CCCL_TEMPLATE(class _Ip, class _Sp, class _Pred, class _Proj = identity)
-  _CCCL_REQUIRES(forward_iterator<_Ip> _CCCL_AND sentinel_for<_Sp, _Ip> _CCCL_AND
-                   indirect_unary_predicate<_Pred, projected<_Ip, _Proj>>)
-  [[nodiscard]] _CCCL_API constexpr subrange<_Ip>
-  _CCCL_STATIC_CALL_OPERATOR(_Ip __first, _Sp __last, _Pred __pred, _Proj __proj = {})
+  template <class _Pred>
+  struct __not_pred
+  {
+    _CCCL_API constexpr __not_pred(_Pred& __pred) noexcept
+        : __pred_(__pred)
+    {}
+
+    _Pred& __pred_;
+
+    template <class _Tp>
+    [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __e) const
+    {
+      return !::cuda::std::invoke(__pred_, ::cuda::std::forward<_Tp>(__e));
+    }
+  };
+
+  _CCCL_TEMPLATE(class _Iter, class _Sp, class _Pred, class _Proj = identity)
+  _CCCL_REQUIRES(forward_iterator<_Iter> _CCCL_AND sentinel_for<_Sp, _Iter> _CCCL_AND
+                   indirect_unary_predicate<_Pred, projected<_Iter, _Proj>>)
+  [[nodiscard]] _CCCL_API constexpr subrange<_Iter>
+  _CCCL_STATIC_CALL_OPERATOR(_Iter __first, _Sp __last, _Pred __pred, _Proj __proj = {})
   {
     __not_pred<_Pred> __negated{__pred};
     return __find_last_if::__fn::__find_last_if_impl(

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_find_last_if_not.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_find_last_if_not.h
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___ALGORITHM_RANGES_FIND_LAST_IF_NOT_H
+#define _CUDA_STD___ALGORITHM_RANGES_FIND_LAST_IF_NOT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/ranges_find_last_if.h>
+#include <cuda/std/__functional/identity.h>
+#include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/projected.h>
+#include <cuda/std/__ranges/access.h>
+#include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/__ranges/dangling.h>
+#include <cuda/std/__ranges/subrange.h>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/move.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
+
+_CCCL_BEGIN_NAMESPACE_CPO(__find_last_if_not)
+template <class _Pred>
+struct __not_pred
+{
+  _CCCL_API constexpr __not_pred(_Pred& __pred) noexcept
+      : __pred_(__pred)
+  {}
+
+  _Pred& __pred_;
+
+  template <class _Tp>
+  _CCCL_API constexpr auto operator()(_Tp&& __e) const
+  {
+    return !::cuda::std::invoke(__pred_, ::cuda::std::forward<_Tp>(__e));
+  }
+};
+
+struct __fn
+{
+  _CCCL_TEMPLATE(class _Ip, class _Sp, class _Pred, class _Proj = identity)
+  _CCCL_REQUIRES(forward_iterator<_Ip> _CCCL_AND sentinel_for<_Sp, _Ip> _CCCL_AND
+                   indirect_unary_predicate<_Pred, projected<_Ip, _Proj>>)
+  [[nodiscard]] _CCCL_API constexpr subrange<_Ip>
+  _CCCL_STATIC_CALL_OPERATOR(_Ip __first, _Sp __last, _Pred __pred, _Proj __proj = {})
+  {
+    __not_pred<_Pred> __negated{__pred};
+    return __find_last_if::__fn::__find_last_if_impl(
+      ::cuda::std::move(__first), ::cuda::std::move(__last), __negated, __proj);
+  }
+
+  _CCCL_TEMPLATE(class _Rp, class _Pred, class _Proj = identity)
+  _CCCL_REQUIRES(forward_range<_Rp> _CCCL_AND indirect_unary_predicate<_Pred, projected<iterator_t<_Rp>, _Proj>>)
+  [[nodiscard]] _CCCL_API constexpr borrowed_subrange_t<_Rp>
+  _CCCL_STATIC_CALL_OPERATOR(_Rp&& __r, _Pred __pred, _Proj __proj = {})
+  {
+    __not_pred<_Pred> __negated{__pred};
+    return __find_last_if::__fn::__find_last_if_impl(
+      ::cuda::std::ranges::begin(__r), ::cuda::std::ranges::end(__r), __negated, __proj);
+  }
+};
+_CCCL_END_NAMESPACE_CPO
+
+inline namespace __cpo
+{
+_CCCL_GLOBAL_CONSTANT auto find_last_if_not = __find_last_if_not::__fn{};
+} // namespace __cpo
+
+_CCCL_END_NAMESPACE_CUDA_STD_RANGES
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___ALGORITHM_RANGES_FIND_LAST_IF_NOT_H

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_min_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_min_element.h
@@ -38,11 +38,11 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 _CCCL_BEGIN_NAMESPACE_CPO(__min_element)
 struct __fn
 {
-  _CCCL_TEMPLATE(class _Ip, class _Sp, class _Proj = identity, class _Comp = ::cuda::std::ranges::less)
-  _CCCL_REQUIRES(forward_iterator<_Ip> _CCCL_AND sentinel_for<_Sp, _Ip> _CCCL_AND
-                   indirect_strict_weak_order<_Comp, projected<_Ip, _Proj>>)
-  [[nodiscard]] _CCCL_API constexpr _Ip
-  _CCCL_STATIC_CALL_OPERATOR(_Ip __first, _Sp __last, _Comp __comp = {}, _Proj __proj = {})
+  _CCCL_TEMPLATE(class _Iter, class _Sp, class _Proj = identity, class _Comp = ::cuda::std::ranges::less)
+  _CCCL_REQUIRES(forward_iterator<_Iter> _CCCL_AND sentinel_for<_Sp, _Iter> _CCCL_AND
+                   indirect_strict_weak_order<_Comp, projected<_Iter, _Proj>>)
+  [[nodiscard]] _CCCL_API constexpr _Iter
+  _CCCL_STATIC_CALL_OPERATOR(_Iter __first, _Sp __last, _Comp __comp = {}, _Proj __proj = {})
   {
     return ::cuda::std::__min_element(__first, __last, __comp, __proj);
   }

--- a/libcudacxx/include/cuda/std/algorithm
+++ b/libcudacxx/include/cuda/std/algorithm
@@ -51,6 +51,9 @@
 #include <cuda/std/__algorithm/includes.h>
 #include <cuda/std/__algorithm/ranges_find_if.h>
 #include <cuda/std/__algorithm/ranges_find_if_not.h>
+#include <cuda/std/__algorithm/ranges_find_last.h>
+#include <cuda/std/__algorithm/ranges_find_last_if.h>
+#include <cuda/std/__algorithm/ranges_find_last_if_not.h>
 #ifdef _CCCL_HAS_SORTING_ALGORITHMS
 #  include <cuda/std/__algorithm/inplace_merge.h>
 #endif // _CCCL_HAS_SORTING_ALGORITHMS

--- a/libcudacxx/include/cuda/std/algorithm.ranges.find_last.h
+++ b/libcudacxx/include/cuda/std/algorithm.ranges.find_last.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_LAST_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_LAST_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/ranges_find_last.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_LAST_H

--- a/libcudacxx/include/cuda/std/algorithm.ranges.find_last_if.h
+++ b/libcudacxx/include/cuda/std/algorithm.ranges.find_last_if.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_LAST_IF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_LAST_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/ranges_find_last_if.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_LAST_IF_H

--- a/libcudacxx/include/cuda/std/algorithm.ranges.find_last_if_not.h
+++ b/libcudacxx/include/cuda/std/algorithm.ranges.find_last_if_not.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_LAST_IF_NOT_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_LAST_IF_NOT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/ranges_find_last_if_not.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_LAST_IF_NOT_H

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -227,6 +227,7 @@
 // # define __cccl_lib_out_ptr                              202106L
 // # define __cccl_lib_ranges_chunk                         202202L
 // # define __cccl_lib_ranges_chunk_by                      202202L
+#  define __cccl_lib_ranges_find_last 202207L
 // # define __cccl_lib_ranges_iota                          202202L
 // # define __cccl_lib_ranges_join_with                     202202L
 // # define __cccl_lib_ranges_slide                         202202L

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_find_last.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_find_last.pass.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.ranges.find_last.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+TEST_FUNC constexpr bool test()
+{
+  int a[]  = {1, 2, 3, 2};
+  auto ret = cuda::std::ranges::find_last(a, a + 4, 2);
+  assert(ret.begin() == a + 3);
+  assert(ret.end() == a + 4);
+  auto ret2 = cuda::std::ranges::find_last(a, 1);
+  assert(ret2.begin() == a);
+  assert(ret2.end() == a + 4);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_find_last_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_find_last_if.pass.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.ranges.find_last_if.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct ranges_find_last_if_even
+{
+  TEST_FUNC constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+struct ranges_find_last_if_lt3
+{
+  TEST_FUNC constexpr bool operator()(int x) const
+  {
+    return x < 3;
+  }
+};
+
+TEST_FUNC constexpr bool test()
+{
+  int a[]  = {1, 2, 3, 4, 5};
+  auto ret = cuda::std::ranges::find_last_if(a, a + 5, ranges_find_last_if_even{});
+  assert(ret.begin() == a + 3);
+  assert(ret.end() == a + 5);
+  auto ret2 = cuda::std::ranges::find_last_if(a, ranges_find_last_if_lt3{});
+  assert(ret2.begin() == a + 1);
+  assert(ret2.end() == a + 5);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_find_last_if_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_find_last_if_not.pass.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.ranges.find_last_if_not.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct ranges_find_last_if_not_odd
+{
+  TEST_FUNC constexpr bool operator()(int x) const
+  {
+    return x % 2 != 0;
+  }
+};
+struct ranges_find_last_if_not_ge3
+{
+  TEST_FUNC constexpr bool operator()(int x) const
+  {
+    return x >= 3;
+  }
+};
+
+TEST_FUNC constexpr bool test()
+{
+  int a[]  = {1, 2, 3, 4, 5};
+  auto ret = cuda::std::ranges::find_last_if_not(a, a + 5, ranges_find_last_if_not_odd{});
+  assert(ret.begin() == a + 3);
+  assert(ret.end() == a + 5);
+  auto ret2 = cuda::std::ranges::find_last_if_not(a, ranges_find_last_if_not_ge3{});
+  assert(ret2.begin() == a + 1);
+  assert(ret2.end() == a + 5);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last.pass.cpp
@@ -1,0 +1,204 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
+// template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity>
+//   requires indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T*>
+//   constexpr subrange<I> ranges::find_last(I first, S last, const T& value, Proj proj = {});
+// template<forward_range R, class T, class Proj = identity>
+//   requires indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
+//   constexpr borrowed_subrange_t<R> ranges::find_last(R&& r, const T& value, Proj proj = {});
+
+#include <cuda/std/algorithm>
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/ranges>
+
+#include "almost_satisfies_types.h"
+#include "test_iterators.h"
+
+#if TEST_STD_VER > 2017
+template <class It, class Sent = It>
+concept HasFindLastIt = requires(It it, Sent sent) { cuda::std::ranges::find_last(it, sent, *it); };
+#else
+template <class It, class Sent = It, class = void>
+inline constexpr bool HasFindLastIt = false;
+
+template <class It, class Sent>
+inline constexpr bool
+  HasFindLastIt<It,
+                Sent,
+                cuda::std::void_t<decltype(cuda::std::ranges::find_last(
+                  cuda::std::declval<It>(), cuda::std::declval<Sent>(), *cuda::std::declval<It>()))>> = true;
+#endif
+
+static_assert(HasFindLastIt<int*>);
+static_assert(HasFindLastIt<forward_iterator<int*>>);
+// find_last requires a forward iterator, an input iterator is not enough
+static_assert(!HasFindLastIt<cpp20_input_iterator<int*>, sentinel_wrapper<cpp20_input_iterator<int*>>>);
+static_assert(!HasFindLastIt<ForwardIteratorNotDerivedFrom>);
+static_assert(!HasFindLastIt<ForwardIteratorNotIncrementable>);
+static_assert(!HasFindLastIt<forward_iterator<int*>, SentinelForNotSemiregular>);
+
+static_assert(!HasFindLastIt<int*, int>);
+static_assert(!HasFindLastIt<int, int*>);
+
+#if TEST_STD_VER > 2017
+template <class R>
+concept HasFindLastR = requires(R r) { cuda::std::ranges::find_last(r, 0); };
+#else
+template <class R, class = void>
+inline constexpr bool HasFindLastR = false;
+
+template <class R>
+inline constexpr bool
+  HasFindLastR<R, cuda::std::void_t<decltype(cuda::std::ranges::find_last(cuda::std::declval<R>(), 0))>> = true;
+#endif
+
+static_assert(HasFindLastR<cuda::std::array<int, 0>>);
+static_assert(!HasFindLastR<int>);
+static_assert(!HasFindLastR<ForwardRangeNotDerivedFrom>);
+static_assert(!HasFindLastR<ForwardRangeNotIncrementable>);
+static_assert(!HasFindLastR<ForwardRangeNotSentinelSemiregular>);
+
+template <class It, class Sent = It>
+TEST_HOST_DEVICE_FUNC constexpr void test_iterators()
+{
+  {
+    // the *last* match is reported, together with the end of the range
+    int a[]            = {1, 2, 3, 2, 5};
+    decltype(auto) ret = cuda::std::ranges::find_last(It(a), Sent(It(a + 5)), 2);
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<It>>);
+    assert(base(ret.begin()) == a + 3);
+    assert(base(ret.end()) == a + 5);
+    assert(*ret.begin() == 2);
+  }
+  {
+    int a              = 0;
+    auto range         = cuda::std::ranges::subrange<It, Sent>(It(&a), Sent(It(&a + 1)));
+    decltype(auto) ret = cuda::std::ranges::find_last(range, 0);
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<It>>);
+    assert(base(ret.begin()) == &a);
+    assert(base(ret.end()) == &a + 1);
+  }
+  {
+    // no match yields an empty subrange at the end of the range
+    int a[]            = {1, 2, 3};
+    decltype(auto) ret = cuda::std::ranges::find_last(It(a), Sent(It(a + 3)), 4);
+    assert(base(ret.begin()) == a + 3);
+    assert(base(ret.end()) == a + 3);
+    assert(ret.empty());
+  }
+}
+
+struct S
+{
+  int comp;
+  int other;
+};
+
+struct Widget
+{
+  int value;
+
+  TEST_HOST_DEVICE_FUNC friend constexpr bool operator==(const Widget& lhs, const Widget& rhs)
+  {
+    return lhs.value == rhs.value;
+  }
+#if TEST_STD_VER < 2020
+  TEST_HOST_DEVICE_FUNC friend constexpr bool operator!=(const Widget& lhs, const Widget& rhs)
+  {
+    return lhs.value != rhs.value;
+  }
+#endif // TEST_STD_VER < 2020
+};
+
+TEST_HOST_DEVICE_FUNC constexpr bool test()
+{
+  test_iterators<int*>();
+  test_iterators<const int*>();
+  test_iterators<forward_iterator<int*>>();
+  test_iterators<bidirectional_iterator<int*>>();
+  test_iterators<random_access_iterator<int*>>();
+  test_iterators<contiguous_iterator<int*>>();
+  test_iterators<forward_iterator<int*>, sentinel_wrapper<forward_iterator<int*>>>();
+
+  {
+    // check that the last of several matches is returned, not the first
+    S a[]              = {{0, 1}, {0, 2}, {0, 3}};
+    decltype(auto) ret = cuda::std::ranges::find_last(a, 0, &S::comp);
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<S*>>);
+    assert(ret.begin() == a + 2);
+    assert(ret.end() == a + 3);
+    assert(ret.begin()->other == 3);
+  }
+  {
+    // the same through the iterator overload
+    S a[]    = {{0, 1}, {0, 2}, {0, 3}};
+    auto ret = cuda::std::ranges::find_last(a, a + 3, 0, &S::comp);
+    assert(ret.begin() == a + 2);
+    assert(ret.end() == a + 3);
+  }
+
+  {
+    // check that ranges::dangling is returned
+    decltype(auto) ret = cuda::std::ranges::find_last(cuda::std::array<int, 2>{1, 2}, 1);
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::dangling>);
+    unused(ret);
+  }
+
+  {
+    // check that a subrange is returned for a borrowing range
+    int a[]            = {1, 2, 3, 2};
+    decltype(auto) ret = cuda::std::ranges::find_last(cuda::std::views::all(a), 2);
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<int*>>);
+    assert(ret.begin() == a + 3);
+    assert(ret.end() == a + 4);
+  }
+
+  {
+    // check that a class type with a user defined operator== works
+    Widget a[] = {Widget{1}, Widget{2}, Widget{1}};
+    auto ret   = cuda::std::ranges::find_last(a, Widget{1});
+    assert(ret.begin() == a + 2);
+    assert(ret.end() == a + 3);
+  }
+
+  if (!TEST_IS_CONSTANT_EVALUATED())
+  {
+    // check that an empty range works
+    {
+      cuda::std::array<int, 0> a = {};
+      auto ret                   = cuda::std::ranges::find_last(a.begin(), a.end(), 1);
+      assert(ret.begin() == a.begin());
+      assert(ret.end() == a.begin());
+    }
+    {
+      cuda::std::array<int, 0> a = {};
+      auto ret                   = cuda::std::ranges::find_last(a, 1);
+      assert(ret.begin() == a.begin());
+      assert(ret.end() == a.begin());
+    }
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+#if TEST_STD_VER > 2017 && defined(_CCCL_BUILTIN_ADDRESSOF)
+  static_assert(test());
+#endif // TEST_STD_VER > 2017 && defined(_CCCL_BUILTIN_ADDRESSOF)
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last.pass.cpp
@@ -25,6 +25,7 @@
 
 #include "almost_satisfies_types.h"
 #include "test_iterators.h"
+#include "test_macros.h"
 
 #if TEST_STD_VER > 2017
 template <class It, class Sent = It>
@@ -83,12 +84,12 @@ TEST_HOST_DEVICE_FUNC constexpr void test_iterators()
     assert(*ret.begin() == 2);
   }
   {
-    int a              = 0;
-    auto range         = cuda::std::ranges::subrange<It, Sent>(It(&a), Sent(It(&a + 1)));
-    decltype(auto) ret = cuda::std::ranges::find_last(range, 0);
+    int a[]            = {1, 2, 3, 2, 5};
+    auto range         = cuda::std::ranges::subrange<It, Sent>(It(a), Sent(It(a + 5)));
+    decltype(auto) ret = cuda::std::ranges::find_last(range, 2);
     static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<It>>);
-    assert(base(ret.begin()) == &a);
-    assert(base(ret.end()) == &a + 1);
+    assert(base(ret.begin()) == a + 3);
+    assert(base(ret.end()) == a + 5);
   }
   {
     // no match yields an empty subrange at the end of the range

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last.pass.cpp
@@ -131,6 +131,7 @@ TEST_HOST_DEVICE_FUNC constexpr bool test()
   test_iterators<random_access_iterator<int*>>();
   test_iterators<contiguous_iterator<int*>>();
   test_iterators<forward_iterator<int*>, sentinel_wrapper<forward_iterator<int*>>>();
+  test_iterators<bidirectional_iterator<int*>, sentinel_wrapper<bidirectional_iterator<int*>>>();
 
   {
     // check that the last of several matches is returned, not the first

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last.pass.cpp
@@ -99,6 +99,22 @@ TEST_HOST_DEVICE_FUNC constexpr void test_iterators()
     assert(base(ret.end()) == a + 3);
     assert(ret.empty());
   }
+  {
+    // an empty range yields an empty subrange, and the sentinel is honoured rather than the underlying storage
+    int a[]            = {1, 2, 3};
+    decltype(auto) ret = cuda::std::ranges::find_last(It(a), Sent(It(a)), 1);
+    assert(base(ret.begin()) == a);
+    assert(base(ret.end()) == a);
+    assert(ret.empty());
+  }
+  {
+    int a[]            = {1, 2, 3};
+    auto range         = cuda::std::ranges::subrange<It, Sent>(It(a), Sent(It(a)));
+    decltype(auto) ret = cuda::std::ranges::find_last(range, 1);
+    assert(base(ret.begin()) == a);
+    assert(base(ret.end()) == a);
+    assert(ret.empty());
+  }
 }
 
 struct S

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if.pass.cpp
@@ -145,6 +145,22 @@ TEST_HOST_DEVICE_FUNC constexpr void test_iterators()
     assert(base(ret.end()) == a + 3);
     assert(ret.empty());
   }
+  {
+    // an empty range yields an empty subrange, and the sentinel is honoured rather than the underlying storage
+    int a[]            = {2, 2, 2};
+    decltype(auto) ret = cuda::std::ranges::find_last_if(It(a), Sent(It(a)), IsTwo{});
+    assert(base(ret.begin()) == a);
+    assert(base(ret.end()) == a);
+    assert(ret.empty());
+  }
+  {
+    int a[]            = {2, 2, 2};
+    auto range         = cuda::std::ranges::subrange<It, Sent>(It(a), Sent(It(a)));
+    decltype(auto) ret = cuda::std::ranges::find_last_if(range, IsTwo{});
+    assert(base(ret.begin()) == a);
+    assert(base(ret.end()) == a);
+    assert(ret.empty());
+  }
 }
 
 struct S

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if.pass.cpp
@@ -179,6 +179,7 @@ TEST_HOST_DEVICE_FUNC constexpr bool test()
   test_iterators<random_access_iterator<int*>>();
   test_iterators<contiguous_iterator<int*>>();
   test_iterators<forward_iterator<int*>, sentinel_wrapper<forward_iterator<int*>>>();
+  test_iterators<bidirectional_iterator<int*>, sentinel_wrapper<bidirectional_iterator<int*>>>();
 
   {
     // check that projections are used properly and that they are called with the iterator directly

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if.pass.cpp
@@ -1,0 +1,307 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
+// template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
+//          indirect_unary_predicate<projected<I, Proj>> Pred>
+//   constexpr subrange<I> ranges::find_last_if(I first, S last, Pred pred, Proj proj = {});
+// template<forward_range R, class Proj = identity,
+//          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+//   constexpr borrowed_subrange_t<R> ranges::find_last_if(R&& r, Pred pred, Proj proj = {});
+
+#include <cuda/std/algorithm>
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/ranges>
+
+#include "almost_satisfies_types.h"
+#include "boolean_testable.h"
+#include "test_iterators.h"
+
+struct Predicate
+{
+  TEST_HOST_DEVICE_FUNC bool operator()(int);
+};
+
+#if TEST_STD_VER > 2017
+template <class It, class Sent = It>
+concept HasFindLastIfIt = requires(It it, Sent sent) { cuda::std::ranges::find_last_if(it, sent, Predicate{}); };
+#else
+template <class It, class Sent = It, class = void>
+inline constexpr bool HasFindLastIfIt = false;
+
+template <class It, class Sent>
+inline constexpr bool
+  HasFindLastIfIt<It,
+                  Sent,
+                  cuda::std::void_t<decltype(cuda::std::ranges::find_last_if(
+                    cuda::std::declval<It>(), cuda::std::declval<Sent>(), cuda::std::declval<Predicate>()))>> = true;
+#endif
+
+static_assert(HasFindLastIfIt<int*>);
+static_assert(HasFindLastIfIt<forward_iterator<int*>>);
+// find_last_if requires a forward iterator, an input iterator is not enough
+static_assert(!HasFindLastIfIt<cpp20_input_iterator<int*>, sentinel_wrapper<cpp20_input_iterator<int*>>>);
+static_assert(!HasFindLastIfIt<ForwardIteratorNotDerivedFrom>);
+static_assert(!HasFindLastIfIt<ForwardIteratorNotIncrementable>);
+static_assert(!HasFindLastIfIt<forward_iterator<int*>, SentinelForNotSemiregular>);
+
+static_assert(!HasFindLastIfIt<int*, int>);
+static_assert(!HasFindLastIfIt<int, int*>);
+
+#if TEST_STD_VER > 2017
+template <class Pred>
+concept HasFindLastIfPred = requires(int* it, Pred pred) { cuda::std::ranges::find_last_if(it, it, pred); };
+#else
+template <class Pred, class = void>
+inline constexpr bool HasFindLastIfPred = false;
+
+template <class Pred>
+inline constexpr bool
+  HasFindLastIfPred<Pred,
+                    cuda::std::void_t<decltype(cuda::std::ranges::find_last_if(
+                      static_cast<int*>(nullptr), static_cast<int*>(nullptr), cuda::std::declval<Pred>()))>> = true;
+#endif
+
+static_assert(!HasFindLastIfPred<IndirectUnaryPredicateNotCopyConstructible>);
+static_assert(!HasFindLastIfPred<IndirectUnaryPredicateNotPredicate>);
+
+#if TEST_STD_VER > 2017
+template <class R>
+concept HasFindLastIfR = requires(R r) { cuda::std::ranges::find_last_if(r, Predicate{}); };
+#else
+template <class R, class = void>
+inline constexpr bool HasFindLastIfR = false;
+
+template <class R>
+inline constexpr bool HasFindLastIfR<R,
+                                     cuda::std::void_t<decltype(cuda::std::ranges::find_last_if(
+                                       cuda::std::declval<R>(), cuda::std::declval<Predicate>()))>> = true;
+#endif
+
+static_assert(HasFindLastIfR<cuda::std::array<int, 0>>);
+static_assert(!HasFindLastIfR<int>);
+static_assert(!HasFindLastIfR<ForwardRangeNotDerivedFrom>);
+static_assert(!HasFindLastIfR<ForwardRangeNotIncrementable>);
+static_assert(!HasFindLastIfR<ForwardRangeNotSentinelSemiregular>);
+
+struct IsTwo
+{
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
+  {
+    return i == 2;
+  }
+};
+struct AlwaysFalse
+{
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int) const
+  {
+    return false;
+  }
+};
+struct AlwaysTrue
+{
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int) const
+  {
+    return true;
+  }
+};
+
+template <class It, class Sent = It>
+TEST_HOST_DEVICE_FUNC constexpr void test_iterators()
+{
+  {
+    // the *last* match is reported, together with the end of the range
+    int a[]            = {1, 2, 3, 2, 5};
+    decltype(auto) ret = cuda::std::ranges::find_last_if(It(a), Sent(It(a + 5)), IsTwo{});
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<It>>);
+    assert(base(ret.begin()) == a + 3);
+    assert(base(ret.end()) == a + 5);
+    assert(*ret.begin() == 2);
+  }
+  {
+    int a[]            = {1, 2, 3, 2, 5};
+    auto range         = cuda::std::ranges::subrange<It, Sent>(It(a), Sent(It(a + 5)));
+    decltype(auto) ret = cuda::std::ranges::find_last_if(range, IsTwo{});
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<It>>);
+    assert(base(ret.begin()) == a + 3);
+    assert(base(ret.end()) == a + 5);
+  }
+  {
+    // no match yields an empty subrange at the end of the range
+    int a[]            = {1, 1, 1};
+    decltype(auto) ret = cuda::std::ranges::find_last_if(It(a), Sent(It(a + 3)), AlwaysFalse{});
+    assert(base(ret.begin()) == a + 3);
+    assert(base(ret.end()) == a + 3);
+    assert(ret.empty());
+  }
+}
+
+struct S
+{
+  int comp;
+  int other;
+};
+
+struct IsZero
+{
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
+  {
+    return i == 0;
+  }
+};
+
+struct CountPredicate
+{
+  int& predicate_count;
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
+  {
+    ++predicate_count;
+    return i == 2;
+  }
+};
+
+TEST_HOST_DEVICE_FUNC constexpr bool test()
+{
+  test_iterators<int*>();
+  test_iterators<const int*>();
+  test_iterators<forward_iterator<int*>>();
+  test_iterators<bidirectional_iterator<int*>>();
+  test_iterators<random_access_iterator<int*>>();
+  test_iterators<contiguous_iterator<int*>>();
+  test_iterators<forward_iterator<int*>, sentinel_wrapper<forward_iterator<int*>>>();
+
+  {
+    // check that projections are used properly and that they are called with the iterator directly
+    struct ToAddress
+    {
+      TEST_HOST_DEVICE_FUNC constexpr int* operator()(int& i) const
+      {
+        return &i;
+      }
+    };
+    struct PointsToFirst
+    {
+      int* a;
+      TEST_HOST_DEVICE_FUNC constexpr bool operator()(int* i) const
+      {
+        return i == a;
+      }
+    };
+    {
+      int a[]  = {1, 2, 3, 4};
+      auto ret = cuda::std::ranges::find_last_if(a, a + 4, PointsToFirst{a}, ToAddress{});
+      assert(ret.begin() == a);
+      assert(ret.end() == a + 4);
+    }
+    {
+      int a[]  = {1, 2, 3, 4};
+      auto ret = cuda::std::ranges::find_last_if(a, PointsToFirst{a}, ToAddress{});
+      assert(ret.begin() == a);
+      assert(ret.end() == a + 4);
+    }
+  }
+
+  {
+    // check that the last of several matches is returned, not the first
+    S a[]              = {{0, 1}, {0, 2}, {0, 3}};
+    decltype(auto) ret = cuda::std::ranges::find_last_if(a, IsZero{}, &S::comp);
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<S*>>);
+    assert(ret.begin() == a + 2);
+    assert(ret.end() == a + 3);
+    assert(ret.begin()->other == 3);
+  }
+
+  {
+    // check that ranges::dangling is returned
+    decltype(auto) ret = cuda::std::ranges::find_last_if(cuda::std::array<int, 2>{1, 2}, AlwaysTrue{});
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::dangling>);
+    unused(ret);
+  }
+
+  {
+    // check that a subrange is returned for a borrowing range
+    int a[]            = {1, 2, 3, 4};
+    decltype(auto) ret = cuda::std::ranges::find_last_if(cuda::std::views::all(a), AlwaysTrue{});
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<int*>>);
+    assert(ret.begin() == a + 3);
+    assert(ret.end() == a + 4);
+  }
+
+  {
+    // a bidirectional iterator only walks back from the end up to the match
+    int a[]             = {2, 1, 2, 1};
+    int predicate_count = 0;
+    auto ret            = cuda::std::ranges::find_last_if(a, a + 4, CountPredicate{predicate_count});
+    assert(ret.begin() == a + 2);
+    assert(predicate_count == 2);
+  }
+  {
+    // a forward iterator has to traverse the whole range
+    int a[]             = {2, 1, 2, 1};
+    int predicate_count = 0;
+    auto ret            = cuda::std::ranges::find_last_if(
+      forward_iterator<int*>(a), forward_iterator<int*>(a + 4), CountPredicate{predicate_count});
+    assert(base(ret.begin()) == a + 2);
+    assert(predicate_count == 4);
+  }
+
+  if (!TEST_IS_CONSTANT_EVALUATED())
+  {
+    // check that an empty range works
+    {
+      cuda::std::array<int, 0> a = {};
+      auto ret                   = cuda::std::ranges::find_last_if(a.begin(), a.end(), AlwaysTrue{});
+      assert(ret.begin() == a.begin());
+      assert(ret.end() == a.begin());
+    }
+    {
+      cuda::std::array<int, 0> a = {};
+      auto ret                   = cuda::std::ranges::find_last_if(a, AlwaysTrue{});
+      assert(ret.begin() == a.begin());
+      assert(ret.end() == a.begin());
+    }
+  }
+
+  {
+    // check that the implicit conversion to bool works
+    struct ReturnBooleanTestable
+    {
+      TEST_HOST_DEVICE_FUNC constexpr BooleanTestable operator()(const int& i) const
+      {
+        return BooleanTestable{i == 3};
+      }
+    };
+    {
+      int a[]  = {1, 3, 2, 3};
+      auto ret = cuda::std::ranges::find_last_if(a, a + 4, ReturnBooleanTestable{});
+      assert(ret.begin() == a + 3);
+    }
+    {
+      int a[]  = {1, 3, 2, 3};
+      auto ret = cuda::std::ranges::find_last_if(a, ReturnBooleanTestable{});
+      assert(ret.begin() == a + 3);
+    }
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+#if TEST_STD_VER > 2017 && defined(_CCCL_BUILTIN_ADDRESSOF)
+  static_assert(test());
+#endif // TEST_STD_VER > 2017 && defined(_CCCL_BUILTIN_ADDRESSOF)
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if.pass.cpp
@@ -26,6 +26,7 @@
 #include "almost_satisfies_types.h"
 #include "boolean_testable.h"
 #include "test_iterators.h"
+#include "test_macros.h"
 
 struct Predicate
 {

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if_not.pass.cpp
@@ -26,6 +26,7 @@
 #include "almost_satisfies_types.h"
 #include "boolean_testable.h"
 #include "test_iterators.h"
+#include "test_macros.h"
 
 struct Predicate
 {
@@ -170,6 +171,37 @@ TEST_HOST_DEVICE_FUNC constexpr bool test()
   test_iterators<contiguous_iterator<int*>>();
   test_iterators<forward_iterator<int*>, sentinel_wrapper<forward_iterator<int*>>>();
   test_iterators<bidirectional_iterator<int*>, sentinel_wrapper<bidirectional_iterator<int*>>>();
+
+  {
+    // check that projections are used properly and that they are called with the iterator directly
+    struct ToAddress
+    {
+      TEST_HOST_DEVICE_FUNC constexpr int* operator()(int& i) const
+      {
+        return &i;
+      }
+    };
+    struct DoesNotPointToFirst
+    {
+      int* a;
+      TEST_HOST_DEVICE_FUNC constexpr bool operator()(int* i) const
+      {
+        return i != a;
+      }
+    };
+    {
+      int a[]  = {1, 2, 3, 4};
+      auto ret = cuda::std::ranges::find_last_if_not(a, a + 4, DoesNotPointToFirst{a}, ToAddress{});
+      assert(ret.begin() == a);
+      assert(ret.end() == a + 4);
+    }
+    {
+      int a[]  = {1, 2, 3, 4};
+      auto ret = cuda::std::ranges::find_last_if_not(a, DoesNotPointToFirst{a}, ToAddress{});
+      assert(ret.begin() == a);
+      assert(ret.end() == a + 4);
+    }
+  }
 
   {
     // check that the last of several matches is returned, not the first

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if_not.pass.cpp
@@ -145,6 +145,22 @@ TEST_HOST_DEVICE_FUNC constexpr void test_iterators()
     assert(base(ret.end()) == a + 3);
     assert(ret.empty());
   }
+  {
+    // an empty range yields an empty subrange, and the sentinel is honoured rather than the underlying storage
+    int a[]            = {2, 2, 2};
+    decltype(auto) ret = cuda::std::ranges::find_last_if_not(It(a), Sent(It(a)), IsNotTwo{});
+    assert(base(ret.begin()) == a);
+    assert(base(ret.end()) == a);
+    assert(ret.empty());
+  }
+  {
+    int a[]            = {2, 2, 2};
+    auto range         = cuda::std::ranges::subrange<It, Sent>(It(a), Sent(It(a)));
+    decltype(auto) ret = cuda::std::ranges::find_last_if_not(range, IsNotTwo{});
+    assert(base(ret.begin()) == a);
+    assert(base(ret.end()) == a);
+    assert(ret.empty());
+  }
 }
 
 struct S

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if_not.pass.cpp
@@ -169,6 +169,7 @@ TEST_HOST_DEVICE_FUNC constexpr bool test()
   test_iterators<random_access_iterator<int*>>();
   test_iterators<contiguous_iterator<int*>>();
   test_iterators<forward_iterator<int*>, sentinel_wrapper<forward_iterator<int*>>>();
+  test_iterators<bidirectional_iterator<int*>, sentinel_wrapper<bidirectional_iterator<int*>>>();
 
   {
     // check that the last of several matches is returned, not the first

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/ranges.find_last_if_not.pass.cpp
@@ -1,0 +1,248 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: force-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
+// template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
+//          indirect_unary_predicate<projected<I, Proj>> Pred>
+//   constexpr subrange<I> ranges::find_last_if_not(I first, S last, Pred pred, Proj proj = {});
+// template<forward_range R, class Proj = identity,
+//          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+//   constexpr borrowed_subrange_t<R> ranges::find_last_if_not(R&& r, Pred pred, Proj proj = {});
+
+#include <cuda/std/algorithm>
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/ranges>
+
+#include "almost_satisfies_types.h"
+#include "boolean_testable.h"
+#include "test_iterators.h"
+
+struct Predicate
+{
+  TEST_HOST_DEVICE_FUNC bool operator()(int);
+};
+
+#if TEST_STD_VER > 2017
+template <class It, class Sent = It>
+concept HasFindLastIfNotIt = requires(It it, Sent sent) { cuda::std::ranges::find_last_if_not(it, sent, Predicate{}); };
+#else
+template <class It, class Sent = It, class = void>
+inline constexpr bool HasFindLastIfNotIt = false;
+
+template <class It, class Sent>
+inline constexpr bool
+  HasFindLastIfNotIt<It,
+                     Sent,
+                     cuda::std::void_t<decltype(cuda::std::ranges::find_last_if_not(
+                       cuda::std::declval<It>(), cuda::std::declval<Sent>(), cuda::std::declval<Predicate>()))>> = true;
+#endif
+
+static_assert(HasFindLastIfNotIt<int*>);
+static_assert(HasFindLastIfNotIt<forward_iterator<int*>>);
+// find_last_if_not requires a forward iterator, an input iterator is not enough
+static_assert(!HasFindLastIfNotIt<cpp20_input_iterator<int*>, sentinel_wrapper<cpp20_input_iterator<int*>>>);
+static_assert(!HasFindLastIfNotIt<ForwardIteratorNotDerivedFrom>);
+static_assert(!HasFindLastIfNotIt<ForwardIteratorNotIncrementable>);
+static_assert(!HasFindLastIfNotIt<forward_iterator<int*>, SentinelForNotSemiregular>);
+
+static_assert(!HasFindLastIfNotIt<int*, int>);
+static_assert(!HasFindLastIfNotIt<int, int*>);
+
+#if TEST_STD_VER > 2017
+template <class Pred>
+concept HasFindLastIfNotPred = requires(int* it, Pred pred) { cuda::std::ranges::find_last_if_not(it, it, pred); };
+#else
+template <class Pred, class = void>
+inline constexpr bool HasFindLastIfNotPred = false;
+
+template <class Pred>
+inline constexpr bool
+  HasFindLastIfNotPred<Pred,
+                       cuda::std::void_t<decltype(cuda::std::ranges::find_last_if_not(
+                         static_cast<int*>(nullptr), static_cast<int*>(nullptr), cuda::std::declval<Pred>()))>> = true;
+#endif
+
+static_assert(!HasFindLastIfNotPred<IndirectUnaryPredicateNotCopyConstructible>);
+static_assert(!HasFindLastIfNotPred<IndirectUnaryPredicateNotPredicate>);
+
+#if TEST_STD_VER > 2017
+template <class R>
+concept HasFindLastIfNotR = requires(R r) { cuda::std::ranges::find_last_if_not(r, Predicate{}); };
+#else
+template <class R, class = void>
+inline constexpr bool HasFindLastIfNotR = false;
+
+template <class R>
+inline constexpr bool HasFindLastIfNotR<R,
+                                        cuda::std::void_t<decltype(cuda::std::ranges::find_last_if_not(
+                                          cuda::std::declval<R>(), cuda::std::declval<Predicate>()))>> = true;
+#endif
+
+static_assert(HasFindLastIfNotR<cuda::std::array<int, 0>>);
+static_assert(!HasFindLastIfNotR<int>);
+static_assert(!HasFindLastIfNotR<ForwardRangeNotDerivedFrom>);
+static_assert(!HasFindLastIfNotR<ForwardRangeNotIncrementable>);
+static_assert(!HasFindLastIfNotR<ForwardRangeNotSentinelSemiregular>);
+
+struct IsNotTwo
+{
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
+  {
+    return i != 2;
+  }
+};
+struct AlwaysFalse
+{
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int) const
+  {
+    return false;
+  }
+};
+struct AlwaysTrue
+{
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int) const
+  {
+    return true;
+  }
+};
+
+template <class It, class Sent = It>
+TEST_HOST_DEVICE_FUNC constexpr void test_iterators()
+{
+  {
+    // the *last* element not satisfying the predicate is reported
+    int a[]            = {1, 2, 3, 2, 5};
+    decltype(auto) ret = cuda::std::ranges::find_last_if_not(It(a), Sent(It(a + 5)), IsNotTwo{});
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<It>>);
+    assert(base(ret.begin()) == a + 3);
+    assert(base(ret.end()) == a + 5);
+    assert(*ret.begin() == 2);
+  }
+  {
+    int a[]            = {1, 2, 3, 2, 5};
+    auto range         = cuda::std::ranges::subrange<It, Sent>(It(a), Sent(It(a + 5)));
+    decltype(auto) ret = cuda::std::ranges::find_last_if_not(range, IsNotTwo{});
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<It>>);
+    assert(base(ret.begin()) == a + 3);
+    assert(base(ret.end()) == a + 5);
+  }
+  {
+    // no match yields an empty subrange at the end of the range
+    int a[]            = {1, 1, 1};
+    decltype(auto) ret = cuda::std::ranges::find_last_if_not(It(a), Sent(It(a + 3)), AlwaysTrue{});
+    assert(base(ret.begin()) == a + 3);
+    assert(base(ret.end()) == a + 3);
+    assert(ret.empty());
+  }
+}
+
+struct S
+{
+  int comp;
+  int other;
+};
+
+struct IsNotZero
+{
+  TEST_HOST_DEVICE_FUNC constexpr bool operator()(int i) const
+  {
+    return i != 0;
+  }
+};
+
+TEST_HOST_DEVICE_FUNC constexpr bool test()
+{
+  test_iterators<int*>();
+  test_iterators<const int*>();
+  test_iterators<forward_iterator<int*>>();
+  test_iterators<bidirectional_iterator<int*>>();
+  test_iterators<random_access_iterator<int*>>();
+  test_iterators<contiguous_iterator<int*>>();
+  test_iterators<forward_iterator<int*>, sentinel_wrapper<forward_iterator<int*>>>();
+
+  {
+    // check that the last of several matches is returned, not the first
+    S a[]              = {{0, 1}, {0, 2}, {0, 3}};
+    decltype(auto) ret = cuda::std::ranges::find_last_if_not(a, IsNotZero{}, &S::comp);
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<S*>>);
+    assert(ret.begin() == a + 2);
+    assert(ret.end() == a + 3);
+    assert(ret.begin()->other == 3);
+  }
+
+  {
+    // check that ranges::dangling is returned
+    decltype(auto) ret = cuda::std::ranges::find_last_if_not(cuda::std::array<int, 2>{1, 2}, AlwaysFalse{});
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::dangling>);
+    unused(ret);
+  }
+
+  {
+    // check that a subrange is returned for a borrowing range
+    int a[]            = {1, 2, 3, 4};
+    decltype(auto) ret = cuda::std::ranges::find_last_if_not(cuda::std::views::all(a), AlwaysFalse{});
+    static_assert(cuda::std::same_as<decltype(ret), cuda::std::ranges::subrange<int*>>);
+    assert(ret.begin() == a + 3);
+    assert(ret.end() == a + 4);
+  }
+
+  if (!TEST_IS_CONSTANT_EVALUATED())
+  {
+    // check that an empty range works
+    {
+      cuda::std::array<int, 0> a = {};
+      auto ret                   = cuda::std::ranges::find_last_if_not(a.begin(), a.end(), AlwaysFalse{});
+      assert(ret.begin() == a.begin());
+      assert(ret.end() == a.begin());
+    }
+    {
+      cuda::std::array<int, 0> a = {};
+      auto ret                   = cuda::std::ranges::find_last_if_not(a, AlwaysFalse{});
+      assert(ret.begin() == a.begin());
+      assert(ret.end() == a.begin());
+    }
+  }
+
+  {
+    // check that the implicit conversion to bool works
+    struct ReturnBooleanTestable
+    {
+      TEST_HOST_DEVICE_FUNC constexpr BooleanTestable operator()(const int& i) const
+      {
+        return BooleanTestable{i != 3};
+      }
+    };
+    {
+      int a[]  = {1, 3, 2, 3};
+      auto ret = cuda::std::ranges::find_last_if_not(a, a + 4, ReturnBooleanTestable{});
+      assert(ret.begin() == a + 3);
+    }
+    {
+      int a[]  = {1, 3, 2, 3};
+      auto ret = cuda::std::ranges::find_last_if_not(a, ReturnBooleanTestable{});
+      assert(ret.begin() == a + 3);
+    }
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+#if TEST_STD_VER > 2017 && defined(_CCCL_BUILTIN_ADDRESSOF)
+  static_assert(test());
+#endif // TEST_STD_VER > 2017 && defined(_CCCL_BUILTIN_ADDRESSOF)
+
+  return 0;
+}


### PR DESCRIPTION
Implements [P1223R5](https://wg21.link/P1223R5), closing #10437.

Adds `cuda::std::ranges::find_last`, `find_last_if` and `find_last_if_not`. Each returns a `subrange` that starts at the last matching element and ends at the end of the input range, or an empty subrange at the end when there is no match.

### Implementation

The shared helper lives in `__algorithm/ranges_find_last_if.h` and picks one of two strategies:

* A bidirectional iterator walks back from the end and stops at the first match it sees.
* A forward-only iterator has to traverse the whole range, remembering the most recent match.

`find_last` and `find_last_if_not` call that helper directly rather than going through the public `find_last_if` CPO, so their own constraints are the only ones checked.

Two things worth flagging for review:

* libcu++ has no `projected_value_t`, so the value overloads use the C++23 spelling `class T` rather than the C++26 P2248R8 spelling `class T = projected_value_t<I, Proj>`. Happy to add the alias in a follow-up if you would rather have the newer signature.
* The execution policy overloads that appear in the current draft of [alg.find.last] come from P3179R9, which is tracked separately in #10357, so they are not part of this PR.

### Also included

* Per-algorithm subheaders `<cuda/std/algorithm.ranges.find_last{,_if,_if_not}.h>`.
* The `__cccl_lib_ranges_find_last` feature macro.
* A docs correction: `algorithms_library.rst` claimed that no algorithm in namespace `ranges` is supported, which stopped being true once `find_if`, `for_each`, `min` and friends landed. It now lists the supported set. Let me know if you would prefer that split out.

### Testing

New tests under `alg.nonmodifying/alg.find` cover the constraints (including that an input iterator is correctly rejected), seven iterator categories including bidirectional and forward iterators with a non-common sentinel, return types, the last of several matches being returned, no match, empty ranges, projections, `dangling` versus a borrowed range, and implicit conversion to `bool`. A predicate invocation count asserts that the bidirectional path really does scan backwards instead of traversing the whole range.

Verified locally on Windows with MSVC 14.50 and CUDA 13.3 (sm_120): all six new tests compile and run green in both C++17 and C++20, all six new headers compile standalone, and clang-format is clean. I could not exercise the C++23 dialect locally because nvcc's device frontend caps out at C++20 here, so the static `operator()` path is left to CI.
