### PR TITLE
Further optimize lldb debugger pretty printers

### DIFF
--- a/libcudacxx/share/libcudacxx/gdb/cccl_common.py
+++ b/libcudacxx/share/libcudacxx/gdb/cccl_common.py
@@ -12,11 +12,15 @@ import gdb
 
 _ABI_NAMESPACE_PATTERN = re.compile(r"::__(?:\d+|version_bump_ver\d+_)(?=::)")
 _REFERENCE_CODES = (gdb.TYPE_CODE_REF, gdb.TYPE_CODE_RVALUE_REF)
+# GDB writes non-type template arguments as C literals, so extents<int, 3ul, 4ul>
+# breaks anything that parses the name.
+_INTEGER_SUFFIX_PATTERN = re.compile(r"\b(\d+)[uUlL]+\b")
 
 
 def public_type_name(value_type: gdb.Type) -> str:
-    """Return a type name without CUDA ABI inline namespaces."""
-    return _ABI_NAMESPACE_PATTERN.sub("", str(value_type))
+    """Return a type name without CUDA ABI inline namespaces or integer suffixes."""
+    name = _ABI_NAMESPACE_PATTERN.sub("", str(value_type))
+    return _INTEGER_SUFFIX_PATTERN.sub(r"\1", name)
 
 
 def template_name(value_type: gdb.Type | str) -> str:

--- a/libcudacxx/share/libcudacxx/gdb/mdspan.py
+++ b/libcudacxx/share/libcudacxx/gdb/mdspan.py
@@ -69,7 +69,7 @@ def _find_ebco_base(value: gdb.Value) -> gdb.Value | None:
     """
     bases = _direct_bases(value.type)
     for field in bases:
-        if _EBCO_PATTERN.search(str(field.type)):
+        if _EBCO_PATTERN.search(cccl_common.public_type_name(field.type)):
             return value.cast(field.type)
     if len(bases) == 1:
         return _find_ebco_base(value.cast(bases[0].type))
@@ -82,7 +82,7 @@ def _ebco_element(ebco_value: gdb.Value, index: int) -> gdb.Value | None:
     Held in an ``__elem_`` member, or (EBCO) inherited directly for empty types.
     """
     for field in _direct_bases(ebco_value.type):
-        match = _EBCO_IMPL_PATTERN.search(str(field.type))
+        match = _EBCO_IMPL_PATTERN.search(cccl_common.public_type_name(field.type))
         if match is None or int(match.group(1)) != index:
             continue
         impl = ebco_value.cast(field.type)

--- a/libcudacxx/share/libcudacxx/gdb/stream.py
+++ b/libcudacxx/share/libcudacxx/gdb/stream.py
@@ -22,8 +22,14 @@ _CUDA_STREAM_LEGACY_HANDLE = 1
 _CUDA_STREAM_PER_THREAD_HANDLE = 2
 _CUDA_STREAM_CAPTURE_STATUS_NONE = 0
 _CUDA_STREAM_CAPTURE_STATUS_ACTIVE = 1
-_CUDA_STREAM_IS_CAPTURING = "((int (*)(cudaStream_t, int*))cudaStreamIsCapturing)"
+# The queries use the driver API. libcuda is always shared, so its symbols are
+# always present; the cudart equivalents are absent from a statically linked
+# runtime unless the program itself calls them, which silently drops a field.
+_CU_STREAM_IS_CAPTURING = "((int (*)(void*, int*))cuStreamIsCapturing)"
 _CU_STREAM_GET_ID = "((int (*)(void*, unsigned long long*))cuStreamGetId)"
+_CU_STREAM_GET_DEVICE = "((int (*)(void*, int*))cuStreamGetDevice)"
+_CU_STREAM_GET_PRIORITY = "((int (*)(void*, int*))cuStreamGetPriority)"
+_CU_STREAM_GET_FLAGS = "((int (*)(void*, unsigned int*))cuStreamGetFlags)"
 
 
 class StreamInfo(NamedTuple):
@@ -63,7 +69,7 @@ def _query_stream_property(handle: int, function: str, output_type: str) -> int 
         if address == 0:
             return None
         status = gdb.parse_and_eval(
-            f"(int){function}((cudaStream_t){handle:#x}, ({output_type}*){address:#x})"
+            f"(int){function}((void*){handle:#x}, ({output_type}*){address:#x})"
         )
         if int(status) != 0:
             return None
@@ -112,13 +118,15 @@ def _query_stream_id(handle: int) -> int | None:
     unique_id = _query_stream_property(handle, _CU_STREAM_GET_ID, "unsigned long long")
     if unique_id is not None:
         return unique_id
+    # cuStreamGetId needs a CUDA 12.0 driver. The runtime entry point is the only
+    # way to read the ID on an older one, when the program happens to keep it.
     return _query_stream_property(handle, "cudaStreamGetId", "unsigned long long")
 
 
 def _query_stream_device(handle: int) -> int | None:
-    # cudaStreamGetDevice is unavailable before CUDA 12.8. Reporting no device
-    # there is safer than changing the current CUDA context from a formatter.
-    return _query_stream_property(handle, "cudaStreamGetDevice", "int")
+    # cuStreamGetDevice arrived in CUDA 12.8. Reporting no device on an older
+    # driver is safer than changing the current CUDA context from a formatter.
+    return _query_stream_property(handle, _CU_STREAM_GET_DEVICE, "int")
 
 
 def _stream_info(handle_value: gdb.Value) -> StreamInfo:
@@ -134,9 +142,7 @@ def _stream_info(handle_value: gdb.Value) -> StreamInfo:
         return StreamInfo(handle, description, None, None, None, None, None)
 
     try:
-        capture_status = _query_stream_property(
-            handle, _CUDA_STREAM_IS_CAPTURING, "int"
-        )
+        capture_status = _query_stream_property(handle, _CU_STREAM_IS_CAPTURING, "int")
         is_capturing = (
             capture_status == _CUDA_STREAM_CAPTURE_STATUS_ACTIVE
             if capture_status is not None
@@ -152,9 +158,9 @@ def _stream_info(handle_value: gdb.Value) -> StreamInfo:
             description,
             _query_stream_id(handle),
             _query_stream_device(handle),
-            _query_stream_property(handle, "cudaStreamGetPriority", "int"),
+            _query_stream_property(handle, _CU_STREAM_GET_PRIORITY, "int"),
             is_capturing,
-            _query_stream_property(handle, "cudaStreamGetFlags", "unsigned int"),
+            _query_stream_property(handle, _CU_STREAM_GET_FLAGS, "unsigned int"),
         )
     finally:
         if original_context == 0:

--- a/libcudacxx/share/libcudacxx/lldb/buffer.py
+++ b/libcudacxx/share/libcudacxx/lldb/buffer.py
@@ -139,7 +139,7 @@ class BufferSyntheticProvider:
             self.size = info.size
         except cccl_common.StagingError:
             pass
-        # Staging advances the stop ID, so record what the next call will see.
+        # Staging advances the stop ID, so record what the next call sees.
         self.stop_id = self._current_stop_id()
         return True
 

--- a/libcudacxx/share/libcudacxx/lldb/buffer.py
+++ b/libcudacxx/share/libcudacxx/lldb/buffer.py
@@ -15,10 +15,6 @@ import memory_resource
 import lldb
 
 _BUFFER_PATTERN = re.compile(r"^cuda::buffer<.+>$")
-# LLDB sees cudaMemcpyKind through cudaMemcpy's declaration, but its expression
-# parser does not necessarily import the enum constants. This is the value of
-# cudaMemcpyDefault from the CUDA Runtime API.
-_CUDA_MEMCPY_DEFAULT = 4
 InternalDict = dict[str, object]
 
 
@@ -109,87 +105,41 @@ class BufferSyntheticProvider:
         self.declared_type = value.GetType()
         value = cccl_common.strip_reference_value(value)
         self.value = value.GetNonSyntheticValue()
-        self.host_copy = lldb.SBValue()
         self.stop_id: int | None = None
-        self.clear()
         self.update()
-
-    def __del__(self) -> None:
-        self.clear()
-
-    def _evaluate(self, expression: str) -> lldb.SBValue:
-        frame = self.value.GetFrame()
-        if not frame.IsValid():
-            return lldb.SBValue()
-        options = lldb.SBExpressionOptions()
-        options.SetIgnoreBreakpoints(True)
-        options.SetUnwindOnError(True)
-        return frame.EvaluateExpression(expression, options)
-
-    def clear(self) -> None:
-        """Release the staged copy and reset all cached buffer information."""
-        if self.host_copy.IsValid():
-            address = self.host_copy.GetValueAsUnsigned(0)
-            if address:
-                self._evaluate(f"(void)free((void*){address:#x})")
-        self.host_copy = lldb.SBValue()
-        self.stop_id = None
-        self.size = 0
-        self.data_address = 0
-        self.value_type = lldb.SBType()
-        self.value_size = 0
-
-    def _copy_to_host(self) -> bool:
-        if self.size == 0:
-            return True
-
-        byte_count = self.size * self.value_size
-        self.host_copy = self._evaluate(f"(void*)malloc({byte_count})")
-        if not self.host_copy.IsValid() or self.host_copy.GetError().Fail():
-            return False
-
-        host_address = self.host_copy.GetValueAsUnsigned(0)
-        result = self._evaluate(
-            "(int)cudaMemcpy((void*)"
-            f"{host_address:#x}, (const void*){self.data_address:#x}, {byte_count}, "
-            f"{_CUDA_MEMCPY_DEFAULT})"
-        )
-        if (
-            not result.IsValid()
-            or result.GetError().Fail()
-            or result.GetValueAsSigned(-1) != 0
-        ):
-            self.clear()
-            return False
-        return True
 
     def _current_stop_id(self) -> int | None:
         process = self.value.GetProcess()
         return process.GetStopID() if process.IsValid() else None
 
     def update(self) -> bool:
-        # LLDB calls update() before every read of a synthetic value, so one
-        # print causes hundreds of calls. Copy the device memory only when the
-        # process has stopped again since the last copy. Anything that changes
-        # target memory must resume and re-stop the process, which includes a
-        # cudaMemcpy the user runs at this breakpoint, so this cannot report
-        # stale data.
+        # update() runs before every read of a synthetic child, so one print
+        # causes hundreds of calls. Restage only after the process stops again.
+        # Anything that changes target memory must resume and re-stop it, so this
+        # cannot report stale data.
         if self.stop_id is not None and self._current_stop_id() == self.stop_id:
             return True
 
-        self.clear()
+        self.host_address = 0
+        self.size = 0
+        self.value_type = lldb.SBType()
+        self.value_size = 0
 
         info = _buffer_info(self.value)
         if info is None:
             return False
 
-        self.size = info.size
-        self.data_address = info.data_address
         self.value_type = info.value_type
         self.value_size = self.value_type.GetByteSize()
-        self._copy_to_host()
-        # The copy itself runs inferior calls that advance the stop ID, so
-        # record the value the next update() will see.
+        # A formatter must not raise into the debugger; report no elements.
+        try:
+            self.host_address = cccl_common.stage_device_memory(
+                self.value, info.data_address, info.size * self.value_size
+            )
+            self.size = info.size
+        except cccl_common.StagingError:
+            pass
+        # Staging advances the stop ID, so record what the next call will see.
         self.stop_id = self._current_stop_id()
         return True
 
@@ -218,12 +168,10 @@ class BufferSyntheticProvider:
         return -1
 
     def get_child_at_index(self, index: int) -> lldb.SBValue | None:
-        if index < 0:
+        if index < 0 or index >= self.size or not self.host_address:
             return None
-        if index >= self.size:
-            return None
-        offset = index * self.value_size
-        return self.host_copy.CreateChildAtOffset(f"[{index}]", offset, self.value_type)
+        address = self.host_address + index * self.value_size
+        return self.value.CreateValueFromAddress(f"[{index}]", address, self.value_type)
 
 
 def register(debugger: lldb.SBDebugger, category: str, module: str) -> None:

--- a/libcudacxx/share/libcudacxx/lldb/cccl_common.py
+++ b/libcudacxx/share/libcudacxx/lldb/cccl_common.py
@@ -45,18 +45,79 @@ class StagingError(RuntimeError):
     """Report a failure to stage inferior memory for a formatter."""
 
 
-# Keyed by inferior address, not by provider: LLDB builds a synthetic provider
-# per stop and keeps every one alive, so a provider can never free its own copy.
-# Maps a device address to (host address, size, stop id).
-_staged_copies: dict[int, tuple[int, int, int]] = {}
-_staged_process_id: int | None = None
+class _StagingCache:
+    """Own the host copies that the formatters read.
+
+    LLDB builds a synthetic provider per stop and keeps every one alive, so a
+    provider cannot free its own copy. The cache frees a copy when the program
+    runs again, because every provider restages after that.
+    """
+
+    def __init__(self) -> None:
+        self.reset(None)
+
+    def reset(self, process_id: int | None) -> None:
+        # A copy belongs to (device address, byte count): two views can address
+        # one allocation with different lengths, and both stay readable.
+        self.copies: dict[tuple[int, int], int] = {}
+        self.process_id = process_id
+        self.installed = False
+        self.stop_id: int | None = None
+
+    def call(self, value: lldb.SBValue, expression: str) -> lldb.SBValue:
+        result = evaluate(value, expression)
+        process = value.GetProcess()
+        if process.IsValid():
+            self.stop_id = process.GetStopID()
+        return result
+
+    def install(
+        self, value: lldb.SBValue, frame: lldb.SBFrame, target: lldb.SBTarget
+    ) -> bool:
+        # An unresolved identifier fails the whole unit. A statically linked
+        # cudart that the program never calls has no cudaMemcpy symbol.
+        if any(
+            not target.FindSymbols(name).GetSize()
+            for name in ("cudaMemcpy", "malloc", "free")
+        ):
+            return False
+        options = lldb.SBExpressionOptions()
+        options.SetIgnoreBreakpoints(True)
+        options.SetUnwindOnError(True)
+        options.SetTopLevel(True)
+        options.SetLanguage(lldb.eLanguageTypeC_plus_plus)
+        frame.EvaluateExpression(_STAGE_DEFINITION, options)
+        # A top-level expression has no result, and it goes to the JIT, so it
+        # appears in no symbol table. A call is the only proof that it compiled.
+        probe = self.call(value, "__cccl_stage((const void*)0, 0ull)")
+        if probe.GetError().Fail():
+            return False
+        # malloc(0) still returns a pointer that nothing else will free.
+        host = probe.GetValueAsUnsigned(0)
+        if host:
+            self.call(value, f"(void)free((void*){host:#x})")
+        return True
+
+    def release_if_resumed(self, value: lldb.SBValue, stop_id: int) -> None:
+        # Every inferior call advances the stop ID, so call() records the value
+        # its own calls produced. A higher one means the user resumed.
+        if self.stop_id is None or stop_id == self.stop_id:
+            self.stop_id = stop_id
+            return
+        self.stop_id = stop_id
+        for host in list(self.copies.values()):
+            self.call(value, f"(void)free((void*){host:#x})")
+        self.copies.clear()
+
+
+_staging = _StagingCache()
 
 
 def stage_device_memory(value: lldb.SBValue, device: int, bytes_: int) -> int:
     """Copy ``bytes_`` from inferior address ``device`` to the host heap.
 
     Returns the host address, or 0 when nothing was requested. Reuses the copy
-    from an identical request at the same stop, and otherwise frees it first.
+    of an identical request at the same stop.
 
     Raises
     ------
@@ -64,47 +125,34 @@ def stage_device_memory(value: lldb.SBValue, device: int, bytes_: int) -> int:
         If the frame is dead, the staging function does not compile, or the
         inferior allocation or copy fails.
     """
-    global _staged_process_id
-
     frame = value.GetFrame()
     process = value.GetProcess()
-    if not frame.IsValid() or not process.IsValid():
+    target = value.GetTarget()
+    if not frame.IsValid() or not process.IsValid() or not target.IsValid():
         raise StagingError("value has no live frame")
     if bytes_ == 0:
         return 0
 
-    if _staged_process_id != process.GetUniqueID():
-        # A restarted process reuses heap addresses, so a stale entry would free
+    if _staging.process_id != process.GetUniqueID():
+        # A restarted process reuses heap addresses, so an old entry would free
         # memory it does not own.
-        _staged_copies.clear()
-        options = lldb.SBExpressionOptions()
-        options.SetIgnoreBreakpoints(True)
-        options.SetUnwindOnError(True)
-        options.SetTopLevel(True)
-        options.SetLanguage(lldb.eLanguageTypeC_plus_plus)
-        # A top-level expression has no result, so it reports a generic error
-        # even when it compiled.
-        error = frame.EvaluateExpression(_STAGE_DEFINITION, options).GetError()
-        if error.GetType() == lldb.eErrorTypeExpression:
-            raise StagingError(f"staging function did not compile: {error}")
-        _staged_process_id = process.GetUniqueID()
+        _staging.reset(process.GetUniqueID())
+        _staging.installed = _staging.install(value, frame, target)
+    if not _staging.installed:
+        raise StagingError("staging function is not available")
 
-    # LLDB may build several providers for one value at one stop, and each asks
-    # to stage. Repeating the copy would cost a round trip and change nothing.
-    stop_id = process.GetStopID()
-    previous = _staged_copies.pop(device, None)
-    if previous is not None:
-        host, staged_bytes, staged_stop = previous
-        if (staged_bytes, staged_stop) == (bytes_, stop_id):
-            _staged_copies[device] = previous
-            return host
-        evaluate(value, f"(void)free((void*){host:#x})")
+    _staging.release_if_resumed(value, process.GetStopID())
+    host = _staging.copies.get((device, bytes_))
+    if host is not None:
+        return host
 
-    result = evaluate(value, f"__cccl_stage((const void*){device:#x}, {bytes_}ull)")
+    result = _staging.call(
+        value, f"__cccl_stage((const void*){device:#x}, {bytes_}ull)"
+    )
     host = result.GetValueAsUnsigned(0)
     if result.GetError().Fail() or not host:
         raise StagingError(f"cannot stage {bytes_} bytes from {device:#x}")
-    _staged_copies[device] = (host, bytes_, stop_id)
+    _staging.copies[(device, bytes_)] = host
     return host
 
 

--- a/libcudacxx/share/libcudacxx/lldb/cccl_common.py
+++ b/libcudacxx/share/libcudacxx/lldb/cccl_common.py
@@ -12,6 +12,101 @@ import lldb
 
 _ABI_NAMESPACE_PATTERN = re.compile(r"::__(?:\d+|version_bump_ver\d+_)(?=::)")
 
+# Allocate and copy in one compiled function: an inferior round trip costs far
+# more than the work. 4 is cudaMemcpyDefault; the expression parser does not
+# import the enum constants.
+_STAGE_DEFINITION = """
+extern "C" void* __cccl_stage(const void* device, unsigned long long bytes)
+{
+  void* host = ((void* (*)(unsigned long long))malloc)(bytes);
+  if (host != 0
+      && ((int (*)(void*, const void*, unsigned long long, int))cudaMemcpy)(
+           host, device, bytes, 4) != 0) {
+    ((void (*)(void*))free)(host);
+    host = 0;
+  }
+  return host;
+}
+"""
+
+
+def evaluate(value: lldb.SBValue, expression: str) -> lldb.SBValue:
+    """Evaluate an expression in the frame of a value, without side effects."""
+    frame = value.GetFrame()
+    if not frame.IsValid():
+        return lldb.SBValue()
+    options = lldb.SBExpressionOptions()
+    options.SetIgnoreBreakpoints(True)
+    options.SetUnwindOnError(True)
+    return frame.EvaluateExpression(expression, options)
+
+
+class StagingError(RuntimeError):
+    """Report a failure to stage inferior memory for a formatter."""
+
+
+# Keyed by inferior address, not by provider: LLDB builds a synthetic provider
+# per stop and keeps every one alive, so a provider can never free its own copy.
+# Maps a device address to (host address, size, stop id).
+_staged_copies: dict[int, tuple[int, int, int]] = {}
+_staged_process_id: int | None = None
+
+
+def stage_device_memory(value: lldb.SBValue, device: int, bytes_: int) -> int:
+    """Copy ``bytes_`` from inferior address ``device`` to the host heap.
+
+    Returns the host address, or 0 when nothing was requested. Reuses the copy
+    from an identical request at the same stop, and otherwise frees it first.
+
+    Raises
+    ------
+    StagingError
+        If the frame is dead, the staging function does not compile, or the
+        inferior allocation or copy fails.
+    """
+    global _staged_process_id
+
+    frame = value.GetFrame()
+    process = value.GetProcess()
+    if not frame.IsValid() or not process.IsValid():
+        raise StagingError("value has no live frame")
+    if bytes_ == 0:
+        return 0
+
+    if _staged_process_id != process.GetUniqueID():
+        # A restarted process reuses heap addresses, so a stale entry would free
+        # memory it does not own.
+        _staged_copies.clear()
+        options = lldb.SBExpressionOptions()
+        options.SetIgnoreBreakpoints(True)
+        options.SetUnwindOnError(True)
+        options.SetTopLevel(True)
+        options.SetLanguage(lldb.eLanguageTypeC_plus_plus)
+        # A top-level expression has no result, so it reports a generic error
+        # even when it compiled.
+        error = frame.EvaluateExpression(_STAGE_DEFINITION, options).GetError()
+        if error.GetType() == lldb.eErrorTypeExpression:
+            raise StagingError(f"staging function did not compile: {error}")
+        _staged_process_id = process.GetUniqueID()
+
+    # LLDB may build several providers for one value at one stop, and each asks
+    # to stage. Repeating the copy would cost a round trip and change nothing.
+    stop_id = process.GetStopID()
+    previous = _staged_copies.pop(device, None)
+    if previous is not None:
+        host, staged_bytes, staged_stop = previous
+        if (staged_bytes, staged_stop) == (bytes_, stop_id):
+            _staged_copies[device] = previous
+            return host
+        evaluate(value, f"(void)free((void*){host:#x})")
+
+    result = evaluate(value, f"__cccl_stage((const void*){device:#x}, {bytes_}ull)")
+    host = result.GetValueAsUnsigned(0)
+    if result.GetError().Fail() or not host:
+        raise StagingError(f"cannot stage {bytes_} bytes from {device:#x}")
+    _staged_copies[device] = (host, bytes_, stop_id)
+    return host
+
 
 def strip_reference(value_type: lldb.SBType) -> lldb.SBType:
     """Return the type behind any reference, typedef, or cv-qualifier.

--- a/libcudacxx/share/libcudacxx/lldb/mdspan.py
+++ b/libcudacxx/share/libcudacxx/lldb/mdspan.py
@@ -328,6 +328,7 @@ class MdspanSyntheticProvider:
     """Expose cuda::std::mdspan elements as LLDB synthetic children."""
 
     def __init__(self, value: lldb.SBValue, _internal_dict: InternalDict) -> None:
+        self.declared_type = value.GetType()
         value = cccl_common.strip_reference_value(value)
         self.value = value.GetNonSyntheticValue()
         self.info: MdspanInfo | None = None
@@ -404,7 +405,9 @@ class MdspanSyntheticProvider:
         return self.num_children() != 0
 
     def get_type_name(self) -> str:
-        name = cccl_common.canonical_type_name(self.value.GetType())
+        # Report the declared type, so a reference parameter keeps its "const &".
+        # canonical_type_name() strips the reference, which hides it from the user.
+        name = self.declared_type.GetDisplayTypeName() or ""
         dynamic_extent = _dynamic_extent(self.value.GetTarget())
         return _readable_type_name(name, dynamic_extent)
 

--- a/libcudacxx/share/libcudacxx/lldb/mdspan.py
+++ b/libcudacxx/share/libcudacxx/lldb/mdspan.py
@@ -18,8 +18,6 @@ _EBCO_PATTERN = re.compile(r"__mdspan_ebco<")
 _EBCO_IMPL_PATTERN = re.compile(r"__mdspan_ebco_impl<\s*(\d+)\s*,")
 _EXTENTS_PATTERN = re.compile(r"extents<\s*([^>]*)>$")
 _LAYOUT_KINDS = ("layout_left", "layout_right", "layout_stride")
-# cudaMemcpyDefault: infer host/device direction from the pointers themselves.
-_CUDA_MEMCPY_DEFAULT = 4
 # cuda:: accessibility wrappers around cuda::std::mdspan.
 _WRAPPER_MDSPAN_NAMES = frozenset(
     {
@@ -216,49 +214,6 @@ def _required_span_size(
     return size
 
 
-def _stage_host_copy(
-    frame: lldb.SBFrame, data_address: int, byte_count: int
-) -> lldb.SBValue | None:
-    """Copy byte_count bytes from data_address into inferior-heap memory
-    (mirrors cuda::buffer's printer), since it may be device memory LLDB
-    would silently read as zeros. Returns a void* SBValue, or None on failure.
-    """
-    if not frame.IsValid():
-        return None
-    options = lldb.SBExpressionOptions()
-    options.SetIgnoreBreakpoints(True)
-    options.SetUnwindOnError(True)
-    host_copy = frame.EvaluateExpression(f"(void*)malloc({byte_count})", options)
-    if not host_copy.IsValid() or host_copy.GetError().Fail():
-        return None
-    host_address = host_copy.GetValueAsUnsigned(0)
-    if not host_address:
-        return None
-    result = frame.EvaluateExpression(
-        "(int)cudaMemcpy((void*)"
-        f"{host_address:#x}, (const void*){data_address:#x}, {byte_count}, "
-        f"{_CUDA_MEMCPY_DEFAULT})",
-        options,
-    )
-    if (
-        not result.IsValid()
-        or result.GetError().Fail()
-        or result.GetValueAsSigned(-1) != 0
-    ):
-        _release_host_copy(frame, host_address)
-        return None
-    return host_copy
-
-
-def _release_host_copy(frame: lldb.SBFrame, address: int) -> None:
-    if not frame.IsValid() or not address:
-        return
-    options = lldb.SBExpressionOptions()
-    options.SetIgnoreBreakpoints(True)
-    options.SetUnwindOnError(True)
-    frame.EvaluateExpression(f"(void)free((void*){address:#x})", options)
-
-
 def _offset(
     kind: str, extents: list[int], strides: list[int] | None, indices: tuple[int, ...]
 ) -> int:
@@ -380,24 +335,12 @@ class MdspanSyntheticProvider:
         self.stop_id: int | None = None
         self.update()
 
-    def __del__(self) -> None:
-        self._clear_copy()
-
-    def _clear_copy(self) -> None:
-        if self.host_copy.IsValid():
-            _release_host_copy(
-                self.value.GetFrame(), self.host_copy.GetValueAsUnsigned(0)
-            )
-        self.host_copy = lldb.SBValue()
-
     def _current_stop_id(self) -> int | None:
         process = self.value.GetProcess()
         return process.GetStopID() if process.IsValid() else None
 
     def _copy_to_host(self) -> None:
-        """Stage the mapping's addressed elements into debugger-owned host
-        memory via an inferior cudaMemcpy call. See _stage_host_copy for the
-        rationale (real device memory reads as zeros, not an error)."""
+        """Stage the addressed elements, which LLDB reads as zeros in device memory."""
         if (
             self.info is None
             or self.info.data is None
@@ -411,20 +354,28 @@ class MdspanSyntheticProvider:
         if span == 0:
             return
         element_type = self.info.data.GetType().GetPointeeType()
-        byte_count = span * element_type.GetByteSize()
-        host_copy = _stage_host_copy(
-            self.value.GetFrame(), self.info.data.GetValueAsUnsigned(0), byte_count
-        )
-        if host_copy is None:
+        pointer_type = element_type.GetPointerType()
+        # A formatter must not raise into the debugger; report no elements.
+        try:
+            address = cccl_common.stage_device_memory(
+                self.value,
+                self.info.data.GetValueAsUnsigned(0),
+                span * element_type.GetByteSize(),
+            )
+        except cccl_common.StagingError:
             return
-        self.host_copy = host_copy.Cast(element_type.GetPointerType())
+        self.host_copy = self.value.CreateValueFromData(
+            "__cccl_host_copy",
+            lldb.SBData.CreateDataFromInt(address, pointer_type.GetByteSize()),
+            pointer_type,
+        )
 
     def update(self) -> bool:
-        # Recopy only when the process has stopped again since the last
-        # copy: update() runs before every read (mirrors BufferSyntheticProvider).
+        # update() runs before every read of a synthetic child; see
+        # BufferSyntheticProvider.update.
         if self.stop_id is not None and self._current_stop_id() == self.stop_id:
             return True
-        self._clear_copy()
+        self.host_copy = lldb.SBValue()
         self.info = _mdspan_info(self.value)
         self._copy_to_host()
         self.stop_id = self._current_stop_id()

--- a/libcudacxx/share/libcudacxx/lldb/stream.py
+++ b/libcudacxx/share/libcudacxx/lldb/stream.py
@@ -21,77 +21,80 @@ _CUDA_STREAM_PER_THREAD_HANDLE = 2
 _CUDA_STREAM_CAPTURE_STATUS_NONE = 0
 _CUDA_STREAM_CAPTURE_STATUS_ACTIVE = 1
 _SUMMARY_UNIQUE_ID_CHILD = "__cccl_summary_unique_id"
-_UINT32_BITS = 32
-_UINT32_MASK = (1 << _UINT32_BITS) - 1
-_CAPTURE_STATUS_VALID = 1 << 0
-_UNIQUE_ID_VALID = 1 << 1
-_DEVICE_VALID = 1 << 2
-_PRIORITY_VALID = 1 << 3
-_FLAGS_VALID = 1 << 4
 InternalDict = dict[str, object]
 
 
-# LLDB cannot materialize a locally declared struct returned by an expression.
-# A Clang vector keeps this to one inferior call and exposes six stable lanes:
-# unique ID, device, priority, capture status, flags, and a validity mask.
-_STREAM_SNAPSHOT_EXPRESSION = """
-(unsigned long long __attribute__((ext_vector_type(6))))(([](cudaStream_t stream) {
-  using Snapshot = unsigned long long __attribute__((ext_vector_type(6)));
-  constexpr unsigned long long capture_status_valid = 1 << 0;
-  constexpr unsigned long long unique_id_valid = 1 << 1;
-  constexpr unsigned long long device_valid = 1 << 2;
-  constexpr unsigned long long priority_valid = 1 << 3;
-  constexpr unsigned long long flags_valid = 1 << 4;
+# Compiled once per process, then called per stream: an inferior round trip costs
+# far more than the queries, so one call collects every field.
+#
+# The queries use the driver API. libcuda is always shared, so its symbols are
+# always present; the cudart equivalents are absent from a statically linked
+# runtime unless the program itself calls them, which silently drops a field.
+#
+# An unresolved identifier fails the whole unit, so the device query is spliced in
+# only when its symbol resolves. The rest predate the oldest supported driver.
+_STREAM_SNAPSHOT_DEFINITION = """
+struct __cccl_stream_snapshot_result
+{
+  unsigned long long unique_id;
+  int device;
+  int priority;
+  int capture_status;
+  unsigned int flags;
+  bool has_unique_id;
+  bool has_device;
+  bool has_priority;
+  bool has_capture_status;
+  bool has_flags;
+};
 
-  void* original_context{};
+extern "C" __cccl_stream_snapshot_result __cccl_stream_snapshot(void* stream)
+{
+  __cccl_stream_snapshot_result result = {};
+  void* original_context = 0;
   const int context_status =
     ((int (*)(void**))cuCtxGetCurrent)(&original_context);
-  int capture_status{};
-  unsigned long long unique_id{};
-  int device{};
-  int priority{};
-  unsigned int flags{};
-  unsigned long long validity{};
 
   if (context_status == 0
-      && ((int (*)(cudaStream_t, int*))cudaStreamIsCapturing)(
-           stream, &capture_status) == 0) {
-    validity |= capture_status_valid;
-    if (capture_status == 0) {
-      if (((int (*)(void*, unsigned long long*))cuStreamGetId)(
-            (void*)stream, &unique_id) == 0) {
-        validity |= unique_id_valid;
-      }
+      && ((int (*)(void*, int*))cuStreamIsCapturing)(
+           stream, &result.capture_status) == 0) {
+    result.has_capture_status = true;
+    if (result.capture_status == 0) {
+      result.has_unique_id =
+        ((int (*)(void*, unsigned long long*))cuStreamGetId)(
+          stream, &result.unique_id) == 0;
 %s
-      if ((int)cudaStreamGetPriority(stream, &priority) == 0) {
-        validity |= priority_valid;
-      }
-      if ((int)cudaStreamGetFlags(stream, &flags) == 0) {
-        validity |= flags_valid;
-      }
+      result.has_priority =
+        ((int (*)(void*, int*))cuStreamGetPriority)(
+          stream, &result.priority) == 0;
+      result.has_flags =
+        ((int (*)(void*, unsigned int*))cuStreamGetFlags)(
+          stream, &result.flags) == 0;
     }
   }
 
-  if (context_status == 0 && original_context == nullptr) {
-    (void)((int (*)(void*))cuCtxSetCurrent)(nullptr);
+  if (context_status == 0 && original_context == 0) {
+    (void)((int (*)(void*))cuCtxSetCurrent)(0);
   }
-
-  return Snapshot{
-    unique_id,
-    (unsigned int)device,
-    (unsigned int)priority,
-    (unsigned int)capture_status,
-    flags,
-    validity,
-  };
-})((cudaStream_t)%#x))
+  return result;
+}
 """
 
+# cuStreamGetDevice arrived in CUDA 12.8. Reporting no device on an older driver
+# is safer than changing the current CUDA context from a formatter.
 _STREAM_DEVICE_QUERY = """
-  if ((int)cudaStreamGetDevice(stream, &device) == 0) {
-    validity |= device_valid;
-  }
+      result.has_device =
+        ((int (*)(void*, int*))cuStreamGetDevice)(
+          stream, &result.device) == 0;
 """
+# Each value member has a has_<name> companion. int members read as signed.
+_SNAPSHOT_FIELDS = {
+    "unique_id": False,
+    "device": True,
+    "priority": True,
+    "capture_status": True,
+    "flags": False,
+}
 
 
 class StreamInfo(NamedTuple):
@@ -139,69 +142,81 @@ def _handle_description(handle: int, byte_size: int) -> str:
     return f"{handle:#x}"
 
 
-def _evaluate(value: lldb.SBValue, expression: str) -> lldb.SBValue:
+def _snapshot_fields(value: lldb.SBValue, handle: int) -> dict[str, int] | None:
+    """Compile the snapshot if needed, then run it for one handle."""
     frame = value.GetFrame()
-    if not frame.IsValid():
-        return lldb.SBValue()
+    process = value.GetProcess()
+    target = value.GetTarget()
+    if not frame.IsValid() or not process.IsValid() or not target.IsValid():
+        return None
+
+    process_id = process.GetUniqueID()
+    if _snapshot_fields.process_id != process_id:
+        _snapshot_fields.process_id = process_id
+        definition = _STREAM_SNAPSHOT_DEFINITION % (
+            _STREAM_DEVICE_QUERY
+            if target.FindSymbols("cuStreamGetDevice").GetSize()
+            else ""
+        )
+        top_level = lldb.SBExpressionOptions()
+        top_level.SetIgnoreBreakpoints(True)
+        top_level.SetUnwindOnError(True)
+        top_level.SetTopLevel(True)
+        top_level.SetLanguage(lldb.eLanguageTypeC_plus_plus)
+        # A top-level expression has no result, so it reports a generic error
+        # even when it compiled.
+        error = frame.EvaluateExpression(definition, top_level).GetError()
+        _snapshot_fields.installed = error.GetType() != lldb.eErrorTypeExpression
+    if not _snapshot_fields.installed:
+        return None
+
     options = lldb.SBExpressionOptions()
     options.SetIgnoreBreakpoints(True)
     options.SetUnwindOnError(True)
-    return frame.EvaluateExpression(expression, options)
-
-
-def _snapshot_values(
-    result: lldb.SBValue,
-) -> tuple[int, int, int, int, int, int] | None:
-    if result.GetNumChildren() != 6:
+    result = frame.EvaluateExpression(
+        f"__cccl_stream_snapshot((void*){handle:#x})", options
+    )
+    if result.GetError().Fail():
         return None
 
-    lanes: list[int] = []
-    for index in range(6):
-        lane = result.GetChildAtIndex(index)
-        if not lane.IsValid() or lane.GetError().Fail():
-            return None
-        lanes.append(lane.GetValueAsUnsigned(0))
-    return lanes[0], lanes[1], lanes[2], lanes[3], lanes[4], lanes[5]
+    fields: dict[str, int] = {}
+    for name, signed in _SNAPSHOT_FIELDS.items():
+        for member_name in (name, f"has_{name}"):
+            member = result.GetChildMemberWithName(member_name)
+            if not member.IsValid() or member.GetError().Fail():
+                return None
+            fields[member_name] = (
+                member.GetValueAsSigned(0)
+                if signed and member_name == name
+                else member.GetValueAsUnsigned(0)
+            )
+    return fields
 
 
-def _signed32(value: int) -> int:
-    value &= _UINT32_MASK
-    return value - (1 << _UINT32_BITS) if value & (1 << 31) else value
+_snapshot_fields.process_id = None
+_snapshot_fields.installed = False
 
 
 def _query_stream_snapshot(value: lldb.SBValue, handle: int) -> StreamSnapshot | None:
-    # One vector-valued expression avoids target allocations and
-    # debugger-visible state changes.
-    result = _evaluate(
-        value, _STREAM_SNAPSHOT_EXPRESSION % (_STREAM_DEVICE_QUERY, handle)
-    )
-    if not result.IsValid() or result.GetError().Fail():
-        # cudaStreamGetDevice was added in CUDA 12.8. Older runtimes can still
-        # provide the remaining metadata without changing the current context.
-        result = _evaluate(value, _STREAM_SNAPSHOT_EXPRESSION % ("", handle))
-    if not result.IsValid() or result.GetError().Fail():
-        return None
-
-    snapshot = _snapshot_values(result)
+    snapshot = _snapshot_fields(value, handle)
     if snapshot is None:
         return None
-    unique_id, device, priority, capture_status, flags, validity = snapshot
 
-    if not validity & _CAPTURE_STATUS_VALID:
+    if not snapshot["has_capture_status"]:
         return StreamSnapshot(None, StreamInfo(None, None, None, None))
 
-    capture_status = _signed32(capture_status)
+    capture_status = snapshot["capture_status"]
     is_capturing = capture_status == _CUDA_STREAM_CAPTURE_STATUS_ACTIVE
     if capture_status != _CUDA_STREAM_CAPTURE_STATUS_NONE:
         return StreamSnapshot(None, StreamInfo(None, None, is_capturing, None))
 
     return StreamSnapshot(
-        unique_id if validity & _UNIQUE_ID_VALID else None,
+        snapshot["unique_id"] if snapshot["has_unique_id"] else None,
         StreamInfo(
-            _signed32(device) if validity & _DEVICE_VALID else None,
-            _signed32(priority) if validity & _PRIORITY_VALID else None,
+            snapshot["device"] if snapshot["has_device"] else None,
+            snapshot["priority"] if snapshot["has_priority"] else None,
             is_capturing,
-            flags if validity & _FLAGS_VALID else None,
+            snapshot["flags"] if snapshot["has_flags"] else None,
         ),
     )
 

--- a/libcudacxx/share/libcudacxx/lldb/stream.py
+++ b/libcudacxx/share/libcudacxx/lldb/stream.py
@@ -163,10 +163,17 @@ def _snapshot_fields(value: lldb.SBValue, handle: int) -> dict[str, int] | None:
         top_level.SetUnwindOnError(True)
         top_level.SetTopLevel(True)
         top_level.SetLanguage(lldb.eLanguageTypeC_plus_plus)
-        # A top-level expression has no result, so it reports a generic error
-        # even when it compiled.
-        error = frame.EvaluateExpression(definition, top_level).GetError()
-        _snapshot_fields.installed = error.GetType() != lldb.eErrorTypeExpression
+        frame.EvaluateExpression(definition, top_level)
+        # A top-level expression has no result, and it goes to the JIT, so it
+        # appears in no symbol table. A call is the only proof that it compiled.
+        probe = lldb.SBExpressionOptions()
+        probe.SetIgnoreBreakpoints(True)
+        probe.SetUnwindOnError(True)
+        _snapshot_fields.installed = (
+            frame.EvaluateExpression("__cccl_stream_snapshot((void*)0)", probe)
+            .GetError()
+            .Success()
+        )
     if not _snapshot_fields.installed:
         return None
 

--- a/libcudacxx/test/debugging/CMakeLists.txt
+++ b/libcudacxx/test/debugging/CMakeLists.txt
@@ -204,7 +204,7 @@ function(libcudacxx_add_pretty_printer_test)
     )
     # Set an aggressive timeout because pretty printers should not be slow. If they are,
     # then it's a problem with the printer and/or it is doing too much
-    set_tests_properties(${test_name} PROPERTIES TIMEOUT 5 SKIP_RETURN_CODE 77)
+    set_tests_properties(${test_name} PROPERTIES TIMEOUT 10 SKIP_RETURN_CODE 77)
   endforeach()
 endfunction()
 

--- a/libcudacxx/test/debugging/CMakeLists.txt
+++ b/libcudacxx/test/debugging/CMakeLists.txt
@@ -204,7 +204,7 @@ function(libcudacxx_add_pretty_printer_test)
     )
     # Set an aggressive timeout because pretty printers should not be slow. If they are,
     # then it's a problem with the printer and/or it is doing too much
-    set_tests_properties(${test_name} PROPERTIES TIMEOUT 10 SKIP_RETURN_CODE 77)
+    set_tests_properties(${test_name} PROPERTIES TIMEOUT 5 SKIP_RETURN_CODE 77)
   endforeach()
 endfunction()
 

--- a/libcudacxx/test/debugging/mdspan/CMakeLists.txt
+++ b/libcudacxx/test/debugging/mdspan/CMakeLists.txt
@@ -27,5 +27,9 @@ libcudacxx_add_pretty_printer_test(
     --case inspect_array mdspan.array values
     --case inspect_before_update mdspan.update.before values
     --case inspect_after_update mdspan.update.after values
+    --case inspect_aliased_before_update mdspan.aliased.before.whole whole
+    --case inspect_aliased_before_update mdspan.aliased.before.prefix prefix
+    --case inspect_aliased_after_update mdspan.aliased.after.whole whole
+    --case inspect_aliased_after_update mdspan.aliased.after.prefix prefix
     # gersemi: on
 )

--- a/libcudacxx/test/debugging/mdspan/gdb.expected
+++ b/libcudacxx/test/debugging/mdspan/gdb.expected
@@ -193,3 +193,31 @@ cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>> rank=1, extents=
   [2] = 15
 }
 =============== mdspan.update.after end ===============
+=============== mdspan.aliased.before.whole begin ===============
+cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>> rank=1, extents=[4], data=<address> = {
+  [0] = 31,
+  [1] = 32,
+  [2] = 33,
+  [3] = 34
+}
+=============== mdspan.aliased.before.whole end ===============
+=============== mdspan.aliased.before.prefix begin ===============
+cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>> rank=1, extents=[2], data=<address> = {
+  [0] = 31,
+  [1] = 32
+}
+=============== mdspan.aliased.before.prefix end ===============
+=============== mdspan.aliased.after.whole begin ===============
+cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>> rank=1, extents=[4], data=<address> = {
+  [0] = -41,
+  [1] = -42,
+  [2] = -43,
+  [3] = -44
+}
+=============== mdspan.aliased.after.whole end ===============
+=============== mdspan.aliased.after.prefix begin ===============
+cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>> rank=1, extents=[2], data=<address> = {
+  [0] = -41,
+  [1] = -42
+}
+=============== mdspan.aliased.after.prefix end ===============

--- a/libcudacxx/test/debugging/mdspan/lldb.expected
+++ b/libcudacxx/test/debugging/mdspan/lldb.expected
@@ -1,5 +1,5 @@
 =============== mdspan.rank1_dynamic begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>>) <address> rank=1, extents=[4], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>> &) <address> rank=1, extents=[4], data=<address>: {
   [0] = 10
   [1] = -3
   [2] = 7
@@ -7,7 +7,7 @@
 }
 =============== mdspan.rank1_dynamic end ===============
 =============== mdspan.rank2_static begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, 3, 4>>) <address> rank=2, extents=[3, 4], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int, 3, 4>> &) <address> rank=2, extents=[3, 4], data=<address>: {
   [0,0] = 0
   [0,1] = 1
   [0,2] = 2
@@ -23,7 +23,7 @@
 }
 =============== mdspan.rank2_static end ===============
 =============== mdspan.rank2_mixed begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, 3, dynamic_extent>>) <address> rank=2, extents=[3, 4], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int, 3, dynamic_extent>> &) <address> rank=2, extents=[3, 4], data=<address>: {
   [0,0] = 100
   [0,1] = 101
   [0,2] = 102
@@ -39,7 +39,7 @@
 }
 =============== mdspan.rank2_mixed end ===============
 =============== mdspan.rank2_dynamic begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent, dynamic_extent>>) <address> rank=2, extents=[2, 3], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent, dynamic_extent>> &) <address> rank=2, extents=[2, 3], data=<address>: {
   [0,0] = 1000
   [0,1] = 1001
   [0,2] = 1002
@@ -49,15 +49,15 @@
 }
 =============== mdspan.rank2_dynamic end ===============
 =============== mdspan.rank0 begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int>>) <address> rank=0, extents=[], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int>> &) <address> rank=0, extents=[], data=<address>: {
   [] = 77
 }
 =============== mdspan.rank0 end ===============
 =============== mdspan.empty begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, 0, 3>>) <address> rank=2, extents=[0, 3], data=<address>
+(const cuda::std::mdspan<int, cuda::std::extents<int, 0, 3>> &) <address> rank=2, extents=[0, 3], data=<address>
 =============== mdspan.empty end ===============
 =============== mdspan.layout_right begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, 3, 3>>) <address> rank=2, extents=[3, 3], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int, 3, 3>> &) <address> rank=2, extents=[3, 3], data=<address>: {
   [0,0] = 1
   [0,1] = 2
   [0,2] = 3
@@ -70,7 +70,7 @@
 }
 =============== mdspan.layout_right end ===============
 =============== mdspan.layout_left begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, 3, 3>, cuda::std::layout_left>) <address> rank=2, extents=[3, 3], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int, 3, 3>, cuda::std::layout_left> &) <address> rank=2, extents=[3, 3], data=<address>: {
   [0,0] = 1
   [0,1] = 4
   [0,2] = 7
@@ -83,33 +83,33 @@
 }
 =============== mdspan.layout_left end ===============
 =============== mdspan.layout_stride begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, 3>, cuda::std::layout_stride>) <address> rank=1, extents=[3], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int, 3>, cuda::std::layout_stride> &) <address> rank=1, extents=[3], data=<address>: {
   [0] = 1
   [1] = 5
   [2] = 9
 }
 =============== mdspan.layout_stride end ===============
 =============== mdspan.rank0_layout_stride begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int>, cuda::std::layout_stride>) <address> rank=0, extents=[], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int>, cuda::std::layout_stride> &) <address> rank=0, extents=[], data=<address>: {
   [] = 55
 }
 =============== mdspan.rank0_layout_stride end ===============
 =============== mdspan.const_element begin ===============
-(cuda::std::mdspan<const int, cuda::std::extents<int, dynamic_extent>>) <address> rank=1, extents=[3], data=<address>: {
+(const cuda::std::mdspan<const int, cuda::std::extents<int, dynamic_extent>> &) <address> rank=1, extents=[3], data=<address>: {
   [0] = 5
   [1] = 6
   [2] = 7
 }
 =============== mdspan.const_element end ===============
 =============== mdspan.pointer_element begin ===============
-(cuda::std::mdspan<int *, cuda::std::extents<int, dynamic_extent>>) <address> rank=1, extents=[3], data=<address>: {
+(const cuda::std::mdspan<int *, cuda::std::extents<int, dynamic_extent>> &) <address> rank=1, extents=[3], data=<address>: {
   [0] = <address>
   [1] = <address>
   [2] = <address>
 }
 =============== mdspan.pointer_element end ===============
 =============== mdspan.nested begin ===============
-(cuda::std::mdspan<cuda::std::mdspan<int, cuda::std::extents<int, 2>>, cuda::std::extents<int, 2>>) <address> rank=1, extents=[2], data=<address>: {
+(const cuda::std::mdspan<cuda::std::mdspan<int, cuda::std::extents<int, 2>>, cuda::std::extents<int, 2>> &) <address> rank=1, extents=[2], data=<address>: {
   [0] = rank=1, extents=[2], data=<address> {
     [0] = 1
     [1] = 2
@@ -121,7 +121,7 @@
 }
 =============== mdspan.nested end ===============
 =============== mdspan.custom_accessor begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>, cuda::std::layout_right, cuda::std::aligned_accessor<int, 16>>) <address> rank=1, extents=[4], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>, cuda::std::layout_right, cuda::std::aligned_accessor<int, 16>> &) <address> rank=1, extents=[4], data=<address>: {
   [0] = -7
   [1] = 8
   [2] = -9
@@ -129,40 +129,40 @@
 }
 =============== mdspan.custom_accessor end ===============
 =============== mdspan.host_mdspan begin ===============
-(cuda::host_mdspan<int, cuda::std::extents<int, 2>>) <address> rank=1, extents=[2], data=<address>: {
+(const cuda::host_mdspan<int, cuda::std::extents<int, 2>> &) <address> rank=1, extents=[2], data=<address>: {
   [0] = 41
   [1] = 42
 }
 =============== mdspan.host_mdspan end ===============
 =============== mdspan.device_mdspan begin ===============
-(cuda::device_mdspan<int, cuda::std::extents<int, 2>>) <address> rank=1, extents=[2], data=<address>: {
+(const cuda::device_mdspan<int, cuda::std::extents<int, 2>> &) <address> rank=1, extents=[2], data=<address>: {
   [0] = 51
   [1] = 52
 }
 =============== mdspan.device_mdspan end ===============
 =============== mdspan.device_mdspan_real_memory begin ===============
-(cuda::device_mdspan<int, cuda::std::extents<int, 2>>) <address> rank=1, extents=[2], data=<address>: {
+(const cuda::device_mdspan<int, cuda::std::extents<int, 2>> &) <address> rank=1, extents=[2], data=<address>: {
   [0] = 91
   [1] = 92
 }
 =============== mdspan.device_mdspan_real_memory end ===============
 =============== mdspan.device_backed begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, 2>>) <address> rank=1, extents=[2], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int, 2>> &) <address> rank=1, extents=[2], data=<address>: {
   [0] = 93
   [1] = 94
 }
 =============== mdspan.device_backed end ===============
 =============== mdspan.copy_failure begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, 1>>) <address> rank=1, extents=[1], data=0x0
+(const cuda::std::mdspan<int, cuda::std::extents<int, 1>> &) <address> rank=1, extents=[1], data=0x0
 =============== mdspan.copy_failure end ===============
 =============== mdspan.managed_mdspan begin ===============
-(cuda::managed_mdspan<int, cuda::std::extents<int, 2>>) <address> rank=1, extents=[2], data=<address>: {
+(const cuda::managed_mdspan<int, cuda::std::extents<int, 2>> &) <address> rank=1, extents=[2], data=<address>: {
   [0] = 61
   [1] = 62
 }
 =============== mdspan.managed_mdspan end ===============
 =============== mdspan.restrict_mdspan begin ===============
-(cuda::restrict_mdspan<int, cuda::std::extents<int, 2>>) <address> rank=1, extents=[2], data=<address>: {
+(const cuda::restrict_mdspan<int, cuda::std::extents<int, 2>> &) <address> rank=1, extents=[2], data=<address>: {
   [0] = 71
   [1] = 72
 }
@@ -180,16 +180,44 @@
 }
 =============== mdspan.array end ===============
 =============== mdspan.update.before begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>>) <address> rank=1, extents=[3], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>> &) <address> rank=1, extents=[3], data=<address>: {
   [0] = 1
   [1] = 2
   [2] = 3
 }
 =============== mdspan.update.before end ===============
 =============== mdspan.update.after begin ===============
-(cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>>) <address> rank=1, extents=[3], data=<address>: {
+(const cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>> &) <address> rank=1, extents=[3], data=<address>: {
   [0] = 9
   [1] = -3
   [2] = 15
 }
 =============== mdspan.update.after end ===============
+=============== mdspan.aliased.before.whole begin ===============
+(const cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>> &) <address> rank=1, extents=[4], data=<address>: {
+  [0] = 31
+  [1] = 32
+  [2] = 33
+  [3] = 34
+}
+=============== mdspan.aliased.before.whole end ===============
+=============== mdspan.aliased.before.prefix begin ===============
+(const cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>> &) <address> rank=1, extents=[2], data=<address>: {
+  [0] = 31
+  [1] = 32
+}
+=============== mdspan.aliased.before.prefix end ===============
+=============== mdspan.aliased.after.whole begin ===============
+(const cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>> &) <address> rank=1, extents=[4], data=<address>: {
+  [0] = -41
+  [1] = -42
+  [2] = -43
+  [3] = -44
+}
+=============== mdspan.aliased.after.whole end ===============
+=============== mdspan.aliased.after.prefix begin ===============
+(const cuda::std::mdspan<int, cuda::std::extents<int, dynamic_extent>> &) <address> rank=1, extents=[2], data=<address>: {
+  [0] = -41
+  [1] = -42
+}
+=============== mdspan.aliased.after.prefix end ===============

--- a/libcudacxx/test/debugging/mdspan/source.cu
+++ b/libcudacxx/test/debugging/mdspan/source.cu
@@ -154,6 +154,22 @@ inspect_array(const cuda::std::array<cuda::std::mdspan<int, cuda::std::extents<i
   KEEP_FOR_DEBUGGER(values);
 }
 
+// Two spans of different lengths over one device allocation. The printer caches its
+// host copies per (address, length), so both must appear and both must refresh.
+[[gnu::noinline]] void inspect_aliased_before_update(const cuda::std::mdspan<int, cuda::std::dextents<int, 1>>& whole,
+                                                     const cuda::std::mdspan<int, cuda::std::dextents<int, 1>>& prefix)
+{
+  KEEP_FOR_DEBUGGER(whole);
+  KEEP_FOR_DEBUGGER(prefix);
+}
+
+[[gnu::noinline]] void inspect_aliased_after_update(const cuda::std::mdspan<int, cuda::std::dextents<int, 1>>& whole,
+                                                    const cuda::std::mdspan<int, cuda::std::dextents<int, 1>>& prefix)
+{
+  KEEP_FOR_DEBUGGER(whole);
+  KEEP_FOR_DEBUGGER(prefix);
+}
+
 int main()
 {
   // Build the CUDA context before the first breakpoint. The printer copies elements
@@ -327,4 +343,26 @@ int main()
   mutable_data[1] = -3;
   mutable_data[2] = 15;
   inspect_after_update(mutable_values);
+
+  int* aliased_data = nullptr;
+  if (cudaMalloc(&aliased_data, 4 * sizeof(int)) != cudaSuccess)
+  {
+    return 1;
+  }
+  const int aliased_initial[4] = {31, 32, 33, 34};
+  if (cudaMemcpy(aliased_data, aliased_initial, sizeof(aliased_initial), cudaMemcpyHostToDevice) != cudaSuccess)
+  {
+    return 1;
+  }
+  const cuda::std::mdspan<int, cuda::std::dextents<int, 1>> aliased_whole(aliased_data, 4);
+  const cuda::std::mdspan<int, cuda::std::dextents<int, 1>> aliased_prefix(aliased_data, 2);
+  inspect_aliased_before_update(aliased_whole, aliased_prefix);
+
+  const int aliased_updated[4] = {-41, -42, -43, -44};
+  if (cudaMemcpy(aliased_data, aliased_updated, sizeof(aliased_updated), cudaMemcpyHostToDevice) != cudaSuccess)
+  {
+    return 1;
+  }
+  inspect_aliased_after_update(aliased_whole, aliased_prefix);
+  cudaFree(aliased_data);
 }

--- a/libcudacxx/test/debugging/stream/source.cu
+++ b/libcudacxx/test/debugging/stream/source.cu
@@ -91,6 +91,9 @@ using stream_ref_alias = cuda::stream_ref;
 
 int main()
 {
+  cudaSetDevice(0);
+  cudaFree(nullptr);
+
   constexpr cuda::device_ref device{0};
   const cuda::stream owning_stream{device};
   const cuda::stream_ref stream_reference{owning_stream};


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

- Fix a bug in the gdb printers where `12344ul` wouldn't match for the `dynamic_extent` replacement.
- For `llbd/stream.py` pre-compile the entire stream query expression and call it with the stream as an argument instead of a new bespoke string each time. `lldb` does seem to cache these but the string has to match exactly.
- Use the driver API instead of runtime to avoid pushing/popping contexts unnecessarily.
- Aggressively optimize d2h memory copies by caching them. This results in a roughly 43% speedup since we elide several copies when we don't need them.
- Also fix a bug in the mdspan printers which did not show reference types correctly.
- Fix a bug in the mdspan printers where different views over the same data could fail to show updates in certain circumstances.

With the new buffer caching optimization, we could consider making the timeouts even more aggressive at 5s. But some of them initialize CUDA which could take an unbounded amount of time so maybe best to leave as-is

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
