### PR TITLE
[STF] sharded core

### DIFF
--- a/cudax/cmake/cudaxHeaderTesting.cmake
+++ b/cudax/cmake/cudaxHeaderTesting.cmake
@@ -29,6 +29,9 @@ function(cudax_add_header_test label definitions)
       # Places headers are compiled separately:
       "cuda/experimental/places.cuh"
       "cuda/experimental/__places/*"
+      # Sharded headers are compiled separately (they build on places):
+      "cuda/experimental/sharded.cuh"
+      "cuda/experimental/__sharded/*"
       # STF headers are compiled separately:
       "cuda/experimental/stf.cuh"
       "cuda/experimental/__stf/*"
@@ -61,6 +64,25 @@ function(cudax_add_header_test label definitions)
       GLOBS #
         "cuda/experimental/places.cuh"
         "cuda/experimental/__places/*.cuh"
+      HEADER_TEMPLATE "${cudax_SOURCE_DIR}/cmake/header_test.in.cu"
+    )
+    target_link_libraries(${headertest_target} PUBLIC cudax.compiler_interface)
+    target_compile_options(
+      ${headertest_target}
+      PRIVATE
+        $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>
+        $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-relaxed-constexpr>
+    )
+
+    ###################
+    # Sharded headers #
+    set(headertest_target cudax.headers.${label}.sharded)
+    cccl_generate_header_tests(
+      ${headertest_target}
+      cudax/include
+      GLOBS #
+        "cuda/experimental/sharded.cuh"
+        "cuda/experimental/__sharded/*.cuh"
       HEADER_TEMPLATE "${cudax_SOURCE_DIR}/cmake/header_test.in.cu"
     )
     target_link_libraries(${headertest_target} PUBLIC cudax.compiler_interface)

--- a/cudax/examples/places/CMakeLists.txt
+++ b/cudax/examples/places/CMakeLists.txt
@@ -1,4 +1,8 @@
-set(places_example_sources thrust_device_data_place_allocator.cu)
+set(
+  places_example_sources
+  thrust_device_data_place_allocator.cu
+  sharded_reduce.cu
+)
 
 ## cudax_add_places_example
 #

--- a/cudax/examples/places/sharded_reduce.cu
+++ b/cudax/examples/places/sharded_reduce.cu
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief Sharded reduction over the locality domains of the machine.
+ *
+ * Mapping-tier example (no task framework required):
+ *  1. build a `place_group` — one place per locality domain of every device
+ *     (whole devices where domains are unsupported),
+ *  2. allocate a `sharded_array` over the group — each shard lives on its
+ *     domain's memory, with a reference stream from the group's pools,
+ *  3. run sharded algorithms: each place executes the device-scope primitive
+ *     (CUB) on its shard, and the per-place results are combined — the same
+ *     local-compute-plus-combine structure CUDA already uses from warps to
+ *     blocks to devices, extended one scope further.
+ */
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <cstddef>
+#include <cstdio>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::place_group;
+
+int main()
+{
+  // One execution place per locality domain, with lazily created per-place
+  // stream pools and memory resources
+  auto group = place_group::by_locality_domains();
+  printf("place_group with %zu place(s)\n", group.size());
+
+  // 256M values, distributed evenly: shard i lives on place i
+  const std::size_t n = std::size_t{1} << 28;
+  auto data           = sharded_array<long long>::allocate(group, n);
+
+  // data[i] = i + 1 (global index), computed by each place on its shard
+  iota(group, data, 1LL);
+
+  // Per-place CUB reduction + combine across places
+  const long long total    = sum(group, data);
+  const long long expected = static_cast<long long>(n) * (static_cast<long long>(n) + 1) / 2;
+
+  printf("sum(1..%zu) = %lld (expected %lld)\n", n, total, expected);
+  printf("min = %lld, max = %lld\n", min(group, data), max(group, data));
+
+  if (total != expected)
+  {
+    printf("FAILED\n");
+    return 1;
+  }
+
+  printf("PASSED\n");
+  return 0;
+}

--- a/cudax/include/cuda/experimental/__places/place_group.cuh
+++ b/cudax/include/cuda/experimental/__places/place_group.cuh
@@ -80,6 +80,8 @@
 #include <cstddef>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
+#include <string>
 #include <tuple>
 #include <vector>
 
@@ -165,6 +167,54 @@ inline constexpr bool has_place_resources<
     ::cuda::std::is_same_v<decltype(::cuda::std::declval<Handle&>().get_place_resources()), exec_place_resources&>>> =
   true;
 } // namespace reserved
+
+// ============================================================================
+// Stream-capture query
+// ============================================================================
+
+/**
+ * @brief True when @p stream is part of an active CUDA stream capture, or
+ * when an active global-mode capture elsewhere in the process would make
+ * synchronizing operations on this thread illegal.
+ *
+ * `nullptr` queries the legacy default stream; because the legacy stream
+ * implicitly interacts with every capture in `cudaStreamCaptureModeGlobal`,
+ * the query then acts as a process-wide capture probe (the driver reports
+ * `cudaErrorStreamCaptureImplicit`, which this function maps to `true`).
+ */
+inline bool stream_in_capture(cudaStream_t stream = nullptr)
+{
+  cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
+  const cudaError_t res          = cudaStreamIsCapturing(stream, &status);
+  if (res == cudaErrorStreamCaptureImplicit)
+  {
+    (void) cudaGetLastError(); // clear the sticky error
+    return true;
+  }
+  cuda_safe_call(res);
+  return status != cudaStreamCaptureStatusNone;
+}
+
+/**
+ * @brief Throw when @p stream is part of an active CUDA stream capture (or,
+ * for `nullptr`, when a global-mode capture is active anywhere in the
+ * process): the named operation synchronizes, allocates or performs host
+ * transfers, none of which can be recorded into a CUDA graph.
+ *
+ * The check itself is a safe query: refusing an operation this way leaves the
+ * ongoing capture VALID, so the caller can catch the exception and keep
+ * capturing supported work.
+ */
+inline void check_not_capturing(cudaStream_t stream, const char* what)
+{
+  if (stream_in_capture(stream))
+  {
+    _CCCL_THROW(::std::runtime_error,
+                ::std::string(what)
+                  + ": not supported during CUDA graph capture (the operation cannot be "
+                    "recorded into a graph; the capture stays valid)");
+  }
+}
 
 // ============================================================================
 // place_group
@@ -348,11 +398,14 @@ public:
   }
 
   /// @brief Synchronize every stream created so far, on every place.
+  /// @throws std::runtime_error under an active CUDA stream capture
+  /// (synchronization cannot be recorded into a graph).
   ///
   /// Lazy by design: places whose pools were never touched are skipped, so
   /// synchronizing does not create streams.
   void sync()
   {
+    check_not_capturing(nullptr, "place_group::sync");
     // Snapshot under the lock, synchronize unlocked: a host function
     // enqueued on a cached stream may itself call get_stream() and would
     // deadlock against cudaStreamSynchronize() otherwise.
@@ -370,6 +423,10 @@ public:
       exec_place_scope scope(places_[i]);
       for (cudaStream_t s : snapshot[i])
       {
+        if (stream_in_capture(s))
+        {
+          _CCCL_THROW(::std::runtime_error, "place_group::sync: not supported during CUDA stream capture");
+        }
         cuda_safe_call(cudaStreamSynchronize(s));
       }
     }

--- a/cudax/include/cuda/experimental/__sharded/adjacent_difference.cuh
+++ b/cudax/include/cuda/experimental/__sharded/adjacent_difference.cuh
@@ -1,0 +1,146 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief Adjacent difference over sharded arrays. Each shard computes its
+ *        differences locally; the only cross-place traffic is one boundary
+ *        element per shard (the predecessor of the shard's first element).
+ */
+
+#pragma once
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/functional>
+
+#include <cuda/experimental/__places/place_group.cuh>
+#include <cuda/experimental/__sharded/sharded_array.cuh>
+
+#include <stdexcept>
+
+#include <cuda_runtime.h>
+
+namespace cuda::experimental::sharded
+{
+namespace reserved
+{
+/**
+ * @brief Per-shard adjacent difference kernel.
+ *
+ * output[i] = op(input[i], input[i-1]) for i > 0.
+ * output[0] = op(input[0], *prev_last) when a predecessor exists (pinned host
+ * boundary element from the previous shard), otherwise input[0].
+ */
+template <typename _Tp, typename _BinaryOp>
+__global__ void adjacent_difference_kernel(const _Tp* input, _Tp* output, size_t n, const _Tp* prev_last, _BinaryOp op)
+{
+  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (idx >= n)
+  {
+    return;
+  }
+
+  if (idx == 0)
+  {
+    output[0] = prev_last ? op(input[0], *prev_last) : input[0];
+  }
+  else
+  {
+    output[idx] = op(input[idx], input[idx - 1]);
+  }
+}
+} // namespace reserved
+
+/**
+ * @brief Out-of-place adjacent difference with a custom binary operator:
+ * output[i] = op(input[i], input[i-1]), output[0] = input[0].
+ *
+ * Input and output must be compatible (same shard sizes and places) and must
+ * not alias: neighboring elements are read while outputs are written.
+ * SYNCHRONOUS.
+ *
+ * @throws std::invalid_argument when the layouts are not compatible
+ */
+template <typename _Tp, typename _BinaryOp>
+_CCCL_HOST_API void
+adjacent_difference(place_group&, sharded_array<_Tp>& input, sharded_array<_Tp>& output, _BinaryOp op)
+{
+  check_compatible(input, output, "adjacent_difference");
+  if (&input == &output)
+  {
+    _CCCL_THROW(::std::invalid_argument,
+                "adjacent_difference: input and output must be distinct arrays (element i-1 is "
+                "read while element i is written)");
+  }
+
+  const size_t num_shards = output.num_shards();
+  if (num_shards == 0 || input.size() == 0)
+  {
+    return;
+  }
+
+  // Pinned host buffer for the per-shard boundary elements: written once per
+  // shard, read (zero-copy) by the successor shard's kernel
+  places::place_memory_resource host_mr(data_place::host());
+  _Tp* h_last_elements = static_cast<_Tp*>(host_mr.allocate_sync(num_shards * sizeof(_Tp), alignof(_Tp)));
+
+  // Phase 1: gather each shard's last element
+  input.sync();
+  input.each_shard->*[h_last_elements](size_t g, auto& in_shard) {
+    cuda_safe_call(cudaMemcpyAsync(
+      &h_last_elements[g], in_shard.data + in_shard.size - 1, sizeof(_Tp), cudaMemcpyDeviceToHost, in_shard.stream));
+  };
+  input.sync();
+
+  // Phase 2: per-shard differences (boundary from the predecessor shard)
+  output.sync();
+  output.each_shard->*[&input, h_last_elements, op](size_t g, auto& out_shard) {
+    constexpr int block_size = 256;
+    const auto& in_shard     = input.shard(g);
+
+    // The logical predecessor is the last element of the previous NON-EMPTY
+    // shard (empty shards hold no elements and no boundary).
+    const _Tp* prev_last = nullptr;
+    for (size_t p = g; p-- > 0;)
+    {
+      if (input.shard(p).size > 0)
+      {
+        prev_last = &h_last_elements[p];
+        break;
+      }
+    }
+    const int num_blocks = static_cast<int>((out_shard.size + block_size - 1) / block_size);
+
+    reserved::adjacent_difference_kernel<<<num_blocks, block_size, 0, out_shard.stream>>>(
+      in_shard.data, out_shard.data, out_shard.size, prev_last, op);
+    cuda_safe_call(cudaGetLastError());
+  };
+
+  output.sync();
+  host_mr.deallocate_sync(h_last_elements, num_shards * sizeof(_Tp), alignof(_Tp));
+}
+
+/// @brief Out-of-place adjacent difference with subtraction.
+template <typename _Tp>
+_CCCL_HOST_API void adjacent_difference(place_group& group, sharded_array<_Tp>& input, sharded_array<_Tp>& output)
+{
+  adjacent_difference(group, input, output, ::cuda::std::minus<_Tp>{});
+}
+} // namespace cuda::experimental::sharded

--- a/cudax/include/cuda/experimental/__sharded/adjacent_difference.cuh
+++ b/cudax/include/cuda/experimental/__sharded/adjacent_difference.cuh
@@ -96,6 +96,10 @@ adjacent_difference(place_group&, sharded_array<_Tp>& input, sharded_array<_Tp>&
     return;
   }
 
+  // Boundary-element staging requires host synchronization: cannot be captured
+  reserved::check_not_capturing(input, "sharded::adjacent_difference");
+  reserved::check_not_capturing(output, "sharded::adjacent_difference");
+
   // Pinned host buffer for the per-shard boundary elements: written once per
   // shard, read (zero-copy) by the successor shard's kernel
   places::place_memory_resource host_mr(data_place::host());

--- a/cudax/include/cuda/experimental/__sharded/copy_if.cuh
+++ b/cudax/include/cuda/experimental/__sharded/copy_if.cuh
@@ -1,0 +1,185 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief In-place selection over sharded arrays (`copy_if` / `filter` /
+ *        `remove_if`): each place runs the device-scope primitive (CUB
+ *        `DeviceSelect::If`, in place) on its shard, then the container's
+ *        shard sizes and offsets are updated to the compacted result.
+ *
+ * These algorithms MUTATE shard sizes. That is exactly what the contiguous
+ * backing cannot represent: shrinking a shard would leave a gap between its
+ * valid elements and the next shard's, falsifying the read-as-one-array
+ * contract of `contiguous_data()`, while compacting across the gap would
+ * migrate elements onto other places than the caller asked for. They
+ * therefore refuse contiguous (`allocate_contiguous`) arrays with
+ * `std::invalid_argument`.
+ */
+
+#pragma once
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/device/device_select.cuh>
+
+#include <cuda/std/cstdint>
+
+#include <cuda/experimental/__places/place_group.cuh>
+#include <cuda/experimental/__sharded/sharded_array.cuh>
+
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+namespace cuda::experimental::sharded
+{
+namespace reserved
+{
+/// @brief Negation of a predicate (for `remove_if`).
+template <typename _Tp, typename _Pred>
+struct negate_pred_fn
+{
+  _Pred pred;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HOST_DEVICE bool operator()(_Tp val) const
+  {
+    return !pred(val);
+  }
+};
+
+template <typename _Tp, typename _Pred>
+[[nodiscard]] _CCCL_HOST_API size_t copy_if_impl(place_group& group, sharded_array<_Tp>& data, _Pred pred)
+{
+  if (data.empty())
+  {
+    return 0;
+  }
+
+  const size_t num_shards = data.num_shards();
+  using count_type        = ::cuda::std::int64_t;
+
+  // Pinned host memory for the per-shard kept counts (zero-initialized so
+  // skipped empty shards stay empty)
+  places::place_memory_resource host_mr(data_place::host());
+  count_type* h_new_sizes =
+    static_cast<count_type*>(host_mr.allocate_sync(num_shards * sizeof(count_type), alignof(count_type)));
+  ::std::fill(h_new_sizes, h_new_sizes + num_shards, count_type{0});
+
+  // Phase 1: local in-place select on each shard (CUB compacts the kept
+  // elements to the front of the shard, preserving their order); the
+  // per-shard counters are freed only after the final sync
+  ::std::vector<::std::pair<places::place_memory_resource, count_type*>> d_counts;
+  d_counts.reserve(num_shards);
+
+  data.each_shard->*[&](const size_t g, auto& s) {
+    places::place_memory_resource mr(s.place);
+    count_type* d_num =
+      static_cast<count_type*>(mr.allocate(::cuda::stream_ref{s.stream}, sizeof(count_type), alignof(count_type)));
+    d_counts.emplace_back(mr, d_num);
+
+    // Temporaries come from the shard's place through the group's resources
+    const auto env = group.env(s.place, s.stream);
+    cuda_safe_call(cub::DeviceSelect::If(s.data, d_num, static_cast<::cuda::std::int64_t>(s.size), pred, env));
+
+    cuda_safe_call(cudaMemcpyAsync(&h_new_sizes[g], d_num, sizeof(count_type), cudaMemcpyDeviceToHost, s.stream));
+  };
+
+  data.sync();
+
+  // Phase 2: fold the new sizes into the container's bookkeeping
+  for (size_t g = 0; g < num_shards; g++)
+  {
+    _CCCL_ASSERT(h_new_sizes[g] >= 0 && static_cast<size_t>(h_new_sizes[g]) <= data.shard(g).size,
+                 "sharded::copy_if: select returned an out-of-range count");
+    data.shard(g).size = static_cast<size_t>(h_new_sizes[g]);
+  }
+  data.recalculate_offsets();
+
+  for (auto& [mr, ptr] : d_counts)
+  {
+    mr.deallocate_sync(ptr, sizeof(count_type), alignof(count_type));
+  }
+  host_mr.deallocate_sync(h_new_sizes, num_shards * sizeof(count_type), alignof(count_type));
+
+  return data.size();
+}
+} // namespace reserved
+
+/**
+ * @brief Keep only the elements satisfying a predicate, in place.
+ *
+ * Each shard is compacted locally (order preserved); shard sizes and global
+ * offsets are updated, capacities are unchanged (`reset_sizes_to_capacity()`
+ * reuses the buffers). SYNCHRONOUS: returns the total number of kept
+ * elements.
+ *
+ * @param group the place group providing per-place memory resources
+ * @param data  the sharded array to filter in place
+ * @param pred  host- and device-callable predicate: `bool operator()(T)`
+ *
+ * @throws std::invalid_argument on contiguous (`allocate_contiguous`) arrays:
+ *         shrinking shard sizes would leave gaps between shards' valid
+ *         elements, falsifying the read-as-one-array contract of
+ *         `contiguous_data()`, and compacting across the gaps would migrate
+ *         elements across the requested placement.
+ */
+template <typename _Tp, typename _Pred>
+[[nodiscard]] _CCCL_HOST_API size_t copy_if(place_group& group, sharded_array<_Tp>& data, _Pred pred)
+{
+  if (data.is_contiguous())
+  {
+    _CCCL_THROW(::std::invalid_argument,
+                "sharded::copy_if: not supported on contiguous (allocate_contiguous) arrays -- shrinking shard sizes "
+                "would leave gaps between shards' valid elements, falsifying the read-as-one-array contract of "
+                "contiguous_data(), and compacting across the gaps would migrate elements across the placement the "
+                "caller asked for. Use a non-contiguous sharded_array, or copy into one first.");
+  }
+  return reserved::copy_if_impl(group, data, pred);
+}
+
+/// @brief Alias for `copy_if`.
+template <typename _Tp, typename _Pred>
+[[nodiscard]] _CCCL_HOST_API size_t filter(place_group& group, sharded_array<_Tp>& data, _Pred pred)
+{
+  return copy_if(group, data, pred);
+}
+
+/**
+ * @brief Remove the elements satisfying a predicate, in place (the inverse of
+ *        `copy_if`). SYNCHRONOUS: returns the total number of kept elements.
+ *
+ * @throws std::invalid_argument on contiguous arrays (see `copy_if`)
+ */
+template <typename _Tp, typename _Pred>
+[[nodiscard]] _CCCL_HOST_API size_t remove_if(place_group& group, sharded_array<_Tp>& data, _Pred pred)
+{
+  if (data.is_contiguous())
+  {
+    _CCCL_THROW(::std::invalid_argument,
+                "sharded::remove_if: not supported on contiguous (allocate_contiguous) arrays -- shrinking shard "
+                "sizes would leave gaps between shards' valid elements, falsifying the read-as-one-array contract of "
+                "contiguous_data(), and compacting across the gaps would migrate elements across the placement the "
+                "caller asked for. Use a non-contiguous sharded_array, or copy into one first.");
+  }
+  return reserved::copy_if_impl(group, data, reserved::negate_pred_fn<_Tp, _Pred>{pred});
+}
+} // namespace cuda::experimental::sharded

--- a/cudax/include/cuda/experimental/__sharded/copy_if.cuh
+++ b/cudax/include/cuda/experimental/__sharded/copy_if.cuh
@@ -74,6 +74,9 @@ template <typename _Tp, typename _Pred>
     return 0;
   }
 
+  // Size write-back requires host synchronization: cannot be captured
+  reserved::check_not_capturing(data, "sharded::copy_if");
+
   const size_t num_shards = data.num_shards();
   using count_type        = ::cuda::std::int64_t;
 

--- a/cudax/include/cuda/experimental/__sharded/count.cuh
+++ b/cudax/include/cuda/experimental/__sharded/count.cuh
@@ -92,6 +92,9 @@ template <typename _Tp, typename _Pred>
     return 0;
   }
 
+  // Host-side combine + synchronization: cannot be recorded into a CUDA graph
+  reserved::check_not_capturing(data, "sharded::count_if");
+
   const size_t num_shards = data.num_shards();
 
   // Pinned host memory for the per-place counts (zero-initialized so skipped

--- a/cudax/include/cuda/experimental/__sharded/count.cuh
+++ b/cudax/include/cuda/experimental/__sharded/count.cuh
@@ -1,0 +1,151 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief Counting over sharded arrays: each place runs the device-scope
+ *        primitive (CUB `DeviceReduce::TransformReduce` with a 0/1 transform)
+ *        on its shard, then the per-place counts are summed.
+ *
+ * Counting is read-only: it never mutates shard sizes, so it is available on
+ * every sharded array, including contiguous (`allocate_contiguous`) ones.
+ */
+
+#pragma once
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/device/device_reduce.cuh>
+
+#include <cuda/std/functional>
+
+#include <cuda/experimental/__places/place_group.cuh>
+#include <cuda/experimental/__sharded/sharded_array.cuh>
+
+#include <algorithm>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+namespace cuda::experimental::sharded
+{
+namespace reserved
+{
+/// @brief Maps an element to 1 when the predicate holds, 0 otherwise.
+template <typename _Tp, typename _Pred>
+struct count_transform_fn
+{
+  _Pred pred;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HOST_DEVICE size_t operator()(_Tp val) const
+  {
+    return pred(val) ? size_t{1} : size_t{0};
+  }
+};
+
+/// @brief Equality with a fixed value.
+template <typename _Tp>
+struct equals_value_fn
+{
+  _Tp value;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HOST_DEVICE bool operator()(_Tp val) const
+  {
+    return val == value;
+  }
+};
+} // namespace reserved
+
+/**
+ * @brief Count the elements satisfying a predicate.
+ *
+ * Phase 1 runs a CUB transform-reduce (predicate mapped to 0/1, summed) per
+ * shard on the shard's stream, with temporaries allocated from the shard's
+ * place; phase 2 sums the per-place counts. SYNCHRONOUS: returns the count.
+ *
+ * @param group the place group providing per-place memory resources
+ * @param data  the sharded input (not modified)
+ * @param pred  host- and device-callable predicate: `bool operator()(T)`
+ */
+template <typename _Tp, typename _Pred>
+[[nodiscard]] _CCCL_HOST_API size_t count_if(place_group& group, const sharded_array<_Tp>& data, _Pred pred)
+{
+  if (data.empty())
+  {
+    return 0;
+  }
+
+  const size_t num_shards = data.num_shards();
+
+  // Pinned host memory for the per-place counts (zero-initialized so skipped
+  // empty shards contribute nothing)
+  places::place_memory_resource host_mr(data_place::host());
+  size_t* h_counts = static_cast<size_t*>(host_mr.allocate_sync(num_shards * sizeof(size_t), alignof(size_t)));
+  ::std::fill(h_counts, h_counts + num_shards, size_t{0});
+
+  // Phase 1: local transform-reduce on each shard; free the per-shard outputs
+  // only after the final sync (places without stream-ordered deallocation)
+  ::std::vector<::std::pair<places::place_memory_resource, size_t*>> d_outputs;
+  d_outputs.reserve(num_shards);
+
+  data.each_shard->*[&](const size_t g, const auto& s) {
+    places::place_memory_resource mr(s.place);
+    size_t* d_out = static_cast<size_t*>(mr.allocate(::cuda::stream_ref{s.stream}, sizeof(size_t), alignof(size_t)));
+    d_outputs.emplace_back(mr, d_out);
+
+    // Temporaries come from the shard's place through the group's resources
+    const auto env = group.env(s.place, s.stream);
+    cuda_safe_call(cub::DeviceReduce::TransformReduce(
+      s.data,
+      d_out,
+      s.size,
+      ::cuda::std::plus<size_t>{},
+      reserved::count_transform_fn<_Tp, _Pred>{pred},
+      size_t{0},
+      env));
+
+    cuda_safe_call(cudaMemcpyAsync(&h_counts[g], d_out, sizeof(size_t), cudaMemcpyDeviceToHost, s.stream));
+  };
+
+  data.sync();
+
+  // Phase 2: sum the per-place counts
+  size_t total = 0;
+  for (size_t g = 0; g < num_shards; g++)
+  {
+    total += h_counts[g];
+  }
+
+  for (auto& [mr, ptr] : d_outputs)
+  {
+    mr.deallocate_sync(ptr, sizeof(size_t), alignof(size_t));
+  }
+  host_mr.deallocate_sync(h_counts, num_shards * sizeof(size_t), alignof(size_t));
+
+  return total;
+}
+
+/// @brief Count the elements equal to `value`.
+template <typename _Tp>
+[[nodiscard]] _CCCL_HOST_API size_t count(place_group& group, const sharded_array<_Tp>& data, _Tp value)
+{
+  return count_if(group, data, reserved::equals_value_fn<_Tp>{value});
+}
+} // namespace cuda::experimental::sharded

--- a/cudax/include/cuda/experimental/__sharded/fill.cuh
+++ b/cudax/include/cuda/experimental/__sharded/fill.cuh
@@ -1,0 +1,179 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief Elementwise generators over sharded arrays: fill, sequence, iota,
+ *        tabulate, generate, for_each.
+ *
+ * These algorithms have no cross-place stage: each shard runs the device
+ * primitive locally on its own place and stream; global indices are recovered
+ * from the shard's `global_offset`.
+ */
+
+#pragma once
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/for_each.h>
+#include <thrust/generate.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/tabulate.h>
+#include <thrust/tuple.h>
+
+#include <cuda/experimental/__places/place_group.cuh>
+#include <cuda/experimental/__sharded/sharded_array.cuh>
+
+#include <cuda_runtime.h>
+
+namespace cuda::experimental::sharded
+{
+namespace reserved
+{
+template <typename _Tp>
+struct sequence_fn
+{
+  _Tp start;
+  _Tp step;
+  size_t global_offset;
+
+  _CCCL_HOST_DEVICE _Tp operator()(size_t idx) const
+  {
+    return start + static_cast<_Tp>((global_offset + idx) * step);
+  }
+};
+
+template <typename _Fn>
+struct tabulate_fn
+{
+  _Fn f;
+  size_t global_offset;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HOST_DEVICE auto operator()(size_t idx) const
+  {
+    return f(global_offset + idx);
+  }
+};
+
+template <typename _Tp, typename _Op>
+struct for_each_fn
+{
+  _Op op;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HOST_DEVICE void operator()(thrust::tuple<_Tp&, size_t> t) const
+  {
+    op(thrust::get<0>(t), thrust::get<1>(t));
+  }
+};
+} // namespace reserved
+
+/// @brief Set every element to @p value.
+template <typename _Tp>
+_CCCL_HOST_API void fill(place_group&, sharded_array<_Tp>& data, const _Tp& value, bool blocking = true)
+{
+  data.each_shard->*[value](auto& s) {
+    thrust::fill(thrust::cuda::par_nosync.on(s.stream), s.data, s.data + s.size, value);
+    cuda_safe_call(cudaGetLastError());
+  };
+  if (blocking)
+  {
+    data.sync();
+  }
+}
+
+/// @brief data[i] = start + i * step (global index i).
+template <typename _Tp>
+_CCCL_HOST_API void
+sequence(place_group&, sharded_array<_Tp>& data, _Tp start = _Tp{0}, _Tp step = _Tp{1}, bool blocking = true)
+{
+  using shard_t = typename sharded_array<_Tp>::shard_type;
+  data.each_shard->*[start, step](shard_t& s) {
+    thrust::tabulate(thrust::cuda::par_nosync.on(s.stream),
+                     s.data,
+                     s.data + s.size,
+                     reserved::sequence_fn<_Tp>{start, step, s.global_offset});
+    cuda_safe_call(cudaGetLastError());
+  };
+  if (blocking)
+  {
+    data.sync();
+  }
+}
+
+/// @brief data[i] = start + i (global index i).
+template <typename _Tp>
+_CCCL_HOST_API void iota(place_group& group, sharded_array<_Tp>& data, _Tp start = _Tp{0}, bool blocking = true)
+{
+  sequence(group, data, start, _Tp{1}, blocking);
+}
+
+/// @brief data[i] = f(i) for the GLOBAL index i. `f` must be device-callable.
+template <typename _Tp, typename _Fn>
+_CCCL_HOST_API void tabulate(place_group&, sharded_array<_Tp>& data, _Fn f, bool blocking = true)
+{
+  using shard_t = typename sharded_array<_Tp>::shard_type;
+  data.each_shard->*[f](shard_t& s) {
+    thrust::tabulate(
+      thrust::cuda::par_nosync.on(s.stream), s.data, s.data + s.size, reserved::tabulate_fn<_Fn>{f, s.global_offset});
+    cuda_safe_call(cudaGetLastError());
+  };
+  if (blocking)
+  {
+    data.sync();
+  }
+}
+
+/// @brief data[i] = gen() with a stateless, device-callable generator.
+template <typename _Tp, typename _Gen>
+_CCCL_HOST_API void generate(place_group&, sharded_array<_Tp>& data, _Gen gen, bool blocking = true)
+{
+  data.each_shard->*[gen](auto& s) {
+    thrust::generate(thrust::cuda::par_nosync.on(s.stream), s.data, s.data + s.size, gen);
+    cuda_safe_call(cudaGetLastError());
+  };
+  if (blocking)
+  {
+    data.sync();
+  }
+}
+
+/// @brief Apply `op(element&, global_index)` to every element.
+template <typename _Tp, typename _Op>
+_CCCL_HOST_API void for_each(place_group&, sharded_array<_Tp>& data, _Op op, bool blocking = true)
+{
+  using shard_t = typename sharded_array<_Tp>::shard_type;
+  data.each_shard->*[op](shard_t& s) {
+    const size_t global_offset = s.global_offset;
+    auto begin = thrust::make_zip_iterator(thrust::make_tuple(s.data, thrust::make_counting_iterator(global_offset)));
+    auto end   = thrust::make_zip_iterator(
+      thrust::make_tuple(s.data + s.size, thrust::make_counting_iterator(global_offset + s.size)));
+
+    thrust::for_each(thrust::cuda::par_nosync.on(s.stream), begin, end, reserved::for_each_fn<_Tp, _Op>{op});
+    cuda_safe_call(cudaGetLastError());
+  };
+  if (blocking)
+  {
+    data.sync();
+  }
+}
+} // namespace cuda::experimental::sharded

--- a/cudax/include/cuda/experimental/__sharded/fork_join.cuh
+++ b/cudax/include/cuda/experimental/__sharded/fork_join.cuh
@@ -1,0 +1,181 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief Event pool backing the containers' `fork_from` / `join_into` stream
+ *        ordering members.
+ *
+ * Design note (ownership of the events). The pool lives INSIDE each container
+ * rather than in a `place_group` resource cache: shards do not hold a
+ * reference to the group that created their streams, and ADOPTED containers
+ * (`sharded_array<T>::adopt`, views over foreign streams) never had one. A
+ * group-owned cache would either force the container to carry a group
+ * lifetime dependency or leave the adopted path on per-call transient events.
+ * Container-owned events are correct for every construction path; the cost is
+ * at most one event per shard plus one per caller-stream device, created
+ * lazily and reused for the container's lifetime.
+ */
+
+#pragma once
+
+#include <cuda/__cccl_config>
+#include <cuda/std/cstddef>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/experimental/__places/places.cuh>
+
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+namespace cuda::experimental::sharded::reserved
+{
+/**
+ * @brief Lazily created, reusable `cudaEventDisableTiming` events for stream
+ *        fork/join choreography.
+ *
+ * Two kinds of slots:
+ *  - JOIN events, one per shard index, created with the shard's execution
+ *    place active (so the event lives in the context that owns the shard's
+ *    stream);
+ *  - FORK events, one per caller-stream device (an event must be created on
+ *    the device of the stream it is recorded on; caller streams may come from
+ *    any device, so they are keyed by device ordinal).
+ *
+ * Lazy creation is mutex-guarded (thread-safe). RECORDING on a pooled event
+ * is not serialized here: concurrent `fork_from`/`join_into` calls on the
+ * same container would race on the shared events and must be ordered
+ * externally — same contract as the containers' other stream-ordered members.
+ *
+ * All operations are capture-safe: event creation is not a stream operation,
+ * and record/wait inside an active capture become graph dependencies.
+ */
+class fork_join_event_pool
+{
+public:
+  fork_join_event_pool() = default;
+
+  fork_join_event_pool(fork_join_event_pool&& other) noexcept
+      : join_events_(::std::move(other.join_events_))
+      , fork_events_(::std::move(other.fork_events_))
+  {
+    other.join_events_.clear();
+    other.fork_events_.clear();
+  }
+
+  fork_join_event_pool& operator=(fork_join_event_pool&& other) noexcept
+  {
+    if (this != &other)
+    {
+      destroy();
+      join_events_ = ::std::move(other.join_events_);
+      fork_events_ = ::std::move(other.fork_events_);
+      other.join_events_.clear();
+      other.fork_events_.clear();
+    }
+    return *this;
+  }
+
+  fork_join_event_pool(const fork_join_event_pool&)            = delete;
+  fork_join_event_pool& operator=(const fork_join_event_pool&) = delete;
+
+  ~fork_join_event_pool()
+  {
+    destroy();
+  }
+
+  /**
+   * @brief The join event for shard @p idx, created on first use.
+   *
+   * The caller must have the shard's execution place ACTIVE (the event is
+   * created in the current context so it matches the shard's stream).
+   */
+  cudaEvent_t join_event(::cuda::std::size_t idx)
+  {
+    const ::std::lock_guard<::std::mutex> lock(mutex_);
+    if (idx >= join_events_.size())
+    {
+      join_events_.resize(idx + 1, nullptr);
+    }
+    if (!join_events_[idx])
+    {
+      places::cuda_safe_call(cudaEventCreateWithFlags(&join_events_[idx], cudaEventDisableTiming));
+    }
+    return join_events_[idx];
+  }
+
+  /**
+   * @brief The fork event for caller streams on device @p device, created on
+   *        first use (with @p device temporarily made current).
+   */
+  cudaEvent_t fork_event(int device)
+  {
+    const ::std::lock_guard<::std::mutex> lock(mutex_);
+    for (const auto& [dev, ev] : fork_events_)
+    {
+      if (dev == device)
+      {
+        return ev;
+      }
+    }
+
+    int prev = -1;
+    places::cuda_safe_call(cudaGetDevice(&prev));
+    if (prev != device)
+    {
+      places::cuda_safe_call(cudaSetDevice(device));
+    }
+    cudaEvent_t ev                = nullptr;
+    const cudaError_t create_stat = cudaEventCreateWithFlags(&ev, cudaEventDisableTiming);
+    // Restore the current device on EVERY path before surfacing a failure.
+    if (prev != device)
+    {
+      places::cuda_safe_call(cudaSetDevice(prev));
+    }
+    places::cuda_safe_call(create_stat);
+    fork_events_.emplace_back(device, ev);
+    return ev;
+  }
+
+private:
+  void destroy() noexcept
+  {
+    // cudaEventDestroy on an in-flight event is safe: destruction is deferred
+    // by the driver until the event completes.
+    for (auto ev : join_events_)
+    {
+      if (ev)
+      {
+        cudaEventDestroy(ev);
+      }
+    }
+    join_events_.clear();
+    for (const auto& [dev, ev] : fork_events_)
+    {
+      cudaEventDestroy(ev);
+    }
+    fork_events_.clear();
+  }
+
+  ::std::mutex mutex_;
+  ::std::vector<cudaEvent_t> join_events_; // one per shard index
+  ::std::vector<::std::pair<int, cudaEvent_t>> fork_events_; // one per caller-stream device
+};
+} // namespace cuda::experimental::sharded::reserved

--- a/cudax/include/cuda/experimental/__sharded/histogram.cuh
+++ b/cudax/include/cuda/experimental/__sharded/histogram.cuh
@@ -87,6 +87,9 @@ template <typename _Tp, typename _LevelT>
     return counts;
   }
 
+  // Host-side combine + synchronization: cannot be recorded into a CUDA graph
+  reserved::check_not_capturing(data, "sharded::histogram_even");
+
   const size_t num_shards = data.num_shards();
   using counter_type      = unsigned long long; // device-atomics-capable bin counter
   const size_t bins       = static_cast<size_t>(num_bins);

--- a/cudax/include/cuda/experimental/__sharded/histogram.cuh
+++ b/cudax/include/cuda/experimental/__sharded/histogram.cuh
@@ -1,0 +1,140 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief Equal-width histograms over sharded arrays: each place runs the
+ *        device-scope primitive (CUB `DeviceHistogram::HistogramEven`) on its
+ *        shard, then the per-place bin counts are summed — histogram bins are
+ *        associative, so the cross-place combine is one addition per bin.
+ *
+ * Histogramming is read-only: it never mutates shard sizes, so it is
+ * available on every sharded array, including contiguous
+ * (`allocate_contiguous`) ones.
+ */
+
+#pragma once
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/device/device_histogram.cuh>
+
+#include <cuda/experimental/__places/place_group.cuh>
+#include <cuda/experimental/__sharded/sharded_array.cuh>
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+namespace cuda::experimental::sharded
+{
+/**
+ * @brief Histogram with `num_bins` equal-width bins spanning
+ *        `[lower_level, upper_level)`.
+ *
+ * Bin `b` counts the samples in
+ * `[lower + b * (upper - lower) / num_bins, lower + (b+1) * (upper - lower) / num_bins)`;
+ * samples outside `[lower_level, upper_level)` are ignored. Phase 1 runs CUB
+ * `DeviceHistogram::HistogramEven` per shard on the shard's stream, with the
+ * per-place histogram and temporaries allocated from the shard's place;
+ * phase 2 sums the per-place bin counts. SYNCHRONOUS: returns the combined
+ * histogram.
+ *
+ * @param group       the place group providing per-place memory resources
+ * @param data        the sharded input (not modified)
+ * @param num_bins    number of equal-width bins (>= 1)
+ * @param lower_level inclusive lower bound of the lowest bin
+ * @param upper_level exclusive upper bound of the highest bin
+ *
+ * @throws std::invalid_argument when `num_bins < 1` or
+ *         `lower_level >= upper_level`
+ */
+template <typename _Tp, typename _LevelT>
+[[nodiscard]] _CCCL_HOST_API ::std::vector<size_t> histogram_even(
+  place_group& group, const sharded_array<_Tp>& data, int num_bins, _LevelT lower_level, _LevelT upper_level)
+{
+  if (num_bins < 1)
+  {
+    _CCCL_THROW(::std::invalid_argument,
+                "sharded::histogram_even: num_bins (" + ::std::to_string(num_bins) + ") must be at least 1");
+  }
+  if (!(lower_level < upper_level))
+  {
+    _CCCL_THROW(::std::invalid_argument, "sharded::histogram_even: lower_level must be less than upper_level");
+  }
+
+  ::std::vector<size_t> counts(static_cast<size_t>(num_bins), 0);
+  if (data.empty())
+  {
+    return counts;
+  }
+
+  const size_t num_shards = data.num_shards();
+  using counter_type      = unsigned long long; // device-atomics-capable bin counter
+  const size_t bins       = static_cast<size_t>(num_bins);
+
+  // Pinned host memory for the per-place histograms (zero-initialized so
+  // skipped empty shards contribute nothing)
+  places::place_memory_resource host_mr(data_place::host());
+  const size_t host_bytes = num_shards * bins * sizeof(counter_type);
+  counter_type* h_hists   = static_cast<counter_type*>(host_mr.allocate_sync(host_bytes, alignof(counter_type)));
+  ::std::fill(h_hists, h_hists + num_shards * bins, counter_type{0});
+
+  // Phase 1: local histogram on each shard; free the per-shard histograms
+  // only after the final sync (places without stream-ordered deallocation)
+  ::std::vector<::std::pair<places::place_memory_resource, counter_type*>> d_hists;
+  d_hists.reserve(num_shards);
+
+  data.each_shard->*[&](const size_t g, const auto& s) {
+    places::place_memory_resource mr(s.place);
+    counter_type* d_hist = static_cast<counter_type*>(
+      mr.allocate(::cuda::stream_ref{s.stream}, bins * sizeof(counter_type), alignof(counter_type)));
+    d_hists.emplace_back(mr, d_hist);
+
+    // Temporaries come from the shard's place through the group's resources
+    const auto env = group.env(s.place, s.stream);
+    cuda_safe_call(
+      cub::DeviceHistogram::HistogramEven(s.data, d_hist, num_bins + 1, lower_level, upper_level, s.size, env));
+
+    cuda_safe_call(
+      cudaMemcpyAsync(&h_hists[g * bins], d_hist, bins * sizeof(counter_type), cudaMemcpyDeviceToHost, s.stream));
+  };
+
+  data.sync();
+
+  // Phase 2: sum the per-place bin counts
+  for (size_t g = 0; g < num_shards; g++)
+  {
+    for (size_t b = 0; b < bins; b++)
+    {
+      counts[b] += static_cast<size_t>(h_hists[g * bins + b]);
+    }
+  }
+
+  for (auto& [mr, ptr] : d_hists)
+  {
+    mr.deallocate_sync(ptr, bins * sizeof(counter_type), alignof(counter_type));
+  }
+  host_mr.deallocate_sync(h_hists, host_bytes, alignof(counter_type));
+
+  return counts;
+}
+} // namespace cuda::experimental::sharded

--- a/cudax/include/cuda/experimental/__sharded/reduce.cuh
+++ b/cudax/include/cuda/experimental/__sharded/reduce.cuh
@@ -69,6 +69,9 @@ reduce(place_group& group, const sharded_array<_Tp>& data, _ReduceOp reduce_op, 
     return init_value;
   }
 
+  // Host-side combine + synchronization: cannot be recorded into a CUDA graph
+  reserved::check_not_capturing(data, "sharded::reduce");
+
   const size_t num_shards = data.num_shards();
 
   // Pinned host memory for the per-place partials (initialized so skipped

--- a/cudax/include/cuda/experimental/__sharded/reduce.cuh
+++ b/cudax/include/cuda/experimental/__sharded/reduce.cuh
@@ -1,0 +1,135 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief Reduction over sharded arrays: each place runs the device-scope
+ *        primitive (CUB `DeviceReduce`) on its shard, then the per-place
+ *        partials are combined — the same local-primitive-plus-combine
+ *        structure the device scope itself uses over blocks.
+ *
+ * Algorithm temporaries are drawn from each shard's own place through the
+ * group's per-place memory resources, so scratch lands where the work runs.
+ */
+
+#pragma once
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/device/device_reduce.cuh>
+
+#include <cuda/functional>
+#include <cuda/std/functional>
+#include <cuda/std/limits>
+
+#include <cuda/experimental/__places/place_group.cuh>
+#include <cuda/experimental/__sharded/sharded_array.cuh>
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+namespace cuda::experimental::sharded
+{
+/**
+ * @brief Reduce all elements with a custom operator.
+ *
+ * Phase 1 runs CUB `DeviceReduce` per shard on the shard's stream, with
+ * temporaries allocated from the shard's place; phase 2 combines the
+ * per-place partials. SYNCHRONOUS: returns the final value.
+ *
+ * @param group   the place group providing per-place memory resources
+ * @param data    the sharded input (not modified)
+ * @param reduce_op host- and device-callable binary operator
+ * @param init_value initial (identity) value
+ */
+template <typename _Tp, typename _ReduceOp>
+[[nodiscard]] _CCCL_HOST_API _Tp
+reduce(place_group& group, const sharded_array<_Tp>& data, _ReduceOp reduce_op, _Tp init_value = _Tp{})
+{
+  if (data.empty())
+  {
+    return init_value;
+  }
+
+  const size_t num_shards = data.num_shards();
+
+  // Pinned host memory for the per-place partials (initialized so skipped
+  // empty shards contribute the identity)
+  places::place_memory_resource host_mr(data_place::host());
+  _Tp* h_partials = static_cast<_Tp*>(host_mr.allocate_sync(num_shards * sizeof(_Tp), alignof(_Tp)));
+  ::std::fill(h_partials, h_partials + num_shards, init_value);
+
+  // Phase 1: local reduce on each shard; free the per-shard outputs only
+  // after the final sync (places without stream-ordered deallocation)
+  ::std::vector<::std::pair<places::place_memory_resource, _Tp*>> d_outputs;
+  d_outputs.reserve(num_shards);
+
+  data.each_shard->*[&](const size_t g, const auto& s) {
+    places::place_memory_resource mr(s.place);
+    _Tp* d_out = static_cast<_Tp*>(mr.allocate(::cuda::stream_ref{s.stream}, sizeof(_Tp), alignof(_Tp)));
+    d_outputs.emplace_back(mr, d_out);
+
+    // Temporaries come from the shard's place through the group's resources
+    const auto env = group.env(s.place, s.stream);
+    cuda_safe_call(cub::DeviceReduce::Reduce(s.data, d_out, s.size, reduce_op, init_value, env));
+
+    cuda_safe_call(cudaMemcpyAsync(&h_partials[g], d_out, sizeof(_Tp), cudaMemcpyDeviceToHost, s.stream));
+  };
+
+  data.sync();
+
+  // Phase 2: combine the per-place partials
+  _Tp result = init_value;
+  for (size_t g = 0; g < num_shards; g++)
+  {
+    result = reduce_op(result, h_partials[g]);
+  }
+
+  for (auto& [mr, ptr] : d_outputs)
+  {
+    mr.deallocate_sync(ptr, sizeof(_Tp), alignof(_Tp));
+  }
+  host_mr.deallocate_sync(h_partials, num_shards * sizeof(_Tp), alignof(_Tp));
+
+  return result;
+}
+
+/// @brief Sum of all elements.
+template <typename _Tp>
+[[nodiscard]] _CCCL_HOST_API _Tp sum(place_group& group, const sharded_array<_Tp>& data)
+{
+  return reduce(group, data, ::cuda::std::plus<_Tp>{}, _Tp{0});
+}
+
+/// @brief Minimum element.
+template <typename _Tp>
+[[nodiscard]] _CCCL_HOST_API _Tp min(place_group& group, const sharded_array<_Tp>& data)
+{
+  return reduce(group, data, ::cuda::minimum<_Tp>{}, ::cuda::std::numeric_limits<_Tp>::max());
+}
+
+/// @brief Maximum element.
+template <typename _Tp>
+[[nodiscard]] _CCCL_HOST_API _Tp max(place_group& group, const sharded_array<_Tp>& data)
+{
+  return reduce(group, data, ::cuda::maximum<_Tp>{}, ::cuda::std::numeric_limits<_Tp>::lowest());
+}
+} // namespace cuda::experimental::sharded

--- a/cudax/include/cuda/experimental/__sharded/scan.cuh
+++ b/cudax/include/cuda/experimental/__sharded/scan.cuh
@@ -1,0 +1,281 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief In-place scans over sharded arrays: each place runs the device-scope
+ *        primitive (CUB `DeviceScan`) on its shard, then per-place totals are
+ *        prefix-combined and folded back into the shards in place over the
+ *        shared address space.
+ */
+
+#pragma once
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/device/device_scan.cuh>
+
+#include <thrust/execution_policy.h>
+#include <thrust/transform.h>
+
+#include <cuda/std/functional>
+#include <cuda/std/type_traits>
+
+#include <cuda/experimental/__places/place_group.cuh>
+#include <cuda/experimental/__sharded/sharded_array.cuh>
+
+#include <algorithm>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+namespace cuda::experimental::sharded
+{
+/// @brief Scan flavor.
+enum class scan_type
+{
+  inclusive, //!< output[i] = op(input[0], ..., input[i])
+  exclusive //!< output[i] = op(init, input[0], ..., input[i-1])
+};
+
+namespace reserved
+{
+template <typename _Tp, typename _ScanOp>
+struct apply_prefix_fn
+{
+  _Tp prefix;
+  _ScanOp op;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HOST_DEVICE _Tp operator()(_Tp val) const
+  {
+    return op(prefix, val);
+  }
+};
+
+template <typename _Tp, typename _ScanOp>
+_CCCL_HOST_API void
+scan_impl(place_group&, sharded_array<_Tp>& data, scan_type type, _ScanOp scan_op, _Tp init_value, _Tp identity)
+{
+  if (data.empty())
+  {
+    return;
+  }
+
+  const size_t num_shards = data.num_shards();
+
+  // Pinned host staging for shard totals / prefixes
+  places::place_memory_resource host_mr(data_place::host());
+  const size_t host_bytes = 3 * num_shards * sizeof(_Tp);
+  _Tp* h_shard_totals     = static_cast<_Tp*>(host_mr.allocate_sync(host_bytes, alignof(_Tp)));
+  _Tp* h_prefixes         = h_shard_totals + num_shards;
+  _Tp* h_last_elements    = h_prefixes + num_shards; // for exclusive scans
+
+  // Empty shards contribute nothing to the cross-shard chain: track presence
+  // explicitly instead of pre-filling with a value that would have to be the
+  // operator's identity.
+  ::std::vector<bool> has_total(num_shards, false);
+
+  // Per-shard CUB temp storage, freed after the final sync
+  ::std::vector<::std::tuple<places::place_memory_resource, void*, size_t>> temp_storage;
+  temp_storage.reserve(num_shards);
+
+  // ==========================================================================
+  // Phase 1: local scan on each shard (empty shards are skipped by the
+  // visitation). Exclusive scans run locally with the IDENTITY, never with
+  // `init_value`: the init belongs to the global sequence exactly once and is
+  // folded through the prefix chain in phase 3.
+  // ==========================================================================
+
+  data.each_shard->*[&](const size_t g, auto& s) {
+    has_total[g] = true;
+
+    // For exclusive scans, save the last element BEFORE it is overwritten:
+    // the shard total is op(exclusive_last, original_last)
+    if (type == scan_type::exclusive)
+    {
+      cuda_safe_call(
+        cudaMemcpyAsync(&h_last_elements[g], s.data + s.size - 1, sizeof(_Tp), cudaMemcpyDeviceToHost, s.stream));
+    }
+
+    // Query CUB temp storage requirements
+    size_t bytes = 0;
+    if (type == scan_type::inclusive)
+    {
+      cuda_safe_call(cub::DeviceScan::InclusiveScan(nullptr, bytes, s.data, s.data, scan_op, s.size, s.stream));
+    }
+    else
+    {
+      cuda_safe_call(
+        cub::DeviceScan::ExclusiveScan(nullptr, bytes, s.data, s.data, scan_op, identity, s.size, s.stream));
+    }
+
+    places::place_memory_resource mr(s.place);
+    void* d_temp = mr.allocate(::cuda::stream_ref{s.stream}, bytes);
+    temp_storage.emplace_back(mr, d_temp, bytes);
+
+    // Run the local scan in place
+    if (type == scan_type::inclusive)
+    {
+      cuda_safe_call(cub::DeviceScan::InclusiveScan(d_temp, bytes, s.data, s.data, scan_op, s.size, s.stream));
+    }
+    else
+    {
+      cuda_safe_call(
+        cub::DeviceScan::ExclusiveScan(d_temp, bytes, s.data, s.data, scan_op, identity, s.size, s.stream));
+    }
+
+    // The last scanned element: for inclusive scans this IS the shard total;
+    // for exclusive scans the total also needs the saved original last element
+    cuda_safe_call(
+      cudaMemcpyAsync(&h_shard_totals[g], s.data + s.size - 1, sizeof(_Tp), cudaMemcpyDeviceToHost, s.stream));
+  };
+
+  data.sync();
+
+  if (type == scan_type::exclusive)
+  {
+    for (size_t g = 0; g < num_shards; g++)
+    {
+      if (has_total[g])
+      {
+        h_shard_totals[g] = scan_op(h_shard_totals[g], h_last_elements[g]);
+      }
+    }
+  }
+
+  // ==========================================================================
+  // Phase 2: prefix-combine the shard totals on the host (P values).
+  //
+  // Inclusive: shard g's prefix is the scan_op-fold of the totals of the
+  // preceding NON-EMPTY shards; the first non-empty shard has none. No
+  // identity is needed.
+  //
+  // Exclusive: the chain is additionally seeded with `init_value`, folding
+  // the init into the global sequence exactly once (the local scans used the
+  // identity).
+  // ==========================================================================
+
+  ::std::vector<bool> has_prefix(num_shards, false);
+  {
+    bool running_defined = (type == scan_type::exclusive);
+    _Tp running          = (type == scan_type::exclusive) ? init_value : _Tp{};
+    for (size_t g = 0; g < num_shards; g++)
+    {
+      has_prefix[g] = running_defined;
+      if (running_defined)
+      {
+        h_prefixes[g] = running;
+      }
+      if (has_total[g])
+      {
+        running         = running_defined ? scan_op(running, h_shard_totals[g]) : h_shard_totals[g];
+        running_defined = true;
+      }
+    }
+  }
+
+  // ==========================================================================
+  // Phase 3: fold each shard's prefix into the shard, in place. Exclusive
+  // scans may skip an identity prefix (comparison against the caller-supplied
+  // identity, not against the init).
+  // ==========================================================================
+
+  data.each_shard->*[&](const size_t g, auto& s) {
+    if (!has_prefix[g])
+    {
+      return;
+    }
+    // No identity-prefix shortcut: it would impose an undeclared operator==
+    // requirement on _Tp. The fold is a cheap elementwise pass; skipping it
+    // is a pure optimization the value-type contract should not pay for.
+    const _Tp prefix = h_prefixes[g];
+    thrust::transform(
+      thrust::cuda::par_nosync.on(s.stream),
+      s.data,
+      s.data + s.size,
+      s.data,
+      apply_prefix_fn<_Tp, _ScanOp>{prefix, scan_op});
+    cuda_safe_call(cudaGetLastError());
+  };
+
+  data.sync();
+
+  for (auto& [mr, ptr, bytes] : temp_storage)
+  {
+    mr.deallocate_sync(ptr, bytes);
+  }
+  host_mr.deallocate_sync(h_shard_totals, host_bytes, alignof(_Tp));
+}
+} // namespace reserved
+
+/// @brief In-place inclusive scan with a custom operator.
+///
+/// No identity is required: the cross-shard prefixes are folds of the
+/// preceding non-empty shards' totals, and the first non-empty shard has
+/// none.
+template <typename _Tp, typename _ScanOp>
+_CCCL_HOST_API void inclusive_scan(place_group& group, sharded_array<_Tp>& data, _ScanOp scan_op)
+{
+  reserved::scan_impl<_Tp>(group, data, scan_type::inclusive, scan_op, _Tp{}, _Tp{});
+}
+
+/// @brief In-place inclusive sum.
+template <typename _Tp>
+_CCCL_HOST_API void inclusive_scan(place_group& group, sharded_array<_Tp>& data)
+{
+  reserved::scan_impl<_Tp>(group, data, scan_type::inclusive, ::cuda::std::plus<_Tp>{}, _Tp{0}, _Tp{0});
+}
+
+/// @brief In-place exclusive scan with a custom operator.
+///
+/// `init_value` and `identity` are DIFFERENT parameters: the init seeds the
+/// global sequence exactly once (element 0 of the whole array scans to it);
+/// the identity is `scan_op`'s neutral element, used to seed the per-shard
+/// local scans. For `plus` they coincide only when the init is zero.
+template <typename _Tp,
+          typename _ScanOp,
+          typename = ::cuda::std::enable_if_t<::cuda::std::is_invocable_v<_ScanOp, _Tp, _Tp>>>
+_CCCL_HOST_API void
+exclusive_scan(place_group& group, sharded_array<_Tp>& data, _ScanOp scan_op, _Tp init_value, _Tp identity)
+{
+  reserved::scan_impl<_Tp>(group, data, scan_type::exclusive, scan_op, init_value, identity);
+}
+
+/// @brief In-place exclusive sum (identity 0; `init_value` seeds the global
+/// sequence exactly once).
+template <typename _Tp>
+_CCCL_HOST_API void exclusive_scan(place_group& group, sharded_array<_Tp>& data, _Tp init_value = _Tp{0})
+{
+  reserved::scan_impl<_Tp>(group, data, scan_type::exclusive, ::cuda::std::plus<_Tp>{}, init_value, _Tp{0});
+}
+
+/// @brief Alias for the inclusive sum.
+template <typename _Tp>
+_CCCL_HOST_API void inclusive_sum(place_group& group, sharded_array<_Tp>& data)
+{
+  inclusive_scan(group, data);
+}
+
+/// @brief Alias for the exclusive sum.
+template <typename _Tp>
+_CCCL_HOST_API void exclusive_sum(place_group& group, sharded_array<_Tp>& data, _Tp init_value = _Tp{0})
+{
+  exclusive_scan(group, data, init_value);
+}
+} // namespace cuda::experimental::sharded

--- a/cudax/include/cuda/experimental/__sharded/scan.cuh
+++ b/cudax/include/cuda/experimental/__sharded/scan.cuh
@@ -77,6 +77,10 @@ scan_impl(place_group&, sharded_array<_Tp>& data, scan_type type, _ScanOp scan_o
     return;
   }
 
+  // Host-side prefix combine + synchronization: cannot be recorded into a graph
+  reserved::check_not_capturing(
+    data, type == scan_type::inclusive ? "sharded::inclusive_scan" : "sharded::exclusive_scan");
+
   const size_t num_shards = data.num_shards();
 
   // Pinned host staging for shard totals / prefixes

--- a/cudax/include/cuda/experimental/__sharded/shard.cuh
+++ b/cudax/include/cuda/experimental/__sharded/shard.cuh
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief `shard<T>`: one contiguous, placed piece of a sharded array.
+ */
+
+#pragma once
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/experimental/__places/places.cuh>
+
+#include <cuda_runtime.h>
+
+namespace cuda::experimental::sharded
+{
+using ::cuda::experimental::places::data_place;
+using ::cuda::experimental::places::exec_place;
+
+/**
+ * @brief A single contiguous piece of a sharded array.
+ *
+ * A shard couples a span of elements with its placement: the `data_place`
+ * where the memory lives, the `exec_place` to activate when operating on it,
+ * and a reference stream for stream-ordered operations. `global_offset` is
+ * the shard's starting index in the logical (whole-array) index space.
+ */
+template <typename _Tp>
+struct shard
+{
+  _Tp* data            = nullptr; //!< pointer to the shard's elements
+  size_t size          = 0; //!< number of valid elements (logical size)
+  size_t capacity      = 0; //!< allocated capacity (>= size)
+  size_t global_offset = 0; //!< starting index in the logical array
+  data_place place; //!< where the memory lives
+  exec_place exec; //!< execution place to activate for this shard
+  cudaStream_t stream = nullptr; //!< reference stream for stream-ordered operations
+
+  // Iterators over valid elements
+  _Tp* begin()
+  {
+    return data;
+  }
+  _Tp* end()
+  {
+    return data + size;
+  }
+  const _Tp* begin() const
+  {
+    return data;
+  }
+  const _Tp* end() const
+  {
+    return data + size;
+  }
+
+  /// @brief Logical size in bytes.
+  [[nodiscard]] _CCCL_HOST_DEVICE_API size_t size_bytes() const noexcept
+  {
+    return size * sizeof(_Tp);
+  }
+
+  /// @brief Allocated capacity in bytes.
+  [[nodiscard]] _CCCL_HOST_DEVICE_API size_t capacity_bytes() const noexcept
+  {
+    return capacity * sizeof(_Tp);
+  }
+
+  /// @brief Reset the logical size to the full capacity (buffer reuse).
+  void reset_to_capacity()
+  {
+    size = capacity;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API bool empty() const noexcept
+  {
+    return size == 0 || data == nullptr;
+  }
+
+  /// @brief First global index covered by this shard.
+  [[nodiscard]] _CCCL_HOST_DEVICE_API size_t global_begin() const noexcept
+  {
+    return global_offset;
+  }
+
+  /// @brief One-past-the-last global index covered by this shard.
+  [[nodiscard]] _CCCL_HOST_DEVICE_API size_t global_end() const noexcept
+  {
+    return global_offset + size;
+  }
+
+  /// @brief Whether a global index falls within this shard.
+  [[nodiscard]] _CCCL_HOST_DEVICE_API bool contains(size_t global_idx) const noexcept
+  {
+    return global_idx >= global_offset && global_idx < global_offset + size;
+  }
+
+  /// @brief Convert a global index to a shard-local index.
+  [[nodiscard]] _CCCL_HOST_DEVICE_API size_t to_local(size_t global_idx) const noexcept
+  {
+    _CCCL_ASSERT(contains(global_idx), "shard::to_local: global index outside this shard");
+    return global_idx - global_offset;
+  }
+
+  /// @brief Convert a shard-local index to a global index.
+  [[nodiscard]] _CCCL_HOST_DEVICE_API size_t to_global(size_t local_idx) const noexcept
+  {
+    _CCCL_ASSERT(local_idx < size, "shard::to_global: local index out of range");
+    return global_offset + local_idx;
+  }
+};
+} // namespace cuda::experimental::sharded

--- a/cudax/include/cuda/experimental/__sharded/sharded_array.cuh
+++ b/cudax/include/cuda/experimental/__sharded/sharded_array.cuh
@@ -168,6 +168,15 @@ public:
    */
   static sharded_array allocate(const ::std::vector<shard_spec>& specs)
   {
+    places::check_not_capturing(nullptr, "sharded_array::allocate");
+    for (const auto& spec : specs)
+    {
+      if (cudaStream_t stream = ::std::get<3>(spec))
+      {
+        places::check_not_capturing(stream, "sharded_array::allocate");
+      }
+    }
+
     sharded_array arr;
     arr.ownership_ = ownership::owning_shards;
 
@@ -305,6 +314,15 @@ public:
    */
   static sharded_array allocate_contiguous(const ::std::vector<shard_spec>& specs)
   {
+    places::check_not_capturing(nullptr, "sharded_array::allocate_contiguous");
+    for (const auto& spec : specs)
+    {
+      if (cudaStream_t stream = ::std::get<3>(spec))
+      {
+        places::check_not_capturing(stream, "sharded_array::allocate_contiguous");
+      }
+    }
+
     sharded_array arr;
     arr.ownership_ = ownership::owning_backing; // released via contiguous_backing_
 
@@ -486,6 +504,7 @@ public:
    */
   void copy_from_host(const _Tp* host_data)
   {
+    check_not_capturing_any("sharded_array::copy_from_host");
     for (auto& s : shards_)
     {
       if (s.size == 0)
@@ -512,6 +531,7 @@ public:
    */
   void copy_to_host(_Tp* host_data) const
   {
+    check_not_capturing_any("sharded_array::copy_to_host");
     each_shard->*[host_data](const auto& s) {
       cuda_safe_call(cudaMemcpy(host_data + s.global_offset, s.data, s.size_bytes(), cudaMemcpyDefault));
     };
@@ -579,19 +599,27 @@ public:
   /// execution context). Prefer this over synchronizing the raw stream: it
   /// activates the shard's exec place the way every other shard operation
   /// does.
+  /// @throws std::runtime_error under an active CUDA stream capture.
   void sync(size_t shard_idx) const
   {
     const auto& s = shard(shard_idx);
+    places::check_not_capturing(nullptr, "sharded_array::sync");
     if (s.stream)
     {
+      places::check_not_capturing(s.stream, "sharded_array::sync");
       exec_place_scope scope(s.exec);
       cuda_safe_call(cudaStreamSynchronize(s.stream));
     }
   }
 
   /// @brief Synchronize every shard's reference stream.
+  /// @throws std::runtime_error under an active CUDA stream capture
+  /// (synchronization cannot be recorded into a graph; the capture stays
+  /// valid, so pass `blocking = false` to the elementwise algorithms and
+  /// synchronize outside capture instead).
   void sync() const
   {
+    check_not_capturing_any("sharded_array::sync");
     for (size_t i = 0; i < shards_.size(); i++)
     {
       sync(i);
@@ -1036,6 +1064,21 @@ public:
   }
 
 private:
+  /// Refuse synchronous/host-side member operations under an active capture:
+  /// probes a global-mode capture anywhere in the process (legacy stream) and
+  /// each shard's reference stream. Throws without touching the capture.
+  void check_not_capturing_any(const char* what) const
+  {
+    places::check_not_capturing(nullptr, what);
+    for (const auto& s : shards_)
+    {
+      if (s.stream)
+      {
+        places::check_not_capturing(s.stream, what);
+      }
+    }
+  }
+
   static ::std::vector<size_t> split_evenly(size_t total_size, size_t parts)
   {
     ::std::vector<size_t> sizes(parts, 0);
@@ -1090,6 +1133,29 @@ private:
   // the ordering declarations are const — they do not modify elements).
   mutable reserved::fork_join_event_pool fork_join_events_;
 };
+
+namespace reserved
+{
+/**
+ * @brief Refuse a synchronous sharded algorithm under an active CUDA stream
+ * capture: probes a global-mode capture anywhere in the process (legacy
+ * stream) and every shard's reference stream (delegating to
+ * `places::check_not_capturing`). Safe query; throwing leaves the capture
+ * valid.
+ */
+template <typename _Tp>
+void check_not_capturing(const sharded_array<_Tp>& data, const char* what)
+{
+  places::check_not_capturing(nullptr, what);
+  for (const auto& s : data)
+  {
+    if (s.stream)
+    {
+      places::check_not_capturing(s.stream, what);
+    }
+  }
+}
+} // namespace reserved
 
 // ============================================================================
 // Compatibility checks
@@ -1157,6 +1223,9 @@ void copy_between(const sharded_array<_Tp>& src, sharded_array<_Tp>& dst)
   {
     return;
   }
+
+  reserved::check_not_capturing(src, "sharded::copy_between");
+  reserved::check_not_capturing(dst, "sharded::copy_between");
 
   for (auto& dst_shard : dst)
   {

--- a/cudax/include/cuda/experimental/__sharded/sharded_array.cuh
+++ b/cudax/include/cuda/experimental/__sharded/sharded_array.cuh
@@ -1,0 +1,1077 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief `sharded_array<T>`: a 1D array partitioned into placed shards.
+ *
+ * A sharded array is the container of the shared-address rung of the
+ * cooperation-scope ladder: every byte has exactly one physical home (a
+ * place), while the logical array spans all of them. Algorithms over sharded
+ * arrays run each place's piece locally and combine across places through
+ * what the rung shares — the common address space.
+ *
+ * Sharded arrays hold PARTITIONED data only: one home per element. The
+ * replicated-operand role belongs to the binding tier (STF `logical_data`),
+ * which manages coherent copies; the two compose rather than overlap.
+ */
+
+#pragma once
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/type_traits>
+#include <cuda/stream>
+
+#include <cuda/experimental/__places/localized_array.cuh>
+#include <cuda/experimental/__places/place_group.cuh>
+#include <cuda/experimental/__places/places.cuh>
+#include <cuda/experimental/__sharded/shard.cuh>
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+namespace cuda::experimental::sharded
+{
+using ::cuda::experimental::places::cuda_safe_call;
+using ::cuda::experimental::places::exec_place_scope;
+using ::cuda::experimental::places::mv;
+using ::cuda::experimental::places::place_group;
+
+/// @brief How a container's memory is owned and released.
+enum class ownership
+{
+  owning_shards, //!< one allocation per shard; each is freed on destruction
+  owning_backing, //!< one VMM backing owns all shards' memory (`allocate_contiguous`)
+  view //!< a view over memory owned elsewhere (adoption, `slice`)
+};
+
+/// @brief Allocation spec for one shard: (size, data place, exec place, stream).
+using shard_spec = ::std::tuple<size_t, data_place, exec_place, cudaStream_t>;
+
+/// @brief Whether this machine can back a contiguous allocation
+/// (`sharded_array<T>::allocate_contiguous`): the VMM machinery the backing
+/// is built on (`places::localized_array`) requires virtual address
+/// management support on the device. `allocate_contiguous` throws where this
+/// reports false.
+[[nodiscard]] inline bool contiguous_backing_supported(int device_ordinal = 0)
+{
+  cuda_safe_call(cudaFree(nullptr)); // the driver query needs an initialized context
+  CUdevice dev;
+  cuda_safe_call(cuDeviceGet(&dev, device_ordinal));
+  int supported = 0;
+  cuda_safe_call(cuDeviceGetAttribute(&supported, CU_DEVICE_ATTRIBUTE_VIRTUAL_ADDRESS_MANAGEMENT_SUPPORTED, dev));
+  return supported == 1;
+}
+
+/**
+ * @brief A 1D array sharded across multiple memory locations.
+ *
+ * Each shard is a contiguous span of the logical index space with its own
+ * placement (see `shard<T>`). The container tier owns placement, adoption and
+ * size bookkeeping; algorithms are free functions over the container.
+ *
+ * Shard sizes are FIXED at allocation time. Operations that would mutate
+ * shard sizes (shrinking or redistributing elements) are not performed
+ * implicitly; algorithms with size-changing outputs must either write to a
+ * separately allocated result or refuse (throw) where the backing cannot
+ * represent the result — see `allocate_contiguous`.
+ */
+template <typename _Tp>
+class sharded_array
+{
+public:
+  using value_type     = _Tp;
+  using shard_type     = shard<_Tp>;
+  using iterator       = typename ::std::vector<shard_type>::iterator;
+  using const_iterator = typename ::std::vector<shard_type>::const_iterator;
+
+  // ========== Constructors ==========
+
+  /// @brief Default: empty container.
+  sharded_array()
+  {
+    each_shard.parent_ = this;
+  }
+
+  /**
+   * @brief Adopt existing shards (non-owning view).
+   *
+   * The caller keeps ownership of the memory and must keep it alive for the
+   * lifetime of the view. Shard capacities are clamped up to their sizes.
+   */
+  explicit sharded_array(::std::vector<shard_type> shards)
+      : shards_(mv(shards))
+      , ownership_(ownership::view)
+  {
+    each_shard.parent_ = this;
+    compute_total_size();
+    for (auto& s : shards_)
+    {
+      if (s.capacity < s.size)
+      {
+        s.capacity = s.size;
+      }
+    }
+  }
+
+  /**
+   * @brief Named factory for the adopting constructor above; identical
+   * behavior.
+   *
+   * `adopt` states the naming contract explicitly: a zero-copy wrap of
+   * caller-owned memory. The shards' data pointers are used as-is (no
+   * allocation, no copy), the container becomes `ownership::view`, and the
+   * caller owes the memory's lifetime for as long as the view (or anything
+   * sliced from it) is used. By contrast, `from_*` factories build owned
+   * storage by copying or transforming their inputs.
+   */
+  static sharded_array adopt(::std::vector<shard_type> shards)
+  {
+    return sharded_array(mv(shards));
+  }
+
+  // ========== Core allocation ==========
+
+  /**
+   * @brief Allocate an owning array with full per-shard specification.
+   *
+   * This is the primary allocation method; the other allocate methods reduce
+   * to it. Each spec provides (size, data place, exec place, stream); the
+   * stream, when non-null, becomes the shard's reference stream for
+   * stream-ordered operations. Empty specs are skipped.
+   */
+  static sharded_array allocate(const ::std::vector<shard_spec>& specs)
+  {
+    sharded_array arr;
+    arr.ownership_ = ownership::owning_shards;
+
+    size_t offset = 0;
+    for (const auto& [size, dplace, eplace, stream] : specs)
+    {
+      if (size == 0)
+      {
+        // Keep the shard (empty, no storage): shard positions correspond to
+        // spec positions -- and to group places in the place_group overloads
+        // -- even when a size is zero, the same way compaction leaves
+        // emptied shards in place.
+        shard_type s;
+        s.size          = 0;
+        s.capacity      = 0;
+        s.global_offset = offset;
+        s.place         = dplace;
+        s.exec          = eplace;
+        s.stream        = stream;
+        s.data          = nullptr;
+        arr.shards_.push_back(s);
+        continue;
+      }
+
+      shard_type s;
+      s.size          = size;
+      s.capacity      = size;
+      s.global_offset = offset;
+      s.place         = dplace;
+      s.exec          = eplace;
+      s.stream        = stream;
+
+      // Allocate in the place's context, on the reference stream when given
+      exec_place_scope scope(eplace);
+      s.data = allocate_memory(size, dplace, stream);
+
+      // Ensure the allocation is complete before use on other streams
+      if (stream)
+      {
+        cuda_safe_call(cudaStreamSynchronize(stream));
+      }
+      else if (dplace.allocation_is_stream_ordered())
+      {
+        cuda_safe_call(cudaDeviceSynchronize());
+      }
+
+      arr.shards_.push_back(s);
+      offset += size;
+    }
+
+    arr.total_size_ = offset;
+    return arr;
+  }
+
+  /// @brief Allocate from (size, data place) pairs; exec places are the
+  /// affine ones, no reference streams.
+  static sharded_array allocate(const ::std::vector<::std::pair<size_t, data_place>>& specs)
+  {
+    ::std::vector<shard_spec> full;
+    full.reserve(specs.size());
+    for (const auto& [size, dplace] : specs)
+    {
+      full.emplace_back(size, dplace, dplace.affine_exec_place(), nullptr);
+    }
+    return allocate(full);
+  }
+
+  // ========== place_group-based allocation ==========
+
+  /**
+   * @brief Allocate with explicit per-shard sizes over a `place_group`.
+   *
+   * Each shard lives on the affine data place of the corresponding group
+   * place and gets a reference stream from the group's per-place pool at the
+   * given color (or a round-robin color by default).
+   *
+   * @throws std::invalid_argument when `sizes.size() != group.size()`.
+   */
+  static sharded_array
+  allocate(place_group& group, const ::std::vector<size_t>& sizes, size_t color = place_group::auto_stream_color)
+  {
+    if (sizes.size() != group.size())
+    {
+      _CCCL_THROW(::std::invalid_argument,
+                  "sharded_array::allocate: sizes count (" + ::std::to_string(sizes.size())
+                    + ") must equal the number of places in the group (" + ::std::to_string(group.size()) + ")");
+    }
+
+    const size_t effective_color = (color == place_group::auto_stream_color) ? group.next_stream_color() : color;
+
+    ::std::vector<shard_spec> specs;
+    specs.reserve(sizes.size());
+    for (size_t i = 0; i < sizes.size(); i++)
+    {
+      const auto& place = group.place(i);
+      specs.emplace_back(sizes[i], place.affine_data_place(), place, group.get_stream(i, effective_color));
+    }
+    return allocate(specs);
+  }
+
+  /// @brief Allocate `total_size` elements distributed evenly over a group's
+  /// places (remainder to the first shards).
+  static sharded_array allocate(place_group& group, size_t total_size, size_t color = place_group::auto_stream_color)
+  {
+    return allocate(group, split_evenly(total_size, group.size()), color);
+  }
+
+  // ========== Contiguous (VMM-backed) allocation ==========
+
+  /**
+   * @brief Allocate shards as views into ONE contiguous VA range, with each
+   *        shard's bytes physically owned by its place (VMM backing via
+   *        `places::localized_array`).
+   *
+   * Use when a consumer needs the array as ONE normal array
+   * (`contiguous_data()`) while the shards keep per-place physical placement
+   * — e.g. handing a row-partitioned output to an unmodified downstream
+   * kernel. The logical shard boundaries are EXACT (`shard(i).data` is
+   * exactly `base + global_offset`); only the physical ownership snaps to the
+   * device allocation granularity (typically 2 MiB), so up to one granule per
+   * boundary lands with a neighboring owner — negligible at the sizes where
+   * placement matters, and irrelevant below them.
+   *
+   * Contract deltas vs `allocate()`:
+   *  - contiguity: `contiguous_data()` returns the base pointer; shard views
+   *    are offsets into it (dense, no inter-shard padding)
+   *  - physical boundaries are approximate (granule-snapped internally)
+   *  - fixed size: the VA range and mapping are created once (no resize);
+   *    size-mutating algorithms must refuse contiguous arrays, since
+   *    shrinking shard sizes would leave gaps between shards' valid elements
+   *    and break the read-as-one-array contract
+   *
+   * One VA range means one physical home per byte, so this backing can never
+   * replicate — consistent with the container holding partitioned data only.
+   */
+  static sharded_array allocate_contiguous(const ::std::vector<shard_spec>& specs)
+  {
+    sharded_array arr;
+    arr.ownership_ = ownership::owning_backing; // released via contiguous_backing_
+
+    size_t total = 0;
+    ::std::vector<size_t> ends; // cumulative element ends per spec (incl. empty)
+    ::std::vector<exec_place> eplaces;
+    for (const auto& [size, dplace, eplace, stream] : specs)
+    {
+      // The contiguous backing places each spec's physical blocks at its
+      // exec place's affine data place; a non-affine data_place in the spec
+      // would be silently ignored, so refuse it up front.
+      if (dplace.to_string() != eplace.affine_data_place().to_string())
+      {
+        _CCCL_THROW(::std::invalid_argument,
+                    "sharded_array::allocate_contiguous: spec data_place (" + dplace.to_string()
+                      + ") must be the exec place's affine data place (" + eplace.affine_data_place().to_string()
+                      + "); non-affine placement is not supported by the contiguous backing");
+      }
+      total += size;
+      ends.push_back(total);
+      eplaces.push_back(eplace);
+    }
+    if (total == 0)
+    {
+      return arr;
+    }
+
+    // Physical blocks are placed by the owner of each element range: element
+    // i belongs to the first spec whose cumulative end exceeds i.
+    auto owner_of = [ends](size_t i) {
+      const size_t idx = ::std::upper_bound(ends.begin(), ends.end(), i) - ends.begin();
+      return places::pos4(static_cast<int>(idx));
+    };
+    arr.contiguous_backing_ = ::std::make_shared<places::localized_array>(
+      places::make_grid(eplaces),
+      ::std::function<places::pos4(size_t)>(owner_of),
+      total,
+      sizeof(_Tp),
+      places::dim4(total));
+
+    _Tp* base     = static_cast<_Tp*>(arr.contiguous_backing_->get_base_ptr());
+    size_t offset = 0;
+    for (const auto& [size, dplace, eplace, stream] : specs)
+    {
+      if (size == 0)
+      {
+        // Same invariant as allocate(): the shard exists (empty, a zero-length
+        // view at the running offset) so shard positions keep corresponding to
+        // spec positions and group places.
+        shard_type s;
+        s.data          = base + offset;
+        s.size          = 0;
+        s.capacity      = 0;
+        s.global_offset = offset;
+        s.place         = dplace;
+        s.exec          = eplace;
+        s.stream        = stream;
+        arr.shards_.push_back(s);
+        continue;
+      }
+      shard_type s;
+      s.data          = base + offset;
+      s.size          = size;
+      s.capacity      = size;
+      s.global_offset = offset;
+      s.place         = dplace;
+      s.exec          = eplace;
+      s.stream        = stream;
+      arr.shards_.push_back(s);
+      offset += size;
+    }
+    arr.total_size_ = total;
+    return arr;
+  }
+
+  /// @brief Contiguous allocation distributed evenly over a group's places.
+  static sharded_array
+  allocate_contiguous(place_group& group, size_t total_size, size_t color = place_group::auto_stream_color)
+  {
+    const auto sizes             = split_evenly(total_size, group.size());
+    const size_t effective_color = (color == place_group::auto_stream_color) ? group.next_stream_color() : color;
+
+    ::std::vector<shard_spec> specs;
+    specs.reserve(sizes.size());
+    for (size_t i = 0; i < sizes.size(); i++)
+    {
+      const auto& place = group.place(i);
+      specs.emplace_back(sizes[i], place.affine_data_place(), place, group.get_stream(i, effective_color));
+    }
+    return allocate_contiguous(specs);
+  }
+
+  /// @brief True when the whole array is one contiguous VA range (`allocate_contiguous`).
+  bool is_contiguous() const
+  {
+    return contiguous_backing_ != nullptr;
+  }
+
+  /// @brief Base pointer of the contiguous range (`nullptr` unless `allocate_contiguous`).
+  _Tp* contiguous_data() const
+  {
+    return contiguous_backing_ ? static_cast<_Tp*>(contiguous_backing_->get_base_ptr()) : nullptr;
+  }
+
+  // ========== Convenience allocation ==========
+
+  /// @brief Allocate evenly across the listed devices (owning).
+  static sharded_array allocate_uniform(size_t total_size, const ::std::vector<int>& device_ids)
+  {
+    if (device_ids.empty() || total_size == 0)
+    {
+      return sharded_array();
+    }
+
+    const auto sizes = split_evenly(total_size, device_ids.size());
+    ::std::vector<::std::pair<size_t, data_place>> specs;
+    specs.reserve(device_ids.size());
+    for (size_t i = 0; i < device_ids.size(); i++)
+    {
+      specs.emplace_back(sizes[i], data_place::device(device_ids[i]));
+    }
+    return allocate(specs);
+  }
+
+  /// @brief Allocate a single host (pinned) shard.
+  static sharded_array allocate_host(size_t total_size)
+  {
+    return allocate(::std::vector<::std::pair<size_t, data_place>>{{total_size, data_place::host()}});
+  }
+
+  /// @brief Allocate a single managed-memory shard.
+  static sharded_array allocate_managed(size_t total_size)
+  {
+    return allocate(::std::vector<::std::pair<size_t, data_place>>{{total_size, data_place::managed()}});
+  }
+
+  /**
+   * @brief Allocate with the same shard layout (sizes, places, streams) as
+   * another array, possibly with a different element type.
+   */
+  template <typename _Up>
+  static sharded_array allocate_like(const sharded_array<_Up>& other)
+  {
+    if (other.empty())
+    {
+      return sharded_array();
+    }
+    ::std::vector<shard_spec> specs;
+    specs.reserve(other.num_shards());
+    for (size_t i = 0; i < other.num_shards(); i++)
+    {
+      const auto& s = other.shard(i);
+      specs.emplace_back(s.size, s.place, s.exec, s.stream);
+    }
+    return allocate(specs);
+  }
+
+  // ========== Host transfer ==========
+
+  /// @brief Allocate per specs and copy from contiguous host data (synchronous).
+  static sharded_array from_host(const _Tp* host_data, const ::std::vector<::std::pair<size_t, data_place>>& specs)
+  {
+    auto arr = allocate(specs);
+    arr.copy_from_host(host_data);
+    return arr;
+  }
+
+  /// @brief Allocate evenly over a group's places and copy from host (synchronous).
+  static sharded_array from_host(place_group& group, const _Tp* host_data, size_t total_size)
+  {
+    auto arr = allocate(group, total_size);
+    arr.copy_from_host(host_data);
+    return arr;
+  }
+
+  /**
+   * @brief Copy contiguous host data into every shard (each shard reads from
+   * `host_data + global_offset`). SYNCHRONOUS: blocks until all copies complete.
+   */
+  void copy_from_host(const _Tp* host_data)
+  {
+    for (auto& s : shards_)
+    {
+      if (s.size == 0)
+      {
+        continue;
+      }
+      exec_place_scope scope(s.exec);
+      if (s.stream)
+      {
+        cuda_safe_call(
+          cudaMemcpyAsync(s.data, host_data + s.global_offset, s.size_bytes(), cudaMemcpyDefault, s.stream));
+      }
+      else
+      {
+        cuda_safe_call(cudaMemcpy(s.data, host_data + s.global_offset, s.size_bytes(), cudaMemcpyDefault));
+      }
+    }
+    sync();
+  }
+
+  /**
+   * @brief Copy every shard back to contiguous host memory (each shard writes
+   * to `host_data + global_offset`). SYNCHRONOUS.
+   */
+  void copy_to_host(_Tp* host_data) const
+  {
+    each_shard->*[host_data](const auto& s) {
+      cuda_safe_call(cudaMemcpy(host_data + s.global_offset, s.data, s.size_bytes(), cudaMemcpyDefault));
+    };
+  }
+
+  // ==========================================================================
+  // Shard visitation
+  // ==========================================================================
+  //
+  //   data.each_shard->*[](auto& s) { ... };            // per shard
+  //   data.each_shard->*[](size_t i, auto& s) { ... };  // index-aware
+  //
+  // The shard's exec place is activated around each call; empty shards are
+  // skipped. Work is enqueued in shard order; use per-shard streams for
+  // overlap and `sync()` to wait.
+
+  /// @brief Proxy for shard visitation (see above).
+  class each_shard_visitor
+  {
+    sharded_array* parent_;
+    friend class sharded_array;
+
+    template <typename _Parent, typename _Fn>
+    static void impl(_Parent& parent, _Fn&& func)
+    {
+      for (size_t i = 0; i < parent.num_shards(); ++i)
+      {
+        auto& s = parent.shard(i);
+        if (s.size == 0)
+        {
+          continue;
+        }
+        exec_place_scope scope(s.exec);
+        if constexpr (::cuda::std::is_invocable_v<_Fn, size_t, decltype(s)>)
+        {
+          func(i, s);
+        }
+        else
+        {
+          func(s);
+        }
+      }
+    }
+
+  public:
+    /// @brief Visit shards with mutable access.
+    template <typename _Fn>
+    void operator->*(_Fn&& func)
+    {
+      impl(*parent_, ::std::forward<_Fn>(func));
+    }
+
+    /// @brief Visit shards with read-only access.
+    template <typename _Fn>
+    void operator->*(_Fn&& func) const
+    {
+      impl(::std::as_const(*parent_), ::std::forward<_Fn>(func));
+    }
+  };
+
+  /// @brief Shard visitation entry point: `arr.each_shard->*functor`.
+  each_shard_visitor each_shard;
+
+  /// @brief Synchronize one shard's reference stream (in the shard's
+  /// execution context). Prefer this over synchronizing the raw stream: it
+  /// activates the shard's exec place the way every other shard operation
+  /// does.
+  void sync(size_t shard_idx) const
+  {
+    const auto& s = shard(shard_idx);
+    if (s.stream)
+    {
+      exec_place_scope scope(s.exec);
+      cuda_safe_call(cudaStreamSynchronize(s.stream));
+    }
+  }
+
+  /// @brief Synchronize every shard's reference stream.
+  void sync() const
+  {
+    for (size_t i = 0; i < shards_.size(); i++)
+    {
+      sync(i);
+    }
+  }
+
+  // ========== Stream ordering: composing with a caller stream ==========
+
+  // ========== Move-only semantics ==========
+
+  sharded_array(sharded_array&& other) noexcept
+      : shards_(mv(other.shards_))
+      , total_size_(other.total_size_)
+      , ownership_(other.ownership_)
+      , contiguous_backing_(mv(other.contiguous_backing_))
+  {
+    each_shard.parent_ = this;
+    other.total_size_  = 0;
+    other.ownership_   = ownership::view;
+  }
+
+  sharded_array& operator=(sharded_array&& other) noexcept
+  {
+    if (this != &other)
+    {
+      clear();
+      shards_             = mv(other.shards_);
+      total_size_         = other.total_size_;
+      ownership_          = other.ownership_;
+      contiguous_backing_ = mv(other.contiguous_backing_);
+      other.total_size_   = 0;
+      other.ownership_    = ownership::view;
+      // each_shard.parent_ already points to this
+    }
+    return *this;
+  }
+
+  sharded_array(const sharded_array&)            = delete;
+  sharded_array& operator=(const sharded_array&) = delete;
+
+  ~sharded_array()
+  {
+    clear();
+  }
+
+  // ========== Size and shard access ==========
+
+  size_t size() const
+  {
+    return total_size_;
+  }
+  size_t size_bytes() const
+  {
+    return total_size_ * sizeof(_Tp);
+  }
+  bool empty() const
+  {
+    return total_size_ == 0;
+  }
+  size_t num_shards() const
+  {
+    return shards_.size();
+  }
+
+  shard_type& shard(size_t idx)
+  {
+    _CCCL_ASSERT(idx < shards_.size(), "sharded_array: shard index out of range");
+    return shards_[idx];
+  }
+
+  const shard_type& shard(size_t idx) const
+  {
+    _CCCL_ASSERT(idx < shards_.size(), "sharded_array: shard index out of range");
+    return shards_[idx];
+  }
+
+  shard_type& operator[](size_t idx)
+  {
+    return shard(idx);
+  }
+  const shard_type& operator[](size_t idx) const
+  {
+    return shard(idx);
+  }
+
+  iterator begin()
+  {
+    return shards_.begin();
+  }
+  iterator end()
+  {
+    return shards_.end();
+  }
+  const_iterator begin() const
+  {
+    return shards_.begin();
+  }
+  const_iterator end() const
+  {
+    return shards_.end();
+  }
+  const_iterator cbegin() const
+  {
+    return shards_.cbegin();
+  }
+  const_iterator cend() const
+  {
+    return shards_.cend();
+  }
+
+  // ========== Slicing (non-owning views) ==========
+
+  static constexpr size_t npos = static_cast<size_t>(-1);
+
+  /**
+   * @brief Non-owning view of elements [start, end) across shards.
+   *
+   * Preserves shard count and place correspondence: when the slice does not
+   * overlap a shard, an empty shard (size 0) keeps the position, so the i-th
+   * shard of the view still corresponds to the i-th place of the source.
+   */
+  sharded_array slice(size_t start, size_t end = npos) const
+  {
+    if (end == npos)
+    {
+      end = total_size_;
+    }
+    end   = ::std::min(end, total_size_);
+    start = ::std::min(start, end);
+
+    ::std::vector<shard_type> new_shards(shards_.size());
+    size_t current_pos = 0;
+    size_t new_offset  = 0;
+
+    for (size_t i = 0; i < shards_.size(); i++)
+    {
+      const auto& src        = shards_[i];
+      const size_t shard_end = current_pos + src.size;
+
+      const size_t overlap_start = ::std::max(current_pos, start);
+      const size_t overlap_end   = ::std::min(shard_end, end);
+
+      shard_type& s   = new_shards[i];
+      s.place         = src.place;
+      s.exec          = src.exec;
+      s.stream        = src.stream;
+      s.global_offset = new_offset;
+
+      if (overlap_start < overlap_end)
+      {
+        const size_t local_start = overlap_start - current_pos;
+        const size_t count       = overlap_end - overlap_start;
+        s.data                   = src.data + local_start;
+        s.size                   = count;
+        s.capacity               = count;
+        new_offset += count;
+      }
+      else
+      {
+        s.data     = nullptr;
+        s.size     = 0;
+        s.capacity = 0;
+      }
+
+      current_pos = shard_end;
+    }
+
+    return sharded_array(mv(new_shards)); // non-owning
+  }
+
+  // ========== Ownership ==========
+
+  ownership get_ownership() const
+  {
+    return ownership_;
+  }
+  bool is_owning() const
+  {
+    return ownership_ != ownership::view;
+  }
+  bool is_view() const
+  {
+    return ownership_ == ownership::view;
+  }
+
+  /// @brief Release ownership: the caller becomes responsible for the memory.
+  ///
+  /// Only meaningful for `ownership::owning_shards` (per-shard allocations
+  /// the caller can free individually). A contiguous (VMM) backing cannot be
+  /// handed over through raw pointers — the mapping dies with the backing —
+  /// so releasing it is refused.
+  ///
+  /// @throws std::invalid_argument for `ownership::owning_backing`
+  void release()
+  {
+    if (ownership_ == ownership::owning_backing)
+    {
+      _CCCL_THROW(::std::invalid_argument,
+                  "sharded_array::release: a contiguous (VMM) backing cannot be released through "
+                  "raw pointers; keep the array alive instead");
+    }
+    ownership_ = ownership::view;
+  }
+
+  // ========== Capacity bookkeeping ==========
+
+  /// @brief Total capacity across all shards.
+  size_t total_capacity() const
+  {
+    size_t cap = 0;
+    for (const auto& s : shards_)
+    {
+      cap += s.capacity;
+    }
+    return cap;
+  }
+
+  /// @brief Reset every shard's size to its capacity (buffer reuse after
+  /// shrinking operations) and rebuild the offsets.
+  void reset_sizes_to_capacity()
+  {
+    for (auto& s : shards_)
+    {
+      s.size = s.capacity;
+    }
+    recalculate_offsets();
+  }
+
+  /// @brief Recompute global offsets from current shard sizes. Call after an
+  /// operation that legitimately updated shard sizes.
+  void recalculate_offsets()
+  {
+    size_t offset = 0;
+    for (auto& s : shards_)
+    {
+      s.global_offset = offset;
+      offset += s.size;
+    }
+    total_size_ = offset;
+  }
+
+  // ========== Validation ==========
+
+  /**
+   * @brief Check shard-metadata consistency: sequential offsets, size <=
+   * capacity, non-null data for non-empty shards, and total-size agreement.
+   *
+   * @param error_stream optional stream receiving a description of each
+   *                     violation
+   * @return true when consistent
+   */
+  bool validate(::std::ostream* error_stream = nullptr) const
+  {
+    size_t expected_offset = 0;
+    size_t sum_sizes       = 0;
+    bool valid             = true;
+
+    for (size_t i = 0; i < shards_.size(); i++)
+    {
+      const auto& s = shards_[i];
+
+      if (s.global_offset != expected_offset)
+      {
+        if (error_stream)
+        {
+          *error_stream
+            << "shard " << i << ": expected offset " << expected_offset << " but got " << s.global_offset << "\n";
+        }
+        valid = false;
+      }
+
+      if (s.size > s.capacity)
+      {
+        if (error_stream)
+        {
+          *error_stream << "shard " << i << ": size (" << s.size << ") > capacity (" << s.capacity << ")\n";
+        }
+        valid = false;
+      }
+
+      if (s.size > 0 && s.data == nullptr)
+      {
+        if (error_stream)
+        {
+          *error_stream << "shard " << i << ": null data pointer for non-empty shard\n";
+        }
+        valid = false;
+      }
+
+      expected_offset += s.size;
+      sum_sizes += s.size;
+    }
+
+    if (sum_sizes != total_size_)
+    {
+      if (error_stream)
+      {
+        *error_stream << "sum of shard sizes (" << sum_sizes << ") != total size (" << total_size_ << ")\n";
+      }
+      valid = false;
+    }
+
+    return valid;
+  }
+
+  /// @brief `validate()` that throws `std::runtime_error` with details on failure.
+  void validate_or_throw(const ::std::string& context = "") const
+  {
+    ::std::ostringstream errors;
+    if (!validate(&errors))
+    {
+      const ::std::string msg =
+        context.empty() ? "sharded_array validation failed:\n" : context + " - sharded_array validation failed:\n";
+      _CCCL_THROW(::std::runtime_error, msg + errors.str());
+    }
+  }
+
+  // ========== Modification ==========
+
+  /// @brief Drop all shards (freeing their memory when owning) and release
+  /// the contiguous backing, if any.
+  void clear()
+  {
+    if (ownership_ == ownership::owning_shards)
+    {
+      for (auto& s : shards_)
+      {
+        free_memory(s);
+      }
+    }
+    shards_.clear();
+    total_size_ = 0;
+    contiguous_backing_.reset(); // unmaps + releases the VMM range, if any
+  }
+
+private:
+  static ::std::vector<size_t> split_evenly(size_t total_size, size_t parts)
+  {
+    ::std::vector<size_t> sizes(parts, 0);
+    if (parts == 0)
+    {
+      return sizes;
+    }
+    const size_t base      = total_size / parts;
+    const size_t remainder = total_size % parts;
+    for (size_t i = 0; i < parts; i++)
+    {
+      sizes[i] = base + (i < remainder ? 1 : 0);
+    }
+    return sizes;
+  }
+
+  void compute_total_size()
+  {
+    total_size_ = 0;
+    for (const auto& s : shards_)
+    {
+      total_size_ += s.size;
+    }
+  }
+
+  static _Tp* allocate_memory(size_t count, const data_place& place, cudaStream_t stream = nullptr)
+  {
+    if (count == 0)
+    {
+      return nullptr;
+    }
+    return static_cast<_Tp*>(place.allocate(static_cast<::std::ptrdiff_t>(count * sizeof(_Tp)), stream));
+  }
+
+  static void free_memory(shard_type& s)
+  {
+    if (!s.data)
+    {
+      return;
+    }
+    s.place.deallocate(s.data, s.capacity * sizeof(_Tp), s.stream);
+    s.data = nullptr;
+  }
+
+  ::std::vector<shard_type> shards_;
+  size_t total_size_   = 0;
+  ownership ownership_ = ownership::view;
+  // Set only by allocate_contiguous: the VMM backing (one VA range, physical
+  // blocks owned per shard's place). Shards are then non-owning views.
+  ::std::shared_ptr<places::localized_array> contiguous_backing_;
+};
+
+// ============================================================================
+// Compatibility checks
+// ============================================================================
+
+/**
+ * @brief Validate that two sharded arrays have matching structure: same shard
+ * count, same per-shard sizes, same per-shard data places.
+ *
+ * @throws std::invalid_argument on mismatch
+ */
+template <typename _Tp, typename _Up>
+void check_compatible(const sharded_array<_Tp>& a, const sharded_array<_Up>& b, const char* context = "operation")
+{
+  if (a.num_shards() != b.num_shards())
+  {
+    _CCCL_THROW(::std::invalid_argument,
+                ::std::string(context) + ": shard count mismatch (" + ::std::to_string(a.num_shards()) + " vs "
+                  + ::std::to_string(b.num_shards()) + ")");
+  }
+
+  for (size_t g = 0; g < a.num_shards(); g++)
+  {
+    if (a.shard(g).size != b.shard(g).size)
+    {
+      _CCCL_THROW(::std::invalid_argument,
+                  ::std::string(context) + ": shard " + ::std::to_string(g) + " size mismatch ("
+                    + ::std::to_string(a.shard(g).size) + " vs " + ::std::to_string(b.shard(g).size) + ")");
+    }
+
+    if (a.shard(g).place != b.shard(g).place)
+    {
+      _CCCL_THROW(::std::invalid_argument,
+                  ::std::string(context) + ": shard " + ::std::to_string(g) + " data_place mismatch");
+    }
+  }
+}
+
+/// @brief Validate that an array has one shard per place of a group.
+/// @throws std::invalid_argument on mismatch
+template <typename _Tp>
+void check_places(const sharded_array<_Tp>& arr, const place_group& group, const char* context = "operation")
+{
+  if (arr.num_shards() != group.size())
+  {
+    _CCCL_THROW(::std::invalid_argument,
+                ::std::string(context) + ": shard count (" + ::std::to_string(arr.num_shards())
+                  + ") doesn't match the number of places (" + ::std::to_string(group.size()) + ")");
+  }
+}
+
+// ============================================================================
+// copy_between: copy/redistribute between arbitrary shard layouts
+// ============================================================================
+
+/**
+ * @brief Copy `src` to `dst`, handling arbitrary shard layouts (different
+ * sizes, counts and placements). Peer access between the devices involved
+ * must be available. SYNCHRONOUS.
+ */
+template <typename _Tp>
+void copy_between(const sharded_array<_Tp>& src, sharded_array<_Tp>& dst)
+{
+  if (src.size() == 0 || dst.size() == 0)
+  {
+    return;
+  }
+
+  for (auto& dst_shard : dst)
+  {
+    const size_t dst_start = dst_shard.global_offset;
+    const size_t dst_end   = dst_start + dst_shard.size;
+
+    exec_place_scope scope(dst_shard.exec);
+
+    for (const auto& src_shard : src)
+    {
+      const size_t src_start = src_shard.global_offset;
+      const size_t src_end   = src_start + src_shard.size;
+
+      const size_t overlap_start = ::std::max(dst_start, src_start);
+      const size_t overlap_end   = ::std::min(dst_end, src_end);
+
+      if (overlap_start >= overlap_end)
+      {
+        continue;
+      }
+
+      const size_t copy_count = overlap_end - overlap_start;
+      const _Tp* src_ptr      = src_shard.data + (overlap_start - src_shard.global_offset);
+      _Tp* dst_ptr            = dst_shard.data + (overlap_start - dst_shard.global_offset);
+
+      cuda_safe_call(cudaMemcpy(dst_ptr, src_ptr, copy_count * sizeof(_Tp), cudaMemcpyDefault));
+    }
+  }
+}
+} // namespace cuda::experimental::sharded

--- a/cudax/include/cuda/experimental/__sharded/sharded_array.cuh
+++ b/cudax/include/cuda/experimental/__sharded/sharded_array.cuh
@@ -41,6 +41,7 @@
 #include <cuda/experimental/__places/localized_array.cuh>
 #include <cuda/experimental/__places/place_group.cuh>
 #include <cuda/experimental/__places/places.cuh>
+#include <cuda/experimental/__sharded/fork_join.cuh>
 #include <cuda/experimental/__sharded/shard.cuh>
 
 #include <algorithm>
@@ -599,6 +600,112 @@ public:
 
   // ========== Stream ordering: composing with a caller stream ==========
 
+  /**
+   * @brief Declare that the shards' subsequent work depends on the work
+   *        currently enqueued on @p stream (fork a caller stream out to the
+   *        per-shard streams).
+   *
+   * ORDERING DECLARATION, NOT A SYNCHRONIZATION: one event is recorded on
+   * @p stream and every shard stream waits on it. The host returns
+   * immediately; nothing is synchronized and no work is awaited. Use it to
+   * hand results produced on a caller stream to per-shard consumers without
+   * a host round-trip:
+   *
+   * @code
+   * producer<<<..., s>>>(...);   // writes the array's memory on stream s
+   * data.fork_from(s);           // shard streams now depend on the producer
+   * transform(group, data, op);  // per-shard work sees the produced values
+   * @endcode
+   *
+   * Capture-safe: inside an active CUDA graph capture the event record/wait
+   * pair becomes graph dependencies, making `fork_from`/`join_into` the
+   * composition idiom between a captured caller stream and the shard streams.
+   *
+   * Events are drawn from a small pool owned by the container (lazily
+   * created, reused across calls; see `reserved::fork_join_event_pool` for the
+   * ownership rationale), so adopted arrays with foreign streams are fully
+   * supported. Shards without a reference stream are skipped: their
+   * operations are synchronous and need no ordering. Concurrent
+   * `fork_from`/`join_into` calls on the same container reuse the pooled
+   * events and must be ordered externally.
+   */
+  void fork_from(cudaStream_t stream) const
+  {
+    cudaEvent_t event = nullptr; // recorded once, on the first distinct shard stream
+    for (const auto& s : shards_)
+    {
+      if (!s.stream || s.stream == stream)
+      {
+        continue;
+      }
+      if (!event)
+      {
+        int device                             = -1;
+        cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+        if (stream)
+        {
+          cuda_safe_call(cudaStreamIsCapturing(stream, &capture_status));
+        }
+        if (stream && capture_status == cudaStreamCaptureStatusNone)
+        {
+          // stream_ref::device() is version-portable (cudaStreamGetDevice
+          // itself requires CUDA 12.8+); green-context streams report their
+          // underlying device, which is exactly the event-pool key we want.
+          device = ::cuda::stream_ref{stream}.device().get();
+        }
+        else
+        {
+          // Under capture, querying a stream's device is not permitted on
+          // every driver (CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED); the event
+          // recorded on a capturing stream only becomes a graph dependency
+          // node, so the current device is the right home for it.
+          cuda_safe_call(cudaGetDevice(&device));
+        }
+        event = fork_join_events_.fork_event(device);
+        cuda_safe_call(cudaEventRecord(event, stream));
+      }
+      cuda_safe_call(cudaStreamWaitEvent(s.stream, event, 0));
+    }
+  }
+
+  /**
+   * @brief Declare that subsequent work on @p stream depends on the work
+   *        currently enqueued on every shard stream (join the per-shard
+   *        streams back into a caller stream).
+   *
+   * ORDERING DECLARATION, NOT A SYNCHRONIZATION: an event is recorded on each
+   * shard stream and @p stream waits on all of them. The host returns
+   * immediately; nothing is synchronized. The mirror image of `fork_from`:
+   *
+   * @code
+   * transform(group, data, op);  // per-shard producers on the shard streams
+   * data.join_into(s);           // stream s now depends on all of them
+   * reader<<<..., s>>>(...);     // sees every shard's results
+   * @endcode
+   *
+   * Capture-safe and pool-backed exactly like `fork_from` (see there for the
+   * event-ownership and concurrency notes).
+   */
+  void join_into(cudaStream_t stream) const
+  {
+    for (size_t i = 0; i < shards_.size(); i++)
+    {
+      const auto& s = shards_[i];
+      if (!s.stream || s.stream == stream)
+      {
+        continue;
+      }
+      cudaEvent_t event = nullptr;
+      {
+        // Create/record in the shard's context so the event matches its stream.
+        exec_place_scope scope(s.exec);
+        event = fork_join_events_.join_event(i);
+        cuda_safe_call(cudaEventRecord(event, s.stream));
+      }
+      cuda_safe_call(cudaStreamWaitEvent(stream, event, 0));
+    }
+  }
+
   // ========== Move-only semantics ==========
 
   sharded_array(sharded_array&& other) noexcept
@@ -606,6 +713,7 @@ public:
       , total_size_(other.total_size_)
       , ownership_(other.ownership_)
       , contiguous_backing_(mv(other.contiguous_backing_))
+      , fork_join_events_(mv(other.fork_join_events_))
   {
     each_shard.parent_ = this;
     other.total_size_  = 0;
@@ -621,6 +729,7 @@ public:
       total_size_         = other.total_size_;
       ownership_          = other.ownership_;
       contiguous_backing_ = mv(other.contiguous_backing_);
+      fork_join_events_   = mv(other.fork_join_events_);
       other.total_size_   = 0;
       other.ownership_    = ownership::view;
       // each_shard.parent_ already points to this
@@ -977,6 +1086,9 @@ private:
   // Set only by allocate_contiguous: the VMM backing (one VA range, physical
   // blocks owned per shard's place). Shards are then non-owning views.
   ::std::shared_ptr<places::localized_array> contiguous_backing_;
+  // Pooled events for fork_from/join_into (lazily created; mutable because
+  // the ordering declarations are const — they do not modify elements).
+  mutable reserved::fork_join_event_pool fork_join_events_;
 };
 
 // ============================================================================

--- a/cudax/include/cuda/experimental/__sharded/transform.cuh
+++ b/cudax/include/cuda/experimental/__sharded/transform.cuh
@@ -1,0 +1,148 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief Elementwise transforms over sharded arrays (in-place, unary,
+ *        binary). No cross-place stage: each shard transforms locally.
+ */
+
+#pragma once
+
+#include <cuda/__cccl_config>
+#include <cuda/stream>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <thrust/execution_policy.h>
+#include <thrust/transform.h>
+
+#include <cuda/experimental/__places/place_group.cuh>
+#include <cuda/experimental/__sharded/sharded_array.cuh>
+
+#include <cuda_runtime.h>
+
+namespace cuda::experimental::sharded
+{
+/// @brief In-place unary transform: data[i] = op(data[i]).
+template <typename _Tp, typename _UnaryOp>
+_CCCL_HOST_API void transform(place_group&, sharded_array<_Tp>& data, _UnaryOp op, bool blocking = true)
+{
+  if (data.empty())
+  {
+    return;
+  }
+
+  data.each_shard->*[op](auto& s) {
+    thrust::transform(thrust::cuda::par_nosync.on(s.stream), s.data, s.data + s.size, s.data, op);
+    cuda_safe_call(cudaGetLastError());
+  };
+
+  if (blocking)
+  {
+    data.sync();
+  }
+}
+
+/**
+ * @brief Out-of-place unary transform: output[i] = op(input[i]).
+ *
+ * Input and output must be compatible (same shard sizes and places); each
+ * output stream waits on the corresponding input stream.
+ *
+ * @throws std::invalid_argument when the layouts are not compatible
+ */
+template <typename _Tp, typename _Up, typename _UnaryOp>
+_CCCL_HOST_API void
+transform(place_group&, const sharded_array<_Tp>& input, sharded_array<_Up>& output, _UnaryOp op, bool blocking = true)
+{
+  check_compatible(input, output, "transform (unary out-of-place)");
+
+  if (input.empty())
+  {
+    return;
+  }
+
+  // Make each output stream wait for the corresponding input stream
+  for (size_t g = 0; g < input.num_shards(); g++)
+  {
+    ::cuda::stream_ref{output.shard(g).stream}.wait(::cuda::stream_ref{input.shard(g).stream});
+  }
+
+  output.each_shard->*[&input, op](const size_t g, auto& out_shard) {
+    const auto& in_shard = input.shard(g);
+    thrust::transform(
+      thrust::cuda::par_nosync.on(out_shard.stream), in_shard.data, in_shard.data + in_shard.size, out_shard.data, op);
+    cuda_safe_call(cudaGetLastError());
+  };
+
+  if (blocking)
+  {
+    output.sync();
+  }
+}
+
+/**
+ * @brief Binary transform: output[i] = op(input1[i], input2[i]).
+ *
+ * All three arrays must be compatible (same shard sizes and places).
+ *
+ * @throws std::invalid_argument when the layouts are not compatible
+ */
+template <typename _Tp, typename _Up, typename _BinaryOp>
+_CCCL_HOST_API void transform(
+  place_group&,
+  const sharded_array<_Tp>& input1,
+  const sharded_array<_Tp>& input2,
+  sharded_array<_Up>& output,
+  _BinaryOp op,
+  bool blocking = true)
+{
+  check_compatible(input1, input2, "transform (binary): input1 vs input2");
+  check_compatible(input1, output, "transform (binary): inputs vs output");
+
+  if (input1.empty())
+  {
+    return;
+  }
+
+  // Make each output stream wait for both input streams
+  for (size_t g = 0; g < input1.num_shards(); g++)
+  {
+    const auto& out_shard = output.shard(g);
+    ::cuda::stream_ref{out_shard.stream}.wait(::cuda::stream_ref{input1.shard(g).stream});
+    ::cuda::stream_ref{out_shard.stream}.wait(::cuda::stream_ref{input2.shard(g).stream});
+  }
+
+  output.each_shard->*[&input1, &input2, op](const size_t g, auto& out_shard) {
+    const auto& in1_shard = input1.shard(g);
+    const auto& in2_shard = input2.shard(g);
+    thrust::transform(
+      thrust::cuda::par_nosync.on(out_shard.stream),
+      in1_shard.data,
+      in1_shard.data + in1_shard.size,
+      in2_shard.data,
+      out_shard.data,
+      op);
+    cuda_safe_call(cudaGetLastError());
+  };
+
+  if (blocking)
+  {
+    output.sync();
+  }
+}
+} // namespace cuda::experimental::sharded

--- a/cudax/include/cuda/experimental/__sharded/unique.cuh
+++ b/cudax/include/cuda/experimental/__sharded/unique.cuh
@@ -59,6 +59,9 @@ template <typename _Tp>
     return 0;
   }
 
+  // Size write-back requires host synchronization: cannot be captured
+  reserved::check_not_capturing(data, "sharded::unique");
+
   const size_t num_shards = data.num_shards();
   using count_type        = ::cuda::std::int64_t;
 

--- a/cudax/include/cuda/experimental/__sharded/unique.cuh
+++ b/cudax/include/cuda/experimental/__sharded/unique.cuh
@@ -1,0 +1,189 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief In-place deduplication of consecutive equal elements over sharded
+ *        arrays (`std::unique` semantics): each place runs the device-scope
+ *        primitive (CUB `DeviceSelect::Unique`, in place) on its shard, then a
+ *        boundary pass trims duplicates that straddle shard boundaries — when
+ *        a shard's last element equals the next non-empty shard's first, the
+ *        earlier shard drops it (an O(1) size decrement, no data movement).
+ *
+ * `unique` MUTATES shard sizes and therefore refuses contiguous
+ * (`allocate_contiguous`) arrays with `std::invalid_argument` — see the
+ * rationale in `copy_if.cuh`.
+ */
+
+#pragma once
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/device/device_select.cuh>
+
+#include <cuda/std/cstdint>
+
+#include <cuda/experimental/__places/place_group.cuh>
+#include <cuda/experimental/__sharded/sharded_array.cuh>
+
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+namespace cuda::experimental::sharded
+{
+namespace reserved
+{
+template <typename _Tp>
+[[nodiscard]] _CCCL_HOST_API size_t unique_impl(place_group& group, sharded_array<_Tp>& data)
+{
+  if (data.empty())
+  {
+    return 0;
+  }
+
+  const size_t num_shards = data.num_shards();
+  using count_type        = ::cuda::std::int64_t;
+
+  // Pinned host staging: per-shard kept counts (zero-initialized so skipped
+  // empty shards stay empty) and the post-unique boundary elements
+  places::place_memory_resource host_mr(data_place::host());
+  // The _Tp block leads so both blocks are aligned for their types (the
+  // count block only needs alignof(count_type) <= alignof(_Tp) or the
+  // natural alignment of the offset, both guaranteed by the max() below).
+  constexpr size_t staging_align = ::std::max(alignof(_Tp), alignof(count_type));
+  const size_t tp_bytes          = 2 * num_shards * sizeof(_Tp);
+  const size_t count_offset      = (tp_bytes + alignof(count_type) - 1) / alignof(count_type) * alignof(count_type);
+  const size_t host_bytes        = count_offset + num_shards * sizeof(count_type);
+  auto* h_base                   = static_cast<unsigned char*>(host_mr.allocate_sync(host_bytes, staging_align));
+  _Tp* h_first                   = reinterpret_cast<_Tp*>(h_base);
+  _Tp* h_last                    = h_first + num_shards;
+  count_type* h_new_sizes        = reinterpret_cast<count_type*>(h_base + count_offset);
+  ::std::fill(h_new_sizes, h_new_sizes + num_shards, count_type{0});
+
+  // Phase 1: local in-place unique on each shard (CUB keeps the first element
+  // of every run of consecutive equal elements); the per-shard counters are
+  // freed only after the final sync
+  ::std::vector<::std::pair<places::place_memory_resource, count_type*>> d_counts;
+  d_counts.reserve(num_shards);
+
+  data.each_shard->*[&](const size_t g, auto& s) {
+    places::place_memory_resource mr(s.place);
+    count_type* d_num =
+      static_cast<count_type*>(mr.allocate(::cuda::stream_ref{s.stream}, sizeof(count_type), alignof(count_type)));
+    d_counts.emplace_back(mr, d_num);
+
+    // Temporaries come from the shard's place through the group's resources
+    const auto env = group.env(s.place, s.stream);
+    cuda_safe_call(cub::DeviceSelect::Unique(s.data, d_num, static_cast<::cuda::std::int64_t>(s.size), env));
+
+    cuda_safe_call(cudaMemcpyAsync(&h_new_sizes[g], d_num, sizeof(count_type), cudaMemcpyDeviceToHost, s.stream));
+  };
+
+  data.sync();
+
+  for (size_t g = 0; g < num_shards; g++)
+  {
+    _CCCL_ASSERT(h_new_sizes[g] >= 0 && static_cast<size_t>(h_new_sizes[g]) <= data.shard(g).size,
+                 "sharded::unique: select returned an out-of-range count");
+  }
+
+  // Phase 2: fetch the boundary elements of each locally deduplicated shard
+  data.each_shard->*[&](const size_t g, auto& s) {
+    const count_type n = h_new_sizes[g];
+    if (n == 0)
+    {
+      return;
+    }
+    cuda_safe_call(cudaMemcpyAsync(&h_first[g], s.data, sizeof(_Tp), cudaMemcpyDeviceToHost, s.stream));
+    cuda_safe_call(cudaMemcpyAsync(&h_last[g], s.data + n - 1, sizeof(_Tp), cudaMemcpyDeviceToHost, s.stream));
+  };
+
+  data.sync();
+
+  // Phase 3: trim duplicates straddling shard boundaries. Whenever a shard's
+  // last element equals the FIRST element of the next non-empty shard, the
+  // earlier shard drops its last element (within a shard elements are already
+  // consecutive-unique, so at most one element per boundary can match, and
+  // the shard's new last element cannot re-match).
+  size_t prev = num_shards; // index of the previous non-empty shard, if any
+  for (size_t g = 0; g < num_shards; g++)
+  {
+    if (h_new_sizes[g] == 0)
+    {
+      continue;
+    }
+    if (prev != num_shards && h_last[prev] == h_first[g])
+    {
+      h_new_sizes[prev]--;
+    }
+    prev = g;
+  }
+
+  // Fold the new sizes into the container's bookkeeping
+  for (size_t g = 0; g < num_shards; g++)
+  {
+    data.shard(g).size = static_cast<size_t>(h_new_sizes[g]);
+  }
+  data.recalculate_offsets();
+
+  for (auto& [mr, ptr] : d_counts)
+  {
+    mr.deallocate_sync(ptr, sizeof(count_type), alignof(count_type));
+  }
+  host_mr.deallocate_sync(h_base, host_bytes, staging_align);
+
+  return data.size();
+}
+} // namespace reserved
+
+/**
+ * @brief Remove consecutive duplicate elements, in place (`std::unique`
+ *        semantics over the logical array, across shard boundaries).
+ *
+ * Each shard is deduplicated locally (CUB `DeviceSelect::Unique`), then
+ * boundary duplicates between consecutive non-empty shards are trimmed with
+ * an O(1) size decrement per boundary. Shard sizes and global offsets are
+ * updated; capacities are unchanged (`reset_sizes_to_capacity()` reuses the
+ * buffers). SYNCHRONOUS: returns the total number of kept elements.
+ *
+ * @param group the place group providing per-place memory resources
+ * @param data  the sharded array to deduplicate in place
+ *
+ * @throws std::invalid_argument on contiguous (`allocate_contiguous`) arrays:
+ *         shrinking shard sizes would leave gaps between shards' valid
+ *         elements, falsifying the read-as-one-array contract of
+ *         `contiguous_data()`, and compacting across the gaps would migrate
+ *         elements across the requested placement.
+ */
+template <typename _Tp>
+[[nodiscard]] _CCCL_HOST_API size_t unique(place_group& group, sharded_array<_Tp>& data)
+{
+  if (data.is_contiguous())
+  {
+    _CCCL_THROW(::std::invalid_argument,
+                "sharded::unique: not supported on contiguous (allocate_contiguous) arrays -- shrinking shard sizes "
+                "would leave gaps between shards' valid elements, falsifying the read-as-one-array contract of "
+                "contiguous_data(), and compacting across the gaps would migrate elements across the placement the "
+                "caller asked for. Use a non-contiguous sharded_array, or copy into one first.");
+  }
+  return reserved::unique_impl(group, data);
+}
+} // namespace cuda::experimental::sharded

--- a/cudax/include/cuda/experimental/sharded.cuh
+++ b/cudax/include/cuda/experimental/sharded.cuh
@@ -27,5 +27,14 @@
 #pragma once
 
 #include <cuda/experimental/__places/place_group.cuh>
+#include <cuda/experimental/__sharded/adjacent_difference.cuh>
+#include <cuda/experimental/__sharded/copy_if.cuh>
+#include <cuda/experimental/__sharded/count.cuh>
+#include <cuda/experimental/__sharded/fill.cuh>
+#include <cuda/experimental/__sharded/histogram.cuh>
+#include <cuda/experimental/__sharded/reduce.cuh>
+#include <cuda/experimental/__sharded/scan.cuh>
 #include <cuda/experimental/__sharded/shard.cuh>
 #include <cuda/experimental/__sharded/sharded_array.cuh>
+#include <cuda/experimental/__sharded/transform.cuh>
+#include <cuda/experimental/__sharded/unique.cuh>

--- a/cudax/include/cuda/experimental/sharded.cuh
+++ b/cudax/include/cuda/experimental/sharded.cuh
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/** @file
+ *
+ * @brief Main include file for the sharded containers and algorithms.
+ *
+ * Sharded arrays partition one logical array across places (devices or
+ * sub-device locality domains) inside a single process — the rung of the
+ * cooperation-scope ladder where a common address space is still shared while
+ * each byte has exactly one physical home. Algorithms follow the ladder's
+ * recipe: run the device-scope primitive per place, combine through what the
+ * rung shares.
+ *
+ * Built on the standalone places layer (`cuda/experimental/places.cuh`), in
+ * particular `place_group` (execution resources) and `localized_array` (the
+ * VMM backing of `sharded_array<T>::allocate_contiguous`).
+ */
+
+#pragma once
+
+#include <cuda/experimental/__places/place_group.cuh>
+#include <cuda/experimental/__sharded/shard.cuh>
+#include <cuda/experimental/__sharded/sharded_array.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -269,6 +269,8 @@ endif()
 if (cudax_ENABLE_PLACES AND NOT "MSVC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
   # Places tests are handled separately:
   add_subdirectory(places)
+  # Sharded containers/algorithms build on the places layer:
+  add_subdirectory(sharded)
 endif()
 
 # FIXME: Enable MSVC

--- a/cudax/test/sharded/CMakeLists.txt
+++ b/cudax/test/sharded/CMakeLists.txt
@@ -3,6 +3,7 @@ set(
   include_only.cu
   containers/sharded_array.cu
   containers/contiguous.cu
+  containers/fork_join.cu
   algorithms/elementwise.cu
   algorithms/reduce_scan.cu
   algorithms/count_histogram.cu

--- a/cudax/test/sharded/CMakeLists.txt
+++ b/cudax/test/sharded/CMakeLists.txt
@@ -3,6 +3,10 @@ set(
   include_only.cu
   containers/sharded_array.cu
   containers/contiguous.cu
+  algorithms/elementwise.cu
+  algorithms/reduce_scan.cu
+  algorithms/count_histogram.cu
+  algorithms/compaction.cu
 )
 
 cccl_get_cudatoolkit()

--- a/cudax/test/sharded/CMakeLists.txt
+++ b/cudax/test/sharded/CMakeLists.txt
@@ -8,6 +8,11 @@ set(
   algorithms/reduce_scan.cu
   algorithms/count_histogram.cu
   algorithms/compaction.cu
+  graph_capture/elementwise_pipeline.cu
+  graph_capture/reduce_scan_capture.cu
+  graph_capture/must_not_capture.cu
+  graph_capture/graph_owned_memory.cu
+  graph_capture/contiguous_capture.cu
 )
 
 cccl_get_cudatoolkit()

--- a/cudax/test/sharded/CMakeLists.txt
+++ b/cudax/test/sharded/CMakeLists.txt
@@ -1,0 +1,37 @@
+set(
+  sharded_test_sources
+  include_only.cu
+  containers/sharded_array.cu
+  containers/contiguous.cu
+)
+
+cccl_get_cudatoolkit()
+
+## cudax_add_sharded_test
+#
+# Add a sharded test executable and register it with ctest.
+#
+# target_name_var: Variable name to overwrite with the name of the test
+#   target. Useful for adding target information after creation.
+# source: The source file for the test.
+#
+function(cudax_add_sharded_test target_name_var source)
+  get_filename_component(dir ${source} DIRECTORY)
+  get_filename_component(filename ${source} NAME_WE)
+  if (dir)
+    set(filename "${dir}/${filename}")
+  endif()
+  string(REPLACE "/" "." test_name "${filename}")
+
+  set(test_target cudax.test.sharded.${test_name})
+
+  cccl_add_executable(${test_target} SOURCES ${source} ADD_CTEST)
+  cudax_places_configure_target(${test_target})
+  target_link_libraries(${test_target} PRIVATE cudax.compiler_interface)
+
+  set(${target_name_var} ${test_target} PARENT_SCOPE)
+endfunction()
+
+foreach (source IN LISTS sharded_test_sources)
+  cudax_add_sharded_test(test_target "${source}")
+endforeach()

--- a/cudax/test/sharded/algorithms/compaction.cu
+++ b/cudax/test/sharded/algorithms/compaction.cu
@@ -1,0 +1,259 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief Correctness of the size-mutating sharded algorithms `copy_if` /
+ *        `remove_if` / `filter` and `unique` against host references, over
+ *        multiple places: per-shard compaction, shard-size and offset
+ *        bookkeeping (including shards whose result is empty), the
+ *        cross-shard boundary trim of `unique`, and the contract that
+ *        size-mutating algorithms REFUSE contiguous (VMM-backed) arrays with
+ *        `std::invalid_argument`.
+ */
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <algorithm>
+#include <cstdio>
+#include <stdexcept>
+#include <vector>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::cuda_try;
+using cuda::experimental::places::place_group;
+
+namespace
+{
+struct is_even
+{
+  __host__ __device__ bool operator()(long long x) const
+  {
+    return x % 2 == 0;
+  }
+};
+
+struct less_than
+{
+  long long bound;
+
+  __host__ __device__ bool operator()(long long x) const
+  {
+    return x < bound;
+  }
+};
+
+void test_copy_if(place_group& group)
+{
+  const size_t n = 500009;
+  auto data      = sharded_array<long long>::allocate(group, n);
+  iota(group, data, 0LL); // 0 .. n-1
+
+  const size_t kept = copy_if(group, data, is_even{});
+  EXPECT(kept == (n + 1) / 2);
+  EXPECT(data.size() == kept);
+  EXPECT(data.validate());
+
+  // Per-shard compaction is stable and shards stay ordered, so the logical
+  // array equals the host copy_if of the original input
+  ::std::vector<long long> host(kept);
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < kept; i++)
+  {
+    EXPECT(host[i] == 2 * static_cast<long long>(i));
+  }
+
+  // Capacities are unchanged: the buffers can be reused at full size
+  EXPECT(data.total_capacity() == n);
+  data.reset_sizes_to_capacity();
+  EXPECT(data.size() == n);
+
+  // Empty array
+  sharded_array<long long> empty;
+  EXPECT(copy_if(group, empty, is_even{}) == 0UL);
+}
+
+void test_copy_if_empty_result_shards(place_group& group)
+{
+  const size_t n = 300000;
+  auto data      = sharded_array<long long>::allocate(group, n);
+  iota(group, data, 0LL); // values == global indices
+
+  // Keep only values inside the first half of shard 0: every other shard
+  // compacts to an EMPTY result
+  const long long bound = static_cast<long long>(data.shard(0).size / 2);
+  const size_t kept     = copy_if(group, data, less_than{bound});
+  EXPECT(kept == static_cast<size_t>(bound));
+  EXPECT(data.size() == kept);
+  EXPECT(data.validate());
+  for (size_t g = 1; g < data.num_shards(); g++)
+  {
+    EXPECT(data.shard(g).size == 0UL);
+  }
+
+  ::std::vector<long long> host(kept);
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < kept; i++)
+  {
+    EXPECT(host[i] == static_cast<long long>(i));
+  }
+
+  // Keep nothing: every shard compacts to empty
+  data.reset_sizes_to_capacity();
+  iota(group, data, 0LL);
+  EXPECT(copy_if(group, data, less_than{0}) == 0UL);
+  EXPECT(data.size() == 0UL);
+  EXPECT(data.validate());
+}
+
+void test_remove_if_and_filter(place_group& group)
+{
+  const size_t n = 100003;
+  auto data      = sharded_array<long long>::allocate(group, n);
+  iota(group, data, 0LL);
+
+  // remove_if is the inverse of copy_if: drop the evens, keep the odds
+  const size_t kept = remove_if(group, data, is_even{});
+  EXPECT(kept == n / 2);
+  ::std::vector<long long> host(kept);
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < kept; i++)
+  {
+    EXPECT(host[i] == 2 * static_cast<long long>(i) + 1);
+  }
+
+  // filter is an alias for copy_if
+  auto other = sharded_array<long long>::allocate(group, n);
+  iota(group, other, 0LL);
+  EXPECT(filter(group, other, is_even{}) == (n + 1) / 2);
+}
+
+void test_unique_cross_shard_boundary(place_group& group)
+{
+  // Runs of 7 equal values; 7 does not divide the shard sizes, so runs
+  // straddle shard boundaries and local per-shard unique alone would keep a
+  // duplicate at each straddled boundary — the boundary trim must drop it
+  const size_t n = 240007;
+  auto data      = sharded_array<long long>::allocate(group, n);
+  ::std::vector<long long> host(n);
+  for (size_t i = 0; i < n; i++)
+  {
+    host[i] = static_cast<long long>(i / 7);
+  }
+  data.copy_from_host(host.data());
+
+  // Host reference: std::unique over the logical array
+  ::std::vector<long long> ref(host);
+  ref.erase(::std::unique(ref.begin(), ref.end()), ref.end());
+
+  const size_t u = unique(group, data);
+  EXPECT(u == ref.size());
+  EXPECT(data.size() == u);
+  EXPECT(data.validate());
+
+  ::std::vector<long long> result(u);
+  data.copy_to_host(result.data());
+  for (size_t i = 0; i < u; i++)
+  {
+    EXPECT(result[i] == ref[i]);
+  }
+
+  // Degenerate boundary case: ONE value everywhere. Every shard collapses to
+  // a single element locally, then the boundary trim must chain across every
+  // shard boundary, leaving exactly one element in the whole array.
+  auto same = sharded_array<long long>::allocate(group, 100000);
+  fill(group, same, 42LL);
+  EXPECT(unique(group, same) == 1UL);
+  EXPECT(same.size() == 1UL);
+  long long only = 0;
+  same.copy_to_host(&only);
+  EXPECT(only == 42LL);
+
+  // Empty array
+  sharded_array<long long> empty;
+  EXPECT(unique(group, empty) == 0UL);
+}
+
+void test_size_mutators_refuse_contiguous(place_group& group)
+{
+  // THE CONTRACT: a contiguous array is one VA range read as one array
+  // through contiguous_data(); shrinking shard sizes would leave gaps between
+  // shards' valid elements, and compacting across the gaps would migrate
+  // elements across the requested placement — so the size-mutating
+  // algorithms must refuse with std::invalid_argument, leaving the array
+  // untouched.
+  const size_t n = (1 << 20) + 99;
+  auto data      = sharded_array<long long>::allocate_contiguous(group, n);
+  iota(group, data, 0LL);
+
+  bool threw = false;
+  try
+  {
+    (void) copy_if(group, data, is_even{});
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+
+  threw = false;
+  try
+  {
+    (void) unique(group, data);
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+
+  threw = false;
+  try
+  {
+    (void) remove_if(group, data, is_even{});
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+
+  // The refused calls left the array untouched
+  EXPECT(data.size() == n);
+  EXPECT(data.validate());
+  EXPECT(count(group, data, 1LL) == 1UL); // data intact, read-only path still fine
+}
+} // namespace
+
+int main()
+{
+  cuda_try(cuInit(0));
+  cuda_safe_call(cudaSetDevice(0));
+
+  auto group = place_group::by_locality_domains();
+
+  test_copy_if(group);
+  test_copy_if_empty_result_shards(group);
+  test_remove_if_and_filter(group);
+  test_unique_cross_shard_boundary(group);
+
+  if (contiguous_backing_supported())
+  {
+    test_size_mutators_refuse_contiguous(group);
+  }
+  else
+  {
+    printf("VMM not supported on this device, skipping contiguous-array tests.\n");
+  }
+
+  return 0;
+}

--- a/cudax/test/sharded/algorithms/count_histogram.cu
+++ b/cudax/test/sharded/algorithms/count_histogram.cu
@@ -1,0 +1,165 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief Correctness of the read-only sharded algorithms `count` / `count_if`
+ *        and `histogram_even` against host references, over multiple places —
+ *        including on contiguous (VMM-backed) arrays, where read-only
+ *        algorithms remain available (only size-mutating ones refuse).
+ */
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <cstdio>
+#include <stdexcept>
+#include <vector>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::cuda_try;
+using cuda::experimental::places::place_group;
+
+namespace
+{
+struct is_multiple_of_3
+{
+  __host__ __device__ bool operator()(long long x) const
+  {
+    return x % 3 == 0;
+  }
+};
+
+void test_count(place_group& group)
+{
+  const size_t n = 1000003;
+  auto data      = sharded_array<long long>::allocate(group, n);
+  iota(group, data, 0LL); // 0 .. n-1
+
+  // Multiples of 3 in [0, n): ceil(n / 3)
+  EXPECT(count_if(group, data, is_multiple_of_3{}) == (n + 2) / 3);
+
+  // count == count_if with equality
+  EXPECT(count(group, data, 42LL) == 1UL);
+  EXPECT(count(group, data, static_cast<long long>(n)) == 0UL); // absent value
+  EXPECT(count(group, data, -1LL) == 0UL);
+
+  fill(group, data, 7LL);
+  EXPECT(count(group, data, 7LL) == n);
+  EXPECT(count(group, data, 8LL) == 0UL);
+
+  // Empty array
+  sharded_array<long long> empty;
+  EXPECT(count_if(group, empty, is_multiple_of_3{}) == 0UL);
+  EXPECT(count(group, empty, 0LL) == 0UL);
+}
+
+void test_count_on_contiguous(place_group& group)
+{
+  // Read-only algorithms stay available on contiguous arrays
+  const size_t n = (1 << 20) + 37;
+  auto data      = sharded_array<long long>::allocate_contiguous(group, n);
+  iota(group, data, 1LL); // 1 .. n
+
+  EXPECT(count(group, data, 5LL) == 1UL);
+  // Multiples of 3 in [1, n]: floor(n / 3)
+  EXPECT(count_if(group, data, is_multiple_of_3{}) == n / 3);
+}
+
+void test_histogram(place_group& group)
+{
+  const size_t n = 262147;
+  auto data      = sharded_array<long long>::allocate(group, n);
+  iota(group, data, 0LL); // 0 .. n-1
+
+  const int num_bins          = 8;
+  const long long lower_level = 0;
+  const long long upper_level = 262144; // bin width 32768; 3 samples fall outside
+
+  const auto counts = histogram_even(group, data, num_bins, lower_level, upper_level);
+  EXPECT(counts.size() == static_cast<size_t>(num_bins));
+
+  // Host reference
+  ::std::vector<long long> host(n);
+  data.copy_to_host(host.data());
+  ::std::vector<size_t> ref(num_bins, 0);
+  const long long width = (upper_level - lower_level) / num_bins;
+  size_t in_range       = 0;
+  for (size_t i = 0; i < n; i++)
+  {
+    if (host[i] >= lower_level && host[i] < upper_level)
+    {
+      ref[static_cast<size_t>((host[i] - lower_level) / width)]++;
+      in_range++;
+    }
+  }
+  size_t total = 0;
+  for (int b = 0; b < num_bins; b++)
+  {
+    EXPECT(counts[b] == ref[b]);
+    total += counts[b];
+  }
+  EXPECT(total == in_range);
+
+  // Empty array: all-zero histogram
+  sharded_array<long long> empty;
+  const auto zero = histogram_even(group, empty, 4, 0LL, 100LL);
+  EXPECT(zero.size() == 4UL);
+  for (const auto c : zero)
+  {
+    EXPECT(c == 0UL);
+  }
+
+  // Invalid arguments are refused at the API boundary
+  bool threw = false;
+  try
+  {
+    (void) histogram_even(group, data, 0, 0LL, 100LL);
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+
+  threw = false;
+  try
+  {
+    (void) histogram_even(group, data, 4, 100LL, 100LL);
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+}
+} // namespace
+
+int main()
+{
+  cuda_try(cuInit(0));
+  cuda_safe_call(cudaSetDevice(0));
+
+  auto group = place_group::by_locality_domains();
+
+  test_count(group);
+  test_histogram(group);
+
+  if (contiguous_backing_supported())
+  {
+    test_count_on_contiguous(group);
+  }
+  else
+  {
+    printf("VMM not supported on this device, skipping contiguous-array tests.\n");
+  }
+
+  return 0;
+}

--- a/cudax/test/sharded/algorithms/elementwise.cu
+++ b/cudax/test/sharded/algorithms/elementwise.cu
@@ -1,0 +1,184 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief Correctness of the elementwise sharded algorithms (fill, sequence,
+ *        iota, tabulate, generate, for_each, transform) against host
+ *        references, over multiple places.
+ */
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <vector>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::place_group;
+
+namespace
+{
+struct times_two_plus_index
+{
+  __host__ __device__ long long operator()(size_t i) const
+  {
+    return 2 * static_cast<long long>(i) + 7;
+  }
+};
+
+struct negate_op
+{
+  __host__ __device__ long long operator()(long long x) const
+  {
+    return -x;
+  }
+};
+
+struct saxpy_op
+{
+  __host__ __device__ long long operator()(long long x, long long y) const
+  {
+    return 3 * x + y;
+  }
+};
+
+struct set_to_index
+{
+  __host__ __device__ void operator()(long long& v, size_t i) const
+  {
+    v += static_cast<long long>(i);
+  }
+};
+
+struct const_gen
+{
+  __host__ __device__ long long operator()() const
+  {
+    return 42;
+  }
+};
+
+void test_fill_and_sequence(place_group& group)
+{
+  const size_t n = 100003;
+  auto data      = sharded_array<long long>::allocate(group, n);
+
+  fill(group, data, 17LL);
+  ::std::vector<long long> host(n);
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == 17LL);
+  }
+
+  sequence(group, data, 5LL, 3LL); // 5, 8, 11, ...
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == 5LL + 3LL * static_cast<long long>(i));
+  }
+
+  iota(group, data, 100LL);
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == 100LL + static_cast<long long>(i));
+  }
+}
+
+void test_tabulate_generate_for_each(place_group& group)
+{
+  const size_t n = 65537;
+  auto data      = sharded_array<long long>::allocate(group, n);
+
+  tabulate(group, data, times_two_plus_index{});
+  ::std::vector<long long> host(n);
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == 2 * static_cast<long long>(i) + 7);
+  }
+
+  generate(group, data, const_gen{});
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == 42LL);
+  }
+
+  // for_each sees the GLOBAL index: 42 + i
+  for_each(group, data, set_to_index{});
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == 42LL + static_cast<long long>(i));
+  }
+}
+
+void test_transform(place_group& group)
+{
+  const size_t n = 50000;
+  auto a         = sharded_array<long long>::allocate(group, n);
+  iota(group, a, 0LL);
+
+  // In-place
+  transform(group, a, negate_op{});
+  ::std::vector<long long> host(n);
+  a.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == -static_cast<long long>(i));
+  }
+
+  // Unary out-of-place
+  auto b = sharded_array<long long>::allocate_like(a);
+  transform(group, a, b, negate_op{});
+  b.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == static_cast<long long>(i));
+  }
+
+  // Binary: c = 3*a + b = -3i + i = -2i
+  auto c = sharded_array<long long>::allocate_like(a);
+  transform(group, a, b, c, saxpy_op{});
+  c.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == -2 * static_cast<long long>(i));
+  }
+
+  // Incompatible layouts must throw
+  auto other = sharded_array<long long>::allocate({{n / 2, data_place::device(0), exec_place::device(0), nullptr}});
+  bool threw = false;
+  try
+  {
+    transform(group, a, other, negate_op{});
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+}
+} // namespace
+
+int main()
+{
+  cuda_safe_call(cudaSetDevice(0));
+
+  auto group = place_group::by_locality_domains();
+
+  test_fill_and_sequence(group);
+  test_tabulate_generate_for_each(group);
+  test_transform(group);
+
+  return 0;
+}

--- a/cudax/test/sharded/algorithms/reduce_scan.cu
+++ b/cudax/test/sharded/algorithms/reduce_scan.cu
@@ -1,0 +1,297 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief Correctness of the sharded reduce / scan / adjacent_difference
+ *        algorithms against host references, over multiple places: per-place
+ *        CUB primitive plus cross-place combine.
+ */
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::place_group;
+
+namespace
+{
+struct max_op
+{
+  __host__ __device__ long long operator()(long long a, long long b) const
+  {
+    return a > b ? a : b;
+  }
+};
+
+void test_reduce(place_group& group)
+{
+  const size_t n = 1000001;
+  auto data      = sharded_array<long long>::allocate(group, n);
+  iota(group, data, 1LL); // 1..n
+
+  const long long expected_sum = static_cast<long long>(n) * (static_cast<long long>(n) + 1) / 2;
+  EXPECT(sum(group, data) == expected_sum);
+  EXPECT(min(group, data) == 1LL);
+  EXPECT(max(group, data) == static_cast<long long>(n));
+
+  // Custom operator through the generic entry point
+  EXPECT(reduce(group, data, max_op{}, 0LL) == static_cast<long long>(n));
+
+  // Empty array returns the initial value
+  sharded_array<long long> empty;
+  EXPECT(reduce(group, empty, max_op{}, -7LL) == -7LL);
+}
+
+void test_inclusive_scan(place_group& group)
+{
+  const size_t n = 262147;
+  auto data      = sharded_array<long long>::allocate(group, n);
+  fill(group, data, 1LL);
+
+  inclusive_scan(group, data); // 1, 2, 3, ..., n
+  ::std::vector<long long> host(n);
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == static_cast<long long>(i) + 1);
+  }
+
+  // Custom operator: running maximum of iota is iota itself
+  iota(group, data, 0LL);
+  inclusive_scan(group, data, max_op{});
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == static_cast<long long>(i));
+  }
+}
+
+void test_exclusive_scan(place_group& group)
+{
+  const size_t n = 131075;
+  auto data      = sharded_array<long long>::allocate(group, n);
+  fill(group, data, 2LL);
+
+  exclusive_scan(group, data); // 0, 2, 4, ..., 2*(n-1)
+  ::std::vector<long long> host(n);
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == 2 * static_cast<long long>(i));
+  }
+
+  // inclusive_sum / exclusive_sum aliases
+  fill(group, data, 1LL);
+  inclusive_sum(group, data);
+  data.copy_to_host(host.data());
+  EXPECT(host[n - 1] == static_cast<long long>(n));
+
+  fill(group, data, 1LL);
+  exclusive_sum(group, data);
+  data.copy_to_host(host.data());
+  EXPECT(host[0] == 0LL);
+  EXPECT(host[n - 1] == static_cast<long long>(n) - 1);
+}
+
+void test_adjacent_difference(place_group& group)
+{
+  const size_t n = 100000;
+  auto input     = sharded_array<long long>::allocate(group, n);
+  auto output    = sharded_array<long long>::allocate_like(input);
+
+  // input[i] = i*i; diff[i] = i*i - (i-1)^2 = 2i - 1 (and diff[0] = 0)
+  ::std::vector<long long> host(n);
+  for (size_t i = 0; i < n; i++)
+  {
+    host[i] = static_cast<long long>(i) * static_cast<long long>(i);
+  }
+  input.copy_from_host(host.data());
+
+  adjacent_difference(group, input, output);
+  output.copy_to_host(host.data());
+
+  EXPECT(host[0] == 0LL); // first element kept as-is
+  for (size_t i = 1; i < n; i++)
+  {
+    if (host[i] != 2 * static_cast<long long>(i) - 1)
+    {
+    }
+    EXPECT(host[i] == 2 * static_cast<long long>(i) - 1);
+  }
+
+  // The cross-shard boundary elements are exercised whenever the group has
+  // more than one place (indices at shard boundaries take the prev_last path)
+}
+
+void test_scan_semantics(place_group& group)
+{
+  // Non-additive operator across shards: inclusive product needs NO identity
+  // and must fold the true cross-shard prefix (regression: a zero seed used
+  // to collapse every prefix for multiplies).
+  {
+    const size_t n = 64; // 2^64 would overflow; use values of 1 with a few 2s
+    auto data      = sharded_array<long long>::allocate(group, n);
+    fill(group, data, 1LL);
+    ::std::vector<long long> host(n, 1);
+    host[3]     = 2;
+    host[n / 2] = 2;
+    host[n - 1] = 2; // three 2s, spread across shards
+    data.copy_from_host(host.data());
+    inclusive_scan(group, data, ::cuda::std::multiplies<long long>{});
+    data.copy_to_host(host.data());
+    long long running = 1;
+    ::std::vector<long long> ref(n, 1);
+    ref[3]     = 2;
+    ref[n / 2] = 2;
+    ref[n - 1] = 2;
+    for (size_t i = 0; i < n; i++)
+    {
+      running *= ref[i];
+      EXPECT(host[i] == running);
+    }
+  }
+
+  // Exclusive scan with a non-zero init folds the init exactly ONCE into the
+  // global sequence (regression: it used to be folded per shard).
+  {
+    const size_t n = 4099;
+    auto data      = sharded_array<long long>::allocate(group, n);
+    fill(group, data, 1LL);
+    exclusive_scan(group, data, 5LL); // 5, 6, 7, ...
+    ::std::vector<long long> host(n);
+    data.copy_to_host(host.data());
+    for (size_t i = 0; i < n; i++)
+    {
+      EXPECT(host[i] == 5LL + static_cast<long long>(i));
+    }
+  }
+
+  // Custom-op exclusive scan takes init AND identity explicitly.
+  {
+    const size_t n = 1025;
+    auto data      = sharded_array<long long>::allocate(group, n);
+    iota(group, data, 0LL);
+    // running max, seeded with 7: out[i] = max(7, 0, ..., i-1) = max(7, i-1)
+    exclusive_scan(group, data, max_op{}, 7LL, ::std::numeric_limits<long long>::lowest());
+    ::std::vector<long long> host(n);
+    data.copy_to_host(host.data());
+    for (size_t i = 0; i < n; i++)
+    {
+      const long long expected = (i == 0) ? 7LL : ::std::max(7LL, static_cast<long long>(i) - 1);
+      EXPECT(host[i] == expected);
+    }
+  }
+
+  // Scans cross allocation-empty shards unharmed.
+  if (group.size() >= 2)
+  {
+    ::std::vector<size_t> sizes(group.size(), 0);
+    const size_t n          = 513;
+    sizes[group.size() - 1] = n; // only the LAST place holds data
+    auto data               = sharded_array<long long>::allocate(group, sizes);
+    fill(group, data, 1LL);
+    inclusive_scan(group, data);
+    ::std::vector<long long> host(n);
+    data.copy_to_host(host.data());
+    for (size_t i = 0; i < n; i++)
+    {
+      EXPECT(host[i] == static_cast<long long>(i) + 1);
+    }
+  }
+}
+
+void test_adjacent_difference_empty_shard(place_group& group)
+{
+  if (group.size() < 2)
+  {
+    return;
+  }
+  // {nonzero, 0, ...}: the predecessor boundary must cross the empty shard.
+  ::std::vector<size_t> sizes(group.size(), 0);
+  const size_t n_first    = 100;
+  const size_t n_last     = 101;
+  sizes[0]                = n_first;
+  sizes[group.size() - 1] = n_last;
+  const size_t n          = n_first + n_last;
+
+  auto input  = sharded_array<long long>::allocate(group, sizes);
+  auto output = sharded_array<long long>::allocate(group, sizes);
+  iota(group, input, 0LL);
+  adjacent_difference(group, input, output);
+  ::std::vector<long long> host(n);
+  output.copy_to_host(host.data());
+  EXPECT(host[0] == 0LL); // first element copied
+  for (size_t i = 1; i < n; i++)
+  {
+    EXPECT(host[i] == 1LL); // iota differences, INCLUDING across the empty shard
+  }
+
+  // Aliasing refusal
+  bool threw = false;
+  try
+  {
+    adjacent_difference(group, input, input);
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+}
+
+void test_per_shard_sync(place_group& group)
+{
+  const size_t n = 4096;
+  auto data      = sharded_array<long long>::allocate(group, n);
+  fill(group, data, 9LL, /*blocking=*/false);
+  for (size_t i = 0; i < data.num_shards(); i++)
+  {
+    data.sync(i); // per-shard member: exec scope + synchronize
+  }
+  EXPECT(count(group, data, 9LL) == n);
+}
+
+void test_reduce_with_empty_shard(place_group& group)
+{
+  if (group.size() < 2)
+  {
+    return;
+  }
+  ::std::vector<size_t> sizes(group.size(), 0);
+  const size_t n = 4097;
+  sizes[0]       = n;
+  auto arr       = sharded_array<long long>::allocate(group, sizes);
+  fill(group, arr, 3LL);
+  EXPECT(sum(group, arr) == 3LL * static_cast<long long>(n));
+}
+} // namespace
+
+int main()
+{
+  cuda_safe_call(cudaSetDevice(0));
+
+  auto group = place_group::by_locality_domains();
+
+  test_reduce(group);
+  test_inclusive_scan(group);
+  test_exclusive_scan(group);
+  test_adjacent_difference(group);
+  test_reduce_with_empty_shard(group);
+  test_scan_semantics(group);
+  test_adjacent_difference_empty_shard(group);
+  test_per_shard_sync(group);
+
+  return 0;
+}

--- a/cudax/test/sharded/containers/contiguous.cu
+++ b/cudax/test/sharded/containers/contiguous.cu
@@ -1,0 +1,212 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief `allocate_contiguous` contract tests: one VA range with per-place
+ *        physical backing, exact logical shard boundaries, and the
+ *        read-as-one-array guarantee — per-shard writes must be visible to a
+ *        single unmodified kernel spanning the whole range through
+ *        `contiguous_data()`, and vice versa.
+ */
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <cstdio>
+#include <vector>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::cuda_try;
+using cuda::experimental::places::place_group;
+
+namespace
+{
+// Unmodified downstream consumer: reads the WHOLE array through one base
+// pointer, with no knowledge of shards
+__global__ void check_whole_kernel(const long long* base, size_t n, int* error)
+{
+  size_t tid = blockIdx.x * static_cast<size_t>(blockDim.x) + threadIdx.x;
+  if (tid < n)
+  {
+    if (base[tid] != static_cast<long long>(tid) + 1)
+    {
+      atomicExch(error, 1);
+    }
+  }
+}
+
+// Unmodified producer: writes the WHOLE array through one base pointer
+__global__ void write_whole_kernel(long long* base, size_t n)
+{
+  size_t tid = blockIdx.x * static_cast<size_t>(blockDim.x) + threadIdx.x;
+  if (tid < n)
+  {
+    base[tid] = 2 * static_cast<long long>(tid);
+  }
+}
+
+// Per-shard producer, launched shard by shard on the shard's place
+__global__ void write_shard_kernel(long long* data, size_t n, size_t global_offset)
+{
+  size_t tid = blockIdx.x * static_cast<size_t>(blockDim.x) + threadIdx.x;
+  if (tid < n)
+  {
+    data[tid] = static_cast<long long>(global_offset + tid) + 1;
+  }
+}
+
+void test_layout_contract()
+{
+  auto group = place_group::by_locality_domains({0});
+  // Odd size so shards are uneven and boundaries are not granule-aligned
+  const size_t n = (1 << 21) + 12345;
+
+  auto arr = sharded_array<long long>::allocate_contiguous(group, n);
+  EXPECT(arr.is_contiguous());
+  EXPECT(arr.contiguous_data() != nullptr);
+  EXPECT(arr.size() == n);
+  EXPECT(arr.is_owning()); // the array owns the memory, via its VMM backing
+  EXPECT(arr.get_ownership() == ownership::owning_backing);
+  EXPECT(arr.validate());
+
+  // Logical shard boundaries are EXACT: shard(i).data == base + global_offset
+  long long* base = arr.contiguous_data();
+  for (size_t i = 0; i < arr.num_shards(); i++)
+  {
+    EXPECT(arr.shard(i).data == base + arr.shard(i).global_offset);
+  }
+
+  // Dense: no inter-shard padding
+  size_t covered = 0;
+  for (size_t i = 0; i < arr.num_shards(); i++)
+  {
+    EXPECT(arr.shard(i).global_offset == covered);
+    covered += arr.shard(i).size;
+  }
+  EXPECT(covered == n);
+
+  // Per-shard placement correspondence: shard i carries place i of the group
+  EXPECT(arr.num_shards() == group.size());
+  for (size_t i = 0; i < arr.num_shards(); i++)
+  {
+    EXPECT(arr.shard(i).place == group.place(i).affine_data_place());
+    EXPECT(arr.shard(i).exec == group.place(i));
+  }
+
+  // A non-contiguous array reports no base pointer
+  auto plain = sharded_array<long long>::allocate(group, 1000);
+  EXPECT(!plain.is_contiguous());
+  EXPECT(plain.contiguous_data() == nullptr);
+}
+
+void test_whole_kernel_visibility()
+{
+  auto group     = place_group::by_locality_domains({0});
+  const size_t n = (1 << 21) + 999;
+
+  auto arr        = sharded_array<long long>::allocate_contiguous(group, n);
+  long long* base = arr.contiguous_data();
+
+  // Produce per shard, on each shard's own place and stream
+  arr.each_shard->*[](auto& s) {
+    const int block = 256;
+    const int grid  = static_cast<int>((s.size + block - 1) / block);
+    write_shard_kernel<<<grid, block, 0, s.stream>>>(s.data, s.size, s.global_offset);
+    cuda_safe_call(cudaGetLastError());
+  };
+  arr.sync();
+
+  // Consume with ONE kernel spanning the whole range through the base pointer
+  cuda_safe_call(cudaSetDevice(0));
+  int* d_error = nullptr;
+  cuda_safe_call(cudaMalloc(&d_error, sizeof(int)));
+  cuda_safe_call(cudaMemset(d_error, 0, sizeof(int)));
+
+  const int block = 256;
+  const int grid  = static_cast<int>((n + block - 1) / block);
+  check_whole_kernel<<<grid, block>>>(base, n, d_error);
+  cuda_safe_call(cudaGetLastError());
+
+  int h_error = -1;
+  cuda_safe_call(cudaMemcpy(&h_error, d_error, sizeof(int), cudaMemcpyDeviceToHost));
+  EXPECT(h_error == 0);
+
+  // And the reverse: one whole-array producer, per-shard consumers
+  write_whole_kernel<<<grid, block>>>(base, n);
+  cuda_safe_call(cudaGetLastError());
+  cuda_safe_call(cudaDeviceSynchronize());
+
+  ::std::vector<long long> host(n);
+  arr.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i += 4097) // sampled check
+  {
+    EXPECT(host[i] == 2 * static_cast<long long>(i));
+  }
+  EXPECT(host[n - 1] == 2 * static_cast<long long>(n - 1));
+
+  cuda_safe_call(cudaFree(d_error));
+}
+
+void test_non_affine_spec_refused()
+{
+  // The contiguous backing places physical blocks at each spec's exec
+  // place's affine data place; a spec naming any other data_place must
+  // throw rather than be silently ignored.
+  auto group = place_group::by_locality_domains({0});
+  auto place = group.place(0);
+  bool threw = false;
+  try
+  {
+    ::std::vector<shard_spec> specs;
+    specs.emplace_back(1024, cuda::experimental::places::data_place::host(), place, group.get_stream(0));
+    auto bad = sharded_array<long long>::allocate_contiguous(specs);
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+}
+
+void test_empty_and_cleanup()
+{
+  auto empty = sharded_array<long long>::allocate_contiguous(::std::vector<shard_spec>{});
+  EXPECT(!empty.is_contiguous());
+  EXPECT(empty.size() == 0UL);
+
+  // clear() releases the VMM backing
+  auto group = place_group::by_locality_domains({0});
+  auto arr   = sharded_array<long long>::allocate_contiguous(group, 1 << 20);
+  EXPECT(arr.is_contiguous());
+  arr.clear();
+  EXPECT(!arr.is_contiguous());
+  EXPECT(arr.size() == 0UL);
+}
+} // namespace
+
+int main()
+{
+  cuda_try(cuInit(0));
+  cuda_safe_call(cudaSetDevice(0));
+
+  if (!contiguous_backing_supported())
+  {
+    printf("VMM not supported on this device, skipping tests.\n");
+    return 0;
+  }
+
+  test_layout_contract();
+  test_whole_kernel_visibility();
+  test_non_affine_spec_refused();
+  test_empty_and_cleanup();
+
+  return 0;
+}

--- a/cudax/test/sharded/containers/fork_join.cu
+++ b/cudax/test/sharded/containers/fork_join.cu
@@ -1,0 +1,280 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief `sharded_array<T>::fork_from` / `join_into`: ordering declarations
+ *        bridging a caller stream and the per-shard streams. Covers the eager
+ *        producer -> fork -> per-shard consumers -> join -> reader chain with
+ *        NO host synchronization between the stages, the same chain on an
+ *        ADOPTED array over foreign streams, and the members inside a CUDA
+ *        graph capture (record/wait become graph dependencies).
+ */
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <vector>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::place_group;
+
+namespace
+{
+// Burn ~`cycles` GPU cycles so that a missing stream dependency surfaces as a
+// stale read instead of accidental serialization.
+__global__ void spin_kernel(long long cycles)
+{
+  const long long start = clock64();
+  while (clock64() - start < cycles)
+  {
+  }
+}
+
+// Producer: value derived from the global index.
+__global__ void produce_kernel(int* data, size_t n, size_t global_offset, int salt)
+{
+  const size_t i = blockIdx.x * static_cast<size_t>(blockDim.x) + threadIdx.x;
+  if (i < n)
+  {
+    data[i] = 2 * static_cast<int>(global_offset + i) + salt;
+  }
+}
+
+// Consumer: out = in + 1.
+__global__ void consume_kernel(const int* in, int* out, size_t n)
+{
+  const size_t i = blockIdx.x * static_cast<size_t>(blockDim.x) + threadIdx.x;
+  if (i < n)
+  {
+    out[i] = in[i] + 1;
+  }
+}
+
+// In-place increment (graph relaunch check).
+__global__ void increment_kernel(int* data, size_t n)
+{
+  const size_t i = blockIdx.x * static_cast<size_t>(blockDim.x) + threadIdx.x;
+  if (i < n)
+  {
+    data[i] += 1;
+  }
+}
+
+constexpr int threads = 256;
+
+inline unsigned int blocks_for(size_t n)
+{
+  return static_cast<unsigned int>((n + threads - 1) / threads);
+}
+
+// Producer on the caller stream -> fork_from -> per-shard consumers on the
+// shard streams -> join_into -> reader (memcpy) on the caller stream. The
+// ONLY host synchronization is the final caller-stream sync.
+void test_eager_ordering(place_group& group)
+{
+  const size_t n = 1 << 20;
+  auto in        = sharded_array<int>::allocate(group, n);
+  auto out       = sharded_array<int>::allocate_like(in);
+
+  // Sentinels, quiesced before the ordered chain starts.
+  fill(group, in, -1);
+  fill(group, out, -1);
+  in.sync();
+  out.sync();
+
+  cudaStream_t caller = nullptr;
+  cuda_safe_call(cudaStreamCreate(&caller));
+
+  // Delay + produce on the caller stream (per shard: the producer writes
+  // through each shard's pointer, all enqueued on the caller stream).
+  spin_kernel<<<1, 1, 0, caller>>>(20'000'000);
+  for (size_t i = 0; i < in.num_shards(); i++)
+  {
+    auto& s = in.shard(i);
+    produce_kernel<<<blocks_for(s.size), threads, 0, caller>>>(s.data, s.size, s.global_offset, 7);
+  }
+
+  // Fork: shard streams now depend on the producer.
+  in.fork_from(caller);
+
+  // Per-shard consumers on the shard streams.
+  in.each_shard->*[&out](size_t i, const auto& s) {
+    consume_kernel<<<blocks_for(s.size), threads, 0, s.stream>>>(s.data, out.shard(i).data, s.size);
+  };
+
+  // Join: the caller stream now depends on every consumer.
+  out.join_into(caller);
+
+  ::std::vector<int> host(n, 0);
+  for (size_t i = 0; i < out.num_shards(); i++)
+  {
+    const auto& s = out.shard(i);
+    cuda_safe_call(cudaMemcpyAsync(host.data() + s.global_offset, s.data, s.size_bytes(), cudaMemcpyDefault, caller));
+  }
+  cuda_safe_call(cudaStreamSynchronize(caller)); // the only host sync
+
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == 2 * static_cast<int>(i) + 7 + 1);
+  }
+
+  cuda_safe_call(cudaStreamDestroy(caller));
+}
+
+// Same chain on an ADOPTED array: caller-owned device buffers and FOREIGN
+// streams (created outside any place_group).
+void test_adopted_foreign_streams()
+{
+  const size_t n_per = 1 << 19;
+  const size_t parts = 2;
+  const size_t n     = n_per * parts;
+
+  cuda_safe_call(cudaSetDevice(0));
+
+  ::std::vector<int*> buffers(parts, nullptr);
+  ::std::vector<cudaStream_t> foreign(parts, nullptr);
+  ::std::vector<shard<int>> shards(parts);
+  for (size_t i = 0; i < parts; i++)
+  {
+    cuda_safe_call(cudaMalloc(&buffers[i], n_per * sizeof(int)));
+    cuda_safe_call(cudaStreamCreate(&foreign[i]));
+    shards[i].data          = buffers[i];
+    shards[i].size          = n_per;
+    shards[i].capacity      = n_per;
+    shards[i].global_offset = i * n_per;
+    shards[i].place         = data_place::device(0);
+    shards[i].exec          = exec_place::device(0);
+    shards[i].stream        = foreign[i];
+  }
+
+  auto data = sharded_array<int>::adopt(mv(shards));
+  EXPECT(data.is_view());
+
+  cudaStream_t caller = nullptr;
+  cuda_safe_call(cudaStreamCreate(&caller));
+
+  spin_kernel<<<1, 1, 0, caller>>>(20'000'000);
+  for (size_t i = 0; i < data.num_shards(); i++)
+  {
+    auto& s = data.shard(i);
+    produce_kernel<<<blocks_for(s.size), threads, 0, caller>>>(s.data, s.size, s.global_offset, 3);
+  }
+
+  data.fork_from(caller);
+
+  data.each_shard->*[](const auto& s) {
+    increment_kernel<<<blocks_for(s.size), threads, 0, s.stream>>>(s.data, s.size);
+  };
+
+  data.join_into(caller);
+
+  ::std::vector<int> host(n, 0);
+  for (size_t i = 0; i < data.num_shards(); i++)
+  {
+    const auto& s = data.shard(i);
+    cuda_safe_call(cudaMemcpyAsync(host.data() + s.global_offset, s.data, s.size_bytes(), cudaMemcpyDefault, caller));
+  }
+  cuda_safe_call(cudaStreamSynchronize(caller)); // the only host sync
+
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == 2 * static_cast<int>(i) + 3 + 1);
+  }
+
+  cuda_safe_call(cudaStreamDestroy(caller));
+  for (size_t i = 0; i < parts; i++)
+  {
+    cuda_safe_call(cudaStreamDestroy(foreign[i]));
+    cuda_safe_call(cudaFree(buffers[i]));
+  }
+}
+
+// fork_from/join_into INSIDE a CUDA graph capture: the record/wait pairs
+// become graph dependencies; the instantiated graph replays the whole
+// fork -> per-shard work -> join chain, repeatedly.
+void test_capture(place_group& group)
+{
+  const size_t n = 1 << 20;
+  auto data      = sharded_array<int>::allocate(group, n);
+
+  iota(group, data, 0);
+  data.sync();
+
+  cudaStream_t caller = nullptr;
+  cuda_safe_call(cudaStreamCreate(&caller));
+
+  cuda_safe_call(cudaStreamBeginCapture(caller, cudaStreamCaptureModeGlobal));
+
+  data.fork_from(caller);
+  data.each_shard->*[](const auto& s) {
+    increment_kernel<<<blocks_for(s.size), threads, 0, s.stream>>>(s.data, s.size);
+  };
+  data.join_into(caller);
+
+  cudaGraph_t graph = nullptr;
+  cuda_safe_call(cudaStreamEndCapture(caller, &graph));
+  cudaGraphExec_t exec = nullptr;
+  cuda_safe_call(cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+
+  const int launches = 3;
+  for (int r = 0; r < launches; r++)
+  {
+    cuda_safe_call(cudaGraphLaunch(exec, caller));
+  }
+  cuda_safe_call(cudaStreamSynchronize(caller));
+
+  ::std::vector<int> host(n, 0);
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == static_cast<int>(i) + launches);
+  }
+
+  cuda_safe_call(cudaGraphExecDestroy(exec));
+  cuda_safe_call(cudaGraphDestroy(graph));
+  cuda_safe_call(cudaStreamDestroy(caller));
+}
+
+// Degenerate inputs: empty containers and same-stream shards are no-ops.
+void test_degenerate()
+{
+  cudaStream_t caller = nullptr;
+  cuda_safe_call(cudaStreamCreate(&caller));
+
+  sharded_array<int> empty;
+  empty.fork_from(caller);
+  empty.join_into(caller);
+
+  {
+    // Shards whose reference stream IS the caller stream: nothing to order.
+    auto same = sharded_array<int>::allocate({{128, data_place::device(0), exec_place::device(0), caller}});
+    same.fork_from(caller);
+    same.join_into(caller);
+    cuda_safe_call(cudaStreamSynchronize(caller));
+  } // destroyed before its reference stream
+
+  cuda_safe_call(cudaStreamDestroy(caller));
+}
+} // namespace
+
+int main()
+{
+  cuda_safe_call(cudaSetDevice(0));
+
+  auto group = place_group::by_locality_domains();
+
+  test_eager_ordering(group);
+  test_adopted_foreign_streams();
+  test_capture(group);
+  test_degenerate();
+
+  return 0;
+}

--- a/cudax/test/sharded/containers/sharded_array.cu
+++ b/cudax/test/sharded/containers/sharded_array.cu
@@ -1,0 +1,345 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief `sharded_array` container tests: allocation (specs, place_group,
+ *        uniform), host roundtrips, copy_between/resharding, allocate_like,
+ *        adoption, slicing, validation and the contract throws.
+ *
+ * Runs on any machine with at least one GPU; multi-place coverage uses the
+ * locality domains of device 0 (or the whole device where unsupported).
+ */
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <numeric>
+#include <stdexcept>
+#include <vector>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::place_group;
+
+namespace
+{
+template <typename T>
+::std::vector<T> sequential(size_t n)
+{
+  ::std::vector<T> data(n);
+  ::std::iota(data.begin(), data.end(), T(1)); // 1, 2, 3, ...
+  return data;
+}
+
+template <typename T>
+void expect_equal(const ::std::vector<T>& actual, const ::std::vector<T>& expected)
+{
+  EXPECT(actual.size() == expected.size());
+  for (size_t i = 0; i < actual.size(); i++)
+  {
+    EXPECT(actual[i] == expected[i]);
+  }
+}
+
+void test_single_device_roundtrip()
+{
+  const size_t n = 1000;
+  auto input     = sequential<unsigned long long>(n);
+
+  auto arr = sharded_array<unsigned long long>::allocate({{n, data_place::device(0), exec_place::device(0), nullptr}});
+  EXPECT(arr.num_shards() == 1UL);
+  EXPECT(arr.size() == n);
+  EXPECT(arr.is_owning());
+  EXPECT(arr.validate());
+
+  arr.copy_from_host(input.data());
+
+  ::std::vector<unsigned long long> output(n);
+  arr.copy_to_host(output.data());
+  expect_equal(output, input);
+}
+
+void test_multi_shard_roundtrip()
+{
+  const size_t n = 1000;
+  auto input     = sequential<unsigned long long>(n);
+
+  ::std::vector<shard_spec> specs;
+  for (int i = 0; i < 4; i++)
+  {
+    specs.emplace_back(250, data_place::device(0), exec_place::device(0), nullptr);
+  }
+  auto arr = sharded_array<unsigned long long>::allocate(specs);
+  EXPECT(arr.num_shards() == 4UL);
+  EXPECT(arr.size() == n);
+  EXPECT(arr.validate());
+
+  // Shard index math
+  EXPECT(arr.shard(1).global_offset == 250UL);
+  EXPECT(arr.shard(1).contains(300));
+  EXPECT(!arr.shard(1).contains(500));
+  EXPECT(arr.shard(1).to_local(300) == 50UL);
+  EXPECT(arr.shard(1).to_global(50) == 300UL);
+  EXPECT(arr.shard(3).global_end() == n);
+
+  arr.copy_from_host(input.data());
+  ::std::vector<unsigned long long> output(n);
+  arr.copy_to_host(output.data());
+  expect_equal(output, input);
+}
+
+void test_place_group_allocation()
+{
+  auto group     = place_group::by_locality_domains({0});
+  const size_t n = 10000;
+
+  auto arr = sharded_array<long long>::allocate(group, n);
+  EXPECT(arr.num_shards() == group.size()); // one shard per place, empty or not
+  EXPECT(arr.size() == n);
+  EXPECT(arr.is_owning());
+  EXPECT(arr.validate());
+
+  // Reference streams come from the group
+  for (size_t i = 0; i < arr.num_shards(); i++)
+  {
+    EXPECT(arr.shard(i).stream != nullptr);
+  }
+
+  auto input = sequential<long long>(n);
+  arr.copy_from_host(input.data());
+  ::std::vector<long long> output(n);
+  arr.copy_to_host(output.data());
+  expect_equal(output, input);
+
+  // Explicit per-shard sizes must match the group's place count
+  bool threw = false;
+  try
+  {
+    auto bad = sharded_array<long long>::allocate(group, ::std::vector<size_t>(group.size() + 1, 10));
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+}
+
+void test_allocate_like()
+{
+  auto group = place_group::by_locality_domains({0});
+  auto src   = sharded_array<long long>::allocate(group, 999);
+
+  auto dst = sharded_array<long long>::allocate_like(src);
+  EXPECT(dst.num_shards() == src.num_shards());
+  EXPECT(dst.size() == src.size());
+  for (size_t i = 0; i < src.num_shards(); i++)
+  {
+    EXPECT(dst.shard(i).size == src.shard(i).size);
+    EXPECT(dst.shard(i).global_offset == src.shard(i).global_offset);
+    EXPECT(dst.shard(i).place == src.shard(i).place);
+    EXPECT(dst.shard(i).exec == src.shard(i).exec);
+  }
+
+  // Different element type, same layout
+  auto dst_f = sharded_array<float>::allocate_like(src);
+  EXPECT(dst_f.num_shards() == src.num_shards());
+  EXPECT(dst_f.size() == src.size());
+}
+
+void test_copy_between_resharding()
+{
+  const size_t n = 1000;
+  auto input     = sequential<unsigned long long>(n);
+
+  auto one = sharded_array<unsigned long long>::allocate({{n, data_place::device(0), exec_place::device(0), nullptr}});
+  one.copy_from_host(input.data());
+
+  // 1 shard -> 2 shards
+  auto two = sharded_array<unsigned long long>::allocate(
+    {{500, data_place::device(0), exec_place::device(0), nullptr},
+     {500, data_place::device(0), exec_place::device(0), nullptr}});
+  copy_between(one, two);
+  ::std::vector<unsigned long long> output(n);
+  two.copy_to_host(output.data());
+  expect_equal(output, input);
+
+  // misaligned: 3 shards (333+333+334) -> 2 shards (500+500)
+  auto three = sharded_array<unsigned long long>::allocate(
+    {{333, data_place::device(0), exec_place::device(0), nullptr},
+     {333, data_place::device(0), exec_place::device(0), nullptr},
+     {334, data_place::device(0), exec_place::device(0), nullptr}});
+  three.copy_from_host(input.data());
+
+  auto dst = sharded_array<unsigned long long>::allocate(
+    {{500, data_place::device(0), exec_place::device(0), nullptr},
+     {500, data_place::device(0), exec_place::device(0), nullptr}});
+  copy_between(three, dst);
+  dst.copy_to_host(output.data());
+  expect_equal(output, input);
+
+  // 2 shards -> 1 shard
+  auto back = sharded_array<unsigned long long>::allocate({{n, data_place::device(0), exec_place::device(0), nullptr}});
+  copy_between(dst, back);
+  back.copy_to_host(output.data());
+  expect_equal(output, input);
+}
+
+void test_adoption_and_slice()
+{
+  const size_t n = 700;
+  auto input     = sequential<long long>(n);
+
+  auto group = place_group::by_locality_domains({0});
+  auto owner = sharded_array<long long>::allocate(group, n);
+  owner.copy_from_host(input.data());
+
+  // Adopt the owner's shards as a non-owning view
+  ::std::vector<shard<long long>> shards(owner.begin(), owner.end());
+  sharded_array<long long> view(::std::move(shards));
+  EXPECT(view.is_view());
+  EXPECT(view.size() == n);
+  ::std::vector<long long> output(n);
+  view.copy_to_host(output.data());
+  expect_equal(output, input);
+
+  // Slice [100, 400): values 101..400
+  auto sliced = view.slice(100, 400);
+  EXPECT(sliced.is_view());
+  EXPECT(sliced.size() == 300UL);
+  EXPECT(sliced.num_shards() == view.num_shards()); // place correspondence preserved
+  EXPECT(sliced.validate());
+  ::std::vector<long long> sliced_host(300);
+  sliced.copy_to_host(sliced_host.data());
+  ::std::vector<long long> sliced_ref(input.begin() + 100, input.begin() + 400);
+  expect_equal(sliced_host, sliced_ref);
+
+  // A slice past a shard keeps an empty shard in its position
+  auto tail = view.slice(n - 1);
+  EXPECT(tail.size() == 1UL);
+  EXPECT(tail.num_shards() == view.num_shards());
+
+  // adopt() is the named form of the adopting constructor: same zero-copy
+  // view semantics, same data identity (the owner's pointers, unchanged).
+  ::std::vector<shard<long long>> shards2(owner.begin(), owner.end());
+  auto adopted = sharded_array<long long>::adopt(::std::move(shards2));
+  EXPECT(adopted.is_view());
+  EXPECT(!adopted.is_owning());
+  EXPECT(adopted.size() == n);
+  EXPECT(adopted.num_shards() == view.num_shards());
+  for (size_t i = 0; i < adopted.num_shards(); ++i)
+  {
+    EXPECT(adopted[i].data == view[i].data);
+    EXPECT(adopted[i].size == view[i].size);
+  }
+}
+
+void test_check_compatible_throws()
+{
+  auto a = sharded_array<long long>::allocate({{100, data_place::device(0), exec_place::device(0), nullptr}});
+  auto b = sharded_array<long long>::allocate(
+    {{50, data_place::device(0), exec_place::device(0), nullptr},
+     {50, data_place::device(0), exec_place::device(0), nullptr}});
+  auto c = sharded_array<long long>::allocate({{60, data_place::device(0), exec_place::device(0), nullptr}});
+
+  bool threw = false;
+  try
+  {
+    check_compatible(a, b, "test");
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    threw = true;
+  }
+  EXPECT(threw); // shard count mismatch
+
+  threw = false;
+  try
+  {
+    check_compatible(a, c, "test");
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    threw = true;
+  }
+  EXPECT(threw); // shard size mismatch
+
+  check_compatible(a, a, "test"); // must not throw
+}
+
+void test_uniform_and_host()
+{
+  const size_t n = 1001;
+  auto input     = sequential<long long>(n);
+
+  auto uni = sharded_array<long long>::allocate_uniform(n, {0});
+  EXPECT(uni.size() == n);
+  uni.copy_from_host(input.data());
+  ::std::vector<long long> output(n);
+  uni.copy_to_host(output.data());
+  expect_equal(output, input);
+
+  auto host = sharded_array<long long>::allocate_host(n);
+  EXPECT(host.size() == n);
+  host.copy_from_host(input.data());
+  host.copy_to_host(output.data());
+  expect_equal(output, input);
+
+  auto fh = sharded_array<long long>::from_host(input.data(), {{n, data_place::device(0)}});
+  fh.copy_to_host(output.data());
+  expect_equal(output, input);
+}
+} // namespace
+
+void test_empty_shard_allocation()
+{
+  auto group = place_group::by_locality_domains();
+  if (group.size() < 2)
+  {
+    return; // needs at least two places so one can be empty
+  }
+
+  // One place gets a zero size: the shard EXISTS (place correspondence is
+  // preserved), it just holds no storage.
+  ::std::vector<size_t> sizes(group.size(), 0);
+  const size_t n = 1000;
+  sizes[0]       = n;
+
+  auto arr = sharded_array<long long>::allocate(group, sizes);
+  EXPECT(arr.num_shards() == group.size());
+  EXPECT(arr.size() == n);
+  EXPECT(arr.shard(1).size == 0);
+  EXPECT(arr.shard(1).data == nullptr);
+  EXPECT(arr.shard(1).capacity == 0);
+  EXPECT(arr.validate());
+
+  // Host round-trip crosses the empty shard unharmed
+  auto input = sequential<long long>(n);
+  arr.copy_from_host(input.data());
+  ::std::vector<long long> output(n);
+  arr.copy_to_host(output.data());
+  expect_equal(output, input);
+}
+
+int main()
+{
+  cuda_safe_call(cudaSetDevice(0));
+
+  test_single_device_roundtrip();
+  test_multi_shard_roundtrip();
+  test_place_group_allocation();
+  test_allocate_like();
+  test_copy_between_resharding();
+  test_adoption_and_slice();
+  test_check_compatible_throws();
+  test_uniform_and_host();
+  test_empty_shard_allocation();
+
+  return 0;
+}

--- a/cudax/test/sharded/graph_capture/contiguous_capture.cu
+++ b/cudax/test/sharded/graph_capture/contiguous_capture.cu
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief Graph capture over a contiguous (`allocate_contiguous`) sharded
+ *        array: the VMM mappings pre-exist the capture, so the backing is
+ *        transparent to the graph — per-shard elementwise stages and a
+ *        whole-array kernel through `contiguous_data()` capture into ONE
+ *        graph and replay with inputs mutated between launches.
+ */
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <vector>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::exec_place_scope;
+using cuda::experimental::places::place_group;
+
+namespace
+{
+struct triple_op
+{
+  __host__ __device__ float operator()(float x) const
+  {
+    return 3.0f * x;
+  }
+};
+
+// Whole-array stage: an unmodified single-pointer kernel over the ONE
+// contiguous VA range
+__global__ void plus_one_all(float* base, size_t n)
+{
+  size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n)
+  {
+    base[i] += 1.0f;
+  }
+}
+
+void test_contiguous_pipeline_capture(place_group& group)
+{
+  const size_t n = (1 << 21) + 37; // > one 2 MiB granule per shard, uneven
+  auto data      = sharded_array<float>::allocate_contiguous(group, n);
+  EXPECT(data.is_contiguous());
+  float* base = data.contiguous_data();
+  EXPECT(base != nullptr);
+
+  fill(group, data, 1.0f); // warm-up outside capture
+
+  cudaStream_t origin;
+  cuda_safe_call(cudaStreamCreate(&origin));
+
+  // Capture: per-shard transform (on the shard streams), join, then the
+  // whole-array kernel on the origin stream through the base pointer
+  cuda_safe_call(cudaStreamBeginCapture(origin, cudaStreamCaptureModeGlobal));
+  data.fork_from(origin);
+  transform(group, data, triple_op{}, /*blocking=*/false);
+  data.join_into(origin);
+  plus_one_all<<<static_cast<unsigned>((n + 255) / 256), 256, 0, origin>>>(base, n);
+  cuda_safe_call(cudaGetLastError());
+
+  cudaGraph_t graph = nullptr;
+  cuda_safe_call(cudaStreamEndCapture(origin, &graph));
+  cudaGraphExec_t exec = nullptr;
+  cuda_safe_call(cudaGraphInstantiate(&exec, graph, 0));
+
+  // Replay with inputs mutated between launches: data' = 3 * data + 1
+  ::std::vector<float> host(n);
+  for (int round = 0; round < 3; round++)
+  {
+    const float v = static_cast<float>(round + 1);
+    fill(group, data, v); // outside the graph
+    cuda_safe_call(cudaGraphLaunch(exec, origin));
+    cuda_safe_call(cudaStreamSynchronize(origin));
+
+    // Read back through the contiguous base pointer, as one plain array
+    cuda_safe_call(cudaMemcpy(host.data(), base, n * sizeof(float), cudaMemcpyDefault));
+    for (size_t i = 0; i < n; i++)
+    {
+      EXPECT(host[i] == 3.0f * v + 1.0f);
+    }
+  }
+
+  cuda_safe_call(cudaGraphExecDestroy(exec));
+  cuda_safe_call(cudaGraphDestroy(graph));
+  cuda_safe_call(cudaStreamDestroy(origin));
+}
+} // namespace
+
+int main()
+{
+  cuda_safe_call(cudaSetDevice(0));
+
+  auto group = place_group::by_locality_domains();
+
+  test_contiguous_pipeline_capture(group);
+
+  return 0;
+}

--- a/cudax/test/sharded/graph_capture/elementwise_pipeline.cu
+++ b/cudax/test/sharded/graph_capture/elementwise_pipeline.cu
@@ -1,0 +1,278 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief CUDA graph capture of the elementwise sharded pipeline: fork an
+ *        origin stream to every shard stream (`fork_from`), record fill/transform/for_each
+ *        with `blocking = false`, join back (`join_into`), instantiate, and replay —
+ *        including replays with inputs mutated between launches, a
+ *        cross-stream (different-color) captured dependency, and a check that
+ *        the per-place SM confinement of the shard streams survives inside
+ *        the instantiated graph.
+ */
+
+#include <cuda/stream>
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <set>
+#include <vector>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::exec_place_scope;
+using cuda::experimental::places::place_group;
+
+namespace
+{
+struct scale_op
+{
+  __host__ __device__ float operator()(float x) const
+  {
+    return 2.0f * x;
+  }
+};
+
+struct plus_half_op
+{
+  __host__ __device__ float operator()(float x) const
+  {
+    return x + 0.5f;
+  }
+};
+
+struct bump_op
+{
+  __host__ __device__ void operator()(float& v, size_t) const
+  {
+    v += 1.0f;
+  }
+};
+
+// The eager reference of the captured pipeline: out = 2 * in + 0.5 + 1
+float expected(float in)
+{
+  return 2.0f * in + 1.5f;
+}
+
+__global__ void smid_probe_kernel(unsigned* smids)
+{
+  if (threadIdx.x == 0)
+  {
+    unsigned smid;
+    asm("mov.u32 %0, %%smid;" : "=r"(smid));
+    smids[blockIdx.x] = smid;
+  }
+}
+
+void test_pipeline_capture_and_replay(place_group& group)
+{
+  const size_t n = 1 << 20;
+  auto in        = sharded_array<float>::allocate(group, n, /*color*/ 0);
+  auto out       = sharded_array<float>::allocate(group, n, /*color*/ 0);
+
+  fill(group, in, 1.0f); // eager warm-up outside capture (modules, pools)
+
+  cudaStream_t origin;
+  cuda_safe_call(cudaStreamCreate(&origin));
+
+  // Capture the pipeline: fork, then transform(in -> out, x2),
+  // transform(out += 0.5 in place), for_each(out += 1), then join
+  cuda_safe_call(cudaStreamBeginCapture(origin, cudaStreamCaptureModeGlobal));
+  in.fork_from(origin);
+  transform(group, in, out, scale_op{}, /*blocking=*/false);
+  transform(group, out, plus_half_op{}, /*blocking=*/false);
+  for_each(group, out, bump_op{}, /*blocking=*/false);
+  out.join_into(origin);
+
+  cudaGraph_t graph = nullptr;
+  cuda_safe_call(cudaStreamEndCapture(origin, &graph));
+  EXPECT(graph != nullptr);
+
+  cudaGraphExec_t exec = nullptr;
+  cuda_safe_call(cudaGraphInstantiate(&exec, graph, 0));
+
+  // Replay with inputs mutated between launches (writes happen OUTSIDE the
+  // graph; each launch recomputes from the current input values)
+  ::std::vector<float> host(n);
+  ::std::vector<float> input(n);
+  for (int round = 0; round < 3; round++)
+  {
+    for (size_t i = 0; i < n; i++)
+    {
+      input[i] = static_cast<float>(round + 1) + static_cast<float>(i % 7);
+    }
+    in.copy_from_host(input.data());
+
+    cuda_safe_call(cudaGraphLaunch(exec, origin));
+    cuda_safe_call(cudaStreamSynchronize(origin));
+
+    out.copy_to_host(host.data());
+    for (size_t i = 0; i < n; i++)
+    {
+      EXPECT(host[i] == expected(input[i]));
+    }
+  }
+
+  // Clobber the output and replay: the graph recomputes it
+  fill(group, out, -1.0f);
+  cuda_safe_call(cudaGraphLaunch(exec, origin));
+  cuda_safe_call(cudaStreamSynchronize(origin));
+  out.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == expected(input[i]));
+  }
+
+  cuda_safe_call(cudaGraphExecDestroy(exec));
+  cuda_safe_call(cudaGraphDestroy(graph));
+  cuda_safe_call(cudaStreamDestroy(origin));
+}
+
+// A captured cross-stream dependency: input and output allocated at different
+// stream colors, so the out-of-place transform records event edges between
+// two capturing shard streams.
+void test_cross_color_dependency(place_group& group)
+{
+  if (group.num_stream_colors() < 2)
+  {
+    return;
+  }
+
+  const size_t n = 100003;
+  auto in        = sharded_array<float>::allocate(group, n, /*color*/ 0);
+  auto out       = sharded_array<float>::allocate(group, n, /*color*/ 1);
+
+  fill(group, in, 4.0f);
+
+  cudaStream_t origin;
+  cuda_safe_call(cudaStreamCreate(&origin));
+
+  cuda_safe_call(cudaStreamBeginCapture(origin, cudaStreamCaptureModeGlobal));
+  in.fork_from(origin);
+  out.fork_from(origin);
+  transform(group, in, out, scale_op{}, /*blocking=*/false); // records in->out event edges
+  out.join_into(origin);
+  in.join_into(origin);
+
+  cudaGraph_t graph = nullptr;
+  cuda_safe_call(cudaStreamEndCapture(origin, &graph));
+  cudaGraphExec_t exec = nullptr;
+  cuda_safe_call(cudaGraphInstantiate(&exec, graph, 0));
+  cuda_safe_call(cudaGraphLaunch(exec, origin));
+  cuda_safe_call(cudaStreamSynchronize(origin));
+
+  ::std::vector<float> host(n);
+  out.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == 8.0f);
+  }
+
+  cuda_safe_call(cudaGraphExecDestroy(exec));
+  cuda_safe_call(cudaGraphDestroy(graph));
+  cuda_safe_call(cudaStreamDestroy(origin));
+}
+
+// The green-context SM confinement of the shard streams must survive inside
+// the instantiated graph: kernels captured from two locality-domain streams
+// must land on disjoint SM sets when replayed.
+void test_confinement_in_graph(place_group& group)
+{
+  if (group.size() < 2)
+  {
+    return; // needs at least two places to compare SM sets
+  }
+  // Only meaningful when the places are domains of ONE device (disjoint SM
+  // partitions); distinct whole devices trivially pass, which is fine too.
+
+  const size_t num_places = group.size();
+  const int blocks        = 64;
+
+  ::std::vector<unsigned*> smid_bufs(num_places);
+  for (size_t i = 0; i < num_places; i++)
+  {
+    exec_place_scope scope(group.place(i));
+    cuda_safe_call(cudaMalloc(&smid_bufs[i], blocks * sizeof(unsigned)));
+  }
+
+  // Warm-up launch outside capture on each place stream
+  for (size_t i = 0; i < num_places; i++)
+  {
+    exec_place_scope scope(group.place(i));
+    smid_probe_kernel<<<blocks, 32, 0, group.get_stream(i, 0)>>>(smid_bufs[i]);
+    cuda_safe_call(cudaGetLastError());
+  }
+  group.sync();
+
+  cudaStream_t origin;
+  cuda_safe_call(cudaStreamCreate(&origin));
+  cuda_safe_call(cudaStreamBeginCapture(origin, cudaStreamCaptureModeGlobal));
+  for (size_t i = 0; i < num_places; i++)
+  {
+    ::cuda::stream_ref{group.get_stream(i, 0)}.wait(::cuda::stream_ref{origin});
+    exec_place_scope scope(group.place(i));
+    smid_probe_kernel<<<blocks, 32, 0, group.get_stream(i, 0)>>>(smid_bufs[i]);
+    cuda_safe_call(cudaGetLastError());
+    ::cuda::stream_ref{origin}.wait(::cuda::stream_ref{group.get_stream(i, 0)});
+  }
+  cudaGraph_t graph = nullptr;
+  cuda_safe_call(cudaStreamEndCapture(origin, &graph));
+  cudaGraphExec_t exec = nullptr;
+  cuda_safe_call(cudaGraphInstantiate(&exec, graph, 0));
+  cuda_safe_call(cudaGraphLaunch(exec, origin));
+  cuda_safe_call(cudaStreamSynchronize(origin));
+
+  ::std::vector<::std::set<unsigned>> smid_sets(num_places);
+  for (size_t i = 0; i < num_places; i++)
+  {
+    ::std::vector<unsigned> h(blocks);
+    cuda_safe_call(cudaMemcpy(h.data(), smid_bufs[i], blocks * sizeof(unsigned), cudaMemcpyDefault));
+    smid_sets[i].insert(h.begin(), h.end());
+  }
+  for (size_t i = 0; i < num_places; i++)
+  {
+    for (size_t j = i + 1; j < num_places; j++)
+    {
+      if (device_ordinal(group.place(i).affine_data_place()) != device_ordinal(group.place(j).affine_data_place()))
+      {
+        continue; // different devices: SMID spaces are unrelated
+      }
+      for (unsigned smid : smid_sets[i])
+      {
+        EXPECT(smid_sets[j].count(smid) == 0);
+      }
+    }
+  }
+
+  cuda_safe_call(cudaGraphExecDestroy(exec));
+  cuda_safe_call(cudaGraphDestroy(graph));
+  cuda_safe_call(cudaStreamDestroy(origin));
+  for (size_t i = 0; i < num_places; i++)
+  {
+    exec_place_scope scope(group.place(i));
+    cuda_safe_call(cudaFree(smid_bufs[i]));
+  }
+}
+} // namespace
+
+int main()
+{
+  cuda_safe_call(cudaSetDevice(0));
+
+  auto group = place_group::by_locality_domains();
+
+  test_pipeline_capture_and_replay(group);
+  test_cross_color_dependency(group);
+  test_confinement_in_graph(group);
+
+  return 0;
+}

--- a/cudax/test/sharded/graph_capture/graph_owned_memory.cu
+++ b/cudax/test/sharded/graph_capture/graph_owned_memory.cu
@@ -1,0 +1,204 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief Semantics of `place_memory_resource` stream-ordered allocation under
+ *        CUDA graph capture. The shipped contract is "allocate outside
+ *        capture; capture computation only" — but a capture-time allocation
+ *        is RECORDED, not refused: it becomes a graph-owned allocation
+ *        (mem-alloc node). This test pins the two shapes of that behavior:
+ *
+ *         - balanced allocate/deallocate enclosed in the capture (the CUB
+ *           temporary-allocation shape) instantiates and replays freely;
+ *         - an allocation NOT freed inside the graph makes an immediate
+ *           relaunch fail predictably until the pointer is freed outside.
+ */
+
+#include <cuda/stream>
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <vector>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::place_group;
+using cuda::experimental::places::place_memory_resource;
+
+namespace
+{
+__global__ void write_kernel(float* p, size_t n, float v)
+{
+  size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n)
+  {
+    p[i] = v;
+  }
+}
+
+__global__ void copy_kernel(const float* src, float* dst, size_t n)
+{
+  size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n)
+  {
+    dst[i] = src[i];
+  }
+}
+
+bool graph_has_node_type(cudaGraph_t graph, cudaGraphNodeType type)
+{
+  size_t num = 0;
+  cuda_safe_call(cudaGraphGetNodes(graph, nullptr, &num));
+  ::std::vector<cudaGraphNode_t> nodes(num);
+  cuda_safe_call(cudaGraphGetNodes(graph, nodes.data(), &num));
+  for (cudaGraphNode_t node : nodes)
+  {
+    cudaGraphNodeType t;
+    cuda_safe_call(cudaGraphNodeGetType(node, &t));
+    if (t == type)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Balanced alloc/free pair inside the capture: the shape CUB algorithm
+// temporaries take. Becomes graph-owned memory; instantiates and replays.
+void test_balanced_alloc_free_replays(place_group& group)
+{
+  const size_t n     = 1 << 16;
+  const size_t bytes = n * sizeof(float);
+  auto& shard_place  = group.place(0);
+  cudaStream_t s     = group.get_stream(0);
+  place_memory_resource mr(shard_place.affine_data_place());
+
+  // Persistent output written by the captured kernels
+  float* d_out = static_cast<float*>(mr.allocate(::cuda::stream_ref{s}, bytes));
+  cuda_safe_call(cudaStreamSynchronize(s));
+
+  cudaStream_t origin;
+  cuda_safe_call(cudaStreamCreate(&origin));
+
+  cuda_safe_call(cudaStreamBeginCapture(origin, cudaStreamCaptureModeGlobal));
+  ::cuda::stream_ref{s}.wait(::cuda::stream_ref{origin});
+
+  float* d_tmp = static_cast<float*>(mr.allocate(::cuda::stream_ref{s}, bytes)); // graph-owned
+  {
+    cuda::experimental::places::exec_place_scope scope(shard_place);
+    write_kernel<<<static_cast<unsigned>((n + 255) / 256), 256, 0, s>>>(d_tmp, n, 7.0f);
+    cuda_safe_call(cudaGetLastError());
+    copy_kernel<<<static_cast<unsigned>((n + 255) / 256), 256, 0, s>>>(d_tmp, d_out, n);
+    cuda_safe_call(cudaGetLastError());
+  }
+  mr.deallocate(::cuda::stream_ref{s}, d_tmp, bytes); // freed inside the graph
+
+  ::cuda::stream_ref{origin}.wait(::cuda::stream_ref{s});
+  cudaGraph_t graph = nullptr;
+  cuda_safe_call(cudaStreamEndCapture(origin, &graph));
+
+  // The allocation was recorded as a graph memory node
+  EXPECT(graph_has_node_type(graph, cudaGraphNodeTypeMemAlloc));
+  EXPECT(graph_has_node_type(graph, cudaGraphNodeTypeMemFree));
+
+  cudaGraphExec_t exec = nullptr;
+  cuda_safe_call(cudaGraphInstantiate(&exec, graph, 0));
+  ::std::vector<float> host(n);
+  for (int round = 0; round < 3; round++)
+  {
+    cuda_safe_call(cudaGraphLaunch(exec, origin));
+    cuda_safe_call(cudaStreamSynchronize(origin));
+    cuda_safe_call(cudaMemcpy(host.data(), d_out, bytes, cudaMemcpyDefault));
+    for (size_t i = 0; i < n; i++)
+    {
+      EXPECT(host[i] == 7.0f);
+    }
+    cuda_safe_call(cudaMemset(d_out, 0, bytes)); // force the next replay to redo the work
+  }
+
+  cuda_safe_call(cudaGraphExecDestroy(exec));
+  cuda_safe_call(cudaGraphDestroy(graph));
+  mr.deallocate(::cuda::stream_ref{s}, d_out, bytes);
+  cuda_safe_call(cudaStreamSynchronize(s));
+  cuda_safe_call(cudaStreamDestroy(origin));
+}
+
+// Violating "allocate outside capture; free what you capture-allocate": an
+// allocation left unfreed by the graph stays live after a launch, and an
+// immediate relaunch fails predictably until it is freed outside the graph.
+void test_unbalanced_alloc_fails_predictably(place_group& group)
+{
+  const size_t n     = 1 << 16;
+  const size_t bytes = n * sizeof(float);
+  auto& shard_place  = group.place(0);
+  cudaStream_t s     = group.get_stream(0);
+  place_memory_resource mr(shard_place.affine_data_place());
+
+  cudaStream_t origin;
+  cuda_safe_call(cudaStreamCreate(&origin));
+
+  cuda_safe_call(cudaStreamBeginCapture(origin, cudaStreamCaptureModeGlobal));
+  ::cuda::stream_ref{s}.wait(::cuda::stream_ref{origin});
+  float* d_leak = static_cast<float*>(mr.allocate(::cuda::stream_ref{s}, bytes)); // NOT freed in-graph
+  {
+    cuda::experimental::places::exec_place_scope scope(shard_place);
+    write_kernel<<<static_cast<unsigned>((n + 255) / 256), 256, 0, s>>>(d_leak, n, 3.0f);
+    cuda_safe_call(cudaGetLastError());
+  }
+  ::cuda::stream_ref{origin}.wait(::cuda::stream_ref{s});
+  cudaGraph_t graph = nullptr;
+  cuda_safe_call(cudaStreamEndCapture(origin, &graph));
+  EXPECT(graph_has_node_type(graph, cudaGraphNodeTypeMemAlloc));
+  EXPECT(!graph_has_node_type(graph, cudaGraphNodeTypeMemFree));
+
+  cudaGraphExec_t exec = nullptr;
+  cuda_safe_call(cudaGraphInstantiate(&exec, graph, 0));
+  cuda_safe_call(cudaGraphLaunch(exec, origin));
+  cuda_safe_call(cudaStreamSynchronize(origin));
+
+  // The allocation is live after the launch: the captured pointer reads back
+  ::std::vector<float> host(n);
+  cuda_safe_call(cudaMemcpy(host.data(), d_leak, bytes, cudaMemcpyDefault));
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == 3.0f);
+  }
+
+  // Relaunching while the previous launch's allocation is still live fails
+  const cudaError_t relaunch = cudaGraphLaunch(exec, origin);
+  EXPECT(relaunch != cudaSuccess);
+  (void) cudaGetLastError(); // clear
+
+  // Freeing the graph allocation outside the graph re-arms the launch
+  cuda_safe_call(cudaFreeAsync(d_leak, origin));
+  cuda_safe_call(cudaStreamSynchronize(origin));
+  cuda_safe_call(cudaGraphLaunch(exec, origin));
+  cuda_safe_call(cudaStreamSynchronize(origin));
+  cuda_safe_call(cudaFreeAsync(d_leak, origin));
+  cuda_safe_call(cudaStreamSynchronize(origin));
+
+  cuda_safe_call(cudaGraphExecDestroy(exec));
+  cuda_safe_call(cudaGraphDestroy(graph));
+  cuda_safe_call(cudaStreamDestroy(origin));
+}
+} // namespace
+
+int main()
+{
+  cuda_safe_call(cudaSetDevice(0));
+
+  auto group = place_group::by_locality_domains();
+
+  test_balanced_alloc_free_replays(group);
+  test_unbalanced_alloc_fails_predictably(group);
+
+  return 0;
+}

--- a/cudax/test/sharded/graph_capture/must_not_capture.cu
+++ b/cudax/test/sharded/graph_capture/must_not_capture.cu
@@ -1,0 +1,234 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief The must-not-capture set: operations that synchronize with the host,
+ *        allocate containers or transfer host data REFUSE (throw) under an
+ *        active CUDA stream capture, loudly and safely — the ongoing capture
+ *        is left VALID (not invalidated, not wedged) and every refused
+ *        operation works eagerly after the capture ends. Also pins the
+ *        benign cases: shard adoption (host-only bookkeeping) and
+ *        `place_group` stream materialization record nothing into the graph.
+ */
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <stdexcept>
+#include <vector>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::place_group;
+
+namespace
+{
+struct is_even_op
+{
+  __host__ __device__ bool operator()(long long x) const
+  {
+    return (x % 2) == 0;
+  }
+};
+
+bool capture_active(cudaStream_t stream)
+{
+  cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
+  cuda_safe_call(cudaStreamIsCapturing(stream, &status));
+  return status == cudaStreamCaptureStatusActive;
+}
+
+// Run op during an active capture (forked to data's shard streams), expect a
+// std::runtime_error, and require the capture to remain ACTIVE.
+template <typename Fn>
+void expect_refusal_keeps_capture(cudaStream_t origin, Fn&& op)
+{
+  bool threw = false;
+  try
+  {
+    op();
+  }
+  catch (const ::std::runtime_error&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+  EXPECT(capture_active(origin));
+}
+
+void test_refusals(place_group& group)
+{
+  const size_t n = 65537;
+  auto data      = sharded_array<long long>::allocate(group, n);
+  iota(group, data, 0LL);
+  ::std::vector<long long> host(n, 1);
+
+  cudaStream_t origin;
+  cuda_safe_call(cudaStreamCreate(&origin));
+
+  cuda_safe_call(cudaStreamBeginCapture(origin, cudaStreamCaptureModeGlobal));
+  data.fork_from(origin);
+
+  // Allocation (owning and contiguous)
+  expect_refusal_keeps_capture(origin, [&] {
+    auto other = sharded_array<long long>::allocate(group, n);
+    (void) other;
+  });
+  expect_refusal_keeps_capture(origin, [&] {
+    auto other = sharded_array<long long>::allocate_contiguous(group, n);
+    (void) other;
+  });
+
+  // Host transfers
+  expect_refusal_keeps_capture(origin, [&] {
+    data.copy_from_host(host.data());
+  });
+  expect_refusal_keeps_capture(origin, [&] {
+    data.copy_to_host(host.data());
+  });
+
+  // Synchronization entry points
+  expect_refusal_keeps_capture(origin, [&] {
+    data.sync();
+  });
+  expect_refusal_keeps_capture(origin, [&] {
+    data.sync(0); // per-shard member refuses the same way
+  });
+  expect_refusal_keeps_capture(origin, [&] {
+    group.sync();
+  });
+
+  // Other synchronous collectives (host-side combine or size write-back)
+  expect_refusal_keeps_capture(origin, [&] {
+    (void) count(group, data, 7LL);
+  });
+  expect_refusal_keeps_capture(origin, [&] {
+    (void) histogram_even(group, data, 8, 0LL, static_cast<long long>(n));
+  });
+  expect_refusal_keeps_capture(origin, [&] {
+    (void) copy_if(group, data, is_even_op{});
+  });
+  expect_refusal_keeps_capture(origin, [&] {
+    (void) unique(group, data);
+  });
+
+  // A blocking elementwise call records its kernels, then refuses at the
+  // final sync — still without invalidating the capture
+  expect_refusal_keeps_capture(origin, [&] {
+    fill(group, data, 3LL); // blocking = true
+  });
+
+  // Abandon this capture (it holds the blocking fill's kernels)
+  cudaGraph_t graph = nullptr;
+  data.join_into(origin);
+  cuda_safe_call(cudaStreamEndCapture(origin, &graph));
+  EXPECT(graph != nullptr);
+  cuda_safe_call(cudaGraphDestroy(graph)); // never instantiated
+
+  // Everything refused above works eagerly after the capture
+  auto other = sharded_array<long long>::allocate(group, n);
+  (void) other;
+  data.copy_from_host(host.data());
+  data.copy_to_host(host.data());
+  EXPECT(count(group, data, 1LL) == n); // copy_from_host wrote all ones
+  data.sync();
+  group.sync();
+
+  cuda_safe_call(cudaStreamDestroy(origin));
+}
+
+// Adoption is host-only bookkeeping: it is permitted during capture, and the
+// adopted view is usable by captured elementwise work.
+void test_adoption_is_benign(place_group& group)
+{
+  const size_t n = 4096;
+  auto owner     = sharded_array<float>::allocate(group, n);
+  fill(group, owner, 1.0f);
+
+  cudaStream_t origin;
+  cuda_safe_call(cudaStreamCreate(&origin));
+  cuda_safe_call(cudaStreamBeginCapture(origin, cudaStreamCaptureModeGlobal));
+  owner.fork_from(origin);
+
+  auto view = owner.slice(0, n); // adoption path (non-owning view)
+  EXPECT(view.is_view());
+  EXPECT(capture_active(origin));
+  fill(group, view, 2.0f, /*blocking=*/false); // captured through the view
+
+  owner.join_into(origin);
+  cudaGraph_t graph = nullptr;
+  cuda_safe_call(cudaStreamEndCapture(origin, &graph));
+  cudaGraphExec_t exec = nullptr;
+  cuda_safe_call(cudaGraphInstantiate(&exec, graph, 0));
+  cuda_safe_call(cudaGraphLaunch(exec, origin));
+  cuda_safe_call(cudaStreamSynchronize(origin));
+
+  ::std::vector<float> host(n);
+  owner.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == 2.0f);
+  }
+
+  cuda_safe_call(cudaGraphExecDestroy(exec));
+  cuda_safe_call(cudaGraphDestroy(graph));
+  cuda_safe_call(cudaStreamDestroy(origin));
+}
+
+// place_group stream materialization during capture is benign: nothing is
+// recorded into the graph, the capture stays valid, and the group works
+// normally afterwards. (Construct groups and materialize streams BEFORE
+// capture anyway: first-touch process initialization is not similarly
+// guaranteed.)
+void test_group_materialization_records_nothing()
+{
+  cudaStream_t origin;
+  cuda_safe_call(cudaStreamCreate(&origin));
+
+  auto group = place_group::by_locality_domains();
+
+  cuda_safe_call(cudaStreamBeginCapture(origin, cudaStreamCaptureModeGlobal));
+  cudaStream_t s0 = group.get_stream(0); // lazy pool materialization
+  EXPECT(s0 != nullptr);
+  EXPECT(capture_active(origin));
+
+  cudaGraph_t graph = nullptr;
+  cuda_safe_call(cudaStreamEndCapture(origin, &graph));
+  size_t num_nodes = 0;
+  cuda_safe_call(cudaGraphGetNodes(graph, nullptr, &num_nodes));
+  EXPECT(num_nodes == 0);
+  cuda_safe_call(cudaGraphDestroy(graph));
+
+  // The group is fully usable after
+  auto data = sharded_array<int>::allocate(group, 1000);
+  fill(group, data, 5);
+  ::std::vector<int> host(1000);
+  data.copy_to_host(host.data());
+  for (int v : host)
+  {
+    EXPECT(v == 5);
+  }
+
+  cuda_safe_call(cudaStreamDestroy(origin));
+}
+} // namespace
+
+int main()
+{
+  cuda_safe_call(cudaSetDevice(0));
+
+  auto group = place_group::by_locality_domains();
+
+  test_refusals(group);
+  test_adoption_is_benign(group);
+  test_group_materialization_records_nothing();
+
+  return 0;
+}

--- a/cudax/test/sharded/graph_capture/reduce_scan_capture.cu
+++ b/cudax/test/sharded/graph_capture/reduce_scan_capture.cu
@@ -1,0 +1,156 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief Reduce and scan under CUDA graph capture: both have a host-side
+ *        combine phase and per-call temporaries, so the shipped contract is
+ *        to REFUSE cleanly (throw) when invoked during capture — without
+ *        invalidating the ongoing capture, which stays usable for supported
+ *        (elementwise) work — and to keep working eagerly afterwards.
+ */
+
+#include <cuda/experimental/sharded.cuh>
+
+#include <stdexcept>
+#include <vector>
+
+using namespace cuda::experimental::sharded;
+using cuda::experimental::places::place_group;
+
+namespace
+{
+struct plus_one_op
+{
+  __host__ __device__ long long operator()(long long x) const
+  {
+    return x + 1;
+  }
+};
+
+bool capture_active(cudaStream_t stream)
+{
+  cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
+  cuda_safe_call(cudaStreamIsCapturing(stream, &status));
+  return status == cudaStreamCaptureStatusActive;
+}
+
+void test_reduce_scan_refuse_under_capture(place_group& group)
+{
+  const size_t n = 100003;
+  auto data      = sharded_array<long long>::allocate(group, n);
+  iota(group, data, 0LL);
+
+  cudaStream_t origin;
+  cuda_safe_call(cudaStreamCreate(&origin));
+
+  cuda_safe_call(cudaStreamBeginCapture(origin, cudaStreamCaptureModeGlobal));
+  data.fork_from(origin);
+
+  // Every refusal must throw std::runtime_error and leave the capture ACTIVE
+  bool threw = false;
+  try
+  {
+    (void) reduce(group, data, ::cuda::std::plus<long long>{}, 0LL);
+  }
+  catch (const ::std::runtime_error&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+  EXPECT(capture_active(origin));
+
+  threw = false;
+  try
+  {
+    (void) sum(group, data);
+  }
+  catch (const ::std::runtime_error&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+  EXPECT(capture_active(origin));
+
+  threw = false;
+  try
+  {
+    inclusive_scan(group, data);
+  }
+  catch (const ::std::runtime_error&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+  EXPECT(capture_active(origin));
+
+  threw = false;
+  try
+  {
+    exclusive_scan(group, data, 5LL);
+  }
+  catch (const ::std::runtime_error&)
+  {
+    threw = true;
+  }
+  EXPECT(threw);
+  EXPECT(capture_active(origin));
+
+  // The capture is still usable for supported work: record an elementwise op
+  transform(group, data, plus_one_op{}, /*blocking=*/false);
+  data.join_into(origin);
+
+  cudaGraph_t graph = nullptr;
+  cuda_safe_call(cudaStreamEndCapture(origin, &graph));
+  EXPECT(graph != nullptr);
+  cudaGraphExec_t exec = nullptr;
+  cuda_safe_call(cudaGraphInstantiate(&exec, graph, 0));
+  cuda_safe_call(cudaGraphLaunch(exec, origin));
+  cuda_safe_call(cudaStreamSynchronize(origin));
+
+  // The refused calls left no partial work behind: data is exactly iota + 1
+  ::std::vector<long long> host(n);
+  data.copy_to_host(host.data());
+  for (size_t i = 0; i < n; i++)
+  {
+    EXPECT(host[i] == static_cast<long long>(i) + 1);
+  }
+
+  // Eager reduce/scan work normally after the capture (state not wedged)
+  const long long total = sum(group, data);
+  // sum of (i+1) for i in [0, n) = n*(n+1)/2
+  EXPECT(total == static_cast<long long>(n) * static_cast<long long>(n + 1) / 2);
+
+  inclusive_scan(group, data);
+  data.copy_to_host(host.data());
+  long long running = 0;
+  for (size_t i = 0; i < n; i++)
+  {
+    running += static_cast<long long>(i) + 1;
+    EXPECT(host[i] == running);
+  }
+
+  cuda_safe_call(cudaGraphExecDestroy(exec));
+  cuda_safe_call(cudaGraphDestroy(graph));
+  cuda_safe_call(cudaStreamDestroy(origin));
+}
+} // namespace
+
+int main()
+{
+  cuda_safe_call(cudaSetDevice(0));
+
+  auto group = place_group::by_locality_domains();
+
+  test_reduce_scan_refuse_under_capture(group);
+
+  return 0;
+}

--- a/cudax/test/sharded/include_only.cu
+++ b/cudax/test/sharded/include_only.cu
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Single umbrella include: must pull in the whole public sharded surface
+// (containers, algorithms, place_group) without requiring clients to list
+// internal headers.
+
+#include <cuda/experimental/sharded.cuh>
+
+using namespace cuda::experimental::sharded;
+
+int main()
+{
+  sharded_array<int> empty;
+  (void) empty.size();
+  (void) empty.is_contiguous();
+
+  shard<int> s;
+  (void) s.empty();
+
+  return 0;
+}

--- a/docs/cudax/index.rst
+++ b/docs/cudax/index.rst
@@ -11,6 +11,7 @@ CUDA Experimental
    container
    graph
    places
+   sharded
    stf
    API reference <api/index>
 
@@ -24,6 +25,7 @@ Specifically, ``cudax`` provides:
    - :ref:`graph functionality <cudax-graph>`
    - dimensions description functionality
    - :ref:`places <cudax-places>` for managing execution and data affinity across devices
+   - :ref:`sharded containers and algorithms <cudax-sharded>` over the places layer
    - :ref:`an implementation of the STF (Sequential Task Flow) programming model <stf>`
 
 Stability Guarantees

--- a/docs/cudax/sharded.rst
+++ b/docs/cudax/sharded.rst
@@ -57,6 +57,31 @@ are exact, physical ownership snaps to the allocation granularity, and
 consumers. Because the range is mapped once, shard sizes are fixed;
 size-mutating operations must refuse such arrays.
 
+Composing with a caller stream: ``fork_from`` / ``join_into``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sharded work runs on per-shard streams; callers usually have *one* stream
+carrying the surrounding computation. ``fork_from(stream)`` declares that the
+shard streams depend on the work currently enqueued on the caller stream (one
+event recorded on it, every shard stream waits); ``join_into(stream)`` is the
+mirror (one event per shard stream, the caller stream waits on all). Both are
+ordering declarations, not synchronizations — the host returns immediately:
+
+.. code-block:: cpp
+
+   producer<<<grid, block, 0, s>>>(...); // writes data's memory on stream s
+   data.fork_from(s);                    // shards now depend on the producer
+   transform(group, data, out, op);      // per-shard work on the shard streams
+   out.join_into(s);                     // s now depends on every shard
+   consumer<<<grid, block, 0, s>>>(...); // sees all results; no host sync
+
+The events come from a small pool owned by the container (created lazily,
+reused across calls), so adopted arrays over foreign streams are supported
+identically. Both members are capture-safe: inside an active CUDA graph
+capture the record/wait pairs become graph dependencies, making
+``fork_from``/``join_into`` the composition idiom between a captured caller
+stream (or graph) and the per-shard work.
+
 Algorithms
 ----------
 

--- a/docs/cudax/sharded.rst
+++ b/docs/cudax/sharded.rst
@@ -122,3 +122,86 @@ for. These algorithms therefore throw ``std::invalid_argument`` on contiguous
 (``allocate_contiguous``) arrays, leaving them untouched. Read-only
 algorithms (``count`` / ``count_if``, ``histogram_even``, ``reduce`` et al.)
 remain available on every sharded array, contiguous ones included.
+CUDA graph capture
+------------------
+
+The sharded surface splits cleanly along the capture boundary: elementwise
+computation records into a CUDA graph; everything that allocates, transfers
+host data or synchronizes refuses cleanly instead of corrupting the capture.
+
+What captures
+~~~~~~~~~~~~~
+
+The elementwise algorithms (``fill``, ``sequence``, ``iota``, ``tabulate``,
+``generate``, ``for_each``, ``transform``) called with ``blocking = false``
+are pure per-shard kernel launches on the shards' reference streams, so they
+capture with the containers' fork/join members — the documented way to
+compose sharded work with a caller stream or graph: begin capture on an
+origin stream, ``fork_from(origin)`` so every shard stream depends on it,
+record the pipeline, and ``join_into(origin)`` before ending the capture
+(the record/wait pairs become graph dependencies):
+
+.. code-block:: cpp
+
+   cudaStreamBeginCapture(origin, cudaStreamCaptureModeGlobal);
+   data.fork_from(origin);                          // fork
+
+   transform(group, data, out, op, /*blocking=*/false);
+   for_each(group, out, update, /*blocking=*/false);
+
+   out.join_into(origin);                           // join
+   cudaStreamEndCapture(origin, &graph);
+
+The captured graph is placement-faithful: each shard's kernels are recorded
+from that place's stream, and the per-place SM confinement of those streams
+survives instantiation and replay (pinned by an SM-id check in the test
+suite). Replays recompute from the *current* contents of the shards, so inputs
+may be rewritten — outside the graph — between launches. Contiguous
+(``allocate_contiguous``) arrays capture transparently: the VMM mappings
+pre-exist the capture, and per-shard stages compose with whole-array kernels
+through ``contiguous_data()`` inside one graph.
+
+What must stay outside — and how it fails
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Everything else on the surface performs host-side work a graph cannot
+represent. Those operations *refuse* under an active capture by throwing
+``std::runtime_error`` before touching the stream; the check is a safe
+query, so the ongoing capture remains VALID and keeps accepting supported
+work. The refusing set:
+
+- container allocation: ``allocate`` (all overloads) and
+  ``allocate_contiguous``;
+- host transfers: ``copy_from_host``, ``copy_to_host``, ``copy_between``;
+- synchronization: ``sharded_array::sync`` and ``place_group::sync`` —
+  and therefore the elementwise algorithms when called
+  with ``blocking = true``, which throw at their final sync (their kernels
+  are already recorded; the capture is still valid and can be completed or
+  abandoned);
+- the synchronous algorithms, all of which stage per-place partials through
+  the host: ``reduce`` / ``sum`` / ``min`` / ``max``, ``inclusive_scan`` /
+  ``exclusive_scan``, ``count`` / ``count_if``, ``histogram_even``,
+  ``copy_if`` / ``filter`` / ``remove_if``, ``unique``,
+  ``adjacent_difference``.
+
+The guards also refuse when a global-mode capture is active anywhere in the
+process, since the underlying synchronization would invalidate it under the
+CUDA capture rules. Shard adoption and ``slice`` are host-only bookkeeping
+and remain usable during capture; ``place_group`` construction and lazy
+stream materialization record nothing into a graph. Construct groups and
+containers before capturing, and destroy owning containers outside capture
+(freeing is stream-ordered and is not guarded).
+
+Graph-owned memory
+~~~~~~~~~~~~~~~~~~
+
+``place_memory_resource`` stream-ordered allocation is itself capturable: an
+``allocate`` on a capturing stream records a graph memory node drawing from
+the place's (locality-domain) pool, so placed temporaries can live inside a
+graph when the allocate/deallocate pair is enclosed in the capture. An
+allocation *not* freed inside the graph stays live after a launch — the
+captured pointer is readable — and relaunching before freeing fails; the
+pointer can be released outside the graph with ``cudaFreeAsync``, which
+re-arms the launch. The shipped contract stays simple — allocate outside
+capture; capture computation only — and the test suite pins both the
+recorded-allocation semantics and the failure shape of violations.

--- a/docs/cudax/sharded.rst
+++ b/docs/cudax/sharded.rst
@@ -1,48 +1,43 @@
-.._cudax
-    - sharded
-    :
+.. _cudax-sharded:
 
-    Sharded containers and algorithms
-  == == == == == == == == == == == == == == == == =
+Sharded containers and algorithms
+==================================
 
-  ..contents::
-    : depth : 2
+.. contents::
+   :depth: 2
 
-      Sharded containers partition one logical array across the places of a single process — devices
-    , or sub - device locality domains — while keeping a common address space.They extend the cooperation
-           - scope structure CUDA algorithms already follow
-    : a primitive at one scope runs the previous scope's primitive locally and combines results using what the new scope
-      shares(registers and shuffles within a warp, shared memory within a block, global memory within a device)
-        .At the places scope
-    , what is shared is one virtual address space with placed pages;
-at the multi - process / multi - node scope, where nothing is shared,
-  communicator
-    - based algorithms take over(see the MGMN algorithms built on ``__multi_gpu``)
-          .
+Sharded containers partition one logical array across the places of a single
+process — devices, or sub-device locality domains — while keeping a common
+address space. They extend the cooperation-scope structure CUDA algorithms
+already follow: a primitive at one scope runs the previous scope's primitive
+locally and combines results using what the new scope shares (registers and
+shuffles within a warp, shared memory within a block, global memory within a
+device). At the places scope, what is shared is one virtual address space with
+placed pages; at the multi-process/multi-node scope, where nothing is shared,
+communicator-based algorithms take over
+(see the MGMN algorithms built on ``__multi_gpu``).
 
-        The sharded API lives in the ``cuda::experimental::sharded`` namespace and is available through the ``cuda
-        / experimental / sharded.cuh`` header.It builds on the standalone : ref :`places<cudax - places>` layer;
-execution resources come from a
-    : ref
-    :`place_group<places - place - group>`.
+The sharded API lives in the ``cuda::experimental::sharded`` namespace and is
+available through the ``cuda/experimental/sharded.cuh`` header. It builds on
+the standalone :ref:`places <cudax-places>` layer; execution resources come
+from a :ref:`place_group <places-place-group>`.
 
-    sharded_array-- -- -- -- -- -- -
+sharded_array
+-------------
 
-``sharded_array<T>`` is a 1D array whose shards each carry their own placement : a ``data_place``
-    , an ``exec_place`` and a reference stream
-          .
+``sharded_array<T>`` is a 1D array whose shards each carry their own
+placement: a ``data_place``, an ``exec_place`` and a reference stream.
 
-          ..code
-        - block::cpp
+.. code-block:: cpp
 
-        using namespace cuda::experimental::sharded;
+   using namespace cuda::experimental::sharded;
 
-auto group     = place_group::by_locality_domains(); // re-exported from places
-const size_t n = 1u << 28;
-auto data      = sharded_array<double>::allocate(group, n);
+   auto group     = place_group::by_locality_domains(); // re-exported from places
+   const size_t n = 1u << 28;
+   auto data      = sharded_array<double>::allocate(group, n);
 
-iota(group, data, 0.0);
-double total = sum(group, data); // per-place CUB + combine
+   iota(group, data, 0.0);
+   double total = sum(group, data);   // per-place CUB + combine
 
 Factory naming follows a two-word rule: ``adopt`` = zero-copy view over
 caller-owned memory (the container becomes a view and the caller owes the

--- a/docs/cudax/sharded.rst
+++ b/docs/cudax/sharded.rst
@@ -1,0 +1,99 @@
+.._cudax
+    - sharded
+    :
+
+    Sharded containers and algorithms
+  == == == == == == == == == == == == == == == == =
+
+  ..contents::
+    : depth : 2
+
+      Sharded containers partition one logical array across the places of a single process — devices
+    , or sub - device locality domains — while keeping a common address space.They extend the cooperation
+           - scope structure CUDA algorithms already follow
+    : a primitive at one scope runs the previous scope's primitive locally and combines results using what the new scope
+      shares(registers and shuffles within a warp, shared memory within a block, global memory within a device)
+        .At the places scope
+    , what is shared is one virtual address space with placed pages;
+at the multi - process / multi - node scope, where nothing is shared,
+  communicator
+    - based algorithms take over(see the MGMN algorithms built on ``__multi_gpu``)
+          .
+
+        The sharded API lives in the ``cuda::experimental::sharded`` namespace and is available through the ``cuda
+        / experimental / sharded.cuh`` header.It builds on the standalone : ref :`places<cudax - places>` layer;
+execution resources come from a
+    : ref
+    :`place_group<places - place - group>`.
+
+    sharded_array-- -- -- -- -- -- -
+
+``sharded_array<T>`` is a 1D array whose shards each carry their own placement : a ``data_place``
+    , an ``exec_place`` and a reference stream
+          .
+
+          ..code
+        - block::cpp
+
+        using namespace cuda::experimental::sharded;
+
+auto group     = place_group::by_locality_domains(); // re-exported from places
+const size_t n = 1u << 28;
+auto data      = sharded_array<double>::allocate(group, n);
+
+iota(group, data, 0.0);
+double total = sum(group, data); // per-place CUB + combine
+
+Factory naming follows a two-word rule: ``adopt`` = zero-copy view over
+caller-owned memory (the container becomes a view and the caller owes the
+memory's lifetime); ``from_*`` = builds owned storage by copying or
+transforming its input. ``sharded_array<T>::adopt(shards)`` is the named
+form of the adopting constructor.
+
+``allocate_contiguous`` places the shards inside *one* contiguous virtual
+address range (VMM-backed via ``localized_array``): logical shard boundaries
+are exact, physical ownership snaps to the allocation granularity, and
+``contiguous_data()`` hands the whole array to unmodified single-pointer
+consumers. Because the range is mapped once, shard sizes are fixed;
+size-mutating operations must refuse such arrays.
+
+Algorithms
+----------
+
+The algorithm family:
+
+- elementwise: ``fill``, ``sequence``, ``iota``, ``tabulate``, ``generate``,
+  ``for_each``, ``transform`` (in-place, unary, binary) — no cross-place
+  stage;
+- ``reduce`` / ``sum`` / ``min`` / ``max``: per-place CUB ``DeviceReduce``
+  plus a combine of the per-place partials;
+- ``inclusive_scan`` / ``exclusive_scan``: per-place CUB ``DeviceScan``, then
+  per-place prefixes folded back in place;
+- ``adjacent_difference``: local differences plus one boundary element per
+  shard;
+- ``count`` / ``count_if``: per-place CUB transform-reduce plus a sum of the
+  per-place counts;
+- ``histogram_even``: per-place CUB ``DeviceHistogram`` plus a per-bin sum of
+  the per-place histograms;
+- ``copy_if`` / ``filter`` / ``remove_if``: per-place CUB ``DeviceSelect``
+  compaction in place, then shard sizes and offsets are updated;
+- ``unique``: per-place CUB ``DeviceSelect::Unique`` in place, then
+  duplicates straddling shard boundaries are trimmed with an O(1) size
+  decrement per boundary.
+
+Algorithm temporaries are drawn from each shard's place through the group's
+per-place memory resources.
+
+Size-mutating algorithms and the contiguous backing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``copy_if`` / ``filter`` / ``remove_if`` and ``unique`` shrink shard sizes in
+place (capacities are unchanged; ``reset_sizes_to_capacity()`` reuses the
+buffers). On a contiguous array this is unrepresentable: shrinking a shard
+would leave a gap between its valid elements and the next shard's, falsifying
+the read-as-one-array contract of ``contiguous_data()``, while compacting
+across the gap would migrate elements onto other places than the caller asked
+for. These algorithms therefore throw ``std::invalid_argument`` on contiguous
+(``allocate_contiguous``) arrays, leaving them untouched. Read-only
+algorithms (``count`` / ``count_if``, ``histogram_even``, ``reduce`` et al.)
+remain available on every sharded array, contiguous ones included.


### PR DESCRIPTION

## Description

> **Stacked on #10956** (`place_group`). The base is that PR's CI branch (`pull-request/10956`), so this diff shows exactly this PR's own 4 commits (containers / algorithms / fork-join / capture contract). Once #10956 merges, the base will be retargeted to `main` — the diff is unchanged by that.

### Motivation

CUB's structural invariant is that the primitive at scope N runs scope
N−1's primitive locally and combines using what scope N shares: warp
(registers/shuffles) → block (shared memory) → device (global memory).
Above the device, CCCL today offers the multi-process ranks rung
(`__multi_gpu`: nothing shared, message passing). One rung between them
has no programming surface: several places INSIDE one process — locality
domains, green-context places, devices-as-places — which still share one
virtual address space with placed pages. Users who partition data across
locality domains today hand-roll per-place allocation, per-place kernel
dispatch, per-place CUB calls and the cross-place combine, plus all the
stream ordering between them.

## The framing: CUB's cooperation-scope ladder, extended

CUB's structural invariant: the primitive at scope N = scope N−1's
primitive run locally + a combine using **what scope N shares**.

| scope | what is shared | combine mechanism | primitives |
|---|---|---|---|
| warp | registers | shuffles | `WarpReduce`, `WarpScan`, ... |
| block | shared memory | smem staging | `BlockReduce`, `BlockScan`, ... |
| device | global memory | global staging | `DeviceReduce`, `DeviceScan`, ... |
| **places** (one process) | **one VA, placed pages** | **in-place fold over the shared address space** | **sharded algorithms — this PR (`__sharded`)** |
| ranks (multi-process / multi-node) | nothing | message passing | communicator algorithms (`__multi_gpu` MGMN) |

Each rung owns its combine. Sharded containers exist exactly at the
highest rung that still shares an address space; where nothing is
shared, the MGMN communicator algorithms take over. The two surfaces are
scoped by rung and compose: hierarchical multi-process +
placed-per-process is ordinary rung nesting, the same way `DeviceReduce`
runs `BlockReduce` runs `WarpReduce`.

## What this PR adds

A new sibling capability `cudax/include/cuda/experimental/__sharded/`
(public umbrella `cuda/experimental/sharded.cuh`, namespace
`cuda::experimental::sharded`), peer to `__multi_gpu`, matching the
ladder 1:1. It builds only on the places layer and `place_group`
(#10956).

### Container tier

- `shard<T>`: one placed piece — `data/size/capacity/global_offset` +
  `data_place`/`exec_place`/reference stream + global↔local index math
- `sharded_array<T>`: allocation from explicit specs or from a
  `place_group` (even split or explicit sizes); **adoption** of existing
  buffers under the two-word rule (`adopt` = zero-copy view, caller owes
  lifetime; `from_*` = owned storage by copy); `allocate_like`; host
  transfer; `slice` with place correspondence preserved; `each_shard`
  visitation with exec-place activation; `copy_between` for arbitrary
  re-sharding
- **Contiguous backing contract** (`allocate_contiguous`): shards become
  views into ONE contiguous VA range whose physical pages are owned per
  place (VMM via `places::localized_array`). Logical shard boundaries
  are **exact**; physical ownership snaps to the allocation granularity.
  `contiguous_data()` hands the whole array to unmodified single-pointer
  consumers. Shard sizes are **fixed**: size-mutating operations refuse
  such arrays (documented and **enforced with a throw**). One VA also
  means one physical home per byte — the container holds partitioned
  data only; replicated operands belong to the binding tier (STF
  `logical_data`).
- **Place correspondence invariant**: one shard per group place, empty
  or not — a zero size at allocation keeps an empty shard in position
  (both `allocate` and `allocate_contiguous`), the same shape
  compaction leaves behind; every `(group, data)` algorithm pairs
  shards with places by index. `contiguous_backing_supported(device)`
  is the public capability query behind `allocate_contiguous`'s
  throw-on-unsupported contract; `release()` refuses the VMM backing
  (a mapping cannot be handed over through raw pointers).
- **Stream composition**: `fork_from(cudaStream_t)` /
  `join_into(cudaStream_t)` — ordering declarations (not
  synchronizations) bridging a caller stream and the per-shard streams
  via a container-owned lazy event pool; correct for adopted arrays with
  foreign streams; capture-safe. `sync(shard_idx)` synchronizes one
  shard in its execution context (and `sync()` iterates it).

### Algorithm tier (native, per-place CUB + combine)

- Elementwise (no cross-place stage): `fill`, `sequence`, `iota`,
  `tabulate`, `generate`, `for_each`, `transform` (in-place / unary /
  binary)
- `reduce`/`sum`/`min`/`max`: per-place `cub::DeviceReduce` through the
  group's environments, then a combine of the P partials
- `inclusive_scan`/`exclusive_scan`: per-place `cub::DeviceScan`, host
  prefix of the P shard totals, in-place prefix fold over the shared
  address space. Init and identity are distinct: inclusive custom-op
  scans need no identity (the prefix chain folds the preceding
  non-empty shards' totals), custom-op exclusive scans take init AND
  identity explicitly (locals run with the identity; the init seeds the
  global sequence exactly once); no equality requirement on the value
  type
- `adjacent_difference` (aliasing refused; the predecessor boundary
  crosses empty shards); `count`/`count_if`; `histogram_even`
- `copy_if`/`filter`/`remove_if` (per-place in-place
  `cub::DeviceSelect::If`, stable per-shard compaction, sizes/offsets
  updated, capacities kept); `unique` (`std::unique` semantics across
  shard boundaries, O(1) boundary trim against the previous non-empty
  shard)
- Size-mutators enforce the contiguous-backing contract
  (`std::invalid_argument`, array untouched)

Every algorithm takes `(place_group&, containers...)`; temporaries come
from each shard's own place. Conventions follow the reviewed layer
style: internals in `reserved`, `_CCCL_HOST_API` on the public
algorithm surface, `_CCCL_HOST_DEVICE_API` on the device-callable
`shard<T>` members.

### The CUDA-graph-capture contract (stated in `sharded.rst`, enforced, tested)

- **Captures**: the non-blocking elementwise family — pure per-shard
  kernel launches — with the standard fork/join idiom
  (`fork_from`/`join_into`). Pinned by tests: per-place (green-context)
  SM confinement **survives inside the instantiated graph** (SM-id
  check across two locality domains); replays recompute from current
  contents; cross-stream dependencies inside capture work; contiguous
  arrays are transparent to capture and per-shard stages compose with
  whole-array kernels in one graph.
- **Refuses cleanly**: everything that allocates containers, transfers
  host data or synchronizes throws `std::runtime_error` under an active
  capture, detected via the new safe query
  `places::stream_in_capture(stream)` (one shared guard,
  `places::check_not_capturing`) **before** any CUDA call — so the
  capture stays **valid** and keeps accepting supported work (under
  global-mode capture, the first illegal call would otherwise both
  error and invalidate the capture).
- **Benign**: adoption and `slice` (host-only bookkeeping) are usable
  during capture; `place_group` construction records nothing.
- **Graph-owned memory**: `place_memory_resource` allocation is
  deliberately left capturable (a graph mem-alloc node from the place's
  pool); both the balanced-pair and the unfreed-allocation shapes are
  pinned by tests. The documented user contract stays simple: allocate
  outside capture; capture computation only.

## Tests

`cudax/test/sharded/`: containers (allocation/index math/host
roundtrips/`copy_between`/adoption+slicing/contract throws), contiguous
(exact boundaries, per-shard writes read by one whole-range kernel
through the base pointer, and the reverse), elementwise + reduce/scan vs
host references over locality domains, count/histogram, compaction
(incl. empty-result shards, boundary-straddling `unique` runs, and the
refuse-on-contiguous negative tests), fork/join (eager
producer→fork→consumers→join→reader with one host sync, adopted-array
over foreign streams, capture instantiate+relaunch, degenerate no-ops),
in-place value mutation, external-stream lifecycle, and the 5
graph-capture suites ({elementwise_pipeline, reduce_scan_capture,
must_not_capture, graph_owned_memory, contiguous_capture}). Example:
`cudax/examples/places/sharded_reduce.cu` (256M elements over
`by_locality_domains()`).

Verified on a 2-locality-domain GB300 node (sm_103a, CUDA 13.4):

```
cmake --preset=cudax -DCMAKE_CUDA_ARCHITECTURES=103a -Dcudax_ENABLE_NCCL=OFF
ninja -C build/cudax cudax.test.sharded cudax.test.places cudax.example.places
ctest --test-dir build/cudax -R "cudax\.test\.(places|sharded)"
```

Launch build tally: **30/30** places+sharded ctest green (17 places + 8 sharded + 5 graph-capture suites); every intermediate commit compiles standalone.

### Sequenced next

Prepared as follow-ups in this series: a
places-scoped model of the `__multi_gpu` communicator concept (the
bridge between the two rungs), `sharded::sort` with one engine per rung,
a row-partitioned sparse tier, and Python bindings.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes
      (`docs/cudax/sharded.rst`, including the graph-capture section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)