### PR TITLE
[Tile] Disable STD builtins in tile mode

### DIFF
--- a/libcudacxx/include/cuda/std/__memory/addressof.h
+++ b/libcudacxx/include/cuda/std/__memory/addressof.h
@@ -39,6 +39,12 @@
 #  define _CCCL_HAS_BUILTIN_STD_ADDRESSOF() 0
 #endif // _CCCL_FREESTANDING()
 
+// In tile mode the builtin is tile annotated which can have unintended consequences in SIMT code with e.g int128
+#if defined(__CUDACC_TILE__)
+#  undef _CCCL_HAS_BUILTIN_STD_ADDRESSOF
+#  define _CCCL_HAS_BUILTIN_STD_ADDRESSOF() 0
+#endif // defined(__CUDACC_TILE__)
+
 // include minimal std:: headers
 #if _CCCL_HAS_BUILTIN_STD_ADDRESSOF()
 #  if _CCCL_HOST_STD_LIB(LIBSTDCXX) && __has_include(<bits/move.h>)

--- a/libcudacxx/include/cuda/std/__utility/as_const.h
+++ b/libcudacxx/include/cuda/std/__utility/as_const.h
@@ -40,6 +40,12 @@
 #  define _CCCL_HAS_BUILTIN_STD_AS_CONST() 0
 #endif // _CCCL_FREESTANDING()
 
+// In tile mode the builtin is tile annotated which can have unintended consequences in SIMT code with e.g int128
+#if defined(__CUDACC_TILE__)
+#  undef _CCCL_HAS_BUILTIN_STD_AS_CONST
+#  define _CCCL_HAS_BUILTIN_STD_AS_CONST() 0
+#endif // defined(__CUDACC_TILE__)
+
 // include minimal std:: headers
 #if _CCCL_HAS_BUILTIN_STD_AS_CONST()
 #  if _CCCL_HOST_STD_LIB(LIBCXX) && __has_include(<__utility/as_const.h>)

--- a/libcudacxx/include/cuda/std/__utility/forward.h
+++ b/libcudacxx/include/cuda/std/__utility/forward.h
@@ -45,6 +45,12 @@
 #  define _CCCL_HAS_BUILTIN_STD_FORWARD() 0
 #endif // _CCCL_ENABLE_FREESTANDING
 
+// In tile mode the builtin is tile annotated which can have unintended consequences in SIMT code with e.g int128
+#if defined(__CUDACC_TILE__)
+#  undef _CCCL_HAS_BUILTIN_STD_FORWARD
+#  define _CCCL_HAS_BUILTIN_STD_FORWARD() 0
+#endif // defined(__CUDACC_TILE__)
+
 // include minimal std:: headers, nvcc in device mode doesn't need the std:: header
 #if _CCCL_HAS_BUILTIN_STD_FORWARD() && !(_CCCL_CUDA_COMPILER(NVCC) && _CCCL_DEVICE_COMPILATION())
 #  if _CCCL_HOST_STD_LIB(LIBSTDCXX) && __has_include(<bits/move.h>)

--- a/libcudacxx/include/cuda/std/__utility/forward_like.h
+++ b/libcudacxx/include/cuda/std/__utility/forward_like.h
@@ -43,6 +43,12 @@
 #  define _CCCL_HAS_BUILTIN_STD_FORWARD_LIKE() 0
 #endif // _CCCL_FREESTANDING()
 
+// In tile mode the builtin is tile annotated which can have unintended consequences in SIMT code with e.g int128
+#if defined(__CUDACC_TILE__)
+#  undef _CCCL_HAS_BUILTIN_STD_FORWARD_LIKE
+#  define _CCCL_HAS_BUILTIN_STD_FORWARD_LIKE() 0
+#endif // defined(__CUDACC_TILE__)
+
 // include minimal std:: headers
 #if _CCCL_HAS_BUILTIN_STD_FORWARD_LIKE()
 #  if _CCCL_HOST_STD_LIB(LIBSTDCXX) && __has_include(<bits/move.h>)

--- a/libcudacxx/include/cuda/std/__utility/move.h
+++ b/libcudacxx/include/cuda/std/__utility/move.h
@@ -46,6 +46,12 @@
 #  define _CCCL_HAS_BUILTIN_STD_MOVE() 0
 #endif // _CCCL_ENABLE_FREESTANDING
 
+// In tile mode the builtin is tile annotated which can have unintended consequences in SIMT code with e.g int128
+#if defined(__CUDACC_TILE__)
+#  undef _CCCL_HAS_BUILTIN_STD_MOVE
+#  define _CCCL_HAS_BUILTIN_STD_MOVE() 0
+#endif // defined(__CUDACC_TILE__)
+
 #if _CCCL_COMPILER(CLANG, >=, 15)
 #  define _CCCL_HAS_BUILTIN_STD_MOVE_IF_NOEXCEPT() 1
 #else // ^^^ has builtin std::move_if_noexcept ^^^ / vvv no builtin std::move_if_noexcept vvv
@@ -63,6 +69,12 @@
 #  undef _CCCL_HAS_BUILTIN_STD_MOVE_IF_NOEXCEPT
 #  define _CCCL_HAS_BUILTIN_STD_MOVE_IF_NOEXCEPT() 0
 #endif // _CCCL_FREESTANDING()
+
+// In tile mode the builtin is tile annotated which can have unintended consequences in SIMT code with e.g int128
+#if defined(__CUDACC_TILE__)
+#  undef _CCCL_HAS_BUILTIN_STD_MOVE_IF_NOEXCEPT
+#  define _CCCL_HAS_BUILTIN_STD_MOVE_IF_NOEXCEPT() 0
+#endif // defined(__CUDACC_TILE__)
 
 // include minimal std:: headers, nvcc in device mode doesn't need the std:: header
 #if _CCCL_HAS_BUILTIN_STD_MOVE() || _CCCL_HAS_BUILTIN_STD_MOVE_IF_NOEXCEPT()


### PR DESCRIPTION
The compiler generated STD builtins like `std::move` generate a `__tile__` annotation if the program im compiled in tile mode.

That means that any SIMT program that moves a type that contains a type that is unsupported , e.g. `__int128_t` in tile would fail to compile.