### PR TITLE
[libcu++] Improve `is_nothrow_meow` traits

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -327,18 +327,6 @@
 #  define _CCCL_BUILTIN_IS_MEMBER_POINTER(...) __is_member_pointer(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__is_member_pointer)
 
-#if _CCCL_CHECK_BUILTIN(is_nothrow_assignable) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
-#  define _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(...) __is_nothrow_assignable(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(is_nothrow_assignable)
-
-#if _CCCL_CHECK_BUILTIN(is_nothrow_constructible) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
-#  define _CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE(...) __is_nothrow_constructible(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(is_nothrow_constructible)
-
-#if _CCCL_CHECK_BUILTIN(is_nothrow_destructible) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
-#  define _CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE(...) __is_nothrow_destructible(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(is_nothrow_destructible)
-
 #if _CCCL_CHECK_BUILTIN(is_object)
 #  define _CCCL_BUILTIN_IS_OBJECT(...) __is_object(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(is_object)

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_assignable.h
@@ -27,13 +27,17 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_CHECK_BUILTIN(is_nothrow_assignable) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
+#  define _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(...) __is_nothrow_assignable(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(is_nothrow_assignable)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE) && !defined(_LIBCUDACXX_USE_IS_NOTHROW_ASSIGNABLE_FALLBACK)
 
 template <class _Tp, class _Arg>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_assignable : public integral_constant<bool, _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(_Tp, _Arg)>
+is_nothrow_assignable : bool_constant<_CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(_Tp, _Arg)>
 {};
 
 template <class _Tp, class _Arg>
@@ -41,25 +45,19 @@ inline constexpr bool is_nothrow_assignable_v = _CCCL_BUILTIN_IS_NOTHROW_ASSIGNA
 
 #else // ^^^ _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE ^^^ / vvv !_CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE vvv
 
-template <bool, class _Tp, class _Arg>
-struct __cccl_is_nothrow_assignable;
+template <class _Tp, class _Arg, bool _IsAssignable = is_assignable_v<_Tp, _Arg>>
+inline constexpr bool __cccl_is_nothrow_assignable_v = false;
 
 template <class _Tp, class _Arg>
-struct __cccl_is_nothrow_assignable<false, _Tp, _Arg> : public false_type
+inline constexpr bool __cccl_is_nothrow_assignable_v<_Tp, _Arg, true> =
+  noexcept(::cuda::std::declval<_Tp>() = ::cuda::std::declval<_Arg>());
+
+template <class _Tp, class _Arg>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_assignable : bool_constant<__cccl_is_nothrow_assignable_v<_Tp, _Arg>>
 {};
 
 template <class _Tp, class _Arg>
-struct __cccl_is_nothrow_assignable<true, _Tp, _Arg>
-    : public integral_constant<bool, noexcept(::cuda::std::declval<_Tp>() = ::cuda::std::declval<_Arg>())>
-{};
-
-template <class _Tp, class _Arg>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_assignable : public __cccl_is_nothrow_assignable<is_assignable_v<_Tp, _Arg>, _Tp, _Arg>
-{};
-
-template <class _Tp, class _Arg>
-inline constexpr bool is_nothrow_assignable_v = is_nothrow_assignable<_Tp, _Arg>::value;
+inline constexpr bool is_nothrow_assignable_v = __cccl_is_nothrow_assignable_v<_Tp, _Arg>;
 
 #endif // !_CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_constructible.h
@@ -27,13 +27,17 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_CHECK_BUILTIN(is_nothrow_constructible) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
+#  define _CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE(...) __is_nothrow_constructible(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(is_nothrow_constructible)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE) && !defined(_LIBCUDACXX_USE_IS_NOTHROW_CONSTRUCTIBLE_FALLBACK)
 
 template <class _Tp, class... _Args>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_constructible : public integral_constant<bool, _CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE(_Tp, _Args...)>
+is_nothrow_constructible : bool_constant<_CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE(_Tp, _Args...)>
 {};
 
 template <class _Tp, class... _Args>
@@ -41,23 +45,23 @@ inline constexpr bool is_nothrow_constructible_v = _CCCL_BUILTIN_IS_NOTHROW_CONS
 
 #else
 
-template <bool, class _Tp, class... _Args>
-inline constexpr bool __cccl_is_nothrow_constructible = false;
+template <bool _IsConstructible, class _Tp, class... _Args>
+inline constexpr bool __cccl_is_nothrow_constructible_v = false;
 
 template <class _Tp, class... _Args>
-inline constexpr bool __cccl_is_nothrow_constructible<true, _Tp, _Args...> =
+inline constexpr bool __cccl_is_nothrow_constructible_v<true, _Tp, _Args...> =
   noexcept(_Tp(::cuda::std::declval<_Args>()...));
 
 template <class _Tp, class _Arg>
-inline constexpr bool __cccl_is_nothrow_constructible<true, _Tp, _Arg> =
+inline constexpr bool __cccl_is_nothrow_constructible_v<true, _Tp, _Arg> =
   noexcept(static_cast<_Tp>(::cuda::std::declval<_Arg>()));
 
 template <class _Tp, size_t _Ns>
-inline constexpr bool __cccl_is_nothrow_constructible<true, _Tp[_Ns]> = __cccl_is_nothrow_constructible<true, _Tp>;
+inline constexpr bool __cccl_is_nothrow_constructible_v<true, _Tp[_Ns]> = __cccl_is_nothrow_constructible_v<true, _Tp>;
 
 template <class _Tp, class... _Args>
 inline constexpr bool is_nothrow_constructible_v =
-  __cccl_is_nothrow_constructible<is_constructible_v<_Tp, _Args...>, _Tp, _Args...>;
+  __cccl_is_nothrow_constructible_v<is_constructible_v<_Tp, _Args...>, _Tp, _Args...>;
 
 template <class _Tp, class... _Args>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_constructible : bool_constant<is_nothrow_constructible_v<_Tp, _Args...>>

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_copy_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_copy_assignable.h
@@ -32,24 +32,24 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_copy_assignable
-    : public integral_constant<bool,
-                               _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(
-                                 add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<typename add_const<_Tp>::type>)>
+    : bool_constant<_CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(
+        add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<add_const_t<_Tp>>)>
 {};
 
 template <class _Tp>
-inline constexpr bool is_nothrow_copy_assignable_v = _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(
-  add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<typename add_const<_Tp>::type>);
+inline constexpr bool is_nothrow_copy_assignable_v =
+  _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<add_const_t<_Tp>>);
 
 #else
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_copy_assignable
-    : public is_nothrow_assignable<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<typename add_const<_Tp>::type>>
+    : bool_constant<is_nothrow_assignable_v<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<add_const_t<_Tp>>>>
 {};
 
 template <class _Tp>
-inline constexpr bool is_nothrow_copy_assignable_v = is_nothrow_copy_assignable<_Tp>::value;
+inline constexpr bool is_nothrow_copy_assignable_v =
+  is_nothrow_assignable_v<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<add_const_t<_Tp>>>;
 
 #endif
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_copy_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_copy_constructible.h
@@ -42,12 +42,13 @@ inline constexpr bool is_nothrow_copy_constructible_v =
 #else // ^^^ Use builtin ^^^ / vvv No builtin
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_copy_constructible
-    : public is_nothrow_constructible<_Tp, add_lvalue_reference_t<typename add_const<_Tp>::type>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT
+is_nothrow_copy_constructible : bool_constant<is_nothrow_constructible_v<_Tp, add_lvalue_reference_t<add_const_t<_Tp>>>>
 {};
 
 template <class _Tp>
-inline constexpr bool is_nothrow_copy_constructible_v = is_nothrow_copy_constructible<_Tp>::value;
+inline constexpr bool is_nothrow_copy_constructible_v =
+  is_nothrow_constructible_v<_Tp, add_lvalue_reference_t<add_const_t<_Tp>>>;
 
 #endif // No builtin
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_default_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_default_constructible.h
@@ -30,7 +30,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp, class... _Args>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_default_constructible : public integral_constant<bool, _CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE(_Tp)>
+is_nothrow_default_constructible : bool_constant<_CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE(_Tp)>
 {};
 
 template <class _Tp, class... _Args>
@@ -39,11 +39,11 @@ inline constexpr bool is_nothrow_default_constructible_v = _CCCL_BUILTIN_IS_NOTH
 #else
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_default_constructible : public is_nothrow_constructible<_Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_default_constructible : bool_constant<is_nothrow_constructible_v<_Tp>>
 {};
 
 template <class _Tp>
-inline constexpr bool is_nothrow_default_constructible_v = is_nothrow_constructible<_Tp>::value;
+inline constexpr bool is_nothrow_default_constructible_v = is_nothrow_constructible_v<_Tp>;
 
 #endif // defined(_CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE) && !defined(_LIBCUDACXX_USE_IS_NOTHROW_CONSTRUCTIBLE_FALLBACK)
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_destructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_destructible.h
@@ -30,6 +30,10 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_CHECK_BUILTIN(is_nothrow_destructible) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
+#  define _CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE(...) __is_nothrow_destructible(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(is_nothrow_destructible)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 // is_nothrow_destructible
@@ -37,7 +41,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 #if defined(_CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE) && !defined(_LIBCUDACXX_USE_IS_NOTHROW_DESTRUCTIBLE_FALLBACK)
 
 template <class _Tp>
-struct is_nothrow_destructible : public integral_constant<bool, _CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE(_Tp)>
+struct is_nothrow_destructible : bool_constant<_CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE(_Tp)>
 {};
 
 template <class _Tp>
@@ -45,33 +49,23 @@ inline constexpr bool is_nothrow_destructible_v = _CCCL_BUILTIN_IS_NOTHROW_DESTR
 
 #else // ^^^ _CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE ^^^ / vvv !_CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE vvv
 
-template <class _Tp, bool = is_destructible_v<_Tp>>
-struct __cccl_is_nothrow_destructible : false_type
-{};
+template <class _Tp, bool _IsDestructible = is_destructible_v<_Tp>>
+inline constexpr bool __cccl_is_nothrow_destructible_v = false;
+template <class _Tp>
+inline constexpr bool __cccl_is_nothrow_destructible_v<_Tp, true> = noexcept(::cuda::std::declval<_Tp>().~_Tp());
 
 template <class _Tp>
-struct __cccl_is_nothrow_destructible<_Tp, true>
-    : public integral_constant<bool, noexcept(::cuda::std::declval<_Tp>().~_Tp())>
-{};
-
-template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_destructible : public __cccl_is_nothrow_destructible<_Tp>
-{};
-
+inline constexpr bool is_nothrow_destructible_v = __cccl_is_nothrow_destructible_v<_Tp>;
 template <class _Tp, size_t _Ns>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_destructible<_Tp[_Ns]> : public is_nothrow_destructible<_Tp>
-{};
+inline constexpr bool is_nothrow_destructible_v<_Tp[_Ns]> = __cccl_is_nothrow_destructible_v<_Tp>;
+template <class _Tp>
+inline constexpr bool is_nothrow_destructible_v<_Tp&> = true;
+template <class _Tp>
+inline constexpr bool is_nothrow_destructible_v<_Tp&&> = true;
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_destructible<_Tp&> : public true_type
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_destructible : bool_constant<is_nothrow_destructible_v<_Tp>>
 {};
-
-template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_destructible<_Tp&&> : public true_type
-{};
-
-template <class _Tp>
-inline constexpr bool is_nothrow_destructible_v = is_nothrow_destructible<_Tp>::value;
 
 #endif // !_CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_move_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_move_assignable.h
@@ -32,9 +32,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_move_assignable
-    : public integral_constant<
-        bool,
-        _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>)>
+    : bool_constant<_CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>)>
 {};
 
 template <class _Tp>
@@ -44,12 +42,13 @@ inline constexpr bool is_nothrow_move_assignable_v =
 #else
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_move_assignable : public is_nothrow_assignable<add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_move_assignable
+    : bool_constant<is_nothrow_assignable_v<add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>>>
 {};
 
 template <class _Tp>
-inline constexpr bool is_nothrow_move_assignable_v = is_nothrow_move_assignable<_Tp>::value;
+inline constexpr bool is_nothrow_move_assignable_v =
+  is_nothrow_assignable_v<add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>>;
 
 #endif
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_move_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_move_constructible.h
@@ -42,11 +42,11 @@ inline constexpr bool is_nothrow_move_constructible_v =
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_move_constructible : public is_nothrow_constructible<_Tp, add_rvalue_reference_t<_Tp>>
+is_nothrow_move_constructible : bool_constant<is_nothrow_constructible_v<_Tp, add_rvalue_reference_t<_Tp>>>
 {};
 
 template <class _Tp>
-inline constexpr bool is_nothrow_move_constructible_v = is_nothrow_move_constructible<_Tp>::value;
+inline constexpr bool is_nothrow_move_constructible_v = is_nothrow_constructible_v<_Tp, add_rvalue_reference_t<_Tp>>;
 
 #endif // No builtin
 


### PR DESCRIPTION
This PR moves `is_nothrow_meow` builtins directly to the files and reduces the number of type instantiations.