### PR TITLE
Fix deprecated compiler warning

### DIFF
--- a/thrust/testing/CMakeLists.txt
+++ b/thrust/testing/CMakeLists.txt
@@ -163,6 +163,7 @@ endforeach()
 
 # Add specialized tests:
 add_subdirectory(cmake)
+add_subdirectory(config)
 add_subdirectory(cpp)
 add_subdirectory(cuda)
 add_subdirectory(omp)

--- a/thrust/testing/cmake/check_source_files.cmake
+++ b/thrust/testing/cmake/check_source_files.cmake
@@ -171,6 +171,44 @@ foreach (src ${thrust_srcs})
   endif()
 endforeach()
 
+################################################################################
+# Deprecated-compiler warning ordering check in system headers.
+# config.h issues a `_CCCL_WARNING` when the host compiler is below Thrust's
+# minimum version, which expands to a `#pragma GCC/clang warning`. GCC and Clang
+# silently drop diagnostics in files marked as system header.
+# So the deprecated-compiler check must precede the system-header pragma in config.h,
+# or the warning goes silent with no error. See NVIDIA/cccl#1620.
+set(deprecated_compiler_marker "CCCL_IGNORE_DEPRECATED_COMPILER")
+set(system_header_marker "_CCCL_IMPLICIT_SYSTEM_HEADER_GCC")
+set(thrust_config_h "${Thrust_SOURCE_DIR}/thrust/detail/config/config.h")
+
+file(READ "${thrust_config_h}" thrust_config_h_contents)
+string(
+  FIND "${thrust_config_h_contents}"
+  "${deprecated_compiler_marker}"
+  deprecated_compiler_pos
+)
+string(
+  FIND "${thrust_config_h_contents}"
+  "${system_header_marker}"
+  system_header_pos
+)
+
+if (deprecated_compiler_pos EQUAL -1 OR system_header_pos EQUAL -1)
+  message(
+    "'${thrust_config_h}' no longer contains the expected ${deprecated_compiler_marker} (deprecated-compiler) "
+    "or ${system_header_marker} (system-header) macros. Update this check if either moved or was renamed."
+  )
+  set(found_errors 1)
+elseif (NOT deprecated_compiler_pos LESS system_header_pos)
+  message(
+    "'${thrust_config_h}' marks itself a system header before checking for a "
+    "deprecated compiler. GCC/Clang silently drop diagnostics originating "
+    "from system headers, so this ordering must be preserved (see NVIDIA/cccl#1620)."
+  )
+  set(found_errors 1)
+endif()
+
 if (NOT found_errors EQUAL 0)
   message(FATAL_ERROR "Errors detected.")
 endif()

--- a/thrust/testing/cmake/check_source_files.cmake
+++ b/thrust/testing/cmake/check_source_files.cmake
@@ -171,44 +171,6 @@ foreach (src ${thrust_srcs})
   endif()
 endforeach()
 
-################################################################################
-# Deprecated-compiler warning ordering check in system headers.
-# config.h issues a `_CCCL_WARNING` when the host compiler is below Thrust's
-# minimum version, which expands to a `#pragma GCC/clang warning`. GCC and Clang
-# silently drop diagnostics in files marked as system header.
-# So the deprecated-compiler check must precede the system-header pragma in config.h,
-# or the warning goes silent with no error. See NVIDIA/cccl#1620.
-set(deprecated_compiler_marker "CCCL_IGNORE_DEPRECATED_COMPILER")
-set(system_header_marker "_CCCL_IMPLICIT_SYSTEM_HEADER_GCC")
-set(thrust_config_h "${Thrust_SOURCE_DIR}/thrust/detail/config/config.h")
-
-file(READ "${thrust_config_h}" thrust_config_h_contents)
-string(
-  FIND "${thrust_config_h_contents}"
-  "${deprecated_compiler_marker}"
-  deprecated_compiler_pos
-)
-string(
-  FIND "${thrust_config_h_contents}"
-  "${system_header_marker}"
-  system_header_pos
-)
-
-if (deprecated_compiler_pos EQUAL -1 OR system_header_pos EQUAL -1)
-  message(
-    "'${thrust_config_h}' no longer contains the expected ${deprecated_compiler_marker} (deprecated-compiler) "
-    "or ${system_header_marker} (system-header) macros. Update this check if either moved or was renamed."
-  )
-  set(found_errors 1)
-elseif (NOT deprecated_compiler_pos LESS system_header_pos)
-  message(
-    "'${thrust_config_h}' marks itself a system header before checking for a "
-    "deprecated compiler. GCC/Clang silently drop diagnostics originating "
-    "from system headers, so this ordering must be preserved (see NVIDIA/cccl#1620)."
-  )
-  set(found_errors 1)
-endif()
-
 if (NOT found_errors EQUAL 0)
   message(FATAL_ERROR "Errors detected.")
 endif()

--- a/thrust/testing/config/CMakeLists.txt
+++ b/thrust/testing/config/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Compile tests for the deprecated host compiler warning in
+# thrust/detail/config/config.h. See the sources for how and why the compiler
+# detection is faked. See NVIDIA/cccl#1620.
+
+foreach (thrust_target IN LISTS THRUST_TARGETS)
+  thrust_get_target_property(config_device ${thrust_target} DEVICE)
+
+  # The warning is backend independent. Only check it for the CPP device
+  # backend, so that the tests do not require a CUDA compiler.
+  if (NOT config_device STREQUAL "CPP")
+    continue()
+  endif()
+
+  thrust_get_target_property(config_prefix ${thrust_target} PREFIX)
+
+  # The warning has to reach the user. Note that cccl_add_xfail_compile_target_test
+  # picks the target up from the caller's `test_target` variable, so it has to be
+  # named that.
+  set(test_target ${config_prefix}.test.config.deprecated_compiler_warning)
+  cccl_add_executable(
+    ${test_target}
+    SOURCES deprecated_compiler_warning.cpp
+    NO_METATARGETS
+  )
+  target_link_libraries(${test_target} PRIVATE ${thrust_target})
+  cccl_add_xfail_compile_target_test(
+    ${test_target}
+    ERROR_REGEX "Thrust requires at least GCC"
+  )
+
+  # ... and CCCL_IGNORE_DEPRECATED_COMPILER has to silence it again. Warnings
+  # are errors for CCCL targets, so compiling the target is the test.
+  set(
+    suppressed_target
+    ${config_prefix}.test.config.deprecated_compiler_warning_suppressed
+  )
+  cccl_add_executable(
+    ${suppressed_target}
+    SOURCES deprecated_compiler_warning_suppressed.cpp
+  )
+  target_link_libraries(${suppressed_target} PRIVATE ${thrust_target})
+endforeach()

--- a/thrust/testing/config/deprecated_compiler_warning.cpp
+++ b/thrust/testing/config/deprecated_compiler_warning.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Verifies that the deprecated host compiler warning in
+// thrust/detail/config/config.h actually reaches the user.
+//
+// The warning is emitted through `#pragma GCC warning`, which GCC and Clang
+// silently drop from system headers, so config.h has to issue it before marking
+// itself as one. See NVIDIA/cccl#1620.
+//
+// The compiler detection is faked below so that the warning is tested on
+// every configuration, and not only on the deprecated compilers themselves,
+// which CI does not build with.
+
+// CCCL builds its own tests with _CCCL_NO_SYSTEM_HEADER, which prevents its
+// headers from being treated as system headers. Here, we have to drop that again;
+// the warning is only at risk of being dropped when the header is a system header,
+// which is true when the users compile it.
+#undef _CCCL_NO_SYSTEM_HEADER
+
+#include <cuda/__cccl_config>
+
+#undef _CCCL_COMPILER_GCC
+#define _CCCL_COMPILER_GCC() (6, 0)
+
+#include <thrust/detail/config.h>
+
+int main()
+{
+  return 0;
+}

--- a/thrust/testing/config/deprecated_compiler_warning_suppressed.cpp
+++ b/thrust/testing/config/deprecated_compiler_warning_suppressed.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Verifies that CCCL_IGNORE_DEPRECATED_COMPILER silences the deprecated host
+// compiler warning in thrust/detail/config/config.h.
+//
+// The compiler detection is faked below so that the suppression is tested on
+// every configuration, and not only on the deprecated compilers themselves,
+// which CI does not build with. Compiling this file is the test: warnings are
+// errors for CCCL targets, so a warning that escapes the suppression lets the
+// build fail. See NVIDIA/cccl#1620.
+
+#define CCCL_IGNORE_DEPRECATED_COMPILER
+
+// See deprecated_compiler_warning.cpp: CCCL builds its own tests with
+// _CCCL_NO_SYSTEM_HEADER, so drop it again to match how users see the header.
+#undef _CCCL_NO_SYSTEM_HEADER
+
+#include <cuda/__cccl_config>
+
+#undef _CCCL_COMPILER_GCC
+#define _CCCL_COMPILER_GCC() (6, 0)
+
+#include <thrust/detail/config.h>
+
+int main()
+{
+  return 0;
+}

--- a/thrust/thrust/detail/config/config.h
+++ b/thrust/thrust/detail/config/config.h
@@ -10,11 +10,6 @@
 // For _CCCL_IMPLICIT_SYSTEM_HEADER
 #include <cuda/__cccl_config> // IWYU pragma: export
 
-// Deprecation warnings may be silenced by defining the following macro:
-// - CCCL_IGNORE_DEPRECATED_COMPILER
-//   Ignore deprecation warnings when using deprecated compilers.
-//   Compiling with deprecated C++ dialects will still issue warnings.
-//
 // Note: Checks must happen before marking this header and its includes as system
 // headers, otherwise GCC and Clang silently drop diagnostics, including
 // explicit `#pragma GCC warning` originating from system headers.
@@ -26,8 +21,7 @@ _CCCL_WARNING("Thrust requires at least GCC 7.0. Define CCCL_IGNORE_DEPRECATED_C
 _CCCL_WARNING("Thrust requires at least Clang 7.0. Define CCCL_IGNORE_DEPRECATED_COMPILER to suppress this message.")
 #  elif _CCCL_COMPILER(MSVC, <, 19, 10)
 _CCCL_WARNING("Thrust requires at least MSVC 2019(19.20 / 16.0 / 14.20). Define CCCL_IGNORE_DEPRECATED_COMPILER to "
-              "suppress "
-              "this message.")
+              "suppress this message.")
 #  endif
 #endif // CCCL_IGNORE_DEPRECATED_COMPILER
 

--- a/thrust/thrust/detail/config/config.h
+++ b/thrust/thrust/detail/config/config.h
@@ -10,6 +10,27 @@
 // For _CCCL_IMPLICIT_SYSTEM_HEADER
 #include <cuda/__cccl_config> // IWYU pragma: export
 
+// Deprecation warnings may be silenced by defining the following macro:
+// - CCCL_IGNORE_DEPRECATED_COMPILER
+//   Ignore deprecation warnings when using deprecated compilers.
+//   Compiling with deprecated C++ dialects will still issue warnings.
+//
+// Note: Checks must happen before marking this header and its includes as system
+// headers, otherwise GCC and Clang silently drop diagnostics, including
+// explicit `#pragma GCC warning` originating from system headers.
+
+#ifndef CCCL_IGNORE_DEPRECATED_COMPILER
+#  if _CCCL_COMPILER(GCC, <, 7)
+_CCCL_WARNING("Thrust requires at least GCC 7.0. Define CCCL_IGNORE_DEPRECATED_COMPILER to suppress this message.")
+#  elif _CCCL_COMPILER(CLANG, <, 7)
+_CCCL_WARNING("Thrust requires at least Clang 7.0. Define CCCL_IGNORE_DEPRECATED_COMPILER to suppress this message.")
+#  elif _CCCL_COMPILER(MSVC, <, 19, 10)
+_CCCL_WARNING("Thrust requires at least MSVC 2019(19.20 / 16.0 / 14.20). Define CCCL_IGNORE_DEPRECATED_COMPILER to "
+              "suppress "
+              "this message.")
+#  endif
+#endif // CCCL_IGNORE_DEPRECATED_COMPILER
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/thrust/thrust/detail/config/cpp_dialect.h
+++ b/thrust/thrust/detail/config/cpp_dialect.h
@@ -19,41 +19,11 @@
 
 #include <thrust/detail/config/compiler.h> // IWYU pragma: export
 
-// Deprecation warnings may be silenced by defining the following macros. These
-// may be combined.
-// - CCCL_IGNORE_DEPRECATED_COMPILER
-//   Ignore deprecation warnings when using deprecated compilers. Compiling
-//   with deprecated C++ dialects will still issue warnings.
+// Deprecated-compiler warnings live in thrust/detail/config/config.h, which
+// includes this file. These must run before that header marks itself and
+// its includes as system headers, or GCC/Clang silently drop them.
 
 #define THRUST_CPP_DIALECT _CCCL_STD_VER
-
-// Define THRUST_COMPILER_DEPRECATION macro:
-#define THRUST_COMP_DEPR_IMPL(msg) _CCCL_WARNING(#msg)
-
-// Compiler checks:
-// clang-format off
-#define THRUST_COMPILER_DEPRECATION(REQ) \
-  THRUST_COMP_DEPR_IMPL(Thrust requires at least REQ. Define CCCL_IGNORE_DEPRECATED_COMPILER to suppress this message.)
-
-#define THRUST_COMPILER_DEPRECATION_SOFT(REQ, CUR)                                                        \
-  THRUST_COMP_DEPR_IMPL(                                                                                  \
-    Thrust requires at least REQ. CUR is deprecated but still supported. CUR support will be removed in a \
-      future release. Define CCCL_IGNORE_DEPRECATED_COMPILER to suppress this message.)
-// clang-format on
-
-#ifndef CCCL_IGNORE_DEPRECATED_COMPILER
-#  if _CCCL_COMPILER(GCC, <, 7)
-THRUST_COMPILER_DEPRECATION(GCC 7.0);
-#  elif _CCCL_COMPILER(CLANG, <, 7)
-THRUST_COMPILER_DEPRECATION(Clang 7.0);
-#  elif _CCCL_COMPILER(MSVC, <, 19, 10)
-// <2017. Hard upgrade message:
-THRUST_COMPILER_DEPRECATION(MSVC 2019(19.20 / 16.0 / 14.20));
-#  endif
-#endif // CCCL_IGNORE_DEPRECATED_COMPILER
-
-#undef THRUST_COMPILER_DEPRECATION_SOFT
-#undef THRUST_COMPILER_DEPRECATION
 
 // C++17 dialect check:
 #ifndef CCCL_IGNORE_DEPRECATED_CPP_DIALECT
@@ -61,5 +31,3 @@ THRUST_COMPILER_DEPRECATION(MSVC 2019(19.20 / 16.0 / 14.20));
 #    error Thrust requires at least C++17. Define CCCL_IGNORE_DEPRECATED_CPP_DIALECT to suppress this message.
 #  endif // _CCCL_STD_VER < 2017
 #endif
-
-#undef THRUST_COMP_DEPR_IMPL


### PR DESCRIPTION
## Description
closes #1620

The header `thrust/detail/config/config.h` should generate a `_CCCL_WARNING` if the host
compiler is older than the minimum version required by Thrust (GCC<7, Clang<7, MSVC<19.10).
However, it marks itself as a system header before this check is performed. In system headers,
GCC and Clang silently suppress diagnostics, including explicit `#pragma GCC warning` directives. 
So this warning has never actually reached a user, regardless of `CCCL_IGNORE_DEPRECATED_COMPILER`.

@dunga1k58bh has already reproduced this with GCC 14 in the issue thread. 
I verified this with GCC 6.5.0 (via Podman). The warning is indeed missing 
from the current code and is present after this fix.

Two commits:
1. Moves the check for deprecated compilers before the
   system header pragma in `config.h` so that it can actually be triggered.
2. Adds a static check to `check_source_files.cmake` that ensures the 
   order is maintained without requiring an old compiler in CI to detect this. 
   This prevents the change from being silently rolled back, 
   following up on @miscco's and @bernhardmgruber's discussion in the issue

No CUDA toolkit or MSVC available in my environment so I'm 
relying on CI for MSVC and to test beyond what I verified locally.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
