### PR TITLE
[cudax] Isolate and synchronize reduce scratch

### DIFF
--- a/cudax/include/cuda/experimental/__coop/reduce.cuh
+++ b/cudax/include/cuda/experimental/__coop/reduce.cuh
@@ -139,6 +139,8 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np,
     }
     __group.sync_aligned();
     const auto __broadcast_result = __scratch.__bcast_;
+    // Every thread must finish reading shared scratch before another reduction
+    // can reuse it, even though each thread returns its own local copy.
     __group.sync_aligned();
     return __broadcast_result;
   }
@@ -420,6 +422,7 @@ _CCCL_REQUIRES(::cuda::std::is_same_v<warp_level, typename _Group::unit_type>
     }
     __group.sync_aligned();
     const auto __broadcast_result = __values[__first_warp_rank];
+    // Wait for every shared read before the next reduction can overwrite it.
     __group.sync_aligned();
     return __broadcast_result;
   }

--- a/cudax/include/cuda/experimental/__coop/reduce.cuh
+++ b/cudax/include/cuda/experimental/__coop/reduce.cuh
@@ -23,6 +23,7 @@
 
 #include <cub/block/block_reduce.cuh>
 #include <cub/thread/thread_reduce.cuh>
+#include <cub/util_type.cuh>
 #include <cub/warp/warp_reduce.cuh>
 
 #include <cuda/__cmath/ceil_div.h>
@@ -37,6 +38,7 @@
 #include <cuda/std/optional>
 
 #include <cuda/experimental/__coop/shuffle_down.cuh>
+#include <cuda/experimental/__group/queries.cuh>
 #include <cuda/experimental/__utility/result_policy.cuh>
 #include <cuda/experimental/group.cuh>
 
@@ -129,15 +131,20 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np,
   const auto __result = _BlockReduce{__scratch.__block_reduce_}.Reduce(__thread_data, __red_fn);
   if constexpr (_Broadcasted)
   {
+    // Wait until all threads are done using the aliased CUB storage.
+    __group.sync_aligned();
     if (gpu_thread.is_root_rank(__group))
     {
       __scratch.__bcast_ = __result;
     }
     __group.sync_aligned();
-    return __scratch.__bcast_;
+    const auto __broadcast_result = __scratch.__bcast_;
+    __group.sync_aligned();
+    return __broadcast_result;
   }
   else
   {
+    __group.sync_aligned();
     return (gpu_thread.is_root_rank(__group)) ? ::cuda::std::optional{__result} : ::cuda::std::nullopt;
   }
 }
@@ -230,6 +237,7 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np,
     }
     else
     {
+      __group.sync_aligned();
       return (gpu_thread.is_root_rank(__group)) ? ::cuda::std::optional{__result} : ::cuda::std::nullopt;
     }
   }
@@ -299,6 +307,7 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np,
   }
   else
   {
+    __group.sync_aligned();
     return __result;
   }
 }
@@ -343,6 +352,8 @@ _CCCL_REQUIRES(::cuda::std::is_same_v<warp_level, typename _Group::unit_type>
 [[nodiscard]] _CCCL_DEVICE_API auto __reduce_impl(
   ::cuda::std::bool_constant<_Broadcasted>, const _Group& __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
 {
+  using _MappingResult = typename _Group::__mapping_result_type;
+
   // Runtime-known references can't be used in constant expressions, so we create a view that can be used in a constant
   // expression.
   const group_view __group_view{__group};
@@ -350,28 +361,45 @@ _CCCL_REQUIRES(::cuda::std::is_same_v<warp_level, typename _Group::unit_type>
   constexpr auto __nwarps_in_group = warp.static_count(__group_view);
   static_assert(__nwarps_in_group != ::cuda::std::dynamic_extent,
                 "cuda::coop::reduce requires the group to have statically known size");
+  static_assert(_MappingResult::is_always_contiguous(),
+                "cuda::coop::reduce requires the group mapping to be contiguous");
+
+  using _BlockExts = decltype(gpu_thread.extents(block, __group.hierarchy()));
+
+  // CUDA thread blocks contain at most 1024 threads (32 warps). Prefer a smaller
+  // bound when all block extents are known at compile time.
+  constexpr auto __nthreads_in_block =
+    (_BlockExts::rank_dynamic() == 0)
+      ? _BlockExts::static_extent(0) * _BlockExts::static_extent(1) * _BlockExts::static_extent(2)
+      : ::cuda::std::size_t{1024};
+  constexpr auto __nwarps_in_block = ::cuda::ceil_div(__nthreads_in_block, ::cuda::std::size_t{32});
 
   using _WarpReduce = ::cub::WarpReduce<_Tp>;
-  struct _AdditionalScratch
+  struct _Scratch
   {
-    _Tp __partials_[__nwarps_in_group];
-    _Tp __bcast_;
-  };
-
-  union _Scratch
-  {
-    typename _WarpReduce::TempStorage __warp_reduce_[__nwarps_in_group];
-    _AdditionalScratch __additional_;
+    typename _WarpReduce::TempStorage __warp_reduce_[__nwarps_in_block];
+    alignas(_Tp)::cub::Uninitialized<_Tp[__nwarps_in_block]> __values_;
   };
   __shared__ _Scratch __scratch;
 
-  const auto __partial = _WarpReduce{__scratch.__warp_reduce_[warp.rank(__group)]}.Reduce(__thread_data, __red_fn);
-  __group.sync_aligned();
-
   this_warp __warp{__group.hierarchy()};
+  const auto __warp_rank_in_block = __warp.rank(block);
+  const auto __warp_rank_in_group = warp.rank(__group);
+  // This relies on contiguous mappings assigning unit ranks in ascending
+  // physical-warp order, so every warp derives the same first physical rank.
+  const auto __first_warp_rank = __warp_rank_in_block - __warp_rank_in_group;
+  _CCCL_ASSERT(__warp_rank_in_block < __nwarps_in_block, "invalid physical warp rank");
+  _CCCL_ASSERT(__first_warp_rank + __nwarps_in_group <= __nwarps_in_block, "invalid physical warp range");
+
+  // Physical-warp slots remain unique when independent mappings reuse group
+  // ranks or overlap in time.
+  auto& __values = __scratch.__values_.Alias();
+
+  const auto __partial = _WarpReduce{__scratch.__warp_reduce_[__warp_rank_in_block]}.Reduce(__thread_data, __red_fn);
+
   if (gpu_thread.is_root_rank(__warp))
   {
-    __scratch.__additional_.__partials_[warp.rank(__group)] = __partial;
+    __values[__warp_rank_in_block] = __partial;
   }
   __group.sync_aligned();
 
@@ -379,22 +407,25 @@ _CCCL_REQUIRES(::cuda::std::is_same_v<warp_level, typename _Group::unit_type>
   if (warp.is_root_rank(__group))
   {
     const auto __value = (gpu_thread.rank(__warp) < __nwarps_in_group)
-                         ? __scratch.__additional_.__partials_[gpu_thread.rank(__warp)]
+                         ? __values[__first_warp_rank + gpu_thread.rank(__warp)]
                          : ::cuda::identity_element<_RedFn, _Tp>();
-    __result           = _WarpReduce{__scratch.__warp_reduce_[0]}.Reduce(__value, __red_fn);
+    __result           = _WarpReduce{__scratch.__warp_reduce_[__first_warp_rank]}.Reduce(__value, __red_fn);
   }
 
   if constexpr (_Broadcasted)
   {
     if (gpu_thread.is_root_rank(__group))
     {
-      __scratch.__additional_.__bcast_ = __result;
+      __values[__first_warp_rank] = __result;
     }
     __group.sync_aligned();
-    return __scratch.__additional_.__bcast_;
+    const auto __broadcast_result = __values[__first_warp_rank];
+    __group.sync_aligned();
+    return __broadcast_result;
   }
   else
   {
+    __group.sync_aligned();
     return (gpu_thread.is_root_rank(__group)) ? ::cuda::std::optional{__result} : ::cuda::std::nullopt;
   }
 }

--- a/cudax/include/cuda/experimental/__group/concepts.cuh
+++ b/cudax/include/cuda/experimental/__group/concepts.cuh
@@ -48,6 +48,10 @@ _CCCL_CONCEPT is_group = _CCCL_REQUIRES_EXPR((_Group), _Group&& __g, const _Grou
   // todo: add __sub_unit_queryable and __super_unit_queryable
 );
 
+// Semantic requirement: is_always_contiguous() is true only if each group
+// occupies a contiguous range of physical units and unit_rank() numbers them
+// in ascending physical order, starting at zero. This must hold after mapping
+// composition as well; contiguous membership alone is insufficient.
 template <class _Tp>
 _CCCL_CONCEPT __group_mapping_result = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __v)(
   requires(::cuda::std::is_copy_constructible_v<_Tp>),

--- a/cudax/include/cuda/experimental/__group/concepts.cuh
+++ b/cudax/include/cuda/experimental/__group/concepts.cuh
@@ -48,10 +48,10 @@ _CCCL_CONCEPT is_group = _CCCL_REQUIRES_EXPR((_Group), _Group&& __g, const _Grou
   // todo: add __sub_unit_queryable and __super_unit_queryable
 );
 
-// Semantic requirement: is_always_contiguous() is true only if each group
-// occupies a contiguous range of physical units and unit_rank() numbers them
-// in ascending physical order, starting at zero. This must hold after mapping
-// composition as well; contiguous membership alone is insufficient.
+//! @brief Semantic requirement: @c is_always_contiguous() is true only if each group
+//! occupies a contiguous range of physical units and @c unit_rank() numbers them
+//! in ascending physical order, starting at zero. This must hold after mapping
+//! composition as well; contiguous membership alone is insufficient.
 template <class _Tp>
 _CCCL_CONCEPT __group_mapping_result = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __v)(
   requires(::cuda::std::is_copy_constructible_v<_Tp>),

--- a/cudax/test/coop/reduce/this_block.cu
+++ b/cudax/test/coop/reduce/this_block.cu
@@ -26,6 +26,9 @@
 #include <c2h/generators.h>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+inline constexpr int reuse_block_size = 128;
+inline constexpr int reuse_repeats    = 16;
+
 /***********************************************************************************************************************
  * Thread Reduce Wrapper Kernels
  **********************************************************************************************************************/
@@ -66,6 +69,37 @@ struct ReduceKernel
       if (cuda::gpu_thread.is_root_rank(block))
       {
         *d_out = result.value();
+      }
+    }
+  }
+};
+
+template <bool Broadcasted>
+struct RepeatedReduceKernel
+{
+  template <class Config>
+  __device__ void operator()(Config config, int* d_out)
+  {
+    cudax::this_block block{config};
+    const int thread_rank = cuda::gpu_thread.rank_as<int>(block);
+    constexpr int stride  = Broadcasted ? reuse_block_size : 1;
+
+    for (int repeat = 0; repeat < reuse_repeats; ++repeat)
+    {
+      int thread_data[1] = {repeat + 1};
+      if constexpr (Broadcasted)
+      {
+        const auto result = cudax::coop::reduce(cudax::broadcasted, block, thread_data, cuda::std::plus<>{});
+        d_out[repeat * stride + thread_rank] = result;
+      }
+      else
+      {
+        const auto result = cudax::coop::reduce(block, thread_data, cuda::std::plus<>{});
+        REQUIRE(result.has_value() == cuda::gpu_thread.is_root_rank(block));
+        if (result.has_value())
+        {
+          d_out[repeat] = *result;
+        }
       }
     }
   }
@@ -139,8 +173,37 @@ void run_reduce_kernel(
   stream.sync();
 }
 
-constexpr int max_size  = 4;
-constexpr int num_seeds = 10;
+template <bool Broadcasted>
+void run_repeated_reduce_kernel(cuda::stream_ref stream)
+{
+  constexpr int stride      = Broadcasted ? reuse_block_size : 1;
+  constexpr int output_size = reuse_repeats * stride;
+  c2h::device_vector<int> d_out(output_size, -1);
+  const auto out_ptr = thrust::raw_pointer_cast(d_out.data());
+  const auto config  = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<reuse_block_size>());
+  cuda::launch(stream, config, RepeatedReduceKernel<Broadcasted>{}, out_ptr);
+  stream.sync();
+
+  const c2h::host_vector<int> h_out = d_out;
+  for (int repeat = 0; repeat < reuse_repeats; ++repeat)
+  {
+    const int expected = reuse_block_size * (repeat + 1);
+    if constexpr (Broadcasted)
+    {
+      for (int rank = 0; rank < reuse_block_size; ++rank)
+      {
+        REQUIRE(h_out[repeat * stride + rank] == expected);
+      }
+    }
+    else
+    {
+      REQUIRE(h_out[repeat] == expected);
+    }
+  }
+}
+
+inline constexpr int max_size  = 4;
+inline constexpr int num_seeds = 10;
 
 /***********************************************************************************************************************
  * Test cases
@@ -220,4 +283,12 @@ C2H_TEST("reduce/this_block Broadcasted", "[reduce][this_block]", integral_type_
     run_reduce_kernel(stream, block_size_t{}, num_items, d_in, d_out, reduce_op, cuda::std::true_type{});
     verify_results(c2h::host_vector<value_t>(block_size_t::value, reference_result), c2h::host_vector<value_t>(d_out));
   }
+}
+
+C2H_TEST("reduce/this_block can reuse scratch", "[reduce][this_block]")
+{
+  cuda::stream stream{cuda::devices[0]};
+
+  run_repeated_reduce_kernel<false>(stream);
+  run_repeated_reduce_kernel<true>(stream);
 }

--- a/cudax/test/coop/reduce/this_block.cu
+++ b/cudax/test/coop/reduce/this_block.cu
@@ -80,7 +80,7 @@ struct RepeatedReduceKernel
   template <class Config>
   __device__ void operator()(Config config, int* d_out)
   {
-    cudax::this_block block{config};
+    const cudax::this_block block{config};
     const int thread_rank = cuda::gpu_thread.rank_as<int>(block);
     constexpr int stride  = Broadcasted ? reuse_block_size : 1;
 
@@ -287,7 +287,7 @@ C2H_TEST("reduce/this_block Broadcasted", "[reduce][this_block]", integral_type_
 
 C2H_TEST("reduce/this_block can reuse scratch", "[reduce][this_block]")
 {
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
 
   run_repeated_reduce_kernel<false>(stream);
   run_repeated_reduce_kernel<true>(stream);

--- a/cudax/test/coop/reduce/this_cluster.cu
+++ b/cudax/test/coop/reduce/this_cluster.cu
@@ -194,6 +194,7 @@ C2H_TEST("reduce/this_cluster Integral Type Tests",
          cluster_size_list)
 {
   const auto device = cuda::devices[0];
+  // thread block clusters require compute capability at least 9.0
   if (cuda::device_attributes::compute_capability_major(device) < 9)
   {
     return;
@@ -226,6 +227,7 @@ C2H_TEST("reduce/this_cluster Floating-Point Type Tests",
          cluster_size_list)
 {
   const auto device = cuda::devices[0];
+  // thread block clusters require compute capability at least 9.0
   if (cuda::device_attributes::compute_capability_major(device) < 9)
   {
     return;
@@ -254,6 +256,7 @@ C2H_TEST("reduce/this_cluster Floating-Point Type Tests",
 C2H_TEST("reduce/this_cluster Broadcasted", "[reduce][this_cluster]", integral_type_list, cluster_size_list)
 {
   const auto device = cuda::devices[0];
+  // thread block clusters require compute capability at least 9.0
   if (cuda::device_attributes::compute_capability_major(device) < 9)
   {
     return;
@@ -283,6 +286,7 @@ C2H_TEST("reduce/this_cluster Broadcasted", "[reduce][this_cluster]", integral_t
 C2H_TEST("reduce/this_cluster can reuse scratch", "[reduce][this_cluster]")
 {
   const auto device = cuda::devices[0];
+  // thread block clusters require compute capability at least 9.0
   if (cuda::device_attributes::compute_capability_major(device) < 9)
   {
     return;

--- a/cudax/test/coop/reduce/this_cluster.cu
+++ b/cudax/test/coop/reduce/this_cluster.cu
@@ -26,7 +26,9 @@
 #include <c2h/generators.h>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-constexpr int block_size = 64;
+inline constexpr int block_size         = 64;
+inline constexpr int reuse_cluster_size = 2;
+inline constexpr int reuse_repeats      = 16;
 
 /***********************************************************************************************************************
  * Thread Reduce Wrapper Kernels
@@ -65,6 +67,26 @@ struct ReduceKernel
       if (cuda::gpu_thread.is_root_rank(cluster))
       {
         *d_out = result.value();
+      }
+    }
+  }
+};
+
+struct RepeatedReduceKernel
+{
+  template <class Config>
+  __device__ void operator()(Config config, int* d_out)
+  {
+    cudax::this_cluster cluster{config};
+
+    for (int repeat = 0; repeat < reuse_repeats; ++repeat)
+    {
+      int thread_data[1] = {repeat + 1};
+      const auto result  = cudax::coop::reduce(cluster, thread_data, cuda::std::plus<>{});
+      REQUIRE(result.has_value() == cuda::gpu_thread.is_root_rank(cluster));
+      if (result.has_value())
+      {
+        d_out[repeat] = *result;
       }
     }
   }
@@ -139,8 +161,25 @@ void run_reduce_kernel(
   stream.sync();
 }
 
-constexpr int max_size  = 4;
-constexpr int num_seeds = 10;
+void run_repeated_reduce_kernel(cuda::stream_ref stream)
+{
+  c2h::device_vector<int> d_out(reuse_repeats, -1);
+  const auto out_ptr = thrust::raw_pointer_cast(d_out.data());
+  const auto config =
+    cuda::make_config(cuda::grid_dims<1>(), cuda::cluster_dims<reuse_cluster_size>(), cuda::block_dims<block_size>());
+  cuda::launch(stream, config, RepeatedReduceKernel{}, out_ptr);
+  stream.sync();
+
+  const c2h::host_vector<int> h_out = d_out;
+  for (int repeat = 0; repeat < reuse_repeats; ++repeat)
+  {
+    const int expected = reuse_cluster_size * block_size * (repeat + 1);
+    REQUIRE(h_out[repeat] == expected);
+  }
+}
+
+inline constexpr int max_size  = 4;
+inline constexpr int num_seeds = 10;
 
 /***********************************************************************************************************************
  * Test cases
@@ -239,4 +278,16 @@ C2H_TEST("reduce/this_cluster Broadcasted", "[reduce][this_cluster]", integral_t
     verify_results(c2h::host_vector<value_t>(cluster_size_t::value * block_size, reference_result),
                    c2h::host_vector<value_t>(d_out));
   }
+}
+
+C2H_TEST("reduce/this_cluster can reuse scratch", "[reduce][this_cluster]")
+{
+  const auto device = cuda::devices[0];
+  if (cuda::device_attributes::compute_capability_major(device) < 9)
+  {
+    return;
+  }
+
+  cuda::stream stream{device};
+  run_repeated_reduce_kernel(stream);
 }

--- a/cudax/test/coop/reduce/this_cluster.cu
+++ b/cudax/test/coop/reduce/this_cluster.cu
@@ -77,7 +77,7 @@ struct RepeatedReduceKernel
   template <class Config>
   __device__ void operator()(Config config, int* d_out)
   {
-    cudax::this_cluster cluster{config};
+    const cudax::this_cluster cluster{config};
 
     for (int repeat = 0; repeat < reuse_repeats; ++repeat)
     {
@@ -292,6 +292,6 @@ C2H_TEST("reduce/this_cluster can reuse scratch", "[reduce][this_cluster]")
     return;
   }
 
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
   run_repeated_reduce_kernel(stream);
 }

--- a/cudax/test/coop/reduce/this_grid.cu
+++ b/cudax/test/coop/reduce/this_grid.cu
@@ -201,6 +201,7 @@ C2H_TEST("reduce/this_grid Integral Type Tests",
          grid_size_list)
 {
   const auto device = cuda::devices[0];
+  // thread block clusters require compute capability at least 9.0
   if (cuda::device_attributes::compute_capability_major(device) < 9)
   {
     return;
@@ -233,6 +234,7 @@ C2H_TEST(
   "reduce/this_grid Floating-Point Type Tests", "[reduce][this_grid]", fp_type_list, operator_fp_list, grid_size_list)
 {
   const auto device = cuda::devices[0];
+  // thread block clusters require compute capability at least 9.0
   if (cuda::device_attributes::compute_capability_major(device) < 9)
   {
     return;
@@ -264,6 +266,7 @@ C2H_TEST(
 C2H_TEST("reduce/this_grid Broadcasted", "[reduce][this_grid]", integral_type_list, grid_size_list)
 {
   const auto device = cuda::devices[0];
+  // thread block clusters require compute capability at least 9.0
   if (cuda::device_attributes::compute_capability_major(device) < 9)
   {
     return;
@@ -296,6 +299,7 @@ C2H_TEST("reduce/this_grid Broadcasted", "[reduce][this_grid]", integral_type_li
 C2H_TEST("reduce/this_grid can reuse scratch", "[reduce][this_grid]")
 {
   const auto device = cuda::devices[0];
+  // thread block clusters require compute capability at least 9.0
   if (cuda::device_attributes::compute_capability_major(device) < 9)
   {
     return;

--- a/cudax/test/coop/reduce/this_grid.cu
+++ b/cudax/test/coop/reduce/this_grid.cu
@@ -26,8 +26,10 @@
 #include <c2h/generators.h>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-constexpr int cluster_size = 2;
-constexpr int block_size   = 128;
+inline constexpr int cluster_size    = 2;
+inline constexpr int block_size      = 128;
+inline constexpr int reuse_grid_size = 2;
+inline constexpr int reuse_repeats   = 16;
 
 /***********************************************************************************************************************
  * Thread Reduce Wrapper Kernels
@@ -66,6 +68,26 @@ struct ReduceKernel
       if (cuda::gpu_thread.is_root_rank(grid))
       {
         *d_out = result.value();
+      }
+    }
+  }
+};
+
+struct RepeatedReduceKernel
+{
+  template <class Config>
+  __device__ void operator()(Config config, int* d_out)
+  {
+    cudax::this_grid grid{config};
+
+    for (int repeat = 0; repeat < reuse_repeats; ++repeat)
+    {
+      int thread_data[1] = {repeat + 1};
+      const auto result  = cudax::coop::reduce(grid, thread_data, cuda::std::plus<>{});
+      REQUIRE(result.has_value() == cuda::gpu_thread.is_root_rank(grid));
+      if (result.has_value())
+      {
+        d_out[repeat] = *result;
       }
     }
   }
@@ -143,8 +165,28 @@ void run_reduce_kernel(
   stream.sync();
 }
 
-constexpr int max_size  = 4;
-constexpr int num_seeds = 10;
+void run_repeated_reduce_kernel(cuda::stream_ref stream)
+{
+  c2h::device_vector<int> d_out(reuse_repeats, -1);
+  const auto out_ptr = thrust::raw_pointer_cast(d_out.data());
+  const auto config  = cuda::make_config(
+    cuda::grid_dims<reuse_grid_size>(),
+    cuda::cluster_dims<cluster_size>(),
+    cuda::block_dims<block_size>(),
+    cuda::cooperative_launch{});
+  cuda::launch(stream, config, RepeatedReduceKernel{}, out_ptr);
+  stream.sync();
+
+  const c2h::host_vector<int> h_out = d_out;
+  for (int repeat = 0; repeat < reuse_repeats; ++repeat)
+  {
+    const int expected = reuse_grid_size * cluster_size * block_size * (repeat + 1);
+    REQUIRE(h_out[repeat] == expected);
+  }
+}
+
+inline constexpr int max_size  = 4;
+inline constexpr int num_seeds = 10;
 
 /***********************************************************************************************************************
  * Test cases
@@ -249,4 +291,16 @@ C2H_TEST("reduce/this_grid Broadcasted", "[reduce][this_grid]", integral_type_li
     verify_results(c2h::host_vector<value_t>(grid_size_t::value * cluster_size * block_size, reference_result),
                    c2h::host_vector<value_t>(d_out));
   }
+}
+
+C2H_TEST("reduce/this_grid can reuse scratch", "[reduce][this_grid]")
+{
+  const auto device = cuda::devices[0];
+  if (cuda::device_attributes::compute_capability_major(device) < 9)
+  {
+    return;
+  }
+
+  cuda::stream stream{device};
+  run_repeated_reduce_kernel(stream);
 }

--- a/cudax/test/coop/reduce/this_grid.cu
+++ b/cudax/test/coop/reduce/this_grid.cu
@@ -78,7 +78,7 @@ struct RepeatedReduceKernel
   template <class Config>
   __device__ void operator()(Config config, int* d_out)
   {
-    cudax::this_grid grid{config};
+    const cudax::this_grid grid{config};
 
     for (int repeat = 0; repeat < reuse_repeats; ++repeat)
     {
@@ -305,6 +305,6 @@ C2H_TEST("reduce/this_grid can reuse scratch", "[reduce][this_grid]")
     return;
   }
 
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
   run_repeated_reduce_kernel(stream);
 }

--- a/cudax/test/coop/reduce/warps_within_block.cu
+++ b/cudax/test/coop/reduce/warps_within_block.cu
@@ -27,8 +27,13 @@
 #include <c2h/generators.h>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-constexpr int nwarps_in_group = 3;
-constexpr int warp_size       = 32;
+inline constexpr int nwarps_in_group     = 3;
+inline constexpr int warp_size           = 32;
+inline constexpr int multi_group_count   = 2;
+inline constexpr int multi_group_nwarps  = multi_group_count * nwarps_in_group + 1;
+inline constexpr int multi_group_size    = multi_group_nwarps * warp_size;
+inline constexpr int multi_group_repeats = 16;
+inline constexpr int threads_in_group    = nwarps_in_group * warp_size;
 
 /***********************************************************************************************************************
  * Thread Reduce Wrapper Kernels
@@ -81,6 +86,75 @@ struct ReduceKernel
       {
         *d_out = result.value();
       }
+    }
+  }
+};
+
+template <bool Broadcasted, class Group, class Block>
+__device__ void run_multi_group_reductions(const Group& group, const Block& block, int group_rank, int* d_out)
+{
+  const int thread_rank = cuda::gpu_thread.rank_as<int>(block);
+  constexpr int stride  = Broadcasted ? multi_group_size : multi_group_count;
+
+  for (int repeat = 0; repeat < multi_group_repeats; ++repeat)
+  {
+    int thread_data[1] = {repeat + group_rank + 1};
+    if constexpr (Broadcasted)
+    {
+      const auto result = cudax::coop::reduce(cudax::broadcasted, group, thread_data, cuda::std::plus<>{});
+      d_out[repeat * stride + thread_rank] = result;
+    }
+    else
+    {
+      const auto result = cudax::coop::reduce(group, thread_data, cuda::std::plus<>{});
+      REQUIRE(result.has_value() == cuda::gpu_thread.is_root_rank(group));
+      if (result.has_value())
+      {
+        d_out[repeat * stride + group_rank] = *result;
+      }
+    }
+  }
+}
+
+template <bool Broadcasted, bool Nested, bool Viewed>
+struct MultiGroupReduceKernel
+{
+  static_assert(!Viewed || Nested, "a group view requires a nested group");
+
+  template <class Config>
+  __device__ void operator()(Config config, int* d_out)
+  {
+    cudax::this_block block{config};
+
+    using Barriers = cuda::barrier<cuda::thread_scope_block>[multi_group_count];
+    __shared__ cuda::std::aligned_storage_t<sizeof(Barriers), alignof(Barriers)> barriers_storage;
+    auto& barriers = reinterpret_cast<Barriers&>(barriers_storage);
+
+    cudax::group parent{
+      cuda::warp, block, cudax::group_by<nwarps_in_group, false>{}, cudax::barrier_synchronizer{barriers}};
+
+    if (!cuda::gpu_thread.is_part_of(parent))
+    {
+      return;
+    }
+
+    const int group_rank = parent.template rank_as<int>(block);
+    if constexpr (Nested)
+    {
+      cudax::virtual_group group{cuda::warp, parent, cudax::identity_mapping{}};
+      if constexpr (Viewed)
+      {
+        cudax::group_view view{group};
+        run_multi_group_reductions<Broadcasted>(view, block, group_rank, d_out);
+      }
+      else
+      {
+        run_multi_group_reductions<Broadcasted>(group, block, group_rank, d_out);
+      }
+    }
+    else
+    {
+      run_multi_group_reductions<Broadcasted>(parent, block, group_rank, d_out);
     }
   }
 };
@@ -156,8 +230,57 @@ void run_reduce_kernel(
   stream.sync();
 }
 
-constexpr int max_size  = 4;
-constexpr int num_seeds = 10;
+template <bool Broadcasted, bool Nested, bool DynamicExtents, bool Viewed = false>
+void run_multi_group_reduce_kernel(cuda::stream_ref stream)
+{
+  constexpr int stride      = Broadcasted ? multi_group_size : multi_group_count;
+  constexpr int output_size = multi_group_repeats * stride;
+  c2h::device_vector<int> d_out(output_size, -1);
+  const auto out_ptr = thrust::raw_pointer_cast(d_out.data());
+
+  if constexpr (DynamicExtents)
+  {
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims(multi_group_size));
+    cuda::launch(stream, config, MultiGroupReduceKernel<Broadcasted, Nested, Viewed>{}, out_ptr);
+  }
+  else
+  {
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<multi_group_size>());
+    cuda::launch(stream, config, MultiGroupReduceKernel<Broadcasted, Nested, Viewed>{}, out_ptr);
+  }
+  stream.sync();
+
+  const c2h::host_vector<int> h_out = d_out;
+  for (int repeat = 0; repeat < multi_group_repeats; ++repeat)
+  {
+    for (int group_rank = 0; group_rank < multi_group_count; ++group_rank)
+    {
+      const int expected = threads_in_group * (repeat + group_rank + 1);
+      if constexpr (Broadcasted)
+      {
+        for (int rank = 0; rank < threads_in_group; ++rank)
+        {
+          REQUIRE(h_out[repeat * stride + group_rank * threads_in_group + rank] == expected);
+        }
+      }
+      else
+      {
+        REQUIRE(h_out[repeat * stride + group_rank] == expected);
+      }
+    }
+
+    if constexpr (Broadcasted)
+    {
+      for (int rank = multi_group_count * threads_in_group; rank < multi_group_size; ++rank)
+      {
+        REQUIRE(h_out[repeat * stride + rank] == -1);
+      }
+    }
+  }
+}
+
+inline constexpr int max_size  = 4;
+inline constexpr int num_seeds = 10;
 
 /***********************************************************************************************************************
  * Test cases
@@ -231,4 +354,28 @@ C2H_TEST("reduce/warps_within_block Broadcasted", "[reduce][warps_within_block]"
     verify_results(c2h::host_vector<value_t>(nwarps_in_group * warp_size, reference_result),
                    c2h::host_vector<value_t>(d_out));
   }
+}
+
+C2H_TEST("reduce/warps_within_block isolates scratch with static extents", "[reduce][warps_within_block]")
+{
+  cuda::stream stream{cuda::devices[0]};
+
+  run_multi_group_reduce_kernel<false, false, false>(stream);
+  run_multi_group_reduce_kernel<true, false, false>(stream);
+  run_multi_group_reduce_kernel<false, true, false>(stream);
+  run_multi_group_reduce_kernel<true, true, false>(stream);
+  run_multi_group_reduce_kernel<false, true, false, true>(stream);
+  run_multi_group_reduce_kernel<true, true, false, true>(stream);
+}
+
+C2H_TEST("reduce/warps_within_block isolates scratch with dynamic extents", "[reduce][warps_within_block]")
+{
+  cuda::stream stream{cuda::devices[0]};
+
+  run_multi_group_reduce_kernel<false, false, true>(stream);
+  run_multi_group_reduce_kernel<true, false, true>(stream);
+  run_multi_group_reduce_kernel<false, true, true>(stream);
+  run_multi_group_reduce_kernel<true, true, true>(stream);
+  run_multi_group_reduce_kernel<false, true, true, true>(stream);
+  run_multi_group_reduce_kernel<true, true, true, true>(stream);
 }

--- a/cudax/test/coop/reduce/warps_within_block.cu
+++ b/cudax/test/coop/reduce/warps_within_block.cu
@@ -127,13 +127,13 @@ struct MultiGroupReduceKernel
   template <class Config>
   __device__ void operator()(Config config, int* d_out)
   {
-    cudax::this_block block{config};
+    const cudax::this_block block{config};
 
     using Barriers = cuda::barrier<cuda::thread_scope_block>[multi_group_count];
     __shared__ cuda::std::aligned_storage_t<sizeof(Barriers), alignof(Barriers)> barriers_storage;
     auto& barriers = reinterpret_cast<Barriers&>(barriers_storage);
 
-    cudax::group parent{
+    const cudax::group parent{
       cuda::warp, block, cudax::group_by<nwarps_in_group, false>{}, cudax::barrier_synchronizer{barriers}};
 
     if (!cuda::gpu_thread.is_part_of(parent))
@@ -144,10 +144,10 @@ struct MultiGroupReduceKernel
     const int group_rank = parent.template rank_as<int>(block);
     if constexpr (Nested)
     {
-      cudax::virtual_group group{cuda::warp, parent, cudax::identity_mapping{}};
+      const cudax::virtual_group group{cuda::warp, parent, cudax::identity_mapping{}};
       if constexpr (Viewed)
       {
-        cudax::group_view view{group};
+        const cudax::group_view view{group};
         run_multi_group_reductions<Broadcasted>(view, block, group_rank, d_out);
       }
       else
@@ -361,7 +361,7 @@ C2H_TEST("reduce/warps_within_block Broadcasted", "[reduce][warps_within_block]"
 
 C2H_TEST("reduce/warps_within_block isolates scratch with static extents", "[reduce][warps_within_block]")
 {
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
 
   run_multi_group_reduce_kernel<false, false, false>(stream);
   run_multi_group_reduce_kernel<true, false, false>(stream);
@@ -373,7 +373,7 @@ C2H_TEST("reduce/warps_within_block isolates scratch with static extents", "[red
 
 C2H_TEST("reduce/warps_within_block isolates scratch with dynamic extents", "[reduce][warps_within_block]")
 {
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
 
   run_multi_group_reduce_kernel<false, false, true>(stream);
   run_multi_group_reduce_kernel<true, false, true>(stream);

--- a/cudax/test/coop/reduce/warps_within_block.cu
+++ b/cudax/test/coop/reduce/warps_within_block.cu
@@ -96,6 +96,9 @@ __device__ void run_multi_group_reductions(const Group& group, const Block& bloc
   const int thread_rank = cuda::gpu_thread.rank_as<int>(block);
   constexpr int stride  = Broadcasted ? multi_group_size : multi_group_count;
 
+  // Contiguous mappings preserve physical warp order through nesting and views.
+  REQUIRE(cuda::warp.rank_as<int>(group) == (thread_rank / warp_size) % nwarps_in_group);
+
   for (int repeat = 0; repeat < multi_group_repeats; ++repeat)
   {
     int thread_data[1] = {repeat + group_rank + 1};


### PR DESCRIPTION
## Why this is needed

`coop::reduce` keeps its temporary storage internally. The mapped warp-group
overload previously indexed that storage using a warp's rank within its group.
That rank is local to each group, but sibling groups have independent
synchronizers and may execute concurrently.

For example, partitioning a seven-warp block into groups of three produces:

```text
physical block warp:  0 1 2 | 3 4 5 | 6
rank within group:    0 1 2 | 0 1 2 | invalid
old scratch slot:     0 1 2 | 0 1 2 | -
```

Physical warps 0 and 3 could therefore use the same CUB
`WarpReduce::TempStorage` at the same time. The groups also shared partial and
broadcast storage. A barrier within one group does not synchronize the other
group.

The block, cluster, and grid implementations had a related lifetime problem.
Their scratch storage persists across calls, but some paths returned before
every participant had finished consuming it. A subsequent reduction could
overwrite that storage while the previous root was still reading it.

## Examples

### Independently synchronized warp groups shared the same slots

The following pattern creates two valid three-warp groups in one block. The
final warp does not participate.

```cpp
template <class Config>
__device__ void grouped_reduce(Config config, int* output)
{
  constexpr int group_warps = 3;
  constexpr int group_count = 2;

  cudax::this_block block{config};

  using Barriers =
    cuda::barrier<cuda::thread_scope_block>[group_count];

  __shared__
    cuda::std::aligned_storage_t<sizeof(Barriers), alignof(Barriers)>
      barriers_storage;

  auto& barriers = reinterpret_cast<Barriers&>(barriers_storage);

  cudax::group group{
    cuda::warp,
    block,
    cudax::group_by<group_warps, false>{},
    cudax::barrier_synchronizer{barriers}};

  if (!cuda::gpu_thread.is_part_of(group))
  {
    return;
  }

  const int group_rank = group.template rank_as<int>(block);
  int values[1]        = {group_rank + 1};

  const auto result =
    cudax::coop::reduce(group, values, cuda::std::plus<>{});

  if (result.has_value())
  {
    output[group_rank] = *result;
  }
}
```

With a 224-thread launch, both groups execute the same `reduce`
specialization:

```cpp
const auto config =
  cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<224>());
```

Each group numbers its warps from zero. Before this change, physical warp 0 and
physical warp 3 both selected temporary slot 0, physical warps 1 and 4 selected
slot 1, and so on. Since the groups synchronize independently, CUB temporary
storage and partial results could be modified concurrently.

### Back-to-back reductions could reuse scratch too early

Ordinary repeated use was enough to expose the missing terminal barriers:

```cpp
template <class Group>
__device__ void repeated_reduce(const Group& group, int* output)
{
  for (int iteration = 0; iteration < 16; ++iteration)
  {
    int values[1] = {iteration + 1};

    const auto result =
      cudax::coop::reduce(group, values, cuda::std::plus<>{});

    if (result.has_value())
    {
      output[iteration] = *result;
    }
  }
}
```

This pattern applies to `this_block`, `this_cluster`, `this_grid`, and mapped
groups. Without a terminal collective, non-root participants could enter the
next iteration and overwrite scratch while the previous root was still
consuming it.

### Block broadcast could reactivate aliased storage too soon

The block implementation uses a union because the CUB temporary storage and
broadcast value do not need to coexist after the collective finishes:

```cpp
union Scratch
{
  typename BlockReduce::TempStorage block_reduce;
  T broadcast;
};
```

The old sequence effectively did this:

```cpp
const auto result =
  BlockReduce{scratch.block_reduce}.Reduce(values, reduce_op);

if (is_root)
{
  // This aliases block_reduce, but other threads may still be using it.
  scratch.broadcast = result;
}

block.sync_aligned();
return scratch.broadcast;
```

The fixed sequence separates the storage lifetimes and protects the returned
value from the next invocation:

```cpp
const auto result =
  BlockReduce{scratch.block_reduce}.Reduce(values, reduce_op);

// Every thread has finished using the CUB storage.
block.sync_aligned();

if (is_root)
{
  scratch.broadcast = result;
}

// Publish the broadcast value.
block.sync_aligned();

const T value = scratch.broadcast;

// Every thread has copied the value before scratch can be reused.
block.sync_aligned();

return value;
```

## What changed

Mapped warp-group reductions now assign storage by physical block-warp rank:

- Each physical warp receives its own CUB temporary-storage slot.
- Partial and broadcast values use separate, correctly aligned raw storage.
- Independent groups can reuse local ranks without sharing storage.

The implementation requires a statically sized, contiguous mapping. It uses the
exact physical warp count when the block extents are static. For runtime block
extents, it uses the architectural bound of 32 warps per block, derived from
CUDA's maximum of 1024 threads per block. Larger thread counts associated with
some architectures describe residency per SM, not the size of one thread
block.

The collective paths now synchronize before scratch is repurposed or reused:

- Block broadcast waits for all CUB users before activating the aliased
  broadcast member.
- Broadcast results are copied into registers before the final
  synchronization.
- Root-only block, cluster, grid, and mapped-group reductions perform a
  terminal collective before returning.
- Mapped groups retain the barrier that protects partial reads and the final
  barrier that protects the next invocation.

These barriers add synchronization cost, but they are required while `reduce`
owns implicit shared or global scratch.

## Follow-ups

### Support runtime block extents in `this_warp`

The separate `this_warp` overload still computes its shared-memory array bound
directly from `static_extent`. A runtime block configuration therefore fails
during compilation:

```cpp
const auto config =
  cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims(128));

template <class Config>
__device__ void warp_reduce(Config config)
{
  cudax::this_warp warp{config};
  int values[1] = {1};

  // The warp size is static, but the containing block extents are dynamic.
  const auto result =
    cudax::coop::reduce(warp, values, cuda::std::plus<>{});
}
```

This defect predates the mapped-group change. It should be fixed separately
after defining the behavior of a terminal partial warp.

### Make temporary storage caller-provided

`reduce.cuh` already notes that implicit scratch is temporary API design.
Caller-provided storage would make ownership explicit and could remove the
terminal barriers added here.

It should also replace the global grid-partial array. Two concurrent launches
of the same grid-reduction specialization currently refer to the same global
storage:

```cpp
cuda::launch(stream1, config, grid_reduce_kernel{}, input1, output1);
cuda::launch(stream2, config, grid_reduce_kernel{}, input2, output2);
```

The streams may execute concurrently, allowing the two grids to overwrite each
other's partial results.

### Support future strided or permuted mappings

The contiguous mapping contract requires unit ranks to start at zero and
follow ascending physical order, including after mapping composition. The
physical-slot calculation relies on that property, and the direct, nested,
and viewed-group tests check it. Custom mappings that permute physical order
must report `is_always_contiguous() == false`.

Supporting strided or permuted mappings will require a way to query physical
membership without assuming this ordering. They remain outside this change.

## Validation

- [Full CI passed](https://github.com/NVIDIA/cccl/actions/runs/34539584944): Linux and Windows compiler coverage,
  T4/H100 runtime tests, downstream checks, and clang-tidy.
- All seven local C++17 reduction tests and the four affected C++20 tests passed.
- Compute Sanitizer Racecheck passed the repeated block and mapped-group
  scratch tests with zero hazards.
- Pre-commit and CodeRabbit checks passed; current review threads are resolved.
