### PR TITLE
Prevent oversized AI CI failure reports

### DIFF
--- a/.github/actions/ci-failure-analysis-render/action.yml
+++ b/.github/actions/ci-failure-analysis-render/action.yml
@@ -6,13 +6,16 @@ inputs:
     description: "Normalized CI failure analysis JSON file."
     required: true
   format:
-    description: "Output format: github or slack."
+    description: "Output format: github-comment, github-verbose-summary, or slack."
     required: true
 
 outputs:
   content:
-    description: "GitHub Markdown or serialized Slack thread JSON, selected by format."
+    description: "Rendered GitHub comment or Slack thread JSON; empty for verbose summaries."
     value: ${{ steps.render.outputs.content }}
+  rendered_file:
+    description: "Path to the rendered content for use by later steps in this job."
+    value: ${{ steps.render.outputs.rendered_file }}
 
 runs:
   using: "composite"
@@ -25,7 +28,7 @@ runs:
       shell: bash --noprofile --norc -euo pipefail {0}
       run: |
         case "${FORMAT}" in
-          github|slack) ;;
+          github-comment|github-verbose-summary|slack) ;;
           *)
             echo "Unsupported failure analysis format: ${FORMAT}" >&2
             exit 1
@@ -40,9 +43,13 @@ runs:
           --output "${output_file}"
         test -s "${output_file}"
 
-        delimiter="EOF_$(openssl rand -hex 16)"
-        {
-          echo "content<<${delimiter}"
-          cat "${output_file}"
-          echo "${delimiter}"
-        } >> "${GITHUB_OUTPUT}"
+        echo "rendered_file=${output_file}" >> "${GITHUB_OUTPUT}"
+
+        if [[ "${FORMAT}" != "github-verbose-summary" ]]; then
+          delimiter="EOF_$(openssl rand -hex 16)"
+          {
+            echo "content<<${delimiter}"
+            cat "${output_file}"
+            echo "${delimiter}"
+          } >> "${GITHUB_OUTPUT}"
+        fi

--- a/.github/workflows/ci-workflow-nightly.yml
+++ b/.github/workflows/ci-workflow-nightly.yml
@@ -217,21 +217,24 @@ jobs:
           inference_api_key: ${{ secrets.NVINFERENCE_API_KEY }}
           run_id: ${{ github.run_id }}
 
-      - name: Render GitHub failure analysis
-        id: render-github
+      - name: Render GitHub verbose failure analysis summary
+        if: ${{ !cancelled() && steps.analyze.outcome == 'success' }}
+        id: render-github-verbose-summary
         uses: ./.github/actions/ci-failure-analysis-render
         with:
           analysis_file: ${{ steps.analyze.outputs.analysis_file }}
-          format: github
+          format: github-verbose-summary
 
       - name: Add failure analysis to workflow summary
+        if: ${{ !cancelled() && steps.render-github-verbose-summary.outcome == 'success' }}
         env:
-          GITHUB_REPORT: ${{ steps.render-github.outputs.content }}
+          SUMMARY_FILE: ${{ steps.render-github-verbose-summary.outputs.rendered_file }}
         run: |
-          test -n "${GITHUB_REPORT}"
-          printf '%s\n' "${GITHUB_REPORT}" >> "${GITHUB_STEP_SUMMARY}"
+          test -s "${SUMMARY_FILE}"
+          cat "${SUMMARY_FILE}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Render Slack failure analysis
+        if: ${{ !cancelled() && steps.analyze.outcome == 'success' }}
         id: render-slack
         uses: ./.github/actions/ci-failure-analysis-render
         with:

--- a/.github/workflows/ci-workflow-pull-request.yml
+++ b/.github/workflows/ci-workflow-pull-request.yml
@@ -809,7 +809,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
-      github_report: ${{ steps.render-github.outputs.content }}
+      github_comment: ${{ steps.render-github-comment.outputs.content }}
       pr_number: ${{ steps.pull-request.outputs.pr_number }}
     steps:
       - name: Check out CCCL
@@ -835,16 +835,39 @@ jobs:
           run_id: ${{ github.run_id }}
           pr_number: ${{ steps.pull-request.outputs.pr_number }}
 
-      - name: Render GitHub failure analysis
-        id: render-github
+      - name: Render GitHub failure analysis comment
+        if: ${{ !cancelled() && steps.analyze.outcome == 'success' }}
+        id: render-github-comment
         uses: ./.github/actions/ci-failure-analysis-render
         with:
           analysis_file: ${{ steps.analyze.outputs.analysis_file }}
-          format: github
+          format: github-comment
+
+      - name: Render GitHub verbose failure analysis summary
+        if: ${{ !cancelled() && steps.analyze.outcome == 'success' }}
+        id: render-github-verbose-summary
+        uses: ./.github/actions/ci-failure-analysis-render
+        with:
+          analysis_file: ${{ steps.analyze.outputs.analysis_file }}
+          format: github-verbose-summary
+
+      - name: Add failure analysis to workflow summary
+        if: ${{ !cancelled() && steps.render-github-verbose-summary.outcome == 'success' }}
+        env:
+          SUMMARY_FILE: ${{ steps.render-github-verbose-summary.outputs.rendered_file }}
+        run: |
+          test -s "${SUMMARY_FILE}"
+          cat "${SUMMARY_FILE}" >> "${GITHUB_STEP_SUMMARY}"
 
   publish-failure-analysis:
     name: Add failure analysis to CI results
-    if: ${{ always() && needs.analyze-failures.result == 'success' }}
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        needs.analyze-failures.outputs.github_comment != '' &&
+        needs.analyze-failures.outputs.pr_number != ''
+      }}
     needs: analyze-failures
     permissions:
       pull-requests: write
@@ -856,5 +879,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           header: ci-results
           number: ${{ needs.analyze-failures.outputs.pr_number }}
-          message: ${{ needs.analyze-failures.outputs.github_report }}
+          message: ${{ needs.analyze-failures.outputs.github_comment }}
           append: true

--- a/ci/util/ci_failure_analysis/render.py
+++ b/ci/util/ci_failure_analysis/render.py
@@ -11,7 +11,8 @@ import sys
 import unicodedata
 from pathlib import Path
 
-GITHUB_REPORT_LIMIT = 60000
+GITHUB_COMMENT_LIMIT = 60000
+JOB_PREVIEW_LIMIT = 5
 SLACK_MESSAGE_LIMIT = 39000
 # The encoded thread crosses a GitHub job-output and environment-variable boundary.
 SLACK_THREAD_TRANSPORT_LIMIT = 60000
@@ -203,8 +204,12 @@ def code_block(value, limit=None):
     return f"{fence}text\n{value}\n{fence}"
 
 
+def workflow_run_url(repository, run_id):
+    return f"https://github.com/{repository}/actions/runs/{run_id}"
+
+
 def job_url(repository, run_id, job_id):
-    return f"https://github.com/{repository}/actions/runs/{run_id}/job/{job_id}"
+    return f"{workflow_run_url(repository, run_id)}/job/{job_id}"
 
 
 def job_link(job_id, jobs, repository, run_id):
@@ -219,8 +224,14 @@ def render_github_evidence(group):
     return code_block("\n".join(lines), limit=1800)
 
 
-def render_github_group(index, group, jobs, repository, run_id):
+def render_github_group(index, group, jobs, repository, run_id, include_all_jobs):
     job_ids = group["job_ids"]
+    prompt_job_ids = job_ids[:JOB_PREVIEW_LIMIT]
+    visible_job_ids = job_ids if include_all_jobs else prompt_job_ids
+    prompt_omitted_job_count = len(job_ids) - len(prompt_job_ids)
+    prompt_omitted_job_label = "job" if prompt_omitted_job_count == 1 else "jobs"
+    visible_omitted_job_count = len(job_ids) - len(visible_job_ids)
+    visible_omitted_job_label = "job" if visible_omitted_job_count == 1 else "jobs"
     job_label = "job" if len(job_ids) == 1 else "jobs"
     lines = [
         "<details>",
@@ -239,6 +250,16 @@ def render_github_group(index, group, jobs, repository, run_id):
     if evidence:
         lines.extend(["", "**Evidence:**", "", evidence])
 
+    prompt_job_lines = [
+        f"- {jobs[job_id]}: {job_url(repository, run_id, job_id)}"
+        for job_id in prompt_job_ids
+    ]
+    if prompt_omitted_job_count:
+        prompt_job_lines.append(
+            f"- ({prompt_omitted_job_count} additional affected "
+            f"{prompt_omitted_job_label} omitted from this prompt)"
+        )
+
     prompt_lines = [
         (
             "Verify the analyzer guidance below against the linked CI evidence. "
@@ -247,13 +268,10 @@ def render_github_group(index, group, jobs, repository, run_id):
         ),
         "",
         f"Repository: https://github.com/{repository}",
-        f"Workflow run: https://github.com/{repository}/actions/runs/{run_id}",
+        f"Workflow run: {workflow_run_url(repository, run_id)}",
         f"Failure group: {group['title']}",
         "Affected jobs:",
-        *[
-            f"- {jobs[job_id]}: {job_url(repository, run_id, job_id)}"
-            for job_id in job_ids
-        ],
+        *prompt_job_lines,
         "",
         group["agent_prompt"],
     ]
@@ -271,8 +289,15 @@ def render_github_group(index, group, jobs, repository, run_id):
         ]
     )
     lines.extend(
-        f"- {job_link(job_id, jobs, repository, run_id)}" for job_id in job_ids
+        f"- {job_link(job_id, jobs, repository, run_id)}" for job_id in visible_job_ids
     )
+    if visible_omitted_job_count:
+        summary_url = workflow_run_url(repository, run_id)
+        lines.append(
+            f"- *({visible_omitted_job_count} additional affected "
+            f"{visible_omitted_job_label} not shown — "
+            f"[view full group in workflow summary]({summary_url}))*"
+        )
     lines.extend(
         [
             "",
@@ -282,7 +307,7 @@ def render_github_group(index, group, jobs, repository, run_id):
     return lines
 
 
-def render_github_report(analysis, jobs, repository, run_id):
+def render_github_report(analysis, jobs, repository, run_id, include_all_jobs):
     lines = ["### AI failure analysis", ""]
     for index, group in enumerate(analysis["groups"], start=1):
         lines.extend(
@@ -292,14 +317,15 @@ def render_github_report(analysis, jobs, repository, run_id):
                 jobs,
                 repository,
                 run_id,
+                include_all_jobs,
             )
         )
         lines.append("")
 
     report = "\n".join(lines) + "\n"
-    if len(report.encode("utf-8")) > GITHUB_REPORT_LIMIT:
+    if not include_all_jobs and len(report.encode("utf-8")) > GITHUB_COMMENT_LIMIT:
         raise ValidationError(
-            f"rendered GitHub report exceeds {GITHUB_REPORT_LIMIT:,} bytes"
+            f"rendered GitHub comment exceeds {GITHUB_COMMENT_LIMIT:,} bytes"
         )
     return report
 
@@ -350,6 +376,9 @@ def render_slack_thread_reply(
     run_id,
 ):
     job_ids = group["job_ids"]
+    listed_job_ids = job_ids[:JOB_PREVIEW_LIMIT]
+    omitted_job_count = len(job_ids) - len(listed_job_ids)
+    omitted_job_label = "job" if omitted_job_count == 1 else "jobs"
     job_label = "job" if len(job_ids) == 1 else "jobs"
     lines = [
         (
@@ -364,8 +393,14 @@ def render_slack_thread_reply(
     lines.append("*Jobs:*")
     lines.extend(
         f"• {render_slack_job_link(job_id, jobs, repository, run_id)}"
-        for job_id in job_ids
+        for job_id in listed_job_ids
     )
+    if omitted_job_count:
+        summary_url = workflow_run_url(repository, run_id)
+        lines.append(
+            f"• _({omitted_job_count} additional affected {omitted_job_label} not shown — "
+            f"<{summary_url}|view full group in workflow summary>)_"
+        )
 
     reply = "\n".join(lines) + "\n"
     if len(reply) > SLACK_MESSAGE_LIMIT:
@@ -402,7 +437,7 @@ def render_slack_thread(
             f"· {len(job_ids)} {job_label}"
         )
 
-    run_url = f"https://github.com/{repository}/actions/runs/{run_id}"
+    run_url = workflow_run_url(repository, run_id)
     overview_lines.extend(["", f"<{run_url}|GitHub Actions>"])
     if group_count > SLACK_THREAD_REPLY_LIMIT:
         overview_lines.append(
@@ -438,7 +473,11 @@ def parse_args():
         description="Validate and render a structured CI failure analysis."
     )
     parser.add_argument("--analysis-file", type=Path, required=True)
-    parser.add_argument("--format", choices=("github", "slack"), required=True)
+    parser.add_argument(
+        "--format",
+        choices=("github-comment", "github-verbose-summary", "slack"),
+        required=True,
+    )
     parser.add_argument("--repository", required=True)
     parser.add_argument("--output", type=Path, required=True)
     return parser.parse_args()
@@ -450,12 +489,14 @@ def main():
     analysis, jobs, run = load_analysis_context(args.analysis_file)
     run_id = str(run["id"])
 
-    if args.format == "github":
+    if args.format in ("github-comment", "github-verbose-summary"):
+        include_all_jobs = args.format == "github-verbose-summary"
         rendered = render_github_report(
             analysis,
             jobs,
             args.repository,
             run_id,
+            include_all_jobs,
         )
     else:
         slack_thread = render_slack_thread(


### PR DESCRIPTION
## Summary

- Limit affected-job previews in PR comments and Slack replies to five jobs per failure group.
- Keep complete affected-job listings in GitHub workflow summaries.
- Render GitHub comments, verbose summaries, and Slack independently so one destination failure does not suppress the others.

## Context

In https://github.com/NVIDIA/cccl/actions/runs/32804856575, AI analysis succeeded, but a 100+ job failure group caused the GitHub report to exceed 60,000 bytes. Because Slack rendering followed that failed step, the Slack notification had no analysis thread.

## Validation

- Hosted end-to-end workflow: https://github.com/NVIDIA/cccl/actions/runs/32894345689
- Local 103-job regression: five-job PR/Slack previews and all 103 jobs in the verbose summary
- CCCL pre-commit checks on all changed files