### PR TITLE
fix(cub): align temporary vector buffer to VectorT in AgentFind

### DIFF
--- a/cub/cub/agent/agent_find.cuh
+++ b/cub/cub/agent/agent_find.cuh
@@ -93,7 +93,7 @@ struct agent_t
     auto load_ptr = reinterpret_cast<const VectorT*>(d_in + tile_offset + (threadIdx.x * VecSize));
     CacheModifiedInputIterator<LoadModifier, VectorT> d_vec_in(load_ptr);
 
-    alignas(InputT) unsigned char input_bytes[ItemsPerThread * sizeof(InputT)];
+    alignas(VectorT) unsigned char input_bytes[ItemsPerThread * sizeof(InputT)];
     auto* vec_items = reinterpret_cast<VectorT*>(input_bytes);
 
     constexpr int number_of_vectors = ItemsPerThread / VecSize;


### PR DESCRIPTION
## Description

closes #10840

In `cub::DeviceFind::FindIf` (`cub/cub/agent/agent_find.cuh`), the local stack buffer `input_bytes` was declared with `alignas(InputT)`. When `VectorT` requires a stricter alignment than `InputT` (e.g. `InputT = short` requiring 2 bytes vs `VectorT = short4` requiring 8 bytes), writing/reading through `reinterpret_cast<VectorT*>(input_bytes)` caused misaligned memory accesses and undefined behavior (`cudaErrorMisalignedAddress`).

This PR fixes the alignment by declaring `input_bytes` with `alignas(VectorT)`.

## Checklist
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
