### PR TITLE
[libcu++] Avoid warning in cuda::std::remove

### DIFF
--- a/libcudacxx/include/cuda/std/__pstl/remove.h
+++ b/libcudacxx/include/cuda/std/__pstl/remove.h
@@ -46,6 +46,11 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_MSVC(4018) // signed/unsigned mismatch
+_CCCL_DIAG_SUPPRESS_GCC("-Wsign-compare")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wsign-compare")
+
 template <class _Tp>
 struct __remove_compare_not_eq
 {
@@ -62,6 +67,8 @@ struct __remove_compare_not_eq
     return !(__val_ == __rhs);
   }
 };
+
+_CCCL_DIAG_POP
 
 _CCCL_TEMPLATE(class _Policy, class _InputIterator, class _Tp)
 _CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND is_execution_policy_v<_Policy>)


### PR DESCRIPTION
We are potentially comparing integers of different signs, but that is what the user gave us so just disable the warning