### PR TITLE
[CUB] Fix GCC 8/9 segmented-sort tuning tests

### DIFF
--- a/cub/test/catch2_test_device_segmented_sort_keys_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env.cu
@@ -497,7 +497,7 @@ struct segmented_sort_tuning
 {
   _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::SegmentedSortPolicy
   {
-    return {
+    return cub::SegmentedSortPolicy{
       cub::SegmentedSortRadixSortPolicy{
         BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::RADIX_RANK_BASIC, cub::BLOCK_SCAN_WARP_SCANS, 4},
       cub::SegmentedSortSubWarpMergeSortPolicy{

--- a/cub/test/catch2_test_device_segmented_sort_pairs_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs_env.cu
@@ -766,7 +766,7 @@ struct segmented_sort_tuning
 {
   _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::SegmentedSortPolicy
   {
-    return {
+    return cub::SegmentedSortPolicy{
       cub::SegmentedSortRadixSortPolicy{
         BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::RADIX_RANK_BASIC, cub::BLOCK_SCAN_WARP_SCANS, 4},
       cub::SegmentedSortSubWarpMergeSortPolicy{


### PR DESCRIPTION
## Description

Related: #9037

GCC 8 and GCC 9 reject the untyped braced return in the templated segmented-sort tuning selectors. This causes the CUB environment test translation units to fail before the tests run.

Explicitly construct `cub::SegmentedSortPolicy` in both the keys and pairs tuning tests. This preserves behavior while restoring compatibility with the supported compilers.

This PR extracts only the two CUB fixes originally authored by @alliepiper in #9037.

Nightly failure: https://github.com/NVIDIA/cccl/actions/runs/32926367884

## Testing

- CUDA 12.9 / GCC 9.4 / C++17 / SM75:
  - `cub.test.device.segmented_sort_keys_env.lid_0`
  - `cub.test.device.segmented_sort_pairs_env.lid_0`
- Standalone GCC 8 and GCC 9 regression controls
- Repository pre-commit hooks

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes. No documentation changes are required for this test-only compiler compatibility fix.