### PR TITLE
Update links to reference the new CUDA programming guide, NOT the legacy CUDA programming guide.

### DIFF
--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -362,7 +362,7 @@ _CCCL_DEVICE void transform_kernel_vectorized(
 // Implementation notes on memcpy_async and UBLKCP kernels regarding copy alignment and padding
 //
 // For performance considerations of memcpy_async:
-// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#performance-guidance-for-memcpy-async
+// https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/device-callable-apis.html#memcpy-async
 //
 // We basically have to align the base pointer to 16 bytes, and copy a multiple of 16 bytes. To achieve this, when we
 // copy a tile of data from an input buffer, we round down the pointer to the start of the tile to the next lower
@@ -371,10 +371,9 @@ _CCCL_DEVICE void transform_kernel_vectorized(
 // should align to 128 bytes instead of 16 on Hopper.
 //
 // However, padding memory copies like that may access the input buffer out-of-bounds. Here are some thoughts:
-// * According to the CUDA programming guide
-// (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#device-memory-accesses), "any address of a variable
-// residing in global memory or returned by one of the memory allocation routines from the driver or runtime API is
-// always aligned to at least 256 bytes."
+// * According to the CUDA Best Practices guide
+// (https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/#a-sequential-but-misaligned-access-pattern), "Memory
+// allocated through the CUDA Runtime API, such as via cudaMalloc(), is guaranteed to be aligned to at least 256 bytes."
 // * Memory protection is usually done on memory page level, which is even larger than 256 bytes for CUDA and 4KiB on
 // Intel x86 and 4KiB+ ARM. Front and tail padding thus never leaves the memory page of the input buffer.
 // * This should count for device memory, but also for device accessible memory living on the host.

--- a/cub/cub/thread/thread_reduce.cuh
+++ b/cub/cub/thread/thread_reduce.cuh
@@ -160,7 +160,8 @@ namespace detail
  **********************************************************************************************************************/
 
 /// DPX instructions compute min, max, and sum for up to three 16 and 32-bit signed or unsigned integer parameters
-/// see DPX documentation https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#dpx
+/// see DPX documentation
+/// https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#dynamic-programming-extension-dpx-instructions
 /// NOTE: The compiler is able to automatically vectorize all cases with 3 operands
 ///       However, all other cases with per-halfword comparison need to be explicitly vectorized
 ///

--- a/cudax/test/stf/cuda-samples/3_CUDA_Features/graphConditionalNodes/graphConditionalNodes.cu
+++ b/cudax/test/stf/cuda-samples/3_CUDA_Features/graphConditionalNodes/graphConditionalNodes.cu
@@ -31,7 +31,7 @@
  *
  * For more information on conditional nodes, see the programming guide:
  *
- *   https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#conditional-graph-nodes
+ *   https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/cuda-graphs.html#conditional-graph-nodes
  *
  */
 

--- a/docs/cub/benchmarking.rst
+++ b/docs/cub/benchmarking.rst
@@ -213,7 +213,7 @@ Furthermore, the tuning scripts require some additional python dependencies, whi
     pip install --user fpzip pandas scipy
 
 To select the appropriate CUDA GPU, first identify the GPU ID by running `nvidia-smi`, then set the
-desired GPU using `export CUDA_VISIBLE_DEVICES=x <https://docs.nvidia.com/cuda/cuda-c-programming-guide/#cuda-environment-variables>`_,
+desired GPU using `export CUDA_VISIBLE_DEVICES=x <https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/environment-variables.html#cuda-visible-devices>`_,
 where `x` is the ID of the GPU you want to use (e.g., `1`).
 This ensures your application uses only the specified GPU.
 We can then run the full benchmark suite from the build directory with:

--- a/docs/cub/index.rst
+++ b/docs/cub/index.rst
@@ -181,7 +181,7 @@ plurality of state, granularity, throughput, latency, memory bottlenecks, etc.
 
 With the exception of CUB, however, there are few (if any) software libraries of
 *reusable* kernel primitives. In the CUDA ecosystem, CUB is unique in this regard.
-As a `SIMT <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#hardware-implementation>`_
+As a `SIMT <https://docs.nvidia.com/cuda/cuda-programming-guide/01-introduction/programming-model.html#gpu-hardware-model>`_
 library and software abstraction layer, CUB provides:
 
 #. **Simplicity of composition**. CUB enhances programmer productivity by

--- a/docs/libcudacxx/extended_api/execution_model.rst
+++ b/docs/libcudacxx/extended_api/execution_model.rst
@@ -55,7 +55,7 @@ Once a device thread makes progress:
 
 - If it is part of a `Cooperative Grid <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EXECUTION.html#group__CUDART__EXECUTION_1g504b94170f83285c71031be6d5d15f73>`__,
   all device threads in its grid shall eventually make progress.
-- Otherwise, all device threads in its `thread-block cluster <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#thread-block-clusters>`__
+- Otherwise, all device threads in its `thread-block cluster <https://docs.nvidia.com/cuda/cuda-programming-guide/01-introduction/programming-model.html#thread-block-clusters>`__
   shall eventually make progress.
 
     [Note: Threads in other thread-block clusters are not guaranteed to eventually make progress. - end note.]
@@ -248,8 +248,8 @@ Dependencies
 
 A device thread shall not start until all its dependencies have completed.
 
-  [Note: Dependencies that prevent device threads from starting to make progress can be created, for example, via `CUDA Stream Commands <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#streams>`__ .
-  These may include dependencies on the completion of, among others, `CUDA Events <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#events>`__ and `CUDA Kernels <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#kernels>`__ . - end note.]
+  [Note: Dependencies that prevent device threads from starting to make progress can be created, for example, via `CUDA Stream Commands <https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/asynchronous-execution.html#cuda-streams>`__ .
+  These may include dependencies on the completion of, among others, `CUDA Events <https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/asynchronous-execution.html#cuda-events>`__ and `CUDA Kernels <https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/writing-cuda-kernels.html#writing-simt-kernels>`__ . - end note.]
 
 .. dropdown:: Examples of CUDA API forward progress guarantees due to dependencies
 

--- a/docs/libcudacxx/extended_api/mdspan/restrict_accessor.rst
+++ b/docs/libcudacxx/extended_api/mdspan/restrict_accessor.rst
@@ -10,7 +10,7 @@
 
 An alias type to create an accessor with the *restrict aliasing policy* starting from an existing accessor.
 
-More information related to the *restrict aliasing policy* can be found in the CUDA programming guide: `__restrict__ keyword <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#restrict>`_.
+More information related to the *restrict aliasing policy* can be found in the CUDA programming guide: `__restrict__ keyword <https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#restrict-pointers>`_.
 
 ----
 

--- a/docs/libcudacxx/extended_api/memory_access_properties/access_property.rst
+++ b/docs/libcudacxx/extended_api/memory_access_properties/access_property.rst
@@ -186,7 +186,7 @@ Conversion operators
    __host__ __device__ constexpr access_property::streaming::operator  cudaAccessProperty() const noexcept;
    __host__ __device__ constexpr access_property::persisting::operator cudaAccessProperty() const noexcept;
 
-Allows ``constexpr cuda::access_property::normal{}``, ``cuda::access_property::streaming{}``, and ``cuda::access_property::persisting{}`` to be used in lieu of the corresponding CUDA Runtime `cudaAccessProperty <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g4991a8bc9c2356a8da28d093a1da6758>`_. See also `L2 Policy for Persisting Accesses <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#l2-policy-for-persisting-accesses>`_.
+Allows ``constexpr cuda::access_property::normal{}``, ``cuda::access_property::streaming{}``, and ``cuda::access_property::persisting{}`` to be used in lieu of the corresponding CUDA Runtime `cudaAccessProperty <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g4991a8bc9c2356a8da28d093a1da6758>`_. See also `L2 Policy for Persisting Accesses <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/l2-cache-control.html#l2-policy-for-persisting-accesses>`_.
 
 Example
 -------

--- a/docs/libcudacxx/extended_api/memory_model.rst
+++ b/docs/libcudacxx/extended_api/memory_model.rst
@@ -41,7 +41,7 @@ Each program thread is related to each other program thread by one or more threa
    - Each thread in the system is related to each other thread in the system by the *system* thread scope:
      ``thread_scope_system``.
    - Each GPU thread is related to each other GPU thread in the same CUDA device and within the same `memory
-     synchronization domain <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#memory-synchronization-domains>`__
+     synchronization domain <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/memory-sync-domains.html#memory-synchronization-domains>`__
      by the *device* thread scope: ``thread_scope_device``.
    - Each GPU thread is related to each other GPU thread in the same CUDA thread block by the *block* thread scope:
      ``thread_scope_block``.
@@ -61,19 +61,19 @@ An atomic operation is atomic at the scope it specifies if:
    - it specifies a scope other than ``thread_scope_system``, **or**
    - the scope is ``thread_scope_system`` and:
 
-      -  it affects an object in `system allocated memory <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#um-unified-memory-programming-hd>`__ and `pageableMemoryAccess <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1gg49e2f8c2c0bd6fe264f2fc970912e5cddc80992427a92713e699953a6d249d6f>`__ is ``1`` [0],  **or**
+      -  it affects an object in `system allocated memory <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html#unified-memory>`__ and `pageableMemoryAccess <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1gg49e2f8c2c0bd6fe264f2fc970912e5cddc80992427a92713e699953a6d249d6f>`__ is ``1`` [0],  **or**
       -  it affects an object in `managed
-         memory <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#um-unified-memory-programming-hd>`__
+         memory <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html#unified-memory>`__
          and
          `concurrentManagedAccess <https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_116f9619ccc85e93bc456b8c69c80e78b>`__
          is ``1``, **or**
       -  it affects an object in `mapped
-         memory <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#mapped-memory>`__ and
+         memory <https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/understanding-memory.html#mapped-memory>`__ and
          `hostNativeAtomicSupported <https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_1ef82fd7d1d0413c7d6f33287e5b6306f>`__
          is ``1``, **or**
       -  it is a load or store that affects a naturally-aligned object of
          sizes ``1``, ``2``, ``4``, ``8``, or ``16`` bytes on `mapped
-         memory <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#mapped-memory>`__ [1],
+         memory <https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/understanding-memory.html#mapped-memory>`__ [1],
          **or**
       -  it affects an object in GPU memory, only GPU threads access it, and
           - `*val` returned from `cudaDeviceGetP2PAttribute(&val, cudaDevP2PAttrNativeAtomicSupported, srcDev, dstDev) <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g2f597e2acceab33f60bd61c41fea0c1b>`__ between each accessing `srcDev` and the GPU where the object resides, `dstDev`, is ``1``, or
@@ -83,16 +83,16 @@ An atomic operation is atomic at the scope it specifies if:
    - [0] If `PageableMemoryAccessUsesHostPagetables <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1gg49e2f8c2c0bd6fe264f2fc970912e5cdc228cf8983c97d0e035da72a71494eaa>`__ is ``0`` then atomic operations to memory mapped file or ``hugetlbfs`` allocations are not atomic.
    - [1] If `hostNativeAtomicSupported <https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_1ef82fd7d1d0413c7d6f33287e5b6306f>`__ is ``0``, atomic load or store operations at system scope that affect a
      naturally-aligned 16-byte wide object in
-     `unified memory <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#um-unified-memory-programming-hd>`__ or
-     `mapped memory <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#mapped-memory>`__ require system
+     `unified memory <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html#unified-memory>`__ or
+     `mapped memory <https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/understanding-memory.html#mapped-memory>`__ require system
      support. NVIDIA is not aware of any system that lacks this support and there is no CUDA API query available to
      detect such systems.
 
-Refer to the `CUDA programming guide <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html>`__
+Refer to the `CUDA programming guide <https://docs.nvidia.com/cuda/cuda-programming-guide/index.html>`__
 for more information on
-`system allocated memory <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#um-unified-memory-programming-hd>`__,
-`managed memory <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#um-unified-memory-programming-hd>`__,
-`mapped memory <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#mapped-memory>`__,
+`system allocated memory <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html#unified-memory>`__,
+`managed memory <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html#unified-memory>`__,
+`mapped memory <https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/understanding-memory.html#mapped-memory>`__,
 CPU memory, and GPU memory.
 
 Data Races

--- a/docs/libcudacxx/extended_api/memory_resource.rst
+++ b/docs/libcudacxx/extended_api/memory_resource.rst
@@ -64,6 +64,6 @@ adopted through inheritance, it is not properly suited for heterogeneous systems
 With the current design it ranges from cumbersome to impossible to verify whether a memory resource provides allocations
 that are e.g. accessible on device, or whether it can utilize other allocation mechanisms.
 
-To better support asynchronous CUDA `stream-ordered allocations <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#stream-ordered-memory-allocator>`__
+To better support asynchronous CUDA `stream-ordered allocations <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/stream-ordered-memory-allocation.html#stream-ordered-memory-allocator>`__
 libcu++ provides :cpp:class:`cuda::stream_ref <cuda::stream_ref>` as a wrapper around
 ``cudaStream_t``. The definition of ``cuda::stream_ref`` can be found in the ``<cuda/stream>`` header.

--- a/docs/libcudacxx/extended_api/memory_resource/resource.rst
+++ b/docs/libcudacxx/extended_api/memory_resource/resource.rst
@@ -6,7 +6,7 @@ The ``cuda::mr::resource`` and ``cuda::mr::synchronous_resource`` concepts
 
 The `std::pmr::memory_resource <https://en.cppreference.com/w/cpp/header/memory_resource>`__ feature provides only a
 single ``allocate`` interface, which is sufficient for homogeneous memory systems. However, CUDA provides both
-synchronous and `stream-ordered allocation <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#stream-ordered-memory-allocator>`__.
+synchronous and `stream-ordered allocation <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/stream-ordered-memory-allocation.html#stream-ordered-memory-allocator>`__.
 
 With `std::pmr::memory_resource <https://en.cppreference.com/w/cpp/header/memory_resource>`__ there is no way to tell
 whether a memory resource can utilize stream-ordered allocations. Even if the application knows it can, there is no way

--- a/docs/libcudacxx/extended_api/synchronization_primitives/barrier.rst
+++ b/docs/libcudacxx/extended_api/synchronization_primitives/barrier.rst
@@ -94,7 +94,7 @@ regardless of memory characteristics.
 
 Under CUDA Compute Capability 8 (Ampere) or above, when an object of type ``cuda::barrier<thread_scope_block>`` is
 placed in ``__shared__`` memory, the member function ``arrive`` performs a reduction of the arrival count among
-`coalesced threads <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#coalesced-group-cg>`_ followed
+`coalesced threads <https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/device-callable-apis.html#class-coalesced-group>`_ followed
 by the arrival operation in one thread. Programs shall ensure that this transformation would not introduce errors,
 for example relative to the requirements of `thread.barrier.class paragraph 12 <https://eel.is/c++draft/thread.barrier.class#12>`_
 of ISO/IEC IS 14882 (the C++ Standard).
@@ -294,4 +294,4 @@ This example can be found in :ref:`libcudacxx-extended-api-asynchronous-operatio
 .. rubric:: Example: 1D TMA load and store using `cuda::memcpy_async` (sm90+)
 
 This example can be found in the
-`CUDA programming guide <https://docs.nvidia.com/cuda/cuda-c-programming-guide/#using-tma-to-transfer-one-dimensional-arrays>`__.
+`CUDA programming guide <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/async-copies.html#using-tma-to-transfer-one-dimensional-arrays>`__.

--- a/docs/libcudacxx/extended_api/thread_groups.rst
+++ b/docs/libcudacxx/extended_api/thread_groups.rst
@@ -14,7 +14,7 @@ Thread Groups
 
 The *ThreadGroup concept* defines the requirements of a type that represents a group of cooperating threads.
 
-The `CUDA Cooperative Groups Library <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#group-collectives>`_
+The `CUDA Cooperative Groups Library <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/cooperative-groups.html#cooperative-groups>`_
 provides a number of types that satisfy this concept.
 
 Data Members

--- a/docs/libcudacxx/extended_api/tma/make_tma_descriptor.rst
+++ b/docs/libcudacxx/extended_api/tma/make_tma_descriptor.rst
@@ -56,7 +56,7 @@ Defined in the ``<cuda/tma>`` header.
 
     } // namespace cuda
 
-The functions construct a `CUDA Tensor Memory Accelerator (TMA) descriptor <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#using-tma-to-transfer-multi-dimensional-arrays>`__ from a ``DLTensor``. The resulting ``CUtensorMap`` can be bound to TMA-based copy instructions to efficiently stage multi-dimensional tiles in shared memory on Compute Capability 9.0 and newer GPUs.
+The functions construct a `CUDA Tensor Memory Accelerator (TMA) descriptor <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/async-copies.html#using-tma-to-transfer-multi-dimensional-arrays>`__ from a ``DLTensor``. The resulting ``CUtensorMap`` can be bound to TMA-based copy instructions to efficiently stage multi-dimensional tiles in shared memory on Compute Capability 9.0 and newer GPUs.
 
 
 .. note::
@@ -190,7 +190,7 @@ References
 ----------
 
 - `DLPack C API <https://dmlc.github.io/dlpack/latest/c_api.html>`__ documentation.
-- `CUDA Tensor Memory Accelerator (TMA) <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#using-tma-to-transfer-multi-dimensional-arrays>`__ documentation.
+- `CUDA Tensor Memory Accelerator (TMA) <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/async-copies.html#using-tma-to-transfer-multi-dimensional-arrays>`__ documentation.
 - ``cuTensorMapEncodeTiled()`` `CUDA driver API <https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html#group__CUDA__TENSOR__MEMORY_1ga7c7d2aaac9e49294304e755e6f341d7>`__ documentation.
 
 Example

--- a/docs/libcudacxx/extended_api/warp/warp_shuffle.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_shuffle.rst
@@ -144,7 +144,7 @@ The functions allow to exchange data of any data size, including raw arrays, poi
 
 **References**
 
-- `CUDA Warp Shuffle Intrinsics <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#warp-shuffle>`_
+- `CUDA Warp Shuffle Intrinsics <https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#warp-shuffle-functions>`_
 - `PTX Shfl.sync instruction <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-shfl-sync>`_
 
 Example

--- a/docs/libcudacxx/ptx/examples/device_tensormap_initialization.rst
+++ b/docs/libcudacxx/ptx/examples/device_tensormap_initialization.rst
@@ -5,4 +5,4 @@ How to initialize a tensor map on device
 
 How to initialize a tensor map on device is explained in the `CUDA Programming
 Guide
-<https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#encoding-a-tensor-map-on-device>`__.
+<https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/async-copies.html#encoding-a-tensor-map-on-device>`__.

--- a/docs/libcudacxx/ptx/instructions/barrier_cluster.rst
+++ b/docs/libcudacxx/ptx/instructions/barrier_cluster.rst
@@ -9,7 +9,7 @@ barrier.cluster
 Similar functionality is provided through the builtins
 ``__cluster_barrier_arrive(), __cluster_barrier_arrive_relaxed(), __cluster_barrier_wait()``,
 as well as the ``cooperative_groups::cluster_group``
-`API <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#cluster-group>`__.
+`API <https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/device-callable-apis.html#class-cluster-group>`__.
 
 The ``.aligned`` variants of the instructions are not exposed.
 

--- a/docs/libcudacxx/ptx/instructions/mapa.rst
+++ b/docs/libcudacxx/ptx/instructions/mapa.rst
@@ -9,7 +9,7 @@ mapa
 This instruction can `currently not be
 implemented <https://github.com/NVIDIA/cccl/issues/1414>`__ by libcu++.
 The instruction can be accessed through the cooperative groups
-`cluster_group <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#cluster-group>`__
+`cluster_group <https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/device-callable-apis.html#class-cluster-group>`__
 API:
 
 Usage:

--- a/docs/libcudacxx/runtime/buffer.rst
+++ b/docs/libcudacxx/runtime/buffer.rst
@@ -97,7 +97,7 @@ In each case the memory is allocated and initialized in stream order on the prov
    Construction from host iterators or host ranges is stream-ordered: the copy from the source is enqueued on the
    provided stream. The source memory must remain valid until that copy completes on the stream, not just until the
    constructor returns. This follows the same ordering rules as other asynchronous work submitted to a
-   `CUDA stream <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#streams>`__.
+   `CUDA stream <https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/asynchronous-execution.html#cuda-streams>`__.
 
    Avoid returning a buffer constructed from a temporary host source:
 

--- a/libcudacxx/include/cuda/__launch/configuration.h
+++ b/libcudacxx/include/cuda/__launch/configuration.h
@@ -446,7 +446,7 @@ dynamic_shared_memory(::cuda::std::size_t __n, non_portable_t) noexcept
  * This launch option causes the launched grid to be scheduled with the
  * specified priority. More about stream priorities and valid values can be
  * found in the CUDA programming guide `here
- * <https://docs.nvidia.com/cuda/cuda-c-programming-guide/#stream-priorities>`_
+ * <https://docs.nvidia.com/cuda/cuda-programming-guide/03-advanced/advanced-host-programming.html#stream-priorities>`_
  */
 struct launch_priority : public __detail::launch_option
 {

--- a/thrust/thrust/system/cuda/detail/assign_value.h
+++ b/thrust/thrust/system/cuda/detail/assign_value.h
@@ -43,7 +43,8 @@ _CCCL_HOST_DEVICE void assign_value(execution_policy<DerivedPolicy>& exec, Point
 {
   using V1 = thrust::detail::it_value_t<Pointer1>;
   using V2 = thrust::detail::it_value_t<Pointer2>;
-  // Because of https://docs.nvidia.com/cuda/cuda-c-programming-guide/#cuda-arch point 2., if a call from a __host__
+  // Because of https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#cuda-arch
+  // point 2., if a call from a __host__
   // __device__ function leads to the template instantiation of a __global__ function, then this instantiation needs to
   // happen regardless of whether __CUDA_ARCH__ is defined. Therefore, we make the host path visible outside the
   // NV_IF_TARGET switch. See also NVBug 881631.

--- a/thrust/thrust/system/cuda/detail/get_value.h
+++ b/thrust/thrust/system/cuda/detail/get_value.h
@@ -28,7 +28,8 @@ namespace cuda_cub
 template <typename DerivedPolicy, typename Pointer>
 _CCCL_HOST_DEVICE thrust::detail::it_value_t<Pointer> get_value(execution_policy<DerivedPolicy>& exec, Pointer ptr)
 {
-  // Because of https://docs.nvidia.com/cuda/cuda-c-programming-guide/#cuda-arch point 2., if a call from a __host__
+  // Because of https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#cuda-arch
+  // point 2., if a call from a __host__
   // __device__ function leads to the template instantiation of a __global__ function, then this instantiation needs to
   // happen regardless of whether __CUDA_ARCH__ is defined. Therefore, we make the host path visible outside the
   // NV_IF_TARGET switch. See also NVBug 881631.

--- a/thrust/thrust/system/cuda/detail/iter_swap.h
+++ b/thrust/thrust/system/cuda/detail/iter_swap.h
@@ -44,7 +44,8 @@ _CCCL_KERNEL_ATTRIBUTES void iter_swap_kernel(Pointer1 a, Pointer2 b)
 template <typename DerivedPolicy, typename Pointer1, typename Pointer2>
 inline _CCCL_HOST_DEVICE void iter_swap(thrust::cuda::execution_policy<DerivedPolicy>& exec, Pointer1 a, Pointer2 b)
 {
-  // Because of https://docs.nvidia.com/cuda/cuda-c-programming-guide/#cuda-arch point 2., if a call from a __host__
+  // Because of https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#cuda-arch
+  // point 2., if a call from a __host__
   // __device__ function leads to the template instantiation of a __global__ function, then this instantiation needs to
   // happen regardless of whether __CUDA_ARCH__ is defined. Therefore, we make the host path visible outside the
   // NV_IF_TARGET switch. See also NVBug 881631.


### PR DESCRIPTION
Remove/replace all references to the legacy CUDA programming guide and replace them with references to the current CUDA programming guide.