### PR TITLE
[libcu++] Add missing `constexpr` in `bit_compress`

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/bit_compress.h
+++ b/libcudacxx/include/cuda/std/__bit/bit_compress.h
@@ -95,7 +95,7 @@ template <class _Tp>
 #  if defined(_CCCL_BUILTIN_ELEMENTWISE_PEXT)
   return _CCCL_BUILTIN_ELEMENTWISE_PEXT(__v, __mask);
 #  elif defined(_CCCL_BUILTIN_IA32_PEXT_SI) && defined(_CCCL_BUILTIN_IA32_PEXT_DI)
-  if (sizeof(_Tp) <= sizeof(uint32_t))
+  if constexpr (sizeof(_Tp) <= sizeof(uint32_t))
   {
     return static_cast<_Tp>(_CCCL_BUILTIN_IA32_PEXT_SI(uint32_t{__v}, uint32_t{__mask}));
   }


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cccl/pull/10927#discussion_r3855591839 