### PR TITLE
Fix CI failure log collection

### DIFF
--- a/.github/actions/ci-failure-analysis/collect-logs.sh
+++ b/.github/actions/ci-failure-analysis/collect-logs.sh
@@ -47,13 +47,22 @@ gh api --paginate --slurp \
 
 mapfile -t failed_job_ids < <(jq -r '.[].id' "${output_dir}/jobs.json")
 
+collected_log_count=0
 for job_id in "${failed_job_ids[@]}"; do
   log_path="${output_dir}/job-${job_id}.log"
-  if ! gh api "repos/${repository}/actions/jobs/${job_id}/logs" > "${log_path}"; then
+  if ! gh api --allow-escape-sequences \
+    "repos/${repository}/actions/jobs/${job_id}/logs" > "${log_path}"; then
     echo "::warning::Unable to collect logs for job ${job_id}; continuing with job metadata."
     rm -f "${log_path}"
   elif [[ ! -s "${log_path}" ]]; then
     echo "::warning::GitHub returned an empty log for job ${job_id}; continuing with job metadata."
     rm -f "${log_path}"
+  else
+    collected_log_count=$((collected_log_count + 1))
   fi
 done
+
+if [[ "${#failed_job_ids[@]}" -gt 0 && "${collected_log_count}" -eq 0 ]]; then
+  echo "::error::Unable to collect logs for any failed workflow jobs."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- allow `gh api` to write Actions logs containing terminal escape sequences
- stop failure analysis when no failed-job logs can be collected
- retain the existing metadata fallback when only individual logs are unavailable

## Root cause

GitHub CLI 2.97 rejects raw API responses containing terminal escape sequences unless explicitly allowed. Actions logs commonly contain ANSI escapes, so every log download was rejected for PRs #10853 and #10854 and the analysis proceeded without logs.

## Validation

- replayed run [32066598611](https://github.com/NVIDIA/cccl/actions/runs/32066598611) with GitHub CLI 2.97.0 and collected all 4 failed-job logs
- simulated all log downloads failing and confirmed the collector exits with an error
- pre-commit hooks, including ShellCheck
- `bash -n .github/actions/ci-failure-analysis/collect-logs.sh`
- `git diff --check`
