### PR TITLE
[cudax][cuco] Remove noexcept from fixed_capacity_map async APIs that can throw

### DIFF
--- a/cudax/include/cuda/experimental/__cuco/detail/open_addressing/open_addressing_impl.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/open_addressing/open_addressing_impl.cuh
@@ -281,6 +281,7 @@ public:
     __open_addressing::__insert_if_n<__cg_size, detail::__default_block_size>
       <<<static_cast<unsigned>(__grid_size), detail::__default_block_size, 0, __stream.get()>>>(
         __first, __num_keys, __stencil, __pred, __counter.data(), __container_ref);
+    _CCCL_TRY_CUDA_API(::cudaGetLastError, "cuco: failed to insert keys");
 
     return __read_counter(__counter, __stream);
   }
@@ -325,6 +326,7 @@ public:
       __open_addressing::__insert_if_n<__cg_size, detail::__default_block_size>
         <<<static_cast<unsigned>(__grid_size), detail::__default_block_size, 0, __stream.get()>>>(
           __first, __num_keys, __stencil, __pred, __container_ref);
+      _CCCL_TRY_CUDA_API(::cudaGetLastError, "cuco: failed to insert keys");
     }
   }
 
@@ -359,6 +361,7 @@ public:
           ::cuda::std::identity{},
           __output_begin,
           __container_ref);
+      _CCCL_TRY_CUDA_API(::cudaGetLastError, "cuco: failed to query keys");
     }
   }
 
@@ -389,6 +392,7 @@ public:
     __open_addressing::__find_if_n<__cg_size, detail::__default_block_size>
       <<<static_cast<unsigned>(__grid_size), detail::__default_block_size, 0, __stream.get()>>>(
         __first, __num_keys, __stencil, __pred, __output_begin, __container_ref);
+    _CCCL_TRY_CUDA_API(::cudaGetLastError, "cuco: failed to query keys");
   }
 
   //! @brief Asynchronously finds the payloads for keys in `[first, last)`.

--- a/cudax/include/cuda/experimental/__cuco/fixed_capacity_map.cuh
+++ b/cudax/include/cuda/experimental/__cuco/fixed_capacity_map.cuh
@@ -279,7 +279,7 @@ public:
   //! returns zero.
   //!
   //! @param __stream CUDA stream this operation is executed in
-  void clear_async(::cuda::stream_ref __stream) noexcept
+  void clear_async(::cuda::stream_ref __stream)
   {
     __impl->clear_async(__stream);
   }
@@ -315,7 +315,7 @@ public:
   //! @param __first Beginning of the sequence of keys
   //! @param __last End of the sequence of keys
   template <class _InputIt>
-  void insert_async(::cuda::stream_ref __stream, _InputIt __first, _InputIt __last) noexcept
+  void insert_async(::cuda::stream_ref __stream, _InputIt __first, _InputIt __last)
   {
     __impl->insert_async(__stream, __first, __last, ref());
   }
@@ -400,8 +400,7 @@ public:
   //! @param __last End of the sequence of keys
   //! @param __output_begin Beginning of the output sequence of booleans
   template <class _InputIt, class _OutputIt>
-  void contains_async(
-    ::cuda::stream_ref __stream, _InputIt __first, _InputIt __last, _OutputIt __output_begin) const noexcept
+  void contains_async(::cuda::stream_ref __stream, _InputIt __first, _InputIt __last, _OutputIt __output_begin) const
   {
     __impl->contains_async(__stream, __first, __last, __output_begin, ref());
   }
@@ -438,8 +437,7 @@ public:
   //! @param __last End of the sequence of keys
   //! @param __output_begin Beginning of the output sequence of payloads
   template <class _InputIt, class _OutputIt>
-  void
-  find_async(::cuda::stream_ref __stream, _InputIt __first, _InputIt __last, _OutputIt __output_begin) const noexcept
+  void find_async(::cuda::stream_ref __stream, _InputIt __first, _InputIt __last, _OutputIt __output_begin) const
   {
     __impl->find_async(__stream, __first, __last, __output_begin, ref());
   }
@@ -494,7 +492,7 @@ public:
     _InputIt __last,
     _StencilIt __stencil,
     _Predicate __pred,
-    _OutputIt __output_begin) const noexcept
+    _OutputIt __output_begin) const
   {
     __impl->find_if_async(__stream, __first, __last, __stencil, __pred, __output_begin, ref());
   }


### PR DESCRIPTION
## Description

Follow-up to #7705 and https://github.com/NVIDIA/cccl/pull/7705#discussion_r3500676313.

During the review, @davebayer suggested reporting CUDA failures with `_CCCL_THROW(::cuda::cuda_error, ...)` instead of `_CCCL_ASSERT`. That was applied to the `_CCCL_TRY_CUDA_API` call sites in `__open_addressing_impl`, but the cooperative-group paths still launch their kernels without checking the result, and the public `fixed_capacity_map` wrappers kept their `noexcept`. A launch failure is therefore either swallowed silently or, once reported, terminates the process. This PR:

- adds a `_CCCL_TRY_CUDA_API(::cudaGetLastError, ...)` check after each of the four unchecked kernel launches in `__open_addressing_impl`, so the cooperative-group paths report launch failures like the `cg_size == 1` paths already do
- drops `noexcept` from the five `_async` wrappers whose implementations document `@throws cuda_error`, matching `insert_if_async` (#10759) and `contains_if_async` (#10757)

Both parts are needed together: adding the checks alone would turn a silent failure into a hard terminate through the `noexcept` wrappers.

No change on the success path.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
