### PR TITLE
[cudax] Expose `implict_hierarchy[_1d]`

### DIFF
--- a/cudax/include/cuda/experimental/__group/fwd.cuh
+++ b/cudax/include/cuda/experimental/__group/fwd.cuh
@@ -46,6 +46,12 @@ using __implicit_hierarchy_t =
             hierarchy_level_desc<cluster_level, ::cuda::std::dims<3, unsigned>>,
             hierarchy_level_desc<block_level, ::cuda::std::dims<3, unsigned>>>;
 
+using __implicit_hierarchy_1d_t =
+  hierarchy<thread_level,
+            hierarchy_level_desc<grid_level, ::cuda::std::extents<unsigned, ::cuda::std::dynamic_extent, 1, 1>>,
+            hierarchy_level_desc<cluster_level, ::cuda::std::extents<unsigned, ::cuda::std::dynamic_extent, 1, 1>>,
+            hierarchy_level_desc<block_level, ::cuda::std::extents<unsigned, ::cuda::std::dynamic_extent, 1, 1>>>;
+
 // groups
 
 template <class _Level, class _Hierarchy>

--- a/cudax/include/cuda/experimental/__group/implicit_hierarchy.cuh
+++ b/cudax/include/cuda/experimental/__group/implicit_hierarchy.cuh
@@ -22,6 +22,8 @@
 #endif // no system header
 
 #include <cuda/hierarchy>
+#include <cuda/std/__fwd/span.h>
+#include <cuda/std/__mdspan/extents.h>
 
 #include <cuda/experimental/__group/fwd.cuh>
 
@@ -31,13 +33,31 @@
 
 namespace cuda::experimental
 {
-[[nodiscard]] _CCCL_DEVICE_API inline __implicit_hierarchy_t __implicit_hierarchy() noexcept
+[[nodiscard]] _CCCL_DEVICE_API inline __implicit_hierarchy_t implicit_hierarchy() noexcept
 {
   return __implicit_hierarchy_t{
     gpu_thread,
     hierarchy_level_desc<grid_level, ::cuda::std::dims<3, unsigned>>{cluster.extents(grid)},
     hierarchy_level_desc<cluster_level, ::cuda::std::dims<3, unsigned>>{block.extents(cluster)},
     hierarchy_level_desc<block_level, ::cuda::std::dims<3, unsigned>>{gpu_thread.extents(block)}};
+}
+
+[[nodiscard]] _CCCL_DEVICE_API inline __implicit_hierarchy_1d_t implicit_hierarchy_1d() noexcept
+{
+  const auto __grid_dims    = cluster.dims(grid);
+  const auto __cluster_dims = block.dims(cluster);
+  const auto __block_dims   = gpu_thread.dims(block);
+
+  _CCCL_ASSERT(__grid_dims.y == 1 && __grid_dims.z == 1, "The launched hierarchy is multidimensional");
+  _CCCL_ASSERT(__cluster_dims.y == 1 && __cluster_dims.z == 1, "The launched hierarchy is multidimensional");
+  _CCCL_ASSERT(__block_dims.y == 1 && __block_dims.z == 1, "The launched hierarchy is multidimensional");
+
+  using _Exts1D = ::cuda::std::extents<unsigned, ::cuda::std::dynamic_extent, 1, 1>;
+  return __implicit_hierarchy_1d_t{
+    gpu_thread,
+    hierarchy_level_desc<grid_level, _Exts1D>{_Exts1D{__grid_dims.x, 1, 1}},
+    hierarchy_level_desc<cluster_level, _Exts1D>{_Exts1D{__cluster_dims.x, 1, 1}},
+    hierarchy_level_desc<block_level, _Exts1D>{_Exts1D{__block_dims.x, 1, 1}}};
 }
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__group/this_group.cuh
+++ b/cudax/include/cuda/experimental/__group/this_group.cuh
@@ -129,10 +129,6 @@ private:
   _SynchronizerInstance __synchronizer_instance_{};
 
 public:
-  _CCCL_DEVICE_API explicit __this_group_base() noexcept
-      : __hier_{::cuda::experimental::__implicit_hierarchy()}
-  {}
-
   _CCCL_TEMPLATE(class _HierarchyLike)
   _CCCL_REQUIRES(::cuda::std::is_same_v<_Hierarchy, __hierarchy_type_of<_HierarchyLike>>)
   _CCCL_DEVICE_API __this_group_base(const _HierarchyLike& __hier_like) noexcept
@@ -252,6 +248,7 @@ public:
 #  if _CCCL_HAS_COOPERATIVE_GROUPS()
   template <class _Parent>
   _CCCL_DEVICE_API this_thread(const ::cooperative_groups::thread_block_tile<1, _Parent>&) noexcept
+      : __base_type{::cuda::experimental::implicit_hierarchy()}
   {}
 #  endif // _CCCL_HAS_COOPERATIVE_GROUPS()
 };
@@ -278,6 +275,7 @@ public:
 #  if _CCCL_HAS_COOPERATIVE_GROUPS()
   template <class _Parent>
   _CCCL_DEVICE_API this_warp(const ::cooperative_groups::thread_block_tile<32, _Parent>&) noexcept
+      : __base_type{::cuda::experimental::implicit_hierarchy()}
   {}
 #  endif // _CCCL_HAS_COOPERATIVE_GROUPS()
 };
@@ -303,7 +301,9 @@ public:
   using __base_type::__base_type;
 
 #  if _CCCL_HAS_COOPERATIVE_GROUPS()
-  _CCCL_DEVICE_API this_block(const ::cooperative_groups::thread_block&) noexcept {}
+  _CCCL_DEVICE_API this_block(const ::cooperative_groups::thread_block&) noexcept
+      : __base_type{::cuda::experimental::implicit_hierarchy()}
+  {}
 #  endif // _CCCL_HAS_COOPERATIVE_GROUPS()
 };
 
@@ -327,7 +327,9 @@ public:
   using __base_type::__base_type;
 
 #  if _CCCL_HAS_COOPERATIVE_GROUPS() && defined(_CG_HAS_CLUSTER_GROUP)
-  _CCCL_DEVICE_API this_cluster(const ::cooperative_groups::cluster_group&) noexcept {}
+  _CCCL_DEVICE_API this_cluster(const ::cooperative_groups::cluster_group&) noexcept
+      : __base_type{::cuda::experimental::implicit_hierarchy()}
+  {}
 #  endif // _CCCL_HAS_COOPERATIVE_GROUPS() && defined(_CG_HAS_CLUSTER_GROUP)
 };
 
@@ -351,7 +353,9 @@ public:
   using __base_type::__base_type;
 
 #  if _CCCL_HAS_COOPERATIVE_GROUPS()
-  _CCCL_DEVICE_API this_grid(const ::cooperative_groups::grid_group&) noexcept {}
+  _CCCL_DEVICE_API this_grid(const ::cooperative_groups::grid_group&) noexcept
+      : __base_type{::cuda::experimental::implicit_hierarchy()}
+  {}
 #  endif // _CCCL_HAS_COOPERATIVE_GROUPS()
 };
 

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -177,6 +177,9 @@ cudax_add_catch2_test(test_target group.group_view
 cudax_add_catch2_test(test_target group.make_this_group
     group/make_this_group.cu
 )
+cudax_add_catch2_test(test_target group.implicit_hierarchy
+    group/implicit_hierarchy.cu
+)
 cudax_add_catch2_test(test_target group.segmented_algorithm
     group/segmented_algorithm.cu
 )

--- a/cudax/test/coop/any_of/this_thread.cu
+++ b/cudax/test/coop/any_of/this_thread.cu
@@ -121,7 +121,7 @@ struct TestKernel
   template <class Config>
   __device__ void operator()(const Config& config)
   {
-    test_group(cudax::this_thread{});
+    test_group(cudax::this_thread{cudax::implicit_hierarchy()});
     test_group(cudax::this_thread{config});
   }
 };

--- a/cudax/test/coop/any_of/this_warp.cu
+++ b/cudax/test/coop/any_of/this_warp.cu
@@ -138,7 +138,7 @@ struct TestKernel
   template <class Config>
   __device__ void operator()(const Config& config)
   {
-    test_group(cudax::this_warp{});
+    test_group(cudax::this_warp{cudax::implicit_hierarchy()});
     test_group(cudax::this_warp{config});
   }
 };

--- a/cudax/test/group/implicit_hierarchy.cu
+++ b/cudax/test/group/implicit_hierarchy.cu
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/std/type_traits>
+#include <cuda/stream>
+
+#include <cuda/experimental/group.cuh>
+
+#include "group_testing.cuh"
+
+template <bool V>
+struct Is1D_t : cuda::std::bool_constant<V>
+{};
+
+struct TestKernel
+{
+  template <bool Is1D>
+  __device__ void operator()(Is1D_t<Is1D>)
+  {
+    // Test implicit_hierarchy()
+    {
+      using Extents3D = cuda::std::dims<3, unsigned>;
+
+      static_assert(
+        cuda::std::is_same_v<decltype(cudax::implicit_hierarchy()),
+                             cuda::hierarchy<cuda::thread_level,
+                                             cuda::hierarchy_level_desc<cuda::grid_level, Extents3D>,
+                                             cuda::hierarchy_level_desc<cuda::cluster_level, Extents3D>,
+                                             cuda::hierarchy_level_desc<cuda::block_level, Extents3D>>>);
+      static_assert(noexcept(cudax::implicit_hierarchy()));
+
+      const auto hier = cudax::implicit_hierarchy();
+      REQUIRE(cuda::gpu_thread.extents(cuda::block) == cuda::gpu_thread.extents(cuda::block, hier));
+      REQUIRE(cuda::block.extents(cuda::cluster) == cuda::block.extents(cuda::cluster, hier));
+      REQUIRE(cuda::cluster.extents(cuda::grid) == cuda::cluster.extents(cuda::grid, hier));
+    }
+
+    // Test implicit_hierarchy_1d()
+    if constexpr (Is1D)
+    {
+      using Extents1D = cuda::std::extents<unsigned, cuda::std::dynamic_extent, 1, 1>;
+
+      static_assert(
+        cuda::std::is_same_v<decltype(cudax::implicit_hierarchy_1d()),
+                             cuda::hierarchy<cuda::thread_level,
+                                             cuda::hierarchy_level_desc<cuda::grid_level, Extents1D>,
+                                             cuda::hierarchy_level_desc<cuda::cluster_level, Extents1D>,
+                                             cuda::hierarchy_level_desc<cuda::block_level, Extents1D>>>);
+      static_assert(noexcept(cudax::implicit_hierarchy_1d()));
+
+      const auto hier = cudax::implicit_hierarchy_1d();
+      REQUIRE(cuda::gpu_thread.extents(cuda::block) == cuda::gpu_thread.extents(cuda::block, hier));
+      REQUIRE(cuda::block.extents(cuda::cluster) == cuda::block.extents(cuda::cluster, hier));
+      REQUIRE(cuda::cluster.extents(cuda::grid) == cuda::cluster.extents(cuda::grid, hier));
+    }
+  }
+};
+
+C2H_TEST("Implicit Hierarchy", "[group][implicit_hierarchy]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  {
+    const auto config =
+      cuda::make_config(cuda::grid_dims<2, 3>(), cuda::block_dims<4, 6>(), cuda::cooperative_launch{});
+    cuda::launch(stream, config, TestKernel{}, Is1D_t<false>{});
+  }
+  {
+    const auto config = cuda::make_config(cuda::grid_dims<2>(), cuda::block_dims<128>(), cuda::cooperative_launch{});
+    cuda::launch(stream, config, TestKernel{}, Is1D_t<true>{});
+  }
+
+  if (cuda::device_attributes::compute_capability(device) >= cuda::compute_capability{90})
+  {
+    {
+      const auto config_cluster = cuda::make_config(
+        cuda::grid_dims<2, 2>(), cuda::cluster_dims<2, 2>(), cuda::block_dims<2, 2>(), cuda::cooperative_launch{});
+      cuda::launch(stream, config_cluster, TestKernel{}, Is1D_t<false>{});
+    }
+    {
+      const auto config_cluster = cuda::make_config(
+        cuda::grid_dims<2>(), cuda::cluster_dims<2>(), cuda::block_dims<2>(), cuda::cooperative_launch{});
+      cuda::launch(stream, config_cluster, TestKernel{}, Is1D_t<true>{});
+    }
+  }
+
+  stream.sync();
+}

--- a/cudax/test/group/make_this_group.cu
+++ b/cudax/test/group/make_this_group.cu
@@ -23,26 +23,13 @@ namespace
 template <template <class> class GroupTempl, class Level, class Config>
 __device__ void test_make_this_group(const Level& level, const Config& config)
 {
-  // Test default construction.
-  {
-    static_assert(
-      cuda::std::is_same_v<GroupTempl<cudax::__implicit_hierarchy_t>, decltype(cudax::make_this_group(level))>);
-    static_assert(noexcept(cudax::make_this_group(level)));
+  using Hierarchy = typename Config::hierarchy_type;
 
-    auto group = cudax::make_this_group(level);
-    group.sync();
-  }
+  static_assert(cuda::std::is_same_v<GroupTempl<Hierarchy>, decltype(cudax::make_this_group(level, config))>);
+  static_assert(noexcept(cudax::make_this_group(level, config)));
 
-  // Test construction from hierarchy-like.
-  {
-    using Hierarchy = typename Config::hierarchy_type;
-
-    static_assert(cuda::std::is_same_v<GroupTempl<Hierarchy>, decltype(cudax::make_this_group(level, config))>);
-    static_assert(noexcept(cudax::make_this_group(level, config)));
-
-    auto group = cudax::make_this_group(level, config);
-    group.sync();
-  }
+  auto group = cudax::make_this_group(level, config);
+  group.sync();
 }
 
 struct TestKernel

--- a/cudax/test/group/this_group.cu
+++ b/cudax/test/group/this_group.cu
@@ -272,33 +272,18 @@ __device__ void test_cg_interop(const Hierarchy& hierarchy)
 template <template <class> class GroupTempl, class Level, class Config>
 __device__ void test_this_group(const Level& level, const Config& config)
 {
-  const auto implicit_hierarchy = cudax::__implicit_hierarchy();
-
-  // Test implicit construction.
-  {
-    GroupTempl group;
-    static_assert(cuda::std::is_same_v<GroupTempl<cudax::__implicit_hierarchy_t>, decltype(group)>);
-    static_assert(cuda::std::is_nothrow_default_constructible_v<decltype(group)>);
-
-    test_common_properties<Level>(implicit_hierarchy, group);
-    test_this_queries(group);
-  }
-
-  // Test construction from kernel_config.
-  {
-    GroupTempl group{config};
-    // nvcc 12.0 doesn't evaluate these static asserts correctly
+  GroupTempl group{config};
+  // nvcc 12.0 doesn't evaluate these static asserts correctly
 #if !_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0)
-    static_assert(cuda::std::is_same_v<GroupTempl<typename Config::hierarchy_type>, decltype(group)>);
-    static_assert(cuda::std::is_nothrow_constructible_v<decltype(group), const typename Config::hierarchy_type&>);
+  static_assert(cuda::std::is_same_v<GroupTempl<typename Config::hierarchy_type>, decltype(group)>);
+  static_assert(cuda::std::is_nothrow_constructible_v<decltype(group), const typename Config::hierarchy_type&>);
 #endif // !_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0)
 
-    test_common_properties<Level>(config.hierarchy(), group);
-    test_this_queries(group);
-  }
+  test_common_properties<Level>(config.hierarchy(), group);
+  test_this_queries(group);
 
   // Test construction from CG equivalents.
-  test_cg_interop<Level>(implicit_hierarchy);
+  test_cg_interop<Level>(cudax::implicit_hierarchy());
 }
 
 struct TestKernel


### PR DESCRIPTION
This PR makes the `implicit_hierarchy` public and adds the `implicit_hierarchy_1d` function for generating dynamic 1D hierarchy. This will be useful for users that don't use `cuda::launch` to use the groups and need to construct the hierarchy themselves on device.

I've also removed the default constructor from `this_meow` groups. User should be aware he is using the dynamic hierarchy and use `implicit_hierarchy_1d` whenever possible to optimize the queries.