### PR TITLE
Allow a `__logical_device` to also be backed by a `CUcontext`

### DIFF
--- a/libcudacxx/include/cuda/__device/logical_device.h
+++ b/libcudacxx/include/cuda/__device/logical_device.h
@@ -41,10 +41,13 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 class __logical_device : public __logical_device_ref
 {
 public:
-  [[nodiscard]] _CCCL_HOST_API static __logical_device
-  from_native_handle(device_ref __device, ::CUgreenCtx __gctx) noexcept
+  _CCCL_HOST_API explicit __logical_device(device_ref __device)
+      : __logical_device_ref{__device}
+  {}
+
+  [[nodiscard]] _CCCL_HOST_API static __logical_device from_native_handle(device_ref __device, ::CUgreenCtx __gctx)
   {
-    return {__device, __gctx};
+    return __logical_device{__device, __gctx};
   }
 
   static __logical_device from_native_handle(device_ref, int)                    = delete;
@@ -55,8 +58,10 @@ public:
   __logical_device(const __logical_device&)            = delete;
   __logical_device& operator=(const __logical_device&) = delete;
 
-  _CCCL_HOST_API constexpr __logical_device(__logical_device&& __other) noexcept
-      : __logical_device_ref{::cuda::std::move(__other.__device_), ::cuda::std::exchange(__other.__gctx_, nullptr)}
+  _CCCL_HOST_API __logical_device(__logical_device&& __other) noexcept
+      : __logical_device_ref{::cuda::std::move(__other.__device_),
+                             ::cuda::std::exchange(__other.__cu_ctx_, nullptr),
+                             ::cuda::std::exchange(__other.__green_ctx_, nullptr)}
   {}
 
   _CCCL_HOST_API __logical_device& operator=(__logical_device&& __other) noexcept
@@ -64,8 +69,9 @@ public:
     if (this != &__other)
     {
       __reset();
-      __device_ = ::cuda::std::move(__other.__device_);
-      __gctx_   = ::cuda::std::exchange(__other.__gctx_, nullptr);
+      __device_    = ::cuda::std::move(__other.__device_);
+      __cu_ctx_    = ::cuda::std::exchange(__other.__cu_ctx_, nullptr);
+      __green_ctx_ = ::cuda::std::exchange(__other.__green_ctx_, nullptr);
     }
     return *this;
   }
@@ -76,18 +82,19 @@ public:
   }
 
 private:
-  _CCCL_HOST_API constexpr __logical_device(device_ref __device, ::CUgreenCtx __gctx) noexcept
+  _CCCL_HOST_API explicit __logical_device(device_ref __device, ::CUgreenCtx __gctx)
       : __logical_device_ref{__device, __gctx}
   {}
 
   _CCCL_HOST_API void __reset() noexcept
   {
-    if (__gctx_)
+    if (this->kind() == kinds::green_context)
     {
 #  if _CCCL_CTK_AT_LEAST(12, 5)
-      static_cast<void>(::cuda::__driver::__greenCtxDestroyNoThrow(__gctx_));
+      static_cast<void>(::cuda::__driver::__greenCtxDestroyNoThrow(green_context()));
 #  endif // _CCCL_CTK_AT_LEAST(12, 5)
-      __gctx_ = nullptr;
+      __green_ctx_ = nullptr;
+      __cu_ctx_    = nullptr;
     }
   }
 };

--- a/libcudacxx/include/cuda/__device/logical_device_ref.h
+++ b/libcudacxx/include/cuda/__device/logical_device_ref.h
@@ -25,7 +25,9 @@
 
 #  include <cuda/__device/device_ref.h>
 #  include <cuda/__driver/driver_api.h>
+#  include <cuda/__fwd/devices.h>
 #  include <cuda/std/__cstddef/types.h>
+#  include <cuda/std/cstdint>
 
 #  include <cuda/std/__cccl/prologue.h>
 
@@ -38,21 +40,48 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 class __logical_device_ref
 {
 public:
-  __logical_device_ref() = delete;
+  enum class kinds : ::cuda::std::uint8_t
+  {
+    device,
+    green_context
+  };
 
-  _CCCL_HOST_API constexpr __logical_device_ref(device_ref __dev, ::CUgreenCtx __gctx) noexcept
-      : __device_{__dev}
-      , __gctx_{__gctx}
+  __logical_device_ref()                                   = delete;
+  __logical_device_ref(device_ref, int)                    = delete;
+  __logical_device_ref(device_ref, ::cuda::std::nullptr_t) = delete;
+
+  _CCCL_HOST_API explicit __logical_device_ref(device_ref __dev)
+      : __logical_device_ref{__dev, __dev.__primary_context(), ::CUgreenCtx{}}
   {}
 
-  [[nodiscard]] _CCCL_HOST_API constexpr device_ref underlying_device() const noexcept
+  _CCCL_HOST_API __logical_device_ref(device_ref __dev, ::CUgreenCtx __gctx)
+      : __logical_device_ref{__dev,
+#  if _CCCL_CTK_AT_LEAST(12, 5)
+                             ::cuda::__driver::__ctxFromGreenCtx(__gctx),
+#  else // ^^^ 12.5+ ^^^ / vvv 12.4- vvv
+                             ::CUcontext{},
+#  endif // ^^^ 12.4- ^^^
+                             __gctx}
+  {}
+
+  [[nodiscard]] _CCCL_HOST_API device_ref underlying_device() const noexcept
   {
     return __device_;
   }
 
-  [[nodiscard]] _CCCL_HOST_API constexpr ::CUgreenCtx green_context() const noexcept
+  [[nodiscard]] _CCCL_HOST_API kinds kind() const noexcept
   {
-    return __gctx_;
+    return __green_ctx_ == nullptr ? kinds::device : kinds::green_context;
+  }
+
+  [[nodiscard]] _CCCL_HOST_API ::CUgreenCtx green_context() const noexcept
+  {
+    return __green_ctx_;
+  }
+
+  [[nodiscard]] _CCCL_HOST_API ::CUcontext context() const noexcept
+  {
+    return __cu_ctx_;
   }
 
   // Deliberately __ugly (and should stay __ugly after we publicize this class). The exact type
@@ -69,10 +98,10 @@ public:
   [[nodiscard]] _CCCL_HOST_API __locality_domain_result locality_domain() const
   {
 #  if _CCCL_CTK_AT_LEAST(13, 4)
-    if (__gctx_)
+    if (kind() == kinds::green_context)
     {
       const ::CUdevResource __sm_resource =
-        ::cuda::__driver::__ctxGetDevResource(::cuda::__driver::__ctxFromGreenCtx(__gctx_), ::CU_DEV_RESOURCE_TYPE_SM);
+        ::cuda::__driver::__ctxGetDevResource(this->context(), ::CU_DEV_RESOURCE_TYPE_SM);
 
       if (__sm_resource.sm.flags & ::CU_DEV_SM_RESOURCE_GROUP_LOCALITY_DOMAIN_ID)
       {
@@ -92,7 +121,8 @@ public:
   [[nodiscard]] _CCCL_HOST_API friend constexpr bool
   operator==(const __logical_device_ref& __lhs, const __logical_device_ref& __rhs) noexcept
   {
-    return __lhs.__device_ == __rhs.__device_ && __lhs.__gctx_ == __rhs.__gctx_;
+    // It suffices to check the cu context, the same green context will return the same outer context
+    return __lhs.__device_ == __rhs.__device_ && __lhs.__cu_ctx_ == __rhs.__cu_ctx_;
   }
 
 #  if _CCCL_STD_VER <= 2017
@@ -104,8 +134,16 @@ public:
 #  endif // _CCCL_STD_VER <= 2017
 
 protected:
+  _CCCL_HOST_API constexpr __logical_device_ref(
+    device_ref __device, ::CUcontext __cu_ctx, ::CUgreenCtx __green_ctx) noexcept
+      : __device_{__device}
+      , __cu_ctx_{__cu_ctx}
+      , __green_ctx_{__green_ctx}
+  {}
+
   device_ref __device_{0};
-  ::CUgreenCtx __gctx_{};
+  ::CUcontext __cu_ctx_{};
+  ::CUgreenCtx __green_ctx_{};
 };
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__device/physical_device.h
+++ b/libcudacxx/include/cuda/__device/physical_device.h
@@ -183,9 +183,7 @@ class __physical_device
   {
     auto __domains = ::cuda::__make_raw_storage_array<__logical_device>(/*__count=*/1);
 
-    ::cuda::std::__construct_at(__domains.get(),
-                                __logical_device::from_native_handle(
-                                  __device_, ::cuda::__driver::__greenCtxCreate(__device_, /*__descriptor=*/nullptr)));
+    ::cuda::std::__construct_at(__domains.get(), __device_);
     __domains.get_deleter().__count_ = 1;
 
     auto __refs = ::cuda::__make_raw_storage_array<__logical_device_ref>(/*__count=*/1);

--- a/libcudacxx/include/cuda/__runtime/ensure_current_context.h
+++ b/libcudacxx/include/cuda/__runtime/ensure_current_context.h
@@ -72,11 +72,9 @@ struct [[maybe_unused]] __ensure_current_context
   //! @throws cuda_error if the context switch fails
   _CCCL_HOST_API explicit __ensure_current_context(stream_ref __stream);
 
-#    if _CCCL_CTK_AT_LEAST(12, 5)
   _CCCL_HOST_API explicit __ensure_current_context(__logical_device_ref __device)
       : __ensure_current_context{__device.context()}
   {}
-#    endif // _CCCL_CTK_AT_LEAST(12, 5)
 
   __ensure_current_context(__ensure_current_context&&)                 = delete;
   __ensure_current_context(__ensure_current_context const&)            = delete;

--- a/libcudacxx/include/cuda/__runtime/ensure_current_context.h
+++ b/libcudacxx/include/cuda/__runtime/ensure_current_context.h
@@ -74,7 +74,7 @@ struct [[maybe_unused]] __ensure_current_context
 
 #    if _CCCL_CTK_AT_LEAST(12, 5)
   _CCCL_HOST_API explicit __ensure_current_context(__logical_device_ref __device)
-      : __ensure_current_context{::cuda::__driver::__ctxFromGreenCtx(__device.green_context())}
+      : __ensure_current_context{__device.context()}
   {}
 #    endif // _CCCL_CTK_AT_LEAST(12, 5)
 

--- a/libcudacxx/include/cuda/__stream/stream.h
+++ b/libcudacxx/include/cuda/__stream/stream.h
@@ -53,13 +53,33 @@ struct stream : stream_ref
   }
 
 #  if _CCCL_CTK_AT_LEAST(12, 5)
+  // The whole _CCCL_UNREACHABLE() thing was added for MSVC, yet now it complains the
+  // _CCCL_UNREACHABLE() is in fact not reachable. Incredible.
+  _CCCL_DIAG_PUSH
+  _CCCL_DIAG_SUPPRESS_MSVC(4702) // warning C4702: unreachable code
+
   _CCCL_HOST_API explicit stream(__logical_device_ref __device, int __priority = default_priority)
-      : stream_ref{
-          // We do not need __ensure_current_context here, the driver explicitly states it
-          // ignores any context that is current for this call.
-          ::cuda::__driver::__greenCtxStreamCreate(__device.green_context(), ::CU_STREAM_NON_BLOCKING, __priority)}
+      : stream_ref{[&] {
+        switch (__device.kind())
+        {
+          case __logical_device_ref::kinds::device: {
+            const auto _ = __ensure_current_context{__device};
+
+            return ::cuda::__driver::__streamCreateWithPriority(::CU_STREAM_NON_BLOCKING, __priority);
+          }
+          case __logical_device_ref::kinds::green_context:
+            // We do not need __ensure_current_context here, the driver explicitly states it
+            // ignores any context that is current for this call.
+            return ::cuda::__driver::__greenCtxStreamCreate(
+              __device.green_context(), ::CU_STREAM_NON_BLOCKING, __priority);
+        }
+        _CCCL_UNREACHABLE();
+        return ::CUstream{};
+      }()}
   {}
-#  endif
+
+  _CCCL_DIAG_POP
+#  endif // _CCCL_CTK_AT_LEAST(12, 5)
 
   //! @brief Construct a new `stream` object into the moved-from state.
   //!

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/locality_domains.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/locality_domains.c2h.cu
@@ -98,18 +98,18 @@ C2H_CCCLRT_TEST("locality domains", "[device][locality_domain]")
     }
   }
 
-  SECTION("Every domain has a non-null green context")
+  SECTION("Every domain has a non-null driver context")
   {
     for (auto dev : cuda::devices)
     {
       for (auto& domain : dev.__locality_domains())
       {
-        REQUIRE(domain.green_context() != nullptr);
+        REQUIRE(domain.context() != nullptr);
       }
     }
   }
 
-  SECTION("Domains on the same device have distinct green contexts")
+  SECTION("Domains on the same device have distinct contexts")
   {
     for (auto dev : cuda::devices)
     {
@@ -118,7 +118,7 @@ C2H_CCCLRT_TEST("locality domains", "[device][locality_domain]")
       {
         for (::cuda::std::size_t j = i + 1; j < domains.size(); ++j)
         {
-          REQUIRE(domains[i].green_context() != domains[j].green_context());
+          REQUIRE(domains[i].context() != domains[j].context());
           REQUIRE(domains[i] != domains[j]);
         }
       }
@@ -127,7 +127,7 @@ C2H_CCCLRT_TEST("locality domains", "[device][locality_domain]")
 
   SECTION("Domains of different devices are all distinct")
   {
-    // Green context handles come from a process-wide driver allocator, so no handle may repeat
+    // Driver context handles come from a process-wide driver allocator, so no handle may repeat
     // across devices either.
     for (auto lhs_dev : cuda::devices)
     {
@@ -142,7 +142,7 @@ C2H_CCCLRT_TEST("locality domains", "[device][locality_domain]")
         {
           for (auto& rhs : rhs_dev.__locality_domains())
           {
-            REQUIRE(lhs.green_context() != rhs.green_context());
+            REQUIRE(lhs.context() != rhs.context());
             REQUIRE(lhs != rhs);
           }
         }
@@ -215,14 +215,14 @@ C2H_CCCLRT_TEST("locality domains", "[device][locality_domain]")
     REQUIRE(before.size() == after.size());
   }
 
-  SECTION("Each green context converts to a usable driver context on the right device")
+  SECTION("Each domain context is usable on the right device")
   {
     for (auto dev : cuda::devices)
     {
       auto expected_device = cuda::__driver::__deviceGet(dev.get());
       for (auto& domain : dev.__locality_domains())
       {
-        auto ctx = cuda::__driver::__ctxFromGreenCtx(domain.green_context());
+        auto ctx = domain.context();
         REQUIRE(ctx != nullptr);
 
         // The fixture checks that the driver stack is empty at test exit, so the push must be undone
@@ -234,18 +234,36 @@ C2H_CCCLRT_TEST("locality domains", "[device][locality_domain]")
     }
   }
 
-  SECTION("A green context is not the primary context")
+#  if _CCCL_CTK_AT_LEAST(13, 4)
+  SECTION("A localized domain is a green context, not the primary context")
   {
-    // A domain must be a real partition, not a rebranded primary context.
+    // From 13.4 on a domain is a real SM partition, so it must not be a rebranded primary context.
+    // Before that the single domain is device-backed by design and holds the primary context.
     for (auto dev : cuda::devices)
     {
       auto primary = dev.__primary_context();
       for (auto& domain : dev.__locality_domains())
       {
-        REQUIRE(cuda::__driver::__ctxFromGreenCtx(domain.green_context()) != primary);
+        REQUIRE(domain.kind() == cuda::__logical_device_ref::kinds::green_context);
+        REQUIRE(domain.green_context() != nullptr);
+        REQUIRE(domain.context() != primary);
       }
     }
   }
+#  else // ^^^ 13.4+ ^^^ / vvv 13.3- vvv
+  SECTION("The single domain is device-backed and holds the primary context")
+  {
+    for (auto dev : cuda::devices)
+    {
+      auto primary = dev.__primary_context();
+      for (auto& domain : dev.__locality_domains())
+      {
+        REQUIRE(domain.kind() == cuda::__logical_device_ref::kinds::device);
+        REQUIRE(domain.context() == primary);
+      }
+    }
+  }
+#  endif // ^^^ 13.3- ^^^
 
   SECTION("Reading the domains leaves the driver stack empty")
   {

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/logical_device.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/logical_device.c2h.cu
@@ -73,19 +73,38 @@ C2H_CCCLRT_TEST("logical_device_ref traits", "[device][logical_device]", )
     STATIC_REQUIRE(!cuda::std::is_default_constructible_v<cuda::__logical_device_ref>);
   }
 
-  SECTION("A ref is built from exactly a device and a handle")
+  SECTION("A ref is built from a device, with or without a green context")
   {
     constexpr bool from_device_and_gctx =
       cuda::std::is_constructible_v<cuda::__logical_device_ref, cuda::device_ref, ::CUgreenCtx>;
     constexpr bool from_ordinal_and_gctx = cuda::std::is_constructible_v<cuda::__logical_device_ref, int, ::CUgreenCtx>;
     constexpr bool from_device_alone     = cuda::std::is_constructible_v<cuda::__logical_device_ref, cuda::device_ref>;
+    constexpr bool from_ordinal_alone    = cuda::std::is_constructible_v<cuda::__logical_device_ref, int>;
     constexpr bool from_gctx_alone       = cuda::std::is_constructible_v<cuda::__logical_device_ref, ::CUgreenCtx>;
 
     STATIC_REQUIRE(from_device_and_gctx);
     // `device_ref` converts implicitly from `int`, so an ordinal is accepted too.
     STATIC_REQUIRE(from_ordinal_and_gctx);
-    STATIC_REQUIRE(!from_device_alone);
+    STATIC_REQUIRE(from_device_alone);
+    STATIC_REQUIRE(from_ordinal_alone);
     STATIC_REQUIRE(!from_gctx_alone);
+  }
+
+  SECTION("The device-backed constructor is explicit")
+  {
+    STATIC_REQUIRE(!cuda::std::is_convertible_v<cuda::device_ref, cuda::__logical_device_ref>);
+    STATIC_REQUIRE(!cuda::std::is_convertible_v<int, cuda::__logical_device_ref>);
+  }
+
+  SECTION("A ref rejects an ordinal or a null handle where a green context belongs")
+  {
+    constexpr bool from_device_and_int =
+      cuda::std::is_constructible_v<cuda::__logical_device_ref, cuda::device_ref, int>;
+    constexpr bool from_device_and_null =
+      cuda::std::is_constructible_v<cuda::__logical_device_ref, cuda::device_ref, cuda::std::nullptr_t>;
+
+    STATIC_REQUIRE(!from_device_and_int);
+    STATIC_REQUIRE(!from_device_and_null);
   }
 
   SECTION("An owner is move-only and destroys its green context")
@@ -106,15 +125,23 @@ C2H_CCCLRT_TEST("logical_device_ref traits", "[device][logical_device]", )
     STATIC_REQUIRE(!cuda::std::is_trivially_copyable_v<cuda::__logical_device>);
   }
 
-  SECTION("An owner has no default constructor and no public constructor")
+  SECTION("An owner is built from a device alone, but never from a handle directly")
   {
-    // Every owner must come from `from_native_handle`, which is the only place that pairs a handle
-    // with the device it was created on.
+    // A green-context owner must come from `from_native_handle`, which is the only place that pairs
+    // a handle with the device it was created on. A device-backed owner owns nothing, so it needs no
+    // such pairing and its constructor is public.
     constexpr bool from_device_and_gctx =
       cuda::std::is_constructible_v<cuda::__logical_device, cuda::device_ref, ::CUgreenCtx>;
+    constexpr bool from_device_alone = cuda::std::is_constructible_v<cuda::__logical_device, cuda::device_ref>;
 
     STATIC_REQUIRE(!cuda::std::is_default_constructible_v<cuda::__logical_device>);
     STATIC_REQUIRE(!from_device_and_gctx);
+    STATIC_REQUIRE(from_device_alone);
+  }
+
+  SECTION("The device-backed owner constructor is explicit")
+  {
+    STATIC_REQUIRE(!cuda::std::is_convertible_v<cuda::device_ref, cuda::__logical_device>);
   }
 
   SECTION("from_native_handle takes a device and a real handle only")
@@ -128,11 +155,11 @@ C2H_CCCLRT_TEST("logical_device_ref traits", "[device][logical_device]", )
 
   SECTION("from_native_handle returns an owner by value")
   {
-    using result_type = decltype(cuda::__logical_device::from_native_handle(
+    using gctx_result_type = decltype(cuda::__logical_device::from_native_handle(
       cuda::std::declval<cuda::device_ref>(), cuda::std::declval<::CUgreenCtx>()));
 
-    constexpr bool returns_owner_by_value = cuda::std::is_same_v<result_type, cuda::__logical_device>;
-    STATIC_REQUIRE(returns_owner_by_value);
+    constexpr bool gctx_returns_owner_by_value = cuda::std::is_same_v<gctx_result_type, cuda::__logical_device>;
+    STATIC_REQUIRE(gctx_returns_owner_by_value);
   }
 
   SECTION("An owner converts to a ref, but a ref does not slice into an owner")
@@ -178,31 +205,26 @@ C2H_CCCLRT_TEST("logical_device_ref traits", "[device][logical_device]", )
   {
     using device_result_type = decltype(cuda::std::declval<cuda::__logical_device_ref>().underlying_device());
     using gctx_result_type   = decltype(cuda::std::declval<cuda::__logical_device_ref>().green_context());
+    using ctx_result_type    = decltype(cuda::std::declval<cuda::__logical_device_ref>().context());
+    using kind_result_type   = decltype(cuda::std::declval<cuda::__logical_device_ref>().kind());
 
     constexpr bool device_matches = cuda::std::is_same_v<cuda::device_ref, device_result_type>;
     constexpr bool gctx_matches   = cuda::std::is_same_v<::CUgreenCtx, gctx_result_type>;
+    constexpr bool ctx_matches    = cuda::std::is_same_v<::CUcontext, ctx_result_type>;
+    constexpr bool kind_matches   = cuda::std::is_same_v<cuda::__logical_device_ref::kinds, kind_result_type>;
 
     STATIC_REQUIRE(device_matches);
     STATIC_REQUIRE(gctx_matches);
-  }
-
-  SECTION("A ref is usable in a constant expression")
-  {
-    constexpr cuda::__logical_device_ref ref{cuda::device_ref{0}, nullptr};
-    constexpr cuda::__logical_device_ref same{cuda::device_ref{0}, nullptr};
-
-    STATIC_REQUIRE(ref.underlying_device() == 0);
-    STATIC_REQUIRE(ref.green_context() == nullptr);
-    STATIC_REQUIRE(ref == same);
+    STATIC_REQUIRE(ctx_matches);
+    STATIC_REQUIRE(kind_matches);
   }
 }
 
 C2H_CCCLRT_TEST("logical_device_ref locality domain", "[device][logical_device]", )
 {
-  SECTION("A ref with no green context is not localized")
+  SECTION("A device-backed ref is not localized")
   {
-    // A null handle must not reach the driver, so this holds even on a machine with no GPU.
-    const cuda::__logical_device_ref ref{cuda::device_ref{0}, nullptr};
+    const cuda::__logical_device_ref ref{cuda::devices[0]};
     const auto result = ref.locality_domain();
 
     REQUIRE_FALSE(result.localized);
@@ -280,38 +302,60 @@ C2H_CCCLRT_TEST("logical_device_ref locality domain", "[device][logical_device]"
 
 C2H_CCCLRT_TEST("logical_device_ref comparison", "[device][logical_device]")
 {
-  // Two distinct non-null handles. They are never dereferenced, so fabricating them is safe and
-  // keeps this test free of any driver call.
-  auto* const gctx0 = reinterpret_cast<::CUgreenCtx>(0x10);
-  auto* const gctx1 = reinterpret_cast<::CUgreenCtx>(0x20);
+  SECTION("Device-backed refs of the same device are equal")
+  {
+    const cuda::__logical_device_ref first{cuda::devices[0]};
+    const cuda::__logical_device_ref second{cuda::devices[0]};
+    REQUIRE(first == second);
 
-  const cuda::__logical_device_ref dev0_null{cuda::device_ref{0}, nullptr};
-  const cuda::__logical_device_ref dev0_gctx0{cuda::device_ref{0}, gctx0};
-  const cuda::__logical_device_ref dev0_gctx1{cuda::device_ref{0}, gctx1};
+    if (cuda::devices.size() > 1)
+    {
+      REQUIRE(first != cuda::__logical_device_ref{cuda::devices[1]});
+    }
+  }
+
+  if (test::cuda_driver_version() < 12050)
+  {
+    SUCCEED("Driver is too old for green context tests");
+    return;
+  }
+
+  // The constructor converts the handle into a driver context, so the handles must be real ones.
+  // A fabricated handle makes the driver read unmapped memory.
+  const auto ldev0 = ::make_logical_device(cuda::devices[0]);
+  const auto ldev1 = ::make_logical_device(cuda::devices[0]);
+
+  const cuda::__logical_device_ref dev0_gctx0{cuda::device_ref{0}, ldev0.green_context()};
+  const cuda::__logical_device_ref dev0_gctx1{cuda::device_ref{0}, ldev1.green_context()};
 
   SECTION("Equal when both the device and the green context match")
   {
-    const cuda::__logical_device_ref same_null{cuda::device_ref{0}, nullptr};
-    const cuda::__logical_device_ref same_gctx0{cuda::device_ref{0}, gctx0};
-    REQUIRE(dev0_null == same_null);
+    const cuda::__logical_device_ref same_gctx0{cuda::device_ref{0}, ldev0.green_context()};
     REQUIRE(dev0_gctx0 == same_gctx0);
   }
 
   SECTION("Different green contexts on the same device are not equal")
   {
     REQUIRE(dev0_gctx0 != dev0_gctx1);
-    REQUIRE(dev0_gctx0 != dev0_null);
   }
 
   SECTION("The same green context on different devices is not equal")
   {
     if (cuda::devices.size() > 1)
     {
-      const cuda::__logical_device_ref dev1_gctx0{cuda::device_ref{1}, gctx0};
-      const cuda::__logical_device_ref dev1_null{cuda::device_ref{1}, nullptr};
+      // The handle stays the one made on device 0. Only the recorded device changes, which is
+      // enough to make the two refs different.
+      const cuda::__logical_device_ref dev1_gctx0{cuda::device_ref{1}, ldev0.green_context()};
       REQUIRE(dev0_gctx0 != dev1_gctx0);
-      REQUIRE(dev0_null != dev1_null);
     }
+  }
+
+  SECTION("A device-backed ref never equals a green-context ref")
+  {
+    const cuda::__logical_device_ref dev0_backed{cuda::devices[0]};
+    REQUIRE(dev0_backed != dev0_gctx0);
+    REQUIRE(dev0_backed.kind() == cuda::__logical_device_ref::kinds::device);
+    REQUIRE(dev0_gctx0.kind() == cuda::__logical_device_ref::kinds::green_context);
   }
 }
 
@@ -328,7 +372,30 @@ C2H_CCCLRT_TEST("logical_device owns a green context", "[device][logical_device]
     const auto device = cuda::devices[0];
     auto ldev         = ::make_logical_device(device);
     REQUIRE(ldev.underlying_device() == device);
+    REQUIRE(ldev.kind() == cuda::__logical_device_ref::kinds::green_context);
     REQUIRE(ldev.green_context() != nullptr);
+  }
+
+  SECTION("A device-backed owner holds the primary context and no green context")
+  {
+    const auto device = cuda::devices[0];
+    const cuda::__logical_device ldev{device};
+
+    REQUIRE(ldev.underlying_device() == device);
+    REQUIRE(ldev.kind() == cuda::__logical_device_ref::kinds::device);
+    REQUIRE(ldev.green_context() == nullptr);
+    REQUIRE(ldev.context() == device.__primary_context());
+  }
+
+  SECTION("A device-backed owner destroys nothing")
+  {
+    // `__reset()` must not call `__greenCtxDestroy` on a primary context. Compute-sanitizer and the
+    // fixture's driver-stack check catch a violation.
+    const auto device = cuda::devices[0];
+    {
+      [[maybe_unused]] const cuda::__logical_device ldev{device};
+    }
+    REQUIRE(cuda::__logical_device{device}.context() == device.__primary_context());
   }
 
   SECTION("Two green contexts on the same device compare unequal")
@@ -340,7 +407,7 @@ C2H_CCCLRT_TEST("logical_device owns a green context", "[device][logical_device]
       static_cast<const cuda::__logical_device_ref&>(ldev0) != static_cast<const cuda::__logical_device_ref&>(ldev1));
   }
 
-  SECTION("Move construction transfers the handle and nulls the source")
+  SECTION("Move construction transfers the handle and clears the source")
   {
     auto source       = ::make_logical_device(cuda::devices[0]);
     const auto gctx   = source.green_context();
@@ -349,10 +416,13 @@ C2H_CCCLRT_TEST("logical_device owns a green context", "[device][logical_device]
 
     REQUIRE(destination.green_context() == gctx);
     REQUIRE(destination.underlying_device() == device);
-    REQUIRE(source.green_context() == nullptr);
+    // A moved-from owner holds nothing. Both handles are null, so it reports the device kind with a
+    // null driver context.
+    REQUIRE(source.kind() == cuda::__logical_device_ref::kinds::device);
+    REQUIRE(source.context() == nullptr);
   }
 
-  SECTION("Move assignment transfers the handle and nulls the source")
+  SECTION("Move assignment transfers the handle and clears the source")
   {
     auto source      = ::make_logical_device(cuda::devices[0]);
     auto destination = ::make_logical_device(cuda::devices[0]);
@@ -362,7 +432,8 @@ C2H_CCCLRT_TEST("logical_device owns a green context", "[device][logical_device]
     destination = cuda::std::move(source);
 
     REQUIRE(destination.green_context() == gctx);
-    REQUIRE(source.green_context() == nullptr);
+    REQUIRE(source.kind() == cuda::__logical_device_ref::kinds::device);
+    REQUIRE(source.context() == nullptr);
   }
 
   SECTION("Self move assignment leaves the green context intact")
@@ -384,7 +455,8 @@ C2H_CCCLRT_TEST("logical_device owns a green context", "[device][logical_device]
     {
       [[maybe_unused]] auto destination = cuda::std::move(source);
     }
-    REQUIRE(source.green_context() == nullptr);
+    REQUIRE(source.kind() == cuda::__logical_device_ref::kinds::device);
+    REQUIRE(source.context() == nullptr);
   }
 
   SECTION("The green context converts to a usable CUcontext")
@@ -392,6 +464,8 @@ C2H_CCCLRT_TEST("logical_device owns a green context", "[device][logical_device]
     auto ldev      = ::make_logical_device(cuda::devices[0]);
     const auto ctx = cuda::__driver::__ctxFromGreenCtx(ldev.green_context());
     REQUIRE(ctx != nullptr);
+    // `context()` is the same conversion, done by the class.
+    REQUIRE(ldev.context() == ctx);
   }
 
   SECTION("A logical_device on a second device reports that device")

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/logical_device_stream.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/logical_device_stream.c2h.cu
@@ -108,6 +108,30 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
     REQUIRE(stream_ctx == green_ctx);
   }
 
+  SECTION("A device-backed logical device gives a stream on the primary context")
+  {
+    const cuda::__logical_device_ref ldev{device};
+    cuda::stream str{ldev};
+
+    REQUIRE(str.get() != nullptr);
+    REQUIRE(str.device() == device);
+    REQUIRE(cuda::__driver::__streamGetCtx(str.get()) == device.__primary_context());
+
+    ::test::pinned<int> value(0);
+    ::test::launch_kernel_single_thread(str, ::test::assign_42{}, value.get());
+    str.sync();
+    REQUIRE(*value == 42);
+  }
+
+  SECTION("A device-backed stream matches one built from the device_ref directly")
+  {
+    const cuda::__logical_device_ref ldev{device};
+    cuda::stream from_logical{ldev};
+    cuda::stream from_device{device};
+
+    REQUIRE(cuda::__driver::__streamGetCtx(from_logical.get()) == cuda::__driver::__streamGetCtx(from_device.get()));
+  }
+
   SECTION("The default priority is used when none is given")
   {
     auto ldev = ::make_logical_device(device);

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/locality_domain_memory_pool.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/locality_domain_memory_pool.cu
@@ -26,11 +26,11 @@ C2H_CCCLRT_TEST("locality domain memory pool of a non-localized device", "[memor
 {
   test::skip_if_unsupported_memory_pool<cuda::device_memory_pool_ref>();
 
-  SECTION("A ref with no green context yields the plain device default pool")
+  SECTION("A device-backed ref yields the plain device default pool")
   {
     for (auto dev : cuda::devices)
     {
-      const cuda::__logical_device_ref ref{dev, nullptr};
+      const cuda::__logical_device_ref ref{dev};
 
       auto& pool = cuda::__device_default_memory_pool(ref);
 
@@ -45,8 +45,8 @@ C2H_CCCLRT_TEST("locality domain memory pool of a non-localized device", "[memor
   {
     if (cuda::devices.size() > 1)
     {
-      const cuda::__logical_device_ref first{cuda::devices[0], nullptr};
-      const cuda::__logical_device_ref second{cuda::devices[1], nullptr};
+      const cuda::__logical_device_ref first{cuda::devices[0]};
+      const cuda::__logical_device_ref second{cuda::devices[1]};
 
       REQUIRE(cuda::__device_default_memory_pool(first) != cuda::__device_default_memory_pool(second));
     }
@@ -160,7 +160,9 @@ C2H_CCCLRT_TEST("locality domain memory pool", "[memory_resource][locality_domai
     {
       for (auto& domain : dev.__locality_domains())
       {
-        const cuda::__logical_device_ref rebuilt{domain.underlying_device(), domain.green_context()};
+        const auto rebuilt = (domain.kind() == cuda::__logical_device_ref::kinds::green_context)
+                             ? cuda::__logical_device_ref{domain.underlying_device(), domain.green_context()}
+                             : cuda::__logical_device_ref{domain.underlying_device()};
 
         REQUIRE(&cuda::__device_default_memory_pool(rebuilt) == &cuda::__device_default_memory_pool(domain));
       }


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

This restores the functionality of `cudax::logical_device`. The original idea with `__logical_device` is that it would always represent a green context (or rather, a locality domain), but this ends up not being ergonomic when the producing code only knows dynamically whether it is a locality domain or regular context.

Coincidentally, this change then also makes it easier to work with the class pre 12.5 when green contexts don't exist since it has a defined state in all cases now.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
