### PR TITLE
[CUB] Align reduce vector buffer

### DIFF
--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -310,7 +310,7 @@ struct AgentReduceImpl
         reinterpret_cast<VectorT*>(d_in_unqualified));
 
       // Load items as vector items
-      InputT input_items[ITEMS_PER_THREAD];
+      alignas(VectorT) InputT input_items[ITEMS_PER_THREAD];
       VectorT* vec_items = reinterpret_cast<VectorT*>(input_items);
 
       // Alias items as an array of VectorT and load it in striped fashion

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -95,6 +95,20 @@ struct abs_less_t
   }
 };
 
+CUB_TEST("Device reduce handles vectorized 16-bit input", "[reduce][device]", CUB_SMALL)
+{
+  using input_t  = std::int16_t;
+  using output_t = std::int32_t;
+
+  constexpr int num_items = 8192;
+  c2h::device_vector<input_t> input(num_items, input_t{1});
+  c2h::device_vector<output_t> output(1, thrust::no_init);
+
+  device_sum(thrust::raw_pointer_cast(input.data()), thrust::raw_pointer_cast(output.data()), num_items);
+
+  REQUIRE(output[0] == num_items);
+}
+
 CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", CUB_SMALL, full_type_list)
 {
   using params   = params_t<TestType>;


### PR DESCRIPTION
## What changed

- Align the local reduce staging buffer to `VectorT`.
- Add a focused `int16_t` full-tile reduction test.

## Why

`cub/cub/agent/agent_reduce.cuh` reinterprets the `InputT` staging array as `VectorT*`. For types like `int16_t`, `VectorT` can require stricter alignment than `InputT`. This follows the same fix recently made in #10890.

## Testing

- `pre-commit run --files cub/cub/agent/agent_reduce.cuh cub/test/catch2_test_device_reduce.cu`
- Added coverage for vectorized 16-bit input.