### PR TITLE
Add inputs for controlling which repo and branch are checked out

### DIFF
--- a/.github/workflows/workflow-dispatch-standalone-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-standalone-group-linux.yml
@@ -34,6 +34,14 @@ jobs:
       contents: read
     runs-on: ${{ github.repository == 'NVIDIA/cccl' && matrix.runner || 'ubuntu-latest' }}
     steps:
+      - name: Validate repo parameter
+        if: inputs.repo != ''
+        run: |
+          REPO_LOWER=$(echo "${{ inputs.repo }}" | tr '[:upper:]' '[:lower:]')
+          if [[ "$REPO_LOWER" != "nvidia/cccl" && "$REPO_LOWER" != "NVIDIA-dev/cccl_private" ]]; then
+            echo "::error::repo must be 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private' (got: ${{ inputs.repo }})"
+            exit 1
+          fi
       - name: Checkout repo
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/workflow-dispatch-standalone-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-standalone-group-linux.yml
@@ -11,6 +11,16 @@ on:
         description: "The dispatch.json's linux_standalone.jobs.<name> array of dispatch jobs."
         type: string
         required: true
+      repo:
+        description: "Repository to checkout (e.g. 'NVIDIA/cccl')."
+        type: string
+        required: false
+        default: ""
+      commit:
+        description: "Commit SHA or branch/ref to checkout."
+        type: string
+        required: false
+        default: ""
 
 jobs:
   run-jobs:
@@ -28,6 +38,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+          repository: ${{ inputs.repo || github.repository }}
+          ref: ${{ inputs.commit || github.sha }}
       - name: Run job
         uses: ./.github/actions/workflow-run-job-linux
         with:

--- a/.github/workflows/workflow-dispatch-standalone-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-standalone-group-linux.yml
@@ -12,15 +12,15 @@ on:
         type: string
         required: true
       repo:
-        description: "Repository to checkout (e.g. 'NVIDIA/cccl')."
+        description: "Repository to checkout (e.g. 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private')."
         type: string
         required: false
-        default: ""
+        default: ${{ github.repository }}
       commit:
         description: "Commit SHA or branch/ref to checkout."
         type: string
         required: false
-        default: ""
+        default: ${{ github.sha }}
 
 jobs:
   run-jobs:
@@ -32,22 +32,14 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    runs-on: ${{ github.repository == 'NVIDIA/cccl' && matrix.runner || 'ubuntu-latest' }}
+    runs-on: ${{ (github.repository == 'NVIDIA/cccl' || github.repository == 'NVIDIA-dev/cccl_private') && matrix.runner || 'ubuntu-latest' }}
     steps:
-      - name: Validate repo parameter
-        if: inputs.repo != ''
-        run: |
-          REPO_LOWER=$(echo "${{ inputs.repo }}" | tr '[:upper:]' '[:lower:]')
-          if [[ "$REPO_LOWER" != "nvidia/cccl" && "$REPO_LOWER" != "NVIDIA-dev/cccl_private" ]]; then
-            echo "::error::repo must be 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private' (got: ${{ inputs.repo }})"
-            exit 1
-          fi
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          repository: ${{ inputs.repo || github.repository }}
-          ref: ${{ inputs.commit || github.sha }}
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.commit }}
       - name: Run job
         uses: ./.github/actions/workflow-run-job-linux
         with:

--- a/.github/workflows/workflow-dispatch-standalone-group-windows.yml
+++ b/.github/workflows/workflow-dispatch-standalone-group-windows.yml
@@ -11,6 +11,16 @@ on:
         description: "The dispatch.json's windows_standalone.jobs.<name> array of dispatch jobs."
         type: string
         required: true
+      repo:
+        description: "Repository to checkout (e.g. 'NVIDIA/cccl')."
+        type: string
+        required: false
+        default: ""
+      commit:
+        description: "Commit SHA or branch/ref to checkout."
+        type: string
+        required: false
+        default: ""
 
 jobs:
   run-jobs:
@@ -28,6 +38,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+          repository: ${{ inputs.repo || github.repository }}
+          ref: ${{ inputs.commit || github.sha }}
       - name: Run job
         uses: ./.github/actions/workflow-run-job-windows
         with:

--- a/.github/workflows/workflow-dispatch-standalone-group-windows.yml
+++ b/.github/workflows/workflow-dispatch-standalone-group-windows.yml
@@ -34,6 +34,14 @@ jobs:
       matrix:
         include: ${{ fromJSON(inputs.job-array) }}
     steps:
+      - name: Validate repo parameter
+        if: inputs.repo != ''
+        run: |
+          REPO_LOWER=$(echo "${{ inputs.repo }}" | tr '[:upper:]' '[:lower:]')
+          if [[ "$REPO_LOWER" != "nvidia/cccl" && "$REPO_LOWER" != "NVIDIA-dev/cccl_private" ]]; then
+            echo "::error::repo must be 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private' (got: ${{ inputs.repo }})"
+            exit 1
+          fi
       - name: Checkout repo
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/workflow-dispatch-standalone-group-windows.yml
+++ b/.github/workflows/workflow-dispatch-standalone-group-windows.yml
@@ -12,42 +12,34 @@ on:
         type: string
         required: true
       repo:
-        description: "Repository to checkout (e.g. 'NVIDIA/cccl')."
+        description: "Repository to checkout (e.g. 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private')."
         type: string
         required: false
-        default: ""
+        default: ${{ github.repository }}
       commit:
         description: "Commit SHA or branch/ref to checkout."
         type: string
         required: false
-        default: ""
+        default: ${{ github.sha }}
 
 jobs:
   run-jobs:
-    name: ${{ matrix.name }}
-    runs-on: ${{ github.repository == 'NVIDIA/cccl' && matrix.runner || 'windows-latest' }}
-    permissions:
-      id-token: write
-      contents: read
+    name: "${{ matrix.name }}"
     strategy:
       fail-fast: false
       matrix:
         include: ${{ fromJSON(inputs.job-array) }}
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ${{ (github.repository == 'NVIDIA/cccl' || github.repository == 'NVIDIA-dev/cccl_private') && matrix.runner || 'windows-latest' }}
     steps:
-      - name: Validate repo parameter
-        if: inputs.repo != ''
-        run: |
-          REPO_LOWER=$(echo "${{ inputs.repo }}" | tr '[:upper:]' '[:lower:]')
-          if [[ "$REPO_LOWER" != "nvidia/cccl" && "$REPO_LOWER" != "NVIDIA-dev/cccl_private" ]]; then
-            echo "::error::repo must be 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private' (got: ${{ inputs.repo }})"
-            exit 1
-          fi
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          repository: ${{ inputs.repo || github.repository }}
-          ref: ${{ inputs.commit || github.sha }}
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.commit }}
       - name: Run job
         uses: ./.github/actions/workflow-run-job-windows
         with:

--- a/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
@@ -12,30 +12,17 @@ on:
         type: string
         required: true
       repo:
-        description: "Repository to checkout (e.g. 'NVIDIA/cccl')."
+        description: "Repository to checkout (e.g. 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private')."
         type: string
         required: false
-        default: ""
+        default: ${{ github.repository }}
       commit:
         description: "Commit SHA or branch/ref to checkout."
         type: string
         required: false
-        default: ""
+        default: ${{ github.sha }}
 
 jobs:
-  validate-repo:
-    name: Validate repo
-    if: inputs.repo != ''
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check repo value
-        run: |
-          REPO_LOWER=$(echo "${{ inputs.repo }}" | tr '[:upper:]' '[:lower:]')
-          if [[ "$REPO_LOWER" != "nvidia/cccl" && "$REPO_LOWER" != "NVIDIA-dev/cccl_private" ]]; then
-            echo "::error::repo must be 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private' (got: ${{ inputs.repo }})"
-            exit 1
-          fi
-
   dispatch-pcs:
     name: ${{ matrix.id }}
     needs: validate-repo
@@ -50,5 +37,5 @@ jobs:
     with:
       producers: ${{ toJSON(matrix.producers) }}
       consumers: ${{ toJSON(matrix.consumers) }}
-      repo:      ${{ inputs.repo || github.repository }}
-      commit:    ${{ inputs.commit || github.sha }}
+      repo: ${{ inputs.repo }}
+      commit: ${{ inputs.commit }}

--- a/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
@@ -25,7 +25,6 @@ on:
 jobs:
   dispatch-pcs:
     name: ${{ matrix.id }}
-    needs: validate-repo
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
@@ -11,6 +11,16 @@ on:
         description: "The dispatch.json's linux_two_stage.jobs.<name> array of producer/consumer chains."
         type: string
         required: true
+      repo:
+        description: "Repository to checkout (e.g. 'NVIDIA/cccl')."
+        type: string
+        required: false
+        default: ""
+      commit:
+        description: "Commit SHA or branch/ref to checkout."
+        type: string
+        required: false
+        default: ""
 
 jobs:
   dispatch-pcs:
@@ -26,3 +36,5 @@ jobs:
     with:
       producers: ${{ toJSON(matrix.producers) }}
       consumers: ${{ toJSON(matrix.consumers) }}
+      repo:      ${{ inputs.repo || github.repository }}
+      commit:    ${{ inputs.commit || github.sha }}

--- a/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
@@ -23,8 +23,22 @@ on:
         default: ""
 
 jobs:
+  validate-repo:
+    name: Validate repo
+    if: inputs.repo != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repo value
+        run: |
+          REPO_LOWER=$(echo "${{ inputs.repo }}" | tr '[:upper:]' '[:lower:]')
+          if [[ "$REPO_LOWER" != "nvidia/cccl" && "$REPO_LOWER" != "NVIDIA-dev/cccl_private" ]]; then
+            echo "::error::repo must be 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private' (got: ${{ inputs.repo }})"
+            exit 1
+          fi
+
   dispatch-pcs:
     name: ${{ matrix.id }}
+    needs: validate-repo
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/workflow-dispatch-two-stage-group-windows.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-windows.yml
@@ -12,30 +12,17 @@ on:
         type: string
         required: true
       repo:
-        description: "Repository to checkout (e.g. 'NVIDIA/cccl')."
+        description: "Repository to checkout (e.g. 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private')."
         type: string
         required: false
-        default: ""
+        default: ${{ github.repository }}
       commit:
         description: "Commit SHA or branch/ref to checkout."
         type: string
         required: false
-        default: ""
+        default: ${{ github.sha }}
 
 jobs:
-  validate-repo:
-    name: Validate repo
-    if: inputs.repo != ''
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check repo value
-        run: |
-          REPO_LOWER=$(echo "${{ inputs.repo }}" | tr '[:upper:]' '[:lower:]')
-          if [[ "$REPO_LOWER" != "nvidia/cccl" && "$REPO_LOWER" != "NVIDIA-dev/cccl_private" ]]; then
-            echo "::error::repo must be 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private' (got: ${{ inputs.repo }})"
-            exit 1
-          fi
-
   dispatch-pcs:
     name: ${{ matrix.id }}
     needs: validate-repo
@@ -50,5 +37,5 @@ jobs:
     with:
       producers: ${{ toJSON(matrix.producers) }}
       consumers: ${{ toJSON(matrix.consumers) }}
-      repo:      ${{ inputs.repo || github.repository }}
-      commit:    ${{ inputs.commit || github.sha }}
+      repo: ${{ inputs.repo }}
+      commit: ${{ inputs.commit }}

--- a/.github/workflows/workflow-dispatch-two-stage-group-windows.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-windows.yml
@@ -11,6 +11,16 @@ on:
         description: "The dispatch.json's windows_two_stage.jobs.<name> array of producer/consumer chains."
         type: string
         required: true
+      repo:
+        description: "Repository to checkout (e.g. 'NVIDIA/cccl')."
+        type: string
+        required: false
+        default: ""
+      commit:
+        description: "Commit SHA or branch/ref to checkout."
+        type: string
+        required: false
+        default: ""
 
 jobs:
   dispatch-pcs:
@@ -26,3 +36,5 @@ jobs:
     with:
       producers: ${{ toJSON(matrix.producers) }}
       consumers: ${{ toJSON(matrix.consumers) }}
+      repo:      ${{ inputs.repo || github.repository }}
+      commit:    ${{ inputs.commit || github.sha }}

--- a/.github/workflows/workflow-dispatch-two-stage-group-windows.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-windows.yml
@@ -25,7 +25,6 @@ on:
 jobs:
   dispatch-pcs:
     name: ${{ matrix.id }}
-    needs: validate-repo
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/workflow-dispatch-two-stage-group-windows.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-windows.yml
@@ -23,8 +23,22 @@ on:
         default: ""
 
 jobs:
+  validate-repo:
+    name: Validate repo
+    if: inputs.repo != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repo value
+        run: |
+          REPO_LOWER=$(echo "${{ inputs.repo }}" | tr '[:upper:]' '[:lower:]')
+          if [[ "$REPO_LOWER" != "nvidia/cccl" && "$REPO_LOWER" != "NVIDIA-dev/cccl_private" ]]; then
+            echo "::error::repo must be 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private' (got: ${{ inputs.repo }})"
+            exit 1
+          fi
+
   dispatch-pcs:
     name: ${{ matrix.id }}
+    needs: validate-repo
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/workflow-dispatch-two-stage-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-linux.yml
@@ -15,6 +15,16 @@ on:
         description: "The dispatch.json's linux_two_stage.jobs.<name>[*].consumers array."
         type: string
         required: true
+      repo:
+        description: "Repository to checkout (e.g. 'NVIDIA/cccl')."
+        type: string
+        required: false
+        default: ""
+      commit:
+        description: "Commit SHA or branch/ref to checkout."
+        type: string
+        required: false
+        default: ""
 
 jobs:
   # Accumulating results from multiple producers is not easily implemented. For now, only a single producer is supported.
@@ -30,6 +40,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+          repository: ${{ inputs.repo || github.repository }}
+          ref: ${{ inputs.commit || github.sha }}
       - name: Run job
         uses: ./.github/actions/workflow-run-job-linux
         with:
@@ -57,6 +69,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+          repository: ${{ inputs.repo || github.repository }}
+          ref: ${{ inputs.commit || github.sha }}
       - name: Run job
         uses: ./.github/actions/workflow-run-job-linux
         with:

--- a/.github/workflows/workflow-dispatch-two-stage-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-linux.yml
@@ -16,22 +16,22 @@ on:
         type: string
         required: true
       repo:
-        description: "Repository to checkout (e.g. 'NVIDIA/cccl')."
+        description: "Repository to checkout (e.g. 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private')."
         type: string
         required: false
-        default: ""
+        default: ${{ github.repository }}
       commit:
         description: "Commit SHA or branch/ref to checkout."
         type: string
         required: false
-        default: ""
+        default: ${{ github.sha }}
 
 jobs:
   # Accumulating results from multiple producers is not easily implemented. For now, only a single producer is supported.
   # The build-workflow.py script will emit an error if more than one producer is specified.
   producer:
     name: ${{ fromJSON(inputs.producers)[0].name }}
-    runs-on: ${{ github.repository == 'NVIDIA/cccl' && fromJSON(inputs.producers)[0].runner || 'ubuntu-latest' }}
+    runs-on: ${{ (github.repository == 'NVIDIA/cccl' || github.repository == 'NVIDIA-dev/cccl_private') && fromJSON(inputs.producers)[0].runner || 'ubuntu-latest' }}
     permissions:
       id-token: write
       contents: read
@@ -40,8 +40,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          repository: ${{ inputs.repo || github.repository }}
-          ref: ${{ inputs.commit || github.sha }}
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.commit }}
       - name: Run job
         uses: ./.github/actions/workflow-run-job-linux
         with:
@@ -56,7 +56,7 @@ jobs:
   consumers:
     name: "${{ matrix.name }}"
     needs: producer
-    runs-on: ${{ github.repository == 'NVIDIA/cccl' && matrix.runner || 'ubuntu-latest' }}
+    runs-on: ${{ (github.repository == 'NVIDIA/cccl' || github.repository == 'NVIDIA-dev/cccl_private') && matrix.runner || 'ubuntu-latest' }}
     permissions:
       id-token: write
       contents: read
@@ -69,8 +69,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          repository: ${{ inputs.repo || github.repository }}
-          ref: ${{ inputs.commit || github.sha }}
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.commit }}
       - name: Run job
         uses: ./.github/actions/workflow-run-job-linux
         with:

--- a/.github/workflows/workflow-dispatch-two-stage-windows.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-windows.yml
@@ -15,6 +15,16 @@ on:
         description: "The dispatch.json's windows_two_stage.jobs.<name>[*].consumers array."
         type: string
         required: true
+      repo:
+        description: "Repository to checkout (e.g. 'NVIDIA/cccl')."
+        type: string
+        required: false
+        default: ""
+      commit:
+        description: "Commit SHA or branch/ref to checkout."
+        type: string
+        required: false
+        default: ""
 
 jobs:
   # Accumulating results from multiple producers is not easily implemented. For now, only a single producer is supported.
@@ -30,6 +40,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+          repository: ${{ inputs.repo || github.repository }}
+          ref: ${{ inputs.commit || github.sha }}
       - name: Run job
         uses: ./.github/actions/workflow-run-job-windows
         with:
@@ -57,6 +69,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+          repository: ${{ inputs.repo || github.repository }}
+          ref: ${{ inputs.commit || github.sha }}
       - name: Run job
         uses: ./.github/actions/workflow-run-job-windows
         with:

--- a/.github/workflows/workflow-dispatch-two-stage-windows.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-windows.yml
@@ -16,22 +16,22 @@ on:
         type: string
         required: true
       repo:
-        description: "Repository to checkout (e.g. 'NVIDIA/cccl')."
+        description: "Repository to checkout (e.g. 'NVIDIA/cccl' or 'NVIDIA-dev/cccl_private')."
         type: string
         required: false
-        default: ""
+        default: ${{ github.repository }}
       commit:
         description: "Commit SHA or branch/ref to checkout."
         type: string
         required: false
-        default: ""
+        default: ${{ github.sha }}
 
 jobs:
   # Accumulating results from multiple producers is not easily implemented. For now, only a single producer is supported.
   # The build-workflow.py script will emit an error if more than one producer is specified.
   producer:
     name: ${{ fromJSON(inputs.producers)[0].name }}
-    runs-on: ${{ github.repository == 'NVIDIA/cccl' && fromJSON(inputs.producers)[0].runner || 'windows-latest' }}
+    runs-on: ${{ (github.repository == 'NVIDIA/cccl' || github.repository == 'NVIDIA-dev/cccl_private') && fromJSON(inputs.producers)[0].runner || 'windows-latest' }}
     permissions:
       id-token: write
       contents: read
@@ -40,8 +40,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          repository: ${{ inputs.repo || github.repository }}
-          ref: ${{ inputs.commit || github.sha }}
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.commit }}
       - name: Run job
         uses: ./.github/actions/workflow-run-job-windows
         with:
@@ -56,7 +56,7 @@ jobs:
   consumers:
     name: ${{ matrix.name }}
     needs: producer
-    runs-on: ${{ github.repository == 'NVIDIA/cccl' && matrix.runner || 'windows-latest' }}
+    runs-on: ${{ (github.repository == 'NVIDIA/cccl' || github.repository == 'NVIDIA-dev/cccl_private') && matrix.runner || 'windows-latest' }}
     permissions:
       id-token: write
       contents: read
@@ -69,8 +69,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          repository: ${{ inputs.repo || github.repository }}
-          ref: ${{ inputs.commit || github.sha }}
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.commit }}
       - name: Run job
         uses: ./.github/actions/workflow-run-job-windows
         with:


### PR DESCRIPTION
## Description

Allows overriding which repository and branch are used when checking out source code for testing.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
