### PR TITLE
[libcu++] Improve the implementation of `__cccl_is_referenceable`

### DIFF
--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -161,7 +161,7 @@ class transform_iterator : public __transform_iterator_category_base<_Fn, _Iter>
   static_assert(::cuda::std::is_object_v<_Fn>, "cuda::transform_iterator requires that _Fn is a functor object");
   static_assert(::cuda::std::regular_invocable<_Fn&, ::cuda::std::iter_reference_t<_Iter>>,
                 "cuda::transform_iterator requires that _Fn is invocable with iter_reference_t<_Iter>");
-  static_assert(::cuda::std::__can_reference<::cuda::std::invoke_result_t<_Fn&, ::cuda::std::iter_reference_t<_Iter>>>,
+  static_assert(::cuda::std::__referenceable<::cuda::std::invoke_result_t<_Fn&, ::cuda::std::iter_reference_t<_Iter>>>,
                 "cuda::transform_iterator requires that the return type of _Fn is referenceable");
 
   // Not a base because then the friend operators would be ambiguous

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -348,11 +348,6 @@
 #  define _CCCL_BUILTIN_IS_REFERENCE(...) __is_reference(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__is_reference)
 
-// Disabled due to libstdc++ conflict
-#if 0 // _CCCL_HAS_BUILTIN(__is_referenceable)
-#  define _CCCL_BUILTIN_IS_REFERENCEABLE(...) __is_referenceable(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__is_referenceable)
-
 #if _CCCL_HAS_BUILTIN(__is_rvalue_reference)
 #  define _CCCL_BUILTIN_IS_RVALUE_REFERENCE(...) __is_rvalue_reference(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__is_rvalue_reference)

--- a/libcudacxx/include/cuda/std/__iterator/common_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/common_iterator.h
@@ -48,7 +48,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 _LIBCUDACXX_BEGIN_HIDDEN_FRIEND_NAMESPACE
 
 template <class _Iter>
-_CCCL_CONCEPT __postfix_can_reference = _CCCL_REQUIRES_EXPR((_Iter), _Iter& __it)(_Satisfies(__can_reference) * __it++);
+_CCCL_CONCEPT __postfix_can_reference = _CCCL_REQUIRES_EXPR((_Iter), _Iter& __it)(_Satisfies(__referenceable) * __it++);
 
 template <class _Iter>
 _CCCL_CONCEPT __use_postfix_proxy = _CCCL_REQUIRES_EXPR((_Iter), )(

--- a/libcudacxx/include/cuda/std/__iterator/concepts.h
+++ b/libcudacxx/include/cuda/std/__iterator/concepts.h
@@ -116,7 +116,7 @@ concept incrementable = regular<_Ip> && weakly_incrementable<_Ip> && requires(_I
 // [iterator.concept.iterator]
 template <class _Ip>
 concept input_or_output_iterator = requires(_Ip __i) {
-  { *__i } -> __can_reference;
+  { *__i } -> __referenceable;
 } && weakly_incrementable<_Ip>;
 
 // [iterator.concept.sentinel]
@@ -386,7 +386,7 @@ _CCCL_CONCEPT incrementable = _CCCL_REQUIRES_EXPR((_Ip), _Ip __i)(
 template <class _Ip>
 _CCCL_CONCEPT_FRAGMENT(
   __input_or_output_iterator_,
-  requires(_Ip __i)(requires(weakly_incrementable<_Ip>), requires(__can_reference<decltype(*__i)>)));
+  requires(_Ip __i)(requires(weakly_incrementable<_Ip>), requires(__referenceable<decltype(*__i)>)));
 
 template <class _Ip>
 _CCCL_CONCEPT input_or_output_iterator = _CCCL_FRAGMENT(__input_or_output_iterator_, _Ip);

--- a/libcudacxx/include/cuda/std/__iterator/iter_move.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_move.h
@@ -135,7 +135,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 #if _CCCL_HAS_CONCEPTS()
 template <__dereferenceable _Tp>
   requires requires(_Tp& __t) {
-    { ::cuda::std::ranges::iter_move(__t) } -> __can_reference;
+    { ::cuda::std::ranges::iter_move(__t) } -> __referenceable;
   }
 using iter_rvalue_reference_t = decltype(::cuda::std::ranges::iter_move(::cuda::std::declval<_Tp&>()));
 
@@ -144,7 +144,7 @@ using iter_rvalue_reference_t = decltype(::cuda::std::ranges::iter_move(::cuda::
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__can_iter_rvalue_reference_t_,
                        requires(_Tp& __t)(requires(__dereferenceable<_Tp>),
-                                          requires(__can_reference<decltype(::cuda::std::ranges::iter_move(__t))>)));
+                                          requires(__referenceable<decltype(::cuda::std::ranges::iter_move(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_iter_rvalue_reference_t = _CCCL_FRAGMENT(__can_iter_rvalue_reference_t_, _Tp);

--- a/libcudacxx/include/cuda/std/__iterator/iter_swap.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_swap.h
@@ -63,8 +63,8 @@ _CCCL_CONCEPT __readable_swappable = _CCCL_REQUIRES_EXPR((_T1, _T2))(
   requires(!__unqualified_iter_swap<_T1, _T2>),
   requires(indirectly_readable<_T1>),
   requires(indirectly_readable<_T2>),
-  requires(__can_reference<iter_reference_t<_T1>>),
-  requires(__can_reference<iter_reference_t<_T2>>),
+  requires(__referenceable<iter_reference_t<_T1>>),
+  requires(__referenceable<iter_reference_t<_T2>>),
   requires(swappable_with<iter_reference_t<_T1>, iter_reference_t<_T2>>));
 
 #if _CCCL_HAS_NOEXCEPT_MANGLING() // older GCC cannot use noexcept inside a requires clause

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -80,17 +80,11 @@ struct __cccl_std_contiguous_iterator_tag_exists : __cccl_type_is_defined<struct
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-template <class _Tp>
-using __with_reference = _Tp&;
-
-template <class _Tp>
-_CCCL_CONCEPT __can_reference = _CCCL_REQUIRES_EXPR((_Tp))(typename(__with_reference<_Tp>));
-
 // [iterator.traits]
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
 concept __dereferenceable = requires(_Tp& __t) {
-  { *__t } -> __can_reference; // not required to be equality-preserving
+  { *__t } -> __referenceable; // not required to be equality-preserving
 };
 
 template <__dereferenceable _Tp>
@@ -102,7 +96,7 @@ _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wvoid-ptr-dereference")
 
 template <class _Tp>
-_CCCL_CONCEPT __dereferenceable = _CCCL_REQUIRES_EXPR((_Tp), _Tp& __t)(requires(__can_reference<decltype(*__t)>));
+_CCCL_CONCEPT __dereferenceable = _CCCL_REQUIRES_EXPR((_Tp), _Tp& __t)(requires(__referenceable<decltype(*__t)>));
 
 _CCCL_DIAG_POP
 
@@ -251,9 +245,9 @@ namespace __iterator_traits_detail
 template <class _Iter>
 _CCCL_CONCEPT __cpp17_iterator = _CCCL_REQUIRES_EXPR((_Iter), _Iter __i)(
   requires(copyable<_Iter>),
-  _Satisfies(__can_reference)(*__i),
+  _Satisfies(__referenceable)(*__i),
   _Same_as(_Iter&)(++__i),
-  _Satisfies(__can_reference)(*__i++));
+  _Satisfies(__referenceable)(*__i++));
 
 // [iterator.traits#concept:cpp17-input-iterator]
 template <class _Iter>

--- a/libcudacxx/include/cuda/std/__ranges/transform_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/transform_view.h
@@ -63,7 +63,7 @@ _CCCL_CONCEPT __transform_view_constraints = _CCCL_REQUIRES_EXPR((_View, _Fn))(
   requires(view<_View>),
   requires(is_object_v<_Fn>),
   requires(regular_invocable<_Fn&, range_reference_t<_View>>),
-  requires(__can_reference<invoke_result_t<_Fn&, range_reference_t<_View>>>));
+  requires(__referenceable<invoke_result_t<_Fn&, range_reference_t<_View>>>));
 
 template <class, class, class = void>
 struct __transform_view_iterator_category_base

--- a/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
@@ -52,7 +52,7 @@ using add_lvalue_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_LVALUE_REFE
 
 #else // ^^^ _CCCL_BUILTIN_ADD_LVALUE_REFERENCE ^^^ / vvv !_CCCL_BUILTIN_ADD_LVALUE_REFERENCE vvv
 
-template <class _Tp, bool = __cccl_is_referenceable<_Tp>::value>
+template <class _Tp, bool = __is_referenceable_v<_Tp>>
 struct __add_lvalue_reference_impl
 {
   using type _CCCL_NODEBUG_ALIAS = _Tp;

--- a/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
@@ -55,7 +55,7 @@ using add_pointer_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_POINTER(_Tp);
 #  endif // !_CCCL_COMPILER(GCC)
 
 #else // ^^^ _CCCL_BUILTIN_ADD_POINTER ^^^ / vvv !_CCCL_BUILTIN_ADD_POINTER vvv
-template <class _Tp, bool = __cccl_is_referenceable<_Tp>::value || is_void<_Tp>::value>
+template <class _Tp, bool = __is_referenceable_v<_Tp> || is_void_v<_Tp>>
 struct __add_pointer_impl
 {
   using type _CCCL_NODEBUG_ALIAS = remove_reference_t<_Tp>*;

--- a/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
@@ -52,7 +52,7 @@ using add_rvalue_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_RVALUE_REFE
 
 #else // ^^^ _CCCL_BUILTIN_ADD_RVALUE_REFERENCE ^^^ / vvv !_CCCL_BUILTIN_ADD_RVALUE_REFERENCE vvv
 
-template <class _Tp, bool = __cccl_is_referenceable<_Tp>::value>
+template <class _Tp, bool = __is_referenceable_v<_Tp>>
 struct __add_rvalue_reference_impl
 {
   using type _CCCL_NODEBUG_ALIAS = _Tp;

--- a/libcudacxx/include/cuda/std/__type_traits/decay.h
+++ b/libcudacxx/include/cuda/std/__type_traits/decay.h
@@ -81,7 +81,7 @@ private:
   using _Up _CCCL_NODEBUG_ALIAS = remove_reference_t<_Tp>;
 
 public:
-  using type _CCCL_NODEBUG_ALIAS = typename __decay_impl<_Up, __cccl_is_referenceable<_Up>::value>::type;
+  using type _CCCL_NODEBUG_ALIAS = typename __decay_impl<_Up, __is_referenceable_v<_Up>>::type;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_referenceable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_referenceable.h
@@ -20,33 +20,21 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__type_traits/integral_constant.h>
-#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__type_traits/void_t.h>
 
 #include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-#if defined(_CCCL_BUILTIN_IS_REFERENCEABLE) && !defined(_LIBCUDACXX_USE_IS_REFERENCEABLE_FALLBACK)
+template <class _Tp, class = void>
+inline constexpr bool __is_referenceable_v = false;
 
 template <class _Tp>
-struct __cccl_is_referenceable : public integral_constant<bool, _CCCL_BUILTIN_IS_REFERENCEABLE(_Tp)>
-{};
-
-#else
-struct __cccl_is_referenceable_impl
-{
-  template <class _Tp>
-  _CCCL_HOST_DEVICE static _Tp& __test(int);
-  template <class _Tp>
-  _CCCL_HOST_DEVICE static false_type __test(...);
-};
+inline constexpr bool __is_referenceable_v<_Tp, void_t<_Tp&>> = true;
 
 template <class _Tp>
-struct __cccl_is_referenceable
-    : bool_constant<!is_same_v<decltype(__cccl_is_referenceable_impl::__test<_Tp>(0)), false_type>>
-{};
-#endif // defined(_CCCL_BUILTIN_IS_REFERENCEABLE) && !defined(_LIBCUDACXX_USE_IS_REFERENCEABLE_FALLBACK)
+_CCCL_CONCEPT __referenceable = __is_referenceable_v<_Tp>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_swappable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_swappable.h
@@ -161,7 +161,7 @@ struct __is_nothrow_swappable : public integral_constant<bool, __detail::__nothr
 template <class _Tp, class _Up>
 inline constexpr bool is_swappable_with_v = __detail::__swappable_with<_Tp, _Up>::value;
 
-template <class _Tp, bool = __cccl_is_referenceable<_Tp>::value>
+template <class _Tp, bool = __is_referenceable_v<_Tp>>
 inline constexpr bool is_swappable_v = false;
 
 template <class _Tp>
@@ -171,7 +171,7 @@ inline constexpr bool is_swappable_v<_Tp, true> =
 template <class _Tp, class _Up>
 inline constexpr bool is_nothrow_swappable_with_v = __detail::__nothrow_swappable_with<_Tp, _Up>::value;
 
-template <class _Tp, bool = __cccl_is_referenceable<_Tp>::value>
+template <class _Tp, bool = __is_referenceable_v<_Tp>>
 inline constexpr bool is_nothrow_swappable_v = false;
 
 template <class _Tp>

--- a/libcudacxx/test/libcudacxx/libcxx/utilities/meta/is_referenceable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/utilities/meta/is_referenceable.pass.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 //
 
-// __cccl_is_referenceable<Tp>
-//
 // [defns.referenceable] defines "a referenceable type" as:
 // An object type, a function type that does not have cv-qualifiers
 //    or a ref-qualifier, or a reference type.
@@ -22,141 +20,141 @@
 struct Foo
 {};
 
-static_assert((!cuda::std::__cccl_is_referenceable<void>::value));
-static_assert((cuda::std::__cccl_is_referenceable<int>::value));
-static_assert((cuda::std::__cccl_is_referenceable<int[3]>::value));
-static_assert((cuda::std::__cccl_is_referenceable<int[]>::value));
-static_assert((cuda::std::__cccl_is_referenceable<int&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<const int&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<int*>::value));
-static_assert((cuda::std::__cccl_is_referenceable<const int*>::value));
-static_assert((cuda::std::__cccl_is_referenceable<Foo>::value));
-static_assert((cuda::std::__cccl_is_referenceable<const Foo>::value));
-static_assert((cuda::std::__cccl_is_referenceable<Foo&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<const Foo&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<Foo&&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<const Foo&&>::value));
+static_assert((!cuda::std::__is_referenceable_v<void>) );
+static_assert((cuda::std::__is_referenceable_v<int>) );
+static_assert((cuda::std::__is_referenceable_v<int[3]>) );
+static_assert((cuda::std::__is_referenceable_v<int[]>) );
+static_assert((cuda::std::__is_referenceable_v<int&>) );
+static_assert((cuda::std::__is_referenceable_v<const int&>) );
+static_assert((cuda::std::__is_referenceable_v<int*>) );
+static_assert((cuda::std::__is_referenceable_v<const int*>) );
+static_assert((cuda::std::__is_referenceable_v<Foo>) );
+static_assert((cuda::std::__is_referenceable_v<const Foo>) );
+static_assert((cuda::std::__is_referenceable_v<Foo&>) );
+static_assert((cuda::std::__is_referenceable_v<const Foo&>) );
+static_assert((cuda::std::__is_referenceable_v<Foo&&>) );
+static_assert((cuda::std::__is_referenceable_v<const Foo&&>) );
 
 #if !TEST_COMPILER(MSVC)
-static_assert((cuda::std::__cccl_is_referenceable<int __attribute__((__vector_size__(8)))>::value));
-static_assert((cuda::std::__cccl_is_referenceable<const int __attribute__((__vector_size__(8)))>::value));
-static_assert((cuda::std::__cccl_is_referenceable<float __attribute__((__vector_size__(16)))>::value));
-static_assert((cuda::std::__cccl_is_referenceable<const float __attribute__((__vector_size__(16)))>::value));
+static_assert((cuda::std::__is_referenceable_v<int __attribute__((__vector_size__(8)))>) );
+static_assert((cuda::std::__is_referenceable_v<const int __attribute__((__vector_size__(8)))>) );
+static_assert((cuda::std::__is_referenceable_v<float __attribute__((__vector_size__(16)))>) );
+static_assert((cuda::std::__is_referenceable_v<const float __attribute__((__vector_size__(16)))>) );
 #endif // !TEST_COMPILER(MSVC)
 
 // Functions without cv-qualifiers are referenceable
-static_assert((cuda::std::__cccl_is_referenceable<void()>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void() const>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void() &>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void() const&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void() &&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void() const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void()>) );
+static_assert((!cuda::std::__is_referenceable_v<void() const>) );
+static_assert((!cuda::std::__is_referenceable_v<void() &>) );
+static_assert((!cuda::std::__is_referenceable_v<void() const&>) );
+static_assert((!cuda::std::__is_referenceable_v<void() &&>) );
+static_assert((!cuda::std::__is_referenceable_v<void() const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void(int)>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int) const>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int) &>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int) const&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int) &&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void(int)>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int) const>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int) &>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int) const&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int) &&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int) const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void(int, float)>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float) const>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float) &>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float) const&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float) &&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void(int, float)>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float) const>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float) &>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float) const&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float) &&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float) const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void(int, float, Foo&)>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, Foo&) const>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, Foo&) &>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, Foo&) const&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, Foo&) &&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, Foo&) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void(int, float, Foo&)>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&) const>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&) &>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&) const&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&) &&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&) const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void(...)>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(...) const>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(...) &>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(...) const&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(...) &&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(...) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void(...)>) );
+static_assert((!cuda::std::__is_referenceable_v<void(...) const>) );
+static_assert((!cuda::std::__is_referenceable_v<void(...) &>) );
+static_assert((!cuda::std::__is_referenceable_v<void(...) const&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(...) &&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(...) const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void(int, ...)>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, ...) const>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, ...) &>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, ...) const&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, ...) &&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, ...) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void(int, ...)>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, ...) const>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, ...) &>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, ...) const&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, ...) &&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, ...) const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void(int, float, ...)>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, ...) const>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, ...) &>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, ...) const&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, ...) &&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, ...) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void(int, float, ...)>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, ...) const>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, ...) &>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, ...) const&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, ...) &&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, ...) const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void(int, float, Foo&, ...)>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, Foo&, ...) const>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, Foo&, ...) &>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, Foo&, ...) const&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, Foo&, ...) &&>::value));
-static_assert((!cuda::std::__cccl_is_referenceable<void(int, float, Foo&, ...) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void(int, float, Foo&, ...)>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&, ...) const>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&, ...) &>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&, ...) const&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&, ...) &&>) );
+static_assert((!cuda::std::__is_referenceable_v<void(int, float, Foo&, ...) const&&>) );
 
 // member functions with or without cv-qualifiers are referenceable
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)()>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)() const>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)() &>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)() const&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)() &&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)() const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)()>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)() const>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)() &>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)() const&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)() &&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)() const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int)>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int) const>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int) &>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int) const&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int) &&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int)>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int) const>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int) &>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int) const&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int) &&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int) const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float)>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float) const>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float) &>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float) const&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float) &&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float)>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float) const>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float) &>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float) const&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float) &&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float) const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, Foo&)>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, Foo&) const>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, Foo&) &>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, Foo&) const&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, Foo&) &&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, Foo&) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&)>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&) const>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&) &>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&) const&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&) &&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&) const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(...)>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(...) const>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(...) &>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(...) const&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(...) &&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(...) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(...)>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(...) const>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(...) &>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(...) const&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(...) &&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(...) const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, ...)>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, ...) const>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, ...) &>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, ...) const&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, ...) &&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, ...) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, ...)>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, ...) const>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, ...) &>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, ...) const&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, ...) &&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, ...) const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, ...)>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, ...) const>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, ...) &>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, ...) const&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, ...) &&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, ...) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, ...)>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, ...) const>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, ...) &>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, ...) const&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, ...) &&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, ...) const&&>) );
 
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, Foo&, ...)>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, Foo&, ...) const>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, Foo&, ...) &>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, Foo&, ...) const&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, Foo&, ...) &&>::value));
-static_assert((cuda::std::__cccl_is_referenceable<void (Foo::*)(int, float, Foo&, ...) const&&>::value));
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&, ...)>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&, ...) const>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&, ...) &>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&, ...) const&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&, ...) &&>) );
+static_assert((cuda::std::__is_referenceable_v<void (Foo::*)(int, float, Foo&, ...) const&&>) );
 
 int main(int, char**)
 {


### PR DESCRIPTION
We currently use nested types to implement it. Improve the implementation by using a simple variable template