### PR TITLE
[libcu++] Reduce tuple and pair constraint instantiations

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -55,6 +55,27 @@ private:
 
   _BaseT __base_;
 
+  template <class... _UTypes>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor __select_variadic_constructible() noexcept
+  {
+    return ::cuda::std::__tuple_select_variadic_constructible(__tuple_types<_Tp...>{}, __tuple_types<_UTypes...>{});
+  }
+
+  template <class... _UTypes>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor
+  __select_variadic_constructible_less_rank() noexcept
+  {
+    return ::cuda::std::__tuple_select_variadic_constructible_less_rank(
+      __tuple_types<_Tp...>{}, __tuple_types<_UTypes...>{});
+  }
+
+  template <class _UTuple>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor __select_tuple_like_constructible() noexcept
+  {
+    return ::cuda::std::__tuple_select_tuple_like_constructible<_UTuple>(
+      __tuple_types<_Tp...>{}, __make_tuple_indices_t<sizeof...(_Tp)>{});
+  }
+
 public:
   template <size_t _Ip>
   _CCCL_API constexpr tuple_element_t<_Ip, tuple>& __get_impl() & noexcept
@@ -162,19 +183,13 @@ public:
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::move(__t))
   {}
 
-  // Old MSVC chokes about a static constexpr variable needing an initializer. Work around by using a type
-  template <class... _UTypes>
-  using _VariadicConstraints =
-    integral_constant<__select_constructor,
-                      __tuple_select_variadic_constructible_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>>;
-
   template <class... _UTypes>
   using _NothrowVariadic =
     bool_constant<__tuple_all_nothrow_constructible_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>>;
 
   template <class... _UTypes,
             enable_if_t<sizeof...(_Tp) != 0, int>                = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
+            __select_constructor _Trait                          = __select_variadic_constructible<_UTypes...>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr tuple(_UTypes&&... __u) noexcept(_NothrowVariadic<_UTypes...>::value)
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
@@ -182,7 +197,7 @@ public:
 
   template <class... _UTypes,
             enable_if_t<sizeof...(_Tp) != 0, int>                = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
+            __select_constructor _Trait                          = __select_variadic_constructible<_UTypes...>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API constexpr explicit tuple(_UTypes&&... __u) noexcept(_NothrowVariadic<_UTypes...>::value)
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
@@ -191,14 +206,14 @@ public:
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
             enable_if_t<sizeof...(_Tp) != 0, int>  = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait            = _VariadicConstraints<_UTypes...>::value,
+            __select_constructor _Trait            = __select_variadic_constructible<_UTypes...>(),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr tuple(_UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
+            __select_constructor _Trait                          = __select_variadic_constructible<_UTypes...>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API inline tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
     _NothrowVariadic<_UTypes...>::value)
@@ -207,7 +222,7 @@ public:
 
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
+            __select_constructor _Trait                          = __select_variadic_constructible<_UTypes...>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API inline explicit tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
     _NothrowVariadic<_UTypes...>::value)
@@ -217,21 +232,16 @@ public:
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Trait            = _VariadicConstraints<_UTypes...>::value,
+            __select_constructor _Trait            = __select_variadic_constructible<_UTypes...>(),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
-  template <class... _UTypes>
-  using _VariadicConstraintsLessRank = integral_constant<
-    __select_constructor,
-    __tuple_select_variadic_constructible_less_rank_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>>;
-
   template <class... _UTypes,
             enable_if_t<(sizeof...(_UTypes) < sizeof...(_Tp)), int> = 0,
             enable_if_t<(sizeof...(_UTypes) != 0), int>             = 0,
-            __select_constructor _Trait                             = _VariadicConstraintsLessRank<_UTypes...>::value,
-            enable_if_t<__can_construct_explicitly<_Trait>, int>    = 0>
+            __select_constructor _Trait = __select_variadic_constructible_less_rank<_UTypes...>(),
+            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API constexpr explicit tuple(_UTypes&&... __u)
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
@@ -240,8 +250,8 @@ public:
   template <class... _UTypes,
             enable_if_t<(sizeof...(_UTypes) < sizeof...(_Tp)), int> = 0,
             enable_if_t<(sizeof...(_UTypes) != 0), int>             = 0,
-            __select_constructor _Trait                             = _VariadicConstraintsLessRank<_UTypes...>::value,
-            enable_if_t<__is_deleted<_Trait>, int>                  = 0>
+            __select_constructor _Trait            = __select_variadic_constructible_less_rank<_UTypes...>(),
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr tuple(_UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
@@ -260,23 +270,18 @@ public:
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
   template <class _UTuple>
-  using _TupleLikeConstraints = integral_constant<
-    __select_constructor,
-    __tuple_select_tuple_like_constructible_v<_UTuple, __tuple_types<_Tp...>, __make_tuple_indices_t<sizeof...(_Tp)>>>;
-
-  template <class _UTuple>
   using _NothrowTupleLike = bool_constant<
     __tuple_nothrow_tuple_like_constructible_v<_UTuple, __tuple_types<_Tp...>, __make_tuple_indices_t<sizeof...(_Tp)>>>;
 
   template <class... _UTypes,
-            __select_constructor _Trait                          = _TupleLikeConstraints<tuple<_UTypes...>&>::value,
+            __select_constructor _Trait = __select_tuple_like_constructible<tuple<_UTypes...>&>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(_NothrowTupleLike<tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
-            __select_constructor _Trait                          = _TupleLikeConstraints<tuple<_UTypes...>&>::value,
+            __select_constructor _Trait = __select_tuple_like_constructible<tuple<_UTypes...>&>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>& __t) noexcept(_NothrowTupleLike<tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
@@ -284,20 +289,20 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            __select_constructor _Trait            = _TupleLikeConstraints<tuple<_UTypes...>&>::value,
+            __select_constructor _Trait            = __select_tuple_like_constructible<tuple<_UTypes...>&>(),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr tuple(tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            __select_constructor _Trait = _TupleLikeConstraints<const tuple<_UTypes...>&>::value,
+            __select_constructor _Trait = __select_tuple_like_constructible<const tuple<_UTypes...>&>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>& __t) noexcept(_NothrowTupleLike<const tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
-            __select_constructor _Trait = _TupleLikeConstraints<const tuple<_UTypes...>&>::value,
+            __select_constructor _Trait = __select_tuple_like_constructible<const tuple<_UTypes...>&>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
     _NothrowTupleLike<const tuple<_UTypes...>&>::value)
@@ -306,20 +311,20 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            __select_constructor _Trait            = _TupleLikeConstraints<const tuple<_UTypes...>&>::value,
+            __select_constructor _Trait            = __select_tuple_like_constructible<const tuple<_UTypes...>&>(),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            __select_constructor _Trait                          = _TupleLikeConstraints<tuple<_UTypes...>&&>::value,
+            __select_constructor _Trait = __select_tuple_like_constructible<tuple<_UTypes...>&&>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(_NothrowTupleLike<tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
-            __select_constructor _Trait                          = _TupleLikeConstraints<tuple<_UTypes...>&&>::value,
+            __select_constructor _Trait = __select_tuple_like_constructible<tuple<_UTypes...>&&>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>&& __t) noexcept(_NothrowTupleLike<tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
@@ -327,20 +332,20 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            __select_constructor _Trait            = _TupleLikeConstraints<tuple<_UTypes...>&&>::value,
+            __select_constructor _Trait            = __select_tuple_like_constructible<tuple<_UTypes...>&&>(),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr tuple(tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            __select_constructor _Trait = _TupleLikeConstraints<const tuple<_UTypes...>&&>::value,
+            __select_constructor _Trait = __select_tuple_like_constructible<const tuple<_UTypes...>&&>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(_NothrowTupleLike<const tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
-            __select_constructor _Trait = _TupleLikeConstraints<const tuple<_UTypes...>&&>::value,
+            __select_constructor _Trait = __select_tuple_like_constructible<const tuple<_UTypes...>&&>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
     _NothrowTupleLike<const tuple<_UTypes...>&&>::value)
@@ -349,12 +354,12 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            __select_constructor _Trait            = _TupleLikeConstraints<const tuple<_UTypes...>&&>::value,
+            __select_constructor _Trait            = __select_tuple_like_constructible<const tuple<_UTypes...>&&>(),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr tuple(const tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
-  // We cannot instantiate _TupleLikeConstraints eagerly because the leads to recursive constraints
+  // We cannot instantiate the tuple-like constraints eagerly because that leads to recursive constraints
   // We need to SFINAE the constructor away before instantiating the traits
   template <class _Tuple>
   using __disambiguate_tuple_like =
@@ -363,7 +368,7 @@ public:
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
+            __select_constructor _Trait                                = __select_tuple_like_constructible<_Tuple>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int>       = 0>
   _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLike<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
@@ -371,7 +376,7 @@ public:
 
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
+            __select_constructor _Trait                                = __select_tuple_like_constructible<_Tuple>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int>       = 0>
   _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLike<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
@@ -380,7 +385,7 @@ public:
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
+            __select_constructor _Trait                                = __select_tuple_like_constructible<_Tuple>(),
             enable_if_t<__is_deleted<_Trait>, int>                     = 0>
   constexpr tuple(_Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
@@ -389,7 +394,7 @@ public:
   template <class _Alloc,
             class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
+            __select_constructor _Trait                                = __select_tuple_like_constructible<_Tuple>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int>       = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(_NothrowTupleLike<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
@@ -398,7 +403,7 @@ public:
   template <class _Alloc,
             class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
+            __select_constructor _Trait                                = __select_tuple_like_constructible<_Tuple>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int>       = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
     _NothrowTupleLike<_Tuple>::value)
@@ -409,7 +414,7 @@ public:
   template <class _Alloc,
             class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
+            __select_constructor _Trait                                = __select_tuple_like_constructible<_Tuple>(),
             enable_if_t<__is_deleted<_Trait>, int>                     = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -257,10 +257,6 @@ __tuple_select_variadic_constructible(__tuple_types<_Type>, __tuple_types<_UType
   // NOLINTEND(bugprone-branch-clone)
 }
 
-template <class _TupleTypes, class _TupleUTypes>
-inline constexpr __select_constructor __tuple_select_variadic_constructible_v =
-  ::cuda::std::__tuple_select_variadic_constructible(_TupleTypes{}, _TupleUTypes{});
-
 template <class... _Types, class... _UTypes>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
 __tuple_select_variadic_constructible_less_rank(__tuple_types<_Types...>, __tuple_types<_UTypes...>) noexcept
@@ -307,10 +303,6 @@ __tuple_select_variadic_constructible_less_rank(__tuple_types<_Types...>, __tupl
   _CCCL_UNREACHABLE();
   // NOLINTEND(bugprone-branch-clone)
 }
-
-template <class _TupleTypes, class _TupleUTypes>
-inline constexpr __select_constructor __tuple_select_variadic_constructible_less_rank_v =
-  ::cuda::std::__tuple_select_variadic_constructible_less_rank(_TupleTypes{}, _TupleUTypes{});
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _UTuple, class... _Types, size_t... _Indices>
@@ -429,10 +421,6 @@ __tuple_select_tuple_like_constructible(__tuple_types<_Type>, __tuple_indices<_I
   }
   // NOLINTEND(bugprone-branch-clone)
 }
-
-template <class _UTuple, class _TupleTypes, class _TupleIndices>
-inline constexpr __select_constructor __tuple_select_tuple_like_constructible_v =
-  ::cuda::std::__tuple_select_tuple_like_constructible<_UTuple>(_TupleTypes{}, _TupleIndices{});
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _UTuple, class _Type, class... _Types, size_t _Index, size_t... _Indices>

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -116,10 +116,6 @@ template <class _UPair, class _T1, class _T2>
   // NOLINTEND(bugprone-branch-clone)
 }
 
-template <class _UPair, class _T1, class _T2>
-inline constexpr __select_constructor __pair_select_pair_like_constructible_v =
-  ::cuda::std::__pair_select_pair_like_constructible<_UPair, _T1, _T2>();
-
 _CCCL_EXEC_CHECK_DISABLE
 template <bool _IsConst, class _UPair, class _T1, class _T2>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_assignment __pair_select_pair_like_assignable() noexcept
@@ -305,6 +301,20 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   using first_type  = _T1;
   using second_type = _T2;
 
+private:
+  template <class _U1, class _U2>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor __select_variadic_constructible() noexcept
+  {
+    return ::cuda::std::__tuple_select_variadic_constructible(__tuple_types<_T1, _T2>{}, __tuple_types<_U1, _U2>{});
+  }
+
+  template <class _UPair>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor __select_pair_like_constructible() noexcept
+  {
+    return ::cuda::std::__pair_select_pair_like_constructible<_UPair, _T1, _T2>();
+  }
+
+public:
   template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr pair() noexcept(is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
@@ -336,20 +346,18 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
       : __base(__t1, __t2)
   {}
 
-  template <class _U1 = _T1,
-            class _U2 = _T2,
-            __select_constructor _Trait =
-              __tuple_select_variadic_constructible_v<__tuple_types<_T1, _T2>, __tuple_types<_U1, _U2>>,
+  template <class _U1                                            = _T1,
+            class _U2                                            = _T2,
+            __select_constructor _Trait                          = __select_variadic_constructible<_U1, _U2>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::forward<_U1>(__u1), ::cuda::std::forward<_U2>(__u2))
   {}
 
-  template <class _U1 = _T1,
-            class _U2 = _T2,
-            __select_constructor _Trait =
-              __tuple_select_variadic_constructible_v<__tuple_types<_T1, _T2>, __tuple_types<_U1, _U2>>,
+  template <class _U1                                            = _T1,
+            class _U2                                            = _T2,
+            __select_constructor _Trait                          = __select_variadic_constructible<_U1, _U2>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
@@ -357,10 +365,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  template <class _U1 = _T1,
-            class _U2 = _T2,
-            __select_constructor _Trait =
-              __tuple_select_variadic_constructible_v<__tuple_types<_T1, _T2>, __tuple_types<_U1, _U2>>,
+  template <class _U1                              = _T1,
+            class _U2                              = _T2,
+            __select_constructor _Trait            = __select_variadic_constructible<_U1, _U2>(),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr pair(_U1&&, _U2&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
@@ -368,7 +375,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   // converting constructors
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&, _T1, _T2>,
+            __select_constructor _Trait                          = __select_pair_like_constructible<pair<_U1, _U2>&>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr pair(pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1&> && is_nothrow_constructible_v<_T2, _U2&>)
@@ -377,7 +384,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&, _T1, _T2>,
+            __select_constructor _Trait                          = __select_pair_like_constructible<pair<_U1, _U2>&>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr pair(pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1&> && is_nothrow_constructible_v<_T2, _U2&>)
@@ -387,14 +394,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            __select_constructor _Trait            = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&, _T1, _T2>,
+            __select_constructor _Trait            = __select_pair_like_constructible<pair<_U1, _U2>&>(),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr pair(pair<_U1, _U2>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&, _T1, _T2>,
+            __select_constructor _Trait = __select_pair_like_constructible<const pair<_U1, _U2>&>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr pair(const pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
@@ -403,7 +410,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&, _T1, _T2>,
+            __select_constructor _Trait = __select_pair_like_constructible<const pair<_U1, _U2>&>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr pair(const pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
@@ -413,14 +420,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&, _T1, _T2>,
+            __select_constructor _Trait            = __select_pair_like_constructible<const pair<_U1, _U2>&>(),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr pair(const pair<_U1, _U2>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&&, _T1, _T2>,
+            __select_constructor _Trait                          = __select_pair_like_constructible<pair<_U1, _U2>&&>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr pair(pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
@@ -429,7 +436,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&&, _T1, _T2>,
+            __select_constructor _Trait                          = __select_pair_like_constructible<pair<_U1, _U2>&&>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr pair(pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
@@ -439,14 +446,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&&, _T1, _T2>,
+            __select_constructor _Trait            = __select_pair_like_constructible<pair<_U1, _U2>&&>(),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr pair(pair<_U1, _U2>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&&, _T1, _T2>,
+            __select_constructor _Trait = __select_pair_like_constructible<const pair<_U1, _U2>&&>(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr pair(const pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1> && is_nothrow_constructible_v<_T2, const _U2>)
@@ -455,7 +462,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&&, _T1, _T2>,
+            __select_constructor _Trait = __select_pair_like_constructible<const pair<_U1, _U2>&&>(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr pair(const pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1> && is_nothrow_constructible_v<_T2, const _U2>)
@@ -465,7 +472,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&&, _T1, _T2>,
+            __select_constructor _Trait            = __select_pair_like_constructible<const pair<_U1, _U2>&&>(),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr pair(const pair<_U1, _U2>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
@@ -474,8 +481,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<_UPair, _T1, _T2>,
-            enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
+            __select_constructor _Trait                                = __select_pair_like_constructible<_UPair>(),
+            enable_if_t<__can_construct_implicitly<_Trait>, int>       = 0>
   _CCCL_API constexpr pair(_UPair&& __p) noexcept(
     is_nothrow_constructible_v<_T1, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
     && is_nothrow_constructible_v<_T2, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)
@@ -492,8 +499,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
-            __select_constructor _Trait = __pair_select_pair_like_constructible_v<_UPair, _T1, _T2>,
-            enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
+            __select_constructor _Trait                                = __select_pair_like_constructible<_UPair>(),
+            enable_if_t<__can_construct_explicitly<_Trait>, int>       = 0>
   _CCCL_API explicit constexpr pair(_UPair&& __p) noexcept(
     is_nothrow_constructible_v<_T1, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
     && is_nothrow_constructible_v<_T2, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)
@@ -504,8 +511,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
-            __select_constructor _Trait            = __pair_select_pair_like_constructible_v<_UPair, _T1, _T2>,
-            enable_if_t<__is_deleted<_Trait>, int> = 0>
+            __select_constructor _Trait                                = __select_pair_like_constructible<_UPair>(),
+            enable_if_t<__is_deleted<_Trait>, int>                     = 0>
   _CCCL_API constexpr pair(_UPair&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
   // NOLINTEND(bugprone-forwarding-reference-overload)


### PR DESCRIPTION
## Summary

- replace four global inline-variable constructor selectors with private `static consteval` helpers
- remove tuple's intermediate `integral_constant` constructor aliases
- keep the existing selector functions, constraint ordering, overload participation, and `noexcept` expressions unchanged

Closes #10846.

This is a deliberately smaller alternative to #10719. That PR is broader and centralizes tuple/pair construction, assignment, and comparison constraints; this PR only removes the measured constructor-selector variable-template layer.

## Compile-time measurements

Measured with Apple Clang 21.0.0 using the same generated source, SDK, standard library, flags, and alternating run order against an unchanged `upstream/main` worktree.

| Configuration | Metric | Before | After | Change |
| --- | --- | ---: | ---: | ---: |
| C++20, 256 unique cases, 8 runs | mean wall time | 8.82375 s | 8.69375 s | -1.47% |
| C++20, 256 unique cases, 8 runs | median wall time | 8.670 s | 8.570 s | -1.15% |
| C++20, 256 unique cases, 8 runs | mean user CPU time | 8.41250 s | 8.27125 s | -1.68% |
| C++17, 128 unique cases, 10 runs | mean wall time | 5.303 s | 5.244 s | -1.11% |
| C++17, 128 unique cases, 10 runs | median wall time | 5.310 s | 5.240 s | -1.32% |

A C++20 Clang trace with 128 unique cases showed the four targeted inline-variable initializers falling from 4,096 evaluations to zero. Total `EvaluateAsInitializer` events fell from 32,780 to 28,681.

The smaller C++20 128-case wall-time series was neutral by mean (4.377 s to 4.375 s), so no improvement is claimed for that series.

## Validation

- 32 directly affected positive tuple/pair constructor programs passed under C++17
- the same 32 programs passed under C++20
- 10 expected-negative constructor sources remained rejected under C++17
- the same 10 remained rejected under C++20
- generated optimized assembly was byte-for-byte identical before/after under C++17 and C++20
- file-scoped `pre-commit` passed for all three modified headers
- `git diff --check` passed

Not run locally: the official CMake/lit suite, NVCC/device tests, GCC, MSVC, or GPU tests because those toolchains were unavailable.
