### PR TITLE
Simplify AI Slack summary formatting

### DIFF
--- a/.github/actions/ci-failure-analysis/render.py
+++ b/.github/actions/ci-failure-analysis/render.py
@@ -391,11 +391,11 @@ def render_slack_summary_group(index, group):
     job_label = "job" if len(job_ids) == 1 else "jobs"
     return [
         (
-            f"*{index}.* `{sanitize_slack(group['title'], limit=100)}` — "
+            f"*{index}.* {sanitize_slack(group['title'], limit=100)} — "
             f"{len(job_ids)} {job_label}"
         ),
-        f"Root cause: `{sanitize_slack(group['root_cause'], limit=360)}`",
-        f"Next: `{sanitize_slack(group['next_steps'], limit=360)}`",
+        f"*Root cause:* {sanitize_slack(group['root_cause'], limit=360)}",
+        f"*Next:* {sanitize_slack(group['next_steps'], limit=360)}",
     ]
 
 


### PR DESCRIPTION
## Summary

- render failure titles and explanatory prose as regular Slack text
- reserve bold formatting for the Root cause and Next labels

## Why

The current summary wraps each complete field in inline-code formatting, making long failure analyses visually noisy and harder to scan.

## Validation

- rendered a saved real nightly analysis through the updated renderer: 3,467 characters
- `python3 -m py_compile .github/actions/ci-failure-analysis/render.py`
- repository pre-commit hooks
- `git diff --check`