### PR TITLE
[c.parallel] Report the faulting address and stack when a test crashes

### DIFF
--- a/c/parallel.v2/test/CMakeLists.txt
+++ b/c/parallel.v2/test/CMakeLists.txt
@@ -17,7 +17,7 @@ function(cccl_c_parallel_v2_add_test target_name_var source)
   )
   set(${target_name_var} ${target_name} PARENT_SCOPE)
 
-  add_executable(${target_name} "${source}")
+  add_executable(${target_name} "${source}" "${v1_test_dir}/support/crash_report.cpp")
   cccl_configure_target(${target_name} DIALECT 20)
 
   set_target_properties(${target_name} PROPERTIES CUDA_RUNTIME_LIBRARY STATIC)
@@ -31,6 +31,14 @@ function(cccl_c_parallel_v2_add_test target_name_var source)
       CUDA::nvrtc
       cccl.c2h.main
   )
+
+  if (WIN32)
+    # crash_report.cpp symbolizes the faulting stack via dbghelp.
+    target_link_libraries(${target_name} PRIVATE dbghelp)
+    # Sources are already compiled with /Z7, but without /DEBUG the linker emits
+    # no PDB and a crash report can only show module+offset. ~19 MB per test.
+    target_link_options(${target_name} PRIVATE /DEBUG)
+  endif()
 
   target_include_directories(
     ${target_name}

--- a/c/parallel.v2/test/CMakeLists.txt
+++ b/c/parallel.v2/test/CMakeLists.txt
@@ -17,7 +17,11 @@ function(cccl_c_parallel_v2_add_test target_name_var source)
   )
   set(${target_name_var} ${target_name} PARENT_SCOPE)
 
-  add_executable(${target_name} "${source}" "${v1_test_dir}/support/crash_report.cpp")
+  add_executable(
+    ${target_name}
+    "${source}"
+    "${v1_test_dir}/support/crash_report.cpp"
+  )
   cccl_configure_target(${target_name} DIALECT 20)
 
   set_target_properties(${target_name} PROPERTIES CUDA_RUNTIME_LIBRARY STATIC)

--- a/c/parallel/test/CMakeLists.txt
+++ b/c/parallel/test/CMakeLists.txt
@@ -16,7 +16,7 @@ function(cccl_c_parallel_add_test target_name_var source)
     ADD_CTEST
     NO_METATARGETS
     DIALECT 20
-    SOURCES "${source}"
+    SOURCES "${source}" "${CMAKE_CURRENT_LIST_DIR}/support/crash_report.cpp"
   )
 
   set_target_properties(${target_name} PROPERTIES CUDA_RUNTIME_LIBRARY STATIC)
@@ -29,6 +29,14 @@ function(cccl_c_parallel_add_test target_name_var source)
       CUDA::nvrtc
       cccl.c2h.main
   )
+
+  if (WIN32)
+    # crash_report.cpp symbolizes the faulting stack via dbghelp.
+    target_link_libraries(${target_name} PRIVATE dbghelp)
+    # Sources are already compiled with /Z7, but without /DEBUG the linker emits
+    # no PDB and a crash report can only show module+offset. ~19 MB per test.
+    target_link_options(${target_name} PRIVATE /DEBUG)
+  endif()
 
   # Get the first CUDA include directory only
   list(GET CUDAToolkit_INCLUDE_DIRS 0 CUDA_FIRST_INCLUDE_DIR)

--- a/c/parallel/test/support/crash_report.cpp
+++ b/c/parallel/test/support/crash_report.cpp
@@ -52,6 +52,14 @@ namespace
 CRITICAL_SECTION g_report_lock;
 LONG g_reported = 0;
 
+// These two have no EXCEPTION_* spelling in winnt.h. ntstatus.h would name them,
+// but including it alongside windows.h requires defining WIN32_NO_STATUS, which
+// suppresses the STATUS_* definitions that the EXCEPTION_* macros above are
+// themselves defined in terms of, and leaves NTSTATUS undeclared. Naming them
+// here is cheaper than that trade.
+constexpr DWORD kStatusStackBufferOverrun = 0xC0000409; // STATUS_STACK_BUFFER_OVERRUN, also __fastfail
+constexpr DWORD kStatusHeapCorruption     = 0xC0000374; // STATUS_HEAP_CORRUPTION
+
 [[nodiscard]] bool is_fatal(DWORD code) noexcept
 {
   switch (code)
@@ -63,8 +71,8 @@ LONG g_reported = 0;
     case EXCEPTION_IN_PAGE_ERROR:
     case EXCEPTION_INT_DIVIDE_BY_ZERO:
     case EXCEPTION_DATATYPE_MISALIGNMENT:
-    case 0xC0000409: // STATUS_STACK_BUFFER_OVERRUN / __fastfail
-    case 0xC0000374: // STATUS_HEAP_CORRUPTION
+    case kStatusStackBufferOverrun:
+    case kStatusHeapCorruption:
       return true;
     default:
       return false;
@@ -184,16 +192,14 @@ LONG CALLBACK crash_handler(EXCEPTION_POINTERS* info) noexcept
   if (record->ExceptionCode == EXCEPTION_STACK_OVERFLOW)
   {
     // Almost no stack remains here, and the faulting thread may be an LLVM
-    // worker with no stack guarantee reserved. Emit one fixed-size message with
-    // a direct WriteFile: no DbgHelp, no CRT buffering, no lock.
-    char message[160];
-    const int length = wsprintfA(
-      message,
-      "\n[cccl-crash] stack overflow at 0x%p on thread %lu (stack walk skipped)\n",
-      record->ExceptionAddress,
-      GetCurrentThreadId());
-    DWORD written = 0;
-    WriteFile(GetStdHandle(STD_ERROR_HANDLE), message, static_cast<DWORD>(length), &written, nullptr);
+    // worker with no stack guarantee reserved. Write a static message straight
+    // through WriteFile: no formatting, no stack buffer, no DbgHelp, no CRT
+    // buffering and no lock, so nothing here can fault again. The faulting
+    // address is deliberately omitted; formatting it would need the stack we
+    // have just run out of, and for a stack overflow it says little anyway.
+    static const char message[] = "\n[cccl-crash] stack overflow (stack walk skipped)\n";
+    DWORD written               = 0;
+    WriteFile(GetStdHandle(STD_ERROR_HANDLE), message, static_cast<DWORD>(sizeof(message) - 1), &written, nullptr);
     return EXCEPTION_CONTINUE_SEARCH;
   }
 

--- a/c/parallel/test/support/crash_report.cpp
+++ b/c/parallel/test/support/crash_report.cpp
@@ -52,7 +52,7 @@ namespace
 CRITICAL_SECTION g_report_lock;
 LONG g_reported = 0;
 
-[[nodiscard]] bool is_fatal(DWORD code)
+[[nodiscard]] bool is_fatal(DWORD code) noexcept
 {
   switch (code)
   {
@@ -73,7 +73,7 @@ LONG g_reported = 0;
 
 //! Module name plus offset, resolved without dbghelp so it still works when no
 //! symbols are available.
-void print_module_offset(void* addr)
+void print_module_offset(void* addr) noexcept
 {
   HMODULE module = nullptr;
   if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
@@ -96,7 +96,7 @@ void print_module_offset(void* addr)
   std::fprintf(stderr, "<unknown module>");
 }
 
-void print_stack(CONTEXT* context)
+void print_stack(CONTEXT* context) noexcept
 {
   const HANDLE process = GetCurrentProcess();
   const HANDLE thread  = GetCurrentThread();
@@ -169,7 +169,7 @@ void print_stack(CONTEXT* context)
   std::fflush(stderr);
 }
 
-LONG CALLBACK crash_handler(EXCEPTION_POINTERS* info)
+LONG CALLBACK crash_handler(EXCEPTION_POINTERS* info) noexcept
 {
   const EXCEPTION_RECORD* const record = info ? info->ExceptionRecord : nullptr;
   if (record == nullptr || !is_fatal(record->ExceptionCode))

--- a/c/parallel/test/support/crash_report.cpp
+++ b/c/parallel/test/support/crash_report.cpp
@@ -1,0 +1,233 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+//! Prints the faulting address and a symbolized stack when a C Parallel test
+//! dies from a native fault.
+//!
+//! Catch2's fatal-signal handler can only report the last *completed*
+//! assertion, so a crash inside a long-running call shows up as
+//!
+//!     test_util.h(706): FAILED:
+//!       {Unknown expression after the reported line}
+//!     due to a fatal error condition:
+//!       SIGSEGV - Segmentation violation signal
+//!
+//! which does not say where the process actually faulted. See NVIDIA/cccl#10802.
+//!
+//! This installs a vectored exception handler that runs before Catch2's filter,
+//! prints the crash location, and then returns EXCEPTION_CONTINUE_SEARCH so that
+//! Catch2 and ctest report exactly as they do today. The output is purely
+//! additive.
+
+#ifdef _WIN32
+
+#  include <cstdio>
+#  include <cstring>
+
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <windows.h>
+// dbghelp.h must follow windows.h.
+#  include <dbghelp.h>
+
+namespace
+{
+// dbghelp is single-threaded; serialize and only let the first faulting thread
+// report, so a secondary fault while unwinding cannot interleave or recurse.
+CRITICAL_SECTION g_report_lock;
+LONG g_reported = 0;
+
+bool is_fatal(DWORD code)
+{
+  switch (code)
+  {
+    case EXCEPTION_ACCESS_VIOLATION:
+    case EXCEPTION_STACK_OVERFLOW:
+    case EXCEPTION_ILLEGAL_INSTRUCTION:
+    case EXCEPTION_PRIV_INSTRUCTION:
+    case EXCEPTION_IN_PAGE_ERROR:
+    case EXCEPTION_INT_DIVIDE_BY_ZERO:
+    case EXCEPTION_DATATYPE_MISALIGNMENT:
+    case 0xC0000409: // STATUS_STACK_BUFFER_OVERRUN / __fastfail
+    case 0xC0000374: // STATUS_HEAP_CORRUPTION
+      return true;
+    default:
+      return false;
+  }
+}
+
+//! Module name plus offset, resolved without dbghelp so it still works when no
+//! symbols are available.
+void print_module_offset(void* addr)
+{
+  HMODULE module = nullptr;
+  if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                         static_cast<LPCSTR>(addr),
+                         &module)
+      && module != nullptr)
+  {
+    char path[MAX_PATH] = {};
+    if (GetModuleFileNameA(module, path, MAX_PATH) != 0)
+    {
+      const char* base = std::strrchr(path, '\\');
+      std::fprintf(
+        stderr,
+        "%s+0x%llx",
+        base ? base + 1 : path,
+        static_cast<unsigned long long>(static_cast<unsigned char*>(addr) - reinterpret_cast<unsigned char*>(module)));
+      return;
+    }
+  }
+  std::fprintf(stderr, "<unknown module>");
+}
+
+void print_stack(CONTEXT* context)
+{
+  const HANDLE process = GetCurrentProcess();
+  const HANDLE thread  = GetCurrentThread();
+
+  // SYMOPT_DEFERRED_LOADS is deliberately not set: it makes SymFromAddr fail to
+  // resolve anything here, which defeats the point of this handler.
+  SymSetOptions(SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_FAIL_CRITICAL_ERRORS | SYMOPT_NO_PROMPTS);
+  if (!SymInitialize(process, nullptr, TRUE))
+  {
+    std::fprintf(stderr, "[cccl-crash]   (SymInitialize failed: %lu; frames show module+offset only)\n", GetLastError());
+  }
+
+  // StackWalk64 mutates the context it is given.
+  CONTEXT walk_context = *context;
+  STACKFRAME64 frame{};
+  frame.AddrPC.Offset    = walk_context.Rip;
+  frame.AddrPC.Mode      = AddrModeFlat;
+  frame.AddrFrame.Offset = walk_context.Rbp;
+  frame.AddrFrame.Mode   = AddrModeFlat;
+  frame.AddrStack.Offset = walk_context.Rsp;
+  frame.AddrStack.Mode   = AddrModeFlat;
+
+  alignas(SYMBOL_INFO) unsigned char symbol_storage[sizeof(SYMBOL_INFO) + 1024] = {};
+  auto* symbol         = reinterpret_cast<SYMBOL_INFO*>(symbol_storage);
+  symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+  symbol->MaxNameLen   = 1024;
+
+  for (int i = 0; i < 64; ++i)
+  {
+    if (!StackWalk64(
+          IMAGE_FILE_MACHINE_AMD64,
+          process,
+          thread,
+          &frame,
+          &walk_context,
+          nullptr,
+          SymFunctionTableAccess64,
+          SymGetModuleBase64,
+          nullptr)
+        || frame.AddrPC.Offset == 0)
+    {
+      break;
+    }
+
+    auto* pc = reinterpret_cast<void*>(frame.AddrPC.Offset);
+    std::fprintf(stderr, "[cccl-crash]   %2d  ", i);
+    print_module_offset(pc);
+
+    DWORD64 displacement = 0;
+    if (SymFromAddr(process, frame.AddrPC.Offset, &displacement, symbol))
+    {
+      std::fprintf(stderr, "  %s+0x%llx", symbol->Name, static_cast<unsigned long long>(displacement));
+    }
+
+    IMAGEHLP_LINE64 line{};
+    line.SizeOfStruct       = sizeof(line);
+    DWORD line_displacement = 0;
+    if (SymGetLineFromAddr64(process, frame.AddrPC.Offset, &line_displacement, &line))
+    {
+      std::fprintf(stderr, "  [%s:%lu]", line.FileName, line.LineNumber);
+    }
+    std::fprintf(stderr, "\n");
+  }
+  std::fflush(stderr);
+}
+
+LONG CALLBACK crash_handler(EXCEPTION_POINTERS* info)
+{
+  const EXCEPTION_RECORD* record = info ? info->ExceptionRecord : nullptr;
+  if (record == nullptr || !is_fatal(record->ExceptionCode))
+  {
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+  if (InterlockedCompareExchange(&g_reported, 1, 0) != 0)
+  {
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+
+  EnterCriticalSection(&g_report_lock);
+
+  std::fprintf(stderr, "\n[cccl-crash] ===== native fault, see NVIDIA/cccl#10802 =====\n");
+  std::fprintf(stderr,
+               "[cccl-crash] code=0x%08lX  address=0x%p  thread=%lu\n",
+               record->ExceptionCode,
+               record->ExceptionAddress,
+               GetCurrentThreadId());
+
+  std::fprintf(stderr, "[cccl-crash] faulting site: ");
+  print_module_offset(record->ExceptionAddress);
+  std::fprintf(stderr, "\n");
+
+  if (record->ExceptionCode == EXCEPTION_ACCESS_VIOLATION && record->NumberParameters >= 2)
+  {
+    const ULONG_PTR operation = record->ExceptionInformation[0];
+    std::fprintf(
+      stderr,
+      "[cccl-crash] %s address 0x%llx\n",
+      operation == 0   ? "read from"
+      : operation == 1 ? "write to"
+                       : "execute at",
+      static_cast<unsigned long long>(record->ExceptionInformation[1]));
+  }
+
+  if (record->ExceptionCode == EXCEPTION_STACK_OVERFLOW)
+  {
+    // Walking the stack needs stack we do not have here.
+    std::fprintf(stderr, "[cccl-crash] stack overflow: skipping stack walk\n");
+  }
+  else if (info->ContextRecord != nullptr)
+  {
+    std::fprintf(stderr, "[cccl-crash] stack:\n");
+    print_stack(info->ContextRecord);
+  }
+
+  std::fprintf(stderr, "[cccl-crash] ===== end =====\n");
+  std::fflush(stderr);
+
+  LeaveCriticalSection(&g_report_lock);
+
+  // Let Catch2 and ctest report exactly as before; this output is additive.
+  return EXCEPTION_CONTINUE_SEARCH;
+}
+
+struct crash_handler_installer
+{
+  crash_handler_installer()
+  {
+    InitializeCriticalSection(&g_report_lock);
+    // First in the vectored chain, so the report is produced before Catch2's
+    // fatal-condition handler unwinds the state we want to see.
+    AddVectoredExceptionHandler(1, crash_handler);
+  }
+};
+
+const crash_handler_installer g_installer{};
+} // namespace
+
+#endif // _WIN32

--- a/c/parallel/test/support/crash_report.cpp
+++ b/c/parallel/test/support/crash_report.cpp
@@ -26,7 +26,11 @@
 //! Catch2 and ctest report exactly as they do today. The output is purely
 //! additive.
 
-#ifdef _WIN32
+// _WIN32 is also defined for Windows on ARM64, where CONTEXT exposes Pc/Sp/Fp
+// instead of Rip/Rsp/Rbp and StackWalk64 needs IMAGE_FILE_MACHINE_ARM64. The
+// supported Windows configuration is x64, so restrict this to x64 rather than
+// carry an untested second stack walker.
+#if defined(_WIN32) && (defined(_M_X64) || defined(_M_AMD64))
 
 #  include <cstdio>
 #  include <cstring>
@@ -48,7 +52,7 @@ namespace
 CRITICAL_SECTION g_report_lock;
 LONG g_reported = 0;
 
-bool is_fatal(DWORD code)
+[[nodiscard]] bool is_fatal(DWORD code)
 {
   switch (code)
   {
@@ -80,7 +84,7 @@ void print_module_offset(void* addr)
     char path[MAX_PATH] = {};
     if (GetModuleFileNameA(module, path, MAX_PATH) != 0)
     {
-      const char* base = std::strrchr(path, '\\');
+      const char* const base = std::strrchr(path, '\\');
       std::fprintf(
         stderr,
         "%s+0x%llx",
@@ -102,7 +106,13 @@ void print_stack(CONTEXT* context)
   SymSetOptions(SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_FAIL_CRITICAL_ERRORS | SYMOPT_NO_PROMPTS);
   if (!SymInitialize(process, nullptr, TRUE))
   {
-    std::fprintf(stderr, "[cccl-crash]   (SymInitialize failed: %lu; frames show module+offset only)\n", GetLastError());
+    // Another component in this process -- LLVM inside libnvcc also uses
+    // DbgHelp -- may already own the session. Reuse it, but pick up anything
+    // loaded since it was created.
+    if (!SymRefreshModuleList(process))
+    {
+      std::fprintf(stderr, "[cccl-crash]   (no DbgHelp session: %lu; frames show module+offset only)\n", GetLastError());
+    }
   }
 
   // StackWalk64 mutates the context it is given.
@@ -116,7 +126,7 @@ void print_stack(CONTEXT* context)
   frame.AddrStack.Mode   = AddrModeFlat;
 
   alignas(SYMBOL_INFO) unsigned char symbol_storage[sizeof(SYMBOL_INFO) + 1024] = {};
-  auto* symbol         = reinterpret_cast<SYMBOL_INFO*>(symbol_storage);
+  auto* const symbol   = reinterpret_cast<SYMBOL_INFO*>(symbol_storage);
   symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
   symbol->MaxNameLen   = 1024;
 
@@ -137,7 +147,7 @@ void print_stack(CONTEXT* context)
       break;
     }
 
-    auto* pc = reinterpret_cast<void*>(frame.AddrPC.Offset);
+    auto* const pc = reinterpret_cast<void*>(frame.AddrPC.Offset);
     std::fprintf(stderr, "[cccl-crash]   %2d  ", i);
     print_module_offset(pc);
 
@@ -161,13 +171,29 @@ void print_stack(CONTEXT* context)
 
 LONG CALLBACK crash_handler(EXCEPTION_POINTERS* info)
 {
-  const EXCEPTION_RECORD* record = info ? info->ExceptionRecord : nullptr;
+  const EXCEPTION_RECORD* const record = info ? info->ExceptionRecord : nullptr;
   if (record == nullptr || !is_fatal(record->ExceptionCode))
   {
     return EXCEPTION_CONTINUE_SEARCH;
   }
   if (InterlockedCompareExchange(&g_reported, 1, 0) != 0)
   {
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+
+  if (record->ExceptionCode == EXCEPTION_STACK_OVERFLOW)
+  {
+    // Almost no stack remains here, and the faulting thread may be an LLVM
+    // worker with no stack guarantee reserved. Emit one fixed-size message with
+    // a direct WriteFile: no DbgHelp, no CRT buffering, no lock.
+    char message[160];
+    const int length = wsprintfA(
+      message,
+      "\n[cccl-crash] stack overflow at 0x%p on thread %lu (stack walk skipped)\n",
+      record->ExceptionAddress,
+      GetCurrentThreadId());
+    DWORD written = 0;
+    WriteFile(GetStdHandle(STD_ERROR_HANDLE), message, static_cast<DWORD>(length), &written, nullptr);
     return EXCEPTION_CONTINUE_SEARCH;
   }
 
@@ -196,12 +222,7 @@ LONG CALLBACK crash_handler(EXCEPTION_POINTERS* info)
       static_cast<unsigned long long>(record->ExceptionInformation[1]));
   }
 
-  if (record->ExceptionCode == EXCEPTION_STACK_OVERFLOW)
-  {
-    // Walking the stack needs stack we do not have here.
-    std::fprintf(stderr, "[cccl-crash] stack overflow: skipping stack walk\n");
-  }
-  else if (info->ContextRecord != nullptr)
+  if (info->ContextRecord != nullptr)
   {
     std::fprintf(stderr, "[cccl-crash] stack:\n");
     print_stack(info->ContextRecord);
@@ -230,4 +251,4 @@ struct crash_handler_installer
 const crash_handler_installer g_installer{};
 } // namespace
 
-#endif // _WIN32
+#endif // defined(_WIN32) && (defined(_M_X64) || defined(_M_AMD64))


### PR DESCRIPTION
## Problem

When a C Parallel test dies from a native fault, this is the entirety of what CI tells us:

```
C:\cccl\c\parallel\test\test_util.h(706): FAILED:
  {Unknown expression after the reported line}
due to a fatal error condition:
  SIGSEGV - Segmentation violation signal
```

Catch2's fatal-signal handler can only name the last *completed* assertion, so a crash inside a long-running call points at whatever ran before it. For #10802 that is a `pointer_t` constructor, while the fault is actually somewhere inside `cccl_device_*_build`. There is no faulting address, no module, no stack.

## Change

Install a vectored exception handler in the C Parallel test executables. On a fatal exception it prints the code, the faulting address, the module + offset, the accessed address for access violations, and a symbolized stack.

It runs **before** Catch2's filter and returns `EXCEPTION_CONTINUE_SEARCH`, so Catch2 and ctest report exactly as they do today. The output is purely additive. Only fatal codes are considered, and only the first faulting thread reports, so passing runs are untouched.

Example, from a deliberate null dereference:

```
[cccl-crash] ===== native fault, see NVIDIA/cccl#10802 =====
[cccl-crash] code=0xC0000005  address=0x00007FF6BF5C0F77  thread=53516
[cccl-crash] faulting site: cccl.c.parallel.v2.test.crashselftest.exe+0x10f77
[cccl-crash] read from address 0x0
[cccl-crash] stack:
[cccl-crash]    0  ...+0x10f77  CATCH2_INTERNAL_TEMPLATE_TEST_0<...>::test+0x87  [test_crashselftest.cpp:27]
[cccl-crash]    1  ...+0x108c7  Catch::TestInvokerAsMethod<...>::invoke+0xd7    [catch_test_registry.hpp:40]
[cccl-crash]    2  ...+0x8a763  Catch::RunContext::runCurrentTest+0x213         [catch_run_context.cpp:692]
[cccl-crash]    6  ...+0xabea   main+0x26a                                      [c2h/catch2_main.h:47]
[cccl-crash] ===== end =====
```

## The PDB situation

Worth flagging separately: the sources are compiled with `/Z7`, but the link never passed `/DEBUG`, so **no PDBs were being produced at all**. Symbolization could only resolve exported symbols — and a debugger attached to a CI crash today would be equally blind.

This passes `/DEBUG` for the test executables. Measured costs:

| | PDB |
|---|---|
| per test executable | ~19 MB |
| `libnvcc.dll` | **~727 MB** |

`libnvcc` is deliberately left alone — it statically links LLVM, clang and LLD, and 727 MB on every CI run is a lot to ask. A fault inside it still reports `libnvcc.dll+0xOFFSET` together with a symbolized caller chain, which is enough to identify the component and offset. Happy to enable it there too if maintainers would rather have the symbols.

## Scope

**This is diagnostics only — it does not fix #10802.** I was unable to reproduce that crash (~53k builds on the CI toolchain inside the CI container); details and measurements are in [this comment](https://github.com/NVIDIA/cccl/issues/10802#issuecomment-5347330165). The intent here is that the next occurrence produces something actionable instead of `{Unknown expression after the reported line}`.

Applies to both the v1 and v2 test targets, since they share sources. No-op on non-Windows.

## Testing

In the CI container image `rapidsai/devcontainers:26.08-cuda13.3-cl14.50` (CUDA 13.3.33 / MSVC 14.50), the same image as the failing lane:

- a deliberate null dereference produces the symbolized stack above, and Catch2 still reports the failure exactly as before
- full suite: `100% tests passed, 0 tests failed out of 21`
- zero `[cccl-crash]` output across the entire passing suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)