### PR TITLE
[CUB] Make ReduceByKey run-to-run deterministic

### DIFF
--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -43,7 +43,8 @@ template <int ThreadsPerBlock,
           BlockLoadAlgorithm LoadAlgorithm,
           CacheLoadModifier LoadModifier,
           BlockScanAlgorithm ScanAlgorithm,
-          typename DelayConstructorT = detail::fixed_delay_constructor_t<350, 450>>
+          typename DelayConstructorT = detail::fixed_delay_constructor_t<350, 450>,
+          bool StableReductionOrder  = false>
 struct agent_reduce_by_key_policy
 {
   static constexpr int BLOCK_THREADS                 = ThreadsPerBlock;
@@ -51,6 +52,7 @@ struct agent_reduce_by_key_policy
   static constexpr BlockLoadAlgorithm LOAD_ALGORITHM = LoadAlgorithm;
   static constexpr CacheLoadModifier LOAD_MODIFIER   = LoadModifier;
   static constexpr BlockScanAlgorithm SCAN_ALGORITHM = ScanAlgorithm;
+  static constexpr bool STABLE_REDUCTION_ORDER       = StableReductionOrder;
 
   struct detail
   {
@@ -230,7 +232,11 @@ struct AgentReduceByKey
   // Callback type for obtaining tile prefix during block scan
   using DelayConstructorT = typename AgentReduceByKeyPolicyT::detail::delay_constructor_t;
   using TilePrefixCallbackOpT =
-    TilePrefixCallbackOp<OffsetValuePairT, ReduceBySegmentOpT, ScanTileStateT, DelayConstructorT>;
+    TilePrefixCallbackOp<OffsetValuePairT,
+                         ReduceBySegmentOpT,
+                         ScanTileStateT,
+                         DelayConstructorT,
+                         AgentReduceByKeyPolicyT::STABLE_REDUCTION_ORDER>;
 
   // Key and value exchange types
   using KeyExchangeT   = KeyOutputT[TILE_ITEMS + 1];

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -28,7 +28,6 @@
 #include <cuda/__functional/operator_properties.h>
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__type_traits/conditional.h>
-#include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_pointer.h>
 #include <cuda/std/__type_traits/is_same.h>
 CUB_NAMESPACE_BEGIN
@@ -110,10 +109,11 @@ namespace detail::reduce_by_key
  * @tparam AccumT
  *   The type of intermediate accumulator (according to P2322R6)
  *
- * @tparam StableReductionOrderT
+ * @tparam StableReductionOrder
  *   Whether to use a stable reduction order across tiles
  */
 template <typename AgentReduceByKeyPolicyT,
+          bool StableReductionOrder,
           typename KeysInputIteratorT,
           typename UniqueOutputIteratorT,
           typename ValuesInputIteratorT,
@@ -123,8 +123,7 @@ template <typename AgentReduceByKeyPolicyT,
           typename ReductionOpT,
           typename OffsetT,
           typename AccumT,
-          typename StreamingContextT,
-          typename StableReductionOrderT = ::cuda::std::false_type>
+          typename StreamingContextT>
 struct AgentReduceByKey
 {
   // Whether or not this is a streaming invocation (i.e., multiple kernel invocations over partitions of the input)
@@ -235,11 +234,7 @@ struct AgentReduceByKey
   // Callback type for obtaining tile prefix during block scan
   using DelayConstructorT = typename AgentReduceByKeyPolicyT::detail::delay_constructor_t;
   using TilePrefixCallbackOpT =
-    TilePrefixCallbackOp<OffsetValuePairT,
-                         ReduceBySegmentOpT,
-                         ScanTileStateT,
-                         DelayConstructorT,
-                         StableReductionOrderT::value>;
+    TilePrefixCallbackOp<OffsetValuePairT, ReduceBySegmentOpT, ScanTileStateT, DelayConstructorT, StableReductionOrder>;
 
   // Key and value exchange types
   using KeyExchangeT   = KeyOutputT[TILE_ITEMS + 1];

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -28,6 +28,7 @@
 #include <cuda/__functional/operator_properties.h>
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_pointer.h>
 #include <cuda/std/__type_traits/is_same.h>
 CUB_NAMESPACE_BEGIN
@@ -43,8 +44,7 @@ template <int ThreadsPerBlock,
           BlockLoadAlgorithm LoadAlgorithm,
           CacheLoadModifier LoadModifier,
           BlockScanAlgorithm ScanAlgorithm,
-          typename DelayConstructorT = detail::fixed_delay_constructor_t<350, 450>,
-          bool StableReductionOrder  = false>
+          typename DelayConstructorT = detail::fixed_delay_constructor_t<350, 450>>
 struct agent_reduce_by_key_policy
 {
   static constexpr int BLOCK_THREADS                 = ThreadsPerBlock;
@@ -52,7 +52,6 @@ struct agent_reduce_by_key_policy
   static constexpr BlockLoadAlgorithm LOAD_ALGORITHM = LoadAlgorithm;
   static constexpr CacheLoadModifier LOAD_MODIFIER   = LoadModifier;
   static constexpr BlockScanAlgorithm SCAN_ALGORITHM = ScanAlgorithm;
-  static constexpr bool STABLE_REDUCTION_ORDER       = StableReductionOrder;
 
   struct detail
   {
@@ -110,6 +109,9 @@ namespace detail::reduce_by_key
  *
  * @tparam AccumT
  *   The type of intermediate accumulator (according to P2322R6)
+ *
+ * @tparam StableReductionOrderT
+ *   Whether to use a stable reduction order across tiles
  */
 template <typename AgentReduceByKeyPolicyT,
           typename KeysInputIteratorT,
@@ -121,7 +123,8 @@ template <typename AgentReduceByKeyPolicyT,
           typename ReductionOpT,
           typename OffsetT,
           typename AccumT,
-          typename StreamingContextT>
+          typename StreamingContextT,
+          typename StableReductionOrderT = ::cuda::std::false_type>
 struct AgentReduceByKey
 {
   // Whether or not this is a streaming invocation (i.e., multiple kernel invocations over partitions of the input)
@@ -236,7 +239,7 @@ struct AgentReduceByKey
                          ReduceBySegmentOpT,
                          ScanTileStateT,
                          DelayConstructorT,
-                         AgentReduceByKeyPolicyT::STABLE_REDUCTION_ORDER>;
+                         StableReductionOrderT::value>;
 
   // Key and value exchange types
   using KeyExchangeT   = KeyOutputT[TILE_ITEMS + 1];

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -46,6 +46,7 @@
 #include <cuda/__memory_resource/get_memory_resource.h>
 #include <cuda/__stream/get_stream.h>
 #include <cuda/__stream/stream_ref.h>
+#include <cuda/__type_traits/is_floating_point.h>
 #include <cuda/argument>
 #include <cuda/std/__execution/env.h>
 #include <cuda/std/__functional/identity.h>
@@ -53,7 +54,6 @@
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__iterator/indirectly_comparable.h>
 #include <cuda/std/__type_traits/conditional.h>
-#include <cuda/std/__type_traits/is_floating_point.h>
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__utility/forward.h>
@@ -154,7 +154,9 @@ inline constexpr bool is_non_deterministic_v =
 //! ====================================
 //!
 //! ``cub::DeviceReduce`` supports all three :ref:`determinism guarantees <cccl-determinism>`; the
-//! default is ``run_to_run``.
+//! default is ``run_to_run``. ``ReduceByKey`` has separate type/operator constraints, documented in the
+//! :ref:`CUB determinism support matrix <cub-determinism>`. The implementation details below apply to the other
+//! reductions; ``ReduceByKey`` does not use RFA or atomic accumulation.
 //!
 //! - ``run_to_run`` (the default) is reproducible because, for a given GPU, every launch with the same input,
 //!   build, and launch configuration selects the *same* tuning policy and therefore performs the *same* fixed
@@ -2858,7 +2860,7 @@ public:
     constexpr bool is_primitive_min_max_op =
       detail::is_primitive_v<accum_t> && detail::is_cuda_minimum_maximum_v<ReductionOpT, accum_t>;
     constexpr bool is_fp_plus_op =
-      ::cuda::std::is_floating_point_v<accum_t> && detail::is_cuda_std_plus_v<ReductionOpT, accum_t>;
+      ::cuda::is_floating_point_v<accum_t> && detail::is_cuda_std_plus_v<ReductionOpT, accum_t>;
 
     static_assert(!is_run_to_run_required || is_safe_integral_op || is_primitive_min_max_op || is_fp_plus_op,
                   "run_to_run deterministic reduce-by-key requires integral types with known operators, "
@@ -3049,7 +3051,7 @@ public:
     using EqualityOp = ::cuda::std::equal_to<>;
 
     static constexpr bool stable_reduction_order =
-      ::cuda::std::is_floating_point_v<accum_t> && detail::is_cuda_std_plus_v<ReductionOpT, accum_t>;
+      ::cuda::is_floating_point_v<accum_t> && detail::is_cuda_std_plus_v<ReductionOpT, accum_t>;
 
     return detail::reduce_by_key::dispatch<stable_reduction_order>(
       d_temp_storage,

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -53,6 +53,7 @@
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__iterator/indirectly_comparable.h>
 #include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_floating_point.h>
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__utility/forward.h>
@@ -2734,8 +2735,11 @@ public:
   //! respectively. The total number of runs encountered is written to ``d_num_runs_out``.
   //!
   //! - The ``==`` equality operator is used to determine whether keys are equivalent
-  //! - Provides "run-to-run" determinism for pseudo-associative reduction
-  //!   (e.g., addition of floating point types) on the same GPU device.
+  //! - Requests "run-to-run" determinism by default. It is supported for integral types with known operators,
+  //!   primitive types with min/max, and floating-point types with ``cuda::std::plus``.
+  //! - Pass ``cuda::execution::require(cuda::execution::determinism::not_guaranteed)`` in the environment to opt out.
+  //! - "gpu-to-gpu" determinism is supported for integral types with known operators and primitive types with min/max.
+  //!   Other combinations under "run-to-run" or "gpu-to-gpu" are rejected at compile time.
   //! - Let ``out`` be any of
   //!   ``[d_unique_out, d_unique_out + *d_num_runs_out)``
   //!   ``[d_aggregates_out, d_aggregates_out + *d_num_runs_out)``
@@ -2780,7 +2784,8 @@ public:
   //!
   //! @tparam EnvT
   //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
-  //!   Supports customization of stream via ``cuda::get_stream``.
+  //!   Supports customization of stream via ``cuda::get_stream`` and determinism through
+  //!   ``cuda::execution::require``.
   //!
   //! @param[in] d_keys_in
   //!   Pointer to the input sequence of keys
@@ -2830,15 +2835,44 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ReduceByKey");
 
-    using OffsetT                 = detail::choose_offset_t<NumItemsT>;
-    using EqualityOp              = ::cuda::std::equal_to<>;
-    using default_policy_selector = detail::reduce_by_key::policy_selector_from_types<
-      ReductionOpT,
-      ::cuda::std::__accumulator_t<ReductionOpT, detail::it_value_t<ValuesInputIteratorT>>,
-      detail::non_void_value_t<UniqueOutputIteratorT, detail::it_value_t<KeysInputIteratorT>>>;
+    static_assert(!::cuda::std::execution::__queryable_with<EnvT, ::cuda::execution::determinism::__get_determinism_t>,
+                  "Determinism should be used inside requires to have an effect.");
+
+    using requirements_t = ::cuda::std::execution::
+      __query_result_or_t<EnvT, ::cuda::execution::__get_requirements_t, ::cuda::std::execution::env<>>;
+    using requested_determinism_t =
+      ::cuda::std::execution::__query_result_or_t<requirements_t,
+                                                  ::cuda::execution::determinism::__get_determinism_t,
+                                                  ::cuda::execution::determinism::run_to_run_t>;
+    using accum_t    = ::cuda::std::__accumulator_t<ReductionOpT, detail::it_value_t<ValuesInputIteratorT>>;
+    using key_t      = detail::non_void_value_t<UniqueOutputIteratorT, detail::it_value_t<KeysInputIteratorT>>;
+    using OffsetT    = detail::choose_offset_t<NumItemsT>;
+    using EqualityOp = ::cuda::std::equal_to<>;
+
+    constexpr bool is_run_to_run_required =
+      ::cuda::std::is_same_v<requested_determinism_t, ::cuda::execution::determinism::run_to_run_t>;
+    constexpr bool is_gpu_to_gpu_required =
+      ::cuda::std::is_same_v<requested_determinism_t, ::cuda::execution::determinism::gpu_to_gpu_t>;
+    constexpr bool is_safe_integral_op =
+      ::cuda::std::is_integral_v<accum_t> && detail::is_cuda_binary_operator<ReductionOpT>;
+    constexpr bool is_primitive_min_max_op =
+      detail::is_primitive_v<accum_t> && detail::is_cuda_minimum_maximum_v<ReductionOpT, accum_t>;
+    constexpr bool is_fp_plus_op =
+      ::cuda::std::is_floating_point_v<accum_t> && detail::is_cuda_std_plus_v<ReductionOpT, accum_t>;
+
+    static_assert(!is_run_to_run_required || is_safe_integral_op || is_primitive_min_max_op || is_fp_plus_op,
+                  "run_to_run deterministic reduce-by-key requires integral types with known operators, "
+                  "primitive types with min/max, or floating-point types with plus operator");
+    static_assert(!is_gpu_to_gpu_required || is_safe_integral_op || is_primitive_min_max_op,
+                  "gpu_to_gpu deterministic reduce-by-key requires integral types with known operators or "
+                  "primitive types with min/max");
+
+    static constexpr bool stable_reduction_order = is_run_to_run_required && is_fp_plus_op;
+    using default_policy_selector =
+      detail::reduce_by_key::policy_selector_from_types<ReductionOpT, accum_t, key_t, stable_reduction_order>;
     return detail::dispatch_with_env_and_tuning<default_policy_selector>(
       env, [&](auto policy_selector, void* storage, size_t& bytes, cudaStream_t stream) {
-        return detail::reduce_by_key::dispatch(
+        return detail::reduce_by_key::dispatch<stable_reduction_order>(
           storage,
           bytes,
           d_keys_in,
@@ -2867,8 +2901,7 @@ public:
   //! respectively. The total number of runs encountered is written to ``d_num_runs_out``.
   //!
   //! - The ``==`` equality operator is used to determine whether keys are equivalent
-  //! - Provides "run-to-run" determinism for pseudo-associative reduction
-  //!   (e.g., addition of floating point types) on the same GPU device.
+  //! - Provides "run-to-run" determinism for floating-point reduction with ``cuda::std::plus`` on the same GPU device.
   //!   However, results for pseudo-associative reduction may be inconsistent
   //!   from one device to a another device of a different compute-capability
   //!   because CUB can employ different tile-sizing for different architectures.
@@ -3011,10 +3044,14 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ReduceByKey");
 
+    using accum_t    = ::cuda::std::__accumulator_t<ReductionOpT, detail::it_value_t<ValuesInputIteratorT>>;
     using OffsetT    = detail::choose_offset_t<NumItemsT>;
     using EqualityOp = ::cuda::std::equal_to<>;
 
-    return detail::reduce_by_key::dispatch(
+    static constexpr bool stable_reduction_order =
+      ::cuda::std::is_floating_point_v<accum_t> && detail::is_cuda_std_plus_v<ReductionOpT, accum_t>;
+
+    return detail::reduce_by_key::dispatch<stable_reduction_order>(
       d_temp_storage,
       temp_storage_bytes,
       d_keys_in,

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -154,9 +154,9 @@ inline constexpr bool is_non_deterministic_v =
 //! ====================================
 //!
 //! ``cub::DeviceReduce`` supports all three :ref:`determinism guarantees <cccl-determinism>`; the
-//! default is ``run_to_run``. ``ReduceByKey`` has separate type/operator constraints, documented in the
-//! :ref:`CUB determinism support matrix <cub-determinism>`. The implementation details below apply to the other
-//! reductions; ``ReduceByKey`` does not use RFA or atomic accumulation.
+//! default is ``run_to_run``. ``ReduceByKey`` has separate type/operator constraints, documented with its
+//! :cpp:func:`environment overload <cub::DeviceReduce::ReduceByKey>`. The implementation details below apply to the
+//! other reductions; ``ReduceByKey`` does not use RFA or atomic accumulation.
 //!
 //! - ``run_to_run`` (the default) is reproducible because, for a given GPU, every launch with the same input,
 //!   build, and launch configuration selects the *same* tuning policy and therefore performs the *same* fixed
@@ -2740,7 +2740,9 @@ public:
   //! - Requests "run-to-run" determinism by default. It is supported for integral types with known operators,
   //!   primitive types with min/max, and floating-point types with ``cuda::std::plus``.
   //! - Pass ``cuda::execution::require(cuda::execution::determinism::not_guaranteed)`` in the environment to opt out.
+  //!   This removes the determinism requirement without changing the algorithm's other requirements.
   //! - "gpu-to-gpu" determinism is supported for integral types with known operators and primitive types with min/max.
+  //!   Floating-point addition is unsupported; ``ReduceByKey`` does not use RFA.
   //!   Other combinations under "run-to-run" or "gpu-to-gpu" are rejected at compile time.
   //! - Let ``out`` be any of
   //!   ``[d_unique_out, d_unique_out + *d_num_runs_out)``
@@ -2748,6 +2750,12 @@ public:
   //!   ``d_num_runs_out``. The ranges represented by ``out`` shall not overlap
   //!   ``[d_keys_in, d_keys_in + num_items)``,
   //!   ``[d_values_in, d_values_in + num_items)`` nor ``out`` in any way.
+  //!
+  //! These determinism constraints apply to this environment overload and its accumulator type. Known CUDA binary
+  //! operators are ``cuda::minimum``, ``cuda::maximum``, and ``cuda::std::plus``, ``multiplies``, ``bit_and``,
+  //! ``bit_or``, ``bit_xor``, ``logical_and``, and ``logical_or``. Primitive accumulators are the types recognized by
+  //! ``cub::Traits``; floating-point accumulators (including CUDA extended types) are recognized by
+  //! ``cuda::is_floating_point_v``. The operator must support the accumulator type.
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -154,9 +154,9 @@ inline constexpr bool is_non_deterministic_v =
 //! ====================================
 //!
 //! ``cub::DeviceReduce`` supports all three :ref:`determinism guarantees <cccl-determinism>`; the
-//! default is ``run_to_run``. ``ReduceByKey`` has separate type/operator constraints, documented with its
-//! :cpp:func:`environment overload <cub::DeviceReduce::ReduceByKey>`. The implementation details below apply to the
-//! other reductions; ``ReduceByKey`` does not use RFA or atomic accumulation.
+//! default is ``run_to_run``. ``ReduceByKey`` has separate type/operator constraints, documented on its
+//! environment overload below. The implementation details below apply to the other reductions;
+//! ``ReduceByKey`` does not use RFA or atomic accumulation.
 //!
 //! - ``run_to_run`` (the default) is reproducible because, for a given GPU, every launch with the same input,
 //!   build, and launch configuration selects the *same* tuning policy and therefore performs the *same* fixed

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -2878,8 +2878,7 @@ public:
                   "primitive types with min/max");
 
     static constexpr bool stable_reduction_order = is_run_to_run_required && is_fp_plus_op;
-    using default_policy_selector =
-      detail::reduce_by_key::policy_selector_from_types<ReductionOpT, accum_t, key_t, stable_reduction_order>;
+    using default_policy_selector = detail::reduce_by_key::policy_selector_from_types<ReductionOpT, accum_t, key_t>;
     return detail::dispatch_with_env_and_tuning<default_policy_selector>(
       env, [&](auto policy_selector, void* storage, size_t& bytes, cudaStream_t stream) {
         return detail::reduce_by_key::dispatch<stable_reduction_order>(

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -665,7 +665,8 @@ _CCCL_HOST_DEVICE_API auto determine_threads_items_vsmem(PolicyGetter policy_get
     policy.lookback.scan_algorithm,
     delay_constructor_t<policy.lookback.lookback_delay.kind,
                         policy.lookback.lookback_delay.delay,
-                        policy.lookback.lookback_delay.l2_write_latency>>;
+                        policy.lookback.lookback_delay.l2_write_latency>,
+    /* StableReductionOrder */ true>;
   using vsmem_helper_t = vsmem_helper_default_fallback_policy_t<Policy, AgentReduceByKey, Args...>;
   return ::cuda::std::tuple{vsmem_helper_t::agent_policy_t::BLOCK_THREADS,
                             vsmem_helper_t::agent_policy_t::ITEMS_PER_THREAD,
@@ -801,7 +802,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch(
       ReductionOpT,
       OffsetT,
       AccumT,
-      streaming_context_t>;
+      streaming_context_t,
+      /* StableReductionOrder */ true>;
 
     int reduce_by_key_sm_occupancy{};
     if (const auto error =

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -34,7 +34,6 @@
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
 #include <cuda/std/__host_stdlib/sstream>
-#include <cuda/std/__type_traits/integral_constant.h>
 
 CUB_NAMESPACE_BEGIN
 
@@ -113,6 +112,14 @@ struct streaming_context
   }
 };
 
+// Bind the stability flag while selecting the default and fallback agent policies.
+template <bool StableReductionOrder, typename Policy, typename... Args>
+using vsmem_helper_t =
+  vsmem_helper_with_fallback_impl<Policy,
+                                  AgentReduceByKey<Policy, StableReductionOrder, Args...>,
+                                  policy_wrapper_t<Policy, 64, 1>,
+                                  AgentReduceByKey<policy_wrapper_t<Policy, 64, 1>, StableReductionOrder, Args...>>;
+
 /**
  * @brief Multi-block reduce-by-key sweep kernel entry point
  *
@@ -145,6 +152,9 @@ struct streaming_context
  *
  * @tparam OffsetT
  *   Signed integer type for global offsets
+ *
+ * @tparam StableReductionOrder
+ *   Whether to use a stable reduction order across tiles
  *
  * @param d_keys_in
  *   Pointer to the input sequence of keys
@@ -189,7 +199,7 @@ template <typename PolicySelector,
           typename OffsetT,
           typename AccumT,
           typename StreamingContextT,
-          bool StableReductionOrder = false>
+          bool StableReductionOrder>
 #if _CCCL_HAS_CONCEPTS()
   requires reduce_by_key_policy_selector<PolicySelector>
 #endif
@@ -219,9 +229,9 @@ __launch_bounds__(int(current_policy<PolicySelector>().lookback.threads_per_bloc
                         policy.lookback.lookback_delay.delay,
                         policy.lookback.lookback_delay.l2_write_latency>>;
 
-  using vsmem_helper_t = vsmem_helper_default_fallback_policy_t<
+  using vsmem_helper_t = reduce_by_key::vsmem_helper_t<
+    StableReductionOrder,
     AgentReduceByKeyPolicyT,
-    AgentReduceByKey,
     KeysInputIteratorT,
     UniqueOutputIteratorT,
     ValuesInputIteratorT,
@@ -231,8 +241,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().lookback.threads_per_bloc
     ReductionOpT,
     OffsetT,
     AccumT,
-    StreamingContextT,
-    ::cuda::std::bool_constant<StableReductionOrder>>;
+    StreamingContextT>;
 
   // Thread block type for reducing tiles of value segments
   using agent_reduce_by_key_t = typename vsmem_helper_t::agent_t;
@@ -377,9 +386,9 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey
   CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t
   Invoke(ScanInitKernelT init_kernel, ReduceByKeyKernelT reduce_by_key_kernel)
   {
-    using vsmem_helper_t = detail::vsmem_helper_default_fallback_policy_t<
+    using vsmem_helper_t = detail::reduce_by_key::vsmem_helper_t<
+      false,
       typename ActivePolicyT::ReduceByKeyPolicyT,
-      detail::reduce_by_key::AgentReduceByKey,
       KeysInputIteratorT,
       UniqueOutputIteratorT,
       ValuesInputIteratorT,
@@ -558,7 +567,8 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey
         ReductionOpT,
         OffsetT,
         AccumT,
-        streaming_context_t>);
+        streaming_context_t,
+        false>);
   }
 
   /**
@@ -667,17 +677,13 @@ _CCCL_HOST_DEVICE_API auto determine_threads_items_vsmem(PolicyGetter policy_get
     delay_constructor_t<policy.lookback.lookback_delay.kind,
                         policy.lookback.lookback_delay.delay,
                         policy.lookback.lookback_delay.l2_write_latency>>;
-  using vsmem_helper_t =
-    vsmem_helper_default_fallback_policy_t<Policy,
-                                           AgentReduceByKey,
-                                           Args...,
-                                           ::cuda::std::bool_constant<StableReductionOrder>>;
+  using vsmem_helper_t = reduce_by_key::vsmem_helper_t<StableReductionOrder, Policy, Args...>;
   return ::cuda::std::tuple{vsmem_helper_t::agent_policy_t::BLOCK_THREADS,
                             vsmem_helper_t::agent_policy_t::ITEMS_PER_THREAD,
                             vsmem_helper_t::vsmem_per_block};
 }
 
-template <bool StableReductionOrder = false,
+template <bool StableReductionOrder,
           typename KeysInputIteratorT,
           typename UniqueOutputIteratorT,
           typename ValuesInputIteratorT,

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -34,6 +34,7 @@
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
 #include <cuda/std/__host_stdlib/sstream>
+#include <cuda/std/__type_traits/integral_constant.h>
 
 CUB_NAMESPACE_BEGIN
 
@@ -216,8 +217,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().lookback.threads_per_bloc
     policy.lookback.scan_algorithm,
     delay_constructor_t<policy.lookback.lookback_delay.kind,
                         policy.lookback.lookback_delay.delay,
-                        policy.lookback.lookback_delay.l2_write_latency>,
-    StableReductionOrder>;
+                        policy.lookback.lookback_delay.l2_write_latency>>;
 
   using vsmem_helper_t = vsmem_helper_default_fallback_policy_t<
     AgentReduceByKeyPolicyT,
@@ -231,7 +231,8 @@ __launch_bounds__(int(current_policy<PolicySelector>().lookback.threads_per_bloc
     ReductionOpT,
     OffsetT,
     AccumT,
-    StreamingContextT>;
+    StreamingContextT,
+    ::cuda::std::bool_constant<StableReductionOrder>>;
 
   // Thread block type for reducing tiles of value segments
   using agent_reduce_by_key_t = typename vsmem_helper_t::agent_t;
@@ -652,7 +653,7 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey
 namespace detail::reduce_by_key
 {
 // we move the conversion of the policy to the agent policy and its use out of the lambda below, so MSVC does not ICE
-template <typename PolicyGetter, typename... Args>
+template <bool StableReductionOrder, typename PolicyGetter, typename... Args>
 _CCCL_HOST_DEVICE_API auto determine_threads_items_vsmem(PolicyGetter policy_getter)
 {
   // TODO(bgruber): refactor this in the future
@@ -665,15 +666,19 @@ _CCCL_HOST_DEVICE_API auto determine_threads_items_vsmem(PolicyGetter policy_get
     policy.lookback.scan_algorithm,
     delay_constructor_t<policy.lookback.lookback_delay.kind,
                         policy.lookback.lookback_delay.delay,
-                        policy.lookback.lookback_delay.l2_write_latency>,
-    /* StableReductionOrder */ true>;
-  using vsmem_helper_t = vsmem_helper_default_fallback_policy_t<Policy, AgentReduceByKey, Args...>;
+                        policy.lookback.lookback_delay.l2_write_latency>>;
+  using vsmem_helper_t =
+    vsmem_helper_default_fallback_policy_t<Policy,
+                                           AgentReduceByKey,
+                                           Args...,
+                                           ::cuda::std::bool_constant<StableReductionOrder>>;
   return ::cuda::std::tuple{vsmem_helper_t::agent_policy_t::BLOCK_THREADS,
                             vsmem_helper_t::agent_policy_t::ITEMS_PER_THREAD,
                             vsmem_helper_t::vsmem_per_block};
 }
 
-template <typename KeysInputIteratorT,
+template <bool StableReductionOrder = false,
+          typename KeysInputIteratorT,
           typename UniqueOutputIteratorT,
           typename ValuesInputIteratorT,
           typename AggregatesOutputIteratorT,
@@ -683,7 +688,7 @@ template <typename KeysInputIteratorT,
           typename OffsetT,
           typename AccumT         = ::cuda::std::__accumulator_t<ReductionOpT, it_value_t<ValuesInputIteratorT>>,
           typename KeyT           = non_void_value_t<UniqueOutputIteratorT, it_value_t<KeysInputIteratorT>>,
-          typename PolicySelector = policy_selector_from_types<ReductionOpT, AccumT, KeyT>>
+          typename PolicySelector = policy_selector_from_types<ReductionOpT, AccumT, KeyT, StableReductionOrder>>
 #if _CCCL_HAS_CONCEPTS()
   requires reduce_by_key::reduce_by_key_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
@@ -724,6 +729,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch(
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
     const auto [threads_per_block, items_per_thread, vsmem_per_block] = determine_threads_items_vsmem<
+      StableReductionOrder,
       decltype(policy_getter),
       KeysInputIteratorT,
       UniqueOutputIteratorT,
@@ -803,7 +809,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch(
       OffsetT,
       AccumT,
       streaming_context_t,
-      /* StableReductionOrder */ true>;
+      StableReductionOrder>;
 
     int reduce_by_key_sm_occupancy{};
     if (const auto error =

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -187,7 +187,8 @@ template <typename PolicySelector,
           typename ReductionOpT,
           typename OffsetT,
           typename AccumT,
-          typename StreamingContextT>
+          typename StreamingContextT,
+          bool StableReductionOrder = false>
 #if _CCCL_HAS_CONCEPTS()
   requires reduce_by_key_policy_selector<PolicySelector>
 #endif
@@ -215,7 +216,8 @@ __launch_bounds__(int(current_policy<PolicySelector>().lookback.threads_per_bloc
     policy.lookback.scan_algorithm,
     delay_constructor_t<policy.lookback.lookback_delay.kind,
                         policy.lookback.lookback_delay.delay,
-                        policy.lookback.lookback_delay.l2_write_latency>>;
+                        policy.lookback.lookback_delay.l2_write_latency>,
+    StableReductionOrder>;
 
   using vsmem_helper_t = vsmem_helper_default_fallback_policy_t<
     AgentReduceByKeyPolicyT,

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -386,8 +386,9 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey
   CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t
   Invoke(ScanInitKernelT init_kernel, ReduceByKeyKernelT reduce_by_key_kernel)
   {
+    // Preserve the deprecated dispatcher's original reduction ordering.
     using vsmem_helper_t = detail::reduce_by_key::vsmem_helper_t<
-      false,
+      /* StableReductionOrder */ false,
       typename ActivePolicyT::ReduceByKeyPolicyT,
       KeysInputIteratorT,
       UniqueOutputIteratorT,
@@ -568,7 +569,7 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey
         OffsetT,
         AccumT,
         streaming_context_t,
-        false>);
+        /* StableReductionOrder */ false>); // Match the legacy virtual-memory agent's ordering.
   }
 
   /**
@@ -694,7 +695,7 @@ template <bool StableReductionOrder,
           typename OffsetT,
           typename AccumT         = ::cuda::std::__accumulator_t<ReductionOpT, it_value_t<ValuesInputIteratorT>>,
           typename KeyT           = non_void_value_t<UniqueOutputIteratorT, it_value_t<KeysInputIteratorT>>,
-          typename PolicySelector = policy_selector_from_types<ReductionOpT, AccumT, KeyT, StableReductionOrder>>
+          typename PolicySelector = policy_selector_from_types<ReductionOpT, AccumT, KeyT>>
 #if _CCCL_HAS_CONCEPTS()
   requires reduce_by_key::reduce_by_key_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -386,9 +386,8 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey
   CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t
   Invoke(ScanInitKernelT init_kernel, ReduceByKeyKernelT reduce_by_key_kernel)
   {
-    // Preserve the deprecated dispatcher's original reduction ordering.
     using vsmem_helper_t = detail::reduce_by_key::vsmem_helper_t<
-      /* StableReductionOrder */ false,
+      false,
       typename ActivePolicyT::ReduceByKeyPolicyT,
       KeysInputIteratorT,
       UniqueOutputIteratorT,
@@ -569,7 +568,7 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey
         OffsetT,
         AccumT,
         streaming_context_t,
-        /* StableReductionOrder */ false>); // Match the legacy virtual-memory agent's ordering.
+        false>);
   }
 
   /**

--- a/cub/cub/device/dispatch/dispatch_rle_encode.cuh
+++ b/cub/cub/device/dispatch/dispatch_rle_encode.cuh
@@ -111,9 +111,9 @@ __launch_bounds__(int(current_policy<PolicySelector>().lookback.threads_per_bloc
                           policy.lookback.lookback_delay.delay,
                           policy.lookback.lookback_delay.l2_write_latency>>;
 
-    using vsmem_helper_t = vsmem_helper_default_fallback_policy_t<
+    using vsmem_helper_t = reduce_by_key::vsmem_helper_t<
+      false,
       AgentReduceByKeyPolicyT,
-      reduce_by_key::AgentReduceByKey,
       KeysInputIteratorT,
       UniqueOutputIteratorT,
       ValuesInputIteratorT,

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh
@@ -36,7 +36,7 @@ struct reduce_by_key_kernel_source
   template <typename PolicySelector, typename... KernelArgTs>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static constexpr auto reduce_by_key_kernel()
   {
-    return &DeviceReduceByKeyKernel<PolicySelector, KernelArgTs...>;
+    return &DeviceReduceByKeyKernel<PolicySelector, KernelArgTs..., false>;
   }
 };
 
@@ -52,7 +52,8 @@ template <typename KeysInputIteratorT,
           typename PolicySelector =
             policy_selector_from_types<ReductionOpT,
                                        AccumT,
-                                       non_void_value_t<UniqueOutputIteratorT, it_value_t<KeysInputIteratorT>>>,
+                                       non_void_value_t<UniqueOutputIteratorT, it_value_t<KeysInputIteratorT>>,
+                                       false>,
           typename KernelSource = reduce_by_key_kernel_source>
 #if _CCCL_HAS_CONCEPTS()
   requires reduce_by_key_policy_selector<PolicySelector>

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh
@@ -52,8 +52,7 @@ template <typename KeysInputIteratorT,
           typename PolicySelector =
             policy_selector_from_types<ReductionOpT,
                                        AccumT,
-                                       non_void_value_t<UniqueOutputIteratorT, it_value_t<KeysInputIteratorT>>,
-                                       false>,
+                                       non_void_value_t<UniqueOutputIteratorT, it_value_t<KeysInputIteratorT>>>,
           typename KernelSource = reduce_by_key_kernel_source>
 #if _CCCL_HAS_CONCEPTS()
   requires reduce_by_key_policy_selector<PolicySelector>

--- a/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
@@ -1048,6 +1048,7 @@ struct policy_selector
   bool key_is_trivially_copyable;
   bool accum_is_primitive;
   bool op_is_primitive;
+  bool require_stable_reduction_order = false;
 
 private:
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto __make_default_policy(CacheLoadModifier load_mod) const
@@ -1714,7 +1715,7 @@ struct policy_selector_from_hub
   }
 };
 
-template <class ReductionOpT, class AccumT, class KeyT>
+template <class ReductionOpT, class AccumT, class KeyT, bool StableReductionOrder = false>
 struct policy_selector_from_types
 {
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
@@ -1727,7 +1728,8 @@ struct policy_selector_from_types
       is_primitive_v<KeyT>,
       ::cuda::is_trivially_copyable_v<KeyT>,
       is_primitive_v<AccumT>,
-      basic_binary_op_t<ReductionOpT>::value}(cc);
+      basic_binary_op_t<ReductionOpT>::value,
+      StableReductionOrder}(cc);
   }
 };
 } // namespace detail::reduce_by_key

--- a/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
@@ -1048,7 +1048,6 @@ struct policy_selector
   bool key_is_trivially_copyable;
   bool accum_is_primitive;
   bool op_is_primitive;
-  bool require_stable_reduction_order = false;
 
 private:
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto __make_default_policy(CacheLoadModifier load_mod) const
@@ -1715,7 +1714,7 @@ struct policy_selector_from_hub
   }
 };
 
-template <class ReductionOpT, class AccumT, class KeyT, bool StableReductionOrder = false>
+template <class ReductionOpT, class AccumT, class KeyT, bool StableReductionOrder>
 struct policy_selector_from_types
 {
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
@@ -1728,8 +1727,7 @@ struct policy_selector_from_types
       is_primitive_v<KeyT>,
       ::cuda::is_trivially_copyable_v<KeyT>,
       is_primitive_v<AccumT>,
-      basic_binary_op_t<ReductionOpT>::value,
-      StableReductionOrder}(cc);
+      basic_binary_op_t<ReductionOpT>::value}(cc);
   }
 };
 } // namespace detail::reduce_by_key

--- a/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
@@ -1714,7 +1714,7 @@ struct policy_selector_from_hub
   }
 };
 
-template <class ReductionOpT, class AccumT, class KeyT, bool StableReductionOrder>
+template <class ReductionOpT, class AccumT, class KeyT>
 struct policy_selector_from_types
 {
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const

--- a/cub/test/catch2_test_device_reduce_by_key.cu
+++ b/cub/test/catch2_test_device_reduce_by_key.cu
@@ -5,10 +5,8 @@
 
 #include <cub/device/device_reduce.cuh>
 
+#include <cuda/std/__bit/bit_cast.h>
 #include <cuda/std/__functional/operations.h>
-#include <cuda/std/bit>
-
-#include <random>
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
@@ -165,34 +163,32 @@ CUB_TEST("Device reduce-by-key works", "[by_key][reduce][device]", CUB_SMALL, fu
 #if TEST_LAUNCH == 0 && TEST_TYPES == 0
 CUB_TEST_CASE("Device reduce-by-key is run-to-run deterministic for fp64 sums", "[by_key][reduce][device]", CUB_SMALL)
 {
-  constexpr std::size_t num_items = 65'536;
-  constexpr std::size_t long_run  = 50'000;
-  constexpr std::size_t short_run = 64;
-  constexpr int num_repetitions   = 20;
+  // Span several waves of tiles so that the unfixed lookback grouping can vary on large GPUs.
+  constexpr int num_items       = 262'144;
+  constexpr int long_run        = 200'000;
+  constexpr int short_run       = 64;
+  constexpr int num_repetitions = 20;
+  constexpr int num_runs        = 1 + (num_items - long_run + short_run - 1) / short_run;
 
   c2h::host_vector<std::uint64_t> keys(num_items);
-  c2h::host_vector<double> values(num_items);
-  std::mt19937_64 rng{42};
-  std::uniform_real_distribution<double> distribution{-1.0, 1.0};
 
-  for (std::size_t i = 0; i < num_items; ++i)
+  for (int i = 0; i < num_items; ++i)
   {
-    keys[i]   = i < long_run ? 0 : 1 + (i - long_run) / short_run;
-    values[i] = i % 7 == 0 ? distribution(rng) * 1e-2 : 0.0;
-    static_cast<void>(rng()); // Match the issue's integer-control RNG consumption.
+    keys[i] = i < long_run ? 0 : 1 + (i - long_run) / short_run;
   }
 
   c2h::device_vector<std::uint64_t> keys_in = keys;
-  c2h::device_vector<double> values_in      = values;
-  c2h::device_vector<std::uint64_t> unique_out(num_items);
-  c2h::device_vector<double> aggregates_out(num_items);
-  c2h::device_vector<std::size_t> num_runs_out(1);
+  c2h::device_vector<double> values_in(num_items);
+  c2h::gen(C2H_SEED(2), values_in, -1e-2, 1e-2);
+  c2h::device_vector<std::uint64_t> unique_out(num_runs);
+  c2h::device_vector<double> aggregates_out(num_runs);
+  c2h::device_vector<int> num_runs_out(1);
 
-  auto* const d_keys_in        = thrust::raw_pointer_cast(keys_in.data());
-  auto* const d_values_in      = thrust::raw_pointer_cast(values_in.data());
-  auto* const d_unique_out     = thrust::raw_pointer_cast(unique_out.data());
-  auto* const d_aggregates_out = thrust::raw_pointer_cast(aggregates_out.data());
-  auto* const d_num_runs_out   = thrust::raw_pointer_cast(num_runs_out.data());
+  const auto d_keys_in        = thrust::raw_pointer_cast(keys_in.data());
+  const auto d_values_in      = thrust::raw_pointer_cast(values_in.data());
+  const auto d_unique_out     = thrust::raw_pointer_cast(unique_out.data());
+  const auto d_aggregates_out = thrust::raw_pointer_cast(aggregates_out.data());
+  const auto d_num_runs_out   = thrust::raw_pointer_cast(num_runs_out.data());
 
   std::size_t temp_storage_bytes{};
   REQUIRE(
@@ -208,12 +204,13 @@ CUB_TEST_CASE("Device reduce-by-key is run-to-run deterministic for fp64 sums", 
       cuda::std::plus{},
       num_items));
   c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes, thrust::no_init);
-  auto* const d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+  const auto d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
-  std::uint64_t first_result{};
+  c2h::host_vector<std::uint64_t> expected_keys;
+  c2h::host_vector<std::uint64_t> expected_aggregates;
   for (int repetition = 0; repetition < num_repetitions; ++repetition)
   {
-    REQUIRE(cudaSuccess == cudaMemset(d_aggregates_out, 0xee, sizeof(double)));
+    REQUIRE(cudaSuccess == cudaMemset(d_aggregates_out, 0xee, num_runs * sizeof(double)));
     REQUIRE(
       cudaSuccess
       == cub::DeviceReduce::ReduceByKey(
@@ -227,14 +224,23 @@ CUB_TEST_CASE("Device reduce-by-key is run-to-run deterministic for fp64 sums", 
         cuda::std::plus{},
         num_items));
 
-    const auto result = cuda::std::bit_cast<std::uint64_t>(static_cast<double>(aggregates_out[0]));
+    REQUIRE(num_runs_out[0] == num_runs);
+    const c2h::host_vector<std::uint64_t> result_keys = unique_out;
+    const c2h::host_vector<double> result_aggregates  = aggregates_out;
+    c2h::host_vector<std::uint64_t> result_bits(num_runs);
+    for (int run = 0; run < num_runs; ++run)
+    {
+      result_bits[run] = cuda::std::bit_cast<std::uint64_t>(result_aggregates[run]);
+    }
     if (repetition == 0)
     {
-      first_result = result;
+      expected_keys       = result_keys;
+      expected_aggregates = result_bits;
     }
     else
     {
-      REQUIRE(result == first_result);
+      REQUIRE(result_keys == expected_keys);
+      REQUIRE(result_bits == expected_aggregates);
     }
   }
 }

--- a/cub/test/catch2_test_device_reduce_by_key.cu
+++ b/cub/test/catch2_test_device_reduce_by_key.cu
@@ -5,6 +5,7 @@
 
 #include <cub/device/device_reduce.cuh>
 
+#include <cuda/std/__functional/operations.h>
 #include <cuda/std/bit>
 
 #include <random>
@@ -162,14 +163,6 @@ CUB_TEST("Device reduce-by-key works", "[by_key][reduce][device]", CUB_SMALL, fu
 }
 
 #if TEST_LAUNCH == 0 && TEST_TYPES == 0
-struct fp64_sum
-{
-  _CCCL_HOST_DEVICE_API double operator()(double lhs, double rhs) const noexcept
-  {
-    return lhs + rhs;
-  }
-};
-
 CUB_TEST_CASE("Device reduce-by-key is run-to-run deterministic for fp64 sums", "[by_key][reduce][device]", CUB_SMALL)
 {
   constexpr std::size_t num_items = 65'536;
@@ -212,7 +205,7 @@ CUB_TEST_CASE("Device reduce-by-key is run-to-run deterministic for fp64 sums", 
       d_values_in,
       d_aggregates_out,
       d_num_runs_out,
-      fp64_sum{},
+      cuda::std::plus{},
       num_items));
   c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes, thrust::no_init);
   auto* const d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
@@ -231,7 +224,7 @@ CUB_TEST_CASE("Device reduce-by-key is run-to-run deterministic for fp64 sums", 
         d_values_in,
         d_aggregates_out,
         d_num_runs_out,
-        fp64_sum{},
+        cuda::std::plus{},
         num_items));
 
     const auto result = cuda::std::bit_cast<std::uint64_t>(static_cast<double>(aggregates_out[0]));

--- a/cub/test/catch2_test_device_reduce_by_key.cu
+++ b/cub/test/catch2_test_device_reduce_by_key.cu
@@ -5,6 +5,10 @@
 
 #include <cub/device/device_reduce.cuh>
 
+#include <cuda/std/bit>
+
+#include <random>
+
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_launch_helper.h"
 #include "cub_test_macros.h"
@@ -156,3 +160,89 @@ CUB_TEST("Device reduce-by-key works", "[by_key][reduce][device]", CUB_SMALL, fu
     REQUIRE(expected_keys == out_unique_keys);
   }
 }
+
+#if TEST_LAUNCH == 0 && TEST_TYPES == 0
+struct fp64_sum
+{
+  _CCCL_HOST_DEVICE_API double operator()(double lhs, double rhs) const noexcept
+  {
+    return lhs + rhs;
+  }
+};
+
+CUB_TEST_CASE("Device reduce-by-key is run-to-run deterministic for fp64 sums", "[by_key][reduce][device]", CUB_SMALL)
+{
+  constexpr std::size_t num_items = 65'536;
+  constexpr std::size_t long_run  = 50'000;
+  constexpr std::size_t short_run = 64;
+  constexpr int num_repetitions   = 20;
+
+  c2h::host_vector<std::uint64_t> keys(num_items);
+  c2h::host_vector<double> values(num_items);
+  std::mt19937_64 rng{42};
+  std::uniform_real_distribution<double> distribution{-1.0, 1.0};
+
+  for (std::size_t i = 0; i < num_items; ++i)
+  {
+    keys[i]   = i < long_run ? 0 : 1 + (i - long_run) / short_run;
+    values[i] = i % 7 == 0 ? distribution(rng) * 1e-2 : 0.0;
+    static_cast<void>(rng()); // Match the issue's integer-control RNG consumption.
+  }
+
+  c2h::device_vector<std::uint64_t> keys_in = keys;
+  c2h::device_vector<double> values_in      = values;
+  c2h::device_vector<std::uint64_t> unique_out(num_items);
+  c2h::device_vector<double> aggregates_out(num_items);
+  c2h::device_vector<std::size_t> num_runs_out(1);
+
+  auto* const d_keys_in        = thrust::raw_pointer_cast(keys_in.data());
+  auto* const d_values_in      = thrust::raw_pointer_cast(values_in.data());
+  auto* const d_unique_out     = thrust::raw_pointer_cast(unique_out.data());
+  auto* const d_aggregates_out = thrust::raw_pointer_cast(aggregates_out.data());
+  auto* const d_num_runs_out   = thrust::raw_pointer_cast(num_runs_out.data());
+
+  std::size_t temp_storage_bytes{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceReduce::ReduceByKey(
+      nullptr,
+      temp_storage_bytes,
+      d_keys_in,
+      d_unique_out,
+      d_values_in,
+      d_aggregates_out,
+      d_num_runs_out,
+      fp64_sum{},
+      num_items));
+  c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes, thrust::no_init);
+  auto* const d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  std::uint64_t first_result{};
+  for (int repetition = 0; repetition < num_repetitions; ++repetition)
+  {
+    REQUIRE(cudaSuccess == cudaMemset(d_aggregates_out, 0xee, sizeof(double)));
+    REQUIRE(
+      cudaSuccess
+      == cub::DeviceReduce::ReduceByKey(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_keys_in,
+        d_unique_out,
+        d_values_in,
+        d_aggregates_out,
+        d_num_runs_out,
+        fp64_sum{},
+        num_items));
+
+    const auto result = cuda::std::bit_cast<std::uint64_t>(static_cast<double>(aggregates_out[0]));
+    if (repetition == 0)
+    {
+      first_result = result;
+    }
+    else
+    {
+      REQUIRE(result == first_result);
+    }
+  }
+}
+#endif // TEST_LAUNCH == 0 && TEST_TYPES == 0

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -12,6 +12,7 @@
 #include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/std/__execution/env.h>
+#include <cuda/std/__functional/operations.h>
 #include <cuda/stream>
 
 #include "catch2_test_memory_resources.h"
@@ -529,9 +530,9 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run determinism requirem
 {
   // example-begin reduce-by-key-env
   auto keys_in         = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
-  auto values_in       = thrust::device_vector<int>{0, 7, 1, 6, 2, 5, 3, 4};
+  auto values_in       = thrust::device_vector<double>{0, 7, 1, 6, 2, 5, 3, 4};
   auto unique_keys_out = thrust::device_vector<int>(5);
-  auto aggregates_out  = thrust::device_vector<int>(5);
+  auto aggregates_out  = thrust::device_vector<double>(5);
   auto num_runs_out    = thrust::device_vector<int>(1);
 
   auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
@@ -542,7 +543,7 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run determinism requirem
     values_in.begin(),
     aggregates_out.begin(),
     num_runs_out.begin(),
-    cuda::minimum<int>{},
+    cuda::std::plus<>{},
     static_cast<int>(keys_in.size()),
     env);
   if (error != cudaSuccess)
@@ -551,7 +552,7 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run determinism requirem
   }
 
   thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
+  thrust::device_vector<double> expected_aggregates{0, 8, 6, 10, 4};
   // example-end reduce-by-key-env
 
   REQUIRE(error == cudaSuccess);
@@ -566,9 +567,9 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed determinism requ
 {
   // example-begin reduce-by-key-env-non-determinism
   auto keys_in         = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
-  auto values_in       = thrust::device_vector<int>{0, 7, 1, 6, 2, 5, 3, 4};
+  auto values_in       = thrust::device_vector<double>{0, 7, 1, 6, 2, 5, 3, 4};
   auto unique_keys_out = thrust::device_vector<int>(5);
-  auto aggregates_out  = thrust::device_vector<int>(5);
+  auto aggregates_out  = thrust::device_vector<double>(5);
   auto num_runs_out    = thrust::device_vector<int>(1);
 
   auto env = cuda::execution::require(cuda::execution::determinism::not_guaranteed);
@@ -579,7 +580,7 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed determinism requ
     values_in.begin(),
     aggregates_out.begin(),
     num_runs_out.begin(),
-    cuda::minimum<int>{},
+    cuda::std::multiplies<>{},
     static_cast<int>(keys_in.size()),
     env);
   if (error != cudaSuccess)
@@ -588,7 +589,7 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed determinism requ
   }
 
   thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
+  thrust::device_vector<double> expected_aggregates{0, 7, 6, 30, 4};
   // example-end reduce-by-key-env-non-determinism
 
   REQUIRE(error == cudaSuccess);

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -602,15 +602,15 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed determinism requ
 
 CUB_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run for floating-point addition", "[reduce][env]", CUB_SMALL)
 {
-  const auto keys_in   = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
-  const auto values_in = thrust::device_vector<double>{0, 7, 1, 6, 2, 5, 3, 4};
+  auto keys_in         = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto values_in       = thrust::device_vector<double>{0, 7, 1, 6, 2, 5, 3, 4};
   auto unique_keys_out = thrust::device_vector<int>(5);
   auto aggregates_out  = thrust::device_vector<double>(5);
   auto num_runs_out    = thrust::device_vector<int>(1);
 
-  const auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
+  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
 
-  const auto error = cub::DeviceReduce::ReduceByKey(
+  auto error = cub::DeviceReduce::ReduceByKey(
     keys_in.begin(),
     unique_keys_out.begin(),
     values_in.begin(),
@@ -624,8 +624,8 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run for floating-point a
     std::cerr << "cub::DeviceReduce::ReduceByKey failed with status: " << error << '\n';
   }
 
-  const thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  const thrust::device_vector<double> expected_aggregates{0, 8, 6, 10, 4};
+  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  thrust::device_vector<double> expected_aggregates{0, 8, 6, 10, 4};
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(num_runs_out[0] == 5);
@@ -639,15 +639,15 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed for floating-poi
          "[reduce][env]",
          CUB_SMALL)
 {
-  const auto keys_in   = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
-  const auto values_in = thrust::device_vector<double>{0, 7, 1, 6, 2, 5, 3, 4};
+  auto keys_in         = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto values_in       = thrust::device_vector<double>{0, 7, 1, 6, 2, 5, 3, 4};
   auto unique_keys_out = thrust::device_vector<int>(5);
   auto aggregates_out  = thrust::device_vector<double>(5);
   auto num_runs_out    = thrust::device_vector<int>(1);
 
-  const auto env = cuda::execution::require(cuda::execution::determinism::not_guaranteed);
+  auto env = cuda::execution::require(cuda::execution::determinism::not_guaranteed);
 
-  const auto error = cub::DeviceReduce::ReduceByKey(
+  auto error = cub::DeviceReduce::ReduceByKey(
     keys_in.begin(),
     unique_keys_out.begin(),
     values_in.begin(),
@@ -661,8 +661,8 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed for floating-poi
     std::cerr << "cub::DeviceReduce::ReduceByKey failed with status: " << error << '\n';
   }
 
-  const thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  const thrust::device_vector<double> expected_aggregates{0, 7, 6, 30, 4};
+  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  thrust::device_vector<double> expected_aggregates{0, 7, 6, 30, 4};
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(num_runs_out[0] == 5);

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -530,9 +530,9 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run determinism requirem
 {
   // example-begin reduce-by-key-env
   auto keys_in         = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
-  auto values_in       = thrust::device_vector<double>{0, 7, 1, 6, 2, 5, 3, 4};
+  auto values_in       = thrust::device_vector<int>{0, 7, 1, 6, 2, 5, 3, 4};
   auto unique_keys_out = thrust::device_vector<int>(5);
-  auto aggregates_out  = thrust::device_vector<double>(5);
+  auto aggregates_out  = thrust::device_vector<int>(5);
   auto num_runs_out    = thrust::device_vector<int>(1);
 
   auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
@@ -543,7 +543,7 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run determinism requirem
     values_in.begin(),
     aggregates_out.begin(),
     num_runs_out.begin(),
-    cuda::std::plus<>{},
+    cuda::minimum<int>{},
     static_cast<int>(keys_in.size()),
     env);
   if (error != cudaSuccess)
@@ -552,7 +552,7 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run determinism requirem
   }
 
   thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  thrust::device_vector<double> expected_aggregates{0, 8, 6, 10, 4};
+  thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
   // example-end reduce-by-key-env
 
   REQUIRE(error == cudaSuccess);
@@ -567,14 +567,87 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed determinism requ
 {
   // example-begin reduce-by-key-env-non-determinism
   auto keys_in         = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
-  auto values_in       = thrust::device_vector<double>{0, 7, 1, 6, 2, 5, 3, 4};
+  auto values_in       = thrust::device_vector<int>{0, 7, 1, 6, 2, 5, 3, 4};
   auto unique_keys_out = thrust::device_vector<int>(5);
-  auto aggregates_out  = thrust::device_vector<double>(5);
+  auto aggregates_out  = thrust::device_vector<int>(5);
   auto num_runs_out    = thrust::device_vector<int>(1);
 
   auto env = cuda::execution::require(cuda::execution::determinism::not_guaranteed);
 
   auto error = cub::DeviceReduce::ReduceByKey(
+    keys_in.begin(),
+    unique_keys_out.begin(),
+    values_in.begin(),
+    aggregates_out.begin(),
+    num_runs_out.begin(),
+    cuda::minimum<int>{},
+    static_cast<int>(keys_in.size()),
+    env);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceReduce::ReduceByKey failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
+  // example-end reduce-by-key-env-non-determinism
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(num_runs_out[0] == 5);
+  unique_keys_out.resize(5);
+  aggregates_out.resize(5);
+  REQUIRE(unique_keys_out == expected_keys);
+  REQUIRE(aggregates_out == expected_aggregates);
+}
+
+CUB_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run for floating-point addition", "[reduce][env]", CUB_SMALL)
+{
+  const auto keys_in   = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
+  const auto values_in = thrust::device_vector<double>{0, 7, 1, 6, 2, 5, 3, 4};
+  auto unique_keys_out = thrust::device_vector<int>(5);
+  auto aggregates_out  = thrust::device_vector<double>(5);
+  auto num_runs_out    = thrust::device_vector<int>(1);
+
+  const auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
+
+  const auto error = cub::DeviceReduce::ReduceByKey(
+    keys_in.begin(),
+    unique_keys_out.begin(),
+    values_in.begin(),
+    aggregates_out.begin(),
+    num_runs_out.begin(),
+    cuda::std::plus<>{},
+    static_cast<int>(keys_in.size()),
+    env);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceReduce::ReduceByKey failed with status: " << error << '\n';
+  }
+
+  const thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  const thrust::device_vector<double> expected_aggregates{0, 8, 6, 10, 4};
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(num_runs_out[0] == 5);
+  unique_keys_out.resize(5);
+  aggregates_out.resize(5);
+  REQUIRE(unique_keys_out == expected_keys);
+  REQUIRE(aggregates_out == expected_aggregates);
+}
+
+CUB_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed for floating-point multiplication",
+         "[reduce][env]",
+         CUB_SMALL)
+{
+  const auto keys_in   = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
+  const auto values_in = thrust::device_vector<double>{0, 7, 1, 6, 2, 5, 3, 4};
+  auto unique_keys_out = thrust::device_vector<int>(5);
+  auto aggregates_out  = thrust::device_vector<double>(5);
+  auto num_runs_out    = thrust::device_vector<int>(1);
+
+  const auto env = cuda::execution::require(cuda::execution::determinism::not_guaranteed);
+
+  const auto error = cub::DeviceReduce::ReduceByKey(
     keys_in.begin(),
     unique_keys_out.begin(),
     values_in.begin(),
@@ -588,9 +661,8 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed determinism requ
     std::cerr << "cub::DeviceReduce::ReduceByKey failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  thrust::device_vector<double> expected_aggregates{0, 7, 6, 30, 4};
-  // example-end reduce-by-key-env-non-determinism
+  const thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  const thrust::device_vector<double> expected_aggregates{0, 7, 6, 30, 4};
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(num_runs_out[0] == 5);

--- a/cub/test/test_device_reduce_by_key_determinism_fail.cu
+++ b/cub/test/test_device_reduce_by_key_determinism_fail.cu
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+// %PARAM% TEST_ERR err 0:1
+
+#include <cub/device/device_reduce.cuh>
+
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/require.h>
+#include <cuda/std/__functional/operations.h>
+
+int main()
+{
+  int* keys{};
+  double* values{};
+  int* num_runs{};
+
+#if TEST_ERR == 0
+  // clang-format off
+  // expected-error-0 {{"run_to_run deterministic reduce-by-key requires integral types with known operators, primitive types with min/max, or floating-point types with plus operator"}}
+  // clang-format on
+  auto error = cub::DeviceReduce::ReduceByKey(
+    keys,
+    keys,
+    values,
+    values,
+    num_runs,
+    cuda::std::multiplies<>{},
+    0,
+    cuda::execution::require(cuda::execution::determinism::run_to_run));
+#else
+  // clang-format off
+  // expected-error-1 {{"gpu_to_gpu deterministic reduce-by-key requires integral types with known operators or primitive types with min/max"}}
+  // clang-format on
+  auto error = cub::DeviceReduce::ReduceByKey(
+    keys,
+    keys,
+    values,
+    values,
+    num_runs,
+    cuda::std::plus<>{},
+    0,
+    cuda::execution::require(cuda::execution::determinism::gpu_to_gpu));
+#endif
+
+  return error == cudaSuccess ? 0 : 1;
+}

--- a/cub/test/test_device_reduce_by_key_determinism_fail.cu
+++ b/cub/test/test_device_reduce_by_key_determinism_fail.cu
@@ -11,15 +11,15 @@
 
 int main()
 {
-  int* keys{};
-  double* values{};
-  int* num_runs{};
+  int* const keys{};
+  double* const values{};
+  int* const num_runs{};
 
 #if TEST_ERR == 0
   // clang-format off
   // expected-error-0 {{"run_to_run deterministic reduce-by-key requires integral types with known operators, primitive types with min/max, or floating-point types with plus operator"}}
   // clang-format on
-  auto error = cub::DeviceReduce::ReduceByKey(
+  const auto error = cub::DeviceReduce::ReduceByKey(
     keys,
     keys,
     values,
@@ -32,7 +32,7 @@ int main()
   // clang-format off
   // expected-error-1 {{"gpu_to_gpu deterministic reduce-by-key requires integral types with known operators or primitive types with min/max"}}
   // clang-format on
-  auto error = cub::DeviceReduce::ReduceByKey(
+  const auto error = cub::DeviceReduce::ReduceByKey(
     keys,
     keys,
     values,

--- a/cub/test/test_device_reduce_by_key_determinism_fail.cu
+++ b/cub/test/test_device_reduce_by_key_determinism_fail.cu
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // %PARAM% TEST_ERR err 0:1
 

--- a/docs/cub/determinism.rst
+++ b/docs/cub/determinism.rst
@@ -48,10 +48,8 @@ Support matrix
      - ``run_to_run``
    * - ``cub::DeviceReduce::ReduceByKey``
      - Yes
-     - Integral accumulators with known CUDA binary operators; primitive accumulators with min/max;
-       floating-point accumulators (including CUDA extended types) with ``cuda::std::plus``
-     - Integral accumulators with known CUDA binary operators; primitive accumulators with min/max.
-       Floating-point addition is unsupported; ``ReduceByKey`` does not use RFA.
+     - Yes (partial)
+     - Yes (partial)
      - ``run_to_run``
    * - ``cub::DeviceScan`` (``ExclusiveSum``, ``ExclusiveScan``, ``InclusiveSum``, ``InclusiveScan``, ...)
      - Yes
@@ -64,7 +62,12 @@ Support matrix
      - No
      - ``run_to_run``
 
-For ``ReduceByKey``, known CUDA binary operators are ``cuda::minimum``, ``cuda::maximum``, and
+For ``ReduceByKey``, both ``run_to_run`` and ``gpu_to_gpu`` support integral accumulators with known
+CUDA binary operators and primitive accumulators with min/max. ``run_to_run`` additionally supports
+floating-point accumulators (including CUDA extended types) with ``cuda::std::plus``. Floating-point
+addition is unsupported with ``gpu_to_gpu``; ``ReduceByKey`` does not use RFA.
+
+Known CUDA binary operators are ``cuda::minimum``, ``cuda::maximum``, and
 ``cuda::std::plus``, ``multiplies``, ``bit_and``, ``bit_or``, ``bit_xor``, ``logical_and``, and
 ``logical_or``. Primitive accumulators are the types recognized by ``cub::Traits``; floating-point
 accumulators are recognized by ``cuda::is_floating_point_v``. The operator must support the accumulator

--- a/docs/cub/determinism.rst
+++ b/docs/cub/determinism.rst
@@ -41,10 +41,17 @@ Support matrix
      - ``run_to_run``
      - ``gpu_to_gpu``
      - Default
-   * - ``cub::DeviceReduce`` (``Reduce``, ``Sum``, ``Min``, ``Max``, ``TransformReduce``, ...)
+   * - ``cub::DeviceReduce`` (``Reduce``, ``Sum``, ``Min``, ``Max``, ``TransformReduce``, ...; excluding ``ReduceByKey``)
      - Yes
      - Yes
      - Yes (partial)
+     - ``run_to_run``
+   * - ``cub::DeviceReduce::ReduceByKey``
+     - Yes
+     - Integral accumulators with known CUDA binary operators; primitive accumulators with min/max;
+       floating-point accumulators (including CUDA extended types) with ``cuda::std::plus``
+     - Integral accumulators with known CUDA binary operators; primitive accumulators with min/max.
+       Floating-point addition is unsupported; ``ReduceByKey`` does not use RFA.
      - ``run_to_run``
    * - ``cub::DeviceScan`` (``ExclusiveSum``, ``ExclusiveScan``, ``InclusiveSum``, ``InclusiveScan``, ...)
      - Yes
@@ -56,6 +63,13 @@ Support matrix
      - Yes
      - No
      - ``run_to_run``
+
+For ``ReduceByKey``, known CUDA binary operators are ``cuda::minimum``, ``cuda::maximum``, and
+``cuda::std::plus``, ``multiplies``, ``bit_and``, ``bit_or``, ``bit_xor``, ``logical_and``, and
+``logical_or``. Primitive accumulators are the types recognized by ``cub::Traits``; floating-point
+accumulators are recognized by ``cuda::is_floating_point_v``. The operator must support the accumulator
+type. These constraints apply to the environment overload; ``not_guaranteed`` removes the determinism
+requirement without changing the algorithm's other requirements.
 
 .. note::
 

--- a/docs/cub/determinism.rst
+++ b/docs/cub/determinism.rst
@@ -62,18 +62,6 @@ Support matrix
      - No
      - ``run_to_run``
 
-For ``ReduceByKey``, both ``run_to_run`` and ``gpu_to_gpu`` support integral accumulators with known
-CUDA binary operators and primitive accumulators with min/max. ``run_to_run`` additionally supports
-floating-point accumulators (including CUDA extended types) with ``cuda::std::plus``. Floating-point
-addition is unsupported with ``gpu_to_gpu``; ``ReduceByKey`` does not use RFA.
-
-Known CUDA binary operators are ``cuda::minimum``, ``cuda::maximum``, and
-``cuda::std::plus``, ``multiplies``, ``bit_and``, ``bit_or``, ``bit_xor``, ``logical_and``, and
-``logical_or``. Primitive accumulators are the types recognized by ``cub::Traits``; floating-point
-accumulators are recognized by ``cuda::is_floating_point_v``. The operator must support the accumulator
-type. These constraints apply to the environment overload; ``not_guaranteed`` removes the determinism
-requirement without changing the algorithm's other requirements.
-
 .. note::
 
    The set of algorithms that accept determinism requirements, and the type/operator constraints for


### PR DESCRIPTION
@nanan-nvidia @guillaume-michel

## Description

closes #9995

`DeviceReduce::ReduceByKey` can produce different FP64 result bits across identical calls when a segment spans multiple tiles. Cross-tile partial reductions are combined in an order that can depend on tile completion.

This change uses the stable ordering already supported by `TilePrefixCallbackOp` for floating-point `cuda::std::plus`. The stable-order requirement is passed separately from the tuning policy. The environment overload defaults to `run_to_run`, and `not_guaranteed` opts out. Integral operations with known CUDA operators and primitive min/max keep the existing path. Unsupported determinism requests fail at compile time. The legacy temporary-storage overload also uses stable ordering for floating-point `cuda::std::plus`. RLE and the deprecated dispatcher explicitly select the previous ordering and retain their current behavior. The virtual shared-memory sizing path uses the same flag as the kernel.

The regression uses a 262,144-item input with a 200,000-item first run, checks the run count, and compares all output keys and aggregate bits across 20 identical calls. It uses `cuda::std::plus` and runs in one generated test shard. Existing environment tests cover `run_to_run` and `not_guaranteed`, and one compile-fail test covers the two unsupported determinism cases. Existing parameterized tests cover the run count and complete output correctness.

### Verification

- The exact reproducer with `cuda::std::plus` produces one aggregate bit pattern across all 200 calls on an RTX 5090.
- The six targeted C++20 runtime suites pass 4,974 assertions across 72 test cases, and the five C++17 runtime suites pass 4,968 assertions across 70 test cases (ReduceByKey `types_0` only).
- Both compile-fail cases pass under C++17 and C++20.
- The reproducer compiles for sm75, sm90, and sm120. Runtime execution was available for sm120.
- Repository pre-commit hooks pass for all nine changed files.

### Performance

Measurements used CUDA 13.3 on the RTX 5090. The benchmark used one `2^24`-item workload with 256-item runs and three order-balanced process pairs.

| Case | Base median (us) | Patched median (us) | Median paired change | Maximum sample half-range |
| --- | ---: | ---: | ---: | ---: |
| FP64 `cuda::std::plus`, default `run_to_run` | 176.818 | 196.082 | +10.90% | 0.35% |
| FP64 `cuda::std::plus`, `not_guaranteed` | 176.640 | 176.910 | +0.05% | 0.24% |
| int64 `cuda::std::plus`, default | 171.256 | 171.202 | +0.00% | 0.24% |
| FP64 `cuda::minimum`, default | 177.016 | 176.994 | -0.07% | 0.25% |

The last three cases stay within their measured sample variation.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
