### PR TITLE
[cudax] Implement `cudax::virtual_group`

### DIFF
--- a/cudax/include/cuda/experimental/__group/fwd.cuh
+++ b/cudax/include/cuda/experimental/__group/fwd.cuh
@@ -69,6 +69,9 @@ class this_grid;
 template <class _Unit, class _ParentGroup, class _MappingResult, class _Synchronizer>
 class group;
 
+template <class _Unit, class _ParentGroup, class _MappingResult>
+class virtual_group;
+
 template <class _Unit, class _Group>
 class group_view;
 

--- a/cudax/include/cuda/experimental/__group/virtual_group.cuh
+++ b/cudax/include/cuda/experimental/__group/virtual_group.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL___GROUP_GROUP_CUH
-#define _CUDA_EXPERIMENTAL___GROUP_GROUP_CUH
+#ifndef _CUDA_EXPERIMENTAL___GROUP_VIRTUAL_GROUP_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_VIRTUAL_GROUP_CUH
 
 #include <cuda/std/detail/__config>
 
@@ -33,6 +33,7 @@
 #include <cuda/std/__type_traits/is_constructible.h>
 #include <cuda/std/__type_traits/is_integer.h>
 #include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__utility/declval.h>
 #include <cuda/std/span>
 
 #include <cuda/experimental/__group/concepts.cuh>
@@ -40,7 +41,6 @@
 #include <cuda/experimental/__group/mapping/mapping_result.cuh>
 #include <cuda/experimental/__group/this_group.cuh>
 #include <cuda/experimental/__group/traits.cuh>
-#include <cuda/experimental/__group/virtual_group.cuh>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -48,80 +48,86 @@
 
 namespace cuda::experimental
 {
-template <class _Unit, class _ParentGroup, class _MappingResult, class _Synchronizer>
-class group
+template <class _Unit, class _ParentGroup, class _Mapping>
+[[nodiscard]] _CCCL_DEVICE_API auto
+__do_group_mapping(const _Unit& __unit, const _ParentGroup& __parent, const _Mapping& __mapping) noexcept
+{
+  using _ParentMappingResult = typename _ParentGroup::__mapping_result_type;
+  using _InitMappingResult =
+    __mapping_result</*initial static group count*/ 1,
+                     ::cuda::experimental::__static_count_query_group<_Unit, _ParentGroup>(),
+                     _ParentMappingResult::is_always_exhaustive(),
+                     _ParentMappingResult::is_always_contiguous()>;
+  const _InitMappingResult __init_mapping_result{
+    /*initial group count*/ 1,
+    /*initial group rank*/ 0,
+    ::cuda::experimental::__count_query_group<unsigned, _Unit>(__parent),
+    ::cuda::experimental::__rank_query_group<unsigned, _Unit>(__parent),
+    __parent.__mapping_result().lane_mask()};
+
+  const auto __mapping_result = __mapping.map(__unit, __parent, __init_mapping_result);
+  if (__mapping_result.is_valid())
+  {
+    _CCCL_ASSERT(__mapping_result.group_rank() < __mapping_result.group_count(), "invalid group rank");
+    _CCCL_ASSERT(__mapping_result.unit_rank() < __mapping_result.unit_count(), "invalid unit rank");
+
+    if constexpr (::cuda::std::is_same_v<_Unit, thread_level>)
+    {
+      _CCCL_ASSERT(
+        (__mapping_result.lane_mask() & ::cuda::device::lane_mask::this_lane()) != ::cuda::device::lane_mask::none(),
+        "invalid lane mask - this lane must be contained in the lane mask");
+      _CCCL_ASSERT(::cuda::std::popcount(__mapping_result.lane_mask().value()) <= __mapping_result.unit_count(),
+                   "invalid lane mask - too many lanes are set in the lane mask");
+    }
+    else
+    {
+      _CCCL_ASSERT(__mapping_result.lane_mask() == ::cuda::device::lane_mask::all(),
+                   "invalid lane mask - must be equal to cuda::device::lane_mask::all() when _Unit is not "
+                   "cuda::thread_level");
+    }
+  }
+  return __mapping_result;
+}
+
+template <class _Unit, class _ParentGroup, class _Mapping>
+using __group_mapping_result_t = decltype(::cuda::experimental::__do_group_mapping(
+  ::cuda::std::declval<const _Unit&>(),
+  ::cuda::std::declval<const _ParentGroup&>(),
+  ::cuda::std::declval<const _Mapping&>()));
+
+template <class _Unit, class _ParentGroup, class _MappingResult>
+class virtual_group
 {
   static_assert(__is_hierarchy_level_v<_Unit>);
   static_assert(is_group<_ParentGroup>);
   static_assert(__unit_same_as_or_below_v<_Unit, typename _ParentGroup::unit_type>,
                 "unit_type must be same as or below _ParentGroup's unit_type");
 
-  // todo(dabayer): Allow groups stacking and remove this.
-  static_assert(__is_this_group_v<_ParentGroup>);
-
   using _Hierarchy            = typename _ParentGroup::hierarchy_type;
   using _ParentMappingResult  = typename _ParentGroup::__mapping_result_type;
-  using _SynchronizerInstance = __group_synchronizer_instance_t<_Synchronizer, _Unit, _ParentGroup, _MappingResult>;
+  using _SynchronizerInstance = decltype(::cuda::std::declval<const _ParentGroup&>().__synchronizer_instance().view());
   static_assert(__group_mapping_result<_MappingResult>);
 
   _Hierarchy __hier_;
   _MappingResult __mapping_result_;
-  _Synchronizer __synchronizer_;
   _SynchronizerInstance __synchronizer_instance_;
-
-  [[nodiscard]] _CCCL_DEVICE_API static _SynchronizerInstance __make_synchronizer_instance(
-    const _Unit& __unit,
-    const _Synchronizer& __synchronizer,
-    const _ParentGroup& __parent,
-    const _MappingResult& __mapping_result) noexcept
-  {
-    // Do not invoke the synchronizer instance creation for threads that are not part of the parent group. On the other
-    // hand threads that are not part of this group must create the synchronizer instance, too, because the operation
-    // can synchronize the parent group.
-    if constexpr (!_ParentMappingResult::is_always_exhaustive())
-    {
-      if (!__parent.__mapping_result().is_valid())
-      {
-        return _SynchronizerInstance::invalid();
-      }
-    }
-    return __synchronizer.make_instance(__unit, __parent, __mapping_result);
-  }
 
 public:
   using unit_type             = _Unit;
   using level_type            = typename _ParentGroup::level_type;
   using hierarchy_type        = _Hierarchy;
   using __mapping_result_type = _MappingResult;
-  using synchronizer_type     = _Synchronizer;
+  using synchronizer_type     = typename _ParentGroup::synchronizer_type;
 
-  _CCCL_TEMPLATE(class _Mapping)
-  _CCCL_REQUIRES(::cuda::std::is_same_v<_MappingResult, __group_mapping_result_t<_Unit, _ParentGroup, _Mapping>>)
-  _CCCL_DEVICE_API explicit group(
-    const _Unit& __unit,
-    const _ParentGroup& __parent,
-    const _Mapping& __mapping,
-    const _Synchronizer& __synchronizer) noexcept
+  template <class _Mapping>
+  _CCCL_DEVICE_API explicit virtual_group(
+    const _Unit& __unit, const _ParentGroup& __parent, const _Mapping& __mapping) noexcept
       : __hier_{__parent.hierarchy()}
       , __mapping_result_{::cuda::experimental::__do_group_mapping(__unit, __parent, __mapping)}
-      , __synchronizer_{__synchronizer}
-      , __synchronizer_instance_{__make_synchronizer_instance(__unit, __synchronizer_, __parent, __mapping_result_)}
-  {}
-
-  // todo(dabayer): Delete copy constructor.
-  // group(const group&) = delete;
-
-  _CCCL_DEVICE_API ~group()
+      , __synchronizer_instance_{__parent.__synchronizer_instance().view()}
   {
-    // Skip the synchronization for threads that are not part of this group.
-    if constexpr (!_MappingResult::is_always_exhaustive())
-    {
-      if (!__mapping_result_.is_valid())
-      {
-        return;
-      }
-    }
-    __synchronizer_instance_.deinit(__mapping_result_, __hier_);
+    // todo(dabayer): Remove this if we allow non-exhaustive virtual groups.
+    _CCCL_ASSERT(__mapping_result_.is_valid(), "virtual_group requires all units to be part of the group");
   }
 
   [[nodiscard]] _CCCL_DEVICE_API const hierarchy_type& hierarchy() const noexcept
@@ -129,18 +135,11 @@ public:
     return __hier_;
   }
 
-  // todo(dabayer): Do we want to expose mapping result getter?
   [[nodiscard]] _CCCL_DEVICE_API _MappingResult __mapping_result() const noexcept
   {
     return __mapping_result_;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API const synchronizer_type& synchronizer() const noexcept
-  {
-    return __synchronizer_;
-  }
-
-  // todo(dabayer): Do we want to expose synchronizer instance getter?
   [[nodiscard]] _CCCL_DEVICE_API const _SynchronizerInstance& __synchronizer_instance() const noexcept
   {
     return __synchronizer_instance_;
@@ -150,27 +149,11 @@ public:
   //                aligned/unaligned variants?
   _CCCL_DEVICE_API void sync() const noexcept
   {
-    // Skip the synchronization for threads that are not part of this group.
-    if constexpr (!_MappingResult::is_always_exhaustive())
-    {
-      if (!__mapping_result_.is_valid())
-      {
-        return;
-      }
-    }
     __synchronizer_instance_.do_sync(__mapping_result_, __hier_);
   }
 
   _CCCL_DEVICE_API void sync_aligned() const noexcept
   {
-    // Skip the synchronization for threads that are not part of this group.
-    if constexpr (!_MappingResult::is_always_exhaustive())
-    {
-      if (!__mapping_result_.is_valid())
-      {
-        return;
-      }
-    }
     __synchronizer_instance_.do_sync_aligned(__mapping_result_, __hier_);
   }
 
@@ -218,15 +201,15 @@ public:
   }
 };
 
-_CCCL_TEMPLATE(class _Unit, class _ParentGroup, class _Mapping, class _Synchronizer)
+_CCCL_TEMPLATE(class _Unit, class _ParentGroup, class _Mapping)
 _CCCL_REQUIRES(__is_hierarchy_level_v<_Unit> _CCCL_AND is_group<_ParentGroup> _CCCL_AND
                  __unit_same_as_or_below_v<_Unit, typename _ParentGroup::unit_type>)
-_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group(const _Unit&, const _ParentGroup&, const _Mapping&, const _Synchronizer&)
-  -> group<_Unit, _ParentGroup, __group_mapping_result_t<_Unit, _ParentGroup, _Mapping>, _Synchronizer>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES virtual_group(const _Unit&, const _ParentGroup&, const _Mapping&)
+  -> virtual_group<_Unit, _ParentGroup, __group_mapping_result_t<_Unit, _ParentGroup, _Mapping>>;
 } // namespace cuda::experimental
 
 #endif // !_CCCL_DOXYGEN_INVOKED
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_EXPERIMENTAL___GROUP_GROUP_CUH
+#endif // _CUDA_EXPERIMENTAL___GROUP_VIRTUAL_GROUP_CUH

--- a/cudax/include/cuda/experimental/__group/virtual_group.cuh
+++ b/cudax/include/cuda/experimental/__group/virtual_group.cuh
@@ -49,7 +49,7 @@
 namespace cuda::experimental
 {
 template <class _Unit, class _ParentGroup, class _Mapping>
-[[nodiscard]] _CCCL_DEVICE_API auto
+[[nodiscard]] _CCCL_DEVICE_API constexpr auto
 __do_group_mapping(const _Unit& __unit, const _ParentGroup& __parent, const _Mapping& __mapping) noexcept
 {
   using _ParentMappingResult = typename _ParentGroup::__mapping_result_type;
@@ -119,7 +119,8 @@ public:
   using __mapping_result_type = _MappingResult;
   using synchronizer_type     = typename _ParentGroup::synchronizer_type;
 
-  template <class _Mapping>
+  _CCCL_TEMPLATE(class _Mapping)
+  _CCCL_REQUIRES(::cuda::std::is_same_v<_MappingResult, __group_mapping_result_t<_Unit, _ParentGroup, _Mapping>>)
   _CCCL_DEVICE_API explicit virtual_group(
     const _Unit& __unit, const _ParentGroup& __parent, const _Mapping& __mapping) noexcept
       : __hier_{__parent.hierarchy()}

--- a/cudax/include/cuda/experimental/group.cuh
+++ b/cudax/include/cuda/experimental/group.cuh
@@ -39,5 +39,6 @@
 #include <cuda/experimental/__group/synchronizer/level_synchronizer.cuh>
 #include <cuda/experimental/__group/this_group.cuh>
 #include <cuda/experimental/__group/traits.cuh>
+#include <cuda/experimental/__group/virtual_group.cuh>
 
 #endif // _CUDA_EXPERIMENTAL_GROUP

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -168,6 +168,9 @@ cudax_add_catch2_test(test_target group.cooperative_algorithm
 cudax_add_catch2_test(test_target group.group
     group/group.cu
 )
+cudax_add_catch2_test(test_target group.virtual_group
+    group/virtual_group.cu
+)
 cudax_add_catch2_test(test_target group.group_view
     group/group_view.cu
 )

--- a/cudax/test/group/virtual_group.cu
+++ b/cudax/test/group/virtual_group.cu
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/atomic>
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+#include <cuda/stream>
+
+#include <cuda/experimental/group.cuh>
+
+#include "group_testing.cuh"
+
+template <class Config, class Level>
+__device__ void test_virtual_group(Config config, Level level)
+{
+  const auto g = cudax::make_this_group(level, config);
+
+  // Test virtual group with identity mapping.
+  {
+    cudax::virtual_group vg{cuda::gpu_thread, g, cudax::identity_mapping{}};
+
+    REQUIRE(cuda::gpu_thread.is_part_of(vg));
+
+    REQUIRE(cuda::gpu_thread.count(vg) == cuda::gpu_thread.count(g));
+    REQUIRE(cuda::gpu_thread.rank(vg) == cuda::gpu_thread.rank(g));
+
+    static_assert(vg.static_count(g) == 1);
+    REQUIRE(vg.count(g) == 1);
+    REQUIRE(vg.rank(g) == 0);
+
+    vg.sync();
+    vg.sync_aligned();
+  }
+
+  // Test virtual group with group_by mapping.
+  if constexpr (!cuda::std::is_same_v<Level, cuda::thread_level>)
+  {
+    constexpr auto n = 4;
+
+    cudax::virtual_group vg{cuda::gpu_thread, g, cudax::group_by<n>{}};
+
+    REQUIRE(cuda::gpu_thread.is_part_of(vg));
+
+    REQUIRE(cuda::gpu_thread.count(vg) == n);
+    REQUIRE(cuda::gpu_thread.rank(vg) == cuda::gpu_thread.rank(g) % n);
+
+    REQUIRE(vg.count(g) == cuda::gpu_thread.count(g) / n);
+    REQUIRE(vg.rank(g) == cuda::gpu_thread.rank(g) / n);
+
+    vg.sync();
+    vg.sync_aligned();
+  }
+}
+
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(Config config) const
+  {
+    test_virtual_group(config, cuda::gpu_thread);
+    test_virtual_group(config, cuda::warp);
+    test_virtual_group(config, cuda::block);
+    test_virtual_group(config, cuda::cluster);
+    test_virtual_group(config, cuda::grid);
+  }
+};
+
+C2H_TEST("Virtual Group", "[virtual_group]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  const auto config = cuda::make_config(cuda::grid_dims<2>(), cuda::block_dims<128>(), cuda::cooperative_launch{});
+  cuda::launch(stream, config, TestKernel{});
+
+  if (cuda::device_attributes::compute_capability(device) >= cuda::compute_capability{90})
+  {
+    const auto config_cluster = cuda::make_config(
+      cuda::grid_dims<2>(), cuda::cluster_dims<3>(), cuda::block_dims<128>(), cuda::cooperative_launch{});
+    cuda::launch(stream, config_cluster, TestKernel{});
+  }
+
+  stream.sync();
+}


### PR DESCRIPTION
Fixes #9869

In #10787, I introduced the `group_view` that only provides a view over an existing group - it has no parent group and has the same group count and rank as the viewed group.

This PR implements `virtual_group` that is an ordinary group similar to `group`. The only difference is that `virtual_group` hasn't got its own synchronization mechanism. Instead, the parent's synchronizer is re-used.

This class gives you the tools to create an abstraction over an existing group as far as all of the threads share the synchronization calls.


The motivation why we need this type can be simply described on an example when you'd like to do inter-warp reduction, but use `__syncthreads()` for synchronization, because you know that all threads will do the same thing, just communicate with different warps.

With the just the `group` implementation we have right now, you would need to do something like:
```cpp
int data[]{...};

__shared__ cuda::barrier<...> barriers[]{...};

cudax::this block block{...};
cudax::group g{cuda::warp, block, cudax::group_by<4>{}, cudax::barrier_synchronizer{barriers}};

return cudax::coop::reduce(g, data);
```
which requires us to allocate more resources. Alternatively, we could use `cudax::level_synchronizer` to force the class to use `__syncthreads()`, however that's dangerous, because it violates the `group`'s preconditions and we have no way to detect that the user needs us to do sychronizations uniformly for all `g`s.

With the `virtual_group`, we can make this behaviour the type's precondition. And we can modify the cooperative algorithms accordingly. And the example looks as:
```cpp
int data[]{...};

cudax::this block block{...};
cudax::virtual_group g{cuda::warp, block, cudax::group_by<4>{}};

return cudax::coop::reduce(g, data);
```