### PR TITLE
Add cuda::__call_once now that the paradigm is used quite often

### DIFF
--- a/cub/cub/util_allocator.cuh
+++ b/cub/cub/util_allocator.cuh
@@ -30,9 +30,9 @@
 #include <cub/util_namespace.cuh>
 
 #include <cuda/std/__host_stdlib/math.h>
+#include <cuda/std/__host_stdlib/mutex>
 
 #include <map>
-#include <mutex>
 #include <set>
 
 CUB_NAMESPACE_BEGIN

--- a/libcudacxx/include/cuda/__device/physical_device.h
+++ b/libcudacxx/include/cuda/__device/physical_device.h
@@ -27,6 +27,7 @@
 #  include <cuda/__device/logical_device.h>
 #  include <cuda/__driver/driver_api.h>
 #  include <cuda/__fwd/devices.h>
+#  include <cuda/__utility/call_once.h>
 #  include <cuda/std/__concepts/constructible.h>
 #  include <cuda/std/__cstddef/byte.h>
 #  include <cuda/std/__cstddef/types.h>
@@ -35,10 +36,6 @@
 #  include <cuda/std/__utility/move.h>
 #  include <cuda/std/span>
 #  include <cuda/std/string_view>
-
-#  if _CCCL_HOSTED()
-#    include <mutex>
-#  endif // _CCCL_HOSTED()
 
 #  include <cuda/std/__cccl/prologue.h>
 
@@ -103,30 +100,22 @@ class __physical_device
 
   ::CUdevice __device_{};
 
-#  if _CCCL_HOSTED()
-  ::std::once_flag __primary_ctx_once_flag_{};
-#  endif // _CCCL_HOSTED()
+  __once_flag __primary_ctx_once_flag_{};
   ::CUcontext __primary_ctx_{};
 
   static constexpr ::cuda::std::size_t __max_name_length{256};
-#  if _CCCL_HOSTED()
-  ::std::once_flag __name_once_flag_{};
-#  endif // _CCCL_HOSTED()
+  __once_flag __name_once_flag_{};
   char __name_[__max_name_length]{};
   ::cuda::std::size_t __name_length_{};
 
-#  if _CCCL_HOSTED()
-  ::std::once_flag __peers_once_flag_{};
-#  endif // _CCCL_HOSTED()
+  __once_flag __peers_once_flag_{};
   ::cuda::std::unique_ptr<device_ref[]> __peers_{};
   ::cuda::std::size_t __num_peers_{};
 
-#  if _CCCL_HOSTED()
-  ::std::once_flag __locality_domains_once_flag_{};
-#  endif // _CCCL_HOSTED()
+  __once_flag __locality_domains_once_flag_{};
   __raw_storage_array<__logical_device> __locality_domains_{};
   __raw_storage_array<__logical_device_ref> __locality_domain_refs_{};
-  ::cuda::std::size_t __num_domains_{static_cast<::cuda::std::size_t>(-1)};
+  ::cuda::std::size_t __num_domains_{};
 
   _CCCL_HOST_API void __set_name()
   {
@@ -246,7 +235,7 @@ class __physical_device
     // interesting in a destructor
     __locality_domain_refs_.reset();
     __locality_domains_.reset();
-    __num_domains_ = static_cast<::cuda::std::size_t>(-1);
+    __num_domains_ = 0;
 
     __set_locality_domains_impl();
   }
@@ -267,62 +256,37 @@ public:
   //! @return A reference to the primary context for this device.
   [[nodiscard]] _CCCL_HOST_API ::CUcontext __primary_context()
   {
-#  if _CCCL_HOSTED()
-    ::std::call_once(__primary_ctx_once_flag_, [this]() {
+    ::cuda::__call_once(__primary_ctx_once_flag_, [this]() {
       __primary_ctx_ = ::cuda::__driver::__primaryCtxRetain(__device_);
     });
-#  else // ^^^ _CCCL_HOSTED() ^^^ / vvv _CCCL_FREESTANDING() vvv
-    if (!__primary_ctx_)
-    {
-      __primary_ctx_ = ::cuda::__driver::__primaryCtxRetain(__device_);
-    }
-#  endif // _CCCL_FREESTANDING()
+
     return __primary_ctx_;
   }
 
   [[nodiscard]] _CCCL_HOST_API ::cuda::std::string_view __name()
   {
-#  if _CCCL_HOSTED()
-    ::std::call_once(__name_once_flag_, [this]() {
+    ::cuda::__call_once(__name_once_flag_, [this]() {
       this->__set_name();
     });
-#  else // ^^^ _CCCL_HOSTED() ^^^ / vvv _CCCL_FREESTANDING() vvv
-    if (__name_length_ != 0)
-    {
-      this->__set_name();
-    }
-#  endif // _CCCL_FREESTANDING()
+
     return ::cuda::std::string_view{__name_, __name_length_};
   }
 
   [[nodiscard]] _CCCL_HOST_API ::cuda::std::span<const device_ref> __peers()
   {
-#  if _CCCL_HOSTED()
-    ::std::call_once(__peers_once_flag_, [this]() {
+    ::cuda::__call_once(__peers_once_flag_, [this]() {
       this->__set_peers();
     });
-#  else // ^^^ _CCCL_HOSTED() ^^^ / vvv _CCCL_FREESTANDING() vvv
-    if (!__peers_)
-    {
-      this->__set_peers();
-    }
-#  endif //  _CCCL_FREESTANDING()
+
     return ::cuda::std::span<const device_ref>{__peers_.get(), __num_peers_};
   }
 
   [[nodiscard]] _CCCL_HOST_API ::cuda::std::span<const __logical_device_ref> __locality_domains()
   {
-#  if _CCCL_HOSTED()
-    ::std::call_once(__locality_domains_once_flag_, [this]() {
+    ::cuda::__call_once(__locality_domains_once_flag_, [this]() {
       this->__set_locality_domains();
     });
-#  else // ^^^ _CCCL_HOSTED() ^^^ / vvv _CCCL_FREESTANDING() vvv
-    // `__num_domains_` holds `-1` until the domains are computed, so this runs exactly once.
-    if (__num_domains_ == static_cast<::cuda::std::size_t>(-1))
-    {
-      this->__set_locality_domains();
-    }
-#  endif //  _CCCL_FREESTANDING()
+
     return ::cuda::std::span<const __logical_device_ref>{__locality_domain_refs_.get(), __num_domains_};
   }
 };

--- a/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
@@ -28,15 +28,12 @@
 #  include <cuda/__memory_resource/memory_resource_base.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/__runtime/api_wrapper.h>
+#  include <cuda/__utility/call_once.h>
 #  include <cuda/__utility/no_init.h>
 #  include <cuda/std/__concepts/concept_macros.h>
 #  include <cuda/std/__memory/construct_at.h>
 #  include <cuda/std/__memory/unique_ptr.h>
 #  include <cuda/std/__type_traits/is_trivially_destructible.h>
-
-#  if _CCCL_HOSTED()
-#    include <mutex>
-#  endif // _CCCL_HOSTED()
 
 #  include <cuda/std/__cccl/prologue.h>
 
@@ -95,11 +92,7 @@ public:
 
 struct __default_device_memory_pool
 {
-#  if _CCCL_HOSTED()
-  ::std::once_flag __once_{};
-#  else // ^^^ _CCCL_HOSTED() ^^^ / vvv _CCCL_FREESTANDING() vvv
-  bool __initialized_{false};
-#  endif // _CCCL_FREESTANDING()
+  __once_flag __once_{};
 
   union __storage_t
   {
@@ -117,23 +110,14 @@ struct __default_device_memory_pool
       &__storage_.__pool_,
       ::cuda::__get_default_memory_pool(
         ::CUmemLocation{::CU_MEM_LOCATION_TYPE_DEVICE, __device.get()}, ::CU_MEM_ALLOCATION_TYPE_PINNED));
-#  if !_CCCL_HOSTED()
-    __initialized_ = true;
-#  endif // !_CCCL_HOSTED()
   }
 
   [[nodiscard]] _CCCL_HOST_API device_memory_pool_ref& __get(::cuda::device_ref __device)
   {
-#  if _CCCL_HOSTED()
-    ::std::call_once(__once_, [this, __device]() {
+    ::cuda::__call_once(__once_, [this, __device]() {
       this->__init(__device);
     });
-#  else // ^^^ _CCCL_HOSTED() ^^^ / vvv _CCCL_FREESTANDING() vvv
-    if (!__initialized_)
-    {
-      this->__init(__device);
-    }
-#  endif // _CCCL_FREESTANDING()
+
     return __storage_.__pool_;
   }
 };

--- a/libcudacxx/include/cuda/__utility/call_once.h
+++ b/libcudacxx/include/cuda/__utility/call_once.h
@@ -62,6 +62,7 @@ _CCCL_HOST_API void __call_once(__once_flag& __flag, _Fn&& __fn, _Args&&... __ar
     __flag.__state_ = 1;
   }
 }
+
 #endif // ^^^ _CCCL_FREESTANDING() ^^^
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__utility/call_once.h
+++ b/libcudacxx/include/cuda/__utility/call_once.h
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___UTILITY_CALL_ONCE_H
+#define _CUDA___UTILITY_CALL_ONCE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__host_stdlib/mutex>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/cstdint>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+#if _CCCL_HOSTED()
+
+using __once_flag = ::std::once_flag;
+
+template <class _Fn, class... _Args>
+_CCCL_HOST_API void __call_once(__once_flag& __flag, _Fn&& __fn, _Args&&... __args)
+{
+  ::std::call_once(__flag, ::cuda::std::forward<_Fn>(__fn), ::cuda::std::forward<_Args>(__args)...);
+}
+
+#else // ^^^ _CCCL_HOSTED() ^^^ / vvv _CCCL_FREESTANDING() vvv
+
+// Needs to be a struct with default value so that `__once_flag flag` correctly initializes the
+// state to 0.
+struct __once_flag
+{
+  // uint32_t instead of bool is deliberate:
+  //
+  // 1. If we ever want to implement a real call_once then we will need 3 states
+  //    (uninitialized, in progress, complete).
+  // 2. Atomic access to uint32_t is lock-free on the overwhelming majority of platforms.
+  ::cuda::std::uint32_t __state_{};
+};
+
+template <class _Fn, class... _Args>
+_CCCL_HOST_API void __call_once(__once_flag& __flag, _Fn&& __fn, _Args&&... __args)
+{
+  if (__flag.__state_ == 0)
+  {
+    ::cuda::std::forward<_Fn>(__fn)(::cuda::std::forward<_Args>(__args)...);
+    __flag.__state_ = 1;
+  }
+}
+#endif // ^^^ _CCCL_FREESTANDING() ^^^
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___UTILITY_CALL_ONCE_H

--- a/libcudacxx/include/cuda/std/__host_stdlib/mutex
+++ b/libcudacxx/include/cuda/std/__host_stdlib/mutex
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___HOST_STDLIB_MUTEX
+#define _CUDA_STD___HOST_STDLIB_MUTEX
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HOSTED()
+#  include <mutex> // IWYU pragma: export
+#endif // _CCCL_HOSTED()
+
+#endif // _CUDA_STD___HOST_STDLIB_MUTEX


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

There are enough places now that use the
```c++
#if _CCCL_HOSTED()
std::once_flag __flag;
#else
bool __flag;
#endif
```
Paradigm and corresponding `std::call_once()` to warrant pulling this out into a separate helper. As a bonus also add `__host_stdlib/mutex`.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
