### PR TITLE
Add retries to debugger tests and move timeout handling into the script

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -65,6 +65,9 @@ workflows:
   #
   # IMPORTANT: Do NOT delete or remove the `override:` key below, even when it is empty.
   override:
+    # Reproduce the failing job only:
+    # libcu++ nvcc Clang / RA / [CTK13.3 Clang21 C++20] Test(amd64, T4)
+    - {jobs: ['test'], project: 'libcudacxx', std: 20, ctk: '13.3', cxx: 'clang21', gpu: 't4'}
 
   pull_request:
     # Old CTK: Oldest/newest supported host compilers:

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -65,9 +65,6 @@ workflows:
   #
   # IMPORTANT: Do NOT delete or remove the `override:` key below, even when it is empty.
   override:
-    # Reproduce the failing job only:
-    # libcu++ nvcc Clang / RA / [CTK13.3 Clang21 C++20] Test(amd64, T4)
-    - {jobs: ['test'], project: 'libcudacxx', std: 20, ctk: '13.3', cxx: 'clang21', gpu: 't4'}
 
   pull_request:
     # Old CTK: Oldest/newest supported host compilers:

--- a/libcudacxx/test/debugging/CMakeLists.txt
+++ b/libcudacxx/test/debugging/CMakeLists.txt
@@ -188,6 +188,13 @@ function(libcudacxx_add_pretty_printer_test)
       "${libcudacxx_SOURCE_DIR}/share/libcudacxx/${debugger}/__init__.py"
     )
     set(test_name "${target_name}.${debugger}")
+    # The runner owns the timeout so that it can retry a timed-out attempt, which CTest
+    # cannot do. The per-attempt limit is aggressive because pretty printers must not be
+    # slow. If they are, then it's a problem with the printer and/or it is doing too much.
+    # A timeout is still possible on a loaded machine, so the runner retries it.
+    set(attempt_timeout 10)
+    # read: retry 2 more times after failure
+    set(retries 2)
     add_test(
       NAME ${test_name}
       COMMAND
@@ -199,12 +206,18 @@ function(libcudacxx_add_pretty_printer_test)
         --formatter-init "${formatter}"
         --expected "${CMAKE_CURRENT_SOURCE_DIR}/${debugger}.expected"
         --output-log "${CMAKE_CURRENT_BINARY_DIR}/${debugger}.log"
+        --timeout "${attempt_timeout}"
+        --retries "${retries}"
         ${pretty_printer_CASES}
       # gersemi: on
     )
-    # Set an aggressive timeout because pretty printers should not be slow. If they are,
-    # then it's a problem with the printer and/or it is doing too much
-    set_tests_properties(${test_name} PROPERTIES TIMEOUT 10 SKIP_RETURN_CODE 77)
+    # Backstop only. It must exceed the total runner budget so that the runner, and not
+    # CTest, reports a timeout. It catches a hung runner instead of a hung debugger.
+    math(EXPR ctest_timeout "${attempt_timeout} * (${retries} + 1) + 30")
+    set_tests_properties(
+      ${test_name}
+      PROPERTIES TIMEOUT ${ctest_timeout} SKIP_RETURN_CODE 77
+    )
   endforeach()
 endfunction()
 

--- a/libcudacxx/test/debugging/run_pretty_printer_test.py
+++ b/libcudacxx/test/debugging/run_pretty_printer_test.py
@@ -56,6 +56,10 @@ class DebuggerError(RuntimeError):
     """Report a debugger launch, timeout, or exit failure."""
 
 
+class DebuggerTimeoutError(DebuggerError):
+    """Report a debugger run that exceeded the per-attempt timeout."""
+
+
 class Debugger(StrEnum):
     LLDB = "lldb"
     GDB = "gdb"
@@ -580,6 +584,33 @@ def compare_expected(
     )
 
 
+def _nonnegative_int(value: str) -> int:
+    """Parse a command-line argument that must be a nonnegative integer.
+
+    Parameters
+    ----------
+    value : str
+        Raw command-line value.
+
+    Returns
+    -------
+    int
+        Parsed nonnegative integer.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If the value is not an integer, or if it is negative.
+    """
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(f"{value!r} is not an integer") from error
+    if parsed < 0:
+        raise argparse.ArgumentTypeError(f"{value!r} must not be negative")
+    return parsed
+
+
 def _parse_arguments(arguments: Sequence[str] | None) -> argparse.Namespace:
     """Parse debugger configuration and ordered case definitions.
 
@@ -601,6 +632,12 @@ def _parse_arguments(arguments: Sequence[str] | None) -> argparse.Namespace:
     parser.add_argument("--expected", type=Path, required=True)
     parser.add_argument("--output-log", type=Path, required=True)
     parser.add_argument("--timeout", type=float, default=90.0)
+    parser.add_argument(
+        "--retries",
+        type=_nonnegative_int,
+        default=0,
+        help="Number of extra attempts after a timeout. Zero means one attempt.",
+    )
     parser.add_argument("--update-expected", action="store_true")
     parser.add_argument(
         "--case",
@@ -661,8 +698,10 @@ def _run_debugger(
 
     Raises
     ------
+    DebuggerTimeoutError
+        If the debugger exceeds the per-attempt timeout.
     DebuggerError
-        If the debugger cannot launch, times out, or exits with a nonzero status.
+        If the debugger cannot launch or exits with a nonzero status.
     OSError
         If the transcript cannot be written.
     """
@@ -677,7 +716,7 @@ def _run_debugger(
     except subprocess.TimeoutExpired as error:
         if isinstance(error.stdout, str):
             args.output_log.write_text(error.stdout)
-        raise DebuggerError(
+        raise DebuggerTimeoutError(
             f"{debugger.kind} timed out after {args.timeout:g} seconds"
         ) from error
     except OSError as error:
@@ -689,6 +728,52 @@ def _run_debugger(
             f"{debugger.kind} exited with status {completed.returncode}"
         )
     return completed.stdout
+
+
+def _run_debugger_with_retries(
+    args: argparse.Namespace, debugger: DebuggerAdapter, command_file: Path
+) -> str:
+    """Run the debugger and retry only the attempts that time out.
+
+    A timeout usually comes from a loaded machine and not from the pretty
+    printer, so a repeated attempt is worth more than an immediate failure.
+    Every other failure is deterministic and fails on the first attempt.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed runner arguments.
+    debugger : DebuggerAdapter
+        Configured debugger adapter.
+    command_file : Path
+        Generated debugger command-file path.
+
+    Returns
+    -------
+    str
+        Complete combined debugger output.
+
+    Raises
+    ------
+    DebuggerError
+        If every attempt times out, or if any attempt fails for another reason.
+    OSError
+        If the transcript cannot be written.
+    """
+    attempts = args.retries + 1
+    for attempt in range(1, attempts + 1):
+        try:
+            return _run_debugger(args, debugger, command_file)
+        except DebuggerTimeoutError as error:
+            if attempt == attempts:
+                raise DebuggerTimeoutError(
+                    f"{error} on all {attempts} attempts"
+                ) from error
+            print(
+                f"warning: {error} on attempt {attempt} of {attempts}; retrying",
+                file=sys.stderr,
+            )
+    raise AssertionError("unreachable")
 
 
 def _match_output(
@@ -789,7 +874,7 @@ def main(arguments: Sequence[str] | None = None) -> int:
     command_file.write_text(commands)
 
     try:
-        transcript = _run_debugger(args, debugger, command_file)
+        transcript = _run_debugger_with_retries(args, debugger, command_file)
     except DebuggerError as error:
         _report_error(args, debugger, command_file, error)
         return 1


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

The pretty printers (specifically buffer) are still stubbornly timing out even after several rounds of optimization. Try and mitigate this with retries.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
