### PR TITLE
Fix mypy cache_dir and re-enable mypy on pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
     autoupdate_branch: ''
     autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
     autoupdate_schedule: quarterly
-    skip: [mypy, secret-scan-trufflehog] # mypy fails on pre-commit.ci due to numpy stub incompatibility with Python 3.14
+    skip: [secret-scan-trufflehog]
     submodules: false
 
 repos:

--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -163,7 +163,7 @@ git_describe_command = ["git", "describe", "--tags", "--match", "v[0-9]*"]
 "cuda" = "cuda"
 
 [tool.mypy]
-cache_dir = "../../.cache/mypy"
+cache_dir = ".cache/mypy"
 python_version = "3.10"
 
 [[tool.mypy.overrides]]

--- a/python/cuda_stf/pyproject.toml
+++ b/python/cuda_stf/pyproject.toml
@@ -147,7 +147,7 @@ fallback_version = "0.0.0"
 "cuda/stf/_experimental/interop" = "cuda/stf/_experimental/interop"
 
 [tool.mypy]
-cache_dir = "../../.cache/mypy"
+cache_dir = ".cache/mypy"
 python_version = "3.10"
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
mypy resolves a relative `cache_dir` against the CWD, not the config file. Since pre-commit runs from the repo root, `../../.cache/mypy` points two levels *above* the checkout — for a repo cloned at `~/cccl` that's `/home/.cache`, which isn't writable. mypy ≤1.16 silently tolerated this, but 2.1.0 (bumped in #10729) crashes with `INTERNAL ERROR` on startup, breaking `pre-commit run` locally for anyone whose checkout isn't at the "right" depth.

Changing it to `.cache/mypy` puts the cache at the repo root, as #8171 intended.

Also removes `mypy` from the pre-commit.ci skip list. The numpy stub issue it cited is already handled by the `follow_imports = "skip"` overrides from #9568 — verified mypy 2.1.0 passes cleanly under Python 3.14 with the hook's exact environment. The skip meant mypy ran nowhere in CI, which is how the broken 2.1.0 bump merged green. The pre-commit.ci run on this PR doubles as the proof it works.
