### PR TITLE
[CUB] Revert "[CUB] Avoid compiler error on nonintegral __nv_atomic argument (#10623)"

### DIFF
--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -27,9 +27,7 @@
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__bit/popcount.h>
 #include <cuda/std/__type_traits/is_same.h>
-#include <cuda/std/__type_traits/make_nbit_int.h>
 #include <cuda/std/__type_traits/underlying_type.h>
-#include <cuda/std/climits>
 
 #if !_CCCL_HAS_NV_ATOMIC_BUILTINS()
 #  include <cuda/atomic>
@@ -88,11 +86,7 @@ storeTileAggregate(tile_state_t<AccumT>* ptrTileStates, scan_state scanState, Ac
     tile_state_t<AccumT> tmp{scanState, aggr};
 
 #  if _CCCL_HAS_NV_ATOMIC_BUILTINS()
-    using __as_integer = ::cuda::std::__make_nbit_uint_t<sizeof(tile_state_t<AccumT>) * CHAR_BIT>;
-    __nv_atomic_store(reinterpret_cast<__as_integer*>(ptrTileStates + index),
-                      reinterpret_cast<__as_integer*>(&tmp),
-                      __NV_ATOMIC_RELAXED,
-                      __NV_THREAD_SCOPE_DEVICE);
+    __nv_atomic_store(ptrTileStates + index, &tmp, __NV_ATOMIC_RELAXED, __NV_THREAD_SCOPE_DEVICE);
 #  else // ^^^ _CCCL_HAS_NV_ATOMIC_BUILTINS() ^^^ / vvv !_CCCL_HAS_NV_ATOMIC_BUILTINS() vvv
     ::cuda::atomic_ref<tile_state_t<AccumT>, ::cuda::std::thread_scope_device>{ptrTileStates[index]}.store(
       tmp, ::cuda::std::memory_order_relaxed);
@@ -118,11 +112,7 @@ _CCCL_DEVICE_API tile_state_t<AccumT> loadTileAggregate(tile_state_t<AccumT>* pt
   {
     static_assert(::cuda::is_power_of_two(sizeof(tile_state_t<AccumT>)));
 #  if _CCCL_HAS_NV_ATOMIC_BUILTINS()
-    using __as_integer = ::cuda::std::__make_nbit_uint_t<sizeof(tile_state_t<AccumT>) * CHAR_BIT>;
-    __nv_atomic_load(reinterpret_cast<__as_integer*>(ptrTileStates + index),
-                     reinterpret_cast<__as_integer*>(&res),
-                     __NV_ATOMIC_RELAXED,
-                     __NV_THREAD_SCOPE_DEVICE);
+    __nv_atomic_load(ptrTileStates + index, &res, __NV_ATOMIC_RELAXED, __NV_THREAD_SCOPE_DEVICE);
 #  else // ^^^ _CCCL_HAS_NV_ATOMIC_BUILTINS() ^^^ / vvv !_CCCL_HAS_NV_ATOMIC_BUILTINS() vvv
     res = ::cuda::atomic_ref<tile_state_t<AccumT>, ::cuda::std::thread_scope_device>{ptrTileStates[index]}.load(
       ::cuda::std::memory_order_relaxed);

--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -41,9 +41,7 @@ namespace detail::warpspeed
 {
 [[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL ::cuda::std::size_t max_native_atomic_size() noexcept
 {
-#if !_CCCL_HAS_INT128()
-  return 8;
-#elif _CCCL_CUDA_COMPILER(NVHPC)
+#if _CCCL_CUDA_COMPILER(NVHPC)
   return 8;
 #else // ^^^ _CCCL_CUDA_COMPILER(NVHPC) ^^^ / vvv !_CCCL_CUDA_COMPILER(NVHPC)  vvv
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90, (return 16;), (return 8;))


### PR DESCRIPTION
This reverts commit c239044514476e9f195cd89f8d8dbd9612aa47f4.

We also drop the constraint that we cannot use 16 wide atomics in tile mode because we are not forced through int128 anymore