### PR TITLE
libcu++: atomic backend naming unification.

### DIFF
--- a/libcudacxx/codegen/generators/compare_and_swap.h
+++ b/libcudacxx/codegen/generators/compare_and_swap.h
@@ -20,28 +20,28 @@ inline void FormatCompareAndSwap(std::ostream& out)
 {
   out << R"XXX(
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_swap_memory_order_dispatch(_Fn& __cuda_cas, int __success_memorder, int __failure_memorder, _Sco) {
+static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_order_dispatch(_Fn& __cuda_cas, int __success_memorder, int __failure_memorder, _Sco) {
   bool __res = false;
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
-      switch (__stronger_order_cuda(__success_memorder, __failure_memorder)) {
-        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __atomic_cuda_seq_cst{}); [[fallthrough]];
+      switch (__cuda_atomic_stronger_order(__success_memorder, __failure_memorder)) {
+        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_seq_cst{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __res = __cuda_cas(__atomic_cuda_acquire{}); break;
-        case __ATOMIC_ACQ_REL: __res = __cuda_cas(__atomic_cuda_acq_rel{}); break;
-        case __ATOMIC_RELEASE: __res = __cuda_cas(__atomic_cuda_release{}); break;
-        case __ATOMIC_RELAXED: __res = __cuda_cas(__atomic_cuda_relaxed{}); break;
+        case __ATOMIC_ACQUIRE: __res = __cuda_cas(__cuda_atomic_order_acquire{}); break;
+        case __ATOMIC_ACQ_REL: __res = __cuda_cas(__cuda_atomic_order_acq_rel{}); break;
+        case __ATOMIC_RELEASE: __res = __cuda_cas(__cuda_atomic_order_release{}); break;
+        case __ATOMIC_RELAXED: __res = __cuda_cas(__cuda_atomic_order_relaxed{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     ),
     NV_IS_DEVICE, (
-      switch (__stronger_order_cuda(__success_memorder, __failure_memorder)) {
+      switch (__cuda_atomic_stronger_order(__success_memorder, __failure_memorder)) {
         case __ATOMIC_SEQ_CST: [[fallthrough]];
         case __ATOMIC_ACQ_REL: __cuda_atomic_membar(_Sco{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __res = __cuda_cas(__atomic_cuda_volatile{}); __cuda_atomic_membar(_Sco{}); break;
-        case __ATOMIC_RELEASE: __cuda_atomic_membar(_Sco{}); __res = __cuda_cas(__atomic_cuda_volatile{}); break;
-        case __ATOMIC_RELAXED: __res = __cuda_cas(__atomic_cuda_volatile{}); break;
+        case __ATOMIC_ACQUIRE: __res = __cuda_cas(__cuda_atomic_order_volatile{}); __cuda_atomic_membar(_Sco{}); break;
+        case __ATOMIC_RELEASE: __cuda_atomic_membar(_Sco{}); __res = __cuda_cas(__cuda_atomic_order_volatile{}); break;
+        case __ATOMIC_RELAXED: __res = __cuda_cas(__cuda_atomic_order_volatile{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     )
@@ -61,7 +61,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_swap_memory_order_dispatch
   constexpr auto asm_intrinsic_format_128 = R"XXX(
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, {4}, __atomic_cuda_operand_{0}{1}, {6})
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, {4}, __cuda_atomic_operand_{0}{1}, {6})
 {{
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -82,7 +82,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   constexpr auto asm_intrinsic_format = R"XXX(
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, {4}, __atomic_cuda_operand_{0}{1}, {6})
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, {4}, __cuda_atomic_operand_{0}{1}, {6})
 {{ asm volatile("atom.cas{3}{5}.{0}{1} %0,[%1],%2,%3;" : "={2}"(__dst) : "l"(__ptr), "{2}"(__cmp), "{2}"(__op) : "memory"); return __dst == __cmp; }})XXX";
 
   constexpr Operand supported_types[] = {
@@ -170,30 +170,30 @@ struct __cuda_atomic_bind_compare_exchange {
   }
 };
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE bool __atomic_compare_exchange_cuda(_Type* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
+static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_dispatch(_Type* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __exp_proxy = reinterpret_cast<__proxy_t*>(__exp);
   __proxy_t* __des_proxy  = reinterpret_cast<__proxy_t*>(&__des);
   bool __res = false;
-  if (__cuda_compare_exchange_weak_if_local(__ptr_proxy, __exp_proxy, __des_proxy, &__res)) {return __res;}
+  if (__cuda_atomic_compare_exchange_weak_if_local(__ptr_proxy, __exp_proxy, __des_proxy, &__res)) {return __res;}
   __cuda_atomic_bind_compare_exchange<__proxy_t, __proxy_tag, _Sco> __bound_compare_swap{__ptr_proxy, __exp_proxy, __des_proxy};
-  return __cuda_atomic_compare_swap_memory_order_dispatch(__bound_compare_swap, __success_memorder, __failure_memorder, _Sco{});
+  return __cuda_atomic_compare_exchange_order_dispatch(__bound_compare_swap, __success_memorder, __failure_memorder, _Sco{});
 }
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE bool __atomic_compare_exchange_cuda(_Type volatile* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
+static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_dispatch(_Type volatile* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __exp_proxy = reinterpret_cast<__proxy_t*>(__exp);
   __proxy_t* __des_proxy  = reinterpret_cast<__proxy_t*>(&__des);
   bool __res = false;
-  if (__cuda_compare_exchange_weak_if_local(__ptr_proxy, __exp_proxy, __des_proxy, &__res)) {return __res;}
+  if (__cuda_atomic_compare_exchange_weak_if_local(__ptr_proxy, __exp_proxy, __des_proxy, &__res)) {return __res;}
   __cuda_atomic_bind_compare_exchange<__proxy_t, __proxy_tag, _Sco> __bound_compare_swap{__ptr_proxy, __exp_proxy, __des_proxy};
-  return __cuda_atomic_compare_swap_memory_order_dispatch(__bound_compare_swap, __success_memorder, __failure_memorder, _Sco{});
+  return __cuda_atomic_compare_exchange_order_dispatch(__bound_compare_swap, __success_memorder, __failure_memorder, _Sco{});
 }
 )XXX";
 }

--- a/libcudacxx/codegen/generators/definitions.h
+++ b/libcudacxx/codegen/generators/definitions.h
@@ -35,8 +35,8 @@ inline std::string mmio(Mmio m)
 inline std::string mmio_tag(Mmio m)
 {
   static const char* mmio_map[]{
-    "__atomic_cuda_mmio_disable",
-    "__atomic_cuda_mmio_enable",
+    "__cuda_atomic_mmio_disable",
+    "__cuda_atomic_mmio_enable",
   };
   return mmio_map[std::underlying_type_t<Mmio>(m)];
 }
@@ -143,12 +143,12 @@ inline std::string semantic(Semantic sem)
 inline std::string semantic_tag(Semantic sem)
 {
   static std::map sem_map = {
-    std::pair{Semantic::Relaxed, "__atomic_cuda_relaxed"},
-    std::pair{Semantic::Release, "__atomic_cuda_release"},
-    std::pair{Semantic::Acquire, "__atomic_cuda_acquire"},
-    std::pair{Semantic::Acq_Rel, "__atomic_cuda_acq_rel"},
-    std::pair{Semantic::Seq_Cst, "__atomic_cuda_seq_cst"},
-    std::pair{Semantic::Volatile, "__atomic_cuda_volatile"},
+    std::pair{Semantic::Relaxed, "__cuda_atomic_order_relaxed"},
+    std::pair{Semantic::Release, "__cuda_atomic_order_release"},
+    std::pair{Semantic::Acquire, "__cuda_atomic_order_acquire"},
+    std::pair{Semantic::Acq_Rel, "__cuda_atomic_order_acq_rel"},
+    std::pair{Semantic::Seq_Cst, "__cuda_atomic_order_seq_cst"},
+    std::pair{Semantic::Volatile, "__cuda_atomic_order_volatile"},
   };
   return sem_map[sem];
 }

--- a/libcudacxx/codegen/generators/exchange.h
+++ b/libcudacxx/codegen/generators/exchange.h
@@ -20,16 +20,16 @@ inline void FormatExchange(std::ostream& out)
 {
   out << R"XXX(
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange_memory_order_dispatch(_Fn& __cuda_exch, int __memorder, _Sco) {
+static inline _CCCL_DEVICE void __cuda_atomic_exchange_order_dispatch(_Fn& __cuda_exch, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
-        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __atomic_cuda_seq_cst{}); [[fallthrough]];
+        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_seq_cst{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __cuda_exch(__atomic_cuda_acquire{}); break;
-        case __ATOMIC_ACQ_REL: __cuda_exch(__atomic_cuda_acq_rel{}); break;
-        case __ATOMIC_RELEASE: __cuda_exch(__atomic_cuda_release{}); break;
-        case __ATOMIC_RELAXED: __cuda_exch(__atomic_cuda_relaxed{}); break;
+        case __ATOMIC_ACQUIRE: __cuda_exch(__cuda_atomic_order_acquire{}); break;
+        case __ATOMIC_ACQ_REL: __cuda_exch(__cuda_atomic_order_acq_rel{}); break;
+        case __ATOMIC_RELEASE: __cuda_exch(__cuda_atomic_order_release{}); break;
+        case __ATOMIC_RELAXED: __cuda_exch(__cuda_atomic_order_relaxed{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     ),
@@ -38,9 +38,9 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange_memory_order_dispatch(_Fn
         case __ATOMIC_SEQ_CST: [[fallthrough]];
         case __ATOMIC_ACQ_REL: __cuda_atomic_membar(_Sco{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __cuda_exch(__atomic_cuda_volatile{}); __cuda_atomic_membar(_Sco{}); break;
-        case __ATOMIC_RELEASE: __cuda_atomic_membar(_Sco{}); __cuda_exch(__atomic_cuda_volatile{}); break;
-        case __ATOMIC_RELAXED: __cuda_exch(__atomic_cuda_volatile{}); break;
+        case __ATOMIC_ACQUIRE: __cuda_exch(__cuda_atomic_order_volatile{}); __cuda_atomic_membar(_Sco{}); break;
+        case __ATOMIC_RELEASE: __cuda_atomic_membar(_Sco{}); __cuda_exch(__cuda_atomic_order_volatile{}); break;
+        case __ATOMIC_RELAXED: __cuda_exch(__cuda_atomic_order_volatile{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     )
@@ -59,7 +59,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange_memory_order_dispatch(_Fn
   constexpr auto asm_intrinsic_format_128 = R"XXX(
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, {4}, __atomic_cuda_operand_{0}{1}, {6})
+  _Type* __ptr, _Type& __old, _Type __new, {4}, __cuda_atomic_operand_{0}{1}, {6})
 {{
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -80,7 +80,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   constexpr auto asm_intrinsic_format = R"XXX(
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, {4}, __atomic_cuda_operand_{0}{1}, {6})
+  _Type* __ptr, _Type& __old, _Type __new, {4}, __cuda_atomic_operand_{0}{1}, {6})
 {{ asm volatile("atom.exch{3}{5}.{0}{1} %0,[%1],%2;" : "={2}"(__old) : "l"(__ptr), "{2}"(__new) : "memory"); }})XXX";
 
   constexpr Operand supported_types[] = {
@@ -170,26 +170,26 @@ struct __cuda_atomic_bind_exchange {
 template <class _Type, class _Sco>
 static inline _CCCL_DEVICE void __atomic_exchange_cuda(_Type* __ptr, _Type& __old, _Type __new, int __memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __old_proxy = reinterpret_cast<__proxy_t*>(&__old);
   __proxy_t* __new_proxy  = reinterpret_cast<__proxy_t*>(&__new);
-  if(__cuda_exchange_weak_if_local(__ptr_proxy, __new_proxy, __old_proxy)) {{return;}}
+  if(__cuda_atomic_exchange_weak_if_local(__ptr_proxy, __new_proxy, __old_proxy)) {{return;}}
   __cuda_atomic_bind_exchange<__proxy_t, __proxy_tag, _Sco> __bound_swap{__ptr_proxy, __old_proxy, __new_proxy};
-  __cuda_atomic_exchange_memory_order_dispatch(__bound_swap, __memorder, _Sco{});
+  __cuda_atomic_exchange_order_dispatch(__bound_swap, __memorder, _Sco{});
 }
 template <class _Type, class _Sco>
 static inline _CCCL_DEVICE void __atomic_exchange_cuda(_Type volatile* __ptr, _Type& __old, _Type __new, int __memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __old_proxy = reinterpret_cast<__proxy_t*>(&__old);
   __proxy_t* __new_proxy  = reinterpret_cast<__proxy_t*>(&__new);
-  if(__cuda_exchange_weak_if_local(__ptr_proxy, __new_proxy, __old_proxy)) {{return;}}
+  if(__cuda_atomic_exchange_weak_if_local(__ptr_proxy, __new_proxy, __old_proxy)) {{return;}}
   __cuda_atomic_bind_exchange<__proxy_t, __proxy_tag, _Sco> __bound_swap{__ptr_proxy, __old_proxy, __new_proxy};
-  __cuda_atomic_exchange_memory_order_dispatch(__bound_swap, __memorder, _Sco{});
+  __cuda_atomic_exchange_order_dispatch(__bound_swap, __memorder, _Sco{});
 }
 )XXX";
 }

--- a/libcudacxx/codegen/generators/fence.h
+++ b/libcudacxx/codegen/generators/fence.h
@@ -78,15 +78,15 @@ static inline _CCCL_DEVICE void __cuda_atomic_fence({0}, {2})
   out << "\n"
       << R"XXX(
 template <typename _Sco>
-static inline _CCCL_DEVICE void __atomic_thread_fence_cuda(int __memorder, _Sco) {
+static inline _CCCL_DEVICE void __cuda_atomic_thread_fence(int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
-        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __atomic_cuda_seq_cst{}); break;
+        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_seq_cst{}); break;
         case __ATOMIC_CONSUME: [[fallthrough]];
         case __ATOMIC_ACQUIRE: [[fallthrough]];
         case __ATOMIC_ACQ_REL: [[fallthrough]];
-        case __ATOMIC_RELEASE: __cuda_atomic_fence(_Sco{}, __atomic_cuda_acq_rel{}); break;
+        case __ATOMIC_RELEASE: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_acq_rel{}); break;
         case __ATOMIC_RELAXED: break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }

--- a/libcudacxx/codegen/generators/fetch_ops.h
+++ b/libcudacxx/codegen/generators/fetch_ops.h
@@ -53,16 +53,16 @@ inline void FormatFetchOps(std::ostream& out)
   // Memory order dispatcher
   out << R"XXX(
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_memory_order_dispatch(_Fn& __cuda_fetch, int __memorder, _Sco) {
+static inline _CCCL_DEVICE void __cuda_atomic_fetch_order_dispatch(_Fn& __cuda_fetch, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
-        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __atomic_cuda_seq_cst{}); [[fallthrough]];
+        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_seq_cst{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __cuda_fetch(__atomic_cuda_acquire{}); break;
-        case __ATOMIC_ACQ_REL: __cuda_fetch(__atomic_cuda_acq_rel{}); break;
-        case __ATOMIC_RELEASE: __cuda_fetch(__atomic_cuda_release{}); break;
-        case __ATOMIC_RELAXED: __cuda_fetch(__atomic_cuda_relaxed{}); break;
+        case __ATOMIC_ACQUIRE: __cuda_fetch(__cuda_atomic_order_acquire{}); break;
+        case __ATOMIC_ACQ_REL: __cuda_fetch(__cuda_atomic_order_acq_rel{}); break;
+        case __ATOMIC_RELEASE: __cuda_fetch(__cuda_atomic_order_release{}); break;
+        case __ATOMIC_RELAXED: __cuda_fetch(__cuda_atomic_order_relaxed{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     ),
@@ -71,9 +71,9 @@ static inline _CCCL_DEVICE void __cuda_atomic_fetch_memory_order_dispatch(_Fn& _
         case __ATOMIC_SEQ_CST: [[fallthrough]];
         case __ATOMIC_ACQ_REL: __cuda_atomic_membar(_Sco{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __cuda_fetch(__atomic_cuda_volatile{}); __cuda_atomic_membar(_Sco{}); break;
-        case __ATOMIC_RELEASE: __cuda_atomic_membar(_Sco{}); __cuda_fetch(__atomic_cuda_volatile{}); break;
-        case __ATOMIC_RELAXED: __cuda_fetch(__atomic_cuda_volatile{}); break;
+        case __ATOMIC_ACQUIRE: __cuda_fetch(__cuda_atomic_order_volatile{}); __cuda_atomic_membar(_Sco{}); break;
+        case __ATOMIC_RELEASE: __cuda_atomic_membar(_Sco{}); __cuda_fetch(__cuda_atomic_order_volatile{}); break;
+        case __ATOMIC_RELAXED: __cuda_fetch(__cuda_atomic_order_volatile{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     )
@@ -93,7 +93,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_fetch_memory_order_dispatch(_Fn& _
   constexpr auto asm_intrinsic_format = R"XXX(
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_{0}(
-  _Type* __ptr, _Type& __dst, _Type __op, {5}, __atomic_cuda_operand_{1}{2}, {7})
+  _Type* __ptr, _Type& __dst, _Type __op, {5}, __cuda_atomic_operand_{1}{2}, {7})
 {{ asm volatile("atom.{0}{4}{6}.{1}{2} %0,[%1],%2;" : "={3}"(__dst) : "l"(__ptr), "{3}"(__op) : "memory"); }})XXX";
 
   // 0 - Atomic Operation
@@ -112,35 +112,35 @@ struct __cuda_atomic_bind_fetch_{0} {{
   }}
 }};
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_{1}<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_{0}_cuda(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_{0}_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {{
   {2}
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_{1}<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_{1}<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_{1}<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_{1}<_Type>::__tag;
   _Type __dst{{}};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_{0}_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {{return __dst;}}
+  if (__cuda_atomic_fetch_{0}_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {{return __dst;}}
   __cuda_atomic_bind_fetch_{0}<__proxy_t, __proxy_tag, _Sco> __bound_{0}{{__ptr_proxy, __dst_proxy, __op_proxy}};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_{0}, __memorder, _Sco{{}});
+  __cuda_atomic_fetch_order_dispatch(__bound_{0}, __memorder, _Sco{{}});
   return __dst;
 }}
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_{1}<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_{0}_cuda(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_{0}_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {{
   {2}
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_{1}<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_{1}<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_{1}<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_{1}<_Type>::__tag;
   _Type __dst{{}};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_{0}_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {{return __dst;}}
+  if (__cuda_atomic_fetch_{0}_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {{return __dst;}}
   __cuda_atomic_bind_fetch_{0}<__proxy_t, __proxy_tag, _Sco> __bound_{0}{{__ptr_proxy, __dst_proxy, __op_proxy}};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_{0}, __memorder, _Sco{{}});
+  __cuda_atomic_fetch_order_dispatch(__bound_{0}, __memorder, _Sco{{}});
   return __dst;
 }}
 )XXX";
@@ -204,14 +204,14 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_{1}<_Typ
 
   out << R"XXX(
 template <class _Type, class _Up, class _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_sub_cuda(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_sub_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
-  return __atomic_fetch_add_cuda(__ptr, -__op, __memorder, _Sco{});
+  return __cuda_atomic_fetch_add_dispatch(__ptr, -__op, __memorder, _Sco{});
 }
 template <class _Type, class _Up, class _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_sub_cuda(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_sub_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
-  return __atomic_fetch_add_cuda(__ptr, -__op, __memorder, _Sco{});
+  return __cuda_atomic_fetch_add_dispatch(__ptr, -__op, __memorder, _Sco{});
 }
 )XXX";
 }

--- a/libcudacxx/codegen/generators/ld_st.h
+++ b/libcudacxx/codegen/generators/ld_st.h
@@ -40,14 +40,14 @@ inline void FormatLoad(std::ostream& out)
 {
   out << R"XXX(
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_load_memory_order_dispatch(_Fn &__cuda_load, int __memorder, _Sco) {
+static inline _CCCL_DEVICE void __cuda_atomic_load_order_dispatch(_Fn &__cuda_load, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
-        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __atomic_cuda_seq_cst{}); [[fallthrough]];
+        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_seq_cst{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __cuda_load(__atomic_cuda_acquire{}); break;
-        case __ATOMIC_RELAXED: __cuda_load(__atomic_cuda_relaxed{}); break;
+        case __ATOMIC_ACQUIRE: __cuda_load(__cuda_atomic_order_acquire{}); break;
+        case __ATOMIC_RELAXED: __cuda_load(__cuda_atomic_order_relaxed{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     ),
@@ -55,8 +55,8 @@ static inline _CCCL_DEVICE void __cuda_atomic_load_memory_order_dispatch(_Fn &__
       switch (__memorder) {
         case __ATOMIC_SEQ_CST: __cuda_atomic_membar(_Sco{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __cuda_load(__atomic_cuda_volatile{}); __cuda_atomic_membar(_Sco{}); break;
-        case __ATOMIC_RELAXED: __cuda_load(__atomic_cuda_volatile{}); break;
+        case __ATOMIC_ACQUIRE: __cuda_load(__cuda_atomic_order_volatile{}); __cuda_atomic_membar(_Sco{}); break;
+        case __ATOMIC_RELAXED: __cuda_load(__cuda_atomic_order_volatile{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     )
@@ -77,7 +77,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load_memory_order_dispatch(_Fn &__
   constexpr auto asm_intrinsic_format_128 = R"XXX(
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, {3}, __atomic_cuda_operand_{0}{1}, {5}, {7})
+  const _Type* __ptr, _Type& __dst, {3}, __cuda_atomic_operand_{0}{1}, {5}, {7})
 {{
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -95,12 +95,12 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   constexpr auto asm_intrinsic_format     = R"XXX(
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, {3}, __atomic_cuda_operand_{0}{1}, {5}, {7})
+  const _Type* __ptr, _Type& __dst, {3}, __cuda_atomic_operand_{0}{1}, {5}, {7})
 {{ asm volatile("ld{8}{4}{6}.{0}{1} %0,[%1];" : "={2}"(__dst) : "l"(__ptr) : "memory"); }})XXX";
   constexpr auto asm_intrinsic_format_8   = R"XXX(
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, {3}, __atomic_cuda_operand_{0}{1}, {5}, {7})
+  const _Type* __ptr, _Type& __dst, {3}, __cuda_atomic_operand_{0}{1}, {5}, {7})
 {{
   uint16_t __tmp;
   asm volatile("ld{8}{4}{6}.{0}{1} %0,[%1];" : "={2}"(__tmp) : "l"(__ptr) : "memory");
@@ -225,24 +225,24 @@ struct __cuda_atomic_bind_load {
 template <class _Type, class _Sco>
 static inline _CCCL_DEVICE void __atomic_load_cuda(const _Type* __ptr, _Type& __dst, int __memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   const __proxy_t* __ptr_proxy = reinterpret_cast<const __proxy_t*>(__ptr);
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
-  if (__cuda_load_weak_if_local(__ptr_proxy, __dst_proxy, sizeof(__proxy_t))) {{return;}}
-  __cuda_atomic_bind_load<__proxy_t, __proxy_tag, _Sco, __atomic_cuda_mmio_disable> __bound_load{__ptr_proxy, __dst_proxy};
-  __cuda_atomic_load_memory_order_dispatch(__bound_load, __memorder, _Sco{});
+  if (__cuda_atomic_load_weak_if_local(__ptr_proxy, __dst_proxy, sizeof(__proxy_t))) {{return;}}
+  __cuda_atomic_bind_load<__proxy_t, __proxy_tag, _Sco, __cuda_atomic_mmio_disable> __bound_load{__ptr_proxy, __dst_proxy};
+  __cuda_atomic_load_order_dispatch(__bound_load, __memorder, _Sco{});
 }
 template <class _Type, class _Sco>
 static inline _CCCL_DEVICE void __atomic_load_cuda(const _Type volatile* __ptr, _Type& __dst, int __memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   const __proxy_t* __ptr_proxy = reinterpret_cast<const __proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
-  if (__cuda_load_weak_if_local(__ptr_proxy, __dst_proxy, sizeof(__proxy_t))) {{return;}}
-  __cuda_atomic_bind_load<__proxy_t, __proxy_tag, _Sco, __atomic_cuda_mmio_disable> __bound_load{__ptr_proxy, __dst_proxy};
-  __cuda_atomic_load_memory_order_dispatch(__bound_load, __memorder, _Sco{});
+  if (__cuda_atomic_load_weak_if_local(__ptr_proxy, __dst_proxy, sizeof(__proxy_t))) {{return;}}
+  __cuda_atomic_bind_load<__proxy_t, __proxy_tag, _Sco, __cuda_atomic_mmio_disable> __bound_load{__ptr_proxy, __dst_proxy};
+  __cuda_atomic_load_order_dispatch(__bound_load, __memorder, _Sco{});
 }
 )XXX";
 }
@@ -251,13 +251,13 @@ inline void FormatStore(std::ostream& out)
 {
   out << R"XXX(
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_store_memory_order_dispatch(_Fn &__cuda_store, int __memorder, _Sco) {
+static inline _CCCL_DEVICE void __cuda_atomic_store_order_dispatch(_Fn &__cuda_store, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
-        case __ATOMIC_RELEASE: __cuda_store(__atomic_cuda_release{}); break;
-        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __atomic_cuda_seq_cst{}); [[fallthrough]];
-        case __ATOMIC_RELAXED: __cuda_store(__atomic_cuda_relaxed{}); break;
+        case __ATOMIC_RELEASE: __cuda_store(__cuda_atomic_order_release{}); break;
+        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_seq_cst{}); [[fallthrough]];
+        case __ATOMIC_RELAXED: __cuda_store(__cuda_atomic_order_relaxed{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     ),
@@ -265,7 +265,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store_memory_order_dispatch(_Fn &_
       switch (__memorder) {
         case __ATOMIC_RELEASE: [[fallthrough]];
         case __ATOMIC_SEQ_CST: __cuda_atomic_membar(_Sco{}); [[fallthrough]];
-        case __ATOMIC_RELAXED: __cuda_store(__atomic_cuda_volatile{}); break;
+        case __ATOMIC_RELAXED: __cuda_store(__cuda_atomic_order_volatile{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     )
@@ -285,7 +285,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store_memory_order_dispatch(_Fn &_
   constexpr auto asm_intrinsic_format_128 = R"XXX(
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, {3}, __atomic_cuda_operand_{0}{1}, {5}, {7})
+  _Type* __ptr, _Type& __val, {3}, __cuda_atomic_operand_{0}{1}, {5}, {7})
 {{
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -303,12 +303,12 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   constexpr auto asm_intrinsic_format     = R"XXX(
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, {3}, __atomic_cuda_operand_{0}{1}, {5}, {7})
+  _Type* __ptr, _Type& __val, {3}, __cuda_atomic_operand_{0}{1}, {5}, {7})
 {{ asm volatile("st{8}{4}{6}.{0}{1} [%0],%1;" :: "l"(__ptr), "{2}"(__val) : "memory"); }})XXX";
   constexpr auto asm_intrinsic_format_8   = R"XXX(
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, {3}, __atomic_cuda_operand_{0}{1}, {5}, {7})
+  _Type* __ptr, _Type& __val, {3}, __cuda_atomic_operand_{0}{1}, {5}, {7})
 {{
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st{8}{4}{6}.{0}{1} [%0],%1;" :: "l"(__ptr), "{2}"(__tmp) : "memory");
@@ -429,24 +429,24 @@ struct __cuda_atomic_bind_store {
 template <class _Type, class _Sco>
 static inline _CCCL_DEVICE void __atomic_store_cuda(_Type* __ptr, _Type& __val, int __memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __val_proxy = reinterpret_cast<__proxy_t*>(&__val);
-  if (__cuda_store_weak_if_local(__ptr_proxy, __val_proxy, sizeof(__proxy_t))) {{return;}}
-  __cuda_atomic_bind_store<__proxy_t, __proxy_tag, _Sco, __atomic_cuda_mmio_disable> __bound_store{__ptr_proxy, __val_proxy};
-  __cuda_atomic_store_memory_order_dispatch(__bound_store, __memorder, _Sco{});
+  if (__cuda_atomic_store_weak_if_local(__ptr_proxy, __val_proxy, sizeof(__proxy_t))) {{return;}}
+  __cuda_atomic_bind_store<__proxy_t, __proxy_tag, _Sco, __cuda_atomic_mmio_disable> __bound_store{__ptr_proxy, __val_proxy};
+  __cuda_atomic_store_order_dispatch(__bound_store, __memorder, _Sco{});
 }
 template <class _Type, class _Sco>
 static inline _CCCL_DEVICE void __atomic_store_cuda(volatile _Type* __ptr, _Type& __val, int __memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __val_proxy = reinterpret_cast<__proxy_t*>(&__val);
-  if (__cuda_store_weak_if_local(__ptr_proxy, __val_proxy, sizeof(__proxy_t))) {{return;}}
-  __cuda_atomic_bind_store<__proxy_t, __proxy_tag, _Sco, __atomic_cuda_mmio_disable> __bound_store{__ptr_proxy, __val_proxy};
-  __cuda_atomic_store_memory_order_dispatch(__bound_store, __memorder, _Sco{});
+  if (__cuda_atomic_store_weak_if_local(__ptr_proxy, __val_proxy, sizeof(__proxy_t))) {{return;}}
+  __cuda_atomic_bind_store<__proxy_t, __proxy_tag, _Sco, __cuda_atomic_mmio_disable> __bound_store{__ptr_proxy, __val_proxy};
+  __cuda_atomic_store_order_dispatch(__bound_store, __memorder, _Sco{});
 }
 )XXX";
 }

--- a/libcudacxx/include/cuda/__atomic/atomic.h
+++ b/libcudacxx/include/cuda/__atomic/atomic.h
@@ -123,13 +123,13 @@ atomic_thread_fence(memory_order __m, [[maybe_unused]] thread_scope _Scope = thr
     NV_IS_DEVICE,
     (switch (_Scope) {
       case thread_scope::thread_scope_system:
-        ::cuda::std::__atomic_thread_fence_cuda((int) __m, __thread_scope_system_tag{});
+        ::cuda::std::__cuda_atomic_thread_fence((int) __m, __thread_scope_system_tag{});
         break;
       case thread_scope::thread_scope_device:
-        ::cuda::std::__atomic_thread_fence_cuda((int) __m, __thread_scope_device_tag{});
+        ::cuda::std::__cuda_atomic_thread_fence((int) __m, __thread_scope_device_tag{});
         break;
       case thread_scope::thread_scope_block:
-        ::cuda::std::__atomic_thread_fence_cuda((int) __m, __thread_scope_block_tag{});
+        ::cuda::std::__cuda_atomic_thread_fence((int) __m, __thread_scope_block_tag{});
         break;
       // Atomics scoped to themselves do not require fencing
       case thread_scope::thread_scope_thread:

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_local.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_local.h
@@ -39,7 +39,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if _CCCL_CUDA_COMPILATION()
 
-_CCCL_DEVICE_API inline bool __cuda_is_local(const volatile void* __ptr)
+_CCCL_DEVICE_API inline bool __cuda_atomic_is_local(const volatile void* __ptr)
 {
 #  if defined(_CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE) && !defined(_LIBCUDACXX_FORCE_PTX_AUTOMATIC_STORAGE_PATH)
   return false;
@@ -52,44 +52,44 @@ _CCCL_DEVICE_API inline bool __cuda_is_local(const volatile void* __ptr)
 }
 
 template <class _Type>
-_CCCL_DEVICE_API void __cuda_fetch_local_bop_and(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_local_bop_and(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __atom & __v;
 }
 template <class _Type>
-_CCCL_DEVICE_API void __cuda_fetch_local_bop_or(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_local_bop_or(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __atom | __v;
 }
 template <class _Type>
-_CCCL_DEVICE_API void __cuda_fetch_local_bop_xor(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_local_bop_xor(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __atom ^ __v;
 }
 template <class _Type>
-_CCCL_DEVICE_API void __cuda_fetch_local_bop_add(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_local_bop_add(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __atom + __v;
 }
 template <class _Type>
-_CCCL_DEVICE_API void __cuda_fetch_local_bop_sub(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_local_bop_sub(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __atom - __v;
 }
 template <class _Type>
-_CCCL_DEVICE_API void __cuda_fetch_local_bop_max(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_local_bop_max(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __atom < __v ? __v : __atom;
 }
 template <class _Type>
-_CCCL_DEVICE_API void __cuda_fetch_local_bop_min(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_local_bop_min(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __v < __atom ? __v : __atom;
 }
 
-_CCCL_DEVICE_API inline bool __cuda_load_weak_if_local(const volatile void* __ptr, void* __ret, size_t __size)
+_CCCL_DEVICE_API inline bool __cuda_atomic_load_weak_if_local(const volatile void* __ptr, void* __ret, size_t __size)
 {
-  if (!__cuda_is_local(__ptr))
+  if (!__cuda_atomic_is_local(__ptr))
   {
     return false;
   }
@@ -99,9 +99,9 @@ _CCCL_DEVICE_API inline bool __cuda_load_weak_if_local(const volatile void* __pt
   return true;
 }
 
-_CCCL_DEVICE_API inline bool __cuda_store_weak_if_local(volatile void* __ptr, const void* __val, size_t __size)
+_CCCL_DEVICE_API inline bool __cuda_atomic_store_weak_if_local(volatile void* __ptr, const void* __val, size_t __size)
 {
-  if (!__cuda_is_local(__ptr))
+  if (!__cuda_atomic_is_local(__ptr))
   {
     return false;
   }
@@ -110,10 +110,10 @@ _CCCL_DEVICE_API inline bool __cuda_store_weak_if_local(volatile void* __ptr, co
 }
 
 template <class _Type>
-_CCCL_DEVICE_API bool
-__cuda_compare_exchange_weak_if_local(volatile _Type* __ptr, _Type* __expected, const _Type* __desired, bool* __success)
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange_weak_if_local(
+  volatile _Type* __ptr, _Type* __expected, const _Type* __desired, bool* __success)
 {
-  if (!__cuda_is_local(__ptr))
+  if (!__cuda_atomic_is_local(__ptr))
   {
     return false;
   }
@@ -132,9 +132,9 @@ __cuda_compare_exchange_weak_if_local(volatile _Type* __ptr, _Type* __expected, 
 }
 
 template <class _Type>
-_CCCL_DEVICE_API bool __cuda_exchange_weak_if_local(volatile _Type* __ptr, _Type* __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_atomic_exchange_weak_if_local(volatile _Type* __ptr, _Type* __val, _Type* __ret)
 {
-  if (!__cuda_is_local(__ptr))
+  if (!__cuda_atomic_is_local(__ptr))
   {
     return false;
   }
@@ -145,9 +145,9 @@ _CCCL_DEVICE_API bool __cuda_exchange_weak_if_local(volatile _Type* __ptr, _Type
 }
 
 template <class _Type, class _BOp>
-_CCCL_DEVICE_API bool __cuda_fetch_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret, _BOp&& __bop)
+_CCCL_DEVICE_API bool __cuda_atomic_fetch_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret, _BOp&& __bop)
 {
-  if (!__cuda_is_local(__ptr))
+  if (!__cuda_atomic_is_local(__ptr))
   {
     return false;
   }
@@ -158,45 +158,45 @@ _CCCL_DEVICE_API bool __cuda_fetch_weak_if_local(volatile _Type* __ptr, _Type __
 }
 
 template <class _Type>
-_CCCL_DEVICE_API bool __cuda_fetch_and_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_atomic_fetch_and_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
-  return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_and<_Type>);
+  return __cuda_atomic_fetch_weak_if_local(__ptr, __val, __ret, __cuda_atomic_fetch_local_bop_and<_Type>);
 }
 
 template <class _Type>
-_CCCL_DEVICE_API bool __cuda_fetch_or_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_atomic_fetch_or_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
-  return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_or<_Type>);
+  return __cuda_atomic_fetch_weak_if_local(__ptr, __val, __ret, __cuda_atomic_fetch_local_bop_or<_Type>);
 }
 
 template <class _Type>
-_CCCL_DEVICE_API bool __cuda_fetch_xor_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_atomic_fetch_xor_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
-  return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_xor<_Type>);
+  return __cuda_atomic_fetch_weak_if_local(__ptr, __val, __ret, __cuda_atomic_fetch_local_bop_xor<_Type>);
 }
 
 template <class _Type>
-_CCCL_DEVICE_API bool __cuda_fetch_add_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_atomic_fetch_add_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
-  return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_add<_Type>);
+  return __cuda_atomic_fetch_weak_if_local(__ptr, __val, __ret, __cuda_atomic_fetch_local_bop_add<_Type>);
 }
 
 template <class _Type>
-_CCCL_DEVICE_API bool __cuda_fetch_sub_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_atomic_fetch_sub_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
-  return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_sub<_Type>);
+  return __cuda_atomic_fetch_weak_if_local(__ptr, __val, __ret, __cuda_atomic_fetch_local_bop_sub<_Type>);
 }
 
 template <class _Type>
-_CCCL_DEVICE_API bool __cuda_fetch_max_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_atomic_fetch_max_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
-  return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_max<_Type>);
+  return __cuda_atomic_fetch_weak_if_local(__ptr, __val, __ret, __cuda_atomic_fetch_local_bop_max<_Type>);
 }
 
 template <class _Type>
-_CCCL_DEVICE_API bool __cuda_fetch_min_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_atomic_fetch_min_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
-  return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_min<_Type>);
+  return __cuda_atomic_fetch_weak_if_local(__ptr, __val, __ret, __cuda_atomic_fetch_local_bop_min<_Type>);
 }
 
 #endif // _CCCL_CUDA_COMPILATION()

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_derived.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_derived.h
@@ -36,7 +36,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Operand>
 using __cuda_atomic_enable_non_native_arithmetic =
-  enable_if_t<_Operand::__size <= 16 || _Operand::__op == __atomic_cuda_operand::_f, bool>;
+  enable_if_t<_Operand::__size <= 16 || _Operand::__op == __cuda_atomic_operand::_f, bool>;
 
 template <class _Operand>
 using __cuda_atomic_enable_non_native_bitwise = enable_if_t<_Operand::__size <= 16, bool>;
@@ -64,9 +64,19 @@ __cuda_atomic_compare_exchange(_Type* __ptr, _Type& __dst, _Type __cmp, _Type __
   NV_IF_TARGET(
     NV_PROVIDES_SM_70,
     (__cuda_atomic_load(
-       __aligned, __old, __atomic_cuda_relaxed{}, __atomic_cuda_operand_b32{}, _Sco{}, __atomic_cuda_mmio_disable{});),
+       __aligned,
+       __old,
+       __cuda_atomic_order_relaxed{},
+       __cuda_atomic_operand_b32{},
+       _Sco{},
+       __cuda_atomic_mmio_disable{});),
     (__cuda_atomic_load(
-       __aligned, __old, __atomic_cuda_volatile{}, __atomic_cuda_operand_b32{}, _Sco{}, __atomic_cuda_mmio_disable{});))
+       __aligned,
+       __old,
+       __cuda_atomic_order_volatile{},
+       __cuda_atomic_operand_b32{},
+       _Sco{},
+       __cuda_atomic_mmio_disable{});))
   // Reemit CAS instructions until we succeed or the old value is a mismatch
   while (__cmpOffset == (__old & __valueMask))
   {
@@ -74,7 +84,7 @@ __cuda_atomic_compare_exchange(_Type* __ptr, _Type& __dst, _Type __cmp, _Type __
     const uint32_t __attempt = (__old & __windowMask) | __opOffset;
 
     if (__cuda_atomic_compare_exchange(
-          __aligned, __old, __old, __attempt, _Order{}, __atomic_cuda_operand_b32{}, _Sco{}))
+          __aligned, __old, __old, __attempt, _Order{}, __cuda_atomic_operand_b32{}, _Sco{}))
     {
       // CAS was successful
       return true;
@@ -106,9 +116,19 @@ _CCCL_DEVICE_API _Type __cuda_atomic_fetch_update(_Type* __ptr, const _Fn& __op,
   NV_IF_TARGET(
     NV_PROVIDES_SM_70,
     (__cuda_atomic_load(
-       __aligned, __old, __atomic_cuda_relaxed{}, __atomic_cuda_operand_b32{}, _Sco{}, __atomic_cuda_mmio_disable{});),
+       __aligned,
+       __old,
+       __cuda_atomic_order_relaxed{},
+       __cuda_atomic_operand_b32{},
+       _Sco{},
+       __cuda_atomic_mmio_disable{});),
     (__cuda_atomic_load(
-       __aligned, __old, __atomic_cuda_volatile{}, __atomic_cuda_operand_b32{}, _Sco{}, __atomic_cuda_mmio_disable{});))
+       __aligned,
+       __old,
+       __cuda_atomic_order_volatile{},
+       __cuda_atomic_operand_b32{},
+       _Sco{},
+       __cuda_atomic_mmio_disable{});))
 
   // Reemit CAS instructions until we succeed
   while (true)
@@ -120,7 +140,7 @@ _CCCL_DEVICE_API _Type __cuda_atomic_fetch_update(_Type* __ptr, const _Fn& __op,
       | (__old & __windowMask);
 
     if (__cuda_atomic_compare_exchange(
-          __aligned, __old, __old, __attempt, _Order{}, __atomic_cuda_operand_b32{}, _Sco{}))
+          __aligned, __old, __old, __attempt, _Order{}, __cuda_atomic_operand_b32{}, _Sco{}))
     {
       // CAS was successful
       return static_cast<_Type>(__old >> __offset);
@@ -180,9 +200,19 @@ _CCCL_DEVICE_API _Type __cuda_atomic_fetch_update(_Type* __ptr, const _Fn& __op,
   NV_IF_TARGET(
     NV_PROVIDES_SM_70,
     (__cuda_atomic_load(
-       __ptr, __expected, __atomic_cuda_relaxed{}, __atomic_cuda_operand_b32{}, _Sco{}, __atomic_cuda_mmio_disable{});),
+       __ptr,
+       __expected,
+       __cuda_atomic_order_relaxed{},
+       __cuda_atomic_operand_b32{},
+       _Sco{},
+       __cuda_atomic_mmio_disable{});),
     (__cuda_atomic_load(
-       __ptr, __expected, __atomic_cuda_volatile{}, __atomic_cuda_operand_b32{}, _Sco{}, __atomic_cuda_mmio_disable{});))
+       __ptr,
+       __expected,
+       __cuda_atomic_order_volatile{},
+       __cuda_atomic_operand_b32{},
+       _Sco{},
+       __cuda_atomic_mmio_disable{});))
 
   _Type __desired = __op(__expected);
   while (!__cuda_atomic_compare_exchange(__ptr, __expected, __expected, __desired, _Order{}, _Operand{}, _Sco{}))
@@ -199,7 +229,7 @@ _CCCL_DEVICE static void __cuda_atomic_fetch_add(_Type* __ptr, _Type& __dst, _Ty
     __ptr,
     __cuda_atomic_op_bind<_Type, ::cuda::std::plus>{__op},
     _Order{},
-    __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, _Operand::__size>{},
+    __cuda_atomic_operand_tag<__cuda_atomic_operand::_b, _Operand::__size>{},
     _Sco{});
 }
 
@@ -210,7 +240,7 @@ _CCCL_DEVICE static void __cuda_atomic_fetch_and(_Type* __ptr, _Type& __dst, _Ty
     __ptr,
     __cuda_atomic_op_bind<_Type, ::cuda::std::bit_and>{__op},
     _Order{},
-    __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, _Operand::__size>{},
+    __cuda_atomic_operand_tag<__cuda_atomic_operand::_b, _Operand::__size>{},
     _Sco{});
 }
 
@@ -221,7 +251,7 @@ _CCCL_DEVICE static void __cuda_atomic_fetch_xor(_Type* __ptr, _Type& __dst, _Ty
     __ptr,
     __cuda_atomic_op_bind<_Type, ::cuda::std::bit_xor>{__op},
     _Order{},
-    __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, _Operand::__size>{},
+    __cuda_atomic_operand_tag<__cuda_atomic_operand::_b, _Operand::__size>{},
     _Sco{});
 }
 
@@ -232,7 +262,7 @@ _CCCL_DEVICE static void __cuda_atomic_fetch_or(_Type* __ptr, _Type& __dst, _Typ
     __ptr,
     __cuda_atomic_op_bind<_Type, ::cuda::std::bit_or>{__op},
     _Order{},
-    __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, _Operand::__size>{},
+    __cuda_atomic_operand_tag<__cuda_atomic_operand::_b, _Operand::__size>{},
     _Sco{});
 }
 
@@ -243,7 +273,7 @@ _CCCL_DEVICE static void __cuda_atomic_fetch_min(_Type* __ptr, _Type& __dst, _Ty
     __ptr,
     __cuda_atomic_op_bind<_Type, __cuda_atomic_op_fetch_min>{__op},
     _Order{},
-    __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, _Operand::__size>{},
+    __cuda_atomic_operand_tag<__cuda_atomic_operand::_b, _Operand::__size>{},
     _Sco{});
 }
 
@@ -254,7 +284,7 @@ _CCCL_DEVICE static void __cuda_atomic_fetch_max(_Type* __ptr, _Type& __dst, _Ty
     __ptr,
     __cuda_atomic_op_bind<_Type, __cuda_atomic_op_fetch_max>{__op},
     _Order{},
-    __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, _Operand::__size>{},
+    __cuda_atomic_operand_tag<__cuda_atomic_operand::_b, _Operand::__size>{},
     _Sco{});
 }
 
@@ -265,16 +295,16 @@ _CCCL_DEVICE static void __cuda_atomic_exchange(_Type* __ptr, _Type& __dst, _Typ
     __ptr,
     __cuda_atomic_op_bind<_Type, ::cuda::std::__cuda_atomic_op_store>{__op},
     _Order{},
-    __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, _Operand::__size>{},
+    __cuda_atomic_operand_tag<__cuda_atomic_operand::_b, _Operand::__size>{},
     _Sco{});
 }
 
 template <typename _Tp, typename _Fn, typename _Sco>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_update_cuda(_Tp* __ptr, const _Fn& __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_update(_Tp* __ptr, const _Fn& __op, int __memorder, _Sco)
 {
   _Tp __expected = __atomic_load_n_cuda(__ptr, __ATOMIC_RELAXED, _Sco{});
   _Tp __desired  = __op(__expected);
-  while (!__atomic_compare_exchange_cuda(__ptr, &__expected, __desired, true, __memorder, __memorder, _Sco{}))
+  while (!__cuda_atomic_compare_exchange_dispatch(__ptr, &__expected, __desired, true, __memorder, __memorder, _Sco{}))
   {
     __desired = __op(__expected);
   }
@@ -282,11 +312,11 @@ template <typename _Tp, typename _Fn, typename _Sco>
 }
 template <typename _Tp, typename _Fn, typename _Sco>
 [[nodiscard]] _CCCL_DEVICE static _Tp
-__atomic_fetch_update_cuda(_Tp volatile* __ptr, const _Fn& __op, int __memorder, _Sco)
+__cuda_atomic_fetch_update(_Tp volatile* __ptr, const _Fn& __op, int __memorder, _Sco)
 {
   _Tp __expected = __atomic_load_n_cuda(__ptr, __ATOMIC_RELAXED, _Sco{});
   _Tp __desired  = __op(__expected);
-  while (!__atomic_compare_exchange_cuda(__ptr, &__expected, __desired, true, __memorder, __memorder, _Sco{}))
+  while (!__cuda_atomic_compare_exchange_dispatch(__ptr, &__expected, __desired, true, __memorder, __memorder, _Sco{}))
   {
     __desired = __op(__expected);
   }
@@ -335,76 +365,82 @@ template <typename _Tp, typename _Sco>
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_arithmetic<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_add_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_add_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
-  return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::plus>{__val}, __memorder, _Sco{});
+  return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::plus>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_arithmetic<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_add_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE static _Tp
+__cuda_atomic_fetch_add_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
-  return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::plus>{__val}, __memorder, _Sco{});
+  return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::plus>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_and_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_and_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
-  return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_and>{__val}, __memorder, _Sco{});
+  return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_and>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_and_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE static _Tp
+__cuda_atomic_fetch_and_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
-  return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_and>{__val}, __memorder, _Sco{});
-}
-
-template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_or_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
-{
-  return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_or>{__val}, __memorder, _Sco{});
-}
-template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_or_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
-{
-  return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_or>{__val}, __memorder, _Sco{});
+  return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_and>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_xor_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_or_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
-  return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_xor>{__val}, __memorder, _Sco{});
+  return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_or>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_xor_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE static _Tp
+__cuda_atomic_fetch_or_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
-  return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_xor>{__val}, __memorder, _Sco{});
+  return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_or>{__val}, __memorder, _Sco{});
+}
+
+template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
+[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_xor_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+{
+  return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_xor>{__val}, __memorder, _Sco{});
+}
+template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
+[[nodiscard]] _CCCL_DEVICE static _Tp
+__cuda_atomic_fetch_xor_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+{
+  return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_xor>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_minmax<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_min_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_min_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
-  return __atomic_fetch_update_cuda(
+  return __cuda_atomic_fetch_update(
     __ptr, __cuda_atomic_op_bind<_Tp, __cuda_atomic_op_fetch_min>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_minmax<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_min_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE static _Tp
+__cuda_atomic_fetch_min_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
-  return __atomic_fetch_update_cuda(
+  return __cuda_atomic_fetch_update(
     __ptr, __cuda_atomic_op_bind<_Tp, __cuda_atomic_op_fetch_min>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_minmax<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_max_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_max_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
-  return __atomic_fetch_update_cuda(
+  return __cuda_atomic_fetch_update(
     __ptr, __cuda_atomic_op_bind<_Tp, __cuda_atomic_op_fetch_max>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_minmax<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_fetch_max_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE static _Tp
+__cuda_atomic_fetch_max_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
-  return __atomic_fetch_update_cuda(
+  return __cuda_atomic_fetch_update(
     __ptr, __cuda_atomic_op_bind<_Tp, __cuda_atomic_op_fetch_max>{__val}, __memorder, _Sco{});
 }
 
-_CCCL_DEVICE static inline void __atomic_signal_fence_cuda(int)
+_CCCL_DEVICE static inline void __cuda_atomic_signal_fence(int)
 {
   asm volatile("" ::: "memory");
 }

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
@@ -53,33 +53,33 @@ static inline _CCCL_DEVICE void __cuda_atomic_membar(__thread_scope_device_tag)
 { asm volatile("membar.gl;" ::: "memory"); }
 static inline _CCCL_DEVICE void __cuda_atomic_membar(__thread_scope_system_tag)
 { asm volatile("membar.sys;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_block_tag, __atomic_cuda_acq_rel)
+static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_block_tag, __cuda_atomic_order_acq_rel)
 { asm volatile("fence.acq_rel.cta;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_block_tag, __atomic_cuda_seq_cst)
+static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_block_tag, __cuda_atomic_order_seq_cst)
 { asm volatile("fence.sc.cta;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_cluster_tag, __atomic_cuda_acq_rel)
+static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_cluster_tag, __cuda_atomic_order_acq_rel)
 { asm volatile("fence.acq_rel.cluster;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_cluster_tag, __atomic_cuda_seq_cst)
+static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_cluster_tag, __cuda_atomic_order_seq_cst)
 { asm volatile("fence.sc.cluster;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_device_tag, __atomic_cuda_acq_rel)
+static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_device_tag, __cuda_atomic_order_acq_rel)
 { asm volatile("fence.acq_rel.gpu;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_device_tag, __atomic_cuda_seq_cst)
+static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_device_tag, __cuda_atomic_order_seq_cst)
 { asm volatile("fence.sc.gpu;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_system_tag, __atomic_cuda_acq_rel)
+static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_system_tag, __cuda_atomic_order_acq_rel)
 { asm volatile("fence.acq_rel.sys;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_system_tag, __atomic_cuda_seq_cst)
+static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_system_tag, __cuda_atomic_order_seq_cst)
 { asm volatile("fence.sc.sys;" ::: "memory"); }
 
 template <typename _Sco>
-static inline _CCCL_DEVICE void __atomic_thread_fence_cuda(int __memorder, _Sco) {
+static inline _CCCL_DEVICE void __cuda_atomic_thread_fence(int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
-        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __atomic_cuda_seq_cst{}); break;
+        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_seq_cst{}); break;
         case __ATOMIC_CONSUME: [[fallthrough]];
         case __ATOMIC_ACQUIRE: [[fallthrough]];
         case __ATOMIC_ACQ_REL: [[fallthrough]];
-        case __ATOMIC_RELEASE: __cuda_atomic_fence(_Sco{}, __atomic_cuda_acq_rel{}); break;
+        case __ATOMIC_RELEASE: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_acq_rel{}); break;
         case __ATOMIC_RELAXED: break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
@@ -99,14 +99,14 @@ static inline _CCCL_DEVICE void __atomic_thread_fence_cuda(int __memorder, _Sco)
 }
 
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_load_memory_order_dispatch(_Fn &__cuda_load, int __memorder, _Sco) {
+static inline _CCCL_DEVICE void __cuda_atomic_load_order_dispatch(_Fn &__cuda_load, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
-        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __atomic_cuda_seq_cst{}); [[fallthrough]];
+        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_seq_cst{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __cuda_load(__atomic_cuda_acquire{}); break;
-        case __ATOMIC_RELAXED: __cuda_load(__atomic_cuda_relaxed{}); break;
+        case __ATOMIC_ACQUIRE: __cuda_load(__cuda_atomic_order_acquire{}); break;
+        case __ATOMIC_RELAXED: __cuda_load(__cuda_atomic_order_relaxed{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     ),
@@ -114,8 +114,8 @@ static inline _CCCL_DEVICE void __cuda_atomic_load_memory_order_dispatch(_Fn &__
       switch (__memorder) {
         case __ATOMIC_SEQ_CST: __cuda_atomic_membar(_Sco{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __cuda_load(__atomic_cuda_volatile{}); __cuda_atomic_membar(_Sco{}); break;
-        case __ATOMIC_RELAXED: __cuda_load(__atomic_cuda_volatile{}); break;
+        case __ATOMIC_ACQUIRE: __cuda_load(__cuda_atomic_order_volatile{}); __cuda_atomic_membar(_Sco{}); break;
+        case __ATOMIC_RELAXED: __cuda_load(__cuda_atomic_order_volatile{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     )
@@ -124,7 +124,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load_memory_order_dispatch(_Fn &__
 
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.acquire.cta.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -132,7 +132,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.acquire.cluster.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -140,7 +140,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.acquire.gpu.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -148,7 +148,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.acquire.sys.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -156,7 +156,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.relaxed.cta.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -164,7 +164,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.relaxed.cluster.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -172,7 +172,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.relaxed.gpu.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -180,7 +180,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.relaxed.sys.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -188,7 +188,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 {
   uint16_t __tmp;
   asm volatile("ld.mmio.relaxed.sys.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -196,7 +196,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.volatile.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -204,7 +204,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.volatile.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -212,7 +212,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.volatile.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -220,7 +220,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.volatile.b8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -228,7 +228,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.acquire.cta.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -236,7 +236,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.acquire.cluster.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -244,7 +244,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.acquire.gpu.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -252,7 +252,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.acquire.sys.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -260,7 +260,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.relaxed.cta.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -268,7 +268,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.relaxed.cluster.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -276,7 +276,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.relaxed.gpu.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -284,7 +284,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.relaxed.sys.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -292,7 +292,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u8, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u8, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 {
   uint16_t __tmp;
   asm volatile("ld.mmio.relaxed.sys.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -300,7 +300,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.volatile.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -308,7 +308,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.volatile.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -316,7 +316,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.volatile.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -324,7 +324,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.volatile.u8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -332,7 +332,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.acquire.cta.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -340,7 +340,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.acquire.cluster.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -348,7 +348,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.acquire.gpu.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -356,7 +356,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.acquire.sys.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -364,7 +364,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.relaxed.cta.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -372,7 +372,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.relaxed.cluster.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -380,7 +380,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.relaxed.gpu.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -388,7 +388,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.relaxed.sys.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -396,7 +396,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s8, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s8, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 {
   uint16_t __tmp;
   asm volatile("ld.mmio.relaxed.sys.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -404,7 +404,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.volatile.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -412,7 +412,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.volatile.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -420,7 +420,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.volatile.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -428,7 +428,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
   asm volatile("ld.volatile.s8 %0,[%1];" : "=h"(__tmp) : "l"(__ptr) : "memory");
@@ -436,579 +436,579 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b16, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b16, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b16, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b16, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b16, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b16, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b16, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b16, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b16, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b16, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u16, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u16, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u16, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u16, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u16, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u16, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u16, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u16, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u16, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u16, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u16, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s16, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s16, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s16, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s16, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s16, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s16, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s16, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s16, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s16, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s16, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s16, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_f32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_f32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_f32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_f32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_f32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_f32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_f32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_f32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_f32, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_f32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_f32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_f32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_f32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_f64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_f64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_f64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_f64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_f64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_f64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_f64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_f64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_f64, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_f64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_f64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_f64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_f64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_s64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_s64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b128, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1025,7 +1025,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b128, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1042,7 +1042,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b128, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1059,7 +1059,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_acquire, __atomic_cuda_operand_b128, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1076,7 +1076,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1093,7 +1093,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1110,7 +1110,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1127,7 +1127,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1144,7 +1144,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1161,7 +1161,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1178,7 +1178,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1195,7 +1195,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1212,7 +1212,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }
   template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_load(
-  const _Type* __ptr, _Type& __dst, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1241,34 +1241,34 @@ struct __cuda_atomic_bind_load {
 template <class _Type, class _Sco>
 static inline _CCCL_DEVICE void __atomic_load_cuda(const _Type* __ptr, _Type& __dst, int __memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   const __proxy_t* __ptr_proxy = reinterpret_cast<const __proxy_t*>(__ptr);
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
-  if (__cuda_load_weak_if_local(__ptr_proxy, __dst_proxy, sizeof(__proxy_t))) {{return;}}
-  __cuda_atomic_bind_load<__proxy_t, __proxy_tag, _Sco, __atomic_cuda_mmio_disable> __bound_load{__ptr_proxy, __dst_proxy};
-  __cuda_atomic_load_memory_order_dispatch(__bound_load, __memorder, _Sco{});
+  if (__cuda_atomic_load_weak_if_local(__ptr_proxy, __dst_proxy, sizeof(__proxy_t))) {{return;}}
+  __cuda_atomic_bind_load<__proxy_t, __proxy_tag, _Sco, __cuda_atomic_mmio_disable> __bound_load{__ptr_proxy, __dst_proxy};
+  __cuda_atomic_load_order_dispatch(__bound_load, __memorder, _Sco{});
 }
 template <class _Type, class _Sco>
 static inline _CCCL_DEVICE void __atomic_load_cuda(const _Type volatile* __ptr, _Type& __dst, int __memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   const __proxy_t* __ptr_proxy = reinterpret_cast<const __proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
-  if (__cuda_load_weak_if_local(__ptr_proxy, __dst_proxy, sizeof(__proxy_t))) {{return;}}
-  __cuda_atomic_bind_load<__proxy_t, __proxy_tag, _Sco, __atomic_cuda_mmio_disable> __bound_load{__ptr_proxy, __dst_proxy};
-  __cuda_atomic_load_memory_order_dispatch(__bound_load, __memorder, _Sco{});
+  if (__cuda_atomic_load_weak_if_local(__ptr_proxy, __dst_proxy, sizeof(__proxy_t))) {{return;}}
+  __cuda_atomic_bind_load<__proxy_t, __proxy_tag, _Sco, __cuda_atomic_mmio_disable> __bound_load{__ptr_proxy, __dst_proxy};
+  __cuda_atomic_load_order_dispatch(__bound_load, __memorder, _Sco{});
 }
 
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_store_memory_order_dispatch(_Fn &__cuda_store, int __memorder, _Sco) {
+static inline _CCCL_DEVICE void __cuda_atomic_store_order_dispatch(_Fn &__cuda_store, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
-        case __ATOMIC_RELEASE: __cuda_store(__atomic_cuda_release{}); break;
-        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __atomic_cuda_seq_cst{}); [[fallthrough]];
-        case __ATOMIC_RELAXED: __cuda_store(__atomic_cuda_relaxed{}); break;
+        case __ATOMIC_RELEASE: __cuda_store(__cuda_atomic_order_release{}); break;
+        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_seq_cst{}); [[fallthrough]];
+        case __ATOMIC_RELAXED: __cuda_store(__cuda_atomic_order_relaxed{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     ),
@@ -1276,7 +1276,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store_memory_order_dispatch(_Fn &_
       switch (__memorder) {
         case __ATOMIC_RELEASE: [[fallthrough]];
         case __ATOMIC_SEQ_CST: __cuda_atomic_membar(_Sco{}); [[fallthrough]];
-        case __ATOMIC_RELAXED: __cuda_store(__atomic_cuda_volatile{}); break;
+        case __ATOMIC_RELAXED: __cuda_store(__cuda_atomic_order_volatile{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     )
@@ -1285,254 +1285,254 @@ static inline _CCCL_DEVICE void __cuda_atomic_store_memory_order_dispatch(_Fn &_
 
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.release.cta.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.release.cluster.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.release.gpu.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.release.sys.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.relaxed.cta.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.relaxed.cluster.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.relaxed.gpu.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.relaxed.sys.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.mmio.relaxed.sys.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.volatile.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.volatile.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.volatile.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b8, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.volatile.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.cta.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b16, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.cluster.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b16, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.gpu.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b16, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.sys.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.cta.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b16, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.cluster.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b16, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.gpu.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b16, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.sys.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b16, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("st.mmio.relaxed.sys.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b16, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b16, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b16, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b16, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.cta.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.cluster.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.gpu.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.sys.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.cta.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.cluster.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.gpu.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.sys.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("st.mmio.relaxed.sys.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.cta.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.cluster.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.gpu.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.sys.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.cta.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.cluster.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.gpu.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.sys.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("st.mmio.relaxed.sys.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b128, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1549,7 +1549,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b128, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1566,7 +1566,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b128, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1583,7 +1583,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_release, __atomic_cuda_operand_b128, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1600,7 +1600,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1617,7 +1617,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1634,7 +1634,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1651,7 +1651,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1668,7 +1668,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_system_tag, __atomic_cuda_mmio_enable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1685,7 +1685,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_block_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1702,7 +1702,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_cluster_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1719,7 +1719,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_device_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1736,7 +1736,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_store(
-  _Type* __ptr, _Type& __val, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_system_tag, __atomic_cuda_mmio_disable)
+  _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1765,49 +1765,49 @@ struct __cuda_atomic_bind_store {
 template <class _Type, class _Sco>
 static inline _CCCL_DEVICE void __atomic_store_cuda(_Type* __ptr, _Type& __val, int __memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __val_proxy = reinterpret_cast<__proxy_t*>(&__val);
-  if (__cuda_store_weak_if_local(__ptr_proxy, __val_proxy, sizeof(__proxy_t))) {{return;}}
-  __cuda_atomic_bind_store<__proxy_t, __proxy_tag, _Sco, __atomic_cuda_mmio_disable> __bound_store{__ptr_proxy, __val_proxy};
-  __cuda_atomic_store_memory_order_dispatch(__bound_store, __memorder, _Sco{});
+  if (__cuda_atomic_store_weak_if_local(__ptr_proxy, __val_proxy, sizeof(__proxy_t))) {{return;}}
+  __cuda_atomic_bind_store<__proxy_t, __proxy_tag, _Sco, __cuda_atomic_mmio_disable> __bound_store{__ptr_proxy, __val_proxy};
+  __cuda_atomic_store_order_dispatch(__bound_store, __memorder, _Sco{});
 }
 template <class _Type, class _Sco>
 static inline _CCCL_DEVICE void __atomic_store_cuda(volatile _Type* __ptr, _Type& __val, int __memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __val_proxy = reinterpret_cast<__proxy_t*>(&__val);
-  if (__cuda_store_weak_if_local(__ptr_proxy, __val_proxy, sizeof(__proxy_t))) {{return;}}
-  __cuda_atomic_bind_store<__proxy_t, __proxy_tag, _Sco, __atomic_cuda_mmio_disable> __bound_store{__ptr_proxy, __val_proxy};
-  __cuda_atomic_store_memory_order_dispatch(__bound_store, __memorder, _Sco{});
+  if (__cuda_atomic_store_weak_if_local(__ptr_proxy, __val_proxy, sizeof(__proxy_t))) {{return;}}
+  __cuda_atomic_bind_store<__proxy_t, __proxy_tag, _Sco, __cuda_atomic_mmio_disable> __bound_store{__ptr_proxy, __val_proxy};
+  __cuda_atomic_store_order_dispatch(__bound_store, __memorder, _Sco{});
 }
 
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_swap_memory_order_dispatch(_Fn& __cuda_cas, int __success_memorder, int __failure_memorder, _Sco) {
+static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_order_dispatch(_Fn& __cuda_cas, int __success_memorder, int __failure_memorder, _Sco) {
   bool __res = false;
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
-      switch (__stronger_order_cuda(__success_memorder, __failure_memorder)) {
-        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __atomic_cuda_seq_cst{}); [[fallthrough]];
+      switch (__cuda_atomic_stronger_order(__success_memorder, __failure_memorder)) {
+        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_seq_cst{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __res = __cuda_cas(__atomic_cuda_acquire{}); break;
-        case __ATOMIC_ACQ_REL: __res = __cuda_cas(__atomic_cuda_acq_rel{}); break;
-        case __ATOMIC_RELEASE: __res = __cuda_cas(__atomic_cuda_release{}); break;
-        case __ATOMIC_RELAXED: __res = __cuda_cas(__atomic_cuda_relaxed{}); break;
+        case __ATOMIC_ACQUIRE: __res = __cuda_cas(__cuda_atomic_order_acquire{}); break;
+        case __ATOMIC_ACQ_REL: __res = __cuda_cas(__cuda_atomic_order_acq_rel{}); break;
+        case __ATOMIC_RELEASE: __res = __cuda_cas(__cuda_atomic_order_release{}); break;
+        case __ATOMIC_RELAXED: __res = __cuda_cas(__cuda_atomic_order_relaxed{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     ),
     NV_IS_DEVICE, (
-      switch (__stronger_order_cuda(__success_memorder, __failure_memorder)) {
+      switch (__cuda_atomic_stronger_order(__success_memorder, __failure_memorder)) {
         case __ATOMIC_SEQ_CST: [[fallthrough]];
         case __ATOMIC_ACQ_REL: __cuda_atomic_membar(_Sco{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __res = __cuda_cas(__atomic_cuda_volatile{}); __cuda_atomic_membar(_Sco{}); break;
-        case __ATOMIC_RELEASE: __cuda_atomic_membar(_Sco{}); __res = __cuda_cas(__atomic_cuda_volatile{}); break;
-        case __ATOMIC_RELAXED: __res = __cuda_cas(__atomic_cuda_volatile{}); break;
+        case __ATOMIC_ACQUIRE: __res = __cuda_cas(__cuda_atomic_order_volatile{}); __cuda_atomic_membar(_Sco{}); break;
+        case __ATOMIC_RELEASE: __cuda_atomic_membar(_Sco{}); __res = __cuda_cas(__cuda_atomic_order_volatile{}); break;
+        case __ATOMIC_RELAXED: __res = __cuda_cas(__cuda_atomic_order_volatile{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     )
@@ -1817,167 +1817,167 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_swap_memory_order_dispatch
 
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.cas.acquire.cta.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.acquire.cluster.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.cas.acquire.gpu.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.cas.acquire.sys.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.cas.relaxed.cta.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.relaxed.cluster.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.cas.relaxed.gpu.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.cas.relaxed.sys.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.cas.release.cta.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.release.cluster.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.cas.release.gpu.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.cas.release.sys.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.cas.acq_rel.cta.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.acq_rel.cluster.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.cas.acq_rel.gpu.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.cas.acq_rel.sys.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.cas.cta.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.cluster.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.cas.gpu.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.cas.sys.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.cas.acquire.cta.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.acquire.cluster.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.cas.acquire.gpu.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.cas.acquire.sys.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.cas.relaxed.cta.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.relaxed.cluster.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.cas.relaxed.gpu.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.cas.relaxed.sys.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.cas.release.cta.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.release.cluster.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.cas.release.gpu.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.cas.release.sys.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.cas.acq_rel.cta.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.acq_rel.cluster.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.cas.acq_rel.gpu.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.cas.acq_rel.sys.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.cas.cta.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.cluster.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.cas.gpu.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.cas.sys.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b128, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -1996,7 +1996,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b128, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2015,7 +2015,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b128, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2034,7 +2034,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b128, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2053,7 +2053,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2072,7 +2072,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2091,7 +2091,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2110,7 +2110,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2129,7 +2129,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b128, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2148,7 +2148,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b128, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2167,7 +2167,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b128, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2186,7 +2186,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b128, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2205,7 +2205,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b128, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2224,7 +2224,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b128, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2243,7 +2243,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b128, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2262,7 +2262,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b128, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2281,7 +2281,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2300,7 +2300,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2319,7 +2319,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2338,7 +2338,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
 static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
-  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2368,43 +2368,43 @@ struct __cuda_atomic_bind_compare_exchange {
   }
 };
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE bool __atomic_compare_exchange_cuda(_Type* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
+static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_dispatch(_Type* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __exp_proxy = reinterpret_cast<__proxy_t*>(__exp);
   __proxy_t* __des_proxy  = reinterpret_cast<__proxy_t*>(&__des);
   bool __res = false;
-  if (__cuda_compare_exchange_weak_if_local(__ptr_proxy, __exp_proxy, __des_proxy, &__res)) {return __res;}
+  if (__cuda_atomic_compare_exchange_weak_if_local(__ptr_proxy, __exp_proxy, __des_proxy, &__res)) {return __res;}
   __cuda_atomic_bind_compare_exchange<__proxy_t, __proxy_tag, _Sco> __bound_compare_swap{__ptr_proxy, __exp_proxy, __des_proxy};
-  return __cuda_atomic_compare_swap_memory_order_dispatch(__bound_compare_swap, __success_memorder, __failure_memorder, _Sco{});
+  return __cuda_atomic_compare_exchange_order_dispatch(__bound_compare_swap, __success_memorder, __failure_memorder, _Sco{});
 }
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE bool __atomic_compare_exchange_cuda(_Type volatile* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
+static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_dispatch(_Type volatile* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __exp_proxy = reinterpret_cast<__proxy_t*>(__exp);
   __proxy_t* __des_proxy  = reinterpret_cast<__proxy_t*>(&__des);
   bool __res = false;
-  if (__cuda_compare_exchange_weak_if_local(__ptr_proxy, __exp_proxy, __des_proxy, &__res)) {return __res;}
+  if (__cuda_atomic_compare_exchange_weak_if_local(__ptr_proxy, __exp_proxy, __des_proxy, &__res)) {return __res;}
   __cuda_atomic_bind_compare_exchange<__proxy_t, __proxy_tag, _Sco> __bound_compare_swap{__ptr_proxy, __exp_proxy, __des_proxy};
-  return __cuda_atomic_compare_swap_memory_order_dispatch(__bound_compare_swap, __success_memorder, __failure_memorder, _Sco{});
+  return __cuda_atomic_compare_exchange_order_dispatch(__bound_compare_swap, __success_memorder, __failure_memorder, _Sco{});
 }
 
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange_memory_order_dispatch(_Fn& __cuda_exch, int __memorder, _Sco) {
+static inline _CCCL_DEVICE void __cuda_atomic_exchange_order_dispatch(_Fn& __cuda_exch, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
-        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __atomic_cuda_seq_cst{}); [[fallthrough]];
+        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_seq_cst{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __cuda_exch(__atomic_cuda_acquire{}); break;
-        case __ATOMIC_ACQ_REL: __cuda_exch(__atomic_cuda_acq_rel{}); break;
-        case __ATOMIC_RELEASE: __cuda_exch(__atomic_cuda_release{}); break;
-        case __ATOMIC_RELAXED: __cuda_exch(__atomic_cuda_relaxed{}); break;
+        case __ATOMIC_ACQUIRE: __cuda_exch(__cuda_atomic_order_acquire{}); break;
+        case __ATOMIC_ACQ_REL: __cuda_exch(__cuda_atomic_order_acq_rel{}); break;
+        case __ATOMIC_RELEASE: __cuda_exch(__cuda_atomic_order_release{}); break;
+        case __ATOMIC_RELAXED: __cuda_exch(__cuda_atomic_order_relaxed{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     ),
@@ -2413,9 +2413,9 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange_memory_order_dispatch(_Fn
         case __ATOMIC_SEQ_CST: [[fallthrough]];
         case __ATOMIC_ACQ_REL: __cuda_atomic_membar(_Sco{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __cuda_exch(__atomic_cuda_volatile{}); __cuda_atomic_membar(_Sco{}); break;
-        case __ATOMIC_RELEASE: __cuda_atomic_membar(_Sco{}); __cuda_exch(__atomic_cuda_volatile{}); break;
-        case __ATOMIC_RELAXED: __cuda_exch(__atomic_cuda_volatile{}); break;
+        case __ATOMIC_ACQUIRE: __cuda_exch(__cuda_atomic_order_volatile{}); __cuda_atomic_membar(_Sco{}); break;
+        case __ATOMIC_RELEASE: __cuda_atomic_membar(_Sco{}); __cuda_exch(__cuda_atomic_order_volatile{}); break;
+        case __ATOMIC_RELAXED: __cuda_exch(__cuda_atomic_order_volatile{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     )
@@ -2424,167 +2424,167 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange_memory_order_dispatch(_Fn
 
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.exch.acquire.cta.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.acquire.cluster.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.exch.acquire.gpu.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.exch.acquire.sys.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.exch.relaxed.cta.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.relaxed.cluster.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.exch.relaxed.gpu.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.exch.relaxed.sys.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.exch.release.cta.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.release.cluster.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.exch.release.gpu.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.exch.release.sys.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.exch.acq_rel.cta.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.acq_rel.cluster.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.exch.acq_rel.gpu.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.exch.acq_rel.sys.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.exch.cta.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.cluster.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.exch.gpu.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.exch.sys.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.exch.acquire.cta.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.acquire.cluster.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.exch.acquire.gpu.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.exch.acquire.sys.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.exch.relaxed.cta.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.relaxed.cluster.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.exch.relaxed.gpu.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.exch.relaxed.sys.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.exch.release.cta.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.release.cluster.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.exch.release.gpu.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.exch.release.sys.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.exch.acq_rel.cta.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.acq_rel.cluster.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.exch.acq_rel.gpu.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.exch.acq_rel.sys.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.exch.cta.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.cluster.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.exch.gpu.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.exch.sys.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acquire, __atomic_cuda_operand_b128, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2603,7 +2603,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acquire, __atomic_cuda_operand_b128, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2622,7 +2622,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acquire, __atomic_cuda_operand_b128, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2641,7 +2641,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acquire, __atomic_cuda_operand_b128, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2660,7 +2660,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2679,7 +2679,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2698,7 +2698,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2717,7 +2717,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_relaxed, __atomic_cuda_operand_b128, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2736,7 +2736,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_release, __atomic_cuda_operand_b128, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2755,7 +2755,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_release, __atomic_cuda_operand_b128, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2774,7 +2774,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_release, __atomic_cuda_operand_b128, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2793,7 +2793,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_release, __atomic_cuda_operand_b128, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2812,7 +2812,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acq_rel, __atomic_cuda_operand_b128, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2831,7 +2831,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acq_rel, __atomic_cuda_operand_b128, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2850,7 +2850,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acq_rel, __atomic_cuda_operand_b128, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2869,7 +2869,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_acq_rel, __atomic_cuda_operand_b128, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2888,7 +2888,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2907,7 +2907,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2926,7 +2926,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2945,7 +2945,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_exchange(
-  _Type* __ptr, _Type& __old, _Type __new, __atomic_cuda_volatile, __atomic_cuda_operand_b128, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
   NV_DISPATCH_TARGET(
@@ -2977,39 +2977,39 @@ struct __cuda_atomic_bind_exchange {
 template <class _Type, class _Sco>
 static inline _CCCL_DEVICE void __atomic_exchange_cuda(_Type* __ptr, _Type& __old, _Type __new, int __memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __old_proxy = reinterpret_cast<__proxy_t*>(&__old);
   __proxy_t* __new_proxy  = reinterpret_cast<__proxy_t*>(&__new);
-  if(__cuda_exchange_weak_if_local(__ptr_proxy, __new_proxy, __old_proxy)) {{return;}}
+  if(__cuda_atomic_exchange_weak_if_local(__ptr_proxy, __new_proxy, __old_proxy)) {{return;}}
   __cuda_atomic_bind_exchange<__proxy_t, __proxy_tag, _Sco> __bound_swap{__ptr_proxy, __old_proxy, __new_proxy};
-  __cuda_atomic_exchange_memory_order_dispatch(__bound_swap, __memorder, _Sco{});
+  __cuda_atomic_exchange_order_dispatch(__bound_swap, __memorder, _Sco{});
 }
 template <class _Type, class _Sco>
 static inline _CCCL_DEVICE void __atomic_exchange_cuda(_Type volatile* __ptr, _Type& __old, _Type __new, int __memorder, _Sco)
 {
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __old_proxy = reinterpret_cast<__proxy_t*>(&__old);
   __proxy_t* __new_proxy  = reinterpret_cast<__proxy_t*>(&__new);
-  if(__cuda_exchange_weak_if_local(__ptr_proxy, __new_proxy, __old_proxy)) {{return;}}
+  if(__cuda_atomic_exchange_weak_if_local(__ptr_proxy, __new_proxy, __old_proxy)) {{return;}}
   __cuda_atomic_bind_exchange<__proxy_t, __proxy_tag, _Sco> __bound_swap{__ptr_proxy, __old_proxy, __new_proxy};
-  __cuda_atomic_exchange_memory_order_dispatch(__bound_swap, __memorder, _Sco{});
+  __cuda_atomic_exchange_order_dispatch(__bound_swap, __memorder, _Sco{});
 }
 
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_memory_order_dispatch(_Fn& __cuda_fetch, int __memorder, _Sco) {
+static inline _CCCL_DEVICE void __cuda_atomic_fetch_order_dispatch(_Fn& __cuda_fetch, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
-        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __atomic_cuda_seq_cst{}); [[fallthrough]];
+        case __ATOMIC_SEQ_CST: __cuda_atomic_fence(_Sco{}, __cuda_atomic_order_seq_cst{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __cuda_fetch(__atomic_cuda_acquire{}); break;
-        case __ATOMIC_ACQ_REL: __cuda_fetch(__atomic_cuda_acq_rel{}); break;
-        case __ATOMIC_RELEASE: __cuda_fetch(__atomic_cuda_release{}); break;
-        case __ATOMIC_RELAXED: __cuda_fetch(__atomic_cuda_relaxed{}); break;
+        case __ATOMIC_ACQUIRE: __cuda_fetch(__cuda_atomic_order_acquire{}); break;
+        case __ATOMIC_ACQ_REL: __cuda_fetch(__cuda_atomic_order_acq_rel{}); break;
+        case __ATOMIC_RELEASE: __cuda_fetch(__cuda_atomic_order_release{}); break;
+        case __ATOMIC_RELAXED: __cuda_fetch(__cuda_atomic_order_relaxed{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     ),
@@ -3018,9 +3018,9 @@ static inline _CCCL_DEVICE void __cuda_atomic_fetch_memory_order_dispatch(_Fn& _
         case __ATOMIC_SEQ_CST: [[fallthrough]];
         case __ATOMIC_ACQ_REL: __cuda_atomic_membar(_Sco{}); [[fallthrough]];
         case __ATOMIC_CONSUME: [[fallthrough]];
-        case __ATOMIC_ACQUIRE: __cuda_fetch(__atomic_cuda_volatile{}); __cuda_atomic_membar(_Sco{}); break;
-        case __ATOMIC_RELEASE: __cuda_atomic_membar(_Sco{}); __cuda_fetch(__atomic_cuda_volatile{}); break;
-        case __ATOMIC_RELAXED: __cuda_fetch(__atomic_cuda_volatile{}); break;
+        case __ATOMIC_ACQUIRE: __cuda_fetch(__cuda_atomic_order_volatile{}); __cuda_atomic_membar(_Sco{}); break;
+        case __ATOMIC_RELEASE: __cuda_atomic_membar(_Sco{}); __cuda_fetch(__cuda_atomic_order_volatile{}); break;
+        case __ATOMIC_RELAXED: __cuda_fetch(__cuda_atomic_order_volatile{}); break;
         default: _CCCL_ASSERT(false, "invalid memory order");
       }
     )
@@ -3029,403 +3029,403 @@ static inline _CCCL_DEVICE void __cuda_atomic_fetch_memory_order_dispatch(_Fn& _
 
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_f32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_block_tag)
 { asm volatile("atom.add.acquire.cta.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_f32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_block_tag)
 { asm volatile("atom.add.relaxed.cta.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_f32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f32, __thread_scope_block_tag)
 { asm volatile("atom.add.release.cta.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_f32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f32, __thread_scope_block_tag)
 { asm volatile("atom.add.acq_rel.cta.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_f32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_block_tag)
 { asm volatile("atom.add.cta.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_f32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acquire.cluster.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_f32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.relaxed.cluster.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_f32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.release.cluster.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_f32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acq_rel.cluster.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_f32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.cluster.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_f32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_device_tag)
 { asm volatile("atom.add.acquire.gpu.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_f32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_device_tag)
 { asm volatile("atom.add.relaxed.gpu.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_f32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f32, __thread_scope_device_tag)
 { asm volatile("atom.add.release.gpu.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_f32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f32, __thread_scope_device_tag)
 { asm volatile("atom.add.acq_rel.gpu.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_f32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_device_tag)
 { asm volatile("atom.add.gpu.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_f32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_system_tag)
 { asm volatile("atom.add.acquire.sys.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_f32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_system_tag)
 { asm volatile("atom.add.relaxed.sys.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_f32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f32, __thread_scope_system_tag)
 { asm volatile("atom.add.release.sys.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_f32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f32, __thread_scope_system_tag)
 { asm volatile("atom.add.acq_rel.sys.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_f32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_system_tag)
 { asm volatile("atom.add.sys.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_f64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_block_tag)
 { asm volatile("atom.add.acquire.cta.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_f64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_block_tag)
 { asm volatile("atom.add.relaxed.cta.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_f64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f64, __thread_scope_block_tag)
 { asm volatile("atom.add.release.cta.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_f64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f64, __thread_scope_block_tag)
 { asm volatile("atom.add.acq_rel.cta.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_f64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_block_tag)
 { asm volatile("atom.add.cta.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_f64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acquire.cluster.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_f64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.relaxed.cluster.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_f64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.release.cluster.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_f64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acq_rel.cluster.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_f64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.cluster.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_f64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_device_tag)
 { asm volatile("atom.add.acquire.gpu.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_f64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_device_tag)
 { asm volatile("atom.add.relaxed.gpu.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_f64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f64, __thread_scope_device_tag)
 { asm volatile("atom.add.release.gpu.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_f64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f64, __thread_scope_device_tag)
 { asm volatile("atom.add.acq_rel.gpu.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_f64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_device_tag)
 { asm volatile("atom.add.gpu.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_f64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_system_tag)
 { asm volatile("atom.add.acquire.sys.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_f64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_system_tag)
 { asm volatile("atom.add.relaxed.sys.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_f64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f64, __thread_scope_system_tag)
 { asm volatile("atom.add.release.sys.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_f64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f64, __thread_scope_system_tag)
 { asm volatile("atom.add.acq_rel.sys.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_f64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_system_tag)
 { asm volatile("atom.add.sys.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.add.acquire.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.add.relaxed.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.add.release.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.add.acq_rel.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.add.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acquire.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.relaxed.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.release.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acq_rel.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.add.acquire.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.add.relaxed.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.add.release.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.add.acq_rel.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.add.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.add.acquire.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.add.relaxed.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.add.release.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.add.acq_rel.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.add.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.add.acquire.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.add.relaxed.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.add.release.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.add.acq_rel.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.add.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acquire.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.relaxed.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.release.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acq_rel.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.add.acquire.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.add.relaxed.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.add.release.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.add.acq_rel.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.add.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.add.acquire.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.add.relaxed.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.add.release.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.add.acq_rel.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.add.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.add.acquire.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.add.relaxed.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.add.release.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.add.acq_rel.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.add.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acquire.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.relaxed.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.release.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acq_rel.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.add.acquire.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.add.relaxed.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.add.release.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.add.acq_rel.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.add.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.add.acquire.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.add.relaxed.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.add.release.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.add.acq_rel.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.add.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 
 template <typename _Type, typename _Tag, typename _Sco>
@@ -3440,197 +3440,197 @@ struct __cuda_atomic_bind_fetch_add {
   }
 };
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_arithmetic<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_add_cuda(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_add_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = __atomic_ptr_skip_t<_Type>::__skip;
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_arithmetic<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_arithmetic<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_arithmetic<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_arithmetic<_Type>::__tag;
   _Type __dst{};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_add_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
+  if (__cuda_atomic_fetch_add_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
   __cuda_atomic_bind_fetch_add<__proxy_t, __proxy_tag, _Sco> __bound_add{__ptr_proxy, __dst_proxy, __op_proxy};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_add, __memorder, _Sco{});
+  __cuda_atomic_fetch_order_dispatch(__bound_add, __memorder, _Sco{});
   return __dst;
 }
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_arithmetic<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_add_cuda(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_add_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = __atomic_ptr_skip_t<_Type>::__skip;
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_arithmetic<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_arithmetic<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_arithmetic<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_arithmetic<_Type>::__tag;
   _Type __dst{};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_add_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
+  if (__cuda_atomic_fetch_add_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
   __cuda_atomic_bind_fetch_add<__proxy_t, __proxy_tag, _Sco> __bound_add{__ptr_proxy, __dst_proxy, __op_proxy};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_add, __memorder, _Sco{});
+  __cuda_atomic_fetch_order_dispatch(__bound_add, __memorder, _Sco{});
   return __dst;
 }
 
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.and.acquire.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.and.relaxed.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.and.release.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.and.acq_rel.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.and.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.and.acquire.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.and.relaxed.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.and.release.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.and.acq_rel.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.and.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.and.acquire.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.and.relaxed.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.and.release.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.and.acq_rel.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.and.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.and.acquire.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.and.relaxed.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.and.release.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.and.acq_rel.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.and.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.and.acquire.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.and.relaxed.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.and.release.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.and.acq_rel.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.and.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.and.acquire.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.and.relaxed.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.and.release.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.and.acq_rel.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.and.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.and.acquire.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.and.relaxed.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.and.release.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.and.acq_rel.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.and.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.and.acquire.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.and.relaxed.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.and.release.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.and.acq_rel.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.and.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 
 template <typename _Type, typename _Tag, typename _Sco>
@@ -3645,357 +3645,357 @@ struct __cuda_atomic_bind_fetch_and {
   }
 };
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_and_cuda(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_and_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   _Type __dst{};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_and_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
+  if (__cuda_atomic_fetch_and_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
   __cuda_atomic_bind_fetch_and<__proxy_t, __proxy_tag, _Sco> __bound_and{__ptr_proxy, __dst_proxy, __op_proxy};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_and, __memorder, _Sco{});
+  __cuda_atomic_fetch_order_dispatch(__bound_and, __memorder, _Sco{});
   return __dst;
 }
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_and_cuda(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_and_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   _Type __dst{};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_and_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
+  if (__cuda_atomic_fetch_and_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
   __cuda_atomic_bind_fetch_and<__proxy_t, __proxy_tag, _Sco> __bound_and{__ptr_proxy, __dst_proxy, __op_proxy};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_and, __memorder, _Sco{});
+  __cuda_atomic_fetch_order_dispatch(__bound_and, __memorder, _Sco{});
   return __dst;
 }
 
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.max.acquire.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.max.relaxed.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.max.release.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.max.acq_rel.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.max.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acquire.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.relaxed.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.release.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acq_rel.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.max.acquire.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.max.relaxed.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.max.release.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.max.acq_rel.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.max.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.max.acquire.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.max.relaxed.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.max.release.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.max.acq_rel.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.max.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.max.acquire.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.max.relaxed.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.max.release.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.max.acq_rel.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.max.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acquire.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.relaxed.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.release.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acq_rel.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.max.acquire.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.max.relaxed.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.max.release.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.max.acq_rel.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.max.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.max.acquire.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.max.relaxed.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.max.release.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.max.acq_rel.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.max.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.max.acquire.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.max.relaxed.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.max.release.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.max.acq_rel.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.max.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acquire.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.relaxed.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.release.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acq_rel.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.max.acquire.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.max.relaxed.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.max.release.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.max.acq_rel.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.max.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.max.acquire.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.max.relaxed.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.max.release.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.max.acq_rel.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.max.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.max.acquire.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.max.relaxed.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.max.release.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.max.acq_rel.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.max.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acquire.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.relaxed.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.release.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acq_rel.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.max.acquire.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.max.relaxed.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.max.release.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.max.acq_rel.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.max.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.max.acquire.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.max.relaxed.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.max.release.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.max.acq_rel.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.max.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 
 template <typename _Type, typename _Tag, typename _Sco>
@@ -4010,357 +4010,357 @@ struct __cuda_atomic_bind_fetch_max {
   }
 };
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_minmax<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_max_cuda(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_max_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_minmax<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_minmax<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_minmax<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_minmax<_Type>::__tag;
   _Type __dst{};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_max_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
+  if (__cuda_atomic_fetch_max_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
   __cuda_atomic_bind_fetch_max<__proxy_t, __proxy_tag, _Sco> __bound_max{__ptr_proxy, __dst_proxy, __op_proxy};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_max, __memorder, _Sco{});
+  __cuda_atomic_fetch_order_dispatch(__bound_max, __memorder, _Sco{});
   return __dst;
 }
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_minmax<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_max_cuda(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_max_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_minmax<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_minmax<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_minmax<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_minmax<_Type>::__tag;
   _Type __dst{};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_max_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
+  if (__cuda_atomic_fetch_max_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
   __cuda_atomic_bind_fetch_max<__proxy_t, __proxy_tag, _Sco> __bound_max{__ptr_proxy, __dst_proxy, __op_proxy};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_max, __memorder, _Sco{});
+  __cuda_atomic_fetch_order_dispatch(__bound_max, __memorder, _Sco{});
   return __dst;
 }
 
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.min.acquire.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.min.relaxed.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.min.release.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.min.acq_rel.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.min.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acquire.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.relaxed.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.release.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acq_rel.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.min.acquire.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.min.relaxed.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.min.release.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.min.acq_rel.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.min.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.min.acquire.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.min.relaxed.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.min.release.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.min.acq_rel.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.min.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.min.acquire.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.min.relaxed.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.min.release.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.min.acq_rel.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.min.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acquire.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.relaxed.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.release.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acq_rel.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.min.acquire.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.min.relaxed.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.min.release.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.min.acq_rel.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.min.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.min.acquire.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.min.relaxed.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.min.release.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.min.acq_rel.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_u64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.min.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.min.acquire.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.min.relaxed.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.min.release.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.min.acq_rel.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.min.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acquire.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.relaxed.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.release.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acq_rel.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.min.acquire.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.min.relaxed.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.min.release.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.min.acq_rel.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.min.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.min.acquire.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.min.relaxed.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.min.release.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.min.acq_rel.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.min.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.min.acquire.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.min.relaxed.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.min.release.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.min.acq_rel.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.min.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acquire.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.relaxed.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.release.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acq_rel.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.min.acquire.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.min.relaxed.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.min.release.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.min.acq_rel.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.min.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_s64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.min.acquire.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_s64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.min.relaxed.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_s64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.min.release.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_s64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.min.acq_rel.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_s64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.min.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 
 template <typename _Type, typename _Tag, typename _Sco>
@@ -4375,197 +4375,197 @@ struct __cuda_atomic_bind_fetch_min {
   }
 };
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_minmax<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_min_cuda(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_min_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_minmax<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_minmax<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_minmax<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_minmax<_Type>::__tag;
   _Type __dst{};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_min_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
+  if (__cuda_atomic_fetch_min_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
   __cuda_atomic_bind_fetch_min<__proxy_t, __proxy_tag, _Sco> __bound_min{__ptr_proxy, __dst_proxy, __op_proxy};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_min, __memorder, _Sco{});
+  __cuda_atomic_fetch_order_dispatch(__bound_min, __memorder, _Sco{});
   return __dst;
 }
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_minmax<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_min_cuda(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_min_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_minmax<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_minmax<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_minmax<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_minmax<_Type>::__tag;
   _Type __dst{};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_min_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
+  if (__cuda_atomic_fetch_min_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
   __cuda_atomic_bind_fetch_min<__proxy_t, __proxy_tag, _Sco> __bound_min{__ptr_proxy, __dst_proxy, __op_proxy};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_min, __memorder, _Sco{});
+  __cuda_atomic_fetch_order_dispatch(__bound_min, __memorder, _Sco{});
   return __dst;
 }
 
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.or.acquire.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.or.relaxed.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.or.release.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.or.acq_rel.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.or.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.or.acquire.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.or.relaxed.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.or.release.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.or.acq_rel.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.or.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.or.acquire.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.or.relaxed.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.or.release.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.or.acq_rel.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.or.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.or.acquire.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.or.relaxed.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.or.release.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.or.acq_rel.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.or.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.or.acquire.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.or.relaxed.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.or.release.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.or.acq_rel.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.or.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.or.acquire.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.or.relaxed.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.or.release.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.or.acq_rel.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.or.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.or.acquire.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.or.relaxed.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.or.release.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.or.acq_rel.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.or.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.or.acquire.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.or.relaxed.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.or.release.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.or.acq_rel.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.or.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 
 template <typename _Type, typename _Tag, typename _Sco>
@@ -4580,197 +4580,197 @@ struct __cuda_atomic_bind_fetch_or {
   }
 };
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_or_cuda(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_or_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   _Type __dst{};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_or_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
+  if (__cuda_atomic_fetch_or_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
   __cuda_atomic_bind_fetch_or<__proxy_t, __proxy_tag, _Sco> __bound_or{__ptr_proxy, __dst_proxy, __op_proxy};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_or, __memorder, _Sco{});
+  __cuda_atomic_fetch_order_dispatch(__bound_or, __memorder, _Sco{});
   return __dst;
 }
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_or_cuda(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_or_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   _Type __dst{};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_or_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
+  if (__cuda_atomic_fetch_or_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
   __cuda_atomic_bind_fetch_or<__proxy_t, __proxy_tag, _Sco> __bound_or{__ptr_proxy, __dst_proxy, __op_proxy};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_or, __memorder, _Sco{});
+  __cuda_atomic_fetch_order_dispatch(__bound_or, __memorder, _Sco{});
   return __dst;
 }
 
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.xor.acquire.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.xor.relaxed.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.xor.release.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.xor.acq_rel.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.xor.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.acquire.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.relaxed.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.release.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.acq_rel.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.xor.acquire.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.xor.relaxed.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.xor.release.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.xor.acq_rel.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.xor.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.xor.acquire.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.xor.relaxed.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.xor.release.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.xor.acq_rel.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b32, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.xor.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.xor.acquire.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.xor.relaxed.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.xor.release.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.xor.acq_rel.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_block_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.xor.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.acquire.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.relaxed.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.release.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.acq_rel.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_cluster_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.xor.acquire.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.xor.relaxed.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.xor.release.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.xor.acq_rel.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_device_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.xor.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acquire, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.xor.acquire.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_relaxed, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.xor.relaxed.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_release, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.xor.release.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_acq_rel, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.xor.acq_rel.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
 static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
-  _Type* __ptr, _Type& __dst, _Type __op, __atomic_cuda_volatile, __atomic_cuda_operand_b64, __thread_scope_system_tag)
+  _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.xor.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 
 template <typename _Type, typename _Tag, typename _Sco>
@@ -4785,47 +4785,47 @@ struct __cuda_atomic_bind_fetch_xor {
   }
 };
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_xor_cuda(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_xor_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   _Type __dst{};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_xor_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
+  if (__cuda_atomic_fetch_xor_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
   __cuda_atomic_bind_fetch_xor<__proxy_t, __proxy_tag, _Sco> __bound_xor{__ptr_proxy, __dst_proxy, __op_proxy};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_xor, __memorder, _Sco{});
+  __cuda_atomic_fetch_order_dispatch(__bound_xor, __memorder, _Sco{});
   return __dst;
 }
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_xor_cuda(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_xor_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
-  using __proxy_t        = typename __atomic_cuda_deduce_bitwise<_Type>::__type;
-  using __proxy_tag      = typename __atomic_cuda_deduce_bitwise<_Type>::__tag;
+  using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
+  using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
   _Type __dst{};
   __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(const_cast<_Type*>(__ptr));
   __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
   __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
-  if (__cuda_fetch_xor_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
+  if (__cuda_atomic_fetch_xor_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy)) {return __dst;}
   __cuda_atomic_bind_fetch_xor<__proxy_t, __proxy_tag, _Sco> __bound_xor{__ptr_proxy, __dst_proxy, __op_proxy};
-  __cuda_atomic_fetch_memory_order_dispatch(__bound_xor, __memorder, _Sco{});
+  __cuda_atomic_fetch_order_dispatch(__bound_xor, __memorder, _Sco{});
   return __dst;
 }
 
 template <class _Type, class _Up, class _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_sub_cuda(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_sub_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
-  return __atomic_fetch_add_cuda(__ptr, -__op, __memorder, _Sco{});
+  return __cuda_atomic_fetch_add_dispatch(__ptr, -__op, __memorder, _Sco{});
 }
 template <class _Type, class _Up, class _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __atomic_fetch_sub_cuda(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_sub_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
-  return __atomic_fetch_add_cuda(__ptr, -__op, __memorder, _Sco{});
+  return __cuda_atomic_fetch_add_dispatch(__ptr, -__op, __memorder, _Sco{});
 }
 
 #endif // _CCCL_CUDA_COMPILATION()

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated_helper.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated_helper.h
@@ -36,7 +36,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-enum class __atomic_cuda_memorder
+enum class __cuda_atomic_order
 {
   _relaxed,
   _release,
@@ -46,23 +46,23 @@ enum class __atomic_cuda_memorder
   _volatile,
 };
 
-template <__atomic_cuda_memorder _Order>
-using __atomic_cuda_memorder_tag = integral_constant<__atomic_cuda_memorder, _Order>;
+template <__cuda_atomic_order _Order>
+using __cuda_atomic_order_tag = integral_constant<__cuda_atomic_order, _Order>;
 
-using __atomic_cuda_relaxed  = __atomic_cuda_memorder_tag<__atomic_cuda_memorder::_relaxed>;
-using __atomic_cuda_release  = __atomic_cuda_memorder_tag<__atomic_cuda_memorder::_release>;
-using __atomic_cuda_acquire  = __atomic_cuda_memorder_tag<__atomic_cuda_memorder::_acquire>;
-using __atomic_cuda_acq_rel  = __atomic_cuda_memorder_tag<__atomic_cuda_memorder::_acq_rel>;
-using __atomic_cuda_seq_cst  = __atomic_cuda_memorder_tag<__atomic_cuda_memorder::_seq_cst>;
-using __atomic_cuda_volatile = __atomic_cuda_memorder_tag<__atomic_cuda_memorder::_volatile>;
+using __cuda_atomic_order_relaxed  = __cuda_atomic_order_tag<__cuda_atomic_order::_relaxed>;
+using __cuda_atomic_order_release  = __cuda_atomic_order_tag<__cuda_atomic_order::_release>;
+using __cuda_atomic_order_acquire  = __cuda_atomic_order_tag<__cuda_atomic_order::_acquire>;
+using __cuda_atomic_order_acq_rel  = __cuda_atomic_order_tag<__cuda_atomic_order::_acq_rel>;
+using __cuda_atomic_order_seq_cst  = __cuda_atomic_order_tag<__cuda_atomic_order::_seq_cst>;
+using __cuda_atomic_order_volatile = __cuda_atomic_order_tag<__cuda_atomic_order::_volatile>;
 
 template <bool _Volatile>
-using __atomic_cuda_mmio_tag = integral_constant<bool, _Volatile>;
+using __cuda_atomic_mmio_tag = integral_constant<bool, _Volatile>;
 
-using __atomic_cuda_mmio_enable  = __atomic_cuda_mmio_tag<true>;
-using __atomic_cuda_mmio_disable = __atomic_cuda_mmio_tag<false>;
+using __cuda_atomic_mmio_enable  = __cuda_atomic_mmio_tag<true>;
+using __cuda_atomic_mmio_disable = __cuda_atomic_mmio_tag<false>;
 
-enum class __atomic_cuda_operand
+enum class __cuda_atomic_operand
 {
   _f,
   _s,
@@ -70,93 +70,93 @@ enum class __atomic_cuda_operand
   _b,
 };
 
-template <__atomic_cuda_operand _Op, size_t _Size>
-struct __atomic_cuda_operand_tag
+template <__cuda_atomic_operand _Op, size_t _Size>
+struct __cuda_atomic_operand_tag
 {
   static constexpr auto __op   = _Op;
   static constexpr auto __size = _Size;
 };
 
-using __atomic_cuda_operand_f8   = __atomic_cuda_operand_tag<__atomic_cuda_operand::_f, 8>;
-using __atomic_cuda_operand_s8   = __atomic_cuda_operand_tag<__atomic_cuda_operand::_s, 8>;
-using __atomic_cuda_operand_u8   = __atomic_cuda_operand_tag<__atomic_cuda_operand::_u, 8>;
-using __atomic_cuda_operand_b8   = __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, 8>;
-using __atomic_cuda_operand_f16  = __atomic_cuda_operand_tag<__atomic_cuda_operand::_f, 16>;
-using __atomic_cuda_operand_s16  = __atomic_cuda_operand_tag<__atomic_cuda_operand::_s, 16>;
-using __atomic_cuda_operand_u16  = __atomic_cuda_operand_tag<__atomic_cuda_operand::_u, 16>;
-using __atomic_cuda_operand_b16  = __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, 16>;
-using __atomic_cuda_operand_f32  = __atomic_cuda_operand_tag<__atomic_cuda_operand::_f, 32>;
-using __atomic_cuda_operand_s32  = __atomic_cuda_operand_tag<__atomic_cuda_operand::_s, 32>;
-using __atomic_cuda_operand_u32  = __atomic_cuda_operand_tag<__atomic_cuda_operand::_u, 32>;
-using __atomic_cuda_operand_b32  = __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, 32>;
-using __atomic_cuda_operand_f64  = __atomic_cuda_operand_tag<__atomic_cuda_operand::_f, 64>;
-using __atomic_cuda_operand_s64  = __atomic_cuda_operand_tag<__atomic_cuda_operand::_s, 64>;
-using __atomic_cuda_operand_u64  = __atomic_cuda_operand_tag<__atomic_cuda_operand::_u, 64>;
-using __atomic_cuda_operand_b64  = __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, 64>;
-using __atomic_cuda_operand_f128 = __atomic_cuda_operand_tag<__atomic_cuda_operand::_f, 128>;
-using __atomic_cuda_operand_s128 = __atomic_cuda_operand_tag<__atomic_cuda_operand::_s, 128>;
-using __atomic_cuda_operand_u128 = __atomic_cuda_operand_tag<__atomic_cuda_operand::_u, 128>;
-using __atomic_cuda_operand_b128 = __atomic_cuda_operand_tag<__atomic_cuda_operand::_b, 128>;
+using __cuda_atomic_operand_f8   = __cuda_atomic_operand_tag<__cuda_atomic_operand::_f, 8>;
+using __cuda_atomic_operand_s8   = __cuda_atomic_operand_tag<__cuda_atomic_operand::_s, 8>;
+using __cuda_atomic_operand_u8   = __cuda_atomic_operand_tag<__cuda_atomic_operand::_u, 8>;
+using __cuda_atomic_operand_b8   = __cuda_atomic_operand_tag<__cuda_atomic_operand::_b, 8>;
+using __cuda_atomic_operand_f16  = __cuda_atomic_operand_tag<__cuda_atomic_operand::_f, 16>;
+using __cuda_atomic_operand_s16  = __cuda_atomic_operand_tag<__cuda_atomic_operand::_s, 16>;
+using __cuda_atomic_operand_u16  = __cuda_atomic_operand_tag<__cuda_atomic_operand::_u, 16>;
+using __cuda_atomic_operand_b16  = __cuda_atomic_operand_tag<__cuda_atomic_operand::_b, 16>;
+using __cuda_atomic_operand_f32  = __cuda_atomic_operand_tag<__cuda_atomic_operand::_f, 32>;
+using __cuda_atomic_operand_s32  = __cuda_atomic_operand_tag<__cuda_atomic_operand::_s, 32>;
+using __cuda_atomic_operand_u32  = __cuda_atomic_operand_tag<__cuda_atomic_operand::_u, 32>;
+using __cuda_atomic_operand_b32  = __cuda_atomic_operand_tag<__cuda_atomic_operand::_b, 32>;
+using __cuda_atomic_operand_f64  = __cuda_atomic_operand_tag<__cuda_atomic_operand::_f, 64>;
+using __cuda_atomic_operand_s64  = __cuda_atomic_operand_tag<__cuda_atomic_operand::_s, 64>;
+using __cuda_atomic_operand_u64  = __cuda_atomic_operand_tag<__cuda_atomic_operand::_u, 64>;
+using __cuda_atomic_operand_b64  = __cuda_atomic_operand_tag<__cuda_atomic_operand::_b, 64>;
+using __cuda_atomic_operand_f128 = __cuda_atomic_operand_tag<__cuda_atomic_operand::_f, 128>;
+using __cuda_atomic_operand_s128 = __cuda_atomic_operand_tag<__cuda_atomic_operand::_s, 128>;
+using __cuda_atomic_operand_u128 = __cuda_atomic_operand_tag<__cuda_atomic_operand::_u, 128>;
+using __cuda_atomic_operand_b128 = __cuda_atomic_operand_tag<__cuda_atomic_operand::_b, 128>;
 
 template <class _AtomicType, class _OpTag>
-struct __atomic_cuda_operand_deduction
+struct __cuda_atomic_operand_deduction
 {
   using __type = _AtomicType;
   using __tag  = _OpTag;
 };
 
-struct _CCCL_ALIGNAS(16) __atomic_longlong2
+struct _CCCL_ALIGNAS(16) __cuda_atomic_longlong2
 {
   uint64_t __x;
   uint64_t __y;
 };
 
 template <class _Type>
-using __atomic_cuda_deduce_bitwise =
+using __cuda_atomic_deduce_bitwise =
   __type_switch<sizeof(_Type),
-                __type_case<1, __atomic_cuda_operand_deduction<uint8_t, __atomic_cuda_operand_b8>>,
-                __type_case<2, __atomic_cuda_operand_deduction<uint16_t, __atomic_cuda_operand_b16>>,
-                __type_case<4, __atomic_cuda_operand_deduction<uint32_t, __atomic_cuda_operand_b32>>,
-                __type_case<8, __atomic_cuda_operand_deduction<uint64_t, __atomic_cuda_operand_b64>>,
-                __type_default<__atomic_cuda_operand_deduction<__atomic_longlong2, __atomic_cuda_operand_b128>>>;
+                __type_case<1, __cuda_atomic_operand_deduction<uint8_t, __cuda_atomic_operand_b8>>,
+                __type_case<2, __cuda_atomic_operand_deduction<uint16_t, __cuda_atomic_operand_b16>>,
+                __type_case<4, __cuda_atomic_operand_deduction<uint32_t, __cuda_atomic_operand_b32>>,
+                __type_case<8, __cuda_atomic_operand_deduction<uint64_t, __cuda_atomic_operand_b64>>,
+                __type_default<__cuda_atomic_operand_deduction<__cuda_atomic_longlong2, __cuda_atomic_operand_b128>>>;
 
 template <class _Type>
-using __atomic_cuda_deduce_arithmetic = _If<
+using __cuda_atomic_deduce_arithmetic = _If<
   is_floating_point_v<_Type>,
   _If<sizeof(_Type) == 4,
-      __atomic_cuda_operand_deduction<float, __atomic_cuda_operand_f32>,
-      __atomic_cuda_operand_deduction<double, __atomic_cuda_operand_f64>>,
+      __cuda_atomic_operand_deduction<float, __cuda_atomic_operand_f32>,
+      __cuda_atomic_operand_deduction<double, __cuda_atomic_operand_f64>>,
   _If<is_signed_v<_Type>,
       __type_switch<sizeof(_Type),
-                    __type_case<1, __atomic_cuda_operand_deduction<int8_t, __atomic_cuda_operand_s8>>,
-                    __type_case<2, __atomic_cuda_operand_deduction<int16_t, __atomic_cuda_operand_s16>>,
-                    __type_case<4, __atomic_cuda_operand_deduction<int32_t, __atomic_cuda_operand_s32>>,
-                    __type_default<__atomic_cuda_operand_deduction<int64_t, __atomic_cuda_operand_u64>>>, // There is no
+                    __type_case<1, __cuda_atomic_operand_deduction<int8_t, __cuda_atomic_operand_s8>>,
+                    __type_case<2, __cuda_atomic_operand_deduction<int16_t, __cuda_atomic_operand_s16>>,
+                    __type_case<4, __cuda_atomic_operand_deduction<int32_t, __cuda_atomic_operand_s32>>,
+                    __type_default<__cuda_atomic_operand_deduction<int64_t, __cuda_atomic_operand_u64>>>, // There is no
                                                                                                           // atom.add.s64
       __type_switch<sizeof(_Type),
-                    __type_case<1, __atomic_cuda_operand_deduction<uint8_t, __atomic_cuda_operand_u8>>,
-                    __type_case<2, __atomic_cuda_operand_deduction<uint16_t, __atomic_cuda_operand_u16>>,
-                    __type_case<4, __atomic_cuda_operand_deduction<uint32_t, __atomic_cuda_operand_u32>>,
-                    __type_default<__atomic_cuda_operand_deduction<uint64_t, __atomic_cuda_operand_u64>>>>>;
+                    __type_case<1, __cuda_atomic_operand_deduction<uint8_t, __cuda_atomic_operand_u8>>,
+                    __type_case<2, __cuda_atomic_operand_deduction<uint16_t, __cuda_atomic_operand_u16>>,
+                    __type_case<4, __cuda_atomic_operand_deduction<uint32_t, __cuda_atomic_operand_u32>>,
+                    __type_default<__cuda_atomic_operand_deduction<uint64_t, __cuda_atomic_operand_u64>>>>>;
 
 template <class _Type>
-using __atomic_cuda_deduce_minmax = _If<
+using __cuda_atomic_deduce_minmax = _If<
   is_floating_point_v<_Type>,
   _If<sizeof(_Type) == 4,
-      __atomic_cuda_operand_deduction<float, __atomic_cuda_operand_f32>,
-      __atomic_cuda_operand_deduction<double, __atomic_cuda_operand_f64>>,
+      __cuda_atomic_operand_deduction<float, __cuda_atomic_operand_f32>,
+      __cuda_atomic_operand_deduction<double, __cuda_atomic_operand_f64>>,
   _If<is_signed_v<_Type>,
       __type_switch<sizeof(_Type),
-                    __type_case<1, __atomic_cuda_operand_deduction<int8_t, __atomic_cuda_operand_s8>>,
-                    __type_case<2, __atomic_cuda_operand_deduction<int16_t, __atomic_cuda_operand_s16>>,
-                    __type_case<4, __atomic_cuda_operand_deduction<int32_t, __atomic_cuda_operand_s32>>,
-                    __type_default<__atomic_cuda_operand_deduction<int64_t, __atomic_cuda_operand_s64>>>, // atom.min|max.s64
+                    __type_case<1, __cuda_atomic_operand_deduction<int8_t, __cuda_atomic_operand_s8>>,
+                    __type_case<2, __cuda_atomic_operand_deduction<int16_t, __cuda_atomic_operand_s16>>,
+                    __type_case<4, __cuda_atomic_operand_deduction<int32_t, __cuda_atomic_operand_s32>>,
+                    __type_default<__cuda_atomic_operand_deduction<int64_t, __cuda_atomic_operand_s64>>>, // atom.min|max.s64
                                                                                                           // supported
       __type_switch<sizeof(_Type),
-                    __type_case<1, __atomic_cuda_operand_deduction<uint8_t, __atomic_cuda_operand_u8>>,
-                    __type_case<2, __atomic_cuda_operand_deduction<uint16_t, __atomic_cuda_operand_u16>>,
-                    __type_case<4, __atomic_cuda_operand_deduction<uint32_t, __atomic_cuda_operand_u32>>,
-                    __type_default<__atomic_cuda_operand_deduction<uint64_t, __atomic_cuda_operand_u64>>>>>;
+                    __type_case<1, __cuda_atomic_operand_deduction<uint8_t, __cuda_atomic_operand_u8>>,
+                    __type_case<2, __cuda_atomic_operand_deduction<uint16_t, __cuda_atomic_operand_u16>>,
+                    __type_case<4, __cuda_atomic_operand_deduction<uint32_t, __cuda_atomic_operand_u32>>,
+                    __type_default<__cuda_atomic_operand_deduction<uint64_t, __cuda_atomic_operand_u64>>>>>;
 
 template <class _Type>
 using __atomic_enable_if_native_bitwise = enable_if_t<(sizeof(_Type) < 16), bool>;

--- a/libcudacxx/include/cuda/std/__atomic/order.h
+++ b/libcudacxx/include/cuda/std/__atomic/order.h
@@ -96,7 +96,7 @@ using memory_order = enum memory_order {
 
 #endif // _CCCL_STD_VER >= 2020
 
-_CCCL_HOST_DEVICE_API inline int __stronger_order_cuda(int __a, int __b)
+_CCCL_HOST_DEVICE_API inline int __cuda_atomic_stronger_order(int __a, int __b)
 {
   int const __max = __a > __b ? __a : __b;
   if (__max != __ATOMIC_RELEASE)

--- a/libcudacxx/include/cuda/std/__atomic/types/base.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/base.h
@@ -73,7 +73,7 @@ _CCCL_HOST_DEVICE_API inline void __atomic_thread_fence_dispatch(memory_order __
 {
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE,
-    (__atomic_thread_fence_cuda(static_cast<__memory_order_underlying_t>(__order), __thread_scope_system_tag());),
+    (__cuda_atomic_thread_fence(static_cast<__memory_order_underlying_t>(__order), __thread_scope_system_tag());),
     NV_IS_HOST,
     (__atomic_thread_fence_host(__order);))
 }
@@ -81,7 +81,7 @@ _CCCL_HOST_DEVICE_API inline void __atomic_thread_fence_dispatch(memory_order __
 _CCCL_HOST_DEVICE_API inline void __atomic_signal_fence_dispatch(memory_order __order)
 {
   NV_DISPATCH_TARGET(NV_IS_DEVICE,
-                     (__atomic_signal_fence_cuda(static_cast<__memory_order_underlying_t>(__order));),
+                     (__cuda_atomic_signal_fence(static_cast<__memory_order_underlying_t>(__order));),
                      NV_IS_HOST,
                      (__atomic_signal_fence_host(__order);))
 }
@@ -131,7 +131,7 @@ _CCCL_HOST_DEVICE_API bool __atomic_compare_exchange_strong_dispatch(
   bool __result = false;
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE,
-    (__result = __atomic_compare_exchange_cuda(
+    (__result = __cuda_atomic_compare_exchange_dispatch(
        __a->get(),
        __expected,
        __val,
@@ -151,7 +151,7 @@ _CCCL_HOST_DEVICE_API bool __atomic_compare_exchange_weak_dispatch(
   bool __result = false;
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE,
-    (__result = __atomic_compare_exchange_cuda(
+    (__result = __cuda_atomic_compare_exchange_dispatch(
        __a->get(),
        __expected,
        __val,
@@ -170,7 +170,8 @@ _CCCL_HOST_DEVICE_API auto __atomic_fetch_add_dispatch(_Sto* __a, _Up __delta, m
 {
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE,
-    (return __atomic_fetch_add_cuda(__a->get(), __delta, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
+    (return __cuda_atomic_fetch_add_dispatch(
+              __a->get(), __delta, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
     NV_IS_HOST,
     (return __atomic_fetch_add_host(__a->get(), __delta, __order);))
 }
@@ -181,7 +182,8 @@ _CCCL_HOST_DEVICE_API auto __atomic_fetch_sub_dispatch(_Sto* __a, _Up __delta, m
 {
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE,
-    (return __atomic_fetch_sub_cuda(__a->get(), __delta, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
+    (return __cuda_atomic_fetch_sub_dispatch(
+              __a->get(), __delta, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
     NV_IS_HOST,
     (return __atomic_fetch_sub_host(__a->get(), __delta, __order);))
 }
@@ -192,7 +194,8 @@ _CCCL_HOST_DEVICE_API auto __atomic_fetch_and_dispatch(_Sto* __a, _Up __pattern,
 {
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE,
-    (return __atomic_fetch_and_cuda(__a->get(), __pattern, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
+    (return __cuda_atomic_fetch_and_dispatch(
+              __a->get(), __pattern, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
     NV_IS_HOST,
     (return __atomic_fetch_and_host(__a->get(), __pattern, __order);))
 }
@@ -203,7 +206,8 @@ _CCCL_HOST_DEVICE_API auto __atomic_fetch_or_dispatch(_Sto* __a, _Up __pattern, 
 {
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE,
-    (return __atomic_fetch_or_cuda(__a->get(), __pattern, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
+    (return __cuda_atomic_fetch_or_dispatch(
+              __a->get(), __pattern, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
     NV_IS_HOST,
     (return __atomic_fetch_or_host(__a->get(), __pattern, __order);))
 }
@@ -214,7 +218,8 @@ _CCCL_HOST_DEVICE_API auto __atomic_fetch_xor_dispatch(_Sto* __a, _Up __pattern,
 {
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE,
-    (return __atomic_fetch_xor_cuda(__a->get(), __pattern, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
+    (return __cuda_atomic_fetch_xor_dispatch(
+              __a->get(), __pattern, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
     NV_IS_HOST,
     (return __atomic_fetch_xor_host(__a->get(), __pattern, __order);))
 }
@@ -223,20 +228,20 @@ template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_
 _CCCL_HOST_DEVICE_API auto __atomic_fetch_max_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
-  NV_IF_TARGET(
-    NV_IS_DEVICE,
-    (return __atomic_fetch_max_cuda(__a->get(), __val, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
-    (return __atomic_fetch_max_host(__a->get(), __val, __order);))
+  NV_IF_TARGET(NV_IS_DEVICE,
+               (return __cuda_atomic_fetch_max_dispatch(
+                         __a->get(), __val, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
+               (return __atomic_fetch_max_host(__a->get(), __val, __order);))
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
 _CCCL_HOST_DEVICE_API auto __atomic_fetch_min_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
-  NV_IF_TARGET(
-    NV_IS_DEVICE,
-    (return __atomic_fetch_min_cuda(__a->get(), __val, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
-    (return __atomic_fetch_min_host(__a->get(), __val, __order);))
+  NV_IF_TARGET(NV_IS_DEVICE,
+               (return __cuda_atomic_fetch_min_dispatch(
+                         __a->get(), __val, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
+               (return __atomic_fetch_min_host(__a->get(), __val, __order);))
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD


### PR DESCRIPTION
## Description

This is a mechanical extraction of the renaming aspects of #10908 into its own PR.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
