### PR TITLE
[libcudacxx] Do not run constexpr test without __builtin_bit_cast

### DIFF
--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.math/classification.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.math/classification.pass.cpp
@@ -55,9 +55,14 @@ TEST_HOST_DEVICE_FUNC constexpr void test_type()
   Mask inf       = cuda::std::simd::isinf(vec);
   Mask nan       = cuda::std::simd::isnan(vec);
   Mask normal    = cuda::std::simd::isnormal(vec);
-#if !TEST_COMPILER(GCC, <, 8) // GCC 7 does not support constexpr bit_cast used by signbit
-  Mask signs = cuda::std::simd::signbit(vec);
-#endif // !TEST_COMPILER(GCC, <, 8)
+  [[maybe_unused]] Mask signs;
+#if !defined(_CCCL_BUILTIN_BIT_CAST) // constexpr bit_cast used by signbit
+  if (!cuda::std::__cccl_default_is_constant_evaluated())
+#endif // _CCCL_BUILTIN_BIT_CAST
+  {
+    signs = cuda::std::simd::signbit(vec);
+  }
+
   for (int i = 0; i < N; ++i)
   {
     assert(classes[i] == cuda::std::fpclassify(vec[i]));
@@ -65,9 +70,12 @@ TEST_HOST_DEVICE_FUNC constexpr void test_type()
     assert(inf[i] == cuda::std::isinf(vec[i]));
     assert(nan[i] == cuda::std::isnan(vec[i]));
     assert(normal[i] == cuda::std::isnormal(vec[i]));
-#if !TEST_COMPILER(GCC, <, 8)
-    assert(signs[i] == cuda::std::signbit(vec[i]));
-#endif // !TEST_COMPILER(GCC, <, 8)
+#if !defined(_CCCL_BUILTIN_BIT_CAST) // constexpr bit_cast used by signbit
+    if (!cuda::std::__cccl_default_is_constant_evaluated())
+#endif // _CCCL_BUILTIN_BIT_CAST
+    {
+      assert(signs[i] == cuda::std::signbit(vec[i]));
+    }
   }
 }
 


### PR DESCRIPTION
GCC only support `__builtin_bit_cast` from GCC 11 on but the correct check is whether there is the builtin at all