### PR TITLE
[cuda.compute] Exclude device pointers from binary search build cache key (#10689)

### DIFF
--- a/python/cuda_cccl/cuda/compute/algorithms/_binary_search.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_binary_search.py
@@ -24,15 +24,6 @@ from ..op import OpAdapter, OpKind, make_op_adapter
 from ..typing import DeviceArrayLike, IteratorT, Operator
 
 
-def _data_pointer_or_none(array) -> int | None:
-    # A ProxyArray is a build-time placeholder with no GPU allocation and thus no
-    # data pointer; return None for it (these pointers are only cache-key
-    # discriminators) so binary_search can be built without a GPU.
-    from .._proxy import is_proxy
-
-    return None if is_proxy(array) else protocols.get_data_pointer(array)
-
-
 class _BinarySearch:
     # Shared implementation for the lower/upper bound searchers.
     _MODE: ClassVar[_bindings.BinarySearchMode]
@@ -45,8 +36,6 @@ class _BinarySearch:
         "d_values_cccl",
         "d_out_cccl",
         "op_cccl",
-        "data_ptr",
-        "out_ptr",
     ]
 
     __serialization_schema__ = (
@@ -77,9 +66,6 @@ class _BinarySearch:
             raise ValueError(
                 "d_out must use a pointer-sized unsigned integer dtype (np.uintp)."
             )
-
-        self.data_ptr = _data_pointer_or_none(d_data)
-        self.out_ptr = _data_pointer_or_none(d_out)
 
         self.d_data_cccl = cccl.to_cccl_input_iter(d_data)
         self.d_values_cccl = cccl.to_cccl_input_iter(d_values)
@@ -160,8 +146,6 @@ def _make_binary_search(
     d_out: DeviceArrayLike,
     comp: OpAdapter,
     mode: _bindings.BinarySearchMode,
-    data_ptr: int,
-    out_ptr: int,
     compute_capability=None,
 ):
     """Cached factory for the binary_search searchers."""
@@ -209,8 +193,6 @@ def make_lower_bound(
         d_out,
         comp_adapter,
         _bindings.BinarySearchMode.LOWER_BOUND,
-        _data_pointer_or_none(d_data),
-        _data_pointer_or_none(d_out),
         compute_capability=compute_capability,
     )
 
@@ -255,8 +237,6 @@ def make_upper_bound(
         d_out,
         comp_adapter,
         _bindings.BinarySearchMode.UPPER_BOUND,
-        _data_pointer_or_none(d_data),
-        _data_pointer_or_none(d_out),
         compute_capability=compute_capability,
     )
 

--- a/python/cuda_cccl/tests/compute/test_binary_search.py
+++ b/python/cuda_cccl/tests/compute/test_binary_search.py
@@ -285,3 +285,43 @@ def test_serialize_deserialize_upper_bound_round_trip():
 
     expected = np.searchsorted(h_data, h_values, side="right").astype(np.uintp)
     np.testing.assert_array_equal(d_out.copy_to_host(), expected)
+
+
+@pytest.mark.parametrize(
+    "factory, side",
+    [
+        (make_lower_bound, "left"),
+        (make_upper_bound, "right"),
+    ],
+)
+def test_binary_search_cache_reuses_artifact_when_output_allocation_changes(
+    factory, side
+):
+    """Fresh d_out allocations share one wrapper: the cache key excludes pointers."""
+    cuda.compute.clear_all_caches()
+
+    h_data = np.array([1, 3, 3, 5, 7, 9], dtype=np.int32)
+    h_values = np.array([0, 3, 4, 10], dtype=np.int32)
+
+    d_data = DeviceArray.from_numpy(h_data)
+    d_values = DeviceArray.from_numpy(h_values)
+    d_out_1 = DeviceArray.empty(len(h_values), np.uintp)
+    d_out_2 = DeviceArray.empty(len(h_values), np.uintp)
+
+    searcher_1 = factory(d_data=d_data, d_values=d_values, d_out=d_out_1)
+    searcher_2 = factory(d_data=d_data, d_values=d_values, d_out=d_out_2)
+
+    # The compiled artifact depends only on the dtypes and the comparator, so a
+    # different output allocation must not force a new build.
+    assert searcher_1 is searcher_2
+
+    searcher_2(
+        d_data=d_data,
+        num_items=len(h_data),
+        d_values=d_values,
+        num_values=len(h_values),
+        d_out=d_out_2,
+        comp=None,
+    )
+    expected = np.searchsorted(h_data, h_values, side=side).astype(np.uintp)
+    np.testing.assert_array_equal(d_out_2.copy_to_host(), expected)


### PR DESCRIPTION
## Description

closes #10689

`_make_binary_search` (the cached factory behind `make_lower_bound` / `make_upper_bound`) takes `data_ptr` and `out_ptr` positional arguments that its body never uses. They were only ever cache-key discriminators: `_data_pointer_or_none` returns the raw device pointer and `_key_for` falls back to hashing it directly, so a caller that allocates a fresh `d_out` (or `d_data`) each call misses the wrapper cache and rebuilds the searcher object every time — even though the compiled artifact depends only on dtypes and the comparator. Iterator pointers are rebound at call time via `set_cccl_iterator_state`, so the pointers are not compile-relevant.

This mirrors the relaxation already done for `histogram_even` in #9596, which moved the compile-irrelevant runtime values out of the key.

## Changes

- Drop `data_ptr`/`out_ptr` from `_make_binary_search`'s signature and from the `make_lower_bound` / `make_upper_bound` call sites.
- Remove the now-dead `_data_pointer_or_none` helper and the unused `data_ptr`/`out_ptr` slots on `_BinarySearch`. ProxyArray builds are unaffected: `_device_array_to_cccl_iter` already supplies NULL state for proxies.
- Add a regression test asserting that `make_lower_bound` / `make_upper_bound` return the same cached wrapper for same-dtype inputs with distinct output allocations.

## Checklist
- [x] New or existing tests cover these changes.