### PR TITLE
[libcu++] Enable compiler builtins that conflicted with libstdc++

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -77,11 +77,6 @@
 #  define _CCCL_BUILTIN_ADD_POINTER(...) __add_pointer(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__add_pointer)
 
-// NVCC has issues with function pointers
-#if _CCCL_HAS_BUILTIN(__add_rvalue_reference) && _CCCL_CUDA_COMPILER(CLANG)
-#  define _CCCL_BUILTIN_ADD_RVALUE_REFERENCE(...) __add_rvalue_reference(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__add_rvalue_reference)
-
 // TODO: Enable using the builtin __array_rank when https://llvm.org/PR57133 is resolved
 #if 0 // _CCCL_CHECK_BUILTIN(array_rank)
 #  define _CCCL_BUILTIN_ARRAY_RANK(...) __array_rank(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -329,11 +329,6 @@
 #  define _CCCL_BUILTIN_IS_OBJECT(...) __is_object(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(is_object)
 
-// Disabled due to libstdc++ conflict
-#if 0 // _CCCL_HAS_BUILTIN(__is_pointer)
-#  define _CCCL_BUILTIN_IS_POINTER(...) __is_pointer(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__is_pointer)
-
 #if _CCCL_CHECK_BUILTIN(is_pointer_interconvertible_base_of) || _CCCL_COMPILER(MSVC, >=, 19, 29)
 #  define _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF(...) __is_pointer_interconvertible_base_of(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(is_pointer_interconvertible_base_of) || _CCCL_COMPILER(MSVC, >=, 19, 29)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -68,8 +68,12 @@
 #define _CCCL_CHECK_BUILTIN(__x) (_CCCL_HAS_BUILTIN(__##__x) || _CCCL_HAS_KEYWORD(__##__x) || _CCCL_HAS_FEATURE(__x))
 
 // libstdc++ conflicts with some of the builtins. Ensure that we do not use them if affected libstdc++ is present.
-#define _CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(...) \
-  (_CCCL_HOST_STD_LIB(LIBSTDCXX, <, __VA_ARGS__) && !_CCCL_CUDA_COMPILER(CLANG))
+#ifdef _CCCL_DISABLE_CONFLICTING_COMPILER_BUILTINS
+#  define _CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(...) 1
+#else // ^^^ _CCCL_DISABLE_CONFLICTING_COMPILER_BUILTINS ^^^ / vvv !_CCCL_DISABLE_CONFLICTING_COMPILER_BUILTINS vvv
+#  define _CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(...) \
+    (_CCCL_HOST_STD_LIB(LIBSTDCXX, <, __VA_ARGS__) && !_CCCL_CUDA_COMPILER(CLANG))
+#endif // !_CCCL_DISABLE_CONFLICTING_COMPILER_BUILTINS
 
 // TODO: Enable using the builtin __array_rank when https://llvm.org/PR57133 is resolved
 #if 0 // _CCCL_CHECK_BUILTIN(array_rank)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -75,6 +75,14 @@
     (_CCCL_HOST_STD_LIB(LIBSTDCXX, <, __VA_ARGS__) && !_CCCL_CUDA_COMPILER(CLANG))
 #endif // !_CCCL_DISABLE_CONFLICTING_COMPILER_BUILTINS
 
+#if _CCCL_COMPILER(GCC) || _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(NVRTC)
+// NVCC and NVRTC incorrectly reject the builtin if directly used in a SFINAE context. See nvbug6669680
+// GCC error: use of built-in trait in function signature; use library traits instead
+#  define _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() 1
+#else // ^^^ _CCCL_COMPILER(GCC) || _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(NVRTC)  ^^^ / vvv other compilers vvv
+#  define _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() 0
+#endif // other compilers
+
 // TODO: Enable using the builtin __array_rank when https://llvm.org/PR57133 is resolved
 #if 0 // _CCCL_CHECK_BUILTIN(array_rank)
 #  define _CCCL_BUILTIN_ARRAY_RANK(...) __array_rank(__VA_ARGS__)
@@ -365,20 +373,6 @@
 #if _CCCL_HAS_BUILTIN(__reference_converts_from_temporary)
 #  define _CCCL_BUILTIN_REFERENCE_CONVERTS_FROM_TEMPORARY(...) __reference_converts_from_temporary(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__reference_converts_from_temporary)
-
-#if _CCCL_HAS_BUILTIN(__remove_const) && _CCCL_CUDA_COMPILER(CLANG)
-#  define _CCCL_BUILTIN_REMOVE_CONST(...) __remove_const(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__remove_const)
-
-#if _CCCL_HAS_BUILTIN(__remove_reference)
-#  define _CCCL_BUILTIN_REMOVE_REFERENCE_T(...) __remove_reference(__VA_ARGS__)
-#elif _CCCL_HAS_BUILTIN(__remove_reference_t) && _CCCL_CUDA_COMPILER(CLANG)
-#  define _CCCL_BUILTIN_REMOVE_REFERENCE_T(...) __remove_reference_t(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__remove_reference_t)
-
-#if _CCCL_COMPILER(NVRTC, <, 12, 4) // NVRTC below 12.4 fails to properly compile cuda::std::move with that
-#  undef _CCCL_BUILTIN_REMOVE_REFERENCE_T
-#endif // _CCCL_COMPILER(NVRTC, <, 12, 4)
 
 #if _CCCL_HAS_BUILTIN(__remove_volatile) && _CCCL_CUDA_COMPILER(CLANG)
 #  define _CCCL_BUILTIN_REMOVE_VOLATILE(...) __remove_volatile(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -67,10 +67,10 @@
 // https://bugs.llvm.org/show_bug.cgi?id=44517
 #define _CCCL_CHECK_BUILTIN(__x) (_CCCL_HAS_BUILTIN(__##__x) || _CCCL_HAS_KEYWORD(__##__x) || _CCCL_HAS_FEATURE(__x))
 
-// NVCC has issues with function pointers
-#if _CCCL_HAS_BUILTIN(__add_lvalue_reference) && _CCCL_CUDA_COMPILER(CLANG)
-#  define _CCCL_BUILTIN_ADD_LVALUE_REFERENCE(...) __add_lvalue_reference(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__add_lvalue_reference)
+// libstdc++ conflicts with some of the builtins. Ensure that we do not use them if affected libstdc++ is present.
+#define _CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(_VERSION)                                      \
+  (_CCCL_HOST_STD_LIB(LIBSTDCXX, <, _VERSION) || defined(_GLIBCXX_DO_NOT_USE_BUILTIN_TRAITS)) \
+    && !_CCCL_CUDA_COMPILER(CLANG)
 
 // NVCC has issues with function pointers
 #if _CCCL_HAS_BUILTIN(__add_pointer) && _CCCL_CUDA_COMPILER(CLANG)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -68,9 +68,8 @@
 #define _CCCL_CHECK_BUILTIN(__x) (_CCCL_HAS_BUILTIN(__##__x) || _CCCL_HAS_KEYWORD(__##__x) || _CCCL_HAS_FEATURE(__x))
 
 // libstdc++ conflicts with some of the builtins. Ensure that we do not use them if affected libstdc++ is present.
-#define _CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(_VERSION)                                      \
-  (_CCCL_HOST_STD_LIB(LIBSTDCXX, <, _VERSION) || defined(_GLIBCXX_DO_NOT_USE_BUILTIN_TRAITS)) \
-    && !_CCCL_CUDA_COMPILER(CLANG)
+#define _CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(...) \
+  (_CCCL_HOST_STD_LIB(LIBSTDCXX, <, __VA_ARGS__) && !_CCCL_CUDA_COMPILER(CLANG))
 
 // TODO: Enable using the builtin __array_rank when https://llvm.org/PR57133 is resolved
 #if 0 // _CCCL_CHECK_BUILTIN(array_rank)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -253,10 +253,6 @@
 #  define _CCCL_BUILTIN_PREFETCH(...)
 #endif // _CCCL_CHECK_BUILTIN(builtin_prefetch)
 
-#if _CCCL_HAS_BUILTIN(__decay) && _CCCL_CUDA_COMPILER(CLANG)
-#  define _CCCL_BUILTIN_DECAY(...) __decay(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__decay) && clang-cuda
-
 #if _CCCL_CHECK_BUILTIN(has_nothrow_assign) || _CCCL_COMPILER(GCC, >=, 4, 3) || _CCCL_COMPILER(MSVC) \
   || _CCCL_COMPILER(NVRTC)
 #  define _CCCL_BUILTIN_HAS_NOTHROW_ASSIGN(...) __has_nothrow_assign(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -372,10 +372,6 @@
 #  define _CCCL_BUILTIN_REMOVE_CONST(...) __remove_const(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__remove_const)
 
-#if _CCCL_HAS_BUILTIN(__remove_pointer) && _CCCL_CUDA_COMPILER(CLANG)
-#  define _CCCL_BUILTIN_REMOVE_POINTER(...) __remove_pointer(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__remove_pointer)
-
 #if _CCCL_HAS_BUILTIN(__remove_reference)
 #  define _CCCL_BUILTIN_REMOVE_REFERENCE_T(...) __remove_reference(__VA_ARGS__)
 #elif _CCCL_HAS_BUILTIN(__remove_reference_t) && _CCCL_CUDA_COMPILER(CLANG)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -372,10 +372,6 @@
 #  define _CCCL_BUILTIN_REMOVE_CONST(...) __remove_const(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__remove_const)
 
-#if _CCCL_HAS_BUILTIN(__remove_extent) && _CCCL_CUDA_COMPILER(CLANG)
-#  define _CCCL_BUILTIN_REMOVE_EXTENT(...) __remove_extent(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__remove_extent)
-
 #if _CCCL_HAS_BUILTIN(__remove_pointer) && _CCCL_CUDA_COMPILER(CLANG)
 #  define _CCCL_BUILTIN_REMOVE_POINTER(...) __remove_pointer(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__remove_pointer)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -372,14 +372,6 @@
 #  define _CCCL_BUILTIN_REMOVE_CONST(...) __remove_const(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__remove_const)
 
-#if _CCCL_HAS_BUILTIN(__remove_cvref) && _CCCL_CUDA_COMPILER(CLANG)
-#  define _CCCL_BUILTIN_REMOVE_CVREF(...) __remove_cvref(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__remove_cvref)
-
-#if _CCCL_COMPILER(NVRTC, <, 12, 4) // NVRTC below 12.4 fails to properly compile that builtin
-#  undef _CCCL_BUILTIN_REMOVE_CVREF
-#endif // _CCCL_COMPILER(NVRTC, <, 12, 4)
-
 #if _CCCL_HAS_BUILTIN(__remove_extent) && _CCCL_CUDA_COMPILER(CLANG)
 #  define _CCCL_BUILTIN_REMOVE_EXTENT(...) __remove_extent(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__remove_extent)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -372,10 +372,6 @@
 #  define _CCCL_BUILTIN_REMOVE_CONST(...) __remove_const(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__remove_const)
 
-#if _CCCL_HAS_BUILTIN(__remove_cv) && _CCCL_CUDA_COMPILER(CLANG)
-#  define _CCCL_BUILTIN_REMOVE_CV(...) __remove_cv(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__remove_cv)
-
 #if _CCCL_HAS_BUILTIN(__remove_cvref) && _CCCL_CUDA_COMPILER(CLANG)
 #  define _CCCL_BUILTIN_REMOVE_CVREF(...) __remove_cvref(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__remove_cvref)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -72,11 +72,6 @@
   (_CCCL_HOST_STD_LIB(LIBSTDCXX, <, _VERSION) || defined(_GLIBCXX_DO_NOT_USE_BUILTIN_TRAITS)) \
     && !_CCCL_CUDA_COMPILER(CLANG)
 
-// NVCC has issues with function pointers
-#if _CCCL_HAS_BUILTIN(__add_pointer) && _CCCL_CUDA_COMPILER(CLANG)
-#  define _CCCL_BUILTIN_ADD_POINTER(...) __add_pointer(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__add_pointer)
-
 // TODO: Enable using the builtin __array_rank when https://llvm.org/PR57133 is resolved
 #if 0 // _CCCL_CHECK_BUILTIN(array_rank)
 #  define _CCCL_BUILTIN_ARRAY_RANK(...) __array_rank(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
@@ -24,12 +24,31 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if (_CCCL_CHECK_BUILTIN(add_lvalue_reference) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(15))
+#  define _CCCL_BUILTIN_ADD_LVALUE_REFERENCE(...) __add_lvalue_reference(__VA_ARGS__)
+#endif // (_CCCL_CHECK_BUILTIN(add_lvalue_reference) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15))
+
+#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers
+#  undef _CCCL_BUILTIN_ADD_LVALUE_REFERENCE
+#endif // _CCCL_CUDA_COMPILER(NVCC)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_ADD_LVALUE_REFERENCE) && !defined(_LIBCUDACXX_USE_ADD_LVALUE_REFERENCE_FALLBACK)
 
 template <class _Tp>
+struct add_lvalue_reference
+{
+  using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_LVALUE_REFERENCE(_Tp);
+};
+
+#  if _CCCL_COMPILER(GCC) // GCC does not accept the builtin in template signatures
+template <class _Tp>
+using add_lvalue_reference_t _CCCL_NODEBUG_ALIAS = typename add_lvalue_reference<_Tp>::type;
+#  else // ^^^ _CCCL_COMPILER(GCC) ^^^ / vvv !_CCCL_COMPILER(GCC) vvv
+template <class _Tp>
 using add_lvalue_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_LVALUE_REFERENCE(_Tp);
+#  endif // !_CCCL_COMPILER(GCC)
 
 #else // ^^^ _CCCL_BUILTIN_ADD_LVALUE_REFERENCE ^^^ / vvv !_CCCL_BUILTIN_ADD_LVALUE_REFERENCE vvv
 
@@ -47,13 +66,13 @@ struct __add_lvalue_reference_impl<_Tp, true>
 template <class _Tp>
 using add_lvalue_reference_t _CCCL_NODEBUG_ALIAS = typename __add_lvalue_reference_impl<_Tp>::type;
 
-#endif // !_CCCL_BUILTIN_ADD_LVALUE_REFERENCE
-
 template <class _Tp>
 struct add_lvalue_reference
 {
   using type _CCCL_NODEBUG_ALIAS = add_lvalue_reference_t<_Tp>;
 };
+
+#endif // !_CCCL_BUILTIN_ADD_LVALUE_REFERENCE
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
@@ -28,7 +28,7 @@
 #  define _CCCL_BUILTIN_ADD_LVALUE_REFERENCE(...) __add_lvalue_reference(__VA_ARGS__)
 #endif // (_CCCL_CHECK_BUILTIN(add_lvalue_reference) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15))
 
-#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers
+#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers see nvbug6665129
 #  undef _CCCL_BUILTIN_ADD_LVALUE_REFERENCE
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
@@ -28,7 +28,7 @@
 #  define _CCCL_BUILTIN_ADD_LVALUE_REFERENCE(...) __add_lvalue_reference(__VA_ARGS__)
 #endif // (_CCCL_CHECK_BUILTIN(add_lvalue_reference) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15))
 
-#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers see nvbug6665129
+#if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(NVRTC) // NVCC has issues with function pointers see nvbug6665129
 #  undef _CCCL_BUILTIN_ADD_LVALUE_REFERENCE
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
@@ -32,7 +32,7 @@
 #  define _CCCL_BUILTIN_ADD_POINTER(...) __add_pointer(__VA_ARGS__)
 #endif // (_CCCL_CHECK_BUILTIN(add_pointer) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15))
 
-#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers
+#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers see nvbug6665129
 #  undef _CCCL_BUILTIN_ADD_POINTER
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
@@ -32,7 +32,7 @@
 #  define _CCCL_BUILTIN_ADD_POINTER(...) __add_pointer(__VA_ARGS__)
 #endif // (_CCCL_CHECK_BUILTIN(add_pointer) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15))
 
-#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers see nvbug6665129
+#if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(NVRTC) // NVCC has issues with function pointers see nvbug6665129
 #  undef _CCCL_BUILTIN_ADD_POINTER
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
@@ -28,12 +28,31 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if (_CCCL_CHECK_BUILTIN(add_pointer) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(15))
+#  define _CCCL_BUILTIN_ADD_POINTER(...) __add_pointer(__VA_ARGS__)
+#endif // (_CCCL_CHECK_BUILTIN(add_pointer) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15))
+
+#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers
+#  undef _CCCL_BUILTIN_ADD_POINTER
+#endif // _CCCL_CUDA_COMPILER(NVCC)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_ADD_POINTER) && !defined(_LIBCUDACXX_USE_ADD_POINTER_FALLBACK)
 
 template <class _Tp>
+struct add_pointer
+{
+  using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_POINTER(_Tp);
+};
+
+#  if _CCCL_COMPILER(GCC) // GCC does not accept the builtin in function signatures
+template <class _Tp>
+using add_pointer_t _CCCL_NODEBUG_ALIAS = typename add_pointer<_Tp>::type;
+#  else // ^^^ _CCCL_COMPILER(GCC) ^^^ / vvv !_CCCL_COMPILER(GCC) vvv
+template <class _Tp>
 using add_pointer_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_POINTER(_Tp);
+#  endif // !_CCCL_COMPILER(GCC)
 
 #else // ^^^ _CCCL_BUILTIN_ADD_POINTER ^^^ / vvv !_CCCL_BUILTIN_ADD_POINTER vvv
 template <class _Tp, bool = __cccl_is_referenceable<_Tp>::value || is_void<_Tp>::value>
@@ -50,13 +69,13 @@ struct __add_pointer_impl<_Tp, false>
 template <class _Tp>
 using add_pointer_t _CCCL_NODEBUG_ALIAS = typename __add_pointer_impl<_Tp>::type;
 
-#endif // !_CCCL_BUILTIN_ADD_POINTER
-
 template <class _Tp>
 struct add_pointer
 {
   using type _CCCL_NODEBUG_ALIAS = add_pointer_t<_Tp>;
 };
+
+#endif // !_CCCL_BUILTIN_ADD_POINTER
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
@@ -24,12 +24,31 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if (_CCCL_CHECK_BUILTIN(add_rvalue_reference) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(15))
+#  define _CCCL_BUILTIN_ADD_RVALUE_REFERENCE(...) __add_rvalue_reference(__VA_ARGS__)
+#endif // (_CCCL_CHECK_BUILTIN(add_rvalue_reference) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15))
+
+#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers
+#  undef _CCCL_BUILTIN_ADD_RVALUE_REFERENCE
+#endif // _CCCL_CUDA_COMPILER(NVCC)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_ADD_RVALUE_REFERENCE) && !defined(_LIBCUDACXX_USE_ADD_RVALUE_REFERENCE_FALLBACK)
 
 template <class _Tp>
+struct add_rvalue_reference
+{
+  using type = _CCCL_BUILTIN_ADD_RVALUE_REFERENCE(_Tp);
+};
+
+#  if _CCCL_COMPILER(GCC) // GCC does not accept the builtin in template signatures
+template <class _Tp>
+using add_rvalue_reference_t _CCCL_NODEBUG_ALIAS = typename add_rvalue_reference<_Tp>::type;
+#  else // ^^^ _CCCL_COMPILER(GCC) ^^^ / vvv !_CCCL_COMPILER(GCC) vvv
+template <class _Tp>
 using add_rvalue_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_RVALUE_REFERENCE(_Tp);
+#  endif // !_CCCL_COMPILER(GCC)
 
 #else // ^^^ _CCCL_BUILTIN_ADD_RVALUE_REFERENCE ^^^ / vvv !_CCCL_BUILTIN_ADD_RVALUE_REFERENCE vvv
 
@@ -47,13 +66,13 @@ struct __add_rvalue_reference_impl<_Tp, true>
 template <class _Tp>
 using add_rvalue_reference_t _CCCL_NODEBUG_ALIAS = typename __add_rvalue_reference_impl<_Tp>::type;
 
-#endif // _CCCL_BUILTIN_ADD_RVALUE_REFERENCE
-
 template <class _Tp>
 struct add_rvalue_reference
 {
   using type = add_rvalue_reference_t<_Tp>;
 };
+
+#endif // _CCCL_BUILTIN_ADD_RVALUE_REFERENCE
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
@@ -28,7 +28,7 @@
 #  define _CCCL_BUILTIN_ADD_RVALUE_REFERENCE(...) __add_rvalue_reference(__VA_ARGS__)
 #endif // (_CCCL_CHECK_BUILTIN(add_rvalue_reference) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15))
 
-#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers
+#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers see nvbug6665129
 #  undef _CCCL_BUILTIN_ADD_RVALUE_REFERENCE
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
@@ -28,7 +28,7 @@
 #  define _CCCL_BUILTIN_ADD_RVALUE_REFERENCE(...) __add_rvalue_reference(__VA_ARGS__)
 #endif // (_CCCL_CHECK_BUILTIN(add_rvalue_reference) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15))
 
-#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers see nvbug6665129
+#if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(NVRTC) // NVCC has issues with function pointers see nvbug6665129
 #  undef _CCCL_BUILTIN_ADD_RVALUE_REFERENCE
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 

--- a/libcudacxx/include/cuda/std/__type_traits/decay.h
+++ b/libcudacxx/include/cuda/std/__type_traits/decay.h
@@ -35,7 +35,7 @@
 #  define _CCCL_BUILTIN_DECAY(...) __decay(__VA_ARGS__)
 #endif // (_CCCL_CHECK_BUILTIN(decay) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15))
 
-#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers see nvbug6665129
+#if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(NVRTC) // NVCC has issues with function pointers see nvbug6665129
 #  undef _CCCL_BUILTIN_DECAY
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 

--- a/libcudacxx/include/cuda/std/__type_traits/decay.h
+++ b/libcudacxx/include/cuda/std/__type_traits/decay.h
@@ -35,7 +35,7 @@
 #  define _CCCL_BUILTIN_DECAY(...) __decay(__VA_ARGS__)
 #endif // (_CCCL_CHECK_BUILTIN(decay) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15))
 
-#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers
+#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers see nvbug6665129
 #  undef _CCCL_BUILTIN_DECAY
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 

--- a/libcudacxx/include/cuda/std/__type_traits/decay.h
+++ b/libcudacxx/include/cuda/std/__type_traits/decay.h
@@ -31,6 +31,14 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if (_CCCL_CHECK_BUILTIN(decay) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(15))
+#  define _CCCL_BUILTIN_DECAY(...) __decay(__VA_ARGS__)
+#endif // (_CCCL_CHECK_BUILTIN(decay) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15))
+
+#if _CCCL_CUDA_COMPILER(NVCC) // NVCC has issues with function pointers
+#  undef _CCCL_BUILTIN_DECAY
+#endif // _CCCL_CUDA_COMPILER(NVCC)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_DECAY) && !defined(_LIBCUDACXX_USE_DECAY_FALLBACK)
@@ -40,8 +48,13 @@ struct decay
   using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_DECAY(_Tp);
 };
 
+#  if _CCCL_COMPILER(GCC) // GCC does not accept the builtin in template signatures
+template <class _Tp>
+using decay_t _CCCL_NODEBUG_ALIAS = typename decay<_Tp>::type;
+#  else // ^^^ _CCCL_COMPILER(GCC) ^^^ / vvv !_CCCL_COMPILER(GCC) vvv
 template <class _Tp>
 using decay_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_DECAY(_Tp);
+#  endif // !_CCCL_COMPILER(GCC)
 
 #else // ^^^ _CCCL_BUILTIN_DECAY ^^^ / vvv !_CCCL_BUILTIN_DECAY vvv
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_convertible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_convertible.h
@@ -35,7 +35,7 @@
 #if _CCCL_CHECK_BUILTIN(is_convertible_to) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
 #  define _CCCL_BUILTIN_IS_CONVERTIBLE_TO(...) __is_convertible_to(__VA_ARGS__)
 // gcc 13's builin doesn't properly implement some function conversions
-#elif _CCCL_CHECK_BUILTIN(is_convertible) && !_CCCL_COMPILER(GCC, <, 14)
+#elif _CCCL_CHECK_BUILTIN(is_convertible) && !_CCCL_COMPILER(GCC, <, 14) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(14)
 #  define _CCCL_BUILTIN_IS_CONVERTIBLE_TO(...) __is_convertible(__VA_ARGS__)
 #endif // ^^^ has builtin is_convertible_to
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_pointer.h
@@ -25,6 +25,10 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_HAS_BUILTIN(__is_pointer) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(15)
+#  define _CCCL_BUILTIN_IS_POINTER(...) __is_pointer(__VA_ARGS__)
+#endif // _CCCL_HAS_BUILTIN(__is_pointer) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_IS_POINTER) && !defined(_LIBCUDACXX_USE_IS_POINTER_FALLBACK)

--- a/libcudacxx/include/cuda/std/__type_traits/remove_all_extents.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_all_extents.h
@@ -38,8 +38,13 @@ struct remove_all_extents
   using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_ALL_EXTENTS(_Tp);
 };
 
+#  if _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS()
+template <class _Tp>
+using remove_all_extents_t _CCCL_NODEBUG_ALIAS = typename remove_all_extents<_Tp>::type;
+#  else // ^^^ _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() ^^^ / vvv !_CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() vvv
 template <class _Tp>
 using remove_all_extents_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_ALL_EXTENTS(_Tp);
+#  endif // !_CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS()
 
 #else // ^^^ _CCCL_BUILTIN_REMOVE_ALL_EXTENTS ^^^ / vvv !_CCCL_BUILTIN_REMOVE_ALL_EXTENTS vvv
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_const.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_const.h
@@ -24,6 +24,10 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+#if _CCCL_HAS_BUILTIN(__remove_const) && _CCCL_CUDA_COMPILER(CLANG)
+#  define _CCCL_BUILTIN_REMOVE_CONST(...) __remove_const(__VA_ARGS__)
+#endif // _CCCL_HAS_BUILTIN(__remove_const)
+
 #if defined(_CCCL_BUILTIN_REMOVE_CONST) && !defined(_LIBCUDACXX_USE_REMOVE_CONST_FALLBACK)
 template <class _Tp>
 struct remove_const

--- a/libcudacxx/include/cuda/std/__type_traits/remove_cv.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_cv.h
@@ -39,14 +39,13 @@ struct remove_cv
   using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CV(_Tp);
 };
 
-// GCC and NVRTC do not accept the builtin in template signatures, see nvbug6669680
-#  if _CCCL_COMPILER(GCC) || _CCCL_COMPILER(NVRTC)
+#  if _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS()
 template <class _Tp>
 using remove_cv_t _CCCL_NODEBUG_ALIAS = typename remove_cv<_Tp>::type;
-#  else // ^^^ _CCCL_COMPILER(GCC) || _CCCL_COMPILER(NVRTC) ^^^ / vvv other compilers vvv
+#  else // ^^^ _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() ^^^ / vvv !_CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() vvv
 template <class _Tp>
 using remove_cv_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CV(_Tp);
-#  endif // other compilers
+#  endif // !_CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS()
 
 #else
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_cv.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_cv.h
@@ -25,17 +25,28 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_CHECK_BUILTIN(remove_cv) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(14)
+#  define _CCCL_BUILTIN_REMOVE_CV(...) __remove_cv(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(remove_cv) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 14)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_REMOVE_CV) && !defined(_LIBCUDACXX_USE_REMOVE_CV_FALLBACK)
+
 template <class _Tp>
 struct remove_cv
 {
   using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CV(_Tp);
 };
 
+// GCC and NVRTC do not accept the builtin in template signatures, see nvbug6669680
+#  if _CCCL_COMPILER(GCC) || _CCCL_COMPILER(NVRTC)
+template <class _Tp>
+using remove_cv_t _CCCL_NODEBUG_ALIAS = typename remove_cv<_Tp>::type;
+#  else // ^^^ _CCCL_COMPILER(GCC) || _CCCL_COMPILER(NVRTC) ^^^ / vvv other compilers vvv
 template <class _Tp>
 using remove_cv_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CV(_Tp);
+#  endif // other compilers
 
 #else
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_cvref.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_cvref.h
@@ -44,13 +44,13 @@ struct remove_cvref
   using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CVREF(_Tp);
 };
 
-#  if _CCCL_COMPILER(GCC) // GCC does not accept the builtin in template signatures
+#  if _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS()
 template <class _Tp>
 using remove_cvref_t _CCCL_NODEBUG_ALIAS = typename remove_cvref<_Tp>::type;
-#  else // ^^^ _CCCL_COMPILER(GCC) ^^^ / vvv !_CCCL_COMPILER(GCC) vvv
+#  else // ^^^ _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() ^^^ / vvv !_CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() vvv
 template <class _Tp>
 using remove_cvref_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CVREF(_Tp);
-#  endif // !_CCCL_COMPILER(GCC)
+#  endif // !_CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS()
 
 #else // ^^^ _CCCL_BUILTIN_REMOVE_CVREF ^^^ / vvv !_CCCL_BUILTIN_REMOVE_CVREF vvv
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_cvref.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_cvref.h
@@ -26,25 +26,44 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_CHECK_BUILTIN(remove_cvref) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(14)
+#  define _CCCL_BUILTIN_REMOVE_CVREF(...) __remove_cvref(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(remove_cvref) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 14)
+
+#if _CCCL_COMPILER(NVRTC, <, 12, 4) // NVRTC below 12.4 fails to properly compile that builtin
+#  undef _CCCL_BUILTIN_REMOVE_CVREF
+#endif // _CCCL_COMPILER(NVRTC, <, 12, 4)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_REMOVE_CVREF) && !defined(_LIBCUDACXX_USE_REMOVE_CVREF_FALLBACK)
 
 template <class _Tp>
-using remove_cvref_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CVREF(_Tp);
+struct remove_cvref
+{
+  using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CVREF(_Tp);
+};
 
-#else
+#  if _CCCL_COMPILER(GCC) // GCC does not accept the builtin in template signatures
+template <class _Tp>
+using remove_cvref_t _CCCL_NODEBUG_ALIAS = typename remove_cvref<_Tp>::type;
+#  else // ^^^ _CCCL_COMPILER(GCC) ^^^ / vvv !_CCCL_COMPILER(GCC) vvv
+template <class _Tp>
+using remove_cvref_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CVREF(_Tp);
+#  endif // !_CCCL_COMPILER(GCC)
+
+#else // ^^^ _CCCL_BUILTIN_REMOVE_CVREF ^^^ / vvv !_CCCL_BUILTIN_REMOVE_CVREF vvv
+
+template <class _Tp>
+struct remove_cvref
+{
+  using type _CCCL_NODEBUG_ALIAS = remove_cv_t<remove_reference_t<_Tp>>;
+};
 
 template <class _Tp>
 using remove_cvref_t _CCCL_NODEBUG_ALIAS = remove_cv_t<remove_reference_t<_Tp>>;
 
 #endif // defined(_CCCL_BUILTIN_REMOVE_CVREF) && !defined(_LIBCUDACXX_USE_REMOVE_CVREF_FALLBACK)
-
-template <class _Tp>
-struct remove_cvref
-{
-  using type _CCCL_NODEBUG_ALIAS = remove_cvref_t<_Tp>;
-};
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_extent.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_extent.h
@@ -37,8 +37,13 @@ struct remove_extent
   using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_EXTENT(_Tp);
 };
 
+#  if _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS()
+template <class _Tp>
+using remove_extent_t _CCCL_NODEBUG_ALIAS = typename remove_extent<_Tp>::type;
+#  else // ^^^ _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() ^^^ / vvv !_CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() vvv
 template <class _Tp>
 using remove_extent_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_EXTENT(_Tp);
+#  endif // !_CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS()
 
 #else
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/remove_extent.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_extent.h
@@ -24,6 +24,10 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_CHECK_BUILTIN(remove_extent) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(15)
+#  define _CCCL_BUILTIN_REMOVE_EXTENT(...) __remove_extent(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(remove_extent) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 15)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_REMOVE_EXTENT) && !defined(_LIBCUDACXX_USE_REMOVE_EXTENT_FALLBACK)

--- a/libcudacxx/include/cuda/std/__type_traits/remove_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_pointer.h
@@ -22,6 +22,10 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_CHECK_BUILTIN(remove_pointer) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(14)
+#  define _CCCL_BUILTIN_REMOVE_POINTER(...) __remove_pointer(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(remove_pointer) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 14)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_REMOVE_POINTER) && !defined(_LIBCUDACXX_USE_REMOVE_POINTER_FALLBACK)

--- a/libcudacxx/include/cuda/std/__type_traits/remove_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_pointer.h
@@ -35,8 +35,13 @@ struct remove_pointer
   using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_POINTER(_Tp);
 };
 
+#  if _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS()
+template <class _Tp>
+using remove_pointer_t _CCCL_NODEBUG_ALIAS = typename remove_pointer<_Tp>::type;
+#  else // ^^^ _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() ^^^ / vvv !_CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() vvv
 template <class _Tp>
 using remove_pointer_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_POINTER(_Tp);
+#  endif // !_CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS()
 
 #else
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/remove_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_reference.h
@@ -24,6 +24,16 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_HAS_BUILTIN(__remove_reference)
+#  define _CCCL_BUILTIN_REMOVE_REFERENCE_T(...) __remove_reference(__VA_ARGS__)
+#elif _CCCL_HAS_BUILTIN(__remove_reference_t) && _CCCL_CUDA_COMPILER(CLANG)
+#  define _CCCL_BUILTIN_REMOVE_REFERENCE_T(...) __remove_reference_t(__VA_ARGS__)
+#endif // _CCCL_HAS_BUILTIN(__remove_reference_t)
+
+#if _CCCL_COMPILER(NVRTC, <, 12, 4) // NVRTC below 12.4 fails to properly compile cuda::std::move with that
+#  undef _CCCL_BUILTIN_REMOVE_REFERENCE_T
+#endif // _CCCL_COMPILER(NVRTC, <, 12, 4)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_REMOVE_REFERENCE_T) && !defined(_LIBCUDACXX_USE_REMOVE_REFERENCE_T_FALLBACK)
@@ -33,14 +43,13 @@ struct remove_reference
   using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_REFERENCE_T(_Tp);
 };
 
-#  if _CCCL_COMPILER(GCC)
-// error: use of built-in trait in function signature; use library traits instead
+#  if _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS()
 template <class _Tp>
 using remove_reference_t _CCCL_NODEBUG_ALIAS = typename remove_reference<_Tp>::type;
-#  else // ^^^ _CCCL_COMPILER(GCC) ^^^^/  vvv !_CCCL_COMPILER(GCC)
+#  else // ^^^ _CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() ^^^ / vvv !_CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS() vvv
 template <class _Tp>
 using remove_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_REFERENCE_T(_Tp);
-#  endif // !_CCCL_COMPILER(GCC)
+#  endif // !_CCCL_DISALLOW_BUILTIN_IN_TYPE_ALIAS()
 
 #else // ^^^ _CCCL_BUILTIN_REMOVE_REFERENCE_T ^^^ / vvv !_CCCL_BUILTIN_REMOVE_REFERENCE_T vvv
 


### PR DESCRIPTION
There are a lot of compiler builtins we had to disable because they conflicted with libstdc++ symbols.

Recently libstdc++ has moved towards using more compiler builtins itself, which gives us the opportunity to actually use the traits when supported.

There are some builtins that fail because NVCC does not implement LWG2101, see nvbug6665129