### PR TITLE
[libcu++] Handle empty any_resource equality

### DIFF
--- a/libcudacxx/include/cuda/__memory_resource/any_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/any_resource.h
@@ -580,8 +580,9 @@ public:
   //! @pre \c _OtherKind is equal to either \c _Kind or
   //! \c _ResourceKind::_Asynchronous.
   //! @pre The set `_Properties...` is equal to the set `_OtherProperties...`.
-  //! @return `true` if both resources hold objects of the same type and those
-  //! objects compare equal, and `false` otherwise.
+  //! @return `true` if neither resource has a value, or if both resources hold
+  //! objects of the same type and those objects compare equal. Otherwise,
+  //! returns `false`.
   template <_ResourceKind _OtherKind, class... _OtherProperties>
   [[nodiscard]] bool operator==(const basic_any_resource<_OtherKind, _OtherProperties...>& __rhs) const;
 
@@ -591,8 +592,9 @@ public:
   //! @pre \c _OtherKind is equal to either \c _Kind or
   //! \c _ResourceKind::_Asynchronous.
   //! @pre The set `_Properties...` is equal to the set `_OtherProperties...`.
-  //! @return `true` if \c __rhs refers to an object of the same type as that
-  //! wrapped by `*this` and those objects compare equal; `false` otherwise.
+  //! @return `true` if `*this` has a value, \c __rhs refers to an object of the
+  //! same type as that wrapped by `*this`, and those objects compare equal;
+  //! `false` otherwise.
   template <_ResourceKind _OtherKind, class... _OtherProperties>
   [[nodiscard]] bool operator==(const basic_resource_ref<_OtherKind, _OtherProperties...>& __rhs) const;
 

--- a/libcudacxx/include/cuda/__utility/__basic_any/semiregular.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/semiregular.h
@@ -180,7 +180,17 @@ struct iequality_comparable_base : __basic_interface<__iequality_comparable>
   [[nodiscard]] _CCCL_HOST_DEVICE_API friend auto
   operator==(__iequality_comparable<_ILeft> const& __lhs, __iequality_comparable<_IRight> const& __rhs) noexcept -> bool
   {
+    auto const& __self  = ::cuda::__basic_any_from(__lhs);
     auto const& __other = ::cuda::__basic_any_from(__rhs);
+    if (!__self.has_value())
+    {
+      return !__other.has_value();
+    }
+    if (!__other.has_value())
+    {
+      return false;
+    }
+
     constexpr auto __eq = &::cuda::__equal_fn<__iequality_comparable<_ILeft>>;
     return ::cuda::__virtcall<__eq>(&__lhs, __other.type(), __basic_any_access::__get_optr(__other));
   }
@@ -210,6 +220,11 @@ struct iequality_comparable_base : __basic_interface<__iequality_comparable>
   [[nodiscard]] _CCCL_HOST_DEVICE_API friend auto
   operator==(__iequality_comparable<_Interface> const& __lhs, _Object const& __rhs) -> bool
   {
+    if (!::cuda::__basic_any_from(__lhs).has_value())
+    {
+      return false;
+    }
+
     constexpr auto __eq = &::cuda::__equal_fn<__iequality_comparable<_Interface>>;
     return ::cuda::__virtcall<__eq>(&__lhs, _CCCL_TYPEID(_Object), ::cuda::std::addressof(__rhs));
   }
@@ -220,6 +235,11 @@ struct iequality_comparable_base : __basic_interface<__iequality_comparable>
   [[nodiscard]] _CCCL_HOST_DEVICE_API friend auto
   operator==(_Object const& __lhs, __iequality_comparable<_Interface> const& __rhs) noexcept -> bool
   {
+    if (!::cuda::__basic_any_from(__rhs).has_value())
+    {
+      return false;
+    }
+
     constexpr auto __eq = &::cuda::__equal_fn<__iequality_comparable<_Interface>>;
     return ::cuda::__virtcall<__eq>(&__rhs, _CCCL_TYPEID(_Object), ::cuda::std::addressof(__lhs));
   }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_resource.cu
@@ -91,6 +91,47 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
   // Reset the counters:
   this->counts = Counts();
 
+  SECTION("empty equality")
+  {
+    using AnyResource = cuda::mr::any_resource<::cuda::mr::host_accessible>;
+
+    TestResource resource{42, this};
+    AnyResource empty1;
+    AnyResource empty2;
+
+    CHECK(!empty1.has_value());
+    CHECK(!empty2.has_value());
+    CHECK((empty1 == empty2));
+    CHECK(!(empty1 != empty2));
+
+    AnyResource populated{resource};
+    CHECK((empty1 != populated));
+    CHECK((populated != empty1));
+    CHECK(!(empty1 == populated));
+    CHECK(!(populated == empty1));
+
+    CHECK(!(empty1 == resource));
+    CHECK(!(resource == empty1));
+    CHECK((empty1 != resource));
+    CHECK((resource != empty1));
+    CHECK(this->counts.equal_to_count == 0);
+
+    populated.reset();
+    CHECK((populated == empty1));
+    CHECK(!(populated != empty1));
+
+    AnyResource source{resource};
+    AnyResource destination{std::move(source)};
+    CHECK(!source.has_value());
+    CHECK((source == empty1));
+    CHECK((source != destination));
+    CHECK((destination != source));
+    CHECK(this->counts.equal_to_count == 0);
+  }
+
+  // Reset the counters:
+  this->counts = Counts();
+
   SECTION("allocate and deallocate_sync")
   {
     Counts expected{};

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_synchronous_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_synchronous_resource.cu
@@ -98,6 +98,47 @@ TEMPLATE_TEST_CASE_METHOD(
   // Reset the counters:
   this->counts = Counts();
 
+  SECTION("empty equality")
+  {
+    using AnyResource = cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data>;
+
+    TestResource resource{42, this};
+    AnyResource empty1;
+    AnyResource empty2;
+
+    CHECK(!empty1.has_value());
+    CHECK(!empty2.has_value());
+    CHECK((empty1 == empty2));
+    CHECK(!(empty1 != empty2));
+
+    AnyResource populated{resource};
+    CHECK((empty1 != populated));
+    CHECK((populated != empty1));
+    CHECK(!(empty1 == populated));
+    CHECK(!(populated == empty1));
+
+    CHECK(!(empty1 == resource));
+    CHECK(!(resource == empty1));
+    CHECK((empty1 != resource));
+    CHECK((resource != empty1));
+    CHECK(this->counts.equal_to_count == 0);
+
+    populated.reset();
+    CHECK((populated == empty1));
+    CHECK(!(populated != empty1));
+
+    AnyResource source{resource};
+    AnyResource destination{std::move(source)};
+    CHECK(!source.has_value());
+    CHECK((source == empty1));
+    CHECK((source != destination));
+    CHECK((destination != source));
+    CHECK(this->counts.equal_to_count == 0);
+  }
+
+  // Reset the counters:
+  this->counts = Counts();
+
   SECTION("allocate and deallocate_sync")
   {
     Counts expected{};

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_synchronous_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_synchronous_resource.cu
@@ -129,7 +129,7 @@ TEMPLATE_TEST_CASE_METHOD(
 
     AnyResource source{resource};
     AnyResource destination{std::move(source)};
-    CHECK(!source.has_value());
+    CHECK(!source.has_value()); // NOLINT(bugprone-use-after-move)
     CHECK((source == empty1));
     CHECK((source != destination));
     CHECK((destination != source));

--- a/libcudacxx/test/libcudacxx/cuda/utility/basic_any.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utility/basic_any.pass.cpp
@@ -578,6 +578,23 @@ struct BasicAnyTest : BasicAnyTestsFixture<TestType>
     assert(42 == a);
     assert(a != 43);
     assert(43 != a);
+
+    cuda::__basic_any<iregular<>> empty1;
+    cuda::__basic_any<iregular<>> empty2;
+    assert(empty1 == empty2);
+    assert(!(empty1 != empty2));
+    assert(empty1 != a);
+    assert(a != empty1);
+    assert(empty1 != 42);
+    assert(42 != empty1);
+
+    a.reset();
+    assert(a == empty1);
+
+    cuda::__basic_any<iregular<>> moved{::cuda::std::move(b)};
+    assert(!b.has_value());
+    assert(b == empty1);
+    assert(b != moved);
   }
 
   TEST_HOST_DEVICE_FUNC void test_basic_any_test_for_ambiguous_conversions()


### PR DESCRIPTION
## Description

Closes NVIDIA-dev/cccl_private#851

Fixes nvbug6511360

Default construction, reset, and move can leave an owning type-erased resource empty. Equality currently enters virtual dispatch unconditionally, dereferencing the empty object's null vtable.

This defines and implements empty-state equality before dispatch:

- two empty wrappers compare equal;
- exactly one empty wrapper compares unequal;
- an empty wrapper compares unequal to a concrete resource in either operand order;
- populated comparisons retain the existing type-erased dispatch.

The public API documentation now records those semantics. Tests cover default, reset, and moved-from states for the generic `__basic_any` machinery and both asynchronous and synchronous owning resource wrappers.

## Validation

- The new core regression crashes with signal 11 against the unmodified implementation.
- The fixed core test passed as C++17 and C++20 with `-Wall -Wextra -Werror`.
- The fixed core test passed under AddressSanitizer and UndefinedBehaviorSanitizer.
- Targeted repository pre-commit hooks passed.

The public CUDA `.cu` tests were added but not compiled locally because this host does not provide `nvcc` or a GPU.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
