### PR TITLE
[cudax] Use `uint32_t` instead of `unsigned` in groups

### DIFF
--- a/cudax/include/cuda/experimental/__group/concepts.cuh
+++ b/cudax/include/cuda/experimental/__group/concepts.cuh
@@ -26,6 +26,7 @@
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__type_traits/is_copy_constructible.h>
+#include <cuda/std/cstdint>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -51,11 +52,11 @@ template <class _Tp>
 _CCCL_CONCEPT __group_mapping_result = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __v)(
   requires(::cuda::std::is_copy_constructible_v<_Tp>),
   _Same_as(::cuda::std::size_t) _Tp::static_group_count(),
-  _Same_as(unsigned) __v.group_count(),
-  _Same_as(unsigned) __v.group_rank(),
+  _Same_as(::cuda::std::uint32_t) __v.group_count(),
+  _Same_as(::cuda::std::uint32_t) __v.group_rank(),
   _Same_as(::cuda::std::size_t) _Tp::static_unit_count(),
-  _Same_as(unsigned) __v.unit_count(),
-  _Same_as(unsigned) __v.unit_rank(),
+  _Same_as(::cuda::std::uint32_t) __v.unit_count(),
+  _Same_as(::cuda::std::uint32_t) __v.unit_rank(),
   _Same_as(::cuda::device::lane_mask) __v.lane_mask(),
   _Same_as(bool) _Tp::is_always_exhaustive(),
   _Same_as(bool) _Tp::is_always_contiguous());

--- a/cudax/include/cuda/experimental/__group/fwd.cuh
+++ b/cudax/include/cuda/experimental/__group/fwd.cuh
@@ -33,6 +33,7 @@
 #include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__fwd/extents.h>
 #include <cuda/std/__fwd/span.h>
+#include <cuda/std/cstdint>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -132,7 +133,7 @@ inline constexpr bool __is_group_mapping_v<group_as<_Data, _IsExhaustive>> = tru
 
 struct non_exhaustive_t;
 
-inline constexpr unsigned __invalid_count_or_rank = 0xffff'ffff;
+inline constexpr ::cuda::std::uint32_t __invalid_count_or_rank = 0xffff'ffff;
 } // namespace cuda::experimental
 
 #endif // !_CCCL_DOXYGEN_INVOKED

--- a/cudax/include/cuda/experimental/__group/group_view.cuh
+++ b/cudax/include/cuda/experimental/__group/group_view.cuh
@@ -26,6 +26,7 @@
 #include <cuda/std/__type_traits/is_integer.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__utility/declval.h>
+#include <cuda/std/cstdint>
 
 #include <cuda/experimental/__group/concepts.cuh>
 #include <cuda/experimental/__group/fwd.cuh>
@@ -60,8 +61,8 @@ __do_group_view_mapping(const _Unit& __unit, const _Group& __group) noexcept
     return _MappingResult{
       __group_mapping_result.group_count(),
       __group_mapping_result.group_rank(),
-      ::cuda::experimental::__count_query_group<unsigned, _Unit>(__group),
-      ::cuda::experimental::__rank_query_group<unsigned, _Unit>(__group),
+      ::cuda::experimental::__count_query_group<::cuda::std::uint32_t, _Unit>(__group),
+      ::cuda::experimental::__rank_query_group<::cuda::std::uint32_t, _Unit>(__group),
       __group_mapping_result.lane_mask()};
   }
 }

--- a/cudax/include/cuda/experimental/__group/mapping/binary_partition.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/binary_partition.cuh
@@ -30,6 +30,7 @@
 #include <cuda/std/__type_traits/is_move_constructible.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__utility/move.h>
+#include <cuda/std/cstdint>
 
 #include <cuda/experimental/__group/fwd.cuh>
 #include <cuda/experimental/__group/mapping/mapping_result.cuh>
@@ -86,8 +87,8 @@ public:
     return _MappingResult{
       __prev_mapping_result.group_count() * 2,
       __prev_mapping_result.group_rank() + ((__pred) ? __prev_mapping_result.group_count() : 0u),
-      static_cast<unsigned>(::cuda::std::popcount(__match_mask)),
-      static_cast<unsigned>(::cuda::std::popcount(__match_mask & ::cuda::ptx::get_sreg_lanemask_lt())),
+      static_cast<::cuda::std::uint32_t>(::cuda::std::popcount(__match_mask)),
+      static_cast<::cuda::std::uint32_t>(::cuda::std::popcount(__match_mask & ::cuda::ptx::get_sreg_lanemask_lt())),
       ::cuda::device::lane_mask{__match_mask}};
   }
 };

--- a/cudax/include/cuda/experimental/__group/mapping/group_as.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/group_as.cuh
@@ -28,6 +28,7 @@
 #include <cuda/std/__numeric/accumulate.h>
 #include <cuda/std/__utility/cmp.h>
 #include <cuda/std/__utility/integer_sequence.h>
+#include <cuda/std/cstdint>
 #include <cuda/std/span>
 
 #include <cuda/experimental/__group/fwd.cuh>
@@ -50,7 +51,8 @@ template <::cuda::std::size_t... _UnitCounts, bool _IsExhaustive>
 class group_as<__group_as_static_tag<_UnitCounts...>, _IsExhaustive>
 {
   static_assert(((_UnitCounts != 0) && ...), "all _UnitCounts must not be zero");
-  static_assert((::cuda::std::in_range<unsigned>(_UnitCounts) && ...), "all _UnitCounts must be within uint32_t range");
+  static_assert((::cuda::std::in_range<::cuda::std::uint32_t>(_UnitCounts) && ...),
+                "all _UnitCounts must be within uint32_t range");
 
   static constexpr auto __counts_sum = (0 + ... + _UnitCounts);
 
@@ -89,9 +91,9 @@ public:
     return _IsExhaustive;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API constexpr unsigned unit_count(::cuda::std::size_t __i) const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::std::uint32_t unit_count(::cuda::std::size_t __i) const noexcept
   {
-    return static_cast<unsigned>(static_unit_count(__i));
+    return static_cast<::cuda::std::uint32_t>(static_unit_count(__i));
   }
 
   template <class _Unit, class _ParentGroup, class _PrevMappingResult>
@@ -119,7 +121,7 @@ public:
 
     const auto __prev_nunits      = __prev_mapping_result.unit_count();
     const auto __prev_unit_rank   = __prev_mapping_result.unit_rank();
-    constexpr auto __curr_ngroups = static_cast<unsigned>(sizeof...(_UnitCounts));
+    constexpr auto __curr_ngroups = static_cast<::cuda::std::uint32_t>(sizeof...(_UnitCounts));
     const auto __ngroups          = __prev_mapping_result.group_count() * __curr_ngroups;
 
     if constexpr (_IsExhaustive)
@@ -130,7 +132,7 @@ public:
       }
       else
       {
-        _CCCL_ASSERT(__prev_nunits == static_cast<unsigned>(__counts_sum),
+        _CCCL_ASSERT(__prev_nunits == static_cast<::cuda::std::uint32_t>(__counts_sum),
                      "group_as mapping _IsExhaustive precondition violation");
       }
     }
@@ -142,19 +144,19 @@ public:
       }
       else
       {
-        _CCCL_ASSERT(__prev_nunits >= static_cast<unsigned>(__counts_sum),
+        _CCCL_ASSERT(__prev_nunits >= static_cast<::cuda::std::uint32_t>(__counts_sum),
                      "group_as mapping requires more units than are available");
       }
 
-      if (__prev_unit_rank >= static_cast<unsigned>(__counts_sum))
+      if (__prev_unit_rank >= static_cast<::cuda::std::uint32_t>(__counts_sum))
       {
         return _MappingResult::invalid_with_group_count(__ngroups);
       }
     }
 
-    unsigned __sum = 0;
+    ::cuda::std::uint32_t __sum = 0;
     _CCCL_PRAGMA_UNROLL_FULL()
-    for (unsigned __i = 0; __i < __curr_ngroups; ++__i)
+    for (::cuda::std::uint32_t __i = 0; __i < __curr_ngroups; ++__i)
     {
       const auto __i_count = unit_count(__i);
       if (__prev_unit_rank < __sum + __i_count)
@@ -183,12 +185,13 @@ class group_as<__group_as_dynamic_tag<_GroupCount>, _IsExhaustive>
 {
   static_assert(_GroupCount != ::cuda::std::dynamic_extent, "group_as requires static number of groups");
 
-  unsigned __counts_[_GroupCount];
+  ::cuda::std::uint32_t __counts_[_GroupCount];
 
 public:
   _CCCL_TEMPLATE(bool _IsExhaustive2 = _IsExhaustive)
   _CCCL_REQUIRES(_IsExhaustive2)
-  _CCCL_DEVICE_API explicit constexpr group_as(::cuda::std::span<const unsigned, _GroupCount> __counts) noexcept
+  _CCCL_DEVICE_API explicit constexpr group_as(
+    ::cuda::std::span<const ::cuda::std::uint32_t, _GroupCount> __counts) noexcept
   {
     _CCCL_PRAGMA_UNROLL_FULL()
     for (::cuda::std::size_t __i = 0; __i < _GroupCount; ++__i)
@@ -200,7 +203,7 @@ public:
 
   _CCCL_TEMPLATE(bool _IsExhaustive2 = _IsExhaustive)
   _CCCL_REQUIRES((!_IsExhaustive2))
-  _CCCL_DEVICE_API explicit constexpr group_as(::cuda::std::span<const unsigned, _GroupCount> __counts,
+  _CCCL_DEVICE_API explicit constexpr group_as(::cuda::std::span<const ::cuda::std::uint32_t, _GroupCount> __counts,
                                                const non_exhaustive_t&) noexcept
   {
     _CCCL_PRAGMA_UNROLL_FULL()
@@ -230,7 +233,7 @@ public:
     return _IsExhaustive;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API constexpr unsigned unit_count(::cuda::std::size_t __i) const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::std::uint32_t unit_count(::cuda::std::size_t __i) const noexcept
   {
     if (__i >= _GroupCount)
     {
@@ -264,7 +267,7 @@ public:
 
     const auto __prev_nunits      = __prev_mapping_result.unit_count();
     const auto __prev_unit_rank   = __prev_mapping_result.unit_rank();
-    constexpr auto __curr_ngroups = static_cast<unsigned>(_GroupCount);
+    constexpr auto __curr_ngroups = static_cast<::cuda::std::uint32_t>(_GroupCount);
     const auto __ngroups          = __prev_mapping_result.group_count() * __curr_ngroups;
 
     // If the mapping is exhaustive, check the preconditions, otherwise remove the last partial group.
@@ -278,9 +281,9 @@ public:
       return _MappingResult::invalid_with_group_count(__ngroups);
     }
 
-    unsigned __sum = 0;
+    ::cuda::std::uint32_t __sum = 0;
     _CCCL_PRAGMA_UNROLL_FULL()
-    for (unsigned __i = 0; __i < __curr_ngroups; ++__i)
+    for (::cuda::std::uint32_t __i = 0; __i < __curr_ngroups; ++__i)
     {
       const auto __i_count = unit_count(__i);
       if (__prev_unit_rank < __sum + __i_count)
@@ -311,14 +314,16 @@ group_as(const ::cuda::std::integer_sequence<::cuda::std::size_t, _UnitCounts...
   -> group_as<__group_as_static_tag<_UnitCounts...>, false>;
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(__is_spannable<_Tp> _CCCL_AND ::cuda::std::
-                 is_same_v<unsigned, _SpanValueType<decltype(::cuda::std::span(::cuda::std::declval<_Tp&>()))>>)
+_CCCL_REQUIRES(
+  __is_spannable<_Tp> _CCCL_AND ::cuda::std::
+    is_same_v<::cuda::std::uint32_t, _SpanValueType<decltype(::cuda::std::span(::cuda::std::declval<_Tp&>()))>>)
 _CCCL_DEDUCTION_GUIDE_ATTRIBUTES group_as(_Tp& __v)
   -> group_as<__group_as_dynamic_tag<decltype(::cuda::std::span(__v))::extent>, true>;
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(__is_spannable<_Tp> _CCCL_AND ::cuda::std::
-                 is_same_v<unsigned, _SpanValueType<decltype(::cuda::std::span(::cuda::std::declval<_Tp&>()))>>)
+_CCCL_REQUIRES(
+  __is_spannable<_Tp> _CCCL_AND ::cuda::std::
+    is_same_v<::cuda::std::uint32_t, _SpanValueType<decltype(::cuda::std::span(::cuda::std::declval<_Tp&>()))>>)
 _CCCL_DEDUCTION_GUIDE_ATTRIBUTES group_as(_Tp& __v, const non_exhaustive_t&)
   -> group_as<__group_as_dynamic_tag<decltype(::cuda::std::span(__v))::extent>, false>;
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__group/mapping/group_by.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/group_by.cuh
@@ -25,6 +25,7 @@
 #include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__fwd/span.h>
 #include <cuda/std/__utility/cmp.h>
+#include <cuda/std/cstdint>
 
 #include <cuda/experimental/__group/fwd.cuh>
 #include <cuda/experimental/__group/mapping/mapping_result.cuh>
@@ -55,7 +56,7 @@ template <::cuda::std::size_t _UnitCount, bool _IsExhaustive>
 class group_by
 {
   static_assert(_UnitCount != 0, "_UnitCount must not be zero");
-  static_assert(::cuda::std::in_range<unsigned>(_UnitCount), "_UnitCount must be within uint32_t range");
+  static_assert(::cuda::std::in_range<::cuda::std::uint32_t>(_UnitCount), "_UnitCount must be within uint32_t range");
 
 public:
   _CCCL_HIDE_FROM_ABI explicit group_by() = default;
@@ -74,9 +75,9 @@ public:
     return _IsExhaustive;
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr unsigned unit_count() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr ::cuda::std::uint32_t unit_count() const noexcept
   {
-    return static_cast<unsigned>(_UnitCount);
+    return static_cast<::cuda::std::uint32_t>(_UnitCount);
   }
 
   template <class _Unit, class _ParentGroup, class _PrevMappingResult>
@@ -146,10 +147,10 @@ public:
 template <bool _IsExhaustive>
 class group_by<::cuda::std::dynamic_extent, _IsExhaustive>
 {
-  unsigned __count_;
+  ::cuda::std::uint32_t __count_;
 
 public:
-  _CCCL_DEVICE_API explicit constexpr group_by(unsigned __count) noexcept
+  _CCCL_DEVICE_API explicit constexpr group_by(::cuda::std::uint32_t __count) noexcept
       : __count_{__count}
   {
     _CCCL_ASSERT(__count > 0, "__count cannot be 0");
@@ -157,7 +158,7 @@ public:
 
   _CCCL_TEMPLATE(bool _IsExhaustive2 = _IsExhaustive)
   _CCCL_REQUIRES((!_IsExhaustive2))
-  _CCCL_DEVICE_API explicit constexpr group_by(unsigned __count, const non_exhaustive_t&) noexcept
+  _CCCL_DEVICE_API explicit constexpr group_by(::cuda::std::uint32_t __count, const non_exhaustive_t&) noexcept
       : __count_{__count}
   {
     _CCCL_ASSERT(__count > 0, "__count cannot be 0");
@@ -173,7 +174,7 @@ public:
     return _IsExhaustive;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API constexpr unsigned unit_count() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::std::uint32_t unit_count() const noexcept
   {
     return __count_;
   }
@@ -224,9 +225,9 @@ public:
   }
 };
 
-_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group_by(unsigned) -> group_by<::cuda::std::dynamic_extent>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group_by(::cuda::std::uint32_t) -> group_by<::cuda::std::dynamic_extent>;
 
-_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group_by(unsigned, const non_exhaustive_t&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group_by(::cuda::std::uint32_t, const non_exhaustive_t&)
   -> group_by<::cuda::std::dynamic_extent, false>;
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__group/mapping/mapping_result.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/mapping_result.cuh
@@ -25,6 +25,7 @@
 #include <cuda/std/__bit/popcount.h>
 #include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__fwd/span.h>
+#include <cuda/std/cstdint>
 
 #include <cuda/experimental/__group/fwd.cuh>
 
@@ -39,10 +40,10 @@ namespace cuda::experimental
 template <::cuda::std::size_t _StaticGroupCount, ::cuda::std::size_t _StaticCount, bool _IsExhaustive, bool _IsContiguous>
 struct __mapping_result
 {
-  unsigned __group_count_;
-  unsigned __group_rank_;
-  unsigned __unit_count_;
-  unsigned __unit_rank_;
+  ::cuda::std::uint32_t __group_count_;
+  ::cuda::std::uint32_t __group_rank_;
+  ::cuda::std::uint32_t __unit_count_;
+  ::cuda::std::uint32_t __unit_rank_;
   ::cuda::device::lane_mask __lane_mask_;
 
   [[nodiscard]] _CCCL_DEVICE_API static constexpr __mapping_result invalid() noexcept
@@ -55,7 +56,7 @@ struct __mapping_result
   }
 
   [[nodiscard]] _CCCL_DEVICE_API static constexpr __mapping_result
-  invalid_with_group_count(unsigned __group_count) noexcept
+  invalid_with_group_count(::cuda::std::uint32_t __group_count) noexcept
   {
     return {__group_count,
             __invalid_count_or_rank,
@@ -69,11 +70,11 @@ struct __mapping_result
     return _StaticGroupCount;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API unsigned group_count() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint32_t group_count() const noexcept
   {
     if constexpr (_StaticGroupCount != ::cuda::std::dynamic_extent)
     {
-      return static_cast<unsigned>(_StaticGroupCount);
+      return static_cast<::cuda::std::uint32_t>(_StaticGroupCount);
     }
     else
     {
@@ -86,7 +87,7 @@ struct __mapping_result
     }
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API unsigned group_rank() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint32_t group_rank() const noexcept
   {
     if constexpr (!_IsExhaustive)
     {
@@ -100,11 +101,11 @@ struct __mapping_result
     return _StaticCount;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API unsigned unit_count() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint32_t unit_count() const noexcept
   {
     if constexpr (_StaticCount != ::cuda::std::dynamic_extent)
     {
-      return static_cast<unsigned>(_StaticCount);
+      return static_cast<::cuda::std::uint32_t>(_StaticCount);
     }
     else
     {
@@ -116,7 +117,7 @@ struct __mapping_result
     }
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API unsigned unit_rank() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint32_t unit_rank() const noexcept
   {
     if constexpr (!_IsExhaustive)
     {
@@ -158,8 +159,8 @@ struct __mapping_result
 };
 
 template <bool _IsContiguous>
-[[nodiscard]] _CCCL_DEVICE_API inline ::cuda::device::lane_mask
-__make_lane_mask_for_n(::cuda::device::lane_mask __prev_lane_mask, unsigned __n, unsigned __rank) noexcept
+[[nodiscard]] _CCCL_DEVICE_API inline ::cuda::device::lane_mask __make_lane_mask_for_n(
+  ::cuda::device::lane_mask __prev_lane_mask, ::cuda::std::uint32_t __n, ::cuda::std::uint32_t __rank) noexcept
 {
   if constexpr (_IsContiguous)
   {

--- a/cudax/include/cuda/experimental/__group/mapping/take.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/take.cuh
@@ -24,6 +24,7 @@
 #include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__utility/cmp.h>
+#include <cuda/std/cstdint>
 #include <cuda/std/span>
 
 #include <cuda/experimental/__group/fwd.cuh>
@@ -38,7 +39,7 @@ namespace cuda::experimental
 template <::cuda::std::size_t _UnitCount>
 class take
 {
-  static_assert(::cuda::std::in_range<unsigned>(_UnitCount), "_UnitCount must be within uint32_t range");
+  static_assert(::cuda::std::in_range<::cuda::std::uint32_t>(_UnitCount), "_UnitCount must be within uint32_t range");
 
 public:
   _CCCL_HIDE_FROM_ABI explicit take() = default;
@@ -48,9 +49,9 @@ public:
     return _UnitCount;
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr unsigned unit_count() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr ::cuda::std::uint32_t unit_count() const noexcept
   {
-    return unsigned{_UnitCount};
+    return ::cuda::std::uint32_t{_UnitCount};
   }
 
   template <class _Unit, class _ParentGroup, class _PrevMappingResult>
@@ -84,14 +85,14 @@ public:
                    "take mapping requires the previous mapping result to have at least _PrevMappingResult units");
     }
 
-    if (::cuda::std::cmp_greater_equal(__prev_unit_rank, static_cast<unsigned>(_UnitCount)))
+    if (::cuda::std::cmp_greater_equal(__prev_unit_rank, static_cast<::cuda::std::uint32_t>(_UnitCount)))
     {
       return _MappingResult::invalid_with_group_count(__prev_mapping_result.group_count());
     }
 
     const auto __group_count = __prev_mapping_result.group_count();
     const auto __group_rank  = __prev_mapping_result.group_rank();
-    const auto __unit_count  = static_cast<unsigned>(_UnitCount);
+    const auto __unit_count  = static_cast<::cuda::std::uint32_t>(_UnitCount);
     const auto __unit_rank   = __prev_unit_rank;
     const auto __lane_mask =
       (::cuda::std::is_same_v<_Unit, thread_level>)
@@ -105,12 +106,12 @@ public:
 template <>
 class take<::cuda::std::dynamic_extent>
 {
-  unsigned __unit_count_{0};
+  ::cuda::std::uint32_t __unit_count_{0};
 
 public:
   _CCCL_HIDE_FROM_ABI explicit take() = default;
 
-  _CCCL_DEVICE_API constexpr explicit take(unsigned __unit_count) noexcept
+  _CCCL_DEVICE_API constexpr explicit take(::cuda::std::uint32_t __unit_count) noexcept
       : __unit_count_{__unit_count}
   {}
 
@@ -119,7 +120,7 @@ public:
     return ::cuda::std::dynamic_extent;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API constexpr unsigned unit_count() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::std::uint32_t unit_count() const noexcept
   {
     return __unit_count_;
   }
@@ -163,7 +164,7 @@ public:
   }
 };
 
-_CCCL_DEDUCTION_GUIDE_ATTRIBUTES take(unsigned) -> take<::cuda::std::dynamic_extent>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES take(::cuda::std::uint32_t) -> take<::cuda::std::dynamic_extent>;
 } // namespace cuda::experimental
 
 #endif // !_CCCL_DOXYGEN_INVOKED

--- a/cudax/include/cuda/experimental/__group/synchronizer/level_synchronizer.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizer/level_synchronizer.cuh
@@ -23,6 +23,7 @@
 
 #include <cuda/hierarchy>
 #include <cuda/std/__limits/numeric_limits.h>
+#include <cuda/std/cstdint>
 
 #include <cuda/experimental/__group/fwd.cuh>
 
@@ -154,8 +155,8 @@ struct level_synchronizer::__synchronizer_instance<grid_level>
   {
     struct __grid_workspace
     {
-      unsigned __size_;
-      unsigned __barrier_;
+      ::cuda::std::uint32_t __size_;
+      ::cuda::std::uint32_t __barrier_;
     };
 
     __grid_workspace* __grid_workspace_ptr;
@@ -172,16 +173,16 @@ struct level_synchronizer::__synchronizer_instance<grid_level>
     const auto __thread_idx = gpu_thread.index(block, __hier);
     if ((__thread_idx.x | __thread_idx.y | __thread_idx.z) == 0)
     {
-      const auto __expected = block.count_as<unsigned>(grid, __hier);
-      unsigned __nblocks    = 1;
+      const auto __expected           = block.count_as<::cuda::std::uint32_t>(grid, __hier);
+      ::cuda::std::uint32_t __nblocks = 1;
 
       const auto __block_idx = block.index(grid, __hier);
       if ((__block_idx.x | __block_idx.y | __block_idx.z) == 0)
       {
-        __nblocks = unsigned{::cuda::std::numeric_limits<int>::min()} - (__expected - 1);
+        __nblocks = ::cuda::std::uint32_t{::cuda::std::numeric_limits<int>::min()} - (__expected - 1);
       }
 
-      unsigned __old_barrier_value;
+      ::cuda::std::uint32_t __old_barrier_value;
 #  if _CCCL_HAS_NV_ATOMIC_BUILTINS()
       __old_barrier_value =
         __nv_atomic_fetch_add(__barrier_ptr, __nblocks, __NV_ATOMIC_RELEASE, __NV_THREAD_SCOPE_DEVICE);
@@ -191,7 +192,7 @@ struct level_synchronizer::__synchronizer_instance<grid_level>
                    : "l"(__barrier_ptr), "r"(__nblocks)
                    : "memory");
 #  endif // ^^^ !_CCCL_HAS_NV_ATOMIC_BUILTINS() ^^^
-      unsigned __curr_barrier_value;
+      ::cuda::std::uint32_t __curr_barrier_value;
       do
       {
 #  if _CCCL_HAS_NV_ATOMIC_BUILTINS()

--- a/cudax/include/cuda/experimental/__group/this_group.cuh
+++ b/cudax/include/cuda/experimental/__group/this_group.cuh
@@ -27,6 +27,7 @@
 #include <cuda/std/__type_traits/is_integer.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__utility/forward.h>
+#include <cuda/std/cstdint>
 
 #include <cuda/experimental/__group/fwd.cuh>
 #include <cuda/experimental/__group/implicit_hierarchy.cuh>
@@ -54,12 +55,12 @@ struct __this_mapping_result
     return 1;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API unsigned group_count() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint32_t group_count() const noexcept
   {
     return 1;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API unsigned group_rank() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint32_t group_rank() const noexcept
   {
     return 0;
   }
@@ -69,12 +70,12 @@ struct __this_mapping_result
     return 1;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API unsigned unit_count() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint32_t unit_count() const noexcept
   {
     return 1;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API unsigned unit_rank() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint32_t unit_rank() const noexcept
   {
     return 0;
   }

--- a/cudax/include/cuda/experimental/__group/virtual_group.cuh
+++ b/cudax/include/cuda/experimental/__group/virtual_group.cuh
@@ -34,6 +34,7 @@
 #include <cuda/std/__type_traits/is_integer.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__utility/declval.h>
+#include <cuda/std/cstdint>
 #include <cuda/std/span>
 
 #include <cuda/experimental/__group/concepts.cuh>
@@ -61,8 +62,8 @@ __do_group_mapping(const _Unit& __unit, const _ParentGroup& __parent, const _Map
   const _InitMappingResult __init_mapping_result{
     /*initial group count*/ 1,
     /*initial group rank*/ 0,
-    ::cuda::experimental::__count_query_group<unsigned, _Unit>(__parent),
-    ::cuda::experimental::__rank_query_group<unsigned, _Unit>(__parent),
+    ::cuda::experimental::__count_query_group<::cuda::std::uint32_t, _Unit>(__parent),
+    ::cuda::experimental::__rank_query_group<::cuda::std::uint32_t, _Unit>(__parent),
     __parent.__mapping_result().lane_mask()};
 
   const auto __mapping_result = __mapping.map(__unit, __parent, __init_mapping_result);


### PR DESCRIPTION
Fixes #9824