### PR TITLE
[cuda.compute]: fix `h_init` + `d_out` type mismatch bug in reduction algorithms

### DIFF
--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -209,8 +209,10 @@ try
 
   const auto [input_iterator_name, input_iterator_src] =
     get_specialization<reduce_iterator_tag>(template_id<input_iterator_traits>(), input_it);
+  // Specialize the output iterator on its own value type (not accum_t) so the final
+  // store converts the accumulator to the output type instead of reinterpreting bytes.
   const auto [output_iterator_name, output_iterator_src] =
-    get_specialization<reduce_iterator_tag>(template_id<output_iterator_traits>(), output_it, accum_t);
+    get_specialization<reduce_iterator_tag>(template_id<output_iterator_traits>(), output_it, output_it.value_type);
 
   const auto [op_name, op_src] = get_specialization<reduction_operation_tag>(
     template_id<binary_user_operation_traits>(), op, accum_t, accum_t, accum_t);

--- a/c/parallel/src/segmented_reduce.cu
+++ b/c/parallel/src/segmented_reduce.cu
@@ -145,8 +145,10 @@ try
   const auto [input_iterator_name, input_iterator_src] =
     get_specialization<segmented_reduce_input_iterator_tag>(template_id<input_iterator_traits>(), input_it);
 
-  const auto [output_iterator_name, output_iterator_src] =
-    get_specialization<segmented_reduce_output_iterator_tag>(template_id<output_iterator_traits>(), output_it, accum_t);
+  // Specialize the output iterator on its own value type (not accum_t) so the final
+  // store converts the accumulator to the output type instead of reinterpreting bytes.
+  const auto [output_iterator_name, output_iterator_src] = get_specialization<segmented_reduce_output_iterator_tag>(
+    template_id<output_iterator_traits>(), output_it, output_it.value_type);
 
   const auto [start_offset_iterator_name, start_offset_iterator_src] =
     get_specialization<segmented_reduce_start_offset_iterator_tag>(

--- a/c/parallel/test/test_reduce.cpp
+++ b/c/parallel/test/test_reduce.cpp
@@ -386,6 +386,45 @@ C2H_TEST("Reduce accumulator type is influenced by initial value", "[reduce]")
   REQUIRE(output == expected);
 }
 
+struct Reduce_OutputTypeConversion_Fixture_Tag;
+C2H_TEST("Reduce converts the accumulator to the output type on store", "[reduce]")
+{
+  const std::size_t num_items = 1 << 14;
+
+  // Accumulate in float (the init type); the output pointer has a different type.
+  // The result must be value-converted on the final store, not bit-reinterpreted.
+  operation_t op = make_operation("op", get_reduce_op(get_type_info<float>().type));
+  const std::vector<float> input(num_items, 1.0f);
+  pointer_t<float> input_ptr(input);
+  value_t<float> init{0.5f};
+
+  auto& build_cache = get_cache<Reduce_OutputTypeConversion_Fixture_Tag>();
+
+  // Output type narrower than the accumulator.
+  {
+    pointer_t<int> output_ptr(1);
+    const auto& test_key = make_key<float, int>();
+
+    reduce(input_ptr, output_ptr, num_items, op, init, CCCL_RUN_TO_RUN, build_cache, test_key);
+
+    const int output   = output_ptr[0];
+    const int expected = static_cast<int>(static_cast<float>(num_items) + init.value);
+    REQUIRE(output == expected);
+  }
+
+  // Output type wider than the accumulator.
+  {
+    pointer_t<double> output_ptr(1);
+    const auto& test_key = make_key<float, double>();
+
+    reduce(input_ptr, output_ptr, num_items, op, init, CCCL_RUN_TO_RUN, build_cache, test_key);
+
+    const double output   = output_ptr[0];
+    const double expected = static_cast<double>(static_cast<float>(num_items) + init.value);
+    REQUIRE(output == expected);
+  }
+}
+
 C2H_TEST("Reduce works with large inputs", "[reduce]")
 {
   const size_t num_items = 1ull << 33;

--- a/c/parallel/test/test_segmented_reduce.cpp
+++ b/c/parallel/test/test_segmented_reduce.cpp
@@ -424,6 +424,42 @@ extern "C" __device__ void {0}(void* lhs_ptr, void* rhs_ptr, void* out_ptr) {{
   REQUIRE(host_output == host_actual);
 }
 
+struct SegmentedReduce_OutputTypeConversion_Fixture_Tag;
+C2H_TEST("SegmentedReduce converts the accumulator to the output type on store", "[segmented_reduce]")
+{
+  using SizeT                    = cuda::std::size_t;
+  const std::size_t n_segments   = 16;
+  const std::size_t segment_size = 512;
+
+  std::vector<SizeT> segments(n_segments + 1);
+  for (std::size_t i = 0; i <= n_segments; ++i)
+  {
+    segments[i] = i * segment_size;
+  }
+
+  // Accumulate in float (the init type); the output pointer has a different type.
+  // Each segment's result must be value-converted on the final store, not bit-reinterpreted.
+  const std::vector<float> host_input(n_segments * segment_size, 1.0f);
+  pointer_t<float> input_ptr(host_input);
+  pointer_t<int> output_ptr(n_segments);
+  pointer_t<SizeT> offset_ptr(segments);
+
+  auto start_offset_it = static_cast<cccl_iterator_t>(offset_ptr);
+  auto end_offset_it   = start_offset_it;
+  end_offset_it.state  = offset_ptr.ptr + 1;
+
+  operation_t op = make_operation("op", get_reduce_op(get_type_info<float>().type));
+  value_t<float> init{0.25f};
+
+  auto& build_cache    = get_cache<SegmentedReduce_OutputTypeConversion_Fixture_Tag>();
+  const auto& test_key = make_key<float, int>();
+
+  segmented_reduce(input_ptr, output_ptr, n_segments, start_offset_it, end_offset_it, op, init, build_cache, test_key);
+
+  const int expected = static_cast<int>(static_cast<float>(segment_size) + init.value);
+  REQUIRE(std::vector<int>(output_ptr) == std::vector<int>(n_segments, expected));
+}
+
 struct SegmentedReduce_CustomTypes_WellKnown_Fixture_Tag;
 C2H_TEST("SegmentedReduce works with custom types with well-known operations", "[segmented_reduce][well_known]")
 {

--- a/python/cuda_cccl/cuda/compute/algorithms/_reduce.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_reduce.py
@@ -162,6 +162,11 @@ def make_reduce_into(
 ):
     """Computes a device-wide reduction using the specified binary ``op`` and initial value ``init``.
 
+    Mixed scalar dtypes are supported: input elements are loaded in their own
+    dtype and each is converted to the dtype of ``h_init`` before accumulation;
+    the accumulated result is converted to the dtype of ``d_out`` on the final
+    store.
+
     Example:
         Below, ``make_reduce_into`` is used to create a reduction object that can be reused.
 
@@ -239,6 +244,11 @@ def reduce_into(
     Performs device-wide reduction.
 
     This function automatically handles temporary storage allocation and execution.
+
+    Mixed scalar dtypes are supported: input elements are loaded in their own
+    dtype and each is converted to the dtype of ``h_init`` before accumulation;
+    the accumulated result is converted to the dtype of ``d_out`` on the final
+    store.
 
     Example:
         Below, ``reduce_into`` is used to compute the sum of a sequence of integers.

--- a/python/cuda_cccl/cuda/compute/algorithms/_reduce.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_reduce.py
@@ -196,8 +196,10 @@ def make_reduce_into(
 
     # Validate d_in and d_out if they are device arrays (iterators may not expose
     # dtype reliably here). Additionally, only require equality of dtypes for
-    # struct objects; mixed scalar dtypes (e.g. int8 input with int64 output)
-    # is acceptable
+    # struct objects; mixed scalar dtypes are acceptable: input elements are
+    # loaded in their own dtype and each is converted to the accumulator dtype
+    # (h_init's dtype) before accumulation; the accumulated result is converted
+    # to d_out's dtype on the final store.
     if isinstance(h_init, _Struct):
         for arr, name in ((d_in, "input"), (d_out, "output")):
             if isinstance(arr, IteratorBase):

--- a/python/cuda_cccl/cuda/compute/algorithms/_segmented_reduce.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_segmented_reduce.py
@@ -180,6 +180,11 @@ def make_segmented_reduce(
 ):
     """Computes a device-wide segmented reduction using the specified binary ``op`` and initial value ``init``.
 
+    Mixed scalar dtypes are supported: input elements are loaded in their own
+    dtype and each is converted to the dtype of ``h_init`` before accumulation;
+    each segment's accumulated result is converted to the dtype of ``d_out`` on
+    the final store.
+
     Example:
         Below, ``make_segmented_reduce`` is used to create a segmented reduction object that can be reused.
 
@@ -234,6 +239,11 @@ def segmented_reduce(
     Performs device-wide segmented reduction.
 
     This function automatically handles temporary storage allocation and execution.
+
+    Mixed scalar dtypes are supported: input elements are loaded in their own
+    dtype and each is converted to the dtype of ``h_init`` before accumulation;
+    each segment's accumulated result is converted to the dtype of ``d_out`` on
+    the final store.
 
     Example:
         Below, ``segmented_reduce`` is used to compute the minimum value of segments in a sequence of integers.

--- a/python/cuda_cccl/tests/compute/test_reduce.py
+++ b/python/cuda_cccl/tests/compute/test_reduce.py
@@ -89,6 +89,24 @@ def test_device_reduce(dtype, num_items, op):
     )  # obtained relative error value from c2h/include/c2h/check_results.cuh
 
 
+@pytest.mark.parametrize("out_dtype", [np.float32, np.float16, np.int32, np.float64])
+def test_device_reduce_output_dtype_differs_from_init(out_dtype):
+    """The reduction is computed in h_init's dtype and value-converted (not
+    bit-reinterpreted) to d_out's dtype on the final store."""
+    num_items = 3000
+    h_init = np.array([0.5], dtype=np.float32)
+    d_input = DeviceArray.from_numpy(np.ones(num_items, dtype=np.float32))
+    d_output = DeviceArray.empty(1, out_dtype)
+
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=add_op, h_init=h_init
+    )
+
+    expected = np.dtype(out_dtype).type(np.float32(num_items) + np.float32(0.5))
+    h_output = d_output.copy_to_host()
+    assert h_output[0] == expected
+
+
 def test_device_reduce_with_lambda():
     """Test that lambda functions can be used as reducers."""
     dtype = np.int32

--- a/python/cuda_cccl/tests/compute/test_segmented_reduce.py
+++ b/python/cuda_cccl/tests/compute/test_segmented_reduce.py
@@ -102,6 +102,42 @@ def test_segmented_reduce(input_array, offset_dtype, monkeypatch):
         np.testing.assert_array_equal(result, expected)
 
 
+@pytest.mark.parametrize("out_dtype", [np.float16, np.int32, np.float64])
+def test_segmented_reduce_output_dtype_differs_from_init(out_dtype, monkeypatch):
+    """Each segment's reduction is computed in h_init's dtype and value-converted
+    (not bit-reinterpreted) to d_out's dtype on the final store."""
+    # Disable SASS verification for this test (LDL instruction in SASS).
+    monkeypatch.setattr(
+        cuda.compute._cccl_interop,
+        "_check_sass",
+        False,
+    )
+
+    n_segments = 16
+    segment_size = 512
+
+    offsets = np.arange(n_segments + 1, dtype="int64") * segment_size
+    d_in = DeviceArray.from_numpy(np.ones(n_segments * segment_size, dtype=np.float32))
+    d_out = DeviceArray.empty(n_segments, out_dtype)
+    start_offsets = DeviceArray.from_numpy(offsets[:-1])
+    end_offsets = DeviceArray.from_numpy(offsets[1:])
+    h_init = np.array(0.5, dtype=np.float32)
+
+    cuda.compute.segmented_reduce(
+        d_in=d_in,
+        d_out=d_out,
+        num_segments=n_segments,
+        start_offsets_in=start_offsets,
+        end_offsets_in=end_offsets,
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
+
+    expected_val = np.dtype(out_dtype).type(np.float32(segment_size) + np.float32(0.5))
+    expected = np.full(n_segments, expected_val, dtype=out_dtype)
+    np.testing.assert_array_equal(d_out.copy_to_host(), expected)
+
+
 def test_segmented_reduce_struct_type(monkeypatch):
     # Disable SASS verification for this test (LDL instruction in SASS).
     monkeypatch.setattr(


### PR DESCRIPTION
## Description

closes #10935

This also makes this behavior consistent with CUB

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
