### PR TITLE
libcu++: atomics SASS FileCheck suite for atomic fences

### DIFF
--- a/libcudacxx/test/atomic_codegen/sass/fence_cuda.cu
+++ b/libcudacxx/test/atomic_codegen/sass/fence_cuda.cu
@@ -13,6 +13,8 @@
 // %PARAM% ORDER,SASS_SEMANTIC order acquire=moa,ALL:release=more,ALL:acq_rel=moar,ALL:seq_cst=mosc,SC
 // clang-format on
 
+#include <cuda/std/cstdint>
+
 #include "atomic_codegen_helpers.h"
 
 extern "C" __device__ int32_t atomic_codegen_test(int32_t* before, const int32_t* after, int32_t value)

--- a/libcudacxx/test/atomic_codegen/sass/fence_cuda.cu
+++ b/libcudacxx/test/atomic_codegen/sass/fence_cuda.cu
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+// %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
+// %PARAM% ORDER,SASS_SEMANTIC order acquire=moa,ALL:release=more,ALL:acq_rel=moar,ALL:seq_cst=mosc,SC
+// clang-format on
+
+#include "atomic_codegen_helpers.h"
+
+extern "C" __device__ int32_t atomic_codegen_test(int32_t* before, const int32_t* after, int32_t value)
+{
+  *before = value;
+  cuda::atomic_thread_fence(ORDER, SCOPE);
+  return *after;
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
+; SMXX: {{.*}}ST{{G?}}.E{{.*}}
+; SMXX-NOT: {{.*}}ST{{G?}}.E{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
+; BLOCK-NOT: {{.*}}MEMBAR.{{.*}}
+; NON_BLOCK-NOT: {{.*}}MEMBAR.{{.*}}.[[SASS_SCOPE]]{{.*}}
+; SMXX: {{.*}}MEMBAR.[[SASS_SEMANTIC]].[[SASS_SCOPE]]{{.*}}
+; BLOCK-NOT: {{.*}}MEMBAR.{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK-NOT: {{.*}}MEMBAR.{{.*}}
+; NON_BLOCK: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK-NOT: {{.*}}MEMBAR.{{.*}}
+; NON_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; SMXX: {{.*}}LD{{G?}}.E{{.*}}
+; SMXX-NOT: {{.*}}LD{{G?}}.E{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/fence_cuda_relaxed.cu
+++ b/libcudacxx/test/atomic_codegen/sass/fence_cuda_relaxed.cu
@@ -10,6 +10,8 @@
 
 // %PARAM% SCOPE scope tsb:tsd:tss
 
+#include <cuda/std/cstdint>
+
 #include "atomic_codegen_helpers.h"
 
 extern "C" __device__ int32_t atomic_codegen_test(int32_t* before, const int32_t* after, int32_t value)

--- a/libcudacxx/test/atomic_codegen/sass/fence_cuda_relaxed.cu
+++ b/libcudacxx/test/atomic_codegen/sass/fence_cuda_relaxed.cu
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// %PARAM% SCOPE scope tsb:tsd:tss
+
+#include "atomic_codegen_helpers.h"
+
+extern "C" __device__ int32_t atomic_codegen_test(int32_t* before, const int32_t* after, int32_t value)
+{
+  *before = value;
+  cuda::atomic_thread_fence(cuda::std::memory_order_relaxed, SCOPE);
+  return *after;
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
+; SMXX: {{.*}}ST{{G?}}.E{{.*}}
+; SMXX-NOT: {{.*}}ST{{G?}}.E{{.*}}
+; SMXX-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
+; SMXX: {{.*}}LD{{G?}}.E{{.*}}
+; SMXX-NOT: {{.*}}LD{{G?}}.E{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/fence_std.cu
+++ b/libcudacxx/test/atomic_codegen/sass/fence_std.cu
@@ -10,6 +10,8 @@
 
 // %PARAM% ORDER,SASS_SEMANTIC order acquire=moa,ALL:release=more,ALL:acq_rel=moar,ALL:seq_cst=mosc,SC
 
+#include <cuda/std/cstdint>
+
 #include "atomic_codegen_helpers.h"
 
 extern "C" __device__ int32_t atomic_codegen_test(int32_t* before, const int32_t* after, int32_t value)

--- a/libcudacxx/test/atomic_codegen/sass/fence_std.cu
+++ b/libcudacxx/test/atomic_codegen/sass/fence_std.cu
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// %PARAM% ORDER,SASS_SEMANTIC order acquire=moa,ALL:release=more,ALL:acq_rel=moar,ALL:seq_cst=mosc,SC
+
+#include "atomic_codegen_helpers.h"
+
+extern "C" __device__ int32_t atomic_codegen_test(int32_t* before, const int32_t* after, int32_t value)
+{
+  *before = value;
+  cuda::std::atomic_thread_fence(ORDER);
+  return *after;
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
+; SMXX: {{.*}}ST{{G?}}.E{{.*}}
+; SMXX-NOT: {{.*}}ST{{G?}}.E{{.*}}
+; SMXX-NOT: {{.*}}MEMBAR.{{.*}}.SYS{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
+; SMXX: {{.*}}MEMBAR.[[SASS_SEMANTIC]].SYS{{.*}}
+; SMXX-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
+; SMXX: {{.*}}CCTL.IVALL{{.*}}
+; SMXX-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
+; SMXX: {{.*}}LD{{G?}}.E{{.*}}
+; SMXX-NOT: {{.*}}LD{{G?}}.E{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/fence_std_relaxed.cu
+++ b/libcudacxx/test/atomic_codegen/sass/fence_std_relaxed.cu
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include "atomic_codegen_helpers.h"
+
+extern "C" __device__ int32_t atomic_codegen_test(int32_t* before, const int32_t* after, int32_t value)
+{
+  *before = value;
+  cuda::std::atomic_thread_fence(cuda::std::memory_order_relaxed);
+  return *after;
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
+; SMXX: {{.*}}ST{{G?}}.E{{.*}}
+; SMXX-NOT: {{.*}}ST{{G?}}.E{{.*}}
+; SMXX-NOT: {{.*}}MEMBAR.{{.*}}
+; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
+; SMXX: {{.*}}LD{{G?}}.E{{.*}}
+; SMXX-NOT: {{.*}}LD{{G?}}.E{{.*}}
+; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+
+*/

--- a/libcudacxx/test/atomic_codegen/sass/fence_std_relaxed.cu
+++ b/libcudacxx/test/atomic_codegen/sass/fence_std_relaxed.cu
@@ -8,6 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/std/cstdint>
+
 #include "atomic_codegen_helpers.h"
 
 extern "C" __device__ int32_t atomic_codegen_test(int32_t* before, const int32_t* after, int32_t value)


### PR DESCRIPTION
## Description

Resolves #10667.

This PR introduces the fourth SASS FileCheck suite for the atomic codegen, which covers `cuda::atomic_thread_fence` and `cuda::std::atomic_thread_fence` across their supported memory orders and public scopes.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
