### PR TITLE
[CUB] Fix silent sample loss in DeviceHistogram for signed bytes and wide histograms

### DIFF
--- a/c/parallel/src/histogram.cu
+++ b/c/parallel/src/histogram.cu
@@ -330,7 +330,7 @@ static_assert(device_histogram_policy()(detail::current_tuning_cc()) == {4}, "Ho
   const int privatized_smem_bins =
     num_output_levels_val - 1 > cub::detail::histogram::max_privatized_smem_bins ? 0 : 256;
 
-  const bool is_byte_sample = d_samples.value_type.size == 1;
+  const bool is_byte_sample = d_samples.value_type.size == 1 && d_samples.value_type.type != CCCL_INT8;
 
   std::string init_kernel_name  = histogram::get_init_kernel_name(num_active_channels, counter_cpp, offset_cpp);
   std::string sweep_kernel_name = histogram::get_sweep_kernel_name(
@@ -626,8 +626,9 @@ CUresult cccl_device_histogram_even(
   int64_t row_stride_samples,
   CUstream stream)
 {
-  auto histogram_impl = d_samples.value_type.size == 1 ? cccl_device_histogram_even_impl<::cuda::std::true_type>
-                                                       : cccl_device_histogram_even_impl<::cuda::std::false_type>;
+  const bool is_byte_sample = d_samples.value_type.size == 1 && d_samples.value_type.type != CCCL_INT8;
+  auto histogram_impl       = is_byte_sample ? cccl_device_histogram_even_impl<::cuda::std::true_type>
+                                             : cccl_device_histogram_even_impl<::cuda::std::false_type>;
 
   return histogram_impl(
     build,

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -293,7 +293,7 @@ struct AgentHistogram
         int output_bin       = -1;
         const CounterT count = privatized_histograms[ch][bin];
         const bool is_valid  = count > 0;
-        output_decode_op[ch].template BinSelect<load_modifier>(static_cast<SampleT>(bin), output_bin, is_valid);
+        output_decode_op[ch].template BinSelect<load_modifier>(bin, output_bin, is_valid);
 
         if (output_bin >= 0)
         {

--- a/cub/cub/device/device_histogram.cuh
+++ b/cub/cub/device/device_histogram.cuh
@@ -31,6 +31,7 @@
 #include <cuda/__execution/require.h>
 #include <cuda/std/__algorithm/copy.h>
 #include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__type_traits/is_signed.h>
 #include <cuda/std/__type_traits/remove_const.h>
 #include <cuda/std/array>
 #include <cuda/std/limits>
@@ -774,7 +775,8 @@ public:
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceHistogram::MultiHistogramEven");
 
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
-    ::cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
+    // Signed byte samples must not use the pass-thru path: negative values would yield negative privatized bins.
+    ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample;
 
     using default_policy_selector =
       detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, true>;
@@ -1500,7 +1502,8 @@ public:
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceHistogram::MultiHistogramRange");
 
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
-    ::cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
+    // Signed byte samples must not use the pass-thru path: negative values would yield negative privatized bins.
+    ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample;
 
     using default_policy_selector =
       detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, false>;
@@ -2062,7 +2065,8 @@ public:
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceHistogram::MultiHistogramEven");
 
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
-    ::cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
+    // Signed byte samples must not use the pass-thru path: negative values would yield negative privatized bins.
+    ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample;
 
     using default_policy_selector =
       detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, true>;
@@ -2525,7 +2529,8 @@ public:
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceHistogram::MultiHistogramRange");
 
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
-    ::cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
+    // Signed byte samples must not use the pass-thru path: negative values would yield negative privatized bins.
+    ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample;
 
     using default_policy_selector =
       detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, false>;

--- a/cub/cub/device/device_histogram.cuh
+++ b/cub/cub/device/device_histogram.cuh
@@ -776,7 +776,7 @@ public:
 
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     // Signed byte samples must not use the pass-thru path: negative values would yield negative privatized bins.
-    ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample;
+    constexpr ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample{};
 
     using default_policy_selector =
       detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, true>;
@@ -1503,7 +1503,7 @@ public:
 
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     // Signed byte samples must not use the pass-thru path: negative values would yield negative privatized bins.
-    ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample;
+    constexpr ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample{};
 
     using default_policy_selector =
       detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, false>;
@@ -2066,7 +2066,7 @@ public:
 
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     // Signed byte samples must not use the pass-thru path: negative values would yield negative privatized bins.
-    ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample;
+    constexpr ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample{};
 
     using default_policy_selector =
       detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, true>;
@@ -2530,7 +2530,7 @@ public:
 
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     // Signed byte samples must not use the pass-thru path: negative values would yield negative privatized bins.
-    ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample;
+    constexpr ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample{};
 
     using default_policy_selector =
       detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, false>;

--- a/cub/cub/device/device_histogram.cuh
+++ b/cub/cub/device/device_histogram.cuh
@@ -776,7 +776,7 @@ public:
 
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     // Signed byte samples must not use the pass-thru path: negative values would yield negative privatized bins.
-    constexpr ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample{};
+    using is_byte_sample_t = ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>>;
 
     using default_policy_selector =
       detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, true>;
@@ -801,7 +801,7 @@ public:
               (int) num_rows,
               (int) (row_stride_bytes / sizeof(SampleT)),
               stream,
-              is_byte_sample,
+              is_byte_sample_t{},
               policy_selector);
           }
         }
@@ -818,7 +818,7 @@ public:
           num_rows,
           (OffsetT) (row_stride_bytes / sizeof(SampleT)),
           stream,
-          is_byte_sample,
+          is_byte_sample_t{},
           policy_selector);
       });
   }
@@ -1503,7 +1503,7 @@ public:
 
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     // Signed byte samples must not use the pass-thru path: negative values would yield negative privatized bins.
-    constexpr ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample{};
+    using is_byte_sample_t = ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>>;
 
     using default_policy_selector =
       detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, false>;
@@ -1527,7 +1527,7 @@ public:
               (int) num_rows,
               (int) (row_stride_bytes / sizeof(SampleT)),
               stream,
-              is_byte_sample,
+              is_byte_sample_t{},
               policy_selector);
           }
         }
@@ -1543,7 +1543,7 @@ public:
           num_rows,
           (OffsetT) (row_stride_bytes / sizeof(SampleT)),
           stream,
-          is_byte_sample,
+          is_byte_sample_t{},
           policy_selector);
       });
   }
@@ -2066,7 +2066,7 @@ public:
 
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     // Signed byte samples must not use the pass-thru path: negative values would yield negative privatized bins.
-    constexpr ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample{};
+    using is_byte_sample_t = ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>>;
 
     using default_policy_selector =
       detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, true>;
@@ -2088,7 +2088,7 @@ public:
               (int) num_rows,
               (int) (row_stride_bytes / sizeof(SampleT)),
               stream,
-              is_byte_sample,
+              is_byte_sample_t{},
               policy_selector);
           }
         }
@@ -2105,7 +2105,7 @@ public:
           num_rows,
           (OffsetT) (row_stride_bytes / sizeof(SampleT)),
           stream,
-          is_byte_sample,
+          is_byte_sample_t{},
           policy_selector);
       });
   }
@@ -2530,7 +2530,7 @@ public:
 
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     // Signed byte samples must not use the pass-thru path: negative values would yield negative privatized bins.
-    constexpr ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>> is_byte_sample{};
+    using is_byte_sample_t = ::cuda::std::bool_constant<sizeof(SampleT) == 1 && !::cuda::std::is_signed_v<SampleT>>;
 
     using default_policy_selector =
       detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, false>;
@@ -2551,7 +2551,7 @@ public:
               (int) num_rows,
               (int) (row_stride_bytes / sizeof(SampleT)),
               stream,
-              is_byte_sample,
+              is_byte_sample_t{},
               policy_selector);
           }
         }
@@ -2567,7 +2567,7 @@ public:
           num_rows,
           (OffsetT) (row_stride_bytes / sizeof(SampleT)),
           stream,
-          is_byte_sample,
+          is_byte_sample_t{},
           policy_selector);
       });
   }

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -265,9 +265,10 @@ struct Transforms
       m_scale = this->ComputeScale(num_levels, m_max, m_min);
     }
 
-    // Method for converting samples to bin-ids
-    template <CacheLoadModifier LOAD_MODIFIER>
-    _CCCL_HOST_DEVICE _CCCL_FORCEINLINE void BinSelect(SampleT sample, int& bin, bool valid) const
+    // Method for converting samples to bin-ids. The sample type is a template parameter because the
+    // agent also feeds privatized bin indices through this op, which must not round-trip through SampleT.
+    template <CacheLoadModifier LOAD_MODIFIER, typename _SampleT>
+    _CCCL_HOST_DEVICE _CCCL_FORCEINLINE void BinSelect(_SampleT sample, int& bin, bool valid) const
     {
       const CommonT common_sample = static_cast<CommonT>(sample);
 

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -836,11 +836,11 @@ CUB_TEST("DeviceHistogram::HistogramEven bin calculation regression", "[histogra
 // indices in the pass-thru byte-sample path and were never counted.
 CUB_TEST("DeviceHistogram::Histogram* negative signed byte samples", "[histogram][device]", CUB_SMALL)
 {
-  constexpr int num_bins   = 4;
-  constexpr int num_levels = num_bins + 1;
-  const int8_t h_samples[] = {-60, -1, 10, 63};
-  auto d_samples           = c2h::device_vector<int8_t>(cs::begin(h_samples), cs::end(h_samples));
-  const auto* d_sample_ptr = thrust::raw_pointer_cast(d_samples.data());
+  constexpr int num_bins         = 4;
+  constexpr int num_levels       = num_bins + 1;
+  const int8_t h_samples[]       = {-60, -1, 10, 63};
+  auto d_samples                 = c2h::device_vector<int8_t>(cs::begin(h_samples), cs::end(h_samples));
+  const auto* const d_sample_ptr = thrust::raw_pointer_cast(d_samples.data());
   c2h::host_vector<int> h_expected{1, 1, 1, 1};
 
   SECTION("HistogramEven")
@@ -880,8 +880,8 @@ CUB_TEST("DeviceHistogram::Histogram* full 8-bit domain", "[histogram][device]",
   {
     h_all_samples[i] = static_cast<int8_t>(i - 128);
   }
-  auto d_all_samples       = c2h::device_vector<int8_t>(h_all_samples.begin(), h_all_samples.end());
-  const auto* d_sample_ptr = thrust::raw_pointer_cast(d_all_samples.data());
+  auto d_all_samples             = c2h::device_vector<int8_t>(h_all_samples.begin(), h_all_samples.end());
+  const auto* const d_sample_ptr = thrust::raw_pointer_cast(d_all_samples.data());
   c2h::host_vector<int> h_expected(256, 1);
 
   SECTION("HistogramEven")
@@ -929,8 +929,8 @@ CUB_TEST("DeviceHistogram::Histogram* bin indices survive the output decode", "[
   {
     h_i16_samples[i] = static_cast<int16_t>(static_cast<int>(i) - 32768);
   }
-  auto d_samples           = c2h::device_vector<int16_t>(h_i16_samples.begin(), h_i16_samples.end());
-  const auto* d_sample_ptr = thrust::raw_pointer_cast(d_samples.data());
+  auto d_samples                 = c2h::device_vector<int16_t>(h_i16_samples.begin(), h_i16_samples.end());
+  const auto* const d_sample_ptr = thrust::raw_pointer_cast(d_samples.data());
 
   c2h::host_vector<int> h_expected(num_bins, 1);
 

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -974,7 +974,7 @@ CUB_TEST("DeviceHistogram::Histogram* bin indices survive the output decode", "[
     constexpr int half_num_levels = half_num_bins + 1;
     const auto exact_half         = [](int i) {
       const int k = i < 2048 ? i : 2048 + (i - 2048) * 2;
-      return half_t(k / 1024.0f);
+      return half_t(static_cast<float>(k) / 1024.0f);
     };
 
     c2h::host_vector<half_t> h_half_levels(half_num_levels);

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -831,3 +831,175 @@ CUB_TEST("DeviceHistogram::HistogramEven bin calculation regression", "[histogra
     static_cast<int>(d_samples.size()));
   CHECK(h_histogram_ref == d_histogram);
 }
+
+// Regression test for NVIDIA/cccl#10977: signed byte samples produced negative privatized bin
+// indices in the pass-thru byte-sample path and were never counted.
+CUB_TEST("DeviceHistogram::Histogram* negative signed byte samples", "[histogram][device]", CUB_SMALL)
+{
+  constexpr int num_bins   = 4;
+  constexpr int num_levels = num_bins + 1;
+  const int8_t h_samples[] = {-60, -1, 10, 63};
+  auto d_samples           = c2h::device_vector<int8_t>(cs::begin(h_samples), cs::end(h_samples));
+  const auto* d_sample_ptr = thrust::raw_pointer_cast(d_samples.data());
+  c2h::host_vector<int> h_expected{1, 1, 1, 1};
+
+  SECTION("HistogramEven")
+  {
+    auto d_histogram = c2h::device_vector<int>(num_bins);
+    histogram_even(
+      d_sample_ptr,
+      thrust::raw_pointer_cast(d_histogram.data()),
+      num_levels,
+      static_cast<int8_t>(-60),
+      static_cast<int8_t>(64),
+      static_cast<int>(d_samples.size()));
+    CHECK(d_histogram == h_expected);
+  }
+
+  SECTION("HistogramRange")
+  {
+    const int h_levels[] = {-60, -30, 0, 30, 64};
+    auto d_levels        = c2h::device_vector<int>(cs::begin(h_levels), cs::end(h_levels));
+    auto d_histogram     = c2h::device_vector<int>(num_bins);
+    histogram_range(
+      d_sample_ptr,
+      thrust::raw_pointer_cast(d_histogram.data()),
+      num_levels,
+      thrust::raw_pointer_cast(d_levels.data()),
+      static_cast<int>(d_samples.size()));
+    CHECK(d_histogram == h_expected);
+  }
+}
+
+// Regression test for NVIDIA/cccl#10977: with more than 127 bins, full-range int8_t histograms lost
+// bins through the SampleT round trip of privatized bin indices in StoreOutput.
+CUB_TEST("DeviceHistogram::Histogram* full 8-bit domain", "[histogram][device]", CUB_SMALL)
+{
+  c2h::host_vector<int8_t> h_all_samples(256);
+  for (int i = 0; i < 256; ++i)
+  {
+    h_all_samples[i] = static_cast<int8_t>(i - 128);
+  }
+  auto d_all_samples       = c2h::device_vector<int8_t>(h_all_samples.begin(), h_all_samples.end());
+  const auto* d_sample_ptr = thrust::raw_pointer_cast(d_all_samples.data());
+  c2h::host_vector<int> h_expected(256, 1);
+
+  SECTION("HistogramEven")
+  {
+    auto d_histogram = c2h::device_vector<int>(256);
+    histogram_even(
+      d_sample_ptr,
+      thrust::raw_pointer_cast(d_histogram.data()),
+      257,
+      -128,
+      128,
+      static_cast<int>(d_all_samples.size()));
+    CHECK(d_histogram == h_expected);
+  }
+
+  SECTION("HistogramRange")
+  {
+    c2h::host_vector<int> h_levels(257);
+    for (int i = 0; i < 257; ++i)
+    {
+      h_levels[i] = i - 128;
+    }
+    auto d_levels    = c2h::device_vector<int>(h_levels.begin(), h_levels.end());
+    auto d_histogram = c2h::device_vector<int>(256);
+    histogram_range(
+      d_sample_ptr,
+      thrust::raw_pointer_cast(d_histogram.data()),
+      257,
+      thrust::raw_pointer_cast(d_levels.data()),
+      static_cast<int>(d_all_samples.size()));
+    CHECK(d_histogram == h_expected);
+  }
+}
+
+// Regression test for NVIDIA/cccl#10976: the privatized bin index was cast through the sample type
+// before the output decode op, so bin indices that are not exactly representable in the sample type
+// were merged or dropped (and, for float-like types, could write out of bounds).
+CUB_TEST("DeviceHistogram::Histogram* bin indices survive the output decode", "[histogram][device]", CUB_SMALL)
+{
+  constexpr int num_bins   = 1 << 16;
+  constexpr int num_levels = num_bins + 1;
+
+  c2h::host_vector<int16_t> h_i16_samples(num_bins);
+  for (int i = 0; i < num_bins; ++i)
+  {
+    h_i16_samples[i] = static_cast<int16_t>(static_cast<int>(i) - 32768);
+  }
+  auto d_samples           = c2h::device_vector<int16_t>(h_i16_samples.begin(), h_i16_samples.end());
+  const auto* d_sample_ptr = thrust::raw_pointer_cast(d_samples.data());
+
+  c2h::host_vector<int> h_expected(num_bins, 1);
+
+  SECTION("HistogramEven")
+  {
+    auto d_histogram = c2h::device_vector<int>(num_bins);
+    histogram_even(
+      d_sample_ptr,
+      thrust::raw_pointer_cast(d_histogram.data()),
+      num_levels,
+      -32768,
+      32768,
+      static_cast<int>(d_samples.size()));
+    CHECK(d_histogram == h_expected);
+  }
+
+  SECTION("HistogramRange")
+  {
+    c2h::host_vector<int> h_i16_levels(num_levels);
+    for (int i = 0; i < num_levels; ++i)
+    {
+      h_i16_levels[i] = i - 32768;
+    }
+    auto d_levels    = c2h::device_vector<int>(h_i16_levels.begin(), h_i16_levels.end());
+    auto d_histogram = c2h::device_vector<int>(num_bins);
+    histogram_range(
+      d_sample_ptr,
+      thrust::raw_pointer_cast(d_histogram.data()),
+      num_levels,
+      thrust::raw_pointer_cast(d_levels.data()),
+      static_cast<int>(d_samples.size()));
+    CHECK(d_histogram == h_expected);
+  }
+
+#if TEST_HALF_T()
+  SECTION("__half samples with more than 2048 bins")
+  {
+    // Strictly increasing exactly representable half values: k/1024 below 2048, then every second
+    // integer step above, since half needs 11 significand bits and ulp doubles at 2.0.
+    constexpr int half_num_bins   = 3000;
+    constexpr int half_num_levels = half_num_bins + 1;
+    const auto exact_half         = [](int i) {
+      const int k = i < 2048 ? i : 2048 + (i - 2048) * 2;
+      return half_t(k / 1024.0f);
+    };
+
+    c2h::host_vector<half_t> h_half_levels(half_num_levels);
+    for (int i = 0; i < half_num_levels; ++i)
+    {
+      h_half_levels[i] = exact_half(i);
+    }
+    c2h::host_vector<half_t> h_half_samples(half_num_bins);
+    for (int i = 0; i < half_num_bins; ++i)
+    {
+      h_half_samples[i] = exact_half(i);
+    }
+    auto d_half_levels  = c2h::device_vector<half_t>(h_half_levels.begin(), h_half_levels.end());
+    auto d_half_samples = c2h::device_vector<half_t>(h_half_samples.begin(), h_half_samples.end());
+
+    auto d_histogram = c2h::device_vector<int>(half_num_bins);
+    histogram_range(
+      cast_if_half_pointer(thrust::raw_pointer_cast(d_half_samples.data())),
+      thrust::raw_pointer_cast(d_histogram.data()),
+      half_num_levels,
+      cast_if_half_pointer(thrust::raw_pointer_cast(d_half_levels.data())),
+      half_num_bins);
+
+    c2h::host_vector<int> h_half_expected(half_num_bins, 1);
+    CHECK(d_histogram == h_half_expected);
+  }
+#endif // TEST_HALF_T()
+}


### PR DESCRIPTION
## Description

closes #10977
closes #10976

`cub::DeviceHistogram` silently lost samples and corrupted counts in two related ways, both returning `cudaSuccess`:

1. **Negative signed byte samples vanished** (#10977). Byte-sized sample types take a fast path that uses the raw sample value as a privatized bin index into a 256-bin shared-memory histogram (`PassThruTransform`). A negative `int8_t` sample produced a negative bin index, which the agent treats as "outside the histogram", so every negative sample was dropped.

2. **Bin indices were rounded or wrapped after binning** (#10976). When folding per-block privatized histograms into the output, `agent_histogram.cuh` cast each privatized bin index back through the sample type before handing it to the output decode op. Any bin index not exactly representable in the sample type got altered on that round trip: `__nv_bfloat16` above 256 bins merged neighboring bins and could write one element past the end of the output histogram, `__half` broke past 2048 bins, `int16_t` dropped every bin >= 32768, and `float` breaks past 2^24 bins. This affected `HistogramEven`, `HistogramRange`, and the `Multi` variants.

The two bugs compound: fixing only #10977 by routing signed bytes to the generic path still drops bins 128..255 for full-range `int8_t` histograms, because those bin indices wrap negative in the same round trip.

### Changes

- Restrict the byte-sample fast path to unsigned 8-bit sample types: the dispatch condition becomes `sizeof(SampleT) == 1 && !is_signed_v<SampleT>` at all four public entry points. Signed byte types take the generic `ScaleTransform`/`SearchTransform` path, which handles negative samples and levels correctly.
- Stop feeding the output decode op a value that round-trips through the sample type: templatize `ScaleTransform::BinSelect`'s sample parameter and pass the privatized bin index from `StoreOutput` as `int`. The decode ops are exact for any representable bin index; unsigned byte paths are unaffected because their indices are already <= 255.
- Apply the same signedness gate in `c/parallel/src/histogram.cu`, which picked its byte-sample specialization purely from `value_type.size == 1`.

Unsigned byte samples keep the fast path with unchanged behavior. Plain `char` is signed on the
platforms we test (and on MSVC by default), so existing `char`-sampled histograms now take the generic
path: correctness improves wherever levels go negative, and the trade-off is a performance-only change
for those configs.

### Verification

Reproducers from the two issues, CUDA 12.8, sm_90:

- Full-range `int8_t` histogram (256 bins over [-128, 128)): 128 of 256 counted before, 256 of 256 after.
- `HistogramRange` with 300 consecutive bf16 levels, one sample per bin: 33 wrong bins before (plus an out-of-bounds atomicAdd), 0 wrong bins after.

New regression tests in `catch2_test_device_histogram.cu`: negative int8 samples over [-60, 64), the full 8-bit domain with 256 bins (Even and Range), 65536-bin int16 histograms (Even and Range), and a guarded `__half` case with 3000 exactly representable bins. The bf16 configuration is covered by the reproducer above; adding it to the catch2 test needs bf16 support plumbing this test file does not have yet.

Note for reviewers: if the performance of signed-byte histograms matters, a follow-up could teach the pass-thru path to shift signed samples into [0, 256) together with a matching offset in the output decode op; I kept the fix minimal instead.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
