### PR TITLE
[libcu++] Fix the base 10 width of exact powers of ten in to_chars

### DIFF
--- a/libcudacxx/include/cuda/std/__charconv/to_chars.h
+++ b/libcudacxx/include/cuda/std/__charconv/to_chars.h
@@ -104,9 +104,7 @@ template <int _Base, class _Tp>
     return ::cuda::ceil_div(__num_bits_v<_Tp> - ::cuda::std::countl_zero(static_cast<_Tp>(__v | 1)), __base_ilog2);
   }
   else if constexpr (_Base == 10)
-  {
-    // the number of digits of __v is ilog10(__v) + 1; ceil_ilog10(__v) counts the digits of
-    // __v - 1 and undercounts exact powers of ten
+  { // the number of digits of __v is ilog10(__v) + 1
     return (__v > 1) ? ::cuda::ilog10(__v) + 1 : 1;
   }
   else

--- a/libcudacxx/include/cuda/std/__charconv/to_chars.h
+++ b/libcudacxx/include/cuda/std/__charconv/to_chars.h
@@ -105,7 +105,9 @@ template <int _Base, class _Tp>
   }
   else if constexpr (_Base == 10)
   {
-    return (__v > 1) ? ::cuda::ceil_ilog10(__v) : 1;
+    // the number of digits of __v is ilog10(__v) + 1; ceil_ilog10(__v) counts the digits of
+    // __v - 1 and undercounts exact powers of ten
+    return (__v > 1) ? ::cuda::ilog10(__v) + 1 : 1;
   }
   else
   {

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
@@ -21,55 +21,27 @@
 #include "test_macros.h"
 
 template <typename T>
-TEST_FUNC constexpr int digit_count(T value)
+TEST_FUNC constexpr bool test_value(T value, int expected_digits)
 {
-  // counts the characters to_chars writes: one more for the sign when negative.
-  // dividing the magnitude by ten before negating keeps the minimum representable,
-  // and that division drops exactly one digit, which the second increment accounts for
-  int count             = 1;
-  T remaining           = value;
-  constexpr bool is_neg = cuda::std::is_signed_v<T>;
-  if constexpr (is_neg)
-  {
-    if (remaining < 0)
-    {
-      remaining = static_cast<T>(-(remaining / T{10}));
-      ++count;
-    }
-  }
-  while (remaining >= T{10})
-  {
-    remaining /= T{10};
-    ++count;
-  }
-  return count;
-}
-
-template <typename T>
-TEST_FUNC constexpr bool test_value(T value)
-{
-  const int expected_digits = digit_count(value);
-  const int expected_len    = value < 0 ? expected_digits + 1 : expected_digits;
+  const int expected_len = value < 0 ? expected_digits + 1 : expected_digits;
 
   char raw[256] = {};
   char* buf     = raw + 1;
   raw[0]        = '#';
 
   auto res = cuda::std::to_chars(buf, buf + 254, value);
-  if (res.ec != cuda::std::errc{})
-  {
-    return false;
-  }
-  if (res.ptr - buf != expected_len)
-  {
-    return false;
-  }
-  if (raw[0] != '#')
+  if (res.ec != cuda::std::errc{} || res.ptr - buf != expected_len || raw[0] != '#')
   {
     return false;
   }
 
-  // round trip
+  // a buffer one character short of the exact width must fail without writing
+  auto narrow = cuda::std::to_chars(buf, buf + expected_len - 1, value);
+  if (narrow.ec != cuda::std::errc::value_too_large)
+  {
+    return false;
+  }
+
   T parsed{};
   auto pr = cuda::std::from_chars(buf, res.ptr, parsed);
   if (pr.ec != cuda::std::errc{} || parsed != value)
@@ -82,34 +54,61 @@ TEST_FUNC constexpr bool test_value(T value)
 template <typename T>
 TEST_FUNC constexpr bool test_powers_of_ten()
 {
-  T power = T{10};
+  T power    = T{10};
+  int digits = 2;
   while (power <= cuda::std::numeric_limits<T>::max() / T{10})
   {
-    if (!test_value(power))
+    if (!test_value(power, digits))
     {
       return false;
     }
-    if (!test_value(static_cast<T>(-power)))
+    if constexpr (cuda::std::is_signed_v<T>)
     {
-      return false;
+      if (!test_value(T{-1} * power, digits + 1))
+      {
+        return false;
+      }
     }
     power *= T{10};
+    ++digits;
   }
-  return test_value(power);
+  if (!test_value(power, digits))
+  {
+    return false;
+  }
+  if constexpr (cuda::std::is_signed_v<T>)
+  {
+    return test_value(T{-1} * power, digits + 1);
+  }
+  return true;
+}
+
+TEST_FUNC constexpr bool test()
+{
+  bool ok = true;
+  ok = ok && test_powers_of_ten<cuda::std::int8_t>();
+  ok = ok && test_powers_of_ten<cuda::std::int16_t>();
+  ok = ok && test_powers_of_ten<cuda::std::int32_t>();
+  ok = ok && test_powers_of_ten<cuda::std::int64_t>();
+#if _CCCL_HAS_INT128()
+  ok = ok && test_powers_of_ten<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  ok = ok && test_powers_of_ten<cuda::std::uint8_t>();
+  ok = ok && test_powers_of_ten<cuda::std::uint16_t>();
+  ok = ok && test_powers_of_ten<cuda::std::uint32_t>();
+  ok = ok && test_powers_of_ten<cuda::std::uint64_t>();
+#if _CCCL_HAS_INT128()
+  ok = ok && test_powers_of_ten<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return ok;
 }
 
 int main(int, char**)
 {
-  assert(test_powers_of_ten<int32_t>());
-  static_assert(test_powers_of_ten<uint32_t>());
-
-  assert(test_powers_of_ten<uint32_t>());
-  assert(test_powers_of_ten<int64_t>());
-  assert(test_powers_of_ten<uint64_t>());
-#if _CCCL_HAS_INT128()
-  assert(test_powers_of_ten<__int128_t>());
-  assert(test_powers_of_ten<__uint128_t>());
-#endif // _CCCL_HAS_INT128()
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
@@ -38,6 +38,7 @@ TEST_FUNC constexpr void test_value(T value, int expected_digits)
   // a buffer one character short of the exact width must fail without writing
   auto narrow = cuda::std::to_chars(buf, buf + expected_len - 1, value);
   assert(narrow.ec == cuda::std::errc::value_too_large);
+  assert(raw[0] == '#');
 
   T parsed{};
   auto pr = cuda::std::from_chars(buf, res.ptr, parsed);

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
@@ -1,0 +1,115 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Regression test: the base 10 width of exact powers of ten used to be
+// undercounted by one, writing one byte before the output buffer while
+// reporting success
+
+#include <cuda/std/charconv>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+template <typename T>
+TEST_FUNC constexpr int digit_count(T value)
+{
+  // counts the characters to_chars writes: one more for the sign when negative.
+  // dividing the magnitude by ten before negating keeps the minimum representable,
+  // and that division drops exactly one digit, which the second increment accounts for
+  int count             = 1;
+  T remaining           = value;
+  constexpr bool is_neg = cuda::std::is_signed_v<T>;
+  if constexpr (is_neg)
+  {
+    if (remaining < 0)
+    {
+      remaining = static_cast<T>(-(remaining / T{10}));
+      ++count;
+    }
+  }
+  while (remaining >= T{10})
+  {
+    remaining /= T{10};
+    ++count;
+  }
+  return count;
+}
+
+template <typename T>
+TEST_FUNC constexpr bool test_value(T value)
+{
+  const int expected_digits = digit_count(value);
+  const int expected_len    = value < 0 ? expected_digits + 1 : expected_digits;
+
+  char raw[256] = {};
+  char* buf     = raw + 1;
+  raw[0]        = '#';
+
+  auto res = cuda::std::to_chars(buf, buf + 254, value);
+  if (res.ec != cuda::std::errc{})
+  {
+    return false;
+  }
+  if (res.ptr - buf != expected_len)
+  {
+    return false;
+  }
+  if (raw[0] != '#')
+  {
+    return false;
+  }
+
+  // round trip
+  T parsed{};
+  auto pr = cuda::std::from_chars(buf, res.ptr, parsed);
+  if (pr.ec != cuda::std::errc{} || parsed != value)
+  {
+    return false;
+  }
+  return true;
+}
+
+template <typename T>
+TEST_FUNC constexpr bool test_powers_of_ten()
+{
+  T power = T{10};
+  while (power <= cuda::std::numeric_limits<T>::max() / T{10})
+  {
+    if (!test_value(power))
+    {
+      return false;
+    }
+    if (!test_value(static_cast<T>(-power)))
+    {
+      return false;
+    }
+    power *= T{10};
+  }
+  return test_value(power);
+}
+
+int main(int, char**)
+{
+  assert(test_powers_of_ten<int32_t>());
+  static_assert(test_powers_of_ten<uint32_t>());
+
+  assert(test_powers_of_ten<uint32_t>());
+  assert(test_powers_of_ten<int64_t>());
+  assert(test_powers_of_ten<uint64_t>());
+#if _CCCL_HAS_INT128()
+  assert(test_powers_of_ten<__int128_t>());
+  assert(test_powers_of_ten<__uint128_t>());
+#endif // _CCCL_HAS_INT128()
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
@@ -12,6 +12,7 @@
 // undercounted by one, writing one byte before the output buffer while
 // reporting success
 
+#include <cuda/std/cassert>
 #include <cuda/std/charconv>
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
@@ -44,11 +45,7 @@ TEST_FUNC constexpr bool test_value(T value, int expected_digits)
 
   T parsed{};
   auto pr = cuda::std::from_chars(buf, res.ptr, parsed);
-  if (pr.ec != cuda::std::errc{} || parsed != value)
-  {
-    return false;
-  }
-  return true;
+  return !(pr.ec != cuda::std::errc{} || parsed != value);
 }
 
 template <typename T>
@@ -64,7 +61,7 @@ TEST_FUNC constexpr bool test_powers_of_ten()
     }
     if constexpr (cuda::std::is_signed_v<T>)
     {
-      if (!test_value(T{-1} * power, digits + 1))
+      if (!test_value(T{-1} * power, digits))
       {
         return false;
       }
@@ -78,7 +75,7 @@ TEST_FUNC constexpr bool test_powers_of_ten()
   }
   if constexpr (cuda::std::is_signed_v<T>)
   {
-    return test_value(T{-1} * power, digits + 1);
+    return test_value(T{-1} * power, digits);
   }
   return true;
 }
@@ -105,10 +102,26 @@ TEST_FUNC constexpr bool test()
   return ok;
 }
 
+// to_chars is not constexpr for signed types, so constant evaluation covers
+// the unsigned set only.
+TEST_FUNC constexpr bool test_constexpr()
+{
+  bool ok = true;
+  ok = ok && test_powers_of_ten<cuda::std::uint8_t>();
+  ok = ok && test_powers_of_ten<cuda::std::uint16_t>();
+  ok = ok && test_powers_of_ten<cuda::std::uint32_t>();
+  ok = ok && test_powers_of_ten<cuda::std::uint64_t>();
+#if _CCCL_HAS_INT128()
+  ok = ok && test_powers_of_ten<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return ok;
+}
+
 int main(int, char**)
 {
-  test();
-  static_assert(test());
+  assert(test());
+  static_assert(test_constexpr());
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
@@ -83,10 +83,10 @@ TEST_FUNC constexpr bool test_powers_of_ten()
 TEST_FUNC constexpr bool test()
 {
   bool ok = true;
-  ok = ok && test_powers_of_ten<cuda::std::int8_t>();
-  ok = ok && test_powers_of_ten<cuda::std::int16_t>();
-  ok = ok && test_powers_of_ten<cuda::std::int32_t>();
-  ok = ok && test_powers_of_ten<cuda::std::int64_t>();
+  ok      = ok && test_powers_of_ten<cuda::std::int8_t>();
+  ok      = ok && test_powers_of_ten<cuda::std::int16_t>();
+  ok      = ok && test_powers_of_ten<cuda::std::int32_t>();
+  ok      = ok && test_powers_of_ten<cuda::std::int64_t>();
 #if _CCCL_HAS_INT128()
   ok = ok && test_powers_of_ten<__int128_t>();
 #endif // _CCCL_HAS_INT128()
@@ -107,10 +107,10 @@ TEST_FUNC constexpr bool test()
 TEST_FUNC constexpr bool test_constexpr()
 {
   bool ok = true;
-  ok = ok && test_powers_of_ten<cuda::std::uint8_t>();
-  ok = ok && test_powers_of_ten<cuda::std::uint16_t>();
-  ok = ok && test_powers_of_ten<cuda::std::uint32_t>();
-  ok = ok && test_powers_of_ten<cuda::std::uint64_t>();
+  ok      = ok && test_powers_of_ten<cuda::std::uint8_t>();
+  ok      = ok && test_powers_of_ten<cuda::std::uint16_t>();
+  ok      = ok && test_powers_of_ten<cuda::std::uint32_t>();
+  ok      = ok && test_powers_of_ten<cuda::std::uint64_t>();
 #if _CCCL_HAS_INT128()
   ok = ok && test_powers_of_ten<__uint128_t>();
 #endif // _CCCL_HAS_INT128()

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
@@ -24,7 +24,14 @@
 template <typename T>
 TEST_FUNC constexpr void test_value(T value, int expected_digits)
 {
-  const int expected_len = value < 0 ? expected_digits + 1 : expected_digits;
+  int expected_len = expected_digits;
+  if constexpr (cuda::std::is_signed_v<T>)
+  {
+    if (value < 0)
+    {
+      ++expected_len;
+    }
+  }
 
   char raw[256] = {};
   char* buf     = raw + 1;

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/powers_of_ten.pass.cpp
@@ -22,7 +22,7 @@
 #include "test_macros.h"
 
 template <typename T>
-TEST_FUNC constexpr bool test_value(T value, int expected_digits)
+TEST_FUNC constexpr void test_value(T value, int expected_digits)
 {
   const int expected_len = value < 0 ? expected_digits + 1 : expected_digits;
 
@@ -31,97 +31,67 @@ TEST_FUNC constexpr bool test_value(T value, int expected_digits)
   raw[0]        = '#';
 
   auto res = cuda::std::to_chars(buf, buf + 254, value);
-  if (res.ec != cuda::std::errc{} || res.ptr - buf != expected_len || raw[0] != '#')
-  {
-    return false;
-  }
+  assert(res.ec == cuda::std::errc{});
+  assert(res.ptr - buf == expected_len);
+  assert(raw[0] == '#');
 
   // a buffer one character short of the exact width must fail without writing
   auto narrow = cuda::std::to_chars(buf, buf + expected_len - 1, value);
-  if (narrow.ec != cuda::std::errc::value_too_large)
-  {
-    return false;
-  }
+  assert(narrow.ec == cuda::std::errc::value_too_large);
 
   T parsed{};
   auto pr = cuda::std::from_chars(buf, res.ptr, parsed);
-  return !(pr.ec != cuda::std::errc{} || parsed != value);
+  assert(pr.ec == cuda::std::errc{});
+  assert(parsed == value);
 }
 
 template <typename T>
-TEST_FUNC constexpr bool test_powers_of_ten()
+TEST_FUNC constexpr void test_powers_of_ten()
 {
   T power    = T{10};
   int digits = 2;
   while (power <= cuda::std::numeric_limits<T>::max() / T{10})
   {
-    if (!test_value(power, digits))
-    {
-      return false;
-    }
+    test_value(power, digits);
     if constexpr (cuda::std::is_signed_v<T>)
     {
-      if (!test_value(T{-1} * power, digits))
-      {
-        return false;
-      }
+      test_value(-power, digits);
     }
     power *= T{10};
     ++digits;
   }
-  if (!test_value(power, digits))
-  {
-    return false;
-  }
+  test_value(power, digits);
   if constexpr (cuda::std::is_signed_v<T>)
   {
-    return test_value(T{-1} * power, digits);
+    test_value(-power, digits);
   }
-  return true;
 }
 
 TEST_FUNC constexpr bool test()
 {
-  bool ok = true;
-  ok      = ok && test_powers_of_ten<cuda::std::int8_t>();
-  ok      = ok && test_powers_of_ten<cuda::std::int16_t>();
-  ok      = ok && test_powers_of_ten<cuda::std::int32_t>();
-  ok      = ok && test_powers_of_ten<cuda::std::int64_t>();
+  test_powers_of_ten<cuda::std::int8_t>();
+  test_powers_of_ten<cuda::std::int16_t>();
+  test_powers_of_ten<cuda::std::int32_t>();
+  test_powers_of_ten<cuda::std::int64_t>();
 #if _CCCL_HAS_INT128()
-  ok = ok && test_powers_of_ten<__int128_t>();
+  test_powers_of_ten<__int128_t>();
 #endif // _CCCL_HAS_INT128()
 
-  ok = ok && test_powers_of_ten<cuda::std::uint8_t>();
-  ok = ok && test_powers_of_ten<cuda::std::uint16_t>();
-  ok = ok && test_powers_of_ten<cuda::std::uint32_t>();
-  ok = ok && test_powers_of_ten<cuda::std::uint64_t>();
+  test_powers_of_ten<cuda::std::uint8_t>();
+  test_powers_of_ten<cuda::std::uint16_t>();
+  test_powers_of_ten<cuda::std::uint32_t>();
+  test_powers_of_ten<cuda::std::uint64_t>();
 #if _CCCL_HAS_INT128()
-  ok = ok && test_powers_of_ten<__uint128_t>();
+  test_powers_of_ten<__uint128_t>();
 #endif // _CCCL_HAS_INT128()
 
-  return ok;
-}
-
-// to_chars is not constexpr for signed types, so constant evaluation covers
-// the unsigned set only.
-TEST_FUNC constexpr bool test_constexpr()
-{
-  bool ok = true;
-  ok      = ok && test_powers_of_ten<cuda::std::uint8_t>();
-  ok      = ok && test_powers_of_ten<cuda::std::uint16_t>();
-  ok      = ok && test_powers_of_ten<cuda::std::uint32_t>();
-  ok      = ok && test_powers_of_ten<cuda::std::uint64_t>();
-#if _CCCL_HAS_INT128()
-  ok = ok && test_powers_of_ten<__uint128_t>();
-#endif // _CCCL_HAS_INT128()
-
-  return ok;
+  return true;
 }
 
 int main(int, char**)
 {
-  assert(test());
-  static_assert(test_constexpr());
+  test();
+  static_assert(test());
 
   return 0;
 }


### PR DESCRIPTION
## Description

closes #10971

The base 10 width used by `cuda::std::to_chars` was computed with `ceil_ilog10(v)`, which counts the digits of `v - 1`. For exact powers of ten the width is one short, so the capacity check passes wrongly and the backward conversion loop writes one byte before the output buffer while returning success; negative values lose their sign slot instead. Counting digits as `ilog10(v) + 1` gives the exact width for every value.

A regression test walks powers of ten for every integer width, checking the written length against an independently computed digit count, a canary byte in front of the buffer, and a `from_chars` round trip, both at runtime and at compile time.

### AI assistance

This change was prepared with the help of an AI coding agent; a human reviewed, tested and is submitting it.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
