### PR TITLE
[Thrust] Fix memory resource equality

### DIFF
--- a/thrust/testing/mr_memory_resource.cu
+++ b/thrust/testing/mr_memory_resource.cu
@@ -32,7 +32,7 @@ class identity_resource final : public forwarding_resource
 class always_equal_resource final : public forwarding_resource
 {
 public:
-  bool do_is_equal(const thrust::mr::memory_resource<>&) const noexcept override
+  _CCCL_HOST_DEVICE bool do_is_equal(const thrust::mr::memory_resource<>&) const noexcept override
   {
     return true;
   }

--- a/thrust/testing/mr_memory_resource.cu
+++ b/thrust/testing/mr_memory_resource.cu
@@ -1,6 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <thrust/mr/allocator.h>
 #include <thrust/mr/memory_resource.h>
 #include <thrust/mr/new.h>
+
+#include <cstddef>
 
 #include <unittest/unittest.h>
 

--- a/thrust/testing/mr_memory_resource.cu
+++ b/thrust/testing/mr_memory_resource.cu
@@ -1,0 +1,77 @@
+#include <thrust/mr/allocator.h>
+#include <thrust/mr/memory_resource.h>
+#include <thrust/mr/new.h>
+
+#include <unittest/unittest.h>
+
+class forwarding_resource : public thrust::mr::memory_resource<>
+{
+public:
+  void* do_allocate(std::size_t bytes, std::size_t alignment) override
+  {
+    return upstream.do_allocate(bytes, alignment);
+  }
+
+  void do_deallocate(void* pointer, std::size_t bytes, std::size_t alignment) override
+  {
+    upstream.do_deallocate(pointer, bytes, alignment);
+  }
+
+private:
+  thrust::mr::new_delete_resource upstream;
+};
+
+class identity_resource final : public forwarding_resource
+{};
+
+class always_equal_resource final : public forwarding_resource
+{
+public:
+  bool do_is_equal(const thrust::mr::memory_resource<>&) const noexcept override
+  {
+    return true;
+  }
+};
+
+void TestMemoryResourceIdentityEquality()
+{
+  identity_resource first;
+  identity_resource second;
+
+  ASSERT_EQUAL(first == first, true);
+  ASSERT_EQUAL(first != first, false);
+  ASSERT_EQUAL(first == second, false);
+  ASSERT_EQUAL(second == first, false);
+
+  using allocator = thrust::mr::allocator<int, identity_resource>;
+
+  const allocator first_allocator(&first);
+  const allocator same_allocator(&first);
+  const allocator second_allocator(&second);
+
+  ASSERT_EQUAL(first_allocator == same_allocator, true);
+  ASSERT_EQUAL(first_allocator != same_allocator, false);
+  ASSERT_EQUAL(first_allocator == second_allocator, false);
+  ASSERT_EQUAL(second_allocator == first_allocator, false);
+}
+DECLARE_UNITTEST(TestMemoryResourceIdentityEquality);
+
+void TestMemoryResourceEquivalentEquality()
+{
+  always_equal_resource first;
+  always_equal_resource second;
+
+  ASSERT_EQUAL(first == second, true);
+  ASSERT_EQUAL(second == first, true);
+  ASSERT_EQUAL(first != second, false);
+
+  using allocator = thrust::mr::allocator<int, always_equal_resource>;
+
+  const allocator first_allocator(&first);
+  const allocator second_allocator(&second);
+
+  ASSERT_EQUAL(first_allocator == second_allocator, true);
+  ASSERT_EQUAL(second_allocator == first_allocator, true);
+  ASSERT_EQUAL(first_allocator != second_allocator, false);
+}
+DECLARE_UNITTEST(TestMemoryResourceEquivalentEquality);

--- a/thrust/thrust/mr/memory_resource.h
+++ b/thrust/thrust/mr/memory_resource.h
@@ -173,7 +173,7 @@ public:
 template <typename Pointer>
 _CCCL_HOST_DEVICE bool operator==(const memory_resource<Pointer>& lhs, const memory_resource<Pointer>& rhs) noexcept
 {
-  return &lhs == &rhs || rhs.is_equal(rhs);
+  return &lhs == &rhs || lhs.is_equal(rhs);
 }
 
 /*! Compares the memory resources for inequality, first by identity, then by \p is_equal.


### PR DESCRIPTION
## Description

Closes NVIDIA-dev/cccl_private#838

Fixes nvbug6511371

The free `thrust::mr::memory_resource` equality operator asks the right-hand resource whether it equals itself. Reflexive resources therefore make distinct resources compare equal, which also makes allocators backed by different pools compare equal and can route storage to the wrong pool.

This changes the comparison to `lhs.is_equal(rhs)` and adds focused coverage for distinct identity-based resources, equivalent resources, and the corresponding allocator comparisons.

## Validation

- The new identity-resource test fails against `main` and passes with this fix.
- `thrust.cpp.cpp.test.mr_memory_resource`: 2/2 unit tests passed using the host-only CPP backend.
- Targeted repository pre-commit hooks passed.

CUDA compilation was not run because the local host does not provide `nvcc` or a GPU.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
