### PR TITLE
Constrain Rubin bytes-in-flight to not reach sm120

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -308,7 +308,7 @@ _CCCL_HOST_DEVICE constexpr auto bulk_copy_dyn_smem_for_tile_size(
 
 [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int cc_to_min_bytes_in_flight(::cuda::compute_capability cc)
 {
-  if (cc >= ::cuda::compute_capability{10, 7})
+  if (cc >= ::cuda::compute_capability{10, 7} && cc < ::cuda::compute_capability{11, 0})
   {
     return 128 * 1024; // Rubin
   }


### PR DESCRIPTION
fix on top of #10923 

byte-in-flight were unbounded to any archs that were cc >= 107 but we have to make sure they don't reach sm120 (cc < 120) cause we didn't test perf on these ones.

note: check sass diff change from @Jacobfaib as a flyby 
