### PR TITLE
[STF] Validate dim4 index extents

### DIFF
--- a/cudax/include/cuda/experimental/__stf/utility/dimensions.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/dimensions.cuh
@@ -212,10 +212,10 @@ public:
     const size_t pz = static_cast<size_t>(p.get(2));
     const size_t pt = static_cast<size_t>(p.get(3));
 
-    _CCCL_ASSERT(p.get(0) >= 0 && px <= x, "invalid position");
-    _CCCL_ASSERT(p.get(1) >= 0 && py <= y, "invalid position");
-    _CCCL_ASSERT(p.get(2) >= 0 && pz <= z, "invalid position");
-    _CCCL_ASSERT(p.get(3) >= 0 && pt <= t, "invalid position");
+    _CCCL_ASSERT(p.get(0) >= 0 && px < x, "invalid position");
+    _CCCL_ASSERT(p.get(1) >= 0 && py < y, "invalid position");
+    _CCCL_ASSERT(p.get(2) >= 0 && pz < z, "invalid position");
+    _CCCL_ASSERT(p.get(3) >= 0 && pt < t, "invalid position");
 
     return px + x * (py + y * (pz + pt * z));
   }

--- a/cudax/test/stf/CMakeLists.txt
+++ b/cudax/test/stf/CMakeLists.txt
@@ -22,6 +22,7 @@ set(
   dot/with_events.cu
   error_checks/ctx_mismatch.cu
   error_checks/data_interface_mismatch.cu
+  error_checks/dim4_get_index_bounds.cu
   error_checks/double_finalize.cu
   error_checks/erase_frozen.cu
   error_checks/misformed_tasks_dbl_end.cu

--- a/cudax/test/stf/error_checks/dim4_get_index_bounds.cu
+++ b/cudax/test/stf/error_checks/dim4_get_index_bounds.cu
@@ -16,25 +16,16 @@
 #include <cuda/experimental/__stf/utility/dimensions.cuh>
 
 #include <csignal>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 
 using namespace cuda::experimental::stf;
 
-bool should_abort = false;
+volatile ::std::sig_atomic_t should_abort = 0;
 
 void cleanupRoutine(int /*unused*/)
 {
-  if (should_abort)
-  {
-    exit(EXIT_SUCCESS);
-  }
-  else
-  {
-    fprintf(stderr, "Unexpected SIGABRT !\n");
-    exit(EXIT_FAILURE);
-  }
+  ::std::_Exit(should_abort ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
 int main()
@@ -55,9 +46,9 @@ int main()
 
   const dim4 dims(4, 5, 6, 7);
 
-  should_abort = true;
+  should_abort = 1;
   (void) dims.get_index(pos4(4, 0, 0, 0));
-  should_abort = false;
+  should_abort = 0;
 
   return EXIT_FAILURE;
 }

--- a/cudax/test/stf/error_checks/dim4_get_index_bounds.cu
+++ b/cudax/test/stf/error_checks/dim4_get_index_bounds.cu
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDASTF in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief Ensure dim4 rejects coordinates equal to an extent
+ */
+
+#include <cuda/experimental/__stf/utility/dimensions.cuh>
+
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+using namespace cuda::experimental::stf;
+
+bool should_abort = false;
+
+void cleanupRoutine(int /*unused*/)
+{
+  if (should_abort)
+  {
+    exit(EXIT_SUCCESS);
+  }
+  else
+  {
+    fprintf(stderr, "Unexpected SIGABRT !\n");
+    exit(EXIT_FAILURE);
+  }
+}
+
+int main()
+{
+#if _CCCL_COMPILER(MSVC)
+  signal(SIGABRT, &cleanupRoutine);
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
+  struct sigaction sigabrt_action{};
+  memset(&sigabrt_action, 0, sizeof(sigabrt_action));
+  sigabrt_action.sa_handler = &cleanupRoutine;
+
+  if (sigaction(SIGABRT, &sigabrt_action, nullptr) != 0)
+  {
+    perror("sigaction SIGABRT");
+    exit(EXIT_FAILURE);
+  }
+#endif // !_CCCL_COMPILER(MSVC)
+
+  const dim4 dims(4, 5, 6, 7);
+
+  should_abort = true;
+  (void) dims.get_index(pos4(4, 0, 0, 0));
+  should_abort = false;
+
+  return EXIT_FAILURE;
+}


### PR DESCRIPTION
## What changed

- Changed `dim4::get_index()` extent checks from `<=` to `<`.
- Added an STF error test for a coordinate equal to the x extent.

## Why

`dim4` uses half-open extents. `dim4(4).get_index(pos4(4))` was accepted and returned index `4`, even though `size()` is `4`.

## Tests

- `pre-commit run --files ...`
- Clang host syntax check for the new test