### PR TITLE
libcu++: tighten CUDA arch handling in codegen tests.

### DIFF
--- a/libcudacxx/test/atomic_codegen/CMakeLists.txt
+++ b/libcudacxx/test/atomic_codegen/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_custom_target(libcudacxx.test.atomics.ptx)
 
-set(atomic_codegen_cuda_arch 80)
-
 set(libcudacxx_atomic_codegen_tests)
 if (NOT "NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
   file(GLOB libcudacxx_atomic_codegen_tests "*.cu")
@@ -16,11 +14,22 @@ if (NOT libcudacxx_codegen_tests_enabled)
   return()
 endif()
 
-libcudacxx_codegen_add_ptx_tests(
-  AGGREGATE_TARGET libcudacxx.test.atomics.ptx
-  TARGET_PREFIX atomic_codegen
-  ARCH "${atomic_codegen_cuda_arch}"
-  CHECK_PREFIXES SM8X
-  TESTS ${libcudacxx_atomic_codegen_tests}
-  COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1
-)
+libcudacxx_codegen_get_cuda_architectures(atomic_codegen_cuda_archs PTX)
+if (NOT atomic_codegen_cuda_archs)
+  message(
+    STATUS
+    "No compatible CUDA architectures requested; skipping atomic codegen tests"
+  )
+  return()
+endif()
+
+foreach (arch IN LISTS atomic_codegen_cuda_archs)
+  libcudacxx_codegen_add_ptx_tests(
+    AGGREGATE_TARGET libcudacxx.test.atomics.ptx
+    TARGET_PREFIX atomic_codegen
+    ARCH "${arch}"
+    CHECK_PREFIXES SMXX
+    TESTS ${libcudacxx_atomic_codegen_tests}
+    COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1
+  )
+endforeach()

--- a/libcudacxx/test/atomic_codegen/atomic_add_non_volatile.cu
+++ b/libcudacxx/test/atomic_codegen/atomic_add_non_volatile.cu
@@ -26,26 +26,26 @@ __global__ void add_relaxed_system_pointer_non_volatile(int** data, int** out, i
 
 /*
 
-; SM8X-LABEL: .target sm_80
-; SM8X:      .visible .entry [[FUNCTION:_.*add_relaxed_device_non_volatile.*]](
-; SM8X-DAG:  ld.param.{{b|u}}64 %rd[[#ATOM:]], {{.*}}[[FUNCTION]]_param_0{{.*}}
-; SM8X-DAG:  ld.param.{{b|u}}64 %rd[[#RESULT:]], {{.*}}[[FUNCTION]]_param_1{{.*}}
-; SM8X-DAG:  ld.param.{{b|u}}32 %r[[#INPUT:]], {{.*}}[[FUNCTION]]_param_2{{.*}}
-; SM8X-DAG:  cvta.to.global.u64 %rd[[#GOUT:]], %rd[[#RESULT]];
-; SM8X-NEXT: {{/*[[:space:]] *}}atom.add.relaxed.gpu.s32 %r[[#DEST:]],[%rd[[#ATOM]]],%r[[#INPUT]];{{[[:space:]]/*}}
-; SM8X-NEXT: st.global.{{b|u}}32 [%rd[[#GOUT]]], %r[[#DEST]];
-; SM8X-NEXT: ret;
+; SMXX-LABEL: .target sm_{{[0-9]+[af]?}}
+; SMXX:      .visible .entry [[FUNCTION:_.*add_relaxed_device_non_volatile.*]](
+; SMXX-DAG:  ld.param.{{b|u}}64 %rd[[#ATOM:]], {{.*}}[[FUNCTION]]_param_0{{.*}}
+; SMXX-DAG:  ld.param.{{b|u}}64 %rd[[#RESULT:]], {{.*}}[[FUNCTION]]_param_1{{.*}}
+; SMXX-DAG:  ld.param.{{b|u}}32 %r[[#INPUT:]], {{.*}}[[FUNCTION]]_param_2{{.*}}
+; SMXX-DAG:  cvta.to.global.u64 %rd[[#GOUT:]], %rd[[#RESULT]];
+; SMXX-DAG:  {{/*[[:space:]] *}}atom.add.relaxed.gpu.s32 %r[[#DEST:]],[%rd[[#ATOM]]],%r[[#INPUT]];{{[[:space:]]/*}}
+; SMXX-NEXT: st.global.{{b|u}}32 [%rd[[#GOUT]]], %r[[#DEST]];
+; SMXX-NEXT: ret;
 
-; SM8X-LABEL: .visible .entry {{_.*add_relaxed_block_pointer_non_volatile.*}}(
-; SM8X: {{.*}}atom.add.relaxed.cta.u64{{.*}}
-; SM8X: ret;
+; SMXX-LABEL: .visible .entry {{_.*add_relaxed_block_pointer_non_volatile.*}}(
+; SMXX: {{.*}}atom.add.relaxed.cta.u64{{.*}}
+; SMXX: ret;
 
-; SM8X-LABEL: .visible .entry {{_.*add_relaxed_device_pointer_non_volatile.*}}(
-; SM8X: {{.*}}atom.add.relaxed.gpu.u64{{.*}}
-; SM8X: ret;
+; SMXX-LABEL: .visible .entry {{_.*add_relaxed_device_pointer_non_volatile.*}}(
+; SMXX: {{.*}}atom.add.relaxed.gpu.u64{{.*}}
+; SMXX: ret;
 
-; SM8X-LABEL: .visible .entry {{_.*add_relaxed_system_pointer_non_volatile.*}}(
-; SM8X: {{.*}}atom.add.relaxed.sys.u64{{.*}}
-; SM8X: ret;
+; SMXX-LABEL: .visible .entry {{_.*add_relaxed_system_pointer_non_volatile.*}}(
+; SMXX: {{.*}}atom.add.relaxed.sys.u64{{.*}}
+; SMXX: ret;
 
 */

--- a/libcudacxx/test/atomic_codegen/atomic_cas_non_volatile.cu
+++ b/libcudacxx/test/atomic_codegen/atomic_cas_non_volatile.cu
@@ -9,15 +9,15 @@ __global__ void cas_device_relaxed_non_volatile(int* data, int* out, int n)
 // clang-format off
 /*
 
-; SM8X-LABEL: .target sm_80
-; SM8X:      .visible .entry [[FUNCTION:_.*cas_device_relaxed_non_volatile.*]](
-; SM8X-DAG:  ld.param.{{b|u}}64 %rd[[#ATOM:]], {{.*}}[[FUNCTION]]_param_0{{.*}}
-; SM8X-DAG:  ld.param.{{b|u}}64 %rd[[#EXPECTED:]], {{.*}}[[FUNCTION]]_param_1{{.*}}
-; SM8X-DAG:  ld.param.{{b|u}}32 %r[[#INPUT:]], {{.*}}[[FUNCTION]]_param_2{{.*}}
-; SM8X-DAG:  cvta.to.global.u64 %rd[[#GOUT:]], %rd[[#EXPECTED]];
-; SM8X-DAG:  ld.global.{{b|u}}32 %r[[#LOCALEXP:]], [%rd[[#INPUT]]];
-; SM8X-NEXT: {{/*[[:space:]] *}}atom.cas.relaxed.gpu.b32 %r[[#DEST:]],[%rd[[#ATOM]]],%r[[#LOCALEXP]],%r[[#INPUT]];{{[[:space:]]/*}}
-; SM8X-NEXT: st.global.{{b|u}}32 [%rd[[#GOUT]]], %r[[#DEST]];
-; SM8X-NEXT: ret;
+; SMXX-LABEL: .target sm_{{[0-9]+[af]?}}
+; SMXX:      .visible .entry [[FUNCTION:_.*cas_device_relaxed_non_volatile.*]](
+; SMXX-DAG:  ld.param.{{b|u}}64 %rd[[#ATOM:]], {{.*}}[[FUNCTION]]_param_0{{.*}}
+; SMXX-DAG:  ld.param.{{b|u}}64 %rd[[#EXPECTED:]], {{.*}}[[FUNCTION]]_param_1{{.*}}
+; SMXX-DAG:  ld.param.{{b|u}}32 %r[[#INPUT:]], {{.*}}[[FUNCTION]]_param_2{{.*}}
+; SMXX-DAG:  cvta.to.global.u64 %rd[[#GOUT:]], %rd[[#EXPECTED]];
+; SMXX-DAG:  ld.global.{{b|u}}32 %r[[#LOCALEXP:]], [%rd[[#GOUT]]];
+; SMXX-NEXT: {{/*[[:space:]] *}}atom.cas.relaxed.gpu.b32 %r[[#DEST:]],[%rd[[#ATOM]]],%r[[#LOCALEXP]],%r[[#INPUT]];{{[[:space:]]/*}}
+; SMXX-NEXT: st.global.{{b|u}}32 [%rd[[#GOUT]]], %r[[#DEST]];
+; SMXX-NEXT: ret;
 
 */

--- a/libcudacxx/test/atomic_codegen/atomic_exch_non_volatile.cu
+++ b/libcudacxx/test/atomic_codegen/atomic_exch_non_volatile.cu
@@ -8,14 +8,14 @@ __global__ void exch_device_relaxed_non_volatile(int* data, int* out, int n)
 
 /*
 
-; SM8X-LABEL: .target sm_80
-; SM8X:      .visible .entry [[FUNCTION:_.*exch_device_relaxed_non_volatile.*]](
-; SM8X-DAG:  ld.param.{{b|u}}64 %rd[[#ATOM:]], {{.*}}[[FUNCTION]]_param_0{{.*}}
-; SM8X-DAG:  ld.param.{{b|u}}64 %rd[[#EXPECTED:]], {{.*}}[[FUNCTION]]_param_1{{.*}}
-; SM8X-DAG:  ld.param.{{b|u}}32 %r[[#INPUT:]], {{.*}}[[FUNCTION]]_param_2{{.*}}
-; SM8X-DAG:  cvta.to.global.u64 %rd[[#GOUT:]], %rd[[#EXPECTED]];
-; SM8X-NEXT: {{/*[[:space:]] *}}atom.exch.relaxed.gpu.b32 %r[[#DEST:]],[%rd[[#ATOM]]],%r[[#INPUT]];{{[[:space:]]/*}}
-; SM8X-NEXT: st.global.{{b|u}}32 [%rd[[#GOUT]]], %r[[#DEST]];
-; SM8X-NEXT: ret;
+; SMXX-LABEL: .target sm_{{[0-9]+[af]?}}
+; SMXX:      .visible .entry [[FUNCTION:_.*exch_device_relaxed_non_volatile.*]](
+; SMXX-DAG:  ld.param.{{b|u}}64 %rd[[#ATOM:]], {{.*}}[[FUNCTION]]_param_0{{.*}}
+; SMXX-DAG:  ld.param.{{b|u}}64 %rd[[#EXPECTED:]], {{.*}}[[FUNCTION]]_param_1{{.*}}
+; SMXX-DAG:  ld.param.{{b|u}}32 %r[[#INPUT:]], {{.*}}[[FUNCTION]]_param_2{{.*}}
+; SMXX-DAG:  cvta.to.global.u64 %rd[[#GOUT:]], %rd[[#EXPECTED]];
+; SMXX-DAG:  {{/*[[:space:]] *}}atom.exch.relaxed.gpu.b32 %r[[#DEST:]],[%rd[[#ATOM]]],%r[[#INPUT]];{{[[:space:]]/*}}
+; SMXX-NEXT: st.global.{{b|u}}32 [%rd[[#GOUT]]], %r[[#DEST]];
+; SMXX-NEXT: ret;
 
 */

--- a/libcudacxx/test/atomic_codegen/atomic_load_non_volatile.cu
+++ b/libcudacxx/test/atomic_codegen/atomic_load_non_volatile.cu
@@ -8,13 +8,13 @@ __global__ void load_relaxed_device_non_volatile(int* data, int* out)
 
 /*
 
-; SM8X-LABEL: .target sm_80
-; SM8X:      .visible .entry [[FUNCTION:_.*load_relaxed_device_non_volatile.*]](
-; SM8X-DAG:  ld.param.{{b|u}}64 %rd[[#ATOM:]], {{.*}}[[FUNCTION]]_param_0{{.*}}
-; SM8X-DAG:  ld.param.{{b|u}}64 %rd[[#EXPECTED:]], {{.*}}[[FUNCTION]]_param_1{{.*}}
-; SM8X-DAG:  cvta.to.global.u64 %rd[[#GOUT:]], %rd[[#EXPECTED]];
-; SM8X-NEXT: {{/*[[:space:]] *}}ld.relaxed.gpu.b32 %r[[#DEST:]],[%rd[[#ATOM]]];{{[[:space:]]/*}}
-; SM8X-NEXT: st.global.{{b|u}}32 [%rd[[#GOUT]]], %r[[#DEST]];
-; SM8X-NEXT: ret;
+; SMXX-LABEL: .target sm_{{[0-9]+[af]?}}
+; SMXX:      .visible .entry [[FUNCTION:_.*load_relaxed_device_non_volatile.*]](
+; SMXX-DAG:  ld.param.{{b|u}}64 %rd[[#ATOM:]], {{.*}}[[FUNCTION]]_param_0{{.*}}
+; SMXX-DAG:  ld.param.{{b|u}}64 %rd[[#EXPECTED:]], {{.*}}[[FUNCTION]]_param_1{{.*}}
+; SMXX-DAG:  cvta.to.global.u64 %rd[[#GOUT:]], %rd[[#EXPECTED]];
+; SMXX-DAG:  {{/*[[:space:]] *}}ld.relaxed.gpu.b32 %r[[#DEST:]],[%rd[[#ATOM]]];{{[[:space:]]/*}}
+; SMXX-NEXT: st.global.{{b|u}}32 [%rd[[#GOUT]]], %r[[#DEST]];
+; SMXX-NEXT: ret;
 
 */

--- a/libcudacxx/test/atomic_codegen/atomic_store_non_volatile.cu
+++ b/libcudacxx/test/atomic_codegen/atomic_store_non_volatile.cu
@@ -8,11 +8,11 @@ __global__ void store_relaxed_device_non_volatile(int* data, int in)
 
 /*
 
-; SM8X-LABEL: .target sm_80
-; SM8X:      .visible .entry [[FUNCTION:_.*store_relaxed_device_non_volatile.*]](
-; SM8X-DAG:  ld.param.{{b|u}}64 %rd[[#ATOM:]], {{.*}}[[FUNCTION]]_param_0{{.*}}
-; SM8X-DAG:  ld.param.{{b|u}}32 %r[[#INPUT:]], {{.*}}[[FUNCTION]]_param_1{{.*}}
-; SM8X-NEXT: {{/*[[:space:]] *}}st.relaxed.gpu.b32 [%rd[[#ATOM]]],%r[[#INPUT]];{{[[:space:]]/*}}
-; SM8X-NEXT: ret;
+; SMXX-LABEL: .target sm_{{[0-9]+[af]?}}
+; SMXX:      .visible .entry [[FUNCTION:_.*store_relaxed_device_non_volatile.*]](
+; SMXX-DAG:  ld.param.{{b|u}}64 %rd[[#ATOM:]], {{.*}}[[FUNCTION]]_param_0{{.*}}
+; SMXX-DAG:  ld.param.{{b|u}}32 %r[[#INPUT:]], {{.*}}[[FUNCTION]]_param_1{{.*}}
+; SMXX-NEXT: {{/*[[:space:]] *}}st.relaxed.gpu.b32 [%rd[[#ATOM]]],%r[[#INPUT]];{{[[:space:]]/*}}
+; SMXX-NEXT: ret;
 
 */

--- a/libcudacxx/test/atomic_codegen/atomic_sub_non_volatile.cu
+++ b/libcudacxx/test/atomic_codegen/atomic_sub_non_volatile.cu
@@ -26,27 +26,27 @@ __global__ void sub_relaxed_system_pointer_non_volatile(int** data, int** out, i
 
 /*
 
-; SM8X-LABEL: .target sm_80
-; SM8X:      .visible .entry [[FUNCTION:_.*sub_relaxed_device_non_volatile.*]](
-; SM8X-DAG:  ld.param.{{b|u}}64 %rd[[#ATOM:]], {{.*}}[[FUNCTION]]_param_0{{.*}}
-; SM8X-DAG:  ld.param.{{b|u}}64 %rd[[#RESULT:]], {{.*}}[[FUNCTION]]_param_1{{.*}}
-; SM8X-DAG:  ld.param.{{b|u}}32 %r[[#INPUT:]], {{.*}}[[FUNCTION]]_param_2{{.*}}
-; SM8X-DAG:  cvta.to.global.u64 %rd[[#GOUT:]], %rd[[#RESULT]];
-; SM8X-NEXT: neg.s32 %r[[#NEG:]], %r[[#INPUT]];
-; SM8X-NEXT: {{/*[[:space:]] *}}atom.add.relaxed.gpu.s32 %r[[#DEST:]],[%rd[[#ATOM]]],%r[[#NEG]];{{[[:space:]]/*}}
-; SM8X-NEXT: st.global.{{b|u}}32 [%rd[[#GOUT]]], %r[[#DEST]];
-; SM8X-NEXT: ret;
+; SMXX-LABEL: .target sm_{{[0-9]+[af]?}}
+; SMXX:      .visible .entry [[FUNCTION:_.*sub_relaxed_device_non_volatile.*]](
+; SMXX-DAG:  ld.param.{{b|u}}64 %rd[[#ATOM:]], {{.*}}[[FUNCTION]]_param_0{{.*}}
+; SMXX-DAG:  ld.param.{{b|u}}64 %rd[[#RESULT:]], {{.*}}[[FUNCTION]]_param_1{{.*}}
+; SMXX-DAG:  ld.param.{{b|u}}32 %r[[#INPUT:]], {{.*}}[[FUNCTION]]_param_2{{.*}}
+; SMXX-DAG:  cvta.to.global.u64 %rd[[#GOUT:]], %rd[[#RESULT]];
+; SMXX-DAG:  neg.s32 %r[[#NEG:]], %r[[#INPUT]];
+; SMXX-DAG:  {{/*[[:space:]] *}}atom.add.relaxed.gpu.s32 %r[[#DEST:]],[%rd[[#ATOM]]],%r[[#NEG]];{{[[:space:]]/*}}
+; SMXX-NEXT: st.global.{{b|u}}32 [%rd[[#GOUT]]], %r[[#DEST]];
+; SMXX-NEXT: ret;
 
-; SM8X-LABEL: .visible .entry {{_.*sub_relaxed_block_pointer_non_volatile.*}}(
-; SM8X: {{.*}}atom.add.relaxed.cta.u64{{.*}}
-; SM8X: ret;
+; SMXX-LABEL: .visible .entry {{_.*sub_relaxed_block_pointer_non_volatile.*}}(
+; SMXX: {{.*}}atom.add.relaxed.cta.u64{{.*}}
+; SMXX: ret;
 
-; SM8X-LABEL: .visible .entry {{_.*sub_relaxed_device_pointer_non_volatile.*}}(
-; SM8X: {{.*}}atom.add.relaxed.gpu.u64{{.*}}
-; SM8X: ret;
+; SMXX-LABEL: .visible .entry {{_.*sub_relaxed_device_pointer_non_volatile.*}}(
+; SMXX: {{.*}}atom.add.relaxed.gpu.u64{{.*}}
+; SMXX: ret;
 
-; SM8X-LABEL: .visible .entry {{_.*sub_relaxed_system_pointer_non_volatile.*}}(
-; SM8X: {{.*}}atom.add.relaxed.sys.u64{{.*}}
-; SM8X: ret;
+; SMXX-LABEL: .visible .entry {{_.*sub_relaxed_system_pointer_non_volatile.*}}(
+; SMXX: {{.*}}atom.add.relaxed.sys.u64{{.*}}
+; SMXX: ret;
 
 */

--- a/libcudacxx/test/cmake/CodegenTest.cmake
+++ b/libcudacxx/test/cmake/CodegenTest.cmake
@@ -80,12 +80,57 @@ set(
   "${CMAKE_CURRENT_LIST_DIR}/../codegen/dump_and_check.bash"
 )
 
+# Return the concrete CUDA architectures requested for a PTX or SASS test.
+# CMake records the architectures detected for "native" separately, while
+# "all" and "all-major" have compiler-specific expansions.
+function(libcudacxx_codegen_get_cuda_architectures out_var code_kind)
+  if (NOT code_kind MATCHES "^(PTX|SASS)$")
+    message(FATAL_ERROR "Unsupported codegen test kind: ${code_kind}")
+  endif()
+
+  set(requested_architectures)
+  foreach (arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
+    if (arch STREQUAL "native")
+      # Native selects an architecture, rather than a particular output kind.
+      # Strip CMake's -real suffix so both PTX and SASS tests use that arch.
+      foreach (native_arch IN LISTS CMAKE_CUDA_ARCHITECTURES_NATIVE)
+        if (native_arch MATCHES "^([0-9]+[af]?)")
+          list(APPEND requested_architectures "${CMAKE_MATCH_1}")
+        endif()
+      endforeach()
+    elseif (arch STREQUAL "all")
+      list(APPEND requested_architectures ${CMAKE_CUDA_ARCHITECTURES_ALL})
+    elseif (arch STREQUAL "all-major")
+      list(APPEND requested_architectures ${CMAKE_CUDA_ARCHITECTURES_ALL_MAJOR})
+    else()
+      list(APPEND requested_architectures "${arch}")
+    endif()
+  endforeach()
+
+  set(cuda_architectures)
+  foreach (arch IN LISTS requested_architectures)
+    if (arch MATCHES "^([0-9]+[af]?)(-(real|virtual))?$")
+      set(output_kind "${CMAKE_MATCH_3}")
+      if (code_kind STREQUAL "PTX" AND output_kind STREQUAL "real")
+        continue()
+      endif()
+      if (code_kind STREQUAL "SASS" AND output_kind STREQUAL "virtual")
+        continue()
+      endif()
+      list(APPEND cuda_architectures "${CMAKE_MATCH_1}")
+    endif()
+  endforeach()
+  list(REMOVE_DUPLICATES cuda_architectures)
+  set(${out_var} "${cuda_architectures}" PARENT_SCOPE)
+endfunction()
+
 function(libcudacxx_codegen_set_cuda_arch target_name arch)
   if (arch MATCHES "[af]$")
     set_target_properties(${target_name} PROPERTIES CUDA_ARCHITECTURES OFF)
     target_compile_options(
       ${target_name}
-      PRIVATE "--generate-code=arch=compute_${arch},code=sm_${arch}"
+      PRIVATE
+        "--generate-code=arch=compute_${arch},code=[compute_${arch},sm_${arch}]"
     )
   else()
     set_target_properties(

--- a/libcudacxx/test/simd_codegen/CMakeLists.txt
+++ b/libcudacxx/test/simd_codegen/CMakeLists.txt
@@ -51,44 +51,53 @@ if ("Clang" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
   return()
 endif()
 
-set(simd_codegen_sass_cuda_archs 80 90)
-if (
-  CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8
-  AND NOT CMAKE_CUDA_COMPILER_ID STREQUAL Clang
-)
-  list(APPEND simd_codegen_sass_cuda_archs 100 120)
+libcudacxx_codegen_get_cuda_architectures(simd_codegen_ptx_cuda_archs PTX)
+libcudacxx_codegen_get_cuda_architectures(simd_codegen_sass_cuda_archs SASS)
+if (NOT simd_codegen_ptx_cuda_archs AND NOT simd_codegen_sass_cuda_archs)
+  message(
+    STATUS
+    "No compatible CUDA architectures requested; skipping simd codegen tests"
+  )
+  return()
 endif()
 
-if (
-  CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.9
-  AND NOT CMAKE_CUDA_COMPILER_ID STREQUAL Clang
-)
-  list(APPEND simd_codegen_sass_cuda_archs 103 120f)
-endif()
-
-set(simd_codegen_sass_tests)
-file(
-  GLOB simd_codegen_sass_tests
-  "floating_point/*.cu"
-  "integer/*.cu"
-  "min_max/*.cu"
-)
-
-# The 8-bit arithmetic and min/max tests require the PTX ISA 9.2 8-bit SIMD
-# path available with CUDA 13.2 and newer.
-if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.2)
-  list(
-    REMOVE_ITEM simd_codegen_sass_tests
-    "${CMAKE_CURRENT_SOURCE_DIR}/integer/arithmetic_u8x4.cu"
-    "${CMAKE_CURRENT_SOURCE_DIR}/min_max/min_max_i8x4.cu"
+if (simd_codegen_ptx_cuda_archs)
+  add_subdirectory(load_store)
+else()
+  message(
+    STATUS
+    "No compatible CUDA architectures requested; skipping simd PTX codegen tests"
   )
 endif()
 
-add_subdirectory(load_store)
+if (simd_codegen_sass_cuda_archs)
+  set(simd_codegen_sass_tests)
+  file(
+    GLOB simd_codegen_sass_tests
+    "floating_point/*.cu"
+    "integer/*.cu"
+    "min_max/*.cu"
+  )
 
-libcudacxx_codegen_add_sass_tests(
-  AGGREGATE_TARGET libcudacxx.test.simd.sass
-  TARGET_PREFIX simd_codegen
-  ARCHITECTURES ${simd_codegen_sass_cuda_archs}
-  TESTS ${simd_codegen_sass_tests}
-)
+  # The 8-bit arithmetic and min/max tests require the PTX ISA 9.2 8-bit SIMD
+  # path available with CUDA 13.2 and newer.
+  if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.2)
+    list(
+      REMOVE_ITEM simd_codegen_sass_tests
+      "${CMAKE_CURRENT_SOURCE_DIR}/integer/arithmetic_u8x4.cu"
+      "${CMAKE_CURRENT_SOURCE_DIR}/min_max/min_max_i8x4.cu"
+    )
+  endif()
+
+  libcudacxx_codegen_add_sass_tests(
+    AGGREGATE_TARGET libcudacxx.test.simd.sass
+    TARGET_PREFIX simd_codegen
+    ARCHITECTURES ${simd_codegen_sass_cuda_archs}
+    TESTS ${simd_codegen_sass_tests}
+  )
+else()
+  message(
+    STATUS
+    "No compatible CUDA architectures requested; skipping simd SASS codegen tests"
+  )
+endif()

--- a/libcudacxx/test/simd_codegen/load_store/CMakeLists.txt
+++ b/libcudacxx/test/simd_codegen/load_store/CMakeLists.txt
@@ -20,40 +20,25 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/load_store_f64.cu"
 )
 
-set(simd_codegen_default_prefixes SMXXX)
-libcudacxx_codegen_add_ptx_tests(
-  AGGREGATE_TARGET libcudacxx.test.simd.ptx
-  TARGET_PREFIX simd_codegen
-  ARCH 80
-  CHECK_PREFIXES ${simd_codegen_default_prefixes}
-  TESTS ${simd_codegen_load_store_tests}
-)
-libcudacxx_codegen_add_ptx_tests(
-  AGGREGATE_TARGET libcudacxx.test.simd.ptx
-  TARGET_PREFIX simd_codegen
-  ARCH 90
-  CHECK_PREFIXES ${simd_codegen_default_prefixes}
-  TESTS ${simd_codegen_load_store_tests}
-)
+foreach (arch IN LISTS simd_codegen_ptx_cuda_archs)
+  set(simd_codegen_check_prefixes SMXXX)
+  if (arch MATCHES "^([0-9]+)")
+    set(arch_number "${CMAKE_MATCH_1}")
+    # SM100 and newer support the 32-byte vectorized PTX checks.
+    if (
+      arch_number GREATER_EQUAL 100
+      AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.9
+      AND NOT CMAKE_CUDA_COMPILER_ID STREQUAL Clang
+    )
+      list(APPEND simd_codegen_check_prefixes SM100-PLUS)
+    endif()
+  endif()
 
-# SM100/SM120 add 32-byte vectorized checks.
-if (
-  CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.9
-  AND NOT CMAKE_CUDA_COMPILER_ID STREQUAL Clang
-)
-  set(simd_codegen_sm100_prefixes SMXXX SM100-PLUS)
   libcudacxx_codegen_add_ptx_tests(
     AGGREGATE_TARGET libcudacxx.test.simd.ptx
     TARGET_PREFIX simd_codegen
-    ARCH 100
-    CHECK_PREFIXES ${simd_codegen_sm100_prefixes}
+    ARCH "${arch}"
+    CHECK_PREFIXES ${simd_codegen_check_prefixes}
     TESTS ${simd_codegen_load_store_tests}
   )
-  libcudacxx_codegen_add_ptx_tests(
-    AGGREGATE_TARGET libcudacxx.test.simd.ptx
-    TARGET_PREFIX simd_codegen
-    ARCH 120
-    CHECK_PREFIXES ${simd_codegen_sm100_prefixes}
-    TESTS ${simd_codegen_load_store_tests}
-  )
-endif()
+endforeach()


### PR DESCRIPTION
## Description

Follow-up to #10671.

After #10671, the architecture handling in the existing suites was still not up to the standard that #10722 needs. This is an extraction of changes from that PR, that makes the arch handling more consistent with the rest of the CCCL build system.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
