### PR TITLE
[libcu++] Improve error message when NULL stream is used with no current context

### DIFF
--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -323,11 +323,17 @@ _CCCL_HOST_API inline ::CUcontext __ctxPop()
   return __result;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUcontext __ctxGetCurrent()
+[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
+__ctxGetCurrentNoThrow(::CUcontext& __ctx) noexcept // NOLINT(bugprone-exception-escape)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuCtxGetCurrent);
+  return static_cast<::cudaError_t>(__driver_fn(&__ctx));
+}
+
+[[nodiscard]] _CCCL_HOST_API inline ::CUcontext __ctxGetCurrent()
+{
   ::CUcontext __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get current context", &__result);
+  _CCCL_TRY_CUDA_API(::cuda::__driver::__ctxGetCurrentNoThrow, "Failed to get current context", __result);
   return __result;
 }
 
@@ -339,14 +345,50 @@ _CCCL_HOST_API inline ::CUcontext __ctxPop()
   return __result;
 }
 
+// Best-effort diagnostic probe; do not use this to select or retain a context.
+[[nodiscard]] _CCCL_HOST_API inline bool __has_no_current_context() noexcept
+{
+  ::CUcontext __ctx = nullptr;
+  return ::cuda::__driver::__ctxGetCurrentNoThrow(__ctx) == ::cudaSuccess && __ctx == nullptr;
+}
+
+[[nodiscard]] _CCCL_HOST_API inline bool __is_default_stream_without_current_context(::CUstream __stream) noexcept
+{
+  return (__stream == nullptr || __stream == CU_STREAM_LEGACY || __stream == CU_STREAM_PER_THREAD)
+      && ::cuda::__driver::__has_no_current_context();
+}
+
+#  define _CCCLRT_DEFAULT_STREAM_WITHOUT_CONTEXT_MESSAGE(_MSG) \
+    _MSG ". The NULL/default stream requires a current CUDA context. Set the current device or make a CUDA context " \
+         "current before using the NULL/default stream."
+
+#  define _CCCLRT_STREAM_ERROR_MESSAGE(_STREAM, _MSG) \
+    (::cuda::__driver::__is_default_stream_without_current_context(_STREAM) \
+       ? _CCCLRT_DEFAULT_STREAM_WITHOUT_CONTEXT_MESSAGE(_MSG) \
+       : _MSG)
+
+#  define _CCCLRT_CALL_STREAM_DRIVER_FN(_FN, _DIAGNOSTIC_STREAM, _MSG, ...) \
+    do \
+    { \
+      const ::CUresult __status = _FN(__VA_ARGS__); \
+      if (__status != ::CUDA_SUCCESS) \
+      { \
+        _CCCL_THROW( \
+          ::cuda::cuda_error, \
+          static_cast<::cudaError_t>(__status), \
+          _CCCLRT_STREAM_ERROR_MESSAGE(_DIAGNOSTIC_STREAM, _MSG)); \
+      } \
+    } while (0)
+
 // Memory management
 
 _CCCL_HOST_API inline void
 __memcpyAsync(void* __dst, const void* __src, ::cuda::std::size_t __count, ::CUstream __stream)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemcpyAsync);
-  ::cuda::__driver::__call_driver_fn(
+  _CCCLRT_CALL_STREAM_DRIVER_FN(
     __driver_fn,
+    __stream,
     "Failed to perform a memcpy",
     reinterpret_cast<::CUdeviceptr>(__dst),
     reinterpret_cast<::CUdeviceptr>(__src),
@@ -360,8 +402,9 @@ _CCCL_HOST_API inline void __memcpyAsyncWithAttributes(
 {
   static auto __driver_fn    = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuMemcpyBatchAsync, cuMemcpyBatchAsync, 13, 0);
   ::cuda::std::size_t __zero = 0;
-  ::cuda::__driver::__call_driver_fn(
+  _CCCLRT_CALL_STREAM_DRIVER_FN(
     __driver_fn,
+    __stream,
     "Failed to perform a memcpy with attributes",
     reinterpret_cast<::CUdeviceptr*>(&__dst),
     reinterpret_cast<::CUdeviceptr*>(&__src),
@@ -384,8 +427,9 @@ _CCCL_HOST_API inline void __memcpyBatchAsync(
   ::CUstream __stream)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuMemcpyBatchAsync, cuMemcpyBatchAsync, 13, 0);
-  ::cuda::__driver::__call_driver_fn(
+  _CCCLRT_CALL_STREAM_DRIVER_FN(
     __driver_fn,
+    __stream,
     "Failed to perform a memcpy with attributes",
     reinterpret_cast<::CUdeviceptr*>(__dsts),
     reinterpret_cast<::CUdeviceptr*>(__srcs),
@@ -410,22 +454,40 @@ _CCCL_HOST_API void __memsetAsync(void* __dst, _Tp __value, ::cuda::std::size_t 
   {
     static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemsetD8Async);
     auto __bits             = ::cuda::std::bit_cast<unsigned char>(__value);
-    ::cuda::__driver::__call_driver_fn(
-      __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __bits, __count, __stream);
+    _CCCLRT_CALL_STREAM_DRIVER_FN(
+      __driver_fn,
+      __stream,
+      "Failed to perform a memset",
+      reinterpret_cast<::CUdeviceptr>(__dst),
+      __bits,
+      __count,
+      __stream);
   }
   else if constexpr (sizeof(_Tp) == 2)
   {
     static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemsetD16Async);
     auto __bits             = ::cuda::std::bit_cast<unsigned short>(__value);
-    ::cuda::__driver::__call_driver_fn(
-      __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __bits, __count, __stream);
+    _CCCLRT_CALL_STREAM_DRIVER_FN(
+      __driver_fn,
+      __stream,
+      "Failed to perform a memset",
+      reinterpret_cast<::CUdeviceptr>(__dst),
+      __bits,
+      __count,
+      __stream);
   }
   else if constexpr (sizeof(_Tp) == 4)
   {
     static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemsetD32Async);
     auto __bits             = ::cuda::std::bit_cast<unsigned int>(__value);
-    ::cuda::__driver::__call_driver_fn(
-      __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __bits, __count, __stream);
+    _CCCLRT_CALL_STREAM_DRIVER_FN(
+      __driver_fn,
+      __stream,
+      "Failed to perform a memset",
+      reinterpret_cast<::CUdeviceptr>(__dst),
+      __bits,
+      __count,
+      __stream);
   }
 }
 
@@ -478,8 +540,8 @@ __mallocFromPoolAsync(::cuda::std::size_t __bytes, ::CUmemoryPool __pool, ::CUst
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemAllocFromPoolAsync);
   ::CUdeviceptr __result  = 0;
-  ::cuda::__driver::__call_driver_fn(
-    __driver_fn, "Failed to allocate memory from a memory pool", &__result, __bytes, __pool, __stream);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(
+    __driver_fn, __stream, "Failed to allocate memory from a memory pool", &__result, __bytes, __pool, __stream);
   return __result;
 }
 
@@ -656,7 +718,8 @@ _CCCL_HOST_API inline void
 __streamAddCallback(::CUstream __stream, ::CUstreamCallback __cb, void* __data, unsigned __flags = 0)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamAddCallback);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to add a stream callback", __stream, __cb, __data, __flags);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(
+    __driver_fn, __stream, "Failed to add a stream callback", __stream, __cb, __data, __flags);
 }
 
 [[nodiscard]] _CCCL_HOST_API inline ::CUstream __streamCreateWithPriority(unsigned __flags, int __priority)
@@ -676,18 +739,15 @@ __streamSynchronizeNoThrow(::CUstream __stream) noexcept // NOLINT(bugprone-exce
 
 _CCCL_HOST_API inline void __streamSynchronize(::CUstream __stream)
 {
-  cudaError_t __status = __streamSynchronizeNoThrow(__stream);
-  if (__status != cudaSuccess)
-  {
-    _CCCL_THROW(::cuda::cuda_error, __status, "Failed to synchronize a stream");
-  }
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamSynchronize);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(__driver_fn, __stream, "Failed to synchronize a stream", __stream);
 }
 
 [[nodiscard]] _CCCL_HOST_API inline ::CUcontext __streamGetCtx(::CUstream __stream)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamGetCtx);
   ::CUcontext __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get context from a stream", __stream, &__result);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(__driver_fn, __stream, "Failed to get context from a stream", __stream, &__result);
   return __result;
 }
 
@@ -715,7 +775,8 @@ struct __ctx_from_stream
   ::CUcontext __ctx   = nullptr;
   ::CUgreenCtx __gctx = nullptr;
   __ctx_from_stream __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get context from a stream", __stream, &__ctx, &__gctx);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(
+    __driver_fn, __stream, "Failed to get context from a stream", __stream, &__ctx, &__gctx);
   if (__gctx)
   {
     __result.__ctx_kind_  = __ctx_from_stream::__kind::__green;
@@ -736,7 +797,8 @@ struct __ctx_from_stream
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuStreamGetDevice, cuStreamGetDevice, 12, 8);
   ::CUdevice __result{};
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the device of the stream", __stream, &__result);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(
+    __driver_fn, __stream, "Failed to get the device of the stream", __stream, &__result);
   return __result;
 }
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
@@ -744,8 +806,8 @@ struct __ctx_from_stream
 _CCCL_HOST_API inline void __streamWaitEvent(::CUstream __stream, ::CUevent __evnt)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamWaitEvent);
-  ::cuda::__driver::__call_driver_fn(
-    __driver_fn, "Failed to make a stream wait for an event", __stream, __evnt, ::CU_EVENT_WAIT_DEFAULT);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(
+    __driver_fn, __stream, "Failed to make a stream wait for an event", __stream, __evnt, ::CU_EVENT_WAIT_DEFAULT);
 }
 
 [[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
@@ -755,11 +817,26 @@ __streamQueryNoThrow(::CUstream __stream) noexcept // NOLINT(bugprone-exception-
   return static_cast<::cudaError_t>(__driver_fn(__stream));
 }
 
+[[nodiscard]] _CCCL_HOST_API inline bool __streamQuery(::CUstream __stream)
+{
+  const auto __status = ::cuda::__driver::__streamQueryNoThrow(__stream);
+  switch (__status)
+  {
+    case ::cudaErrorNotReady:
+      return false;
+    case ::cudaSuccess:
+      return true;
+    default:
+      _CCCL_THROW(::cuda::cuda_error, __status, _CCCLRT_STREAM_ERROR_MESSAGE(__stream, "Failed to query stream"));
+  }
+}
+
 [[nodiscard]] _CCCL_HOST_API inline int __streamGetPriority(::CUstream __stream)
 {
   int __priority;
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamGetPriority);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the priority of a stream", __stream, &__priority);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(
+    __driver_fn, __stream, "Failed to get the priority of a stream", __stream, &__priority);
   return __priority;
 }
 
@@ -767,7 +844,7 @@ __streamQueryNoThrow(::CUstream __stream) noexcept // NOLINT(bugprone-exception-
 {
   unsigned long long __id;
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamGetId);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the ID of a stream", __stream, &__id);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(__driver_fn, __stream, "Failed to get the ID of a stream", __stream, &__id);
   return __id;
 }
 
@@ -783,7 +860,8 @@ __streamDestroyNoThrow(::CUstream __stream) noexcept // NOLINT(bugprone-exceptio
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamIsCapturing);
   ::CUstreamCaptureStatus __ret{};
 
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the capture status of a stream", __stream, &__ret);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(
+    __driver_fn, __stream, "Failed to get the capture status of a stream", __stream, &__ret);
   return __ret;
 }
 
@@ -822,7 +900,7 @@ __eventQueryNoThrow(::CUevent __evnt) noexcept // NOLINT(bugprone-exception-esca
 _CCCL_HOST_API inline void __eventRecord(::CUevent __evnt, ::CUstream __stream)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventRecord);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to record an event", __evnt, __stream);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(__driver_fn, __stream, "Failed to record an event", __evnt, __stream);
 }
 
 _CCCL_HOST_API inline void __eventSynchronize(::CUevent __evnt)
@@ -970,14 +1048,15 @@ __functionLoadNoThrow(::CUfunction __kernel) noexcept // NOLINT(bugprone-excepti
 _CCCL_HOST_API inline void __launchHostFunc(::CUstream __stream, ::CUhostFn __fn, void* __data)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLaunchHostFunc);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to launch host function", __stream, __fn, __data);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(__driver_fn, __stream, "Failed to launch host function", __stream, __fn, __data);
 }
 
 _CCCL_HOST_API inline void
 __launchKernel(::CUlaunchConfig& __config, ::CUfunction __kernel, void* __args[], void* __extra[] = nullptr)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLaunchKernelEx);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to launch kernel", &__config, __kernel, __args, __extra);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(
+    __driver_fn, __config.hStream, "Failed to launch kernel", &__config, __kernel, __args, __extra);
 }
 
 // Graph management
@@ -1155,6 +1234,9 @@ __cutensormap_size_bytes(::cuda::std::size_t __num_items, ::CUtensorMapDataType 
 
 #  undef _CCCLRT_GET_DRIVER_FUNCTION
 #  undef _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED
+#  undef _CCCLRT_DEFAULT_STREAM_WITHOUT_CONTEXT_MESSAGE
+#  undef _CCCLRT_STREAM_ERROR_MESSAGE
+#  undef _CCCLRT_CALL_STREAM_DRIVER_FN
 
 _CCCL_END_NAMESPACE_CUDA_DRIVER
 

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -358,26 +358,25 @@ __ctxGetCurrentNoThrow(::CUcontext& __ctx) noexcept // NOLINT(bugprone-exception
       && ::cuda::__driver::__has_no_current_context();
 }
 
-#  define _CCCLRT_DEFAULT_STREAM_WITHOUT_CONTEXT_MESSAGE(_MSG) \
+#  define _CCCLRT_DEFAULT_STREAM_WITHOUT_CONTEXT_MESSAGE(_MSG)                                                       \
     _MSG ". The NULL/default stream requires a current CUDA context. Set the current device or make a CUDA context " \
          "current before using the NULL/default stream."
 
-#  define _CCCLRT_STREAM_ERROR_MESSAGE(_STREAM, _MSG) \
+#  define _CCCLRT_STREAM_ERROR_MESSAGE(_STREAM, _MSG)                       \
     (::cuda::__driver::__is_default_stream_without_current_context(_STREAM) \
-       ? _CCCLRT_DEFAULT_STREAM_WITHOUT_CONTEXT_MESSAGE(_MSG) \
+       ? _CCCLRT_DEFAULT_STREAM_WITHOUT_CONTEXT_MESSAGE(_MSG)               \
        : _MSG)
 
-#  define _CCCLRT_CALL_STREAM_DRIVER_FN(_FN, _DIAGNOSTIC_STREAM, _MSG, ...) \
-    do \
-    { \
-      const ::CUresult __status = _FN(__VA_ARGS__); \
-      if (__status != ::CUDA_SUCCESS) \
-      { \
-        _CCCL_THROW( \
-          ::cuda::cuda_error, \
-          static_cast<::cudaError_t>(__status), \
-          _CCCLRT_STREAM_ERROR_MESSAGE(_DIAGNOSTIC_STREAM, _MSG)); \
-      } \
+#  define _CCCLRT_CALL_STREAM_DRIVER_FN(_FN, _DIAGNOSTIC_STREAM, _MSG, ...)  \
+    do                                                                       \
+    {                                                                        \
+      const ::CUresult __status = _FN(__VA_ARGS__);                          \
+      if (__status != ::CUDA_SUCCESS)                                        \
+      {                                                                      \
+        _CCCL_THROW(::cuda::cuda_error,                                      \
+                    static_cast<::cudaError_t>(__status),                    \
+                    _CCCLRT_STREAM_ERROR_MESSAGE(_DIAGNOSTIC_STREAM, _MSG)); \
+      }                                                                      \
     } while (0)
 
 // Memory management
@@ -775,8 +774,7 @@ struct __ctx_from_stream
   ::CUcontext __ctx   = nullptr;
   ::CUgreenCtx __gctx = nullptr;
   __ctx_from_stream __result;
-  _CCCLRT_CALL_STREAM_DRIVER_FN(
-    __driver_fn, __stream, "Failed to get context from a stream", __stream, &__ctx, &__gctx);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(__driver_fn, __stream, "Failed to get context from a stream", __stream, &__ctx, &__gctx);
   if (__gctx)
   {
     __result.__ctx_kind_  = __ctx_from_stream::__kind::__green;
@@ -797,8 +795,7 @@ struct __ctx_from_stream
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuStreamGetDevice, cuStreamGetDevice, 12, 8);
   ::CUdevice __result{};
-  _CCCLRT_CALL_STREAM_DRIVER_FN(
-    __driver_fn, __stream, "Failed to get the device of the stream", __stream, &__result);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(__driver_fn, __stream, "Failed to get the device of the stream", __stream, &__result);
   return __result;
 }
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
@@ -835,8 +832,7 @@ __streamQueryNoThrow(::CUstream __stream) noexcept // NOLINT(bugprone-exception-
 {
   int __priority;
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamGetPriority);
-  _CCCLRT_CALL_STREAM_DRIVER_FN(
-    __driver_fn, __stream, "Failed to get the priority of a stream", __stream, &__priority);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(__driver_fn, __stream, "Failed to get the priority of a stream", __stream, &__priority);
   return __priority;
 }
 
@@ -860,8 +856,7 @@ __streamDestroyNoThrow(::CUstream __stream) noexcept // NOLINT(bugprone-exceptio
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamIsCapturing);
   ::CUstreamCaptureStatus __ret{};
 
-  _CCCLRT_CALL_STREAM_DRIVER_FN(
-    __driver_fn, __stream, "Failed to get the capture status of a stream", __stream, &__ret);
+  _CCCLRT_CALL_STREAM_DRIVER_FN(__driver_fn, __stream, "Failed to get the capture status of a stream", __stream, &__ret);
   return __ret;
 }
 

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -218,16 +218,7 @@ public:
   //! \return `true` if all operations have completed, or `false` if not.
   [[nodiscard]] _CCCL_HOST_API bool is_done() const
   {
-    const auto __result = ::cuda::__driver::__streamQueryNoThrow(__stream);
-    switch (__result)
-    {
-      case ::cudaErrorNotReady:
-        return false;
-      case ::cudaSuccess:
-        return true;
-      default:
-        _CCCL_THROW(::cuda::cuda_error, __result, "Failed to query stream.");
-    }
+    return ::cuda::__driver::__streamQuery(__stream);
   }
 
   //! @brief Queries if all operations on the wrapped stream have completed.

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -14,6 +14,59 @@
 #include <cuda/stream>
 
 #include <testing.cuh>
+
+#include <catch2/matchers/catch_matchers_exception.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <vector>
+
+#if TEST_HAS_EXCEPTIONS()
+namespace
+{
+class restore_driver_context_stack
+{
+public:
+  restore_driver_context_stack()
+  {
+    while (::cuda::__driver::__ctxGetCurrent() != nullptr)
+    {
+      contexts_.push_back(::cuda::__driver::__ctxPop());
+    }
+  }
+
+  restore_driver_context_stack(restore_driver_context_stack&&)                 = delete;
+  restore_driver_context_stack(const restore_driver_context_stack&)            = delete;
+  restore_driver_context_stack& operator=(restore_driver_context_stack&&)      = delete;
+  restore_driver_context_stack& operator=(const restore_driver_context_stack&) = delete;
+
+  ~restore_driver_context_stack() noexcept(false)
+  {
+    for (auto iter = contexts_.rbegin(); iter != contexts_.rend(); ++iter)
+    {
+      ::cuda::__driver::__ctxPush(*iter);
+    }
+  }
+
+private:
+  std::vector<::CUcontext> contexts_;
+};
+
+[[nodiscard]] auto default_stream_invalid_context_message()
+{
+  return Catch::Matchers::MessageMatches(
+    Catch::Matchers::ContainsSubstring("The NULL/default stream requires a current CUDA context.")
+    && Catch::Matchers::ContainsSubstring("Set the current device or make a CUDA context current"));
+}
+
+void check_default_stream_invalid_context_message(::CUstream native_stream)
+{
+  cuda::stream_ref stream{native_stream};
+
+  REQUIRE_THROWS_MATCHES(stream.sync(), cuda::cuda_error, default_stream_invalid_context_message());
+  REQUIRE_THROWS_MATCHES((void) stream.is_done(), cuda::cuda_error, default_stream_invalid_context_message());
+}
+} // namespace
+#endif // TEST_HAS_EXCEPTIONS()
 
 C2H_CCCLRT_TEST("Can create a stream and launch work into it", "[stream]")
 {
@@ -219,6 +272,18 @@ C2H_CCCLRT_TEST("Stream ID", "[stream]")
     CCCLRT_REQUIRE(ref2.id() == id1);
 #endif // ^^^ !_CCCL_COMPILER(NVHPC, <, 25, 11) ^^^
   }
+}
+
+C2H_CCCLRT_TEST("Default stream diagnostics mention the missing current context", "[stream]")
+{
+#if TEST_HAS_EXCEPTIONS()
+  const restore_driver_context_stack context_stack;
+  CCCLRT_REQUIRE(::cuda::__driver::__ctxGetCurrent() == nullptr);
+
+  check_default_stream_invalid_context_message(nullptr);
+  check_default_stream_invalid_context_message(CU_STREAM_LEGACY);
+  check_default_stream_invalid_context_message(CU_STREAM_PER_THREAD);
+#endif // TEST_HAS_EXCEPTIONS()
 }
 
 C2H_CCCLRT_TEST("Invalid stream", "[stream]")

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
@@ -18,39 +18,9 @@
 #include <catch2/matchers/catch_matchers_exception.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
-#include <vector>
-
 #if TEST_HAS_EXCEPTIONS()
 namespace
 {
-class restore_driver_context_stack
-{
-public:
-  restore_driver_context_stack()
-  {
-    while (::cuda::__driver::__ctxGetCurrent() != nullptr)
-    {
-      contexts_.push_back(::cuda::__driver::__ctxPop());
-    }
-  }
-
-  restore_driver_context_stack(restore_driver_context_stack&&)                 = delete;
-  restore_driver_context_stack(const restore_driver_context_stack&)            = delete;
-  restore_driver_context_stack& operator=(restore_driver_context_stack&&)      = delete;
-  restore_driver_context_stack& operator=(const restore_driver_context_stack&) = delete;
-
-  ~restore_driver_context_stack() noexcept(false)
-  {
-    for (auto iter = contexts_.rbegin(); iter != contexts_.rend(); ++iter)
-    {
-      ::cuda::__driver::__ctxPush(*iter);
-    }
-  }
-
-private:
-  std::vector<::CUcontext> contexts_;
-};
-
 [[nodiscard]] auto default_stream_invalid_context_message()
 {
   return Catch::Matchers::MessageMatches(
@@ -277,7 +247,6 @@ C2H_CCCLRT_TEST("Stream ID", "[stream]")
 C2H_CCCLRT_TEST("Default stream diagnostics mention the missing current context", "[stream]")
 {
 #if TEST_HAS_EXCEPTIONS()
-  const restore_driver_context_stack context_stack;
   CCCLRT_REQUIRE(::cuda::__driver::__ctxGetCurrent() == nullptr);
 
   check_default_stream_invalid_context_message(nullptr);

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
@@ -21,21 +21,24 @@
 #if TEST_HAS_EXCEPTIONS()
 namespace
 {
-[[nodiscard]] auto default_stream_invalid_context_message()
-{
-  return Catch::Matchers::MessageMatches(
-    Catch::Matchers::ContainsSubstring("The NULL/default stream requires a current CUDA context.")
-    && Catch::Matchers::ContainsSubstring("Set the current device or make a CUDA context current"));
-}
+#  define CCCLRT_DEFAULT_STREAM_INVALID_CONTEXT_MATCHER()                                            \
+    Catch::Matchers::MessageMatches(                                                                 \
+      Catch::Matchers::ContainsSubstring("The NULL/default stream requires a current CUDA context.") \
+      && Catch::Matchers::ContainsSubstring("Set the current device or make a CUDA context current"))
+
+#  define CCCLRT_REQUIRE_THROWS_DEFAULT_STREAM_INVALID_CONTEXT(EXPR) \
+    REQUIRE_THROWS_MATCHES(EXPR, cuda::cuda_error, CCCLRT_DEFAULT_STREAM_INVALID_CONTEXT_MATCHER())
 
 void check_default_stream_invalid_context_message(::CUstream native_stream)
 {
   cuda::stream_ref stream{native_stream};
 
-  REQUIRE_THROWS_MATCHES(stream.sync(), cuda::cuda_error, default_stream_invalid_context_message());
-  REQUIRE_THROWS_MATCHES((void) stream.is_done(), cuda::cuda_error, default_stream_invalid_context_message());
+  CCCLRT_REQUIRE_THROWS_DEFAULT_STREAM_INVALID_CONTEXT(stream.sync());
+  CCCLRT_REQUIRE_THROWS_DEFAULT_STREAM_INVALID_CONTEXT((void) stream.is_done());
 }
 } // namespace
+#  undef CCCLRT_REQUIRE_THROWS_DEFAULT_STREAM_INVALID_CONTEXT
+#  undef CCCLRT_DEFAULT_STREAM_INVALID_CONTEXT_MATCHER
 #endif // TEST_HAS_EXCEPTIONS()
 
 C2H_CCCLRT_TEST("Can create a stream and launch work into it", "[stream]")

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
@@ -247,6 +247,7 @@ C2H_CCCLRT_TEST("Stream ID", "[stream]")
 C2H_CCCLRT_TEST("Default stream diagnostics mention the missing current context", "[stream]")
 {
 #if TEST_HAS_EXCEPTIONS()
+  test::empty_driver_stack();
   CCCLRT_REQUIRE(::cuda::__driver::__ctxGetCurrent() == nullptr);
 
   check_default_stream_invalid_context_message(nullptr);


### PR DESCRIPTION
We don't expose NULL stream as first class citizens in CCCL Runtime, but it is still valid to wrap on in `stream_ref` and then pass to an API without a current device/context.
This PR adds extra checks after a failure in stream using APIs to check for this case (NULL stream and no current context). It should fail every time for this reason, since the current context gives NULL stream its meaning. In that case we will use a different exception message that provides a hint to the user what went wrong