### PR TITLE
fix broken `--list-benches` in `analyze.py`

### DIFF
--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -875,7 +875,11 @@ def main():
     args = parse_arguments()
 
     if args.list_benches:
-        cccl.bench.list_benches()
+        cccl.bench.list_benches(
+            cccl.bench.filter_benchmarks_by_regex(
+                cccl.bench.Config().benchmarks, args.R
+            )
+        )
         return
 
     if args.coverage:


### PR DESCRIPTION
_I ran into this while working on my `tune-skill` project, during the smart analyzer step._

A long time ago #2778 we added a required `algnames` parameter to `list_benches()` in `search.py` so that `search.py --list-benches` could respect the `-R` regex filter. 

We did not update the caller in `analyze.py` though, so `--list-benches` crashes with a `TypeError` on every invocation.  This PR mirrors `search.py`'s pattern: filter the config's benchmarks by the `-R` regex and pass the result.

_I look forward to a day when our tuning/benchmarking infra will branch off to an autonomous, regression-prone and CI tested sub-project._