### PR TITLE
[STF] Make empty boxes iterate as empty

### DIFF
--- a/cudax/include/cuda/experimental/__stf/utility/dimensions.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/dimensions.cuh
@@ -476,7 +476,7 @@ public:
   };
 
   // Functions to create the begin and end iterators
-  _CCCL_HOST_DEVICE iterator begin()
+  _CCCL_HOST_DEVICE iterator begin() const
   {
     for (size_t i = 0; i < dimensions; ++i)
     {
@@ -488,7 +488,7 @@ public:
     return iterator(*this);
   }
 
-  _CCCL_HOST_DEVICE iterator end()
+  _CCCL_HOST_DEVICE iterator end() const
   {
     return iterator(*this, true);
   }
@@ -596,7 +596,7 @@ UNITTEST("empty box<1>")
 
 UNITTEST("empty box<2>")
 {
-  auto empty_first = box({7, 7}, {2, 5});
+  const auto empty_first = box({7, 7}, {2, 5});
   EXPECT(empty_first.size() == 0);
   EXPECT(empty_first.begin() == empty_first.end());
 
@@ -607,7 +607,7 @@ UNITTEST("empty box<2>")
   }
   EXPECT(first_count == 0);
 
-  auto empty_second = box({2, 5}, {7, 7});
+  const auto empty_second = box({2, 5}, {7, 7});
   EXPECT(empty_second.size() == 0);
   EXPECT(empty_second.begin() == empty_second.end());
 

--- a/cudax/include/cuda/experimental/__stf/utility/dimensions.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/dimensions.cuh
@@ -478,6 +478,13 @@ public:
   // Functions to create the begin and end iterators
   _CCCL_HOST_DEVICE iterator begin()
   {
+    for (size_t i = 0; i < dimensions; ++i)
+    {
+      if (get_extent(i) == 0)
+      {
+        return iterator(*this, true);
+      }
+    }
     return iterator(*this);
   }
 
@@ -585,6 +592,31 @@ UNITTEST("empty box<1>")
   {
     abort();
   }
+};
+
+UNITTEST("empty box<2>")
+{
+  auto empty_first = box({7, 7}, {2, 5});
+  EXPECT(empty_first.size() == 0);
+  EXPECT(empty_first.begin() == empty_first.end());
+
+  size_t first_count = 0;
+  for ([[maybe_unused]] const auto& pos : empty_first)
+  {
+    first_count++;
+  }
+  EXPECT(first_count == 0);
+
+  auto empty_second = box({2, 5}, {7, 7});
+  EXPECT(empty_second.size() == 0);
+  EXPECT(empty_second.begin() == empty_second.end());
+
+  size_t second_count = 0;
+  for ([[maybe_unused]] const auto& pos : empty_second)
+  {
+    second_count++;
+  }
+  EXPECT(second_count == 0);
 };
 
 UNITTEST("mix of integrals and pairs")


### PR DESCRIPTION
## What changed

- Return the canonical end iterator from `box::begin()` when any extent is zero.
- Add 2D tests for an empty first dimension and an empty second dimension.

## Why

A box uses inclusive lower bounds and exclusive upper bounds. If one extent is zero, it has no elements, but `begin()` currently starts at the lower bounds while `end()` starts at the upper bounds. This makes `begin() != end()` and can hit the iterator increment assertion.

## Testing

- `pre-commit run --files cudax/include/cuda/experimental/__stf/utility/dimensions.cuh`
- Added coverage to the existing dimensions header unit test.