### PR TITLE
Temporarily disable compile-time benchmark PR comments

### DIFF
--- a/.github/workflows/compile-time-bench.yml
+++ b/.github/workflows/compile-time-bench.yml
@@ -336,7 +336,8 @@ jobs:
   comment:
     name: "Compile-time comment: ${{ inputs.name }}"
     needs: run
-    if: ${{ always() && inputs.comment == 'true' && inputs.pr_number != '' }}
+    # Temporarily disable posting compile-time results to pull requests.
+    if: ${{ false && always() && inputs.comment == 'true' && inputs.pr_number != '' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Summary

- Disable the compile-time benchmark PR comment job.
- Keep benchmark execution, Actions summaries, and artifacts unchanged.

## Why

Pause automatic comment posting while the longer-term opt-in behavior is decided.

## Validation

- `pre-commit run --files .github/workflows/compile-time-bench.yml`
- `git diff --check`
