### PR TITLE
[libcu++] Update `__cccl_lib_bitops` FTM

### DIFF
--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -29,7 +29,7 @@
 #  include <ciso646> // otherwise go for the smallest possible header
 #endif // _CCCL_HOSTED()
 
-#define __cccl_lib_bitops                       201907L
+#define __cccl_lib_bitops                       202607L
 #define __cccl_lib_bool_constant                201505L
 #define __cccl_lib_bounded_array_traits         201902L
 #define __cccl_lib_byte                         201603L


### PR DESCRIPTION
We implement non-simd part of both [P3104R6](https://wg21.link/P3104R6) and [P3793R2](https://wg21.link/P3793R2), so we can bump the `__cccl_lib_bitops` value.