### PR TITLE
Add `O(sample_size)` sampling algorithm under `cuda/`

### DIFF
--- a/libcudacxx/benchmarks/bench/sample/basic.cu
+++ b/libcudacxx/benchmarks/bench/sample/basic.cu
@@ -45,7 +45,7 @@ template <class Rng, class Kernel>
 void run(
   nvbench::state& state, Kernel kernel, cuda::std::size_t n, cuda::std::size_t k, cuda::std::size_t population_reads)
 {
-  const auto device = cuda::device_ref{state.get_device()->get_id()};
+  const auto device = cuda::device_ref{state.get_device()->get_id()}; // NOLINT(bugprone-unchecked-optional-access)
   auto stream       = cuda::stream{device};
   auto resource     = cuda::device_default_memory_pool(device);
   auto population   = cuda::make_buffer<int>(stream, resource, n, 0);

--- a/libcudacxx/benchmarks/bench/sample/basic.cu
+++ b/libcudacxx/benchmarks/bench/sample/basic.cu
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/algorithm>
+#include <cuda/buffer>
+#include <cuda/memory_resource>
+#include <cuda/std/algorithm>
+#include <cuda/std/cstddef>
+#include <cuda/std/random>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+NVBENCH_DECLARE_TYPE_STRINGS(cuda::std::minstd_rand, "minstd", "cuda::std::minstd_rand");
+NVBENCH_DECLARE_TYPE_STRINGS(cuda::std::philox4x32, "philox", "cuda::std::philox4x32");
+
+using rng_types = nvbench::type_list<cuda::std::minstd_rand, cuda::std::philox4x32>;
+
+template <class Rng>
+__global__ void cuda_sample_kernel(
+  const int* __restrict__ population, cuda::std::size_t n, cuda::std::size_t k, Rng rng, int* __restrict__ out)
+{
+  const auto* end = cuda::sample(population, population + n, out, k, rng);
+  // So nvcc doesn't optimize the sampling away
+  out[0] += static_cast<int>(end - out - k);
+}
+
+template <class Rng>
+__global__ void cuda_std_sample_kernel(
+  const int* __restrict__ population, cuda::std::size_t n, cuda::std::size_t k, Rng rng, int* __restrict__ out)
+{
+  const auto* end = cuda::std::sample(population, population + n, out, k, rng);
+  // So nvcc doesn't optimize the sampling away
+  out[0] += static_cast<int>(end - out - k);
+}
+
+template <class Rng, class Kernel>
+void run(
+  nvbench::state& state, Kernel kernel, cuda::std::size_t n, cuda::std::size_t k, cuda::std::size_t population_reads)
+{
+  const auto device = cuda::device_ref{state.get_device()->get_id()};
+  auto stream       = cuda::stream{device};
+  auto resource     = cuda::device_default_memory_pool(device);
+  auto population   = cuda::make_buffer<int>(stream, resource, n, 0);
+  auto out          = cuda::make_buffer<int>(stream, resource, k, 0);
+  // The fills run on `stream`, the timed kernels run on the nvbench stream.
+  stream.sync();
+
+  state.add_element_count(k);
+  // `k` for `cuda::sample`, `n` for `cuda::std::sample`, but not more than n
+  state.add_global_memory_reads<int>(cuda::std::min(population_reads, n));
+  state.add_global_memory_writes<int>(cuda::std::min(k, n));
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    kernel<<<1, 1, 0, launch.get_stream()>>>(population.data(), n, k, Rng{42}, out.data());
+  });
+}
+
+template <class Rng>
+void cuda_sample(nvbench::state& state, nvbench::type_list<Rng>)
+{
+  const auto n = static_cast<cuda::std::size_t>(state.get_int64("PopulationSize"));
+  const auto k = static_cast<cuda::std::size_t>(state.get_int64("SampleSize"));
+
+  run<Rng>(state, cuda_sample_kernel<Rng>, n, k, k);
+}
+
+NVBENCH_BENCH_TYPES(cuda_sample, NVBENCH_TYPE_AXES(rng_types))
+  .set_name("cuda_sample")
+  .set_type_axes_names({"Rng{ct}"})
+  .add_int64_power_of_two_axis("PopulationSize", nvbench::range(10, 22, 4))
+  .add_int64_power_of_two_axis("SampleSize", {6, 12});
+
+template <class Rng>
+void cuda_std_sample(nvbench::state& state, nvbench::type_list<Rng>)
+{
+  const auto n = static_cast<cuda::std::size_t>(state.get_int64("PopulationSize"));
+  const auto k = static_cast<cuda::std::size_t>(state.get_int64("SampleSize"));
+
+  run<Rng>(state, cuda_std_sample_kernel<Rng>, n, k, n);
+}
+
+NVBENCH_BENCH_TYPES(cuda_std_sample, NVBENCH_TYPE_AXES(rng_types))
+  .set_name("std_sample")
+  .set_type_axes_names({"Rng{ct}"})
+  .add_int64_power_of_two_axis("PopulationSize", nvbench::range(10, 22, 4))
+  .add_int64_power_of_two_axis("SampleSize", {6, 12});

--- a/libcudacxx/include/cuda/__algorithm/sample.h
+++ b/libcudacxx/include/cuda/__algorithm/sample.h
@@ -35,52 +35,44 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 
 namespace __detail
 {
-//! @brief Ratio of remaining population to remaining samples below which Method A is faster.
-//!
-//! Method D stays in its acceptance-rejection loop while `__N > __sample_alpha_inv * __n`, and
-//! hands the rest of the sample to Method A once the sampling fraction rises above `1 / this
-//! value`. The paper calls the reciprocal `alpha` and stores `-1/alpha` in the integer
-//! `negalphainv`. It uses `alpha = 1/13`, and it gives 0.05 to 0.15 as the useful range for
-//! `alpha`, that is, `__sample_alpha_inv` between 7 and 20.
-inline constexpr int __sample_alpha_inv = 13;
-
 //! @brief Selects `__n` elements from `__first[__index, __index + __N)` using Vitter's Method A.
 //!
-//! Method A draws one uniform variate per selected element and walks the remaining population by
-//! whole gaps. It costs `O(__N)` arithmetic, but it avoids the rejection loop of Method D, so it is
-//! faster when the sampling fraction is high.
+//! Method A draws one uniform variate per selected element and walks the remaining population
+//! by whole gaps. It costs `O(__N)` arithmetic, but it avoids the rejection loop of Method D,
+//! so it is faster when the sampling fraction is high.
 //!
 //! @param[in] __first Beginning of the population
 //! @param[out] __output_iter Beginning of the destination range
 //! @param[in,out] __index Index of the next candidate element, advanced past the selected elements
-//! @param[in] __N Number of population elements that remain available
-//! @param[in] __n Number of samples to draw, must satisfy `0 < __n <= __N`
+//! @param[in] __N_int Number of population elements that remain available
+//! @param[in] __n_int Number of samples to draw, must satisfy `0 < __n <= __N`
 //! @param[in,out] __g Uniform random number generator
+//!
 //! @return The end of the written destination range
 template <class _PopulationIterator, class _SampleIterator, class _Distance, class _UniformRandomNumberGenerator>
 [[nodiscard]] _CCCL_API _SampleIterator __vitter_sample_method_a(
   _PopulationIterator __first,
   _SampleIterator __output_iter,
-  _Distance& __index,
-  _Distance __N,
-  _Distance __n,
+  _Distance __index,
+  _Distance __N_int,
+  _Distance __n_int,
   _UniformRandomNumberGenerator& __g)
 {
   ::cuda::std::uniform_real_distribution<double> __uniform{};
 
-  auto __top    = static_cast<double>(__N - __n);
-  auto __N_real = static_cast<double>(__N);
+  auto __top    = static_cast<double>(__N_int - __n_int);
+  auto __N_real = static_cast<double>(__N_int);
 
-  while (__n >= 2)
+  while (__n_int >= 2)
   {
-    // `__top` counts the elements that are still available but will not be selected, and it holds
-    // the invariant `__top == __N_real - __n`. When it reaches zero, the remaining population is
-    // exactly the remaining sample, so every element from here on is selected. The loop below
-    // would still find them, but it would draw one discarded variate per element to do it.
-    if (__top == 0.0)
+    // `__top` counts the elements that are still available but will not be selected, and it
+    // holds the invariant `__top == __N_real - __n`. When it reaches zero (or slightly less
+    // than with floating point arithmetic), the remaining population is exactly the remaining
+    // sample, so every element from here on is selected. The loop below would still find them,
+    // but it would draw one discarded variate per element to do it.
+    if (__top <= 0.0)
     {
-      __output_iter = ::cuda::std::copy(__first + __index, __first + __index + __n, __output_iter);
-      __index += __n;
+      __output_iter = ::cuda::std::copy(__first + __index, __first + __index + __n_int, __output_iter);
       return __output_iter;
     }
 
@@ -102,12 +94,13 @@ template <class _PopulationIterator, class _SampleIterator, class _Distance, cla
     *__output_iter++ = __first[__index++];
 
     __N_real -= 1.0;
-    --__n;
+    --__n_int;
   }
 
-  // The `__n == 1` tail below draws a variate. When `__top` is zero that variate cannot change the
-  // result, because `__N_real` is then 1 and the product truncates to zero.
-  if (__top == 0.0)
+  // The `__n == 1` tail below draws a variate. When `__top` is zero (or slightly less due to
+  // fp math) that variate cannot change the result, because `__N_real` is then 1 and the
+  // product truncates to zero.
+  if (__top <= 0.0)
   {
     *__output_iter++ = __first[__index++];
     return __output_iter;
@@ -127,16 +120,16 @@ template <class _PopulationIterator, class _SampleIterator, class _Distance, cla
 //!
 //! @param[in] __first Beginning of the population
 //! @param[out] __output_iter Beginning of the destination range
-//! @param[in] __N Number of population elements
-//! @param[in] __n Number of samples to draw, must satisfy `0 < __n <= __N`
+//! @param[in] __N_int Number of population elements
+//! @param[in] __n_int Number of samples to draw, must satisfy `0 < __n <= __N`
 //! @param[in,out] __g Uniform random number generator
 //! @return The end of the written destination range
 template <class _PopulationIterator, class _SampleIterator, class _Distance, class _UniformRandomNumberGenerator>
 [[nodiscard]] _CCCL_API _SampleIterator __vitter_sample_method_d(
   _PopulationIterator __first,
   _SampleIterator __output_iter,
-  _Distance __N,
-  _Distance __n,
+  _Distance __N_int,
+  _Distance __n_int,
   _UniformRandomNumberGenerator& __g)
 {
   ::cuda::std::uniform_real_distribution<double> __uniform{};
@@ -144,10 +137,10 @@ template <class _PopulationIterator, class _SampleIterator, class _Distance, cla
   // Index of the next candidate element. Method D never moves it backwards, so the output is stable.
   auto __index = _Distance{0};
 
-  auto __k      = __n;
+  auto __k      = __n_int;
   auto __n_real = static_cast<double>(__k);
   auto __n_inv  = 1.0 / __n_real;
-  auto __N_real = static_cast<double>(__N);
+  auto __N_real = static_cast<double>(__N_int);
 
   // V_prime is the __k-th root of a uniform variate. It carries across loop iterations, because a
   // rejected candidate still yields a usable variate for the next attempt.
@@ -156,12 +149,21 @@ template <class _PopulationIterator, class _SampleIterator, class _Distance, cla
   // to pow()
   auto __V_prime = ::cuda::std::pow(__uniform(__g), __n_inv);
 
-  auto __qu1      = __N - __k + 1;
+  auto __qu1      = __N_int - __k + 1;
   auto __qu1_real = __N_real - __n_real + 1.0;
 
-  auto __threshold = ::cuda::__detail::__sample_alpha_inv * __k;
+  // Ratio of remaining population to remaining samples below which Method A is faster.
+  //
+  // Method D stays in its acceptance-rejection loop while `__N_int > __SAMPLE_ALPHA_INV *
+  // __n_int`, and hands the rest of the sample to Method A once the sampling fraction rises
+  // above `1 / this value`. The paper calls the reciprocal `alpha` and stores `-1/alpha` in
+  // the integer `negalphainv`. It uses `alpha = 1/13`, and it gives 0.05 to 0.15 as the useful
+  // range for `alpha`, that is, `__SAMPLE_ALPHA_INV` between 7 and 20.
+  constexpr int __SAMPLE_ALPHA_INV = 13;
 
-  while ((__k > 1) && (__threshold < __N))
+  auto __threshold = __SAMPLE_ALPHA_INV * __k;
+
+  while ((__k > 1) && (__threshold < __N_int))
   {
     const auto __n_min_1_inv = 1.0 / (__n_real - 1.0);
 
@@ -243,7 +245,7 @@ template <class _PopulationIterator, class _SampleIterator, class _Distance, cla
     __index += __s;
     *__output_iter++ = __first[__index++];
 
-    __N      = __N - __s - 1;
+    __N_int  = __N_int - __s - 1;
     __N_real = __neg_S_real + __N_real - 1.0;
 
     --__k;
@@ -253,13 +255,13 @@ template <class _PopulationIterator, class _SampleIterator, class _Distance, cla
     __qu1      = __qu1 - __s;
     __qu1_real = __neg_S_real + __qu1_real;
 
-    __threshold -= ::cuda::__detail::__sample_alpha_inv;
+    __threshold -= __SAMPLE_ALPHA_INV;
   }
 
   if (__k > 1)
   {
     // The sampling fraction is now high enough that Method A is faster.
-    return ::cuda::__detail::__vitter_sample_method_a(__first, __output_iter, __index, __N, __k, __g);
+    return ::cuda::__detail::__vitter_sample_method_a(__first, __output_iter, __index, __N_int, __k, __g);
   }
 
   // Special case __k == 1. Reuse the carried Vprime rather than drawing again.

--- a/libcudacxx/include/cuda/__algorithm/sample.h
+++ b/libcudacxx/include/cuda/__algorithm/sample.h
@@ -1,0 +1,337 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDA___ALGORITHM_SAMPLE
+#define __CUDA___ALGORITHM_SAMPLE
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/copy.h>
+#include <cuda/std/__algorithm/min.h>
+#include <cuda/std/__cmath/exponential_functions.h>
+#include <cuda/std/__cmath/rounding_functions.h>
+#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__random/uniform_real_distribution.h>
+#include <cuda/std/__type_traits/common_type.h>
+#include <cuda/std/__type_traits/is_signed.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+namespace __detail
+{
+//! @brief Ratio of remaining population to remaining samples below which Method A is faster.
+//!
+//! Method D stays in its acceptance-rejection loop while `__N > __sample_alpha_inv * __n`, and
+//! hands the rest of the sample to Method A once the sampling fraction rises above `1 / this
+//! value`. The paper calls the reciprocal `alpha` and stores `-1/alpha` in the integer
+//! `negalphainv`. It uses `alpha = 1/13`, and it gives 0.05 to 0.15 as the useful range for
+//! `alpha`, that is, `__sample_alpha_inv` between 7 and 20.
+inline constexpr int __sample_alpha_inv = 13;
+
+//! @brief Selects `__n` elements from `__first[__index, __index + __N)` using Vitter's Method A.
+//!
+//! Method A draws one uniform variate per selected element and walks the remaining population by
+//! whole gaps. It costs `O(__N)` arithmetic, but it avoids the rejection loop of Method D, so it is
+//! faster when the sampling fraction is high.
+//!
+//! @param[in] __first Beginning of the population
+//! @param[out] __output_iter Beginning of the destination range
+//! @param[in,out] __index Index of the next candidate element, advanced past the selected elements
+//! @param[in] __N Number of population elements that remain available
+//! @param[in] __n Number of samples to draw, must satisfy `0 < __n <= __N`
+//! @param[in,out] __g Uniform random number generator
+//! @return The end of the written destination range
+template <class _PopulationIterator, class _SampleIterator, class _Distance, class _UniformRandomNumberGenerator>
+[[nodiscard]] _CCCL_API _SampleIterator __vitter_sample_method_a(
+  _PopulationIterator __first,
+  _SampleIterator __output_iter,
+  _Distance& __index,
+  _Distance __N,
+  _Distance __n,
+  _UniformRandomNumberGenerator& __g)
+{
+  ::cuda::std::uniform_real_distribution<double> __uniform{};
+
+  auto __top    = static_cast<double>(__N - __n);
+  auto __N_real = static_cast<double>(__N);
+
+  while (__n >= 2)
+  {
+    // `__top` counts the elements that are still available but will not be selected, and it holds
+    // the invariant `__top == __N_real - __n`. When it reaches zero, the remaining population is
+    // exactly the remaining sample, so every element from here on is selected. The loop below
+    // would still find them, but it would draw one discarded variate per element to do it.
+    if (__top == 0.0)
+    {
+      __output_iter = ::cuda::std::copy(__first + __index, __first + __index + __n, __output_iter);
+      __index += __n;
+      return __output_iter;
+    }
+
+    const auto __v = __uniform(__g);
+
+    auto __s    = _Distance{0};
+    auto __quot = __top / __N_real;
+
+    while (__quot > __v)
+    {
+      ++__s;
+      __top -= 1.0;
+      __N_real -= 1.0;
+      __quot = (__quot * __top) / __N_real;
+    }
+
+    // Skip over the next __s records and select the following one.
+    __index += __s;
+    *__output_iter++ = __first[__index++];
+
+    __N_real -= 1.0;
+    --__n;
+  }
+
+  // The `__n == 1` tail below draws a variate. When `__top` is zero that variate cannot change the
+  // result, because `__N_real` is then 1 and the product truncates to zero.
+  if (__top == 0.0)
+  {
+    *__output_iter++ = __first[__index++];
+    return __output_iter;
+  }
+
+  // Special case __n == 1. The paper rounds Nreal first, then truncates the product, so that
+  // roundoff can never produce the out-of-range value __s == __n_real.
+  const auto __s = static_cast<_Distance>(::cuda::std::round(__N_real) * __uniform(__g));
+
+  __index += __s;
+  *__output_iter++ = __first[__index++];
+
+  return __output_iter;
+}
+
+//! @brief Selects `__n` elements from `__first[0, __N)` using Vitter's Method D.
+//!
+//! @param[in] __first Beginning of the population
+//! @param[out] __output_iter Beginning of the destination range
+//! @param[in] __N Number of population elements
+//! @param[in] __n Number of samples to draw, must satisfy `0 < __n <= __N`
+//! @param[in,out] __g Uniform random number generator
+//! @return The end of the written destination range
+template <class _PopulationIterator, class _SampleIterator, class _Distance, class _UniformRandomNumberGenerator>
+[[nodiscard]] _CCCL_API _SampleIterator __vitter_sample_method_d(
+  _PopulationIterator __first,
+  _SampleIterator __output_iter,
+  _Distance __N,
+  _Distance __n,
+  _UniformRandomNumberGenerator& __g)
+{
+  ::cuda::std::uniform_real_distribution<double> __uniform{};
+
+  // Index of the next candidate element. Method D never moves it backwards, so the output is stable.
+  auto __index = _Distance{0};
+
+  auto __k      = __n;
+  auto __n_real = static_cast<double>(__k);
+  auto __n_inv  = 1.0 / __n_real;
+  auto __N_real = static_cast<double>(__N);
+
+  // V_prime is the __k-th root of a uniform variate. It carries across loop iterations, because a
+  // rejected candidate still yields a usable variate for the next attempt.
+  //
+  // NOTE: The original algorithm uses exp(log(uniform(__g)) * __n_inv) but this just simplifies
+  // to pow()
+  auto __V_prime = ::cuda::std::pow(__uniform(__g), __n_inv);
+
+  auto __qu1      = __N - __k + 1;
+  auto __qu1_real = __N_real - __n_real + 1.0;
+
+  auto __threshold = ::cuda::__detail::__sample_alpha_inv * __k;
+
+  while ((__k > 1) && (__threshold < __N))
+  {
+    const auto __n_min_1_inv = 1.0 / (__n_real - 1.0);
+
+    auto __s          = _Distance{0};
+    auto __neg_S_real = 0.0;
+
+    do
+    {
+      // Step D2: generate U and X.
+      double __x;
+
+      do
+      {
+        __x = __N_real * (1.0 - __V_prime);
+        __s = static_cast<_Distance>(__x);
+        if (__s < __qu1)
+        {
+          break;
+        }
+        // NOTE: The original algorithm uses exp(log(uniform(__g)) * __n_inv) but this just
+        // simplifies to pow()
+        __V_prime = ::cuda::std::pow(__uniform(__g), __n_inv);
+      } while (true);
+
+      const auto __u = __uniform(__g);
+
+      __neg_S_real = -static_cast<double>(__s);
+      // Step D3: accept? This test succeeds with probability 1 - O(__k / __N).
+      //
+      // NOTE: The original algorithm uses exp(log(... * __n_min_1_inv) but this just simplifies
+      // to pow()
+      const auto __y1 = ::cuda::std::pow(__u * __N_real / __qu1_real, __n_min_1_inv);
+
+      __V_prime = __y1 * ((-__x / __N_real) + 1.0) * (__qu1_real / (__neg_S_real + __qu1_real));
+      if (__V_prime <= 1.0)
+      {
+        break;
+      }
+
+      // Step D4: accept? Evaluate the exact ratio with a bounded product.
+      auto __y2     = 1.0;
+      auto __top    = __N_real - 1.0;
+      auto __bottom = 0.0;
+      auto __limit  = 0.0;
+
+      if (__k - 1 > __s)
+      {
+        __bottom = __N_real - __n_real;
+        __limit  = __N_real + __neg_S_real;
+      }
+      else
+      {
+        __bottom = __neg_S_real + __N_real - 1.0;
+        __limit  = static_cast<double>(__qu1);
+      }
+
+      for (auto __t = __N_real - 1.0; __t >= __limit; __t -= 1.0)
+      {
+        __y2 = (__y2 * __top) / __bottom;
+        __top -= 1.0;
+        __bottom -= 1.0;
+      }
+
+      // NOLINTNEXTLINE(readability-suspicious-call-argument)
+      if (__N_real / (-__x + __N_real) >= __y1 * ::cuda::std::pow(__y2, __n_min_1_inv))
+      {
+        // Accept.
+        __V_prime = ::cuda::std::pow(__uniform(__g), __n_min_1_inv);
+        break;
+      }
+
+      __V_prime = ::cuda::std::pow(__uniform(__g), __n_inv);
+    } while (true);
+
+    // Step D5: select the (__s + 1)st record. Skip __s records, then take the next one.
+    __index += __s;
+    *__output_iter++ = __first[__index++];
+
+    __N      = __N - __s - 1;
+    __N_real = __neg_S_real + __N_real - 1.0;
+
+    --__k;
+    __n_real = __n_real - 1.0;
+    __n_inv  = __n_min_1_inv;
+
+    __qu1      = __qu1 - __s;
+    __qu1_real = __neg_S_real + __qu1_real;
+
+    __threshold -= ::cuda::__detail::__sample_alpha_inv;
+  }
+
+  if (__k > 1)
+  {
+    // The sampling fraction is now high enough that Method A is faster.
+    return ::cuda::__detail::__vitter_sample_method_a(__first, __output_iter, __index, __N, __k, __g);
+  }
+
+  // Special case __k == 1. Reuse the carried Vprime rather than drawing again.
+  const auto __s = static_cast<_Distance>(__N_real * __V_prime);
+
+  __index += __s;
+  *__output_iter++ = __first[__index];
+
+  return __output_iter;
+}
+} // namespace __detail
+
+//! @brief Selects `__n` elements from `[__first, __last)` without replacement, in population order.
+//!
+//! Implements Vitter's Method D, "An Efficient Algorithm for Sequential Random Sampling", ACM
+//! Transactions on Mathematical Software, Vol. 13, No. 1, March 1987, pages 58-67
+//! (https://www.ittc.ku.edu/~jsv/Papers/Vit87.RandomSampling.pdf).
+//!
+//! Unlike `cuda::std::sample`, which reads every population element, this algorithm reads exactly
+//! the `min(__n, __last - __first)` selected elements and draws `O(__n)` random numbers. It requires
+//! a random access population iterator so that skipped elements are never touched. Each selected
+//! element is written in increasing population order, so the result is stable.
+//!
+//! The implementation follows Appendix A2 of the paper, and it hands the tail of the sample to
+//! Method A of Appendix A1 once the sampling fraction becomes high. Method A costs `O(__N)`
+//! arithmetic on the remaining population, but it still reads only the selected elements.
+//!
+//! The gap distribution is computed in `double`. The population size must therefore be exactly
+//! representable as a `double`, that is, at most 2^53.
+//!
+//! @param[in] __first Beginning of the population
+//! @param[in] __last End of the population
+//! @param[out] __output_iter Beginning of the destination range
+//! @param[in] __n Number of elements to select
+//! @param[in,out] __g Uniform random number generator
+//! @return The end of the written destination range
+template <class _PopulationIterator,
+          class _PopulationSent,
+          class _SampleIterator,
+          class _Distance,
+          class _UniformRandomNumberGenerator>
+_CCCL_API _SampleIterator sample(
+  _PopulationIterator __first,
+  _PopulationSent __last,
+  _SampleIterator __output_iter,
+  _Distance __n,
+  _UniformRandomNumberGenerator&& __g)
+{
+  static_assert(::cuda::std::__has_random_access_traversal<_PopulationIterator>,
+                "PopulationIterator must meet the requirements of RandomAccessIterator");
+
+  using _Difference = typename ::cuda::std::iterator_traits<_PopulationIterator>::difference_type;
+  using _CommonType = ::cuda::std::common_type_t<_Distance, _Difference>;
+
+  _CCCL_ASSERT(!::cuda::std::is_signed_v<_Distance> || __n >= 0, "N must be a positive number.");
+
+  const auto __N = static_cast<_CommonType>(__last - __first);
+  const auto __k = ::cuda::std::min(static_cast<_CommonType>(__n), __N);
+
+  if (__k <= 0)
+  {
+    return __output_iter;
+  }
+
+  if (__k >= __N)
+  {
+    return ::cuda::std::copy(__first, __last, __output_iter);
+  }
+
+  return ::cuda::__detail::__vitter_sample_method_d(__first, __output_iter, __N, __k, __g);
+}
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // __CUDA___ALGORITHM_SAMPLE

--- a/libcudacxx/include/cuda/__algorithm/sample.h
+++ b/libcudacxx/include/cuda/__algorithm/sample.h
@@ -27,7 +27,6 @@
 #include <cuda/std/__cmath/rounding_functions.h>
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__random/uniform_real_distribution.h>
-#include <cuda/std/__type_traits/common_type.h>
 #include <cuda/std/__type_traits/is_signed.h>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -281,10 +280,6 @@ template <class _PopulationIterator, class _SampleIterator, class _Distance, cla
 //! a random access population iterator so that skipped elements are never touched. Each selected
 //! element is written in increasing population order, so the result is stable.
 //!
-//! The implementation follows Appendix A2 of the paper, and it hands the tail of the sample to
-//! Method A of Appendix A1 once the sampling fraction becomes high. Method A costs `O(__N)`
-//! arithmetic on the remaining population, but it still reads only the selected elements.
-//!
 //! The gap distribution is computed in `double`. The population size must therefore be exactly
 //! representable as a `double`, that is, at most 2^53.
 //!
@@ -293,6 +288,7 @@ template <class _PopulationIterator, class _SampleIterator, class _Distance, cla
 //! @param[out] __output_iter Beginning of the destination range
 //! @param[in] __n Number of elements to select
 //! @param[in,out] __g Uniform random number generator
+//!
 //! @return The end of the written destination range
 template <class _PopulationIterator,
           class _PopulationSent,
@@ -309,13 +305,17 @@ _CCCL_API _SampleIterator sample(
   static_assert(::cuda::std::__has_random_access_traversal<_PopulationIterator>,
                 "PopulationIterator must meet the requirements of RandomAccessIterator");
 
-  using _Difference = typename ::cuda::std::iterator_traits<_PopulationIterator>::difference_type;
-  using _CommonType = ::cuda::std::common_type_t<_Distance, _Difference>;
+  // We would use the usual ::cuda::std::common_type_t machinery, but clang-cuda 21+ crashes
+  // when casting a __int128 to double, see https://github.com/llvm/llvm-project/issues/218919.
+  using _CommonType = ::cuda::std::int64_t;
 
-  _CCCL_ASSERT(!::cuda::std::is_signed_v<_Distance> || __n >= 0, "N must be a positive number.");
+  if constexpr (::cuda::std::is_signed_v<_Distance>)
+  {
+    _CCCL_ASSERT(__n >= 0, "N must be a positive number.");
+  }
 
   const auto __N = static_cast<_CommonType>(__last - __first);
-  const auto __k = ::cuda::std::min(static_cast<_CommonType>(__n), __N);
+  const auto __k = (::cuda::std::min) (static_cast<_CommonType>(__n), __N);
 
   if (__k <= 0)
   {
@@ -326,6 +326,9 @@ _CCCL_API _SampleIterator sample(
   {
     return ::cuda::std::copy(__first, __last, __output_iter);
   }
+
+  _CCCL_ASSERT(__N <= (_CommonType{1} << 53),
+               "Population size must be exactly representable as a double, that is, at most 2^53.");
 
   return ::cuda::__detail::__vitter_sample_method_d(__first, __output_iter, __N, __k, __g);
 }

--- a/libcudacxx/include/cuda/__algorithm/sample.h
+++ b/libcudacxx/include/cuda/__algorithm/sample.h
@@ -22,12 +22,12 @@
 #endif // no system header
 
 #include <cuda/std/__algorithm/copy.h>
-#include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__cmath/exponential_functions.h>
 #include <cuda/std/__cmath/rounding_functions.h>
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__random/uniform_real_distribution.h>
 #include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__utility/cmp.h>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -218,7 +218,7 @@ template <class _PopulationIterator, class _SampleIterator, class _Distance, cla
         __limit  = static_cast<double>(__qu1);
       }
 
-      for (auto __t = __N_real - 1.0; __t >= __limit; __t -= 1.0)
+      for (auto __t = __N_real - 1.0; __t >= __limit; __t -= 1.0) // NOLINT(bugprone-float-loop-counter)
       {
         __y2 = (__y2 * __top) / __bottom;
         __top -= 1.0;
@@ -315,7 +315,9 @@ _CCCL_API _SampleIterator sample(
   }
 
   const auto __N = static_cast<_CommonType>(__last - __first);
-  const auto __k = (::cuda::std::min) (static_cast<_CommonType>(__n), __N);
+  // __n might be UINT128T_MAX, which won't fit in our _CommonType so need safely clamp to __N
+  // instead of just blindly casting min() to _CommonType.
+  const auto __k = ::cuda::std::cmp_greater(__n, __N) ? __N : static_cast<_CommonType>(__n);
 
   if (__k <= 0)
   {

--- a/libcudacxx/include/cuda/__algorithm/sample.h
+++ b/libcudacxx/include/cuda/__algorithm/sample.h
@@ -218,15 +218,18 @@ template <class _PopulationIterator, class _SampleIterator, class _Distance, cla
         __limit  = static_cast<double>(__qu1);
       }
 
-      for (auto __t = __N_real - 1.0; __t >= __limit; __t -= 1.0) // NOLINT(bugprone-float-loop-counter)
+      // NOLINTNEXTLINE(bugprone-float-loop-counter)
+      for (auto __t = __N_real - 1.0; __t >= __limit; __t -= 1.0, __top -= 1.0, __bottom -= 1.0)
       {
         __y2 = (__y2 * __top) / __bottom;
-        __top -= 1.0;
-        __bottom -= 1.0;
       }
 
+      // Note: the paper has this as N/(-x + N) but we move to rhs and multiply because this is
+      // more efficient on device. The compiler won't do this for us because these are all
+      // floating point.
+      //
       // NOLINTNEXTLINE(readability-suspicious-call-argument)
-      if (__N_real / (-__x + __N_real) >= __y1 * ::cuda::std::pow(__y2, __n_min_1_inv))
+      if (__N_real >= (__N_real - __x) * __y1 * ::cuda::std::pow(__y2, __n_min_1_inv))
       {
         // Accept.
         __V_prime = ::cuda::std::pow(__uniform(__g), __n_min_1_inv);

--- a/libcudacxx/include/cuda/algorithm
+++ b/libcudacxx/include/cuda/algorithm
@@ -23,6 +23,7 @@
 
 #include <cuda/__algorithm/copy.h>
 #include <cuda/__algorithm/fill.h>
+#include <cuda/__algorithm/sample.h>
 #include <cuda/std/algorithm>
 
 #endif // _CUDA_ALGORITHM

--- a/libcudacxx/include/cuda/std/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy.h
@@ -140,9 +140,12 @@ _CCCL_API constexpr pair<_Tp*, _Up*> __copy(_Tp* __first, _Tp* __last, _Up* __re
 template <class _InputIterator, class _OutputIterator>
 _CCCL_API constexpr _OutputIterator copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result)
 {
-  return ::cuda::std::__copy<_ClassicAlgPolicy>(
-           ::cuda::std::__unwrap_iter(__first), ::cuda::std::__unwrap_iter(__last), ::cuda::std::__unwrap_iter(__result))
-    .second;
+  auto __ret =
+    ::cuda::std::__copy<_ClassicAlgPolicy>(
+      ::cuda::std::__unwrap_iter(__first), ::cuda::std::__unwrap_iter(__last), ::cuda::std::__unwrap_iter(__result))
+      .second;
+
+  return ::cuda::std::__rewrap_iter(__result, __ret);
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/copy_backward.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy_backward.h
@@ -69,8 +69,10 @@ template <class _BidirectionalIterator1, class _BidirectionalIterator2>
 _CCCL_API inline _CCCL_CONSTEXPR_CXX20 _BidirectionalIterator2
 copy_backward(_BidirectionalIterator1 __first, _BidirectionalIterator1 __last, _BidirectionalIterator2 __result)
 {
-  return ::cuda::std::__copy_backward(
+  auto __ret = ::cuda::std::__copy_backward(
     ::cuda::std::__unwrap_iter(__first), ::cuda::std::__unwrap_iter(__last), ::cuda::std::__unwrap_iter(__result));
+
+  return ::cuda::std::__rewrap_iter(__result, __ret);
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/move.h
+++ b/libcudacxx/include/cuda/std/__algorithm/move.h
@@ -85,8 +85,9 @@ _CCCL_API constexpr _OutputIterator move(_InputIterator __first, _InputIterator 
       .second;
 
   return ::cuda::std::__rewrap_iter(__result, __ret);
+}
 
-  _CCCL_END_NAMESPACE_CUDA_STD
+_CCCL_END_NAMESPACE_CUDA_STD
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/__algorithm/move.h
+++ b/libcudacxx/include/cuda/std/__algorithm/move.h
@@ -79,12 +79,14 @@ _CCCL_API constexpr _OutputIterator move(_InputIterator __first, _InputIterator 
 {
   static_assert(is_copy_constructible_v<_InputIterator>, "Iterators has to be copy constructible.");
   static_assert(is_copy_constructible_v<_OutputIterator>, "The output iterator has to be copy constructible.");
-  return ::cuda::std::__move<_ClassicAlgPolicy>(
-           ::cuda::std::__unwrap_iter(__first), ::cuda::std::__unwrap_iter(__last), ::cuda::std::__unwrap_iter(__result))
-    .second;
-}
+  auto __ret =
+    ::cuda::std::__move<_ClassicAlgPolicy>(
+      ::cuda::std::__unwrap_iter(__first), ::cuda::std::__unwrap_iter(__last), ::cuda::std::__unwrap_iter(__result))
+      .second;
 
-_CCCL_END_NAMESPACE_CUDA_STD
+  return ::cuda::std::__rewrap_iter(__result, __ret);
+
+  _CCCL_END_NAMESPACE_CUDA_STD
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/__algorithm/move_backward.h
+++ b/libcudacxx/include/cuda/std/__algorithm/move_backward.h
@@ -72,9 +72,12 @@ template <class _BidirectionalIterator1, class _BidirectionalIterator2>
 _CCCL_API constexpr _BidirectionalIterator2
 move_backward(_BidirectionalIterator1 __first, _BidirectionalIterator1 __last, _BidirectionalIterator2 __result)
 {
-  return ::cuda::std::__move_backward<_ClassicAlgPolicy>(
-           ::cuda::std::__unwrap_iter(__first), ::cuda::std::__unwrap_iter(__last), ::cuda::std::__unwrap_iter(__result))
-    .second;
+  auto __ret =
+    ::cuda::std::__move_backward<_ClassicAlgPolicy>(
+      ::cuda::std::__unwrap_iter(__first), ::cuda::std::__unwrap_iter(__last), ::cuda::std::__unwrap_iter(__result))
+      .second;
+
+  return ::cuda::std::__rewrap_iter(__result, __ret);
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/test/libcudacxx/cuda/algorithm/sample.cu
+++ b/libcudacxx/test/libcudacxx/cuda/algorithm/sample.cu
@@ -1,0 +1,443 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/algorithm>
+#include <cuda/buffer>
+#include <cuda/hierarchy>
+#include <cuda/iterator>
+#include <cuda/launch>
+#include <cuda/memory_resource>
+#include <cuda/std/cstddef>
+#include <cuda/std/mdspan>
+#include <cuda/std/random>
+#include <cuda/std/span>
+#include <cuda/stream>
+
+#include <cmath>
+#include <unordered_map>
+#include <vector>
+
+#include "test_macros.h"
+#include <c2h/catch2_test_helper.h>
+
+namespace
+{
+template <class Rng>
+struct sample_kernel
+{
+  cuda::std::size_t n_;
+  cuda::std::size_t k_;
+  Rng rng_;
+
+  TEST_DEVICE_FUNC void operator()(cuda::std::span<cuda::std::size_t> out, cuda::std::span<cuda::std::size_t> written)
+  {
+    if (cuda::gpu_thread.rank(cuda::grid) != 0)
+    {
+      return;
+    }
+
+    cuda::counting_iterator<cuda::std::size_t> first{0};
+    cuda::counting_iterator<cuda::std::size_t> last{n_};
+
+    auto end   = cuda::sample(first, last, out.begin(), k_, rng_);
+    written[0] = end - out.begin();
+  }
+};
+
+// Samples `k` indices out of a population of `n` on the device, then returns the result on the
+// host. The population is 0, 1, ... n - 1, so each selected element is also its own index.
+template <class Rng = cuda::std::philox4x64>
+std::vector<cuda::std::size_t> device_sample(cuda::std::size_t n, cuda::std::size_t k, Rng rng = Rng{})
+{
+  auto stream   = cuda::stream{cuda::device_ref{0}};
+  auto resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+
+  const auto expected = cuda::std::min(k, n);
+
+  auto out     = cuda::make_buffer<cuda::std::size_t>(stream, resource, expected, static_cast<cuda::std::size_t>(-1));
+  auto written = cuda::make_buffer<cuda::std::size_t>(stream, resource, cuda::std::size_t{1}, cuda::std::size_t{0});
+
+  cuda::launch(
+    stream, cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<1>()), sample_kernel<Rng>{n, k, rng}, out, written);
+
+  std::vector<cuda::std::size_t> host_out(expected);
+  std::vector<cuda::std::size_t> host_written(1);
+  cuda::copy_bytes(stream, out, host_out);
+  cuda::copy_bytes(stream, written, host_written);
+  stream.sync();
+
+  REQUIRE(host_written[0] == expected);
+  return host_out;
+}
+
+// Every sample must be strictly increasing, and every index must lie in [0, n). Strict increase is
+// the combined statement of stability and sampling without replacement.
+void check_sample(const std::vector<cuda::std::size_t>& sample, cuda::std::size_t n)
+{
+  for (cuda::std::size_t i = 0; i < sample.size(); ++i)
+  {
+    REQUIRE(sample[i] < n);
+    if (i > 0)
+    {
+      REQUIRE(sample[i] > sample[i - 1]);
+    }
+  }
+}
+
+// Draws one sample per row of `out`, which holds `iterations` rows of `k` indices. Work spreads
+// across the grid: thread `t` handles rows t, t + grid_size, t + 2 * grid_size, ... Each row offsets
+// the generator by its own row index, so the streams do not overlap and the result does not depend
+// on the launch shape. A `sample` call consumes O(k) variates, and the stride below far exceeds
+// every `k` tested here.
+template <class Rng>
+struct batched_sample_kernel
+{
+  cuda::std::size_t n_;
+  Rng rng_;
+
+  TEST_DEVICE_FUNC void operator()(cuda::std::mdspan<cuda::std::size_t, cuda::std::dextents<cuda::std::size_t, 2>> out)
+  {
+    const auto rank = static_cast<cuda::std::size_t>(cuda::gpu_thread.rank(cuda::grid));
+    const auto size = static_cast<cuda::std::size_t>(cuda::gpu_thread.count(cuda::grid));
+
+    cuda::counting_iterator<cuda::std::size_t> first{0};
+    cuda::counting_iterator<cuda::std::size_t> last{n_};
+
+    for (cuda::std::size_t i = rank; i < out.extent(0); i += size)
+    {
+      auto rng = rng_;
+      rng.discard(i * 4096);
+
+      cuda::sample(first, last, &out(i, 0), out.extent(1), rng);
+    }
+  }
+};
+
+// Returns `iterations` samples of `k` out of `n`, one per row. Requires `0 < k <= n`.
+template <class Rng = cuda::std::philox4x64>
+std::vector<cuda::std::size_t>
+device_sample_batch(cuda::std::size_t n, cuda::std::size_t k, cuda::std::size_t iterations, Rng rng = Rng{})
+{
+  auto stream   = cuda::stream{cuda::device_ref{0}};
+  auto resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+
+  auto out = cuda::make_buffer<cuda::std::size_t>(stream, resource, iterations * k, static_cast<cuda::std::size_t>(-1));
+
+  cuda::launch(
+    stream,
+    cuda::make_config(cuda::grid_dims(256), cuda::block_dims(128)),
+    batched_sample_kernel<Rng>{n, rng},
+    cuda::std::mdspan<cuda::std::size_t, cuda::std::dextents<cuda::std::size_t, 2>>{out.data(), iterations, k});
+
+  std::vector<cuda::std::size_t> host_out(iterations * k);
+  cuda::copy_bytes(stream, out, host_out);
+  stream.sync();
+
+  return host_out;
+}
+
+// Maximum score that the callers below accept. A correct sampler gets a non-zero score, because
+// random draws do not land exactly on the ideal counts. This ceiling separates that noise from actual
+// bias.
+//
+// `df` is the number of counts minus one. The counts add up to a known total, so the last count
+// follows from the others.
+//
+// A correct sampler goes above this ceiling with probability 1e-9. The usual level of 0.05 fails
+// about one run in twenty. A biased sampler still fails, because its score increases with the
+// number of draws.
+//
+// The formula is the Wilson-Hilferty approximation. It gives a high result in the tail, so the
+// ceiling is safe.
+double chi_squared_critical_value(double df)
+{
+  constexpr double z = 6.0;
+
+  const double a = 2.0 / (9.0 * df);
+  const double t = 1.0 - a + (z * std::sqrt(a));
+
+  return df * t * t * t;
+}
+} // namespace
+
+C2H_TEST("cuda::sample yields a strictly increasing sample", "[algorithm][sample]")
+{
+  // Exhaustive over every k for a range of small populations. This covers k == 0, k == 1,
+  // k == n - 1, k == n, and every sampling fraction between, including the Method D to Method A
+  // crossover.
+  const cuda::std::size_t n = GENERATE(0, 1, 2, 3, 7, 13, 14, 27, 31, 32, 33, 63, 64, 65);
+
+  for (cuda::std::size_t k = 0; k <= n; ++k)
+  {
+    const auto sample = device_sample(n, k);
+
+    REQUIRE(sample.size() == k);
+    check_sample(sample, n);
+  }
+}
+
+C2H_TEST("cuda::sample returns the whole population when k >= n", "[algorithm][sample]")
+{
+  // A sample size at or above the population size has exactly one valid answer.
+  const cuda::std::size_t n    = GENERATE(0, 1, 2, 5, 13, 32, 47);
+  const cuda::std::size_t over = GENERATE(0, 1, 2, 17, 100000);
+
+  const auto sample = device_sample(n, n + over);
+
+  REQUIRE(sample.size() == n);
+
+  for (cuda::std::size_t i = 0; i < n; ++i)
+  {
+    REQUIRE(sample[i] == i);
+  }
+}
+
+C2H_TEST("cuda::sample writes nothing for a degenerate request", "[algorithm][sample]")
+{
+  // A sample size of zero, or an empty population, must write nothing. A negative sample size is
+  // outside the contract: `sample` asserts on it, so it is not tested here.
+  const cuda::std::size_t n = GENERATE(0, 1, 16, 1024);
+  const cuda::std::size_t k = GENERATE(0);
+
+  const auto sample = device_sample(n, k);
+  REQUIRE(sample.empty());
+}
+
+C2H_TEST("cuda::sample draws every subset with equal probability", "[algorithm][sample]")
+{
+  // A choice of `k` out of `n` has a fixed set of answers. For n = 4 and k = 2 the answers are
+  // {0,1} {0,2} {0,3} {1,2} {1,3} {2,3}. A correct sampler returns each answer equally often.
+  //
+  // A count of each index does not prove this. A sampler that returns only {0,1} and {2,3} gives
+  // each index the correct rate, but it never returns {0,2}. Only a count of whole answers finds
+  // this fault.
+  //
+  // These populations are small, so all answers fit in memory.
+  const cuda::std::size_t n = GENERATE(range(2, 11));
+
+  for (cuda::std::size_t k = 1; k < n; ++k)
+  {
+    // Number of answers: `n` choose `k`.
+    cuda::std::size_t n_choose_k = 1;
+    for (cuda::std::size_t i = 0; i < k; ++i)
+    {
+      n_choose_k = n_choose_k * (n - i) / (i + 1);
+    }
+
+    // Draw enough samples for 50 hits per answer. Fewer than 5 hits makes the score below
+    // unreliable.
+    const auto iterations = 50 * n_choose_k;
+
+    auto storage = device_sample_batch(n, k, iterations);
+    const cuda::std::mdspan<cuda::std::size_t, cuda::std::dextents<cuda::std::size_t, 2>> batch{
+      storage.data(), iterations, k};
+
+    // One counter per answer. The key holds the answer as bits: bit `i` is set when index `i` is in
+    // the sample, so {0, 2, 3} becomes binary 1101.
+    std::unordered_map<cuda::std::size_t, cuda::std::size_t> counts;
+
+    for (cuda::std::size_t i = 0; i < batch.extent(0); ++i)
+    {
+      cuda::std::size_t mask = 0;
+
+      for (cuda::std::size_t j = 0; j < batch.extent(1); ++j)
+      {
+        REQUIRE(batch(i, j) < n);
+        if (j > 0)
+        {
+          REQUIRE(batch(i, j) > batch(i, j - 1));
+        }
+        mask |= cuda::std::size_t{1} << batch(i, j);
+      }
+
+      ++counts[mask];
+    }
+
+    // The map holds only the answers that occurred. An equal size shows that all answers occurred,
+    // and that the loop below finds all counters.
+    REQUIRE(counts.size() == n_choose_k);
+
+    // A correct sampler keeps each counter near this value.
+    const double expected = static_cast<double>(iterations) / static_cast<double>(n_choose_k);
+
+    // Score the distance from that value. Each counter adds its error squared, divided by the
+    // expected value. The division scales the error: an error of 10 is large at 50, but small at
+    // 5000. The square prevents a high count and a low count from cancelling.
+    double stat = 0.0;
+    for (const auto& entry : counts)
+    {
+      const double delta = static_cast<double>(entry.second) - expected;
+      stat += (delta * delta) / expected;
+    }
+
+    INFO("n = " << n << ", k = " << k << ", n_choose_k = " << n_choose_k << ", chi2 = " << stat);
+    REQUIRE(stat < chi_squared_critical_value(static_cast<double>(n_choose_k) - 1.0));
+  }
+}
+
+C2H_TEST("cuda::sample covers a large population uniformly", "[algorithm][sample]")
+{
+  // The test above lists all answers, so it applies only to small populations. A choice of 32 out
+  // of 64 has 1.8e18 answers, which is too many to count.
+  //
+  // This test counts each index instead. This check is weaker, but it finds an index that the
+  // sampler never selects, and it finds a sampler that prefers one end of the population.
+  //
+  // The pairs start at a low sampling fraction, which uses Method D, and end at a high one, which
+  // uses the Method A fallback.
+  struct shape
+  {
+    cuda::std::size_t n_;
+    cuda::std::size_t k_;
+  };
+
+  const auto s = GENERATE(shape{64, 1}, shape{64, 8}, shape{64, 32}, shape{24, 20}, shape{16, 15}, shape{13, 12});
+
+  // Give each index the same number of hits in all shapes. Each draw selects `k` of the `n`
+  // indices, so a small `k` needs more draws. A fixed draw count gives those shapes too few hits.
+  constexpr double target_hits = 2000.0;
+
+  const auto iterations =
+    static_cast<cuda::std::size_t>(target_hits * static_cast<double>(s.n_) / static_cast<double>(s.k_));
+
+  auto storage = device_sample_batch(s.n_, s.k_, iterations);
+  const cuda::std::mdspan<cuda::std::size_t, cuda::std::dextents<cuda::std::size_t, 2>> batch{
+    storage.data(), iterations, s.k_};
+
+  std::vector<cuda::std::size_t> hits(s.n_, 0);
+
+  for (cuda::std::size_t i = 0; i < batch.extent(0); ++i)
+  {
+    for (cuda::std::size_t j = 0; j < batch.extent(1); ++j)
+    {
+      REQUIRE(batch(i, j) < s.n_);
+      if (j > 0)
+      {
+        REQUIRE(batch(i, j) > batch(i, j - 1));
+      }
+      ++hits[batch(i, j)];
+    }
+  }
+
+  const double expected = static_cast<double>(iterations) * static_cast<double>(s.k_) / static_cast<double>(s.n_);
+
+  double stat = 0.0;
+  for (auto count : hits)
+  {
+    const double delta = static_cast<double>(count) - expected;
+    stat += (delta * delta) / expected;
+  }
+
+  // Each draw selects `k` different indices, so one index cannot occur two times in a draw. This
+  // limit makes the counts vary less than the score above assumes. The counts vary by the factor
+  // `1 - k / n`, so divide by that factor before the comparison. Without this division the test
+  // accepts a biased sampler.
+  stat /= 1.0 - static_cast<double>(s.k_) / static_cast<double>(s.n_);
+
+  INFO("n = " << s.n_ << ", k = " << s.k_ << ", chi2 = " << stat);
+  REQUIRE(stat < chi_squared_critical_value(static_cast<double>(s.n_) - 1.0));
+}
+
+C2H_TEST("cuda::sample crosses from Method D to Method A", "[algorithm][sample]")
+{
+  // The crossover happens when the remaining population falls below 13 times the remaining sample
+  // size. These ratios start above that threshold and fall below it partway through, so a single
+  // call uses both methods.
+  const cuda::std::size_t n       = GENERATE(200, 500, 1300, 5000);
+  const cuda::std::size_t divisor = GENERATE(13, 12, 10, 4, 2);
+  const cuda::std::size_t k       = n / divisor;
+
+  const auto sample = device_sample(n, k);
+
+  REQUIRE(sample.size() == k);
+  check_sample(sample, n);
+}
+
+C2H_TEST("cuda::sample is O(k) for a large population", "[algorithm][sample]")
+{
+  // These populations are far too large to visit element by element. Completing the call at all is
+  // the assertion. 2^53 is the documented upper bound, because the gap distribution is computed in
+  // double and the population size must stay exactly representable.
+  const cuda::std::size_t n = GENERATE(
+    cuda::std::size_t{1} << 20, cuda::std::size_t{1} << 32, cuda::std::size_t{1} << 40, cuda::std::size_t{1} << 53);
+  const cuda::std::size_t k = GENERATE(1, 2, 16, 1024);
+
+  const auto sample = device_sample(n, k);
+  REQUIRE(sample.size() == k);
+  check_sample(sample, n);
+}
+
+C2H_TEST("cuda::sample spreads a sample across a large population", "[algorithm][sample]")
+{
+  // A correct gap distribution puts the selected indices across the whole range. An implementation
+  // that drew gaps too small would cluster every index near the start.
+  constexpr cuda::std::size_t n = cuda::std::size_t{1} << 32;
+  constexpr cuda::std::size_t k = 4096;
+
+  const auto sample = device_sample(n, k);
+
+  REQUIRE(sample.size() == k);
+  check_sample(sample, n);
+
+  int in_last_quarter = 0;
+  for (auto index : sample)
+  {
+    if (index >= (n / 4) * 3)
+    {
+      ++in_last_quarter;
+    }
+  }
+
+  // A quarter of 4096 draws is 1024. A count near zero would mean the gaps are too small.
+  REQUIRE(in_last_quarter > 850);
+  REQUIRE(in_last_quarter < 1200);
+}
+
+C2H_TEST("cuda::sample is a pure function of the generator state", "[algorithm][sample]")
+{
+  // Two identically seeded runs must agree exactly, and two different states must disagree.
+  const cuda::std::size_t n = GENERATE(256, 4096);
+  const cuda::std::size_t k = GENERATE(1, 32);
+
+  const auto first  = device_sample(n, k, cuda::std::philox4x64{42});
+  const auto second = device_sample(n, k, cuda::std::philox4x64{42});
+
+  REQUIRE(first == second);
+
+  const auto other = device_sample(n, k, cuda::std::philox4x64{1337});
+
+  REQUIRE(first != other);
+}
+
+C2H_TEST("cuda::sample works with several generator types", "[algorithm][sample]")
+{
+  constexpr cuda::std::size_t n = 1024;
+  constexpr cuda::std::size_t k = 64;
+
+  SECTION("minstd_rand")
+  {
+    check_sample(device_sample(n, k, cuda::std::minstd_rand{7}), n);
+  }
+
+  SECTION("minstd_rand0")
+  {
+    check_sample(device_sample(n, k, cuda::std::minstd_rand0{7}), n);
+  }
+
+  SECTION("philox4x32")
+  {
+    check_sample(device_sample(n, k, cuda::std::philox4x32{7}), n);
+  }
+
+  SECTION("philox4x64")
+  {
+    check_sample(device_sample(n, k, cuda::std::philox4x64{7}), n);
+  }
+}

--- a/libcudacxx/test/libcudacxx/cuda/algorithm/sample.cu
+++ b/libcudacxx/test/libcudacxx/cuda/algorithm/sample.cu
@@ -62,7 +62,8 @@ std::vector<cuda::std::size_t> device_sample(cuda::std::size_t n, cuda::std::siz
 
   const auto expected = cuda::std::min(k, n);
 
-  auto out     = cuda::make_buffer<cuda::std::size_t>(stream, resource, expected, static_cast<cuda::std::size_t>(-1));
+  auto out = cuda::make_buffer<cuda::std::size_t>(
+    stream, resource, expected, cuda::std::numeric_limits<cuda::std::size_t>::max());
   auto written = cuda::make_buffer<cuda::std::size_t>(stream, resource, cuda::std::size_t{1}, cuda::std::size_t{0});
 
   cuda::launch(
@@ -103,7 +104,7 @@ struct batched_sample_kernel
   cuda::std::size_t n_;
   Rng rng_;
 
-  TEST_DEVICE_FUNC void operator()(cuda::std::mdspan<cuda::std::size_t, cuda::std::dextents<cuda::std::size_t, 2>> out)
+  TEST_DEVICE_FUNC void operator()(cuda::std::mdspan<cuda::std::size_t, cuda::std::dims<2>> out) const
   {
     const auto rank = static_cast<cuda::std::size_t>(cuda::gpu_thread.rank(cuda::grid));
     const auto size = static_cast<cuda::std::size_t>(cuda::gpu_thread.count(cuda::grid));
@@ -113,9 +114,13 @@ struct batched_sample_kernel
 
     for (cuda::std::size_t i = rank; i < out.extent(0); i += size)
     {
-      auto rng = rng_;
-      rng.discard(i * 4096);
+      constexpr auto max_draws = 4096;
+      auto rng                 = rng_;
 
+      // We assume here that the following sample call will poll the rng less than max_draws
+      // per call. If it doesn't, then subsequent iterations of the loop will get overlapping
+      // streamz of random numbers as a previous iteration which pollutes the result.
+      rng.discard(i * max_draws);
       cuda::sample(first, last, &out(i, 0), out.extent(1), rng);
     }
   }
@@ -131,11 +136,10 @@ device_sample_batch(cuda::std::size_t n, cuda::std::size_t k, cuda::std::size_t 
 
   auto out = cuda::make_buffer<cuda::std::size_t>(stream, resource, iterations * k, static_cast<cuda::std::size_t>(-1));
 
-  cuda::launch(
-    stream,
-    cuda::make_config(cuda::grid_dims(256), cuda::block_dims(128)),
-    batched_sample_kernel<Rng>{n, rng},
-    cuda::std::mdspan<cuda::std::size_t, cuda::std::dextents<cuda::std::size_t, 2>>{out.data(), iterations, k});
+  cuda::launch(stream,
+               cuda::make_config(cuda::grid_dims(256), cuda::block_dims(128)),
+               batched_sample_kernel<Rng>{n, rng},
+               cuda::std::mdspan<cuda::std::size_t, cuda::std::dims<2>>{out.data(), iterations, k});
 
   std::vector<cuda::std::size_t> host_out(iterations * k);
   cuda::copy_bytes(stream, out, host_out);
@@ -255,8 +259,7 @@ C2H_TEST("cuda::sample draws every subset with equal probability", "[algorithm][
     const auto iterations = 50 * n_choose_k;
 
     auto storage = device_sample_batch(n, k, iterations);
-    const cuda::std::mdspan<cuda::std::size_t, cuda::std::dextents<cuda::std::size_t, 2>> batch{
-      storage.data(), iterations, k};
+    const cuda::std::mdspan<cuda::std::size_t, cuda::std::dims<2>> batch{storage.data(), iterations, k};
 
     // One counter per answer. The key holds the answer as bits: bit `i` is set when index `i` is in
     // the sample, so {0, 2, 3} becomes binary 1101.
@@ -327,8 +330,7 @@ C2H_TEST("cuda::sample covers a large population uniformly", "[algorithm][sample
     static_cast<cuda::std::size_t>(target_hits * static_cast<double>(s.n_) / static_cast<double>(s.k_));
 
   auto storage = device_sample_batch(s.n_, s.k_, iterations);
-  const cuda::std::mdspan<cuda::std::size_t, cuda::std::dextents<cuda::std::size_t, 2>> batch{
-    storage.data(), iterations, s.k_};
+  const cuda::std::mdspan<cuda::std::size_t, cuda::std::dims<2>> batch{storage.data(), iterations, s.k_};
 
   std::vector<cuda::std::size_t> hits(s.n_, 0);
 
@@ -422,7 +424,9 @@ C2H_TEST("cuda::sample spreads a sample across a large population", "[algorithm]
 
 C2H_TEST("cuda::sample is a pure function of the generator state", "[algorithm][sample]")
 {
-  // Two identically seeded runs must agree exactly, and two different states must disagree.
+  // Two identically seeded runs must agree exactly, and two different states are likely to
+  // disagree. In this case, since the seeds are constant, there is no likelihood but if we had
+  // a random seed here as well it could spuriously fail.
   const cuda::std::size_t n = GENERATE(256, 4096);
   const cuda::std::size_t k = GENERATE(1, 32);
 

--- a/libcudacxx/test/libcudacxx/cuda/algorithm/sample.cu
+++ b/libcudacxx/test/libcudacxx/cuda/algorithm/sample.cu
@@ -15,6 +15,7 @@
 #include <cuda/launch>
 #include <cuda/memory_resource>
 #include <cuda/std/cstddef>
+#include <cuda/std/limits>
 #include <cuda/std/mdspan>
 #include <cuda/std/random>
 #include <cuda/std/span>
@@ -199,6 +200,24 @@ C2H_TEST("cuda::sample returns the whole population when k >= n", "[algorithm][s
   }
 }
 
+C2H_TEST("cuda::sample returns the whole population for a huge unsigned k", "[algorithm][sample]")
+{
+  // A large unsigned k (e.g. size_t::max) must not wrap to -1 after a narrowing cast to int64_t.
+  // Before the fix, static_cast<int64_t>(size_t::max) == -1 caused __k <= 0 and an early return
+  // with no output written.
+  constexpr cuda::std::size_t n = 5;
+  constexpr cuda::std::size_t k = cuda::std::numeric_limits<cuda::std::size_t>::max();
+
+  const auto sample = device_sample(n, k);
+
+  REQUIRE(sample.size() == n);
+
+  for (cuda::std::size_t i = 0; i < n; ++i)
+  {
+    REQUIRE(sample[i] == i);
+  }
+}
+
 C2H_TEST("cuda::sample writes nothing for a degenerate request", "[algorithm][sample]")
 {
   // A sample size of zero, or an empty population, must write nothing. A negative sample size is
@@ -335,11 +354,12 @@ C2H_TEST("cuda::sample covers a large population uniformly", "[algorithm][sample
     stat += (delta * delta) / expected;
   }
 
-  // Each draw selects `k` different indices, so one index cannot occur two times in a draw. This
-  // limit makes the counts vary less than the score above assumes. The counts vary by the factor
-  // `1 - k / n`, so divide by that factor before the comparison. Without this division the test
+  // Each draw picks `k` different indices, so the same index cannot appear twice in one draw.
+  // This reduces how much the counts vary compared to what the formula above assumes. The
+  // true variance is smaller by the factor `(n - k) / (n - 1)`. Divide `stat` by that factor
+  // to get a value that follows the chi-squared distribution. Without this step the test
   // accepts a biased sampler.
-  stat /= 1.0 - static_cast<double>(s.k_) / static_cast<double>(s.n_);
+  stat *= (static_cast<double>(s.n_) - 1.0) / (static_cast<double>(s.n_) - static_cast<double>(s.k_));
 
   INFO("n = " << s.n_ << ", k = " << s.k_ << ", chi2 = " << stat);
   REQUIRE(stat < chi_squared_critical_value(static_cast<double>(s.n_) - 1.0));


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

`std::sample()` is `O(population_size)`, not `O(sample_size)` including for random access iterators.

Adds a true `O(sample_size)` random sampling implementation based on a hybrid of Vitters sampling algorithm A and D (https://www.ittc.ku.edu/~jsv/Papers/Vit87.RandomSampling.pdf).

I do not pretend to fully know how the algorithm works, but the key idea seems to be that instead of performing an elementwise test of whether it should be kept or rejected, the algorithm determines how many elements should be _skipped_ before choosing another element. This ensures the algorithm is indeed `O(sample_size)` because the size of the skip is entirely dependent on `sample_size`.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
