### PR TITLE
Benchmark compare workflow to execute actual benchmark binaries

### DIFF
--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -302,18 +302,18 @@ select_targets() {
 select_runnable_targets() {
   local base_build_path="$1"
   local test_build_path="$2"
-  local -n selected_targets_ref="$3"
-  local -n selected_runnable_targets_ref="$4"
+  local -n selected_runnable_targets_ref="$3"
   local -a base_targets
   local -a test_targets
   local -a common_targets
+  shift 3
   local target=""
 
   mapfile -t base_targets < <(
-    list_runnable_benchmark_targets_for "${base_build_path}" "${selected_targets_ref[@]}"
+    list_runnable_benchmark_targets_for "${base_build_path}" "$@"
   )
   mapfile -t test_targets < <(
-    list_runnable_benchmark_targets_for "${test_build_path}" "${selected_targets_ref[@]}"
+    list_runnable_benchmark_targets_for "${test_build_path}" "$@"
   )
 
   mapfile -t common_targets < <(
@@ -1354,7 +1354,7 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
   fi
 
   select_targets "${base_build_dir}" "${test_build_dir}" selected_targets
-  select_runnable_targets "${base_build_dir}" "${test_build_dir}" selected_runnable_targets
+  select_runnable_targets "${base_build_dir}" "${test_build_dir}" selected_runnable_targets "${selected_targets[@]}"
 
   printf "%s\n" "${selected_targets[@]}" > "${artifact_dir}/meta/selected_targets.txt"
   printf "%s\n" "${selected_runnable_targets[@]}" > "${artifact_dir}/meta/selected_runnable_targets.txt"

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -179,10 +179,10 @@ list_runnable_benchmark_targets_for() {
   if [[ "$#" -eq 0 ]]; then
     return 0
   fi
-  ninja -C "${build_path}" -t targets all \
-    >/dev/null
-  ninja -C "${build_path}" -t query "$@" \
-    | awk '/^[[:space:]]+bin\/.*\.bench\./ { sub(/^[[:space:]]+bin\//, ""); print }' \
+  {
+    printf "%s\n" "$@"
+    ninja -C "${build_path}" -t inputs "$@"
+  } | awk '/^bin\/.*\.bench\./ { sub(/^bin\//, ""); print }' \
     | sort -u
 }
 
@@ -1038,7 +1038,8 @@ write_summary() {
       echo "- Test build dir: \`${test_build_dir}\`"
       echo "- NVBench SHA/tag: \`${nvbench_sha}\`"
     fi
-    echo "- CUB targets selected: ${#selected_targets[@]}"
+    echo "- CUB build targets selected: ${#selected_targets[@]}"
+    echo "- CUB runnable targets selected: ${#selected_runnable_targets[@]}"
     echo "- CUB comparisons attempted: ${compares_attempted}"
     echo "- CUB comparisons succeeded: ${compares_succeeded}"
     echo "- Python targets selected: ${#selected_py_targets[@]}"
@@ -1082,9 +1083,9 @@ write_summary() {
       echo
     fi
 
-    if [[ "${#selected_targets[@]}" -gt 0 ]]; then
+    if [[ "${#selected_runnable_targets[@]}" -gt 0 ]]; then
       echo "## CUB Compare Reports"
-      for target in "${selected_targets[@]}"; do
+      for target in "${selected_runnable_targets[@]}"; do
         echo
         echo "### \`${target}\`"
         compare_report_file="$(compare_report_path_for_display "${target}" "intervals")"

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -22,7 +22,8 @@ Usage: $0 <base-path> <test-path> \
 Compare benchmark performance between two checked-out CCCL trees.
 
 At least one --cub-filter or --python-filter must be provided.
-CUB filters are regex patterns matched against ninja target names.
+CUB filters are regex patterns matched against CUB benchmark Ninja target names.
+Matching targets are built; only matching runnable binaries are launched.
 Python filters are regex patterns matched against benchmark script paths
 under python/cuda_cccl/benchmarks/ (e.g. compute/reduce/sum.py).
 
@@ -172,6 +173,19 @@ list_all_benchmark_targets() {
     | sort -u
 }
 
+list_runnable_benchmark_targets_for() {
+  local build_path="$1"
+  shift
+  if [[ "$#" -eq 0 ]]; then
+    return 0
+  fi
+  ninja -C "${build_path}" -t targets all \
+    >/dev/null
+  ninja -C "${build_path}" -t query "$@" \
+    | awk '/^[[:space:]]+bin\/.*\.bench\./ { sub(/^[[:space:]]+bin\//, ""); print }' \
+    | sort -u
+}
+
 target_matches_filters() {
   local target="$1"
   local filter=""
@@ -283,6 +297,36 @@ select_targets() {
   if [[ "${#selected_targets_ref[@]}" -eq 0 ]]; then
     die "No CUB benchmark targets matched the supplied filters." 1
   fi
+}
+
+select_runnable_targets() {
+  local base_build_path="$1"
+  local test_build_path="$2"
+  local -n selected_targets_ref="$3"
+  local -n selected_runnable_targets_ref="$4"
+  local -a base_targets
+  local -a test_targets
+  local -a common_targets
+  local target=""
+
+  mapfile -t base_targets < <(
+    list_runnable_benchmark_targets_for "${base_build_path}" "${selected_targets_ref[@]}"
+  )
+  mapfile -t test_targets < <(
+    list_runnable_benchmark_targets_for "${test_build_path}" "${selected_targets_ref[@]}"
+  )
+
+  mapfile -t common_targets < <(
+    comm -12 \
+      <(printf "%s\n" "${base_targets[@]}" | sort -u) \
+      <(printf "%s\n" "${test_targets[@]}" | sort -u)
+  )
+
+  selected_runnable_targets_ref=()
+  for target in "${common_targets[@]}"; do
+    [[ -n "${target}" ]] || continue
+    selected_runnable_targets_ref+=("${target}")
+  done
 }
 
 # ============================================================================
@@ -1168,6 +1212,13 @@ parse_cli_args() {
   done
 }
 
+if [[ "${CCCL_BENCH_COMPARE_PATHS_SOURCE_ONLY:-0}" == "1" ]]; then
+  if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+  fi
+  exit 0
+fi
+
 parse_cli_args "$@"
 
 declare -a NVBENCH_RUN_ARGS
@@ -1265,6 +1316,7 @@ any_failures=0
 compares_attempted=0
 compares_succeeded=0
 declare -a selected_targets=()
+declare -a selected_runnable_targets=()
 py_compares_attempted=0
 py_compares_succeeded=0
 declare -a selected_py_targets=()
@@ -1302,26 +1354,10 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
   fi
 
   select_targets "${base_build_dir}" "${test_build_dir}" selected_targets
+  select_runnable_targets "${base_build_dir}" "${test_build_dir}" selected_runnable_targets
 
   printf "%s\n" "${selected_targets[@]}" > "${artifact_dir}/meta/selected_targets.txt"
-
-  compare_script="$(resolve_compare_script "${test_build_dir}" || true)"
-  if [[ -z "${compare_script}" ]]; then
-    compare_script="$(resolve_compare_script "${base_build_dir}" || true)"
-  fi
-  if [[ -z "${compare_script}" ]]; then
-    die "Unable to locate nvbench_compare_robust.py in build dependencies." 1
-  fi
-  compare_script_dir="$(dirname "${compare_script}")"
-
-  legacy_compare_script="$(resolve_legacy_compare_script "${test_build_dir}" || true)"
-  if [[ -z "${legacy_compare_script}" ]]; then
-    legacy_compare_script="$(resolve_legacy_compare_script "${base_build_dir}" || true)"
-  fi
-  legacy_compare_script_dir=""
-  if [[ -n "${legacy_compare_script}" ]]; then
-    legacy_compare_script_dir="$(dirname "${legacy_compare_script}")"
-  fi
+  printf "%s\n" "${selected_runnable_targets[@]}" > "${artifact_dir}/meta/selected_runnable_targets.txt"
 
   base_build_all_rc=0
   test_build_all_rc=0
@@ -1346,7 +1382,30 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
     any_failures=1
   fi
 
-  for target in "${selected_targets[@]}"; do
+  if [[ "${#selected_runnable_targets[@]}" -gt 0 ]]; then
+    compare_script="$(resolve_compare_script "${test_build_dir}" || true)"
+    if [[ -z "${compare_script}" ]]; then
+      compare_script="$(resolve_compare_script "${base_build_dir}" || true)"
+    fi
+    if [[ -z "${compare_script}" ]]; then
+      die "Unable to locate nvbench_compare_robust.py in build dependencies." 1
+    fi
+    compare_script_dir="$(dirname "${compare_script}")"
+
+    legacy_compare_script="$(resolve_legacy_compare_script "${test_build_dir}" || true)"
+    if [[ -z "${legacy_compare_script}" ]]; then
+      legacy_compare_script="$(resolve_legacy_compare_script "${base_build_dir}" || true)"
+    fi
+    legacy_compare_script_dir=""
+    if [[ -n "${legacy_compare_script}" ]]; then
+      legacy_compare_script_dir="$(dirname "${legacy_compare_script}")"
+    fi
+  else
+    echo "No runnable CUB benchmark targets matched the supplied filters." >&2
+    any_failures=1
+  fi
+
+  for target in "${selected_runnable_targets[@]}"; do
     base_target_run_rc=125
     test_target_run_rc=125
     base_run_log="${artifact_dir}/logs/run.base.${target}.log"

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -173,17 +173,38 @@ list_all_benchmark_targets() {
     | sort -u
 }
 
-list_runnable_benchmark_targets_for() {
+list_built_benchmark_binaries() {
   local build_path="$1"
-  shift
-  if [[ "$#" -eq 0 ]]; then
+  if [[ ! -d "${build_path}/bin" ]]; then
     return 0
   fi
-  {
-    printf "%s\n" "$@"
-    ninja -C "${build_path}" -t inputs "$@"
-  } | awk '/^bin\/.*\.bench\./ { sub(/^bin\//, ""); print }' \
+
+  find "${build_path}/bin" -maxdepth 1 -type f -executable -printf '%f\n' \
     | sort -u
+}
+
+normalize_benchmark_target() {
+  local target="$1"
+  target="${target#./}"
+  target="${target#bin/}"
+  target="${target##*/}"
+  printf "%s" "${target}"
+}
+
+target_was_requested_for_build() {
+  local target="$1"
+  shift
+  local build_target=""
+  local normalized_build_target=""
+
+  for build_target in "$@"; do
+    normalized_build_target="$(normalize_benchmark_target "${build_target}")"
+    if [[ "${target}" == "${normalized_build_target}" || "${target}" == "${normalized_build_target}".* ]]; then
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 target_matches_filters() {
@@ -309,12 +330,8 @@ select_runnable_targets() {
   shift 3
   local target=""
 
-  mapfile -t base_targets < <(
-    list_runnable_benchmark_targets_for "${base_build_path}" "$@"
-  )
-  mapfile -t test_targets < <(
-    list_runnable_benchmark_targets_for "${test_build_path}" "$@"
-  )
+  mapfile -t base_targets < <(list_built_benchmark_binaries "${base_build_path}")
+  mapfile -t test_targets < <(list_built_benchmark_binaries "${test_build_path}")
 
   mapfile -t common_targets < <(
     comm -12 \
@@ -325,7 +342,9 @@ select_runnable_targets() {
   selected_runnable_targets_ref=()
   for target in "${common_targets[@]}"; do
     [[ -n "${target}" ]] || continue
-    selected_runnable_targets_ref+=("${target}")
+    if target_was_requested_for_build "${target}" "$@"; then
+      selected_runnable_targets_ref+=("${target}")
+    fi
   done
 }
 
@@ -1355,10 +1374,8 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
   fi
 
   select_targets "${base_build_dir}" "${test_build_dir}" selected_targets
-  select_runnable_targets "${base_build_dir}" "${test_build_dir}" selected_runnable_targets "${selected_targets[@]}"
 
   printf "%s\n" "${selected_targets[@]}" > "${artifact_dir}/meta/selected_targets.txt"
-  printf "%s\n" "${selected_runnable_targets[@]}" > "${artifact_dir}/meta/selected_runnable_targets.txt"
 
   base_build_all_rc=0
   test_build_all_rc=0
@@ -1383,6 +1400,11 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
     any_failures=1
   fi
 
+  if [[ "${base_build_all_rc}" -eq 0 && "${test_build_all_rc}" -eq 0 ]]; then
+    select_runnable_targets "${base_build_dir}" "${test_build_dir}" selected_runnable_targets "${selected_targets[@]}"
+  fi
+  printf "%s\n" "${selected_runnable_targets[@]}" > "${artifact_dir}/meta/selected_runnable_targets.txt"
+
   if [[ "${#selected_runnable_targets[@]}" -gt 0 ]]; then
     compare_script="$(resolve_compare_script "${test_build_dir}" || true)"
     if [[ -z "${compare_script}" ]]; then
@@ -1401,7 +1423,7 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
     if [[ -n "${legacy_compare_script}" ]]; then
       legacy_compare_script_dir="$(dirname "${legacy_compare_script}")"
     fi
-  else
+  elif [[ "${base_build_all_rc}" -eq 0 && "${test_build_all_rc}" -eq 0 ]]; then
     echo "No runnable CUB benchmark targets matched the supplied filters." >&2
     any_failures=1
   fi

--- a/ci/bench/compare_paths.sh
+++ b/ci/bench/compare_paths.sh
@@ -221,36 +221,14 @@ target_matches_filters() {
   return 1
 }
 
-resolve_compare_script() {
+resolve_robust_compare_script() {
   local build_path="$1"
   local nvbench_src="${build_path}/_deps/nvbench-src"
-  local candidate=""
-  # Different versions have the script at different locations:
-  for candidate in \
-    "${nvbench_src}/python/scripts/nvbench_compare_robust.py" \
-    "${nvbench_src}/scripts/nvbench_compare_robust.py"; do
-    if [[ -f "${candidate}" ]]; then
-      printf "%s" "${candidate}"
-      return 0
-    fi
-  done
-  return 1
-}
-
-resolve_legacy_compare_script() {
-  local build_path="$1"
-  local nvbench_src="${build_path}/_deps/nvbench-src"
-  local candidate=""
-  # Different versions have the script at different locations:
-  for candidate in \
-    "${nvbench_src}/python/scripts/nvbench_compare.py" \
-    "${nvbench_src}/scripts/nvbench_compare.py"; do
-    if [[ -f "${candidate}" ]]; then
-      printf "%s" "${candidate}"
-      return 0
-    fi
-  done
-  return 1
+  local candidate="${nvbench_src}/python/scripts/nvbench_compare_robust.py"
+  if [[ -f "${candidate}" ]]; then
+    printf "%s" "${candidate}"
+  fi
+  return 0
 }
 
 run_target_for_side() {
@@ -871,12 +849,11 @@ run_compare_command_with_pythonpath() {
 
 run_compare_target() {
   local target="$1"
-  local compare_script="$2"
-  local compare_script_dir="$3"
-  local base_json="$4"
-  local test_json="$5"
-  local legacy_compare_script="$6"
-  local legacy_compare_script_dir="$7"
+  local compare_script_dir="$2"
+  local robust_compare_script="$3"
+  local legacy_compare_script="$4"
+  local base_json="$5"
+  local test_json="$6"
 
   local compare_pythonpath="${compare_script_dir}${PYTHONPATH:+:${PYTHONPATH}}"
   local compare_python="${CCCL_BENCH_COMPARE_PYTHON:-python3}"
@@ -891,7 +868,7 @@ run_compare_target() {
     compare_log="$(compare_log_path_for_display "${target}" "${display}")"
     compare_cmd=(
       "${compare_python}"
-      "${compare_script}"
+      "${robust_compare_script}"
       --no-color
       "${NVBENCH_COMPARE_ARGS[@]}"
       --display
@@ -914,7 +891,6 @@ run_compare_target() {
   done
 
   if [[ -n "${legacy_compare_script}" ]]; then
-    compare_pythonpath="${legacy_compare_script_dir}${PYTHONPATH:+:${PYTHONPATH}}"
     compare_cmd=(
       "${compare_python}"
       "${legacy_compare_script}"
@@ -1232,13 +1208,6 @@ parse_cli_args() {
   done
 }
 
-if [[ "${CCCL_BENCH_COMPARE_PATHS_SOURCE_ONLY:-0}" == "1" ]]; then
-  if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
-    return 0
-  fi
-  exit 0
-fi
-
 parse_cli_args "$@"
 
 declare -a NVBENCH_RUN_ARGS
@@ -1406,25 +1375,21 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
   printf "%s\n" "${selected_runnable_targets[@]}" > "${artifact_dir}/meta/selected_runnable_targets.txt"
 
   if [[ "${#selected_runnable_targets[@]}" -gt 0 ]]; then
-    compare_script="$(resolve_compare_script "${test_build_dir}" || true)"
-    if [[ -z "${compare_script}" ]]; then
-      compare_script="$(resolve_compare_script "${base_build_dir}" || true)"
+    robust_compare_script="$(resolve_robust_compare_script "${test_build_dir}")"
+    if [[ -z "${robust_compare_script}" ]]; then
+      robust_compare_script="$(resolve_robust_compare_script "${base_build_dir}")"
     fi
-    if [[ -z "${compare_script}" ]]; then
+    if [[ -z "${robust_compare_script}" ]]; then
       die "Unable to locate nvbench_compare_robust.py in build dependencies." 1
     fi
-    compare_script_dir="$(dirname "${compare_script}")"
+    compare_script_dir="$(dirname "${robust_compare_script}")"
 
-    legacy_compare_script="$(resolve_legacy_compare_script "${test_build_dir}" || true)"
-    if [[ -z "${legacy_compare_script}" ]]; then
-      legacy_compare_script="$(resolve_legacy_compare_script "${base_build_dir}" || true)"
-    fi
-    legacy_compare_script_dir=""
-    if [[ -n "${legacy_compare_script}" ]]; then
-      legacy_compare_script_dir="$(dirname "${legacy_compare_script}")"
+    legacy_compare_script="${compare_script_dir}/nvbench_compare.py"
+    if [[ ! -f "${legacy_compare_script}" ]]; then
+      legacy_compare_script=""
     fi
   elif [[ "${base_build_all_rc}" -eq 0 && "${test_build_all_rc}" -eq 0 ]]; then
-    echo "No runnable CUB benchmark targets matched the supplied filters." >&2
+    echo "No runnable CUB benchmark targets matched the supplied filters; marking comparison as failed." >&2
     any_failures=1
   fi
 
@@ -1473,12 +1438,11 @@ if [[ "${#FILTERS[@]}" -gt 0 ]]; then
       compares_attempted=$((compares_attempted + 1))
       if run_compare_target \
         "${target}" \
-        "${compare_script}" \
         "${compare_script_dir}" \
-        "${base_json}" \
-        "${test_json}" \
+        "${robust_compare_script}" \
         "${legacy_compare_script}" \
-        "${legacy_compare_script_dir}"; then
+        "${base_json}" \
+        "${test_json}"; then
         compares_succeeded=$((compares_succeeded + 1))
       else
         any_failures=1


### PR DESCRIPTION
## Description

Only run actually produced binaries that match `--cub-filter` regular expression.

This avoids compare bench script failure when regex matches phone targets that have no matching binary artifacts to execute.


<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #11006 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
