### PR TITLE
Replace CachingDeviceAllocator in CUB examples

### DIFF
--- a/cub/examples/device/example_device_partition_flagged.cu
+++ b/cub/examples/device/example_device_partition_flagged.cu
@@ -155,14 +155,9 @@ int main(int argc, char** argv)
          (int) sizeof(int));
   fflush(stdout);
 
-  // Allocate problem device arrays
-  auto d_in    = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
-  auto d_flags = cuda::make_buffer<unsigned char>(stream, device_memory_resource, num_items, cuda::no_init);
-
-  // Initialize device input
-  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
-  CubDebugExit(
-    cudaMemcpyAsync(d_flags.data(), h_flags, sizeof(unsigned char) * num_items, cudaMemcpyHostToDevice, stream.get()));
+  // Allocate and initialize problem device arrays
+  auto d_in    = cuda::make_buffer<int>(stream, device_memory_resource, h_in, h_in + num_items);
+  auto d_flags = cuda::make_buffer<unsigned char>(stream, device_memory_resource, h_flags, h_flags + num_items);
 
   // Allocate device output array and num selected
   auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);

--- a/cub/examples/device/example_device_partition_flagged.cu
+++ b/cub/examples/device/example_device_partition_flagged.cu
@@ -127,7 +127,6 @@ int main(int argc, char** argv)
   {
     printf("%s "
            "[--n=<input items> "
-           "[--device=<device-id>] "
            "[--maxseg=<max segment length>] "
            "[--v] "
            "\n",
@@ -135,12 +134,9 @@ int main(int argc, char** argv)
     exit(0);
   }
 
-  // Initialize device
-  int device_ordinal{};
-  args.GetCmdLineArgument("device", device_ordinal);
-  CubDebugExit(args.DeviceInit(device_ordinal));
-  const auto device                 = cuda::devices[device_ordinal];
-  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  // Set up device, stream, and memory resource
+  const auto device                 = cuda::devices[0];
+  const auto stream                 = cuda::stream{device};
   const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
@@ -164,8 +160,9 @@ int main(int argc, char** argv)
   auto d_flags = cuda::make_buffer<unsigned char>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
-  CubDebugExit(cudaMemcpy(d_flags.data(), h_flags, sizeof(unsigned char) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
+  CubDebugExit(
+    cudaMemcpyAsync(d_flags.data(), h_flags, sizeof(unsigned char) * num_items, cudaMemcpyHostToDevice, stream.get()));
 
   // Allocate device output array and num selected
   auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
@@ -197,6 +194,7 @@ int main(int argc, char** argv)
     stream));
 
   // Check for correctness (and display results, if specified)
+  stream.sync();
   int compare = CompareDeviceResults(h_reference, d_out.data(), num_items, true, g_verbose);
   printf("\t Data %s ", compare ? "FAIL" : "PASS");
   compare |= CompareDeviceResults(&num_selected, d_num_selected_out.data(), 1, true, g_verbose);

--- a/cub/examples/device/example_device_partition_flagged.cu
+++ b/cub/examples/device/example_device_partition_flagged.cu
@@ -17,9 +17,13 @@
 #define CUB_STDERR
 
 #include <cub/device/device_partition.cuh>
-#include <cub/util_allocator.cuh>
 
+#include <cuda/buffer>
+#include <cuda/devices>
+#include <cuda/memory_pool>
+#include <cuda/std/cstddef>
 #include <cuda/std/limits>
+#include <cuda/stream>
 
 #include <cstdio>
 
@@ -32,7 +36,6 @@ using namespace cub;
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console
-CachingDeviceAllocator g_allocator(true); // Caching allocator for device memory
 
 //---------------------------------------------------------------------
 // Test generation
@@ -134,6 +137,11 @@ int main(int argc, char** argv)
 
   // Initialize device
   CubDebugExit(args.DeviceInit());
+  int device_ordinal{};
+  CubDebugExit(cudaGetDevice(&device_ordinal));
+  const cuda::device_ref device{device_ordinal};
+  const cuda::stream_ref stream{cudaStream_t{}};
+  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
   int* h_in              = new int[num_items];
@@ -152,37 +160,46 @@ int main(int argc, char** argv)
   fflush(stdout);
 
   // Allocate problem device arrays
-  int* d_in              = nullptr;
-  unsigned char* d_flags = nullptr;
-
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_in, sizeof(int) * num_items));
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_flags, sizeof(unsigned char) * num_items));
+  auto d_in    = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
+  auto d_flags = cuda::make_buffer<unsigned char>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in, h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
-  CubDebugExit(cudaMemcpy(d_flags, h_flags, sizeof(unsigned char) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpy(d_flags.data(), h_flags, sizeof(unsigned char) * num_items, cudaMemcpyHostToDevice));
 
   // Allocate device output array and num selected
-  int* d_out              = nullptr;
-  int* d_num_selected_out = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_out, sizeof(int) * num_items));
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_num_selected_out, sizeof(int)));
+  auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
+  auto d_num_selected_out = cuda::make_buffer<int>(stream, device_memory_resource, 1, cuda::no_init);
 
   // Allocate temporary storage
-  void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  CubDebugExit(
-    DevicePartition::Flagged(d_temp_storage, temp_storage_bytes, d_in, d_flags, d_out, d_num_selected_out, num_items));
-  CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  CubDebugExit(DevicePartition::Flagged(
+    nullptr,
+    temp_storage_bytes,
+    d_in.data(),
+    d_flags.data(),
+    d_out.data(),
+    d_num_selected_out.data(),
+    num_items,
+    stream));
+  auto d_temp_storage =
+    cuda::make_buffer<cuda::std::byte>(stream, device_memory_resource, temp_storage_bytes, cuda::no_init);
 
   // Run
-  CubDebugExit(
-    DevicePartition::Flagged(d_temp_storage, temp_storage_bytes, d_in, d_flags, d_out, d_num_selected_out, num_items));
+  CubDebugExit(DevicePartition::Flagged(
+    d_temp_storage.data(),
+    temp_storage_bytes,
+    d_in.data(),
+    d_flags.data(),
+    d_out.data(),
+    d_num_selected_out.data(),
+    num_items,
+    stream));
 
   // Check for correctness (and display results, if specified)
-  int compare = CompareDeviceResults(h_reference, d_out, num_items, true, g_verbose);
+  int compare = CompareDeviceResults(h_reference, d_out.data(), num_items, true, g_verbose);
   printf("\t Data %s ", compare ? "FAIL" : "PASS");
-  compare |= CompareDeviceResults(&num_selected, d_num_selected_out, 1, true, g_verbose);
+  compare |= CompareDeviceResults(&num_selected, d_num_selected_out.data(), 1, true, g_verbose);
   printf("\t Count %s ", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);
 
@@ -195,25 +212,9 @@ int main(int argc, char** argv)
   {
     delete[] h_reference;
   }
-  if (d_out)
+  if (h_flags)
   {
-    CubDebugExit(g_allocator.DeviceFree(d_out));
-  }
-  if (d_num_selected_out)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_num_selected_out));
-  }
-  if (d_temp_storage)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
-  }
-  if (d_in)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_in));
-  }
-  if (d_flags)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_flags));
+    delete[] h_flags;
   }
 
   printf("\n\n");

--- a/cub/examples/device/example_device_partition_flagged.cu
+++ b/cub/examples/device/example_device_partition_flagged.cu
@@ -136,12 +136,12 @@ int main(int argc, char** argv)
   }
 
   // Initialize device
-  CubDebugExit(args.DeviceInit());
   int device_ordinal{};
-  CubDebugExit(cudaGetDevice(&device_ordinal));
-  const cuda::device_ref device{device_ordinal};
-  const cuda::stream_ref stream{cudaStream_t{}};
-  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
+  args.GetCmdLineArgument("device", device_ordinal);
+  CubDebugExit(args.DeviceInit(device_ordinal));
+  const auto device                 = cuda::devices[device_ordinal];
+  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
   int* h_in              = new int[num_items];

--- a/cub/examples/device/example_device_partition_if.cu
+++ b/cub/examples/device/example_device_partition_if.cu
@@ -138,7 +138,6 @@ int main(int argc, char** argv)
   {
     printf("%s "
            "[--n=<input items> "
-           "[--device=<device-id>] "
            "[--maxseg=<max segment length>]"
            "[--v] "
            "\n",
@@ -146,12 +145,9 @@ int main(int argc, char** argv)
     exit(0);
   }
 
-  // Initialize device
-  int device_ordinal{};
-  args.GetCmdLineArgument("device", device_ordinal);
-  CubDebugExit(args.DeviceInit(device_ordinal));
-  const auto device                 = cuda::devices[device_ordinal];
-  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  // Set up device, stream, and memory resource
+  const auto device                 = cuda::devices[0];
+  const auto stream                 = cuda::stream{device};
   const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
@@ -183,7 +179,7 @@ int main(int argc, char** argv)
   auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
 
   // Allocate device output array and num selected
   auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
@@ -208,6 +204,7 @@ int main(int argc, char** argv)
     stream));
 
   // Check for correctness (and display results, if specified)
+  stream.sync();
   int compare = CompareDeviceResults(h_reference, d_out.data(), num_items, true, g_verbose);
   printf("\t Data %s ", compare ? "FAIL" : "PASS");
   compare = compare | CompareDeviceResults(&num_selected, d_num_selected_out.data(), 1, true, g_verbose);

--- a/cub/examples/device/example_device_partition_if.cu
+++ b/cub/examples/device/example_device_partition_if.cu
@@ -175,11 +175,8 @@ int main(int argc, char** argv)
          (int) sizeof(int));
   fflush(stdout);
 
-  // Allocate problem device arrays
-  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
-
-  // Initialize device input
-  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
+  // Allocate and initialize problem device arrays
+  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, h_in, h_in + num_items);
 
   // Allocate device output array and num selected
   auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);

--- a/cub/examples/device/example_device_partition_if.cu
+++ b/cub/examples/device/example_device_partition_if.cu
@@ -147,12 +147,12 @@ int main(int argc, char** argv)
   }
 
   // Initialize device
-  CubDebugExit(args.DeviceInit());
   int device_ordinal{};
-  CubDebugExit(cudaGetDevice(&device_ordinal));
-  const cuda::device_ref device{device_ordinal};
-  const cuda::stream_ref stream{cudaStream_t{}};
-  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
+  args.GetCmdLineArgument("device", device_ordinal);
+  CubDebugExit(args.DeviceInit(device_ordinal));
+  const auto device                 = cuda::devices[device_ordinal];
+  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
   int* h_in        = new int[num_items];

--- a/cub/examples/device/example_device_partition_if.cu
+++ b/cub/examples/device/example_device_partition_if.cu
@@ -17,9 +17,13 @@
 #define CUB_STDERR
 
 #include <cub/device/device_partition.cuh>
-#include <cub/util_allocator.cuh>
 
+#include <cuda/buffer>
+#include <cuda/devices>
+#include <cuda/memory_pool>
+#include <cuda/std/cstddef>
 #include <cuda/std/limits>
+#include <cuda/stream>
 
 #include <cstdio>
 
@@ -32,7 +36,6 @@ using namespace cub;
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console
-CachingDeviceAllocator g_allocator(true); // Caching allocator for device memory
 
 /// Selection functor type
 struct GreaterThan
@@ -145,6 +148,11 @@ int main(int argc, char** argv)
 
   // Initialize device
   CubDebugExit(args.DeviceInit());
+  int device_ordinal{};
+  CubDebugExit(cudaGetDevice(&device_ordinal));
+  const cuda::device_ref device{device_ordinal};
+  const cuda::stream_ref stream{cudaStream_t{}};
+  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
   int* h_in        = new int[num_items];
@@ -172,33 +180,37 @@ int main(int argc, char** argv)
   fflush(stdout);
 
   // Allocate problem device arrays
-  int* d_in = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_in, sizeof(int) * num_items));
+  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in, h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
 
   // Allocate device output array and num selected
-  int* d_out              = nullptr;
-  int* d_num_selected_out = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_out, sizeof(int) * num_items));
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_num_selected_out, sizeof(int)));
+  auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
+  auto d_num_selected_out = cuda::make_buffer<int>(stream, device_memory_resource, 1, cuda::no_init);
 
   // Allocate temporary storage
-  void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  CubDebugExit(
-    DevicePartition::If(d_temp_storage, temp_storage_bytes, d_in, d_out, d_num_selected_out, num_items, select_op));
-  CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  CubDebugExit(DevicePartition::If(
+    nullptr, temp_storage_bytes, d_in.data(), d_out.data(), d_num_selected_out.data(), num_items, select_op, stream));
+  auto d_temp_storage =
+    cuda::make_buffer<cuda::std::byte>(stream, device_memory_resource, temp_storage_bytes, cuda::no_init);
 
   // Run
-  CubDebugExit(
-    DevicePartition::If(d_temp_storage, temp_storage_bytes, d_in, d_out, d_num_selected_out, num_items, select_op));
+  CubDebugExit(DevicePartition::If(
+    d_temp_storage.data(),
+    temp_storage_bytes,
+    d_in.data(),
+    d_out.data(),
+    d_num_selected_out.data(),
+    num_items,
+    select_op,
+    stream));
 
   // Check for correctness (and display results, if specified)
-  int compare = CompareDeviceResults(h_reference, d_out, num_items, true, g_verbose);
+  int compare = CompareDeviceResults(h_reference, d_out.data(), num_items, true, g_verbose);
   printf("\t Data %s ", compare ? "FAIL" : "PASS");
-  compare = compare | CompareDeviceResults(&num_selected, d_num_selected_out, 1, true, g_verbose);
+  compare = compare | CompareDeviceResults(&num_selected, d_num_selected_out.data(), 1, true, g_verbose);
   printf("\t Count %s ", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);
 
@@ -210,22 +222,6 @@ int main(int argc, char** argv)
   if (h_reference)
   {
     delete[] h_reference;
-  }
-  if (d_in)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_in));
-  }
-  if (d_out)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_out));
-  }
-  if (d_num_selected_out)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_num_selected_out));
-  }
-  if (d_temp_storage)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
   }
 
   printf("\n\n");

--- a/cub/examples/device/example_device_radix_sort.cu
+++ b/cub/examples/device/example_device_radix_sort.cu
@@ -121,12 +121,12 @@ int main(int argc, char** argv)
   }
 
   // Initialize device
-  CubDebugExit(args.DeviceInit());
   int device_ordinal{};
-  CubDebugExit(cudaGetDevice(&device_ordinal));
-  const cuda::device_ref device{device_ordinal};
-  const cuda::stream_ref stream{cudaStream_t{}};
-  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
+  args.GetCmdLineArgument("device", device_ordinal);
+  CubDebugExit(args.DeviceInit(device_ordinal));
+  const auto device                 = cuda::devices[device_ordinal];
+  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   printf("cub::DeviceRadixSort::SortPairs() %d items (%d-byte keys %d-byte values)\n",
          num_items,

--- a/cub/examples/device/example_device_radix_sort.cu
+++ b/cub/examples/device/example_device_radix_sort.cu
@@ -139,10 +139,10 @@ int main(int argc, char** argv)
   // Initialize problem and solution on host
   Initialize(h_keys, h_values, h_reference_keys, h_reference_values, num_items);
 
-  // Allocate device arrays
-  auto d_keys_0   = cuda::make_buffer<float>(stream, device_memory_resource, num_items, cuda::no_init);
+  // Allocate and initialize device arrays
+  auto d_keys_0   = cuda::make_buffer<float>(stream, device_memory_resource, h_keys, h_keys + num_items);
   auto d_keys_1   = cuda::make_buffer<float>(stream, device_memory_resource, num_items, cuda::no_init);
-  auto d_values_0 = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
+  auto d_values_0 = cuda::make_buffer<int>(stream, device_memory_resource, h_values, h_values + num_items);
   auto d_values_1 = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
   DoubleBuffer<float> d_keys{d_keys_0.data(), d_keys_1.data()};
   DoubleBuffer<int> d_values{d_values_0.data(), d_values_1.data()};
@@ -153,12 +153,6 @@ int main(int argc, char** argv)
     nullptr, temp_storage_bytes, d_keys, d_values, num_items, 0, sizeof(float) * 8, stream.get()));
   auto d_temp_storage =
     cuda::make_buffer<cuda::std::byte>(stream, device_memory_resource, temp_storage_bytes, cuda::no_init);
-
-  // Initialize device arrays
-  CubDebugExit(cudaMemcpyAsync(
-    d_keys.d_buffers[d_keys.selector], h_keys, sizeof(float) * num_items, cudaMemcpyHostToDevice, stream.get()));
-  CubDebugExit(cudaMemcpyAsync(
-    d_values.d_buffers[d_values.selector], h_values, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
 
   // Run
   CubDebugExit(DeviceRadixSort::SortPairs(

--- a/cub/examples/device/example_device_radix_sort.cu
+++ b/cub/examples/device/example_device_radix_sort.cu
@@ -113,19 +113,15 @@ int main(int argc, char** argv)
   {
     printf("%s "
            "[--n=<input items> "
-           "[--device=<device-id>] "
            "[--v] "
            "\n",
            argv[0]);
     exit(0);
   }
 
-  // Initialize device
-  int device_ordinal{};
-  args.GetCmdLineArgument("device", device_ordinal);
-  CubDebugExit(args.DeviceInit(device_ordinal));
-  const auto device                 = cuda::devices[device_ordinal];
-  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  // Set up device, stream, and memory resource
+  const auto device                 = cuda::devices[0];
+  const auto stream                 = cuda::stream{device};
   const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   printf("cub::DeviceRadixSort::SortPairs() %d items (%d-byte keys %d-byte values)\n",
@@ -159,16 +155,17 @@ int main(int argc, char** argv)
     cuda::make_buffer<cuda::std::byte>(stream, device_memory_resource, temp_storage_bytes, cuda::no_init);
 
   // Initialize device arrays
-  CubDebugExit(
-    cudaMemcpy(d_keys.d_buffers[d_keys.selector], h_keys, sizeof(float) * num_items, cudaMemcpyHostToDevice));
-  CubDebugExit(
-    cudaMemcpy(d_values.d_buffers[d_values.selector], h_values, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpyAsync(
+    d_keys.d_buffers[d_keys.selector], h_keys, sizeof(float) * num_items, cudaMemcpyHostToDevice, stream.get()));
+  CubDebugExit(cudaMemcpyAsync(
+    d_values.d_buffers[d_values.selector], h_values, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
 
   // Run
   CubDebugExit(DeviceRadixSort::SortPairs(
     d_temp_storage.data(), temp_storage_bytes, d_keys, d_values, num_items, 0, sizeof(float) * 8, stream.get()));
 
   // Check for correctness (and display results, if specified)
+  stream.sync();
   int compare = CompareDeviceResults(h_reference_keys, d_keys.Current(), num_items, true, g_verbose);
   printf("\t Compare keys (selector %d): %s\n", d_keys.selector, compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);

--- a/cub/examples/device/example_device_radix_sort.cu
+++ b/cub/examples/device/example_device_radix_sort.cu
@@ -16,7 +16,12 @@
 #define CUB_STDERR
 
 #include <cub/device/device_radix_sort.cuh>
-#include <cub/util_allocator.cuh>
+
+#include <cuda/buffer>
+#include <cuda/devices>
+#include <cuda/memory_pool>
+#include <cuda/std/cstddef>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <cstdio>
@@ -30,7 +35,6 @@ using namespace cub;
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console
-CachingDeviceAllocator g_allocator(true); // Caching allocator for device memory
 
 //---------------------------------------------------------------------
 // Test generation
@@ -118,6 +122,11 @@ int main(int argc, char** argv)
 
   // Initialize device
   CubDebugExit(args.DeviceInit());
+  int device_ordinal{};
+  CubDebugExit(cudaGetDevice(&device_ordinal));
+  const cuda::device_ref device{device_ordinal};
+  const cuda::stream_ref stream{cudaStream_t{}};
+  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
 
   printf("cub::DeviceRadixSort::SortPairs() %d items (%d-byte keys %d-byte values)\n",
          num_items,
@@ -135,19 +144,19 @@ int main(int argc, char** argv)
   Initialize(h_keys, h_values, h_reference_keys, h_reference_values, num_items);
 
   // Allocate device arrays
-  DoubleBuffer<float> d_keys;
-  DoubleBuffer<int> d_values;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_keys.d_buffers[0], sizeof(float) * num_items));
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_keys.d_buffers[1], sizeof(float) * num_items));
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_values.d_buffers[0], sizeof(int) * num_items));
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_values.d_buffers[1], sizeof(int) * num_items));
+  auto d_keys_0   = cuda::make_buffer<float>(stream, device_memory_resource, num_items, cuda::no_init);
+  auto d_keys_1   = cuda::make_buffer<float>(stream, device_memory_resource, num_items, cuda::no_init);
+  auto d_values_0 = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
+  auto d_values_1 = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
+  DoubleBuffer<float> d_keys{d_keys_0.data(), d_keys_1.data()};
+  DoubleBuffer<int> d_values{d_values_0.data(), d_values_1.data()};
 
   // Allocate temporary storage
   size_t temp_storage_bytes = 0;
-  void* d_temp_storage      = nullptr;
-
-  CubDebugExit(DeviceRadixSort::SortPairs(d_temp_storage, temp_storage_bytes, d_keys, d_values, num_items));
-  CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  CubDebugExit(DeviceRadixSort::SortPairs(
+    nullptr, temp_storage_bytes, d_keys, d_values, num_items, 0, sizeof(float) * 8, stream.get()));
+  auto d_temp_storage =
+    cuda::make_buffer<cuda::std::byte>(stream, device_memory_resource, temp_storage_bytes, cuda::no_init);
 
   // Initialize device arrays
   CubDebugExit(
@@ -156,7 +165,8 @@ int main(int argc, char** argv)
     cudaMemcpy(d_values.d_buffers[d_values.selector], h_values, sizeof(int) * num_items, cudaMemcpyHostToDevice));
 
   // Run
-  CubDebugExit(DeviceRadixSort::SortPairs(d_temp_storage, temp_storage_bytes, d_keys, d_values, num_items));
+  CubDebugExit(DeviceRadixSort::SortPairs(
+    d_temp_storage.data(), temp_storage_bytes, d_keys, d_values, num_items, 0, sizeof(float) * 8, stream.get()));
 
   // Check for correctness (and display results, if specified)
   int compare = CompareDeviceResults(h_reference_keys, d_keys.Current(), num_items, true, g_verbose);
@@ -182,27 +192,6 @@ int main(int argc, char** argv)
   if (h_reference_values)
   {
     delete[] h_reference_values;
-  }
-
-  if (d_keys.d_buffers[0])
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_keys.d_buffers[0]));
-  }
-  if (d_keys.d_buffers[1])
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_keys.d_buffers[1]));
-  }
-  if (d_values.d_buffers[0])
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_values.d_buffers[0]));
-  }
-  if (d_values.d_buffers[1])
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_values.d_buffers[1]));
-  }
-  if (d_temp_storage)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
   }
 
   printf("\n\n");

--- a/cub/examples/device/example_device_reduce.cu
+++ b/cub/examples/device/example_device_reduce.cu
@@ -16,7 +16,12 @@
 #define CUB_STDERR
 
 #include <cub/device/device_reduce.cuh>
-#include <cub/util_allocator.cuh>
+
+#include <cuda/buffer>
+#include <cuda/devices>
+#include <cuda/memory_pool>
+#include <cuda/std/cstddef>
+#include <cuda/stream>
 
 #include <cstdio>
 
@@ -29,7 +34,6 @@ using namespace cub;
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console
-CachingDeviceAllocator g_allocator(true); // Caching allocator for device memory
 
 //---------------------------------------------------------------------
 // Test generation
@@ -101,6 +105,11 @@ int main(int argc, char** argv)
 
   // Initialize device
   CubDebugExit(args.DeviceInit());
+  int device_ordinal{};
+  CubDebugExit(cudaGetDevice(&device_ordinal));
+  const cuda::device_ref device{device_ordinal};
+  const cuda::stream_ref stream{cudaStream_t{}};
+  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
 
   printf("cub::DeviceReduce::Sum() %d items (%d-byte elements)\n", num_items, (int) sizeof(int));
   fflush(stdout);
@@ -114,29 +123,28 @@ int main(int argc, char** argv)
   Solve(h_in, h_reference, num_items);
 
   // Allocate problem device arrays
-  int* d_in = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_in, sizeof(int) * num_items));
+  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in, h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
 
   // Allocate device output array
-  int* d_out = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_out, sizeof(int) * 1));
+  auto d_out = cuda::make_buffer<int>(stream, device_memory_resource, 1, cuda::no_init);
 
   // example-begin temp-storage-query
   // Request and allocate temporary storage
-  void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  CubDebugExit(DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, d_in, d_out, num_items));
-  CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  CubDebugExit(DeviceReduce::Sum(nullptr, temp_storage_bytes, d_in.data(), d_out.data(), num_items, stream.get()));
+  auto d_temp_storage =
+    cuda::make_buffer<cuda::std::byte>(stream, device_memory_resource, temp_storage_bytes, cuda::no_init);
 
   // Run
-  CubDebugExit(DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, d_in, d_out, num_items));
+  CubDebugExit(
+    DeviceReduce::Sum(d_temp_storage.data(), temp_storage_bytes, d_in.data(), d_out.data(), num_items, stream.get()));
   // example-end temp-storage-query
 
   // Check for correctness (and display results, if specified)
-  int compare = CompareDeviceResults(&h_reference, d_out, 1, g_verbose, g_verbose);
+  int compare = CompareDeviceResults(&h_reference, d_out.data(), 1, g_verbose, g_verbose);
   printf("\t%s", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);
 
@@ -144,18 +152,6 @@ int main(int argc, char** argv)
   if (h_in)
   {
     delete[] h_in;
-  }
-  if (d_in)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_in));
-  }
-  if (d_out)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_out));
-  }
-  if (d_temp_storage)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
   }
 
   printf("\n\n");

--- a/cub/examples/device/example_device_reduce.cu
+++ b/cub/examples/device/example_device_reduce.cu
@@ -104,12 +104,12 @@ int main(int argc, char** argv)
   }
 
   // Initialize device
-  CubDebugExit(args.DeviceInit());
   int device_ordinal{};
-  CubDebugExit(cudaGetDevice(&device_ordinal));
-  const cuda::device_ref device{device_ordinal};
-  const cuda::stream_ref stream{cudaStream_t{}};
-  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
+  args.GetCmdLineArgument("device", device_ordinal);
+  CubDebugExit(args.DeviceInit(device_ordinal));
+  const auto device                 = cuda::devices[device_ordinal];
+  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   printf("cub::DeviceReduce::Sum() %d items (%d-byte elements)\n", num_items, (int) sizeof(int));
   fflush(stdout);

--- a/cub/examples/device/example_device_reduce.cu
+++ b/cub/examples/device/example_device_reduce.cu
@@ -96,19 +96,15 @@ int main(int argc, char** argv)
   {
     printf("%s "
            "[--n=<input items> "
-           "[--device=<device-id>] "
            "[--v] "
            "\n",
            argv[0]);
     exit(0);
   }
 
-  // Initialize device
-  int device_ordinal{};
-  args.GetCmdLineArgument("device", device_ordinal);
-  CubDebugExit(args.DeviceInit(device_ordinal));
-  const auto device                 = cuda::devices[device_ordinal];
-  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  // Set up device, stream, and memory resource
+  const auto device                 = cuda::devices[0];
+  const auto stream                 = cuda::stream{device};
   const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   printf("cub::DeviceReduce::Sum() %d items (%d-byte elements)\n", num_items, (int) sizeof(int));
@@ -126,7 +122,7 @@ int main(int argc, char** argv)
   auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
 
   // Allocate device output array
   auto d_out = cuda::make_buffer<int>(stream, device_memory_resource, 1, cuda::no_init);
@@ -144,6 +140,7 @@ int main(int argc, char** argv)
   // example-end temp-storage-query
 
   // Check for correctness (and display results, if specified)
+  stream.sync();
   int compare = CompareDeviceResults(&h_reference, d_out.data(), 1, g_verbose, g_verbose);
   printf("\t%s", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);

--- a/cub/examples/device/example_device_reduce.cu
+++ b/cub/examples/device/example_device_reduce.cu
@@ -118,11 +118,8 @@ int main(int argc, char** argv)
   Initialize(h_in, num_items);
   Solve(h_in, h_reference, num_items);
 
-  // Allocate problem device arrays
-  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
-
-  // Initialize device input
-  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
+  // Allocate and initialize problem device arrays
+  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, h_in, h_in + num_items);
 
   // Allocate device output array
   auto d_out = cuda::make_buffer<int>(stream, device_memory_resource, 1, cuda::no_init);

--- a/cub/examples/device/example_device_scan.cu
+++ b/cub/examples/device/example_device_scan.cu
@@ -118,11 +118,8 @@ int main(int argc, char** argv)
   Initialize(h_in, num_items);
   Solve(h_in, h_reference, num_items);
 
-  // Allocate problem device arrays
-  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
-
-  // Initialize device input
-  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
+  // Allocate and initialize problem device arrays
+  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, h_in, h_in + num_items);
 
   // Allocate device output array
   auto d_out = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);

--- a/cub/examples/device/example_device_scan.cu
+++ b/cub/examples/device/example_device_scan.cu
@@ -16,7 +16,12 @@
 #define CUB_STDERR
 
 #include <cub/device/device_scan.cuh>
-#include <cub/util_allocator.cuh>
+
+#include <cuda/buffer>
+#include <cuda/devices>
+#include <cuda/memory_pool>
+#include <cuda/std/cstddef>
+#include <cuda/stream>
 
 #include <cstdio>
 
@@ -29,7 +34,6 @@ using namespace cub;
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console
-CachingDeviceAllocator g_allocator(true); // Caching allocator for device memory
 
 //---------------------------------------------------------------------
 // Test generation
@@ -101,6 +105,11 @@ int main(int argc, char** argv)
 
   // Initialize device
   CubDebugExit(args.DeviceInit());
+  int device_ordinal{};
+  CubDebugExit(cudaGetDevice(&device_ordinal));
+  const cuda::device_ref device{device_ordinal};
+  const cuda::stream_ref stream{cudaStream_t{}};
+  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
 
   printf("cub::DeviceScan::ExclusiveSum %d items (%d-byte elements)\n", num_items, (int) sizeof(int));
   fflush(stdout);
@@ -114,27 +123,27 @@ int main(int argc, char** argv)
   Solve(h_in, h_reference, num_items);
 
   // Allocate problem device arrays
-  int* d_in = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_in, sizeof(int) * num_items));
+  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in, h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
 
   // Allocate device output array
-  int* d_out = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_out, sizeof(int) * num_items));
+  auto d_out = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Allocate temporary storage
-  void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  CubDebugExit(DeviceScan::ExclusiveSum(d_temp_storage, temp_storage_bytes, d_in, d_out, num_items));
-  CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  CubDebugExit(
+    DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes, d_in.data(), d_out.data(), num_items, stream.get()));
+  auto d_temp_storage =
+    cuda::make_buffer<cuda::std::byte>(stream, device_memory_resource, temp_storage_bytes, cuda::no_init);
 
   // Run
-  CubDebugExit(DeviceScan::ExclusiveSum(d_temp_storage, temp_storage_bytes, d_in, d_out, num_items));
+  CubDebugExit(DeviceScan::ExclusiveSum(
+    d_temp_storage.data(), temp_storage_bytes, d_in.data(), d_out.data(), num_items, stream.get()));
 
   // Check for correctness (and display results, if specified)
-  int compare = CompareDeviceResults(h_reference, d_out, num_items, true, g_verbose);
+  int compare = CompareDeviceResults(h_reference, d_out.data(), num_items, true, g_verbose);
   printf("\t%s", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);
 
@@ -146,18 +155,6 @@ int main(int argc, char** argv)
   if (h_reference)
   {
     delete[] h_reference;
-  }
-  if (d_in)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_in));
-  }
-  if (d_out)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_out));
-  }
-  if (d_temp_storage)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
   }
 
   printf("\n\n");

--- a/cub/examples/device/example_device_scan.cu
+++ b/cub/examples/device/example_device_scan.cu
@@ -96,19 +96,15 @@ int main(int argc, char** argv)
   {
     printf("%s "
            "[--n=<input items> "
-           "[--device=<device-id>] "
            "[--v] "
            "\n",
            argv[0]);
     exit(0);
   }
 
-  // Initialize device
-  int device_ordinal{};
-  args.GetCmdLineArgument("device", device_ordinal);
-  CubDebugExit(args.DeviceInit(device_ordinal));
-  const auto device                 = cuda::devices[device_ordinal];
-  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  // Set up device, stream, and memory resource
+  const auto device                 = cuda::devices[0];
+  const auto stream                 = cuda::stream{device};
   const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   printf("cub::DeviceScan::ExclusiveSum %d items (%d-byte elements)\n", num_items, (int) sizeof(int));
@@ -126,7 +122,7 @@ int main(int argc, char** argv)
   auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
 
   // Allocate device output array
   auto d_out = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
@@ -143,6 +139,7 @@ int main(int argc, char** argv)
     d_temp_storage.data(), temp_storage_bytes, d_in.data(), d_out.data(), num_items, stream.get()));
 
   // Check for correctness (and display results, if specified)
+  stream.sync();
   int compare = CompareDeviceResults(h_reference, d_out.data(), num_items, true, g_verbose);
   printf("\t%s", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);

--- a/cub/examples/device/example_device_scan.cu
+++ b/cub/examples/device/example_device_scan.cu
@@ -104,12 +104,12 @@ int main(int argc, char** argv)
   }
 
   // Initialize device
-  CubDebugExit(args.DeviceInit());
   int device_ordinal{};
-  CubDebugExit(cudaGetDevice(&device_ordinal));
-  const cuda::device_ref device{device_ordinal};
-  const cuda::stream_ref stream{cudaStream_t{}};
-  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
+  args.GetCmdLineArgument("device", device_ordinal);
+  CubDebugExit(args.DeviceInit(device_ordinal));
+  const auto device                 = cuda::devices[device_ordinal];
+  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   printf("cub::DeviceScan::ExclusiveSum %d items (%d-byte elements)\n", num_items, (int) sizeof(int));
   fflush(stdout);

--- a/cub/examples/device/example_device_select_flagged.cu
+++ b/cub/examples/device/example_device_select_flagged.cu
@@ -127,7 +127,6 @@ int main(int argc, char** argv)
   {
     printf("%s "
            "[--n=<input items> "
-           "[--device=<device-id>] "
            "[--maxseg=<max segment length>] "
            "[--v] "
            "\n",
@@ -135,12 +134,9 @@ int main(int argc, char** argv)
     exit(0);
   }
 
-  // Initialize device
-  int device_ordinal{};
-  args.GetCmdLineArgument("device", device_ordinal);
-  CubDebugExit(args.DeviceInit(device_ordinal));
-  const auto device                 = cuda::devices[device_ordinal];
-  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  // Set up device, stream, and memory resource
+  const auto device                 = cuda::devices[0];
+  const auto stream                 = cuda::stream{device};
   const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
@@ -164,8 +160,9 @@ int main(int argc, char** argv)
   auto d_flags = cuda::make_buffer<unsigned char>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
-  CubDebugExit(cudaMemcpy(d_flags.data(), h_flags, sizeof(unsigned char) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
+  CubDebugExit(
+    cudaMemcpyAsync(d_flags.data(), h_flags, sizeof(unsigned char) * num_items, cudaMemcpyHostToDevice, stream.get()));
 
   // Allocate device output array and num selected
   auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
@@ -197,6 +194,7 @@ int main(int argc, char** argv)
     stream));
 
   // Check for correctness (and display results, if specified)
+  stream.sync();
   int compare = CompareDeviceResults(h_reference, d_out.data(), num_selected, true, g_verbose);
   printf("\t Data %s ", compare ? "FAIL" : "PASS");
   compare |= CompareDeviceResults(&num_selected, d_num_selected_out.data(), 1, true, g_verbose);

--- a/cub/examples/device/example_device_select_flagged.cu
+++ b/cub/examples/device/example_device_select_flagged.cu
@@ -155,14 +155,9 @@ int main(int argc, char** argv)
          (int) sizeof(int));
   fflush(stdout);
 
-  // Allocate problem device arrays
-  auto d_in    = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
-  auto d_flags = cuda::make_buffer<unsigned char>(stream, device_memory_resource, num_items, cuda::no_init);
-
-  // Initialize device input
-  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
-  CubDebugExit(
-    cudaMemcpyAsync(d_flags.data(), h_flags, sizeof(unsigned char) * num_items, cudaMemcpyHostToDevice, stream.get()));
+  // Allocate and initialize problem device arrays
+  auto d_in    = cuda::make_buffer<int>(stream, device_memory_resource, h_in, h_in + num_items);
+  auto d_flags = cuda::make_buffer<unsigned char>(stream, device_memory_resource, h_flags, h_flags + num_items);
 
   // Allocate device output array and num selected
   auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);

--- a/cub/examples/device/example_device_select_flagged.cu
+++ b/cub/examples/device/example_device_select_flagged.cu
@@ -17,9 +17,13 @@
 #define CUB_STDERR
 
 #include <cub/device/device_select.cuh>
-#include <cub/util_allocator.cuh>
 
+#include <cuda/buffer>
+#include <cuda/devices>
+#include <cuda/memory_pool>
+#include <cuda/std/cstddef>
 #include <cuda/std/limits>
+#include <cuda/stream>
 
 #include <cstdio>
 
@@ -32,7 +36,6 @@ using namespace cub;
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console
-CachingDeviceAllocator g_allocator(true); // Caching allocator for device memory
 
 //---------------------------------------------------------------------
 // Test generation
@@ -134,6 +137,11 @@ int main(int argc, char** argv)
 
   // Initialize device
   CubDebugExit(args.DeviceInit());
+  int device_ordinal{};
+  CubDebugExit(cudaGetDevice(&device_ordinal));
+  const cuda::device_ref device{device_ordinal};
+  const cuda::stream_ref stream{cudaStream_t{}};
+  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
   int* h_in              = new int[num_items];
@@ -152,37 +160,46 @@ int main(int argc, char** argv)
   fflush(stdout);
 
   // Allocate problem device arrays
-  int* d_in              = nullptr;
-  unsigned char* d_flags = nullptr;
-
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_in, sizeof(int) * num_items));
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_flags, sizeof(unsigned char) * num_items));
+  auto d_in    = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
+  auto d_flags = cuda::make_buffer<unsigned char>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in, h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
-  CubDebugExit(cudaMemcpy(d_flags, h_flags, sizeof(unsigned char) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpy(d_flags.data(), h_flags, sizeof(unsigned char) * num_items, cudaMemcpyHostToDevice));
 
   // Allocate device output array and num selected
-  int* d_out              = nullptr;
-  int* d_num_selected_out = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_out, sizeof(int) * num_items));
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_num_selected_out, sizeof(int)));
+  auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
+  auto d_num_selected_out = cuda::make_buffer<int>(stream, device_memory_resource, 1, cuda::no_init);
 
   // Allocate temporary storage
-  void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  CubDebugExit(
-    DeviceSelect::Flagged(d_temp_storage, temp_storage_bytes, d_in, d_flags, d_out, d_num_selected_out, num_items));
-  CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  CubDebugExit(DeviceSelect::Flagged(
+    nullptr,
+    temp_storage_bytes,
+    d_in.data(),
+    d_flags.data(),
+    d_out.data(),
+    d_num_selected_out.data(),
+    num_items,
+    stream));
+  auto d_temp_storage =
+    cuda::make_buffer<cuda::std::byte>(stream, device_memory_resource, temp_storage_bytes, cuda::no_init);
 
   // Run
-  CubDebugExit(
-    DeviceSelect::Flagged(d_temp_storage, temp_storage_bytes, d_in, d_flags, d_out, d_num_selected_out, num_items));
+  CubDebugExit(DeviceSelect::Flagged(
+    d_temp_storage.data(),
+    temp_storage_bytes,
+    d_in.data(),
+    d_flags.data(),
+    d_out.data(),
+    d_num_selected_out.data(),
+    num_items,
+    stream));
 
   // Check for correctness (and display results, if specified)
-  int compare = CompareDeviceResults(h_reference, d_out, num_selected, true, g_verbose);
+  int compare = CompareDeviceResults(h_reference, d_out.data(), num_selected, true, g_verbose);
   printf("\t Data %s ", compare ? "FAIL" : "PASS");
-  compare |= CompareDeviceResults(&num_selected, d_num_selected_out, 1, true, g_verbose);
+  compare |= CompareDeviceResults(&num_selected, d_num_selected_out.data(), 1, true, g_verbose);
   printf("\t Count %s ", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);
 
@@ -195,25 +212,9 @@ int main(int argc, char** argv)
   {
     delete[] h_reference;
   }
-  if (d_out)
+  if (h_flags)
   {
-    CubDebugExit(g_allocator.DeviceFree(d_out));
-  }
-  if (d_num_selected_out)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_num_selected_out));
-  }
-  if (d_temp_storage)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
-  }
-  if (d_in)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_in));
-  }
-  if (d_flags)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_flags));
+    delete[] h_flags;
   }
 
   printf("\n\n");

--- a/cub/examples/device/example_device_select_flagged.cu
+++ b/cub/examples/device/example_device_select_flagged.cu
@@ -136,12 +136,12 @@ int main(int argc, char** argv)
   }
 
   // Initialize device
-  CubDebugExit(args.DeviceInit());
   int device_ordinal{};
-  CubDebugExit(cudaGetDevice(&device_ordinal));
-  const cuda::device_ref device{device_ordinal};
-  const cuda::stream_ref stream{cudaStream_t{}};
-  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
+  args.GetCmdLineArgument("device", device_ordinal);
+  CubDebugExit(args.DeviceInit(device_ordinal));
+  const auto device                 = cuda::devices[device_ordinal];
+  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
   int* h_in              = new int[num_items];

--- a/cub/examples/device/example_device_select_if.cu
+++ b/cub/examples/device/example_device_select_if.cu
@@ -175,11 +175,8 @@ int main(int argc, char** argv)
          (int) sizeof(int));
   fflush(stdout);
 
-  // Allocate problem device arrays
-  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
-
-  // Initialize device input
-  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
+  // Allocate and initialize problem device arrays
+  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, h_in, h_in + num_items);
 
   // Allocate device output array and num selected
   auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);

--- a/cub/examples/device/example_device_select_if.cu
+++ b/cub/examples/device/example_device_select_if.cu
@@ -17,9 +17,13 @@
 #define CUB_STDERR
 
 #include <cub/device/device_select.cuh>
-#include <cub/util_allocator.cuh>
 
+#include <cuda/buffer>
+#include <cuda/devices>
+#include <cuda/memory_pool>
+#include <cuda/std/cstddef>
 #include <cuda/std/limits>
+#include <cuda/stream>
 
 #include <cstdio>
 
@@ -32,7 +36,6 @@ using namespace cub;
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console
-CachingDeviceAllocator g_allocator(true); // Caching allocator for device memory
 
 /// Selection functor type
 struct GreaterThan
@@ -145,6 +148,11 @@ int main(int argc, char** argv)
 
   // Initialize device
   CubDebugExit(args.DeviceInit());
+  int device_ordinal{};
+  CubDebugExit(cudaGetDevice(&device_ordinal));
+  const cuda::device_ref device{device_ordinal};
+  const cuda::stream_ref stream{cudaStream_t{}};
+  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
   int* h_in        = new int[num_items];
@@ -172,33 +180,37 @@ int main(int argc, char** argv)
   fflush(stdout);
 
   // Allocate problem device arrays
-  int* d_in = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_in, sizeof(int) * num_items));
+  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in, h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
 
   // Allocate device output array and num selected
-  int* d_out              = nullptr;
-  int* d_num_selected_out = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_out, sizeof(int) * num_items));
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_num_selected_out, sizeof(int)));
+  auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
+  auto d_num_selected_out = cuda::make_buffer<int>(stream, device_memory_resource, 1, cuda::no_init);
 
   // Allocate temporary storage
-  void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  CubDebugExit(
-    DeviceSelect::If(d_temp_storage, temp_storage_bytes, d_in, d_out, d_num_selected_out, num_items, select_op));
-  CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  CubDebugExit(DeviceSelect::If(
+    nullptr, temp_storage_bytes, d_in.data(), d_out.data(), d_num_selected_out.data(), num_items, select_op, stream));
+  auto d_temp_storage =
+    cuda::make_buffer<cuda::std::byte>(stream, device_memory_resource, temp_storage_bytes, cuda::no_init);
 
   // Run
-  CubDebugExit(
-    DeviceSelect::If(d_temp_storage, temp_storage_bytes, d_in, d_out, d_num_selected_out, num_items, select_op));
+  CubDebugExit(DeviceSelect::If(
+    d_temp_storage.data(),
+    temp_storage_bytes,
+    d_in.data(),
+    d_out.data(),
+    d_num_selected_out.data(),
+    num_items,
+    select_op,
+    stream));
 
   // Check for correctness (and display results, if specified)
-  int compare = CompareDeviceResults(h_reference, d_out, num_selected, true, g_verbose);
+  int compare = CompareDeviceResults(h_reference, d_out.data(), num_selected, true, g_verbose);
   printf("\t Data %s ", compare ? "FAIL" : "PASS");
-  compare = compare | CompareDeviceResults(&num_selected, d_num_selected_out, 1, true, g_verbose);
+  compare = compare | CompareDeviceResults(&num_selected, d_num_selected_out.data(), 1, true, g_verbose);
   printf("\t Count %s ", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);
 
@@ -210,22 +222,6 @@ int main(int argc, char** argv)
   if (h_reference)
   {
     delete[] h_reference;
-  }
-  if (d_in)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_in));
-  }
-  if (d_out)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_out));
-  }
-  if (d_num_selected_out)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_num_selected_out));
-  }
-  if (d_temp_storage)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
   }
 
   printf("\n\n");

--- a/cub/examples/device/example_device_select_if.cu
+++ b/cub/examples/device/example_device_select_if.cu
@@ -138,7 +138,6 @@ int main(int argc, char** argv)
   {
     printf("%s "
            "[--n=<input items> "
-           "[--device=<device-id>] "
            "[--maxseg=<max segment length>]"
            "[--v] "
            "\n",
@@ -146,12 +145,9 @@ int main(int argc, char** argv)
     exit(0);
   }
 
-  // Initialize device
-  int device_ordinal{};
-  args.GetCmdLineArgument("device", device_ordinal);
-  CubDebugExit(args.DeviceInit(device_ordinal));
-  const auto device                 = cuda::devices[device_ordinal];
-  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  // Set up device, stream, and memory resource
+  const auto device                 = cuda::devices[0];
+  const auto stream                 = cuda::stream{device};
   const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
@@ -183,7 +179,7 @@ int main(int argc, char** argv)
   auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
 
   // Allocate device output array and num selected
   auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
@@ -208,6 +204,7 @@ int main(int argc, char** argv)
     stream));
 
   // Check for correctness (and display results, if specified)
+  stream.sync();
   int compare = CompareDeviceResults(h_reference, d_out.data(), num_selected, true, g_verbose);
   printf("\t Data %s ", compare ? "FAIL" : "PASS");
   compare = compare | CompareDeviceResults(&num_selected, d_num_selected_out.data(), 1, true, g_verbose);

--- a/cub/examples/device/example_device_select_if.cu
+++ b/cub/examples/device/example_device_select_if.cu
@@ -147,12 +147,12 @@ int main(int argc, char** argv)
   }
 
   // Initialize device
-  CubDebugExit(args.DeviceInit());
   int device_ordinal{};
-  CubDebugExit(cudaGetDevice(&device_ordinal));
-  const cuda::device_ref device{device_ordinal};
-  const cuda::stream_ref stream{cudaStream_t{}};
-  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
+  args.GetCmdLineArgument("device", device_ordinal);
+  CubDebugExit(args.DeviceInit(device_ordinal));
+  const auto device                 = cuda::devices[device_ordinal];
+  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
   int* h_in        = new int[num_items];

--- a/cub/examples/device/example_device_select_unique.cu
+++ b/cub/examples/device/example_device_select_unique.cu
@@ -125,7 +125,6 @@ int main(int argc, char** argv)
   {
     printf("%s "
            "[--n=<input items> "
-           "[--device=<device-id>] "
            "[--maxseg=<max segment length>]"
            "[--v] "
            "\n",
@@ -133,12 +132,9 @@ int main(int argc, char** argv)
     exit(0);
   }
 
-  // Initialize device
-  int device_ordinal{};
-  args.GetCmdLineArgument("device", device_ordinal);
-  CubDebugExit(args.DeviceInit(device_ordinal));
-  const auto device                 = cuda::devices[device_ordinal];
-  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  // Set up device, stream, and memory resource
+  const auto device                 = cuda::devices[0];
+  const auto stream                 = cuda::stream{device};
   const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
@@ -160,7 +156,7 @@ int main(int argc, char** argv)
   auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
 
   // Allocate device output array and num selected
   auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
@@ -178,6 +174,7 @@ int main(int argc, char** argv)
     d_temp_storage.data(), temp_storage_bytes, d_in.data(), d_out.data(), d_num_selected_out.data(), num_items, stream));
 
   // Check for correctness (and display results, if specified)
+  stream.sync();
   int compare = CompareDeviceResults(h_reference, d_out.data(), num_selected, true, g_verbose);
   printf("\t Data %s ", compare ? "FAIL" : "PASS");
   compare = compare | CompareDeviceResults(&num_selected, d_num_selected_out.data(), 1, true, g_verbose);

--- a/cub/examples/device/example_device_select_unique.cu
+++ b/cub/examples/device/example_device_select_unique.cu
@@ -152,11 +152,8 @@ int main(int argc, char** argv)
          num_items / num_selected);
   fflush(stdout);
 
-  // Allocate problem device arrays
-  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
-
-  // Initialize device input
-  CubDebugExit(cudaMemcpyAsync(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice, stream.get()));
+  // Allocate and initialize problem device arrays
+  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, h_in, h_in + num_items);
 
   // Allocate device output array and num selected
   auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);

--- a/cub/examples/device/example_device_select_unique.cu
+++ b/cub/examples/device/example_device_select_unique.cu
@@ -17,9 +17,13 @@
 #define CUB_STDERR
 
 #include <cub/device/device_select.cuh>
-#include <cub/util_allocator.cuh>
 
+#include <cuda/buffer>
+#include <cuda/devices>
+#include <cuda/memory_pool>
+#include <cuda/std/cstddef>
 #include <cuda/std/limits>
+#include <cuda/stream>
 
 #include <cstdio>
 
@@ -32,7 +36,6 @@ using namespace cub;
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console
-CachingDeviceAllocator g_allocator(true); // Caching allocator for device memory
 
 //---------------------------------------------------------------------
 // Test generation
@@ -132,6 +135,11 @@ int main(int argc, char** argv)
 
   // Initialize device
   CubDebugExit(args.DeviceInit());
+  int device_ordinal{};
+  CubDebugExit(cudaGetDevice(&device_ordinal));
+  const cuda::device_ref device{device_ordinal};
+  const cuda::stream_ref stream{cudaStream_t{}};
+  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
   int* h_in        = new int[num_items];
@@ -149,31 +157,30 @@ int main(int argc, char** argv)
   fflush(stdout);
 
   // Allocate problem device arrays
-  int* d_in = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_in, sizeof(int) * num_items));
+  auto d_in = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
 
   // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in, h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+  CubDebugExit(cudaMemcpy(d_in.data(), h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
 
   // Allocate device output array and num selected
-  int* d_out              = nullptr;
-  int* d_num_selected_out = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_out, sizeof(int) * num_items));
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_num_selected_out, sizeof(int)));
+  auto d_out              = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
+  auto d_num_selected_out = cuda::make_buffer<int>(stream, device_memory_resource, 1, cuda::no_init);
 
   // Allocate temporary storage
-  void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  CubDebugExit(DeviceSelect::Unique(d_temp_storage, temp_storage_bytes, d_in, d_out, d_num_selected_out, num_items));
-  CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  CubDebugExit(DeviceSelect::Unique(
+    nullptr, temp_storage_bytes, d_in.data(), d_out.data(), d_num_selected_out.data(), num_items, stream));
+  auto d_temp_storage =
+    cuda::make_buffer<cuda::std::byte>(stream, device_memory_resource, temp_storage_bytes, cuda::no_init);
 
   // Run
-  CubDebugExit(DeviceSelect::Unique(d_temp_storage, temp_storage_bytes, d_in, d_out, d_num_selected_out, num_items));
+  CubDebugExit(DeviceSelect::Unique(
+    d_temp_storage.data(), temp_storage_bytes, d_in.data(), d_out.data(), d_num_selected_out.data(), num_items, stream));
 
   // Check for correctness (and display results, if specified)
-  int compare = CompareDeviceResults(h_reference, d_out, num_selected, true, g_verbose);
+  int compare = CompareDeviceResults(h_reference, d_out.data(), num_selected, true, g_verbose);
   printf("\t Data %s ", compare ? "FAIL" : "PASS");
-  compare = compare | CompareDeviceResults(&num_selected, d_num_selected_out, 1, true, g_verbose);
+  compare = compare | CompareDeviceResults(&num_selected, d_num_selected_out.data(), 1, true, g_verbose);
   printf("\t Count %s ", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);
 
@@ -185,22 +192,6 @@ int main(int argc, char** argv)
   if (h_reference)
   {
     delete[] h_reference;
-  }
-  if (d_in)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_in));
-  }
-  if (d_out)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_out));
-  }
-  if (d_num_selected_out)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_num_selected_out));
-  }
-  if (d_temp_storage)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
   }
 
   printf("\n\n");

--- a/cub/examples/device/example_device_select_unique.cu
+++ b/cub/examples/device/example_device_select_unique.cu
@@ -134,12 +134,12 @@ int main(int argc, char** argv)
   }
 
   // Initialize device
-  CubDebugExit(args.DeviceInit());
   int device_ordinal{};
-  CubDebugExit(cudaGetDevice(&device_ordinal));
-  const cuda::device_ref device{device_ordinal};
-  const cuda::stream_ref stream{cudaStream_t{}};
-  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
+  args.GetCmdLineArgument("device", device_ordinal);
+  CubDebugExit(args.DeviceInit(device_ordinal));
+  const auto device                 = cuda::devices[device_ordinal];
+  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays
   int* h_in        = new int[num_items];

--- a/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
+++ b/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
@@ -195,13 +195,12 @@ int main(int argc, char** argv)
   }
 
   // Initialize device
-  CubDebugExit(args.DeviceInit());
-
-  int device_ordinal = 0;
-  CubDebugExit(cudaGetDevice(&device_ordinal));
-  const cuda::device_ref device{device_ordinal};
-  const cuda::stream_ref stream{cudaStream_t{}};
-  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
+  int device_ordinal{};
+  args.GetCmdLineArgument("device", device_ordinal);
+  CubDebugExit(args.DeviceInit(device_ordinal));
+  const auto device                 = cuda::devices[device_ordinal];
+  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays (problem and reference solution)
 

--- a/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
+++ b/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
@@ -17,7 +17,12 @@
 
 #include <cub/device/device_radix_sort.cuh>
 #include <cub/device/device_run_length_encode.cuh>
-#include <cub/util_allocator.cuh>
+
+#include <cuda/buffer>
+#include <cuda/devices>
+#include <cuda/memory_pool>
+#include <cuda/std/cstddef>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <cstdio>
@@ -31,7 +36,6 @@ using namespace cub;
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console
-CachingDeviceAllocator g_allocator(true); // Caching allocator for device memory
 
 //---------------------------------------------------------------------
 // Test generation
@@ -193,6 +197,12 @@ int main(int argc, char** argv)
   // Initialize device
   CubDebugExit(args.DeviceInit());
 
+  int device_ordinal = 0;
+  CubDebugExit(cudaGetDevice(&device_ordinal));
+  const cuda::device_ref device{device_ordinal};
+  const cuda::stream_ref stream{cudaStream_t{}};
+  cuda::device_memory_pool_ref device_memory_resource = cuda::device_default_memory_pool(device);
+
   // Allocate host arrays (problem and reference solution)
 
   Key* h_keys              = new Key[num_items];
@@ -218,17 +228,17 @@ int main(int argc, char** argv)
   for (int i = 0; i <= timing_iterations; ++i)
   {
     // Allocate and initialize device arrays for sorting
-    DoubleBuffer<Key> d_keys;
-    DoubleBuffer<Value> d_values;
-    CubDebugExit(g_allocator.DeviceAllocate((void**) &d_keys.d_buffers[0], sizeof(Key) * num_items));
-    CubDebugExit(g_allocator.DeviceAllocate((void**) &d_keys.d_buffers[1], sizeof(Key) * num_items));
-    CubDebugExit(g_allocator.DeviceAllocate((void**) &d_values.d_buffers[0], sizeof(Value) * num_items));
-    CubDebugExit(g_allocator.DeviceAllocate((void**) &d_values.d_buffers[1], sizeof(Value) * num_items));
+    auto d_keys_0   = cuda::make_buffer<Key>(stream, device_memory_resource, num_items, cuda::no_init);
+    auto d_keys_1   = cuda::make_buffer<Key>(stream, device_memory_resource, num_items, cuda::no_init);
+    auto d_values_0 = cuda::make_buffer<Value>(stream, device_memory_resource, num_items, cuda::no_init);
+    auto d_values_1 = cuda::make_buffer<Value>(stream, device_memory_resource, num_items, cuda::no_init);
+    DoubleBuffer<Key> d_keys{d_keys_0.data(), d_keys_1.data()};
+    DoubleBuffer<Value> d_values{d_values_0.data(), d_values_1.data()};
 
     CubDebugExit(
-      cudaMemcpy(d_keys.d_buffers[d_keys.selector], h_keys, sizeof(float) * num_items, cudaMemcpyHostToDevice));
+      cudaMemcpy(d_keys.d_buffers[d_keys.selector], h_keys, sizeof(Key) * num_items, cudaMemcpyHostToDevice));
     CubDebugExit(
-      cudaMemcpy(d_values.d_buffers[d_values.selector], h_values, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+      cudaMemcpy(d_values.d_buffers[d_values.selector], h_values, sizeof(Value) * num_items, cudaMemcpyHostToDevice));
 
     // Start timer
     gpu_timer.Start();
@@ -236,63 +246,76 @@ int main(int argc, char** argv)
     // Allocate temporary storage for sorting
     size_t temp_storage_bytes = 0;
     void* d_temp_storage      = nullptr;
-    CubDebugExit(DeviceRadixSort::SortPairs(d_temp_storage, temp_storage_bytes, d_keys, d_values, num_items));
-    CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+    CubDebugExit(DeviceRadixSort::SortPairs(
+      d_temp_storage, temp_storage_bytes, d_keys, d_values, num_items, 0, sizeof(Key) * 8, stream.get()));
+    auto sort_temp_storage =
+      cuda::make_buffer<cuda::std::byte>(stream, device_memory_resource, temp_storage_bytes, cuda::no_init);
 
     // Do the sort
-    CubDebugExit(DeviceRadixSort::SortPairs(d_temp_storage, temp_storage_bytes, d_keys, d_values, num_items));
+    CubDebugExit(DeviceRadixSort::SortPairs(
+      sort_temp_storage.data(), temp_storage_bytes, d_keys, d_values, num_items, 0, sizeof(Key) * 8, stream.get()));
 
     // Free unused buffers and sorting temporary storage
-    if (d_keys.d_buffers[d_keys.selector ^ 1])
+    if (d_keys.selector == 0)
     {
-      CubDebugExit(g_allocator.DeviceFree(d_keys.d_buffers[d_keys.selector ^ 1]));
+      d_keys_1.destroy(stream);
     }
-    if (d_values.d_buffers[d_values.selector ^ 1])
+    else
     {
-      CubDebugExit(g_allocator.DeviceFree(d_values.d_buffers[d_values.selector ^ 1]));
+      d_keys_0.destroy(stream);
     }
-    if (d_temp_storage)
+    if (d_values.selector == 0)
     {
-      CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
+      d_values_1.destroy(stream);
     }
+    else
+    {
+      d_values_0.destroy(stream);
+    }
+    sort_temp_storage.destroy(stream);
 
     // Start timer
     gpu_rle_timer.Start();
 
     // Allocate device arrays for enumerating non-trivial runs
-    int* d_offests_out = nullptr;
-    int* d_lengths_out = nullptr;
-    int* d_num_runs    = nullptr;
-    CubDebugExit(g_allocator.DeviceAllocate((void**) &d_offests_out, sizeof(int) * num_items));
-    CubDebugExit(g_allocator.DeviceAllocate((void**) &d_lengths_out, sizeof(int) * num_items));
-    CubDebugExit(g_allocator.DeviceAllocate((void**) &d_num_runs, sizeof(int) * 1));
+    auto d_offsets_out = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
+    auto d_lengths_out = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
+    auto d_num_runs    = cuda::make_buffer<int>(stream, device_memory_resource, 1, cuda::no_init);
 
     // Allocate temporary storage for isolating non-trivial runs
-    d_temp_storage = nullptr;
+    d_temp_storage     = nullptr;
+    temp_storage_bytes = 0;
     CubDebugExit(DeviceRunLengthEncode::NonTrivialRuns(
       d_temp_storage,
       temp_storage_bytes,
       d_keys.d_buffers[d_keys.selector],
-      d_offests_out,
-      d_lengths_out,
-      d_num_runs,
-      num_items));
-    CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+      d_offsets_out.data(),
+      d_lengths_out.data(),
+      d_num_runs.data(),
+      num_items,
+      stream.get()));
+    auto rle_temp_storage =
+      cuda::make_buffer<cuda::std::byte>(stream, device_memory_resource, temp_storage_bytes, cuda::no_init);
 
     // Do the isolation
     CubDebugExit(DeviceRunLengthEncode::NonTrivialRuns(
-      d_temp_storage,
+      rle_temp_storage.data(),
       temp_storage_bytes,
       d_keys.d_buffers[d_keys.selector],
-      d_offests_out,
-      d_lengths_out,
-      d_num_runs,
-      num_items));
+      d_offsets_out.data(),
+      d_lengths_out.data(),
+      d_num_runs.data(),
+      num_items,
+      stream.get()));
 
     // Free keys buffer
-    if (d_keys.d_buffers[d_keys.selector])
+    if (d_keys.selector == 0)
     {
-      CubDebugExit(g_allocator.DeviceFree(d_keys.d_buffers[d_keys.selector]));
+      d_keys_0.destroy(stream);
+    }
+    else
+    {
+      d_keys_1.destroy(stream);
     }
 
     //
@@ -308,15 +331,15 @@ int main(int argc, char** argv)
       // First iteration is a warmup: // Check for correctness (and display results, if specified)
 
       printf("\nRUN OFFSETS: \n");
-      int compare = CompareDeviceResults(h_offsets_reference, d_offests_out, num_runs, true, g_verbose);
+      int compare = CompareDeviceResults(h_offsets_reference, d_offsets_out.data(), num_runs, true, g_verbose);
       printf("\t\t %s ", compare ? "FAIL" : "PASS");
 
       printf("\nRUN LENGTHS: \n");
-      compare |= CompareDeviceResults(h_lengths_reference, d_lengths_out, num_runs, true, g_verbose);
+      compare |= CompareDeviceResults(h_lengths_reference, d_lengths_out.data(), num_runs, true, g_verbose);
       printf("\t\t %s ", compare ? "FAIL" : "PASS");
 
       printf("\nNUM RUNS: \n");
-      compare |= CompareDeviceResults(&num_runs, d_num_runs, 1, true, g_verbose);
+      compare |= CompareDeviceResults(&num_runs, d_num_runs.data(), 1, true, g_verbose);
       printf("\t\t %s ", compare ? "FAIL" : "PASS");
 
       AssertEquals(0, compare);
@@ -325,29 +348,6 @@ int main(int argc, char** argv)
     {
       elapsed_millis += gpu_timer.ElapsedMillis();
       elapsed_rle_millis += gpu_rle_timer.ElapsedMillis();
-    }
-
-    // GPU cleanup
-
-    if (d_values.d_buffers[d_values.selector])
-    {
-      CubDebugExit(g_allocator.DeviceFree(d_values.d_buffers[d_values.selector]));
-    }
-    if (d_offests_out)
-    {
-      CubDebugExit(g_allocator.DeviceFree(d_offests_out));
-    }
-    if (d_lengths_out)
-    {
-      CubDebugExit(g_allocator.DeviceFree(d_lengths_out));
-    }
-    if (d_num_runs)
-    {
-      CubDebugExit(g_allocator.DeviceFree(d_num_runs));
-    }
-    if (d_temp_storage)
-    {
-      CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
     }
   }
 

--- a/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
+++ b/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
@@ -221,17 +221,12 @@ int main(int argc, char** argv)
   for (int i = 0; i <= timing_iterations; ++i)
   {
     // Allocate and initialize device arrays for sorting
-    auto d_keys_0   = cuda::make_buffer<Key>(stream, device_memory_resource, num_items, cuda::no_init);
+    auto d_keys_0   = cuda::make_buffer<Key>(stream, device_memory_resource, h_keys, h_keys + num_items);
     auto d_keys_1   = cuda::make_buffer<Key>(stream, device_memory_resource, num_items, cuda::no_init);
-    auto d_values_0 = cuda::make_buffer<Value>(stream, device_memory_resource, num_items, cuda::no_init);
+    auto d_values_0 = cuda::make_buffer<Value>(stream, device_memory_resource, h_values, h_values + num_items);
     auto d_values_1 = cuda::make_buffer<Value>(stream, device_memory_resource, num_items, cuda::no_init);
     DoubleBuffer<Key> d_keys{d_keys_0.data(), d_keys_1.data()};
     DoubleBuffer<Value> d_values{d_values_0.data(), d_values_1.data()};
-
-    CubDebugExit(cudaMemcpyAsync(
-      d_keys.d_buffers[d_keys.selector], h_keys, sizeof(Key) * num_items, cudaMemcpyHostToDevice, stream.get()));
-    CubDebugExit(cudaMemcpyAsync(
-      d_values.d_buffers[d_values.selector], h_values, sizeof(Value) * num_items, cudaMemcpyHostToDevice, stream.get()));
 
     // Start timer
     const auto start_event = stream.record_timed_event();

--- a/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
+++ b/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
@@ -243,25 +243,6 @@ int main(int argc, char** argv)
     CubDebugExit(DeviceRadixSort::SortPairs(
       sort_temp_storage.data(), temp_storage_bytes, d_keys, d_values, num_items, 0, sizeof(Key) * 8, stream.get()));
 
-    // Free unused buffers and sorting temporary storage
-    if (d_keys.selector == 0)
-    {
-      d_keys_1.destroy(stream);
-    }
-    else
-    {
-      d_keys_0.destroy(stream);
-    }
-    if (d_values.selector == 0)
-    {
-      d_values_1.destroy(stream);
-    }
-    else
-    {
-      d_values_0.destroy(stream);
-    }
-    sort_temp_storage.destroy(stream);
-
     // Start timer
     const auto rle_start_event = stream.record_timed_event();
 
@@ -295,16 +276,6 @@ int main(int argc, char** argv)
       d_num_runs.data(),
       num_items,
       stream.get()));
-
-    // Free keys buffer
-    if (d_keys.selector == 0)
-    {
-      d_keys_0.destroy(stream);
-    }
-    else
-    {
-      d_keys_1.destroy(stream);
-    }
 
     //
     // Hypothetically do stuff with the original key-indices corresponding to non-trivial runs of identical keys

--- a/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
+++ b/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
@@ -184,7 +184,6 @@ int main(int argc, char** argv)
   if (args.CheckCmdLineFlag("help"))
   {
     printf("%s "
-           "[--device=<device-id>] "
            "[--i=<timing iterations> "
            "[--n=<input items, default 40> "
            "[--maxkey=<max key, default 20 (use -1 to test only unique keys)>]"
@@ -194,12 +193,9 @@ int main(int argc, char** argv)
     exit(0);
   }
 
-  // Initialize device
-  int device_ordinal{};
-  args.GetCmdLineArgument("device", device_ordinal);
-  CubDebugExit(args.DeviceInit(device_ordinal));
-  const auto device                 = cuda::devices[device_ordinal];
-  const auto stream                 = cuda::stream_ref{cudaStream_t{}};
+  // Set up device, stream, and memory resource
+  const auto device                 = cuda::devices[0];
+  const auto stream                 = cuda::stream{device};
   const auto device_memory_resource = cuda::device_default_memory_pool(device);
 
   // Allocate host arrays (problem and reference solution)
@@ -220,8 +216,6 @@ int main(int argc, char** argv)
   fflush(stdout);
 
   // Repeat for performance timing
-  GpuTimer gpu_timer;
-  GpuTimer gpu_rle_timer;
   float elapsed_millis     = 0.0;
   float elapsed_rle_millis = 0.0;
   for (int i = 0; i <= timing_iterations; ++i)
@@ -234,13 +228,13 @@ int main(int argc, char** argv)
     DoubleBuffer<Key> d_keys{d_keys_0.data(), d_keys_1.data()};
     DoubleBuffer<Value> d_values{d_values_0.data(), d_values_1.data()};
 
-    CubDebugExit(
-      cudaMemcpy(d_keys.d_buffers[d_keys.selector], h_keys, sizeof(Key) * num_items, cudaMemcpyHostToDevice));
-    CubDebugExit(
-      cudaMemcpy(d_values.d_buffers[d_values.selector], h_values, sizeof(Value) * num_items, cudaMemcpyHostToDevice));
+    CubDebugExit(cudaMemcpyAsync(
+      d_keys.d_buffers[d_keys.selector], h_keys, sizeof(Key) * num_items, cudaMemcpyHostToDevice, stream.get()));
+    CubDebugExit(cudaMemcpyAsync(
+      d_values.d_buffers[d_values.selector], h_values, sizeof(Value) * num_items, cudaMemcpyHostToDevice, stream.get()));
 
     // Start timer
-    gpu_timer.Start();
+    const auto start_event = stream.record_timed_event();
 
     // Allocate temporary storage for sorting
     size_t temp_storage_bytes = 0;
@@ -274,7 +268,7 @@ int main(int argc, char** argv)
     sort_temp_storage.destroy(stream);
 
     // Start timer
-    gpu_rle_timer.Start();
+    const auto rle_start_event = stream.record_timed_event();
 
     // Allocate device arrays for enumerating non-trivial runs
     auto d_offsets_out = cuda::make_buffer<int>(stream, device_memory_resource, num_items, cuda::no_init);
@@ -322,8 +316,8 @@ int main(int argc, char** argv)
     //
 
     // Stop sort timer
-    gpu_timer.Stop();
-    gpu_rle_timer.Stop();
+    const auto end_event = stream.record_timed_event();
+    stream.sync();
 
     if (i == 0)
     {
@@ -345,8 +339,8 @@ int main(int argc, char** argv)
     }
     else
     {
-      elapsed_millis += gpu_timer.ElapsedMillis();
-      elapsed_rle_millis += gpu_rle_timer.ElapsedMillis();
+      elapsed_millis += static_cast<float>((end_event - start_event).count()) / 1.0e6f;
+      elapsed_rle_millis += static_cast<float>((end_event - rle_start_event).count()) / 1.0e6f;
     }
   }
 

--- a/cub/examples/device/example_device_topk_keys.cu
+++ b/cub/examples/device/example_device_topk_keys.cu
@@ -10,7 +10,6 @@
 #define CUB_STDERR
 
 #include <cub/device/device_topk.cuh>
-#include <cub/util_allocator.cuh>
 
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>

--- a/cub/examples/device/example_device_topk_pairs.cu
+++ b/cub/examples/device/example_device_topk_pairs.cu
@@ -11,7 +11,6 @@
 #define CUB_STDERR
 
 #include <cub/device/device_topk.cuh>
-#include <cub/util_allocator.cuh>
 
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>

--- a/cub/test/test_block_radix_rank.cu
+++ b/cub/test/test_block_radix_rank.cu
@@ -9,8 +9,11 @@
 #include <cub/block/block_radix_rank.cuh>
 #include <cub/block/block_store.cuh>
 #include <cub/block/radix_rank_sort_operations.cuh>
-#include <cub/util_allocator.cuh>
 #include <cub/util_vsmem.cuh>
+
+#include <cuda/buffer>
+#include <cuda/devices>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <cstdio>
@@ -23,7 +26,6 @@
 CUB_TEST_MEMORY_CLASS(CUB_SMALL);
 
 bool g_verbose = false;
-cub::CachingDeviceAllocator g_allocator(true);
 
 template <cub::RadixRankAlgorithm RankAlgorithm,
           int ThreadsPerBlock,
@@ -143,43 +145,28 @@ void TestDriver(GenMode gen_mode)
 
   // Allocate host arrays
   std::unique_ptr<Key[]> h_keys(new Key[tile_size]);
-  std::unique_ptr<int[]> h_ranks(new int[tile_size]);
   std::unique_ptr<int[]> h_reference_ranks(new int[tile_size]);
-
-  // Allocate device arrays
-  Key* d_keys  = nullptr;
-  int* d_ranks = nullptr;
-
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_keys, sizeof(Key) * tile_size));
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_ranks, sizeof(int) * tile_size));
 
   // Initialize problem and solution on host
   Initialize<Descending>(gen_mode, h_keys.get(), h_reference_ranks.get(), tile_size, RadixBits);
 
-  // Copy problem to device
-  CubDebugExit(cudaMemcpy(d_keys, h_keys.get(), sizeof(Key) * tile_size, cudaMemcpyHostToDevice));
+  // Allocate device arrays and copy the problem to the device
+  const auto device = cuda::devices[0];
+  const auto stream = cuda::stream{device};
+  auto d_keys       = cuda::make_device_buffer<Key>(stream, device, h_keys.get(), h_keys.get() + tile_size);
+  auto d_ranks      = cuda::make_device_buffer<int>(stream, device, tile_size, cuda::no_init);
 
   // Run kernel
   kernel<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>
-    <<<1, ThreadsPerBlock>>>(d_keys, d_ranks);
+    <<<1, ThreadsPerBlock, 0, stream.get()>>>(d_keys.data(), d_ranks.data());
 
   // Flush kernel output / errors
   CubDebugExit(cudaPeekAtLastError());
   CubDebugExit(cudaDeviceSynchronize());
 
   // Check keys results
-  const bool compare = CompareDeviceResults(h_reference_ranks.get(), d_ranks, tile_size, g_verbose, g_verbose);
+  const bool compare = CompareDeviceResults(h_reference_ranks.get(), d_ranks.data(), tile_size, g_verbose, g_verbose);
   AssertEquals(0, compare);
-
-  if (d_keys)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_keys));
-  }
-
-  if (d_ranks)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_ranks));
-  }
 }
 
 template <cub::RadixRankAlgorithm RankAlgorithm,
@@ -303,22 +290,16 @@ int main(int argc, char** argv)
   if (args.CheckCmdLineFlag("help"))
   {
     printf("%s "
-           "[--device=<device-id>] "
            "[--v] "
            "\n",
            argv[0]);
     exit(0);
   }
 
-  // Initialize device
-  CubDebugExit(args.DeviceInit());
-
   Test<16>();
   Test<32>();
   Test<128>();
   Test<130>();
-
-  g_allocator.FreeAllCached();
 
   return 0;
 }


### PR DESCRIPTION
This is a precursor to deprecating cub::CachingDeviceAllocator by first removing uses of it from CCCL code.

## Summary

- replace the process-global `cub::CachingDeviceAllocator` in nine CUB device examples with `cuda::buffer`
- replace the allocator in `test_block_radix_rank` with `cuda::make_device_buffer`
- use `cuda::devices[0]`, an owning `cuda::stream`, and the default memory pool for device 0
- construct input buffers directly from host ranges instead of issuing raw CUDA copies
- keep transfers, CUB work, timing, and buffer lifetimes ordered on that stream
- remove unused `<cub/util_allocator.cuh>` includes from the TopK examples
- clean up the leaked host flag arrays in the flagged examples

Closes #10869

## Validation

- pre-commit passed on all changed files
- all nine migrated Release C++17/native example targets rebuilt
- all nine migrated example CTests passed on an RTX 3080 with CUDA 13.3
- `cub.test.block.radix_rank` rebuilt and passed on an RTX 3080 with CUDA 13.3
- the multi-iteration sort/find timing path passed with `--i=5 --n=1048576`

The migrated code now requires CUDA stream-ordered memory-pool support.