### PR TITLE
Allow scheduled AI failure analysis

### DIFF
--- a/.github/actions/ci-failure-analysis/action.yml
+++ b/.github/actions/ci-failure-analysis/action.yml
@@ -64,6 +64,8 @@ runs:
         permission-profile: ci_triage
         safety-strategy: drop-sudo
         allow-bot-users: "copy-pr-bot[bot]"
+        # Scheduled runs use the user who last changed the cron expression as their actor.
+        allow-users: ${{ github.event_name == 'schedule' && github.actor || '' }}
         model: openai/openai/gpt-5.6-sol
         effort: medium
         codex-args: --strict-config --ignore-rules --ephemeral

--- a/.github/actions/ci-failure-analysis/action.yml
+++ b/.github/actions/ci-failure-analysis/action.yml
@@ -64,8 +64,8 @@ runs:
         permission-profile: ci_triage
         safety-strategy: drop-sudo
         allow-bot-users: "copy-pr-bot[bot]"
-        # Scheduled runs use the user who last changed the cron expression as their actor.
-        allow-users: ${{ github.event_name == 'schedule' && github.actor || '' }}
+        # Scheduled workflows have no meaningful triggering user, so skip the actor check.
+        allow-users: ${{ github.event_name == 'schedule' && '*' || '' }}
         model: openai/openai/gpt-5.6-sol
         effort: medium
         codex-args: --strict-config --ignore-rules --ephemeral


### PR DESCRIPTION
## Summary

- skip the Codex actor permission check only for GitHub-scheduled runs
- retain the default write-access check for PR, push, and manually triggered runs

## Root cause

GitHub assigns scheduled workflows a historical actor associated with schedule or default-branch changes. The [failed nightly](https://github.com/NVIDIA/cccl/actions/runs/32095072799/job/95630777110) was attributed to `alliepiper`, whose current repository permission is `read`, so `openai/codex-action` rejected the run before inference started.

A schedule event is initiated by GitHub from the default branch, so that historical actor is not a meaningful authorization principal. This schedule-only workaround matches the behavior proposed in [openai/codex-action#73](https://github.com/openai/codex-action/pull/73) without changing the job token permissions or authorization for user-triggered events.

## Validation

- repository pre-commit hooks
- parsed the composite action metadata with PyYAML
- `git diff --check`