### PR TITLE
[CUB] Fix HistogramEven bin arithmetic for level ranges wider than the common type

### DIFF
--- a/ci/bench.yaml
+++ b/ci/bench.yaml
@@ -28,46 +28,6 @@
 # 4. Remove/reset benchmark-request edits before final merge.
 
 benchmarks:
-
-  # Benchmark filters grouped by project.
-  filters:
-    # CUB C++ benchmark filters (regex matched against ninja target names).
-    cub:
-      # Examples:
-      # - '^cub\.bench\.for_each\.base'
-      # - '^cub\.bench\.reduce\.(sum|min)\.'
-
-    # Python benchmark filters (regex matched against paths under benchmarks/).
-    python:
-      # Examples:
-      # - 'compute/reduce/sum\.py'
-      # - 'compute/transform/.*\.py'
-
-  # Select GPUs. These are limited and shared, be intentional and conservative.
-  gpus:
-    # - "t4"         # sm_75, 16 GB
-    # - "rtx2080"    # sm_75,  8 GB
-    # - "rtxa6000"   # sm_86, 48 GB
-    # - "l4"         # sm_89, 24 GB
-    # - "rtx4090"    # sm_89, 24 GB
-    # - "h100"       # sm_90, 80 GB
-    # - "rtxpro6000" # sm_120
-
-  # Extra .devcontainer/launch.sh -d args
-  # launch_args: "--cuda 13.3 --host gcc14"
-  launch_args: "" # Latest nvcc + gcc
-
-  # Advanced:
-  base_ref: "origin/main"
-  test_ref: "HEAD"
-  arch: "native"
-  nvbench_args: >-
-    --timeout 30
-    --skip-time 5e-6
-    --stopping-criterion entropy
-    --throttle-threshold 90
-    --throttle-recovery-delay 0.15
-    --cold-warmup-runs 10
-    --cold-max-warmup-walltime 0.05
-  nvbench_compare_args: ""
-  nvbench_compare_legacy_args: ""
+  base:
+    - '^cub\.bench\.histogram\.even\.base$'
+    - '^cub\.bench\.histogram\.multi\.even\.base$'

--- a/ci/bench.yaml
+++ b/ci/bench.yaml
@@ -1,14 +1,73 @@
 # # CCCL PR benchmark request config.
 #
-# This file must match ci/bench.template.yaml to merge. Reset before merging.
-# [bench-only] on the commit summary keeps unrelated CI jobs from running.
+# ## Overview:
+#
+# This file is used to request benchmark comparisons in PR CI.
+#
+# This file must match ci/bench.template.yaml to merge.
+# CI branch protections will fail if they differ. Reset before merging.
+#
+# To update the defaults (e.g. new GPU pools), modify both this file and
+# ci/bench.template.yaml together in the same PR.
+#
+# !! Strongly consider appending the following to your **commit messages** while benchmarking. !!
+# This prevents wasteful non-benchmark CI jobs if they are not needed.
+#
+#     [bench-only]
+#
+# To skip compile-time benchmark telemetry on unrelated changes, use:
+#
+#     [skip-compile-time-bench]
+#
+# ## Quick start:
+#
+# 1. Add one or more benchmark regexes under benchmarks.filters.cub and/or
+#    benchmarks.filters.python.
+# 2. Enable at least one GPU by uncommenting or adding entries in benchmarks.gpus.
+# 3. Push and inspect the dispatched benchmark jobs/artifacts.
+# 4. Remove/reset benchmark-request edits before final merge.
 
 benchmarks:
+
+  # Benchmark filters grouped by project.
   filters:
+    # CUB C++ benchmark filters (regex matched against ninja target names).
     cub:
-      - '^cub\.bench\.histogram\.even\.base$'
-      - '^cub\.bench\.histogram\.multi\.even\.base$'
+      # Examples:
+      # - '^cub\.bench\.for_each\.base'
+      # - '^cub\.bench\.reduce\.(sum|min)\.'
+
+    # Python benchmark filters (regex matched against paths under benchmarks/).
+    python:
+      # Examples:
+      # - 'compute/reduce/sum\.py'
+      # - 'compute/transform/.*\.py'
+
+  # Select GPUs. These are limited and shared, be intentional and conservative.
   gpus:
-    - "t4"    # sm_75
-    - "l4"    # sm_89
-    - "h100"  # sm_90
+    # - "t4"         # sm_75, 16 GB
+    # - "rtx2080"    # sm_75,  8 GB
+    # - "rtxa6000"   # sm_86, 48 GB
+    # - "l4"         # sm_89, 24 GB
+    # - "rtx4090"    # sm_89, 24 GB
+    # - "h100"       # sm_90, 80 GB
+    # - "rtxpro6000" # sm_120
+
+  # Extra .devcontainer/launch.sh -d args
+  # launch_args: "--cuda 13.3 --host gcc14"
+  launch_args: "" # Latest nvcc + gcc
+
+  # Advanced:
+  base_ref: "origin/main"
+  test_ref: "HEAD"
+  arch: "native"
+  nvbench_args: >-
+    --timeout 30
+    --skip-time 5e-6
+    --stopping-criterion entropy
+    --throttle-threshold 90
+    --throttle-recovery-delay 0.15
+    --cold-warmup-runs 10
+    --cold-max-warmup-walltime 0.05
+  nvbench_compare_args: ""
+  nvbench_compare_legacy_args: ""

--- a/ci/bench.yaml
+++ b/ci/bench.yaml
@@ -1,33 +1,14 @@
 # # CCCL PR benchmark request config.
 #
-# ## Overview:
-#
-# This file is used to request benchmark comparisons in PR CI.
-#
-# This file must match ci/bench.template.yaml to merge.
-# CI branch protections will fail if they differ. Reset before merging.
-#
-# To update the defaults (e.g. new GPU pools), modify both this file and
-# ci/bench.template.yaml together in the same PR.
-#
-# !! Strongly consider appending the following to your **commit messages** while benchmarking. !!
-# This prevents wasteful non-benchmark CI jobs if they are not needed.
-#
-#     [bench-only]
-#
-# To skip compile-time benchmark telemetry on unrelated changes, use:
-#
-#     [skip-compile-time-bench]
-#
-# ## Quick start:
-#
-# 1. Add one or more benchmark regexes under benchmarks.filters.cub and/or
-#    benchmarks.filters.python.
-# 2. Enable at least one GPU by uncommenting or adding entries in benchmarks.gpus.
-# 3. Push and inspect the dispatched benchmark jobs/artifacts.
-# 4. Remove/reset benchmark-request edits before final merge.
+# This file must match ci/bench.template.yaml to merge. Reset before merging.
+# [bench-only] on the commit summary keeps unrelated CI jobs from running.
 
 benchmarks:
-  base:
-    - '^cub\.bench\.histogram\.even\.base$'
-    - '^cub\.bench\.histogram\.multi\.even\.base$'
+  filters:
+    cub:
+      - '^cub\.bench\.histogram\.even\.base$'
+      - '^cub\.bench\.histogram\.multi\.even\.base$'
+  gpus:
+    - "t4"    # sm_75
+    - "l4"    # sm_89
+    - "h100"  # sm_90

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -43,6 +43,7 @@
 #include <cuda/std/__tuple_dir/apply.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/is_void.h>
+#include <cuda/std/__utility/cmp.h>
 #include <cuda/std/array>
 #include <cuda/std/limits>
 #include <cuda/std/tuple>
@@ -147,8 +148,13 @@ struct DeviceHistogramKernelSource
     if constexpr (::cuda::std::is_integral_v<CommonT>)
     {
       using IntArithmeticT = typename TransformsT::ScaleTransform::IntArithmeticT;
-      return static_cast<IntArithmeticT>(upper_level[channel] - lower_level[channel])
-           > (::cuda::std::numeric_limits<IntArithmeticT>::max() / static_cast<IntArithmeticT>(num_bins));
+      if (::cuda::std::cmp_greater(num_bins, ::cuda::std::numeric_limits<CommonT>::max()))
+      {
+        return true;
+      }
+      const IntArithmeticT range =
+        static_cast<IntArithmeticT>(upper_level[channel]) - static_cast<IntArithmeticT>(lower_level[channel]);
+      return range > (::cuda::std::numeric_limits<IntArithmeticT>::max() / static_cast<IntArithmeticT>(num_bins));
     }
     else
     {
@@ -1013,7 +1019,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch_even(
       num_privatized_levels[channel] = 257;
 
       int num_levels = num_output_levels[channel];
-      if (kernel_source.MayOverflow(static_cast<CommonT>(num_levels - 1), upper_level, lower_level, channel))
+      if (kernel_source.MayOverflow(num_levels - 1, upper_level, lower_level, channel))
       {
         if (!d_temp_storage)
         {
@@ -1079,7 +1085,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch_even(
     for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
     {
       int num_levels = num_output_levels[channel];
-      if (kernel_source.MayOverflow(static_cast<CommonT>(num_levels - 1), upper_level, lower_level, channel))
+      if (kernel_source.MayOverflow(num_levels - 1, upper_level, lower_level, channel))
       {
         if (!d_temp_storage)
         {

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -148,7 +148,8 @@ struct DeviceHistogramKernelSource
     if constexpr (::cuda::std::is_integral_v<CommonT>)
     {
       using IntArithmeticT = typename TransformsT::ScaleTransform::IntArithmeticT;
-      if (::cuda::std::cmp_greater(num_bins, ::cuda::std::numeric_limits<CommonT>::max()))
+      // The unary plus promotes plain char to int, which cuda::std::cmp_greater requires
+      if (::cuda::std::cmp_greater(num_bins, +::cuda::std::numeric_limits<CommonT>::max()))
       {
         return true;
       }

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -123,8 +123,8 @@ struct Transforms
       // rounding errors (see NVIDIA/cub#489).
       struct FractionT
       {
-        CommonT bins;
-        CommonT range;
+        IntArithmeticT bins;
+        IntArithmeticT range;
       } fraction;
 
       // Used when CommonT is floating-point as an optimization.
@@ -149,8 +149,8 @@ struct Transforms
     ComputeScale(int num_levels, T max_level, T min_level, ::cuda::std::false_type /* is_fp */)
     {
       ScaleT result;
-      result.fraction.bins  = static_cast<T>(num_levels - 1);
-      result.fraction.range = static_cast<T>(max_level - min_level);
+      result.fraction.bins  = static_cast<IntArithmeticT>(num_levels - 1);
+      result.fraction.range = static_cast<IntArithmeticT>(max_level) - static_cast<IntArithmeticT>(min_level);
       return result;
     }
 
@@ -227,7 +227,8 @@ struct Transforms
     _CCCL_HOST_DEVICE _CCCL_FORCEINLINE int
     ComputeBin(T sample, T min_level, ScaleT scale, ::cuda::std::false_type /* is_fp */) const
     {
-      return static_cast<int>(((sample - min_level) * scale.fraction.bins) / scale.fraction.range);
+      return static_cast<int>(((sample - min_level) * static_cast<CommonT>(scale.fraction.bins))
+                              / static_cast<CommonT>(scale.fraction.range));
     }
 
     //! @brief Bin computation for integral types of up to 64-bit types
@@ -235,8 +236,8 @@ struct Transforms
     _CCCL_HOST_DEVICE _CCCL_FORCEINLINE int ComputeBin(T sample, T min_level, ScaleT scale) const
     {
       return static_cast<int>(
-        (static_cast<IntArithmeticT>(sample - min_level) * static_cast<IntArithmeticT>(scale.fraction.bins))
-        / static_cast<IntArithmeticT>(scale.fraction.range));
+        ((static_cast<IntArithmeticT>(sample) - static_cast<IntArithmeticT>(min_level)) * scale.fraction.bins)
+        / scale.fraction.range);
     }
 
     template <typename T, ::cuda::std::enable_if_t<!is_integral_excl_int128<T>::value, int> = 0>

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -498,20 +498,21 @@ void test_even_and_range(LevelT max_level, int max_level_count, OffsetT width, O
   }
 }
 
-using types =
-  c2h::type_list<std::int8_t,
-                 std::uint8_t,
-                 std::int16_t,
-                 std::uint16_t,
-                 std::int32_t,
-                 std::uint32_t,
-                 std::int64_t,
-                 std::uint64_t,
+using types = c2h::type_list<
+  std::int8_t,
+  char,
+  std::uint8_t,
+  std::int16_t,
+  std::uint16_t,
+  std::int32_t,
+  std::uint32_t,
+  std::int64_t,
+  std::uint64_t,
 #if TEST_HALF_T()
-                 half_t,
+  half_t,
 #endif // TEST_HALF_T()
-                 float,
-                 double>;
+  float,
+  double>;
 
 CUB_TEST("DeviceHistogram::Histogram* basic use", "[histogram][device]", CUB_SMALL, types)
 {

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -831,3 +831,47 @@ CUB_TEST("DeviceHistogram::HistogramEven bin calculation regression", "[histogra
     static_cast<int>(d_samples.size()));
   CHECK(h_histogram_ref == d_histogram);
 }
+
+// Regression tests for NVIDIA/cccl#10975: the even-bin arithmetic computed sample - min_level and
+// max_level - min_level in the narrow common type before widening, so level ranges wider than the
+// common type wrapped around (silently misbinning) or overflowed signed types (spuriously rejected).
+CUB_TEST("DeviceHistogram::HistogramEven level range wider than int16", "[histogram_even][device]", CUB_SMALL)
+{
+  // Full int16 range with 100 equal bins: expected bins are 0, 50, and 99.
+  const int16_t h_samples[] = {-32768, 0, 32766};
+  auto d_samples            = c2h::device_vector<int16_t>(cs::begin(h_samples), cs::end(h_samples));
+  auto d_histogram          = c2h::device_vector<int>(100);
+  histogram_even(
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    101,
+    static_cast<int16_t>(-32768),
+    static_cast<int16_t>(32767),
+    3);
+  c2h::host_vector<int> h_histogram = d_histogram;
+  CHECK(h_histogram[0] == 1);
+  CHECK(h_histogram[50] == 1);
+  CHECK(h_histogram[99] == 1);
+}
+
+CUB_TEST("DeviceHistogram::HistogramEven wide int32 level range is not spuriously rejected",
+         "[histogram_even][device]",
+         CUB_SMALL)
+{
+  // A [-1.5e9, 1.5e9) range with 100 bins is well within the documented uint64 overflow bound,
+  // but used to wrap the level subtraction in int32 and return cudaErrorInvalidValue.
+  const int h_samples[] = {-1500000000, 0, 1400000000};
+  auto d_samples        = c2h::device_vector<int>(cs::begin(h_samples), cs::end(h_samples));
+  auto d_histogram      = c2h::device_vector<int>(100);
+  histogram_even(
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    101,
+    -1500000000,
+    1500000000,
+    3);
+  c2h::host_vector<int> h_histogram = d_histogram;
+  CHECK(h_histogram[0] == 1);
+  CHECK(h_histogram[50] == 1);
+  CHECK(h_histogram[96] == 1);
+}

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -838,9 +838,9 @@ CUB_TEST("DeviceHistogram::HistogramEven bin calculation regression", "[histogra
 CUB_TEST("DeviceHistogram::HistogramEven level range wider than int16", "[histogram_even][device]", CUB_SMALL)
 {
   // Full int16 range with 100 equal bins: expected bins are 0, 50, and 99.
-  const int16_t h_samples[] = {-32768, 0, 32766};
-  auto d_samples            = c2h::device_vector<int16_t>(cs::begin(h_samples), cs::end(h_samples));
-  auto d_histogram          = c2h::device_vector<int>(100);
+  constexpr int16_t h_samples[] = {-32768, 0, 32766};
+  auto d_samples                = c2h::device_vector<int16_t>(cs::begin(h_samples), cs::end(h_samples));
+  auto d_histogram              = c2h::device_vector<int>(100);
   histogram_even(
     thrust::raw_pointer_cast(d_samples.data()),
     thrust::raw_pointer_cast(d_histogram.data()),
@@ -860,9 +860,9 @@ CUB_TEST("DeviceHistogram::HistogramEven wide int32 level range is not spuriousl
 {
   // A [-1.5e9, 1.5e9) range with 100 bins is well within the documented uint64 overflow bound,
   // but used to wrap the level subtraction in int32 and return cudaErrorInvalidValue.
-  const int h_samples[] = {-1500000000, 0, 1400000000};
-  auto d_samples        = c2h::device_vector<int>(cs::begin(h_samples), cs::end(h_samples));
-  auto d_histogram      = c2h::device_vector<int>(100);
+  constexpr int h_samples[] = {-1500000000, 0, 1400000000};
+  auto d_samples            = c2h::device_vector<int>(cs::begin(h_samples), cs::end(h_samples));
+  auto d_histogram          = c2h::device_vector<int>(100);
   histogram_even(
     thrust::raw_pointer_cast(d_samples.data()),
     thrust::raw_pointer_cast(d_histogram.data()),

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -838,20 +838,21 @@ CUB_TEST("DeviceHistogram::HistogramEven bin calculation regression", "[histogra
 CUB_TEST("DeviceHistogram::HistogramEven level range wider than int16", "[histogram_even][device]", CUB_SMALL)
 {
   // Full int16 range with 100 equal bins: expected bins are 0, 50, and 99.
-  constexpr int16_t h_samples[] = {-32768, 0, 32766};
+  constexpr int num_bins        = 100;
+  constexpr int16_t h_samples[] = {cs::numeric_limits<int16_t>::min(), 0, cs::numeric_limits<int16_t>::max() - 1};
   auto d_samples                = c2h::device_vector<int16_t>(cs::begin(h_samples), cs::end(h_samples));
-  auto d_histogram              = c2h::device_vector<int>(100);
+  auto d_histogram              = c2h::device_vector<int>(num_bins);
   histogram_even(
     thrust::raw_pointer_cast(d_samples.data()),
     thrust::raw_pointer_cast(d_histogram.data()),
-    101,
-    static_cast<int16_t>(-32768),
-    static_cast<int16_t>(32767),
-    3);
+    num_bins + 1,
+    cs::numeric_limits<int16_t>::min(),
+    cs::numeric_limits<int16_t>::max(),
+    static_cast<int>(d_samples.size()));
   c2h::host_vector<int> h_histogram = d_histogram;
   CHECK(h_histogram[0] == 1);
-  CHECK(h_histogram[50] == 1);
-  CHECK(h_histogram[99] == 1);
+  CHECK(h_histogram[num_bins / 2] == 1);
+  CHECK(h_histogram[num_bins - 1] == 1);
 }
 
 CUB_TEST("DeviceHistogram::HistogramEven wide int32 level range is not spuriously rejected",
@@ -860,18 +861,22 @@ CUB_TEST("DeviceHistogram::HistogramEven wide int32 level range is not spuriousl
 {
   // A [-1.5e9, 1.5e9) range with 100 bins is well within the documented uint64 overflow bound,
   // but used to wrap the level subtraction in int32 and return cudaErrorInvalidValue.
-  constexpr int h_samples[] = {-1500000000, 0, 1400000000};
+  constexpr int num_bins    = 100;
+  constexpr int lower_level = -1500000000;
+  constexpr int upper_level = 1500000000;
+  // 1400000000 lies 29/30 of the way through the range, so it lands in bin 96.
+  constexpr int h_samples[] = {lower_level, 0, 1400000000};
   auto d_samples            = c2h::device_vector<int>(cs::begin(h_samples), cs::end(h_samples));
-  auto d_histogram          = c2h::device_vector<int>(100);
+  auto d_histogram          = c2h::device_vector<int>(num_bins);
   histogram_even(
     thrust::raw_pointer_cast(d_samples.data()),
     thrust::raw_pointer_cast(d_histogram.data()),
-    101,
-    -1500000000,
-    1500000000,
-    3);
+    num_bins + 1,
+    lower_level,
+    upper_level,
+    static_cast<int>(d_samples.size()));
   c2h::host_vector<int> h_histogram = d_histogram;
   CHECK(h_histogram[0] == 1);
-  CHECK(h_histogram[50] == 1);
+  CHECK(h_histogram[num_bins / 2] == 1);
   CHECK(h_histogram[96] == 1);
 }


### PR DESCRIPTION
## Description

closes #10975

`cub::DeviceHistogram::HistogramEven` mishandled integral level ranges wider than the common type of `LevelT` and `SampleT`. Three symptoms, all from the same root cause: the bin arithmetic subtracted levels in the narrow common type before widening.

- Full-range `int16_t` levels over [-32768, 32767) put every sample in bin 0 (`max_level - min_level` wrapped to -1 in `int16_t`), returning `cudaSuccess`.
- A [-1.5e9, 1.5e9) `int32_t` range with 100 bins was rejected with `cudaErrorInvalidValue` even though `(upper - lower) * (num_levels - 1)` = 3e11 is far below the documented `uint64_t` bound; the subtraction overflowed `int32_t` first.
- Wider spans were rejected through signed-overflow UB rather than by a valid check.
- Bin counts that do not fit `CommonT` slipped past the #6908 rejection for some values because the count was narrowed through `static_cast<CommonT>` before the check and wrapped into a huge unsigned number there.

### Changes

- `ScaleTransform` stores the integral scale fraction in `IntArithmeticT` (the widened arithmetic type) instead of `CommonT`, computes `range` as a widened subtraction, and computes `sample - min_level` after widening both operands. Modular unsigned subtraction of two cast operands is exact here because samples below `min_level` are rejected before bin computation.
- The custom-type/`__int128` bin path casts the fraction fields back to `CommonT`, keeping its semantics unchanged.
- `MayOverflow` now rejects bin counts above `CommonT`'s maximum explicitly (same observable contract as #6908, without relying on narrowing wrap), then checks the widened range against `IntArithmeticT` max divided by the bin count. Both host-init call sites pass the raw bin count instead of pre-narrowing it; the device-init paths get the same rejection they previously lacked.

Documented contract preserved: rejection iff `(upper_level[i] - lower_level[i]) * (num_levels[i] - 1)` exceeds the widened arithmetic type (128-bit when the common type is 128 bits wide). One deliberate gap remains: small sample/level types use a `uint32_t` fast arithmetic path, so products between 2^32 and 2^64 are still rejected where the docs promise acceptance. Fixing that would move those configs to 64-bit division in the per-sample hot loop; I left it alone pending maintainer input on whether the docs or the current policy should change.

### Verification

Reproducers from the issue, CUDA 12.8, sm_90: full-range int16 now reports bins {0, 50, 99} for samples {-32768, 0, 32766} instead of all-in-bin-0; the int32 case returns success instead of `cudaErrorInvalidValue`. New regression tests cover both configurations. The existing "num_bins exceeds LevelT range" and "bin computation does not overflow" tests pin the rejection contract and still pass.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
