### PR TITLE
Fixes some of the uninitialized reads in `device_merge_sort_vsmem ` 

### DIFF
--- a/c2h/include/c2h/custom_type.h
+++ b/c2h/include/c2h/custom_type.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cuda/__cmath/round_up.h>
 #include <cuda/std/limits>
 
 #include <memory>
@@ -17,6 +18,22 @@ struct custom_type_state_t
 };
 
 template <template <typename> class... Policies>
+class custom_type_t;
+
+namespace detail
+{
+//! Number of policies \p CustomType was instantiated with.
+template <class CustomType>
+struct policy_count_t;
+
+template <template <typename> class... Policies>
+struct policy_count_t<custom_type_t<Policies...>>
+{
+  static constexpr std::size_t value = sizeof...(Policies);
+};
+} // namespace detail
+
+template <template <typename> class... Policies>
 class custom_type_t
     : public custom_type_state_t
     , public Policies<custom_type_t<Policies...>>...
@@ -28,14 +45,30 @@ public:
   }
 };
 
+//! Inflates a custom type to roughly \p TotalSize bytes, so that algorithms have to fall back to
+//! temporary storage backed by global memory (vsmem). We let the filler round the object up to a
+//! multiple of its alignment to avoid tail padding, and appease compute-sanitizer's initcheck of
+//! reads of never-written global memory.
 template <std::size_t TotalSize>
 struct huge_data
 {
   template <class CustomType>
   class type
   {
-    static constexpr auto extra_member_bytes = (TotalSize - sizeof(custom_type_state_t));
-    std::uint8_t data[extra_member_bytes];
+    // Every other policy contributes exactly one byte (their MSVC workaround member), so counting
+    // them is enough, and their order does not matter as they are all byte-aligned.
+    static constexpr std::size_t other_policy_bytes = detail::policy_count_t<CustomType>::value - 1;
+
+    // TotalSize already covers custom_type_state_t and the filler, so the other policies add on top.
+    // Sizing the object to a whole number of alignment units to keep it free of tail padding
+    static constexpr std::size_t object_bytes =
+      ::cuda::round_up(TotalSize + other_policy_bytes, alignof(custom_type_state_t));
+
+    // Where the filler starts, i.e. where the bases in front of it end
+    static constexpr std::size_t bytes_before_filler = sizeof(custom_type_state_t) + other_policy_bytes;
+
+    // Whatever the other bases leave over becomes the filler
+    std::uint8_t data[object_bytes - bytes_before_filler]{};
   };
 };
 
@@ -165,7 +198,7 @@ public:
   template <class SizeT = std::size_t>
   static __host__ __device__ c2h::custom_type_t<Policies...> max()
   {
-    c2h::custom_type_t<Policies...> val;
+    c2h::custom_type_t<Policies...> val{};
     val.key = numeric_limits<SizeT>::max();
     val.val = numeric_limits<SizeT>::max();
     return val;
@@ -174,7 +207,7 @@ public:
   template <class SizeT = std::size_t>
   static __host__ __device__ c2h::custom_type_t<Policies...> min()
   {
-    c2h::custom_type_t<Policies...> val;
+    c2h::custom_type_t<Policies...> val{};
     val.key = numeric_limits<SizeT>::min();
     val.val = numeric_limits<SizeT>::min();
     return val;
@@ -183,7 +216,7 @@ public:
   template <class SizeT = std::size_t>
   static __host__ __device__ c2h::custom_type_t<Policies...> lowest()
   {
-    c2h::custom_type_t<Policies...> val;
+    c2h::custom_type_t<Policies...> val{};
     val.key = numeric_limits<SizeT>::lowest();
     val.val = numeric_limits<SizeT>::lowest();
     return val;


### PR DESCRIPTION
## Description

Partially addresses https://github.com/NVIDIA/cccl/issues/5327


Some of the `initcheck` reports on the `vsmem` tests originate in `c2h`'s test types. `c2h::huge_data` inflates `custom_type_t` with some filler bytes so it is too large and no longer fits into shared memory. Those bytes were never written, so moving such a value through temporary storage backed by global memory makes `compute-sanitizer --tool initcheck` report reads of uninitialized memory. 

Two issues fixed in this PR:
(a) the filler `data` member had no initializer and so stayed indeterminate and a compiler may elide copying an indeterminate member, leaving those bytes unwritten in the destination.
(b) `custom_type_t` ended in tail padding, since the byte-sized policy members (the mixins) leave the object short of a multiple of its alignment. Nothing ever writes padding, while whole-object loads read it.