### PR TITLE
[libcu++] Disable remove_cv builtin for older nvcc

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -70,6 +70,9 @@
 // libstdc++ conflicts with some of the builtins. Ensure that we do not use them if affected libstdc++ is present.
 #ifdef _CCCL_DISABLE_CONFLICTING_COMPILER_BUILTINS
 #  define _CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(...) 1
+// We have seen at least one codegen bug in cudax::launch related to one of the builtins. Disable for older NVCC
+#elif _CCCL_CUDA_COMPILER(NVCC, <, 13, 3)
+#  define _CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(...) 1
 #else // ^^^ _CCCL_DISABLE_CONFLICTING_COMPILER_BUILTINS ^^^ / vvv !_CCCL_DISABLE_CONFLICTING_COMPILER_BUILTINS vvv
 #  define _CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX(...) \
     (_CCCL_HOST_STD_LIB(LIBSTDCXX, <, __VA_ARGS__) && !_CCCL_CUDA_COMPILER(CLANG))

--- a/libcudacxx/include/cuda/std/__type_traits/remove_cv.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_cv.h
@@ -29,10 +29,6 @@
 #  define _CCCL_BUILTIN_REMOVE_CV(...) __remove_cv(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(remove_cv) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 14)
 
-#if _CCCL_CUDA_COMPILER(NVCC, <, 13, 3) // nvcc < 13.3 fails to compile cudax launch configurations
-#  undef _CCCL_BUILTIN_REMOVE_CV
-#endif // _CCCL_CUDA_COMPILER(NVCC, <, 13, 3)
-
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_REMOVE_CV) && !defined(_LIBCUDACXX_USE_REMOVE_CV_FALLBACK)

--- a/libcudacxx/include/cuda/std/__type_traits/remove_cv.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_cv.h
@@ -29,6 +29,10 @@
 #  define _CCCL_BUILTIN_REMOVE_CV(...) __remove_cv(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(remove_cv) && !_CCCL_BUILTIN_CONFLICTS_WITH_LIBSTDCXX( 14)
 
+#if _CCCL_CUDA_COMPILER(NVCC, <, 13, 3) // nvcc < 13.3 fails to compile cudax launch configurations
+#  undef _CCCL_BUILTIN_REMOVE_CV
+#endif // _CCCL_CUDA_COMPILER(NVCC, <, 13, 3)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_REMOVE_CV) && !defined(_LIBCUDACXX_USE_REMOVE_CV_FALLBACK)

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/default_config_extended_lambda.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/default_config_extended_lambda.compile.pass.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_FLAGS: --extended-lambda
+// UNSUPPORTED: nvrtc
+
+#include <cuda/launch>
+
+template <typename DefaultConfig>
+struct kernel_with_default_config
+{
+  DefaultConfig config;
+
+  kernel_with_default_config(DefaultConfig c)
+      : config(c)
+  {}
+
+  DefaultConfig default_config() const
+  {
+    return config;
+  }
+};
+
+void test_default_config()
+{
+  auto grid  = cuda::grid_dims(4);
+  auto block = cuda::block_dims<256>;
+
+  [[maybe_unused]] auto verify_lambda = [] __device__(auto config) {
+    static_assert(cuda::gpu_thread.count(cuda::block, config) == 256);
+    static_assert(cuda::block.count(cuda::grid, config) == 4);
+  };
+
+  kernel_with_default_config kernel{cuda::make_config(block, grid, cuda::cooperative_launch())};
+  static_assert(cuda::__is_kernel_config<decltype(kernel.default_config())>);
+  static_assert(cuda::__kernel_has_default_config<decltype(kernel)>);
+  (void) verify_lambda;
+  (void) kernel;
+}
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Disable the `__remove_cv` builtin path for NVCC before 13.3.
- Keep `cuda::std::remove_cv` on the existing fallback implementation for affected older NVCC toolchains.
- Leave the builtin enabled for NVCC 13.3+ and other compilers.

This fixes the cudax launch configuration compile failure observed on upstream/main after #10997, where `cudax.test.launch` failed in `launch_smoke.cu` under older NVCC plus newer GCC.
