### PR TITLE
[STF] capture(target): exception capture as a composable policy

### DIFF
--- a/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
@@ -17,6 +17,7 @@
 
 #include <cuda/__cccl_config>
 #include <cuda/std/expected>
+#include <cuda/std/span>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 
@@ -827,6 +828,171 @@ inline circuit_breaker_t circuit_breaker(::std::shared_ptr<int> __budget)
   _CCCL_ASSERT(__budget, "circuit_breaker requires a non-null budget");
   const int __initial = *__budget;
   return circuit_breaker_t{::std::move(__budget), __initial};
+}
+
+#ifndef _CCCL_DOXYGEN_INVOKED // Do not document
+namespace detail
+{
+// Whether a capture target's variant can decline: only typed-exception targets do (on a
+// dynamic-type mismatch or a throwing copy). exception_ptr, span, and string never decline;
+// their pointer forms fall through these specializations to false.
+template <class _Target>
+inline constexpr bool __capture_may_decline = false;
+template <class _E>
+inline constexpr bool __capture_may_decline<_E*> = ::cuda::std::is_base_of_v<::std::exception, _E>;
+template <class _E>
+inline constexpr bool __capture_may_decline<::std::shared_ptr<_E>> = ::cuda::std::is_base_of_v<::std::exception, _E>;
+} // namespace detail
+#endif // _CCCL_DOXYGEN_INVOKED
+
+/**
+ * @brief Capturing effect: stores the active exception into a caller-owned target, then lets
+ * the chain continue. The boundary pattern's missing name.
+ *
+ * Four target families, selected by the target's type:
+ * - `std::exception_ptr*` (or `shared_ptr` of one): stores `std::current_exception()`,
+ *   full dynamic type preserved, rethrowable later. Never fails.
+ * - `cuda::std::span<char>`: stores the `what()` text (or a fixed note for a nonstandard
+ *   exception), allocation-free via `snprintf`. Fit for a thread-local buffer at a C ABI
+ *   boundary where `bad_alloc` may be the very exception in flight. Never fails. The span is
+ *   a view; the buffer's lifetime stays the caller's.
+ * - `std::string*` (or `shared_ptr` of one): stores the `what()` text, allocating. If the
+ *   assignment itself throws, the target is left unchanged and the chain continues: capture
+ *   never substitutes its own storage problems for the exception being handled.
+ * - a `std::exception` derivative `_E*` (or `shared_ptr` of one): copy-assigns the caught
+ *   object when its dynamic type is EXACTLY `_E` (no slicing, same discipline as typed
+ *   catches elsewhere in this file); any other type declines by rethrowing, so
+ *   `capture(&typed) | capture(&eptr)` is a ladder whose fallback cannot fail. If `_E`'s
+ *   copy assignment throws, the capture declines with the ORIGINAL exception, never with its
+ *   own bookkeeping failure.
+ *
+ * The hook answers `void`: capture is an `&` citizen and an `always` finalizer, never a
+ * final answer. The `exception_ptr`, span, and string variants are `noexcept`, so the
+ * alternation dead-arm theorem correctly rejects them as non-final `|` arms; the typed
+ * variant may decline and composes there deliberately.
+ *
+ * The two canonical boundary spellings:
+ * @code
+ * capture(&last_exc) & capture(msg_span) & subst(nullptr)  // a C API entry's whole guard
+ * always(subst(fallback), capture(&first_error))           // callback: safe result now, rethrow later
+ * @endcode
+ */
+template <class _Target>
+struct capture_t
+{
+  //! @cond
+  using __exception_sink_tag = void;
+  //! @endcond
+
+  _Target __target_;
+
+  template <class _Fn>
+  void operator()([[maybe_unused]] const ::std::exception* __e, const ::cuda::std::source_location, _Fn&) noexcept(
+    !detail::__capture_may_decline<_Target>)
+  {
+    if constexpr (::cuda::std::is_same_v<_Target, ::cuda::std::span<char>>)
+    {
+      if (!__target_.empty())
+      {
+        ::std::snprintf(__target_.data(), __target_.size(), "%s", __e ? __e->what() : "nonstandard exception");
+      }
+    }
+    else
+    {
+      auto& __t   = *__target_; // raw pointer and shared_ptr alike
+      using _Held = ::cuda::std::remove_reference_t<decltype(__t)>;
+      if constexpr (::cuda::std::is_same_v<_Held, ::std::exception_ptr>)
+      {
+        // current_exception, deliberately: building from `*__e` would slice to the static
+        // type; this preserves the full dynamic exception (and is the cheaper call besides).
+        __t = ::std::current_exception();
+      }
+      else if constexpr (::cuda::std::is_same_v<_Held, ::std::string>)
+      {
+        _CCCL_TRY
+        {
+          __t.assign(__e ? __e->what() : "nonstandard exception");
+        }
+        _CCCL_CATCH_ALL
+        {
+          // Best effort: storage failure leaves the target unchanged, the chain continues.
+        }
+      }
+      else
+      {
+        // Typed capture: exact dynamic type only; anything else declines by rethrowing.
+        if (__e == nullptr || typeid(*__e) != typeid(_Held))
+        {
+          throw;
+        }
+        bool __stored = false;
+        _CCCL_TRY
+        {
+          __t      = static_cast<const _Held&>(*__e);
+          __stored = true;
+        }
+        _CCCL_CATCH_ALL
+        {
+          // Swallow the copy failure; the decline below re-raises the ORIGINAL exception
+          // (outside this handler, the enclosing catch's exception is current again).
+        }
+        if (!__stored)
+        {
+          throw;
+        }
+      }
+    }
+  }
+};
+
+//! @brief Capture the active exception, full dynamic type preserved, into `*__target`.
+inline auto capture(::std::exception_ptr* __target)
+{
+  _CCCL_ASSERT(__target != nullptr, "capture requires a non-null target");
+  return capture_t<::std::exception_ptr*>{__target};
+}
+
+//! @brief See @ref capture. Shared-ownership form.
+inline auto capture(::std::shared_ptr<::std::exception_ptr> __target)
+{
+  _CCCL_ASSERT(__target, "capture requires a non-null target");
+  return capture_t<::std::shared_ptr<::std::exception_ptr>>{::cuda::std::move(__target)};
+}
+
+//! @brief Capture the active exception's message into a caller-owned buffer, allocation-free.
+inline auto capture(::cuda::std::span<char> __target)
+{
+  return capture_t<::cuda::std::span<char>>{__target};
+}
+
+//! @brief Capture the active exception's message into `*__target`, allocating; best effort.
+inline auto capture(::std::string* __target)
+{
+  _CCCL_ASSERT(__target != nullptr, "capture requires a non-null target");
+  return capture_t<::std::string*>{__target};
+}
+
+//! @brief See @ref capture. Shared-ownership form.
+inline auto capture(::std::shared_ptr<::std::string> __target)
+{
+  _CCCL_ASSERT(__target, "capture requires a non-null target");
+  return capture_t<::std::shared_ptr<::std::string>>{::cuda::std::move(__target)};
+}
+
+//! @brief Capture an exception of dynamic type exactly `_E` into `*__target`; decline otherwise.
+template <class _E, ::cuda::std::enable_if_t<::cuda::std::is_base_of_v<::std::exception, _E>, int> = 0>
+auto capture(_E* __target)
+{
+  _CCCL_ASSERT(__target != nullptr, "capture requires a non-null target");
+  return capture_t<_E*>{__target};
+}
+
+//! @brief See @ref capture. Shared-ownership form.
+template <class _E, ::cuda::std::enable_if_t<::cuda::std::is_base_of_v<::std::exception, _E>, int> = 0>
+auto capture(::std::shared_ptr<_E> __target)
+{
+  _CCCL_ASSERT(__target, "capture requires a non-null target");
+  return capture_t<::std::shared_ptr<_E>>{::cuda::std::move(__target)};
 }
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
@@ -4094,6 +4260,91 @@ UNITTEST("ON_THROW macro")
     };
     EXPECT(&r == &obj);
   }
+#  endif // _CCCL_HAS_EXCEPTIONS()
+};
+
+UNITTEST("capture")
+{
+  using namespace cuda::experimental::stf;
+  using namespace cuda::experimental::stf::exception_policies;
+#  if _CCCL_HAS_EXCEPTIONS()
+  // exception_ptr target: the deferred-rethrow pattern, full fidelity.
+  {
+    ::std::exception_ptr last;
+    const int v = on_throw(capture(&last) & subst(-1)) << []() -> int {
+      throw ::std::runtime_error("boom");
+    };
+    EXPECT(v == -1);
+    EXPECT(!!last);
+    bool round = false;
+    _CCCL_TRY
+    {
+      ::std::rethrow_exception(last);
+    }
+    _CCCL_CATCH (const ::std::runtime_error& e)
+    {
+      round = ::std::string_view{e.what()} == "boom"; // dynamic type survived: no slicing
+    }
+    _CCCL_CATCH_ALL
+    {
+      throw;
+    }
+    EXPECT(round);
+  }
+  // span target: allocation-free message transport, the C-boundary shape.
+  {
+    char msg[64] = {};
+    const int v  = on_throw(capture(::cuda::std::span<char>{msg}) & subst(0)) << []() -> int {
+      throw ::std::runtime_error("registered twice");
+    };
+    EXPECT(v == 0);
+    EXPECT(::std::string_view{msg} == "registered twice");
+  }
+  // string target, allocating; and the always spelling from the callback pattern.
+  {
+    ::std::string text;
+    const int v = on_throw(always(subst(7), capture(&text))) << []() -> int {
+      throw ::std::logic_error("mapper failed");
+    };
+    EXPECT(v == 7);
+    EXPECT(text == "mapper failed");
+  }
+  // Typed target: exact dynamic type stores and continues...
+  {
+    ::std::runtime_error err{"unset"};
+    const int v = on_throw(capture(&err) & subst(-2)) << []() -> int {
+      throw ::std::runtime_error("typed");
+    };
+    EXPECT(v == -2);
+    EXPECT(::std::string_view{err.what()} == "typed");
+  }
+  // ...a DERIVATIVE declines (no slicing), and the eptr fallback of the ladder takes it.
+  {
+    ::std::runtime_error err{"unset"};
+    ::std::exception_ptr last;
+    const int v = on_throw(capture(&err) & subst(-2) | capture(&last) & subst(-3)) << []() -> int {
+      throw ::std::range_error("derived");
+    };
+    EXPECT(v == -3);
+    EXPECT(::std::string_view{err.what()} == "unset");
+    EXPECT(!!last);
+  }
+  // shared_ptr form shares one target across policy copies.
+  {
+    auto text = ::std::make_shared<::std::string>();
+    static_cast<void>(on_throw((capture(text) & retry) * 2 | subst(0)) << []() -> int {
+      throw ::std::runtime_error("each attempt");
+    });
+    EXPECT(*text == "each attempt");
+  }
+  // noexcept bookkeeping: untyped captures never decline, typed ones may.
+  static_assert(!detail::__capture_may_decline<::std::exception_ptr*>);
+  static_assert(!detail::__capture_may_decline<::std::string*>);
+  static_assert(detail::__capture_may_decline<::std::runtime_error*>);
+
+  // Negative-compile expectations (do not compile; kept as comments near the code they guard):
+  //  - on_throw(capture(&eptr_target) | subst(0)) << ...;
+  //      -> "the left policy never declines; alternatives after it are unreachable"
 #  endif // _CCCL_HAS_EXCEPTIONS()
 };
 


### PR DESCRIPTION
> [!NOTE]
> **For reviewers: this PR is stacked on #10807** and its Files changed tab shows the union of both. To review only what this PR adds, open the [Commits tab](https://github.com/NVIDIA/cccl/pull/10955/commits) and click the last commit (the capture(target) commit); everything before it belongs to #10807. Equivalent view: [compare exception-sinks-nothing...capture-policy](https://github.com/andralex/cccl/compare/exception-sinks-nothing...capture-policy). The tip commit's SHA changes whenever the base PR moves and this one is restacked, so navigate by position, and the last commit is always the whole of this PR: 251 added lines, all in `exception_policy.cuh`. Draft until #10807 lands; it then rebases onto `main` and the diff here collapses to that one commit automatically.

Adds `capture(target)` to the exception-policy vocabulary: a capturing effect that stores the active exception into a caller-owned target and lets the chain continue.

Four target families, selected by the target's type:
- `std::exception_ptr`: full dynamic type, rethrowable later, never fails
- `cuda::std::span<char>`: `what()` text, allocation-free (fit for a thread-local buffer at a C ABI boundary where `bad_alloc` may be the exception in flight)
- `std::string`: allocating, best effort; a storage failure leaves the target unchanged rather than replacing the exception being handled
- an exact-dynamic-type `std::exception` derivative: mismatch declines by rethrowing (so `capture(&typed) | capture(&eptr)` is a ladder whose fallback cannot fail); a throwing copy declines with the *original* exception

`shared_ptr` ownership forms for all but span (a view). The untyped variants are `noexcept`, so the existing dead-arm theorem statically rejects them as non-final `|` arms.

Motivation: the STF/Python C boundary (cf. the binding-abort investigation with @caugonnet) hand-rolls this pattern several mutually inconsistent ways today. With `capture`, an entire C API entry guard is one policy value:

```cpp
capture(&last_exc) & capture(msg_span) & subst(nullptr)
```

Validated: unit tests compiled and executed at C++17 and C++20 (all four families, ladder decline, shared targets across retries, rethrow round-trip fidelity), negative-compile probe for the dead-arm rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
