### PR TITLE
[CUB] Fix result-validation race in env-overload examples

### DIFF
--- a/cub/examples/device/example_device_env_memory_resource.cu
+++ b/cub/examples/device/example_device_env_memory_resource.cu
@@ -132,6 +132,7 @@ int main(int argc, char** argv)
   CubDebugExit(error);
 
   // Check for correctness (and display results, if specified)
+  stream.sync();
   const int compare =
     CompareDeviceResults(&h_reference, thrust::raw_pointer_cast(d_out.data()), 1, g_verbose, g_verbose);
   printf("\t%s", compare ? "FAIL" : "PASS");

--- a/cub/examples/device/example_device_reduce_env.cu
+++ b/cub/examples/device/example_device_reduce_env.cu
@@ -109,12 +109,12 @@ int main(int argc, char** argv)
   CubDebugExit(cub::DeviceReduce::Sum(d_in.data(), d_out.data(), num_items, env));
   // example-end env-overload-run
 
-  // Check for correctness
   // Check for correctness (and display results, if specified)
+  stream.sync();
   const int compare =
     CompareDeviceResults(&h_reference, thrust::raw_pointer_cast(d_out.data()), 1, g_verbose, g_verbose);
   printf("\t%s", compare ? "FAIL" : "PASS");
   printf("\n\n");
 
-  return 0;
+  return compare;
 }


### PR DESCRIPTION
Both env examples read the output without syncing the stream, racing against the reduce kernel. This surfaced as a [flaky FAIL](https://github.com/NVIDIA/cccl/actions/runs/32506598571/job/97488414846?pr=10628) of `cub.example.device.env_memory_resource` in a TestNoLaunch CI job.

Adds `stream.sync()`s where necessary to beat that.