### PR TITLE
[cudax] Restrict generic group queries

### DIFF
--- a/cudax/include/cuda/experimental/__group/group.cuh
+++ b/cudax/include/cuda/experimental/__group/group.cuh
@@ -203,43 +203,33 @@ public:
     __synchronizer_instance_.do_sync_aligned(__mapping_result_, __synchronizer_, __hier_);
   }
 
-  _CCCL_TEMPLATE(class _Tp, class _InLevel)
-  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND __is_hierarchy_level_v<_InLevel>)
-  [[nodiscard]] _CCCL_DEVICE_API constexpr _Tp count_as(const _InLevel&) const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_count(const _ParentGroup&) noexcept
   {
-    _Tp __ret = __mapping_result_.group_count();
-    if constexpr (!::cuda::std::is_same_v<_InLevel, level_type>)
-    {
-      __ret *= __count_query<level_type, _InLevel>::template __call<_Tp>(__hier_);
-    }
-    return __ret;
+    return _MappingResult::static_group_count();
   }
 
-  _CCCL_TEMPLATE(class _InLevel)
-  _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel>)
-  [[nodiscard]] _CCCL_DEVICE_API constexpr auto count(const _InLevel& __in_level) const noexcept
+  _CCCL_TEMPLATE(class _Tp)
+  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)
+  [[nodiscard]] _CCCL_DEVICE_API constexpr _Tp count_as(const _ParentGroup&) const noexcept
   {
-    return count_as<typename _InLevel::__product_type>(__in_level);
+    return static_cast<_Tp>(__mapping_result_.group_count());
   }
 
-  _CCCL_TEMPLATE(class _Tp, class _InLevel)
-  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND __is_hierarchy_level_v<_InLevel>)
-  [[nodiscard]] _CCCL_DEVICE_API _Tp rank_as(const _InLevel&) const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr auto count(const _ParentGroup&) const noexcept
   {
-    _Tp __ret = __mapping_result_.group_rank();
-    if constexpr (!::cuda::std::is_same_v<_InLevel, level_type>)
-    {
-      __ret += static_cast<_Tp>(
-        __rank_query<level_type, _InLevel>::template __call<_Tp>(__hier_) * __mapping_result_.group_count());
-    }
-    return __ret;
+    return __mapping_result_.group_count();
   }
 
-  _CCCL_TEMPLATE(class _InLevel)
-  _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel>)
-  [[nodiscard]] _CCCL_DEVICE_API auto rank(const _InLevel& __in_level) const noexcept
+  _CCCL_TEMPLATE(class _Tp)
+  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)
+  [[nodiscard]] _CCCL_DEVICE_API _Tp rank_as(const _ParentGroup&) const noexcept
   {
-    return rank_as<typename _InLevel::__product_type>(__in_level);
+    return static_cast<_Tp>(__mapping_result_.group_rank());
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API auto rank(const _ParentGroup&) const noexcept
+  {
+    return __mapping_result_.group_rank();
   }
 };
 

--- a/cudax/test/coop/reduce/threads_within_warp.cu
+++ b/cudax/test/coop/reduce/threads_within_warp.cu
@@ -45,8 +45,8 @@ struct ReduceKernel
     T* __restrict__ d_out,
     RedOp red_op)
   {
-    cudax::group group{
-      cuda::gpu_thread, cudax::this_warp{config}, cudax::group_by<NThreadsInGroup, false>{}, cudax::lane_synchronizer{}};
+    cudax::this_warp warp{config};
+    cudax::group group{cuda::gpu_thread, warp, cudax::group_by<NThreadsInGroup, false>{}, cudax::lane_synchronizer{}};
 
     // All threads that are not part of the groups should exit early.
     if (!cuda::gpu_thread.is_part_of(group))
@@ -55,7 +55,7 @@ struct ReduceKernel
     }
 
     // We want to work only with one group, all other groups should exit early.
-    if (group.rank(cuda::warp) > 0)
+    if (group.rank(warp) > 0)
     {
       return;
     }

--- a/cudax/test/group/group.cu
+++ b/cudax/test/group/group.cu
@@ -73,7 +73,8 @@ __device__ void test_common_properties(const Hierarchy&, Group& group)
 }
 
 template <class ParentGroup, class MappingResult, class Synchronizer>
-__device__ void test_queries(const cudax::group<cuda::thread_level, ParentGroup, MappingResult, Synchronizer>& group)
+__device__ void test_queries(const cudax::group<cuda::thread_level, ParentGroup, MappingResult, Synchronizer>& group,
+                             const ParentGroup& parent_group)
 {
   // todo(dabayer): These queries end up in `error: expression must have a constant value`, when group is taken by
   // reference. Can we find a solution that works without copying the group?
@@ -90,17 +91,13 @@ __device__ void test_queries(const cudax::group<cuda::thread_level, ParentGroup,
   REQUIRE(cuda::gpu_thread.is_root_rank(group) == (rank_ref == 0));
   REQUIRE(cuda::gpu_thread.is_part_of(group));
 
-  auto group_count_ref = group.__mapping_result().group_count();
-  auto group_rank_ref  = group.__mapping_result().group_rank();
+  const auto static_group_count_ref = group.__mapping_result().static_group_count();
+  const auto group_count_ref        = group.__mapping_result().group_count();
+  const auto group_rank_ref         = group.__mapping_result().group_rank();
 
-  if constexpr (!cuda::std::is_same_v<Level, cuda::grid_level>)
-  {
-    group_count_ref *= Level{}.count(cuda::grid, group.hierarchy());
-    group_rank_ref += group.__mapping_result().group_count() * Level{}.rank(cuda::grid, group.hierarchy());
-  }
-
-  REQUIRE(group.count(cuda::grid) == group_count_ref);
-  REQUIRE(group.rank(cuda::grid) == group_rank_ref);
+  REQUIRE(group.static_count(parent_group) == static_group_count_ref);
+  REQUIRE(group.count(parent_group) == group_count_ref);
+  REQUIRE(group.rank(parent_group) == group_rank_ref);
 }
 
 template <cuda::std::size_t N, class Unit, class Level, class Config>
@@ -118,7 +115,7 @@ __device__ void test_group_by_group(Unit unit, Level level, Config config)
     cudax::group group{unit, parent_group, mapping, synchronizer};
 
     test_common_properties<Unit, Level>(config.hierarchy(), group);
-    test_queries(group);
+    test_queries(group, parent_group);
     group.sync();
   }
   {
@@ -129,7 +126,7 @@ __device__ void test_group_by_group(Unit unit, Level level, Config config)
     cudax::group group{unit, parent_group, mapping, synchronizer};
 
     test_common_properties<Unit, Level>(config.hierarchy(), group);
-    test_queries(group);
+    test_queries(group, parent_group);
     group.sync();
   }
 }

--- a/cudax/test/group/invoke_one.cu
+++ b/cudax/test/group/invoke_one.cu
@@ -55,12 +55,6 @@ __device__ void check_and_reset_invoke_count(const Group& group)
 template <class Group>
 __device__ void test_invoke_one(const Group& group)
 {
-  // We need only 1 group for these tests.
-  if (group.rank(cuda::grid) > 0)
-  {
-    return;
-  }
-
   // invoke_one callable with void return type
   {
     auto callable = []() {
@@ -255,16 +249,37 @@ struct TestKernel
   template <class Config>
   __device__ void operator()(const Config& config)
   {
+    // We want only 1 unit to be used for the test.
+
     // Test this groups.
-    test_invoke_one(cudax::this_thread{config});
-    test_invoke_one(cudax::this_warp{config});
-    test_invoke_one(cudax::this_block{config});
-    test_invoke_one(cudax::this_cluster{config});
+    if (cuda::gpu_thread.rank(cuda::grid, config) == 0)
+    {
+      test_invoke_one(cudax::this_thread{config});
+    }
+    if (cuda::warp.rank(cuda::grid, config) == 0)
+    {
+      test_invoke_one(cudax::this_warp{config});
+    }
+    if (cuda::block.rank(cuda::grid, config) == 0)
+    {
+      test_invoke_one(cudax::this_block{config});
+    }
+    if (cuda::cluster.rank(cuda::grid, config) == 0)
+    {
+      test_invoke_one(cudax::this_cluster{config});
+    }
+    test_invoke_one(cudax::this_grid{config});
 
     // Test custom groups.
+    if (cuda::warp.rank(cuda::grid, config) == 0)
     {
-      cudax::group group{cuda::gpu_thread, cudax::this_warp{config}, cudax::group_by<4>{}, cudax::lane_synchronizer{}};
-      test_invoke_one(group);
+      cudax::this_warp warp{config};
+      cudax::group group{cuda::gpu_thread, warp, cudax::group_by<4>{}, cudax::lane_synchronizer{}};
+
+      if (group.rank(warp) == 0)
+      {
+        test_invoke_one(group);
+      }
     }
   }
 };


### PR DESCRIPTION
Currently, when a group is created, it supports super-level queries for any native level. However, this approach is not correct in my opinion. Suppose an example as:
```cpp
cudax::group g{cuda::gpu_thread, cudax::this_warp{}, cudax::group_as{2, 4, 6, 8}, cudax::lane_synchronizer{}};

auto v = g.rank(cuda::block); // ??
```
We are splitting each warp into 4 groups of sizes 2, 4, 6 or 8. The question is what should the rank for group's rank within the block return?

As it is implemented now, every group would return a different value - `2 * nwarps`, `4 * nwarps`, `6 * nwarps` and `8 * nwarps`. That doesn't make any sense in my opinion, the only meaningful value would be returned when we would query the group's rank within a warp.


That's why in this PR, I'd like to allow only `group.query(parent_group)` queries, because that's the only way we can guarantee the returned value is valid.

This is done only for the generic groups, not `this_meow` groups. Those don't have a parent group and still support the current query form.