### PR TITLE
Deprecate `[CUB|THRUST]_DEBUG_SYNC`, `CUB_DEBUG_ALL` and drop it from tests

### DIFF
--- a/cub/cub/util_debug.cuh
+++ b/cub/cub/util_debug.cuh
@@ -39,6 +39,8 @@
  * Causes synchronization of the stream after every kernel launch to check
  * for errors. Also causes kernel launch configurations to be printed to the
  * console.
+ *
+ * Deprecated [Since 3.6]
  */
 #  define CUB_DEBUG_SYNC
 
@@ -56,6 +58,14 @@
 
 // CUB_DEBUG_SYNC also enables CUB_DEBUG_LOG
 #ifdef CUB_DEBUG_SYNC
+
+#  if _CCCL_COMPILER(MSVC)
+#    pragma message( \
+      "warning: CUB_DEBUG_SYNC is deprecated. Please just run your executable with CUDA_LAUNCH_BLOCKING=1")
+#  else
+#    warning CUB_DEBUG_SYNC is deprecated. Please just run your executable with CUDA_LAUNCH_BLOCKING=1
+#  endif
+
 #  ifndef CUB_DEBUG_LOG
 #    define CUB_DEBUG_LOG
 #  endif

--- a/cub/cub/util_debug.cuh
+++ b/cub/cub/util_debug.cuh
@@ -51,6 +51,8 @@
  * from that, causes synchronization of the stream after every kernel launch to
  * check for errors. Also causes kernel launch configurations to be printed to
  * the console.
+ *
+ * Deprecated [Since 3.6]
  */
 #  define CUB_DEBUG_ALL
 
@@ -73,6 +75,14 @@
 
 // CUB_DEBUG_ALL = CUB_DEBUG_LOG + CUB_DEBUG_SYNC
 #ifdef CUB_DEBUG_ALL
+
+#  if _CCCL_COMPILER(MSVC)
+#    pragma message( \
+      "warning: CUB_DEBUG_ALL is deprecated. Please just define CUB_DEBUG_LOG and run your executable with CUDA_LAUNCH_BLOCKING=1")
+#  else
+#    warning CUB_DEBUG_ALL is deprecated. Please just define CUB_DEBUG_LOG and run your executable with CUDA_LAUNCH_BLOCKING=1
+#  endif
+
 #  ifndef CUB_DEBUG_LOG
 #    define CUB_DEBUG_LOG
 #  endif // CUB_DEBUG_LOG

--- a/cub/cub/util_debug.cuh
+++ b/cub/cub/util_debug.cuh
@@ -47,10 +47,9 @@
 /**
  * @def CUB_DEBUG_ALL
  *
- * Causes host and device-side precondition assertions to be checked. Apart
- * from that, causes synchronization of the stream after every kernel launch to
- * check for errors. Also causes kernel launch configurations to be printed to
- * the console.
+ * Causes synchronization of the stream after every kernel launch to check
+ * for errors. Also causes kernel launch configurations to be printed to the
+ * console.
  *
  * Deprecated [Since 3.6]
  */

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -336,7 +336,6 @@ function(
         cccl.c2h
     )
     target_include_directories(${test_target} PRIVATE "${CUB_SOURCE_DIR}/test")
-    target_compile_definitions(${test_target} PRIVATE CUB_DEBUG_SYNC)
 
     if ("${test_target}" MATCHES "nvtx_in_usercode")
       target_link_libraries(${test_target} PRIVATE nvtx3-cpp)

--- a/thrust/thrust/system/cuda/config.h
+++ b/thrust/thrust/system/cuda/config.h
@@ -4,6 +4,14 @@
 #pragma once
 
 #ifdef THRUST_DEBUG_SYNC
+
+#  if _CCCL_COMPILER(MSVC)
+#    pragma message( \
+      "warning: THRUST_DEBUG_SYNC is deprecated. Please just run your executable with CUDA_LAUNCH_BLOCKING=1")
+#  else
+#    warning THRUST_DEBUG_SYNC is deprecated. Please just run your executable with CUDA_LAUNCH_BLOCKING=1
+#  endif
+
 #  define THRUST_DEBUG_SYNC_FLAG true
 #  define CUB_DEBUG_SYNC
 #else

--- a/thrust/thrust/system/cuda/config.h
+++ b/thrust/thrust/system/cuda/config.h
@@ -3,6 +3,16 @@
 
 #pragma once
 
+#include <thrust/detail/config.h> // IWYU pragma: export
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
 #ifdef THRUST_DEBUG_SYNC
 
 #  if _CCCL_COMPILER(MSVC)
@@ -17,16 +27,6 @@
 #else
 #  define THRUST_DEBUG_SYNC_FLAG false
 #endif
-
-#include <thrust/detail/config.h> // IWYU pragma: export
-
-#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
-#  pragma GCC system_header
-#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
-#  pragma clang system_header
-#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
-#  pragma system_header
-#endif // no system header
 
 // We don't directly include <cub/version.cuh> since it doesn't exist in
 // older releases. This header will always pull in version info:


### PR DESCRIPTION
Works towards: #10728