### PR TITLE
Lookahead RunLengthEncode should write the last key of the run to be consistent with ReduceByKey

### DIFF
--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -95,7 +95,7 @@ struct DeviceRunLengthEncode
   //! .. versionadded:: 2.2.0
   //!    First appears in CUDA Toolkit 12.3.
   //!
-  //! - For the *i*\ :sup:`th` run encountered, the first key of the run and
+  //! - For the *i*\ :sup:`th` run encountered, the last key of the run and
   //!   its length are written to ``d_unique_out[i]`` and ``d_counts_out[i]``, respectively.
   //! - The total number of runs encountered is written to ``d_num_runs_out``.
   //! - The ``==`` equality operator is used to determine whether values are equivalent
@@ -250,7 +250,7 @@ struct DeviceRunLengthEncode
   //! - Stream: Query via ``cuda::get_stream``
   //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
   //!
-  //! - For the *i*\ :sup:`th` run encountered, the first key of the run and
+  //! - For the *i*\ :sup:`th` run encountered, the last key of the run and
   //!   its length are written to ``d_unique_out[i]`` and ``d_counts_out[i]``, respectively.
   //! - The total number of runs encountered is written to ``d_num_runs_out``.
   //! - The ``==`` equality operator is used to determine whether values are equivalent

--- a/cub/cub/device/dispatch/kernels/kernel_rle_encode_lookahead.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_rle_encode_lookahead.cuh
@@ -1052,8 +1052,11 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_rle_encode_lookahead_body(
               }
               const int run_idx    = it * detail::warp_threads + lane_id;
               const run_span_t run = dec.decode_run(run_idx);
-              buf_key[it]          = tile_keys[warp_tile_offset + run.head_pos_in_warp_tile + skip_elems];
-              // note: this is garbage for the last run head
+              // the run's key is its LAST element (the one before the next run's head). The clamp keeps the
+              // gather in bounds when next_head_pos is garbage (the warp tile's last run); that run's key and
+              // count are both dead here and written by the bookkeeper instead.
+              const int last_pos = (::cuda::std::min) (run.next_head_pos - 1, warp_tile_size - 1);
+              buf_key[it]        = tile_keys[warp_tile_offset + last_pos + skip_elems];
               buf_run_length[it] = run.next_head_pos - run.head_pos_in_warp_tile;
             }
 
@@ -1076,16 +1079,14 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_rle_encode_lookahead_body(
               {
                 break;
               }
-              const int run_idx = it * detail::warp_threads + lane_id;
-              if (run_idx < warp_tile_run_count)
+              const int run_idx         = it * detail::warp_threads + lane_id;
+              const OffT global_run_idx = global_runs_before_warp_tile + run_idx;
+              if (run_idx + 1 < warp_tile_run_count)
               {
-                const OffT global_run_idx = global_runs_before_warp_tile + run_idx;
-                d_unique[global_run_idx]  = buf_key[it];
-                if (run_idx + 1 < warp_tile_run_count)
-                {
-                  // last run's run count is bookkeeper's job
-                  d_counts[global_run_idx] = buf_run_length[it];
-                }
+                // the warp tile's last run ends outside this warp tile: its key and count are the
+                // bookkeeper's job
+                d_unique[global_run_idx] = buf_key[it];
+                d_counts[global_run_idx] = buf_run_length[it];
               }
             }
             __syncwarp();
@@ -1107,40 +1108,60 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_rle_encode_lookahead_body(
           // The warp tile's last run spans into the next warp-tile, so its length is fixed up separately.
           const OffT global_runs_before_warp_tile = curr_prefix_run_count + runs_before_warp_tile;
           const int warp_tile_offset              = warp_tile_id * warp_tile_size;
+          // the run's key is its LAST element, the one before the next run's head;
+          // the warp tile's last run (key and count) is fixed up by the bookkeeper
+          const int full_runs = warp_tile_run_count - 1;
           if (keys_staged)
           {
             const KeyT* tile_keys = tile_buf + static_cast<size_t>(slot_id) * slot_stride + slot_pad;
+            int chunk_base        = 0;
             _CCCL_PRAGMA_UNROLL(2)
-            for (int run_idx = lane_id; run_idx < warp_tile_run_count; run_idx += detail::warp_threads)
+            for (; chunk_base + detail::warp_threads <= full_runs; chunk_base += detail::warp_threads)
+            {
+              const int run_idx         = chunk_base + lane_id;
+              const OffT global_run_idx = global_runs_before_warp_tile + run_idx;
+              const int head_pos = static_cast<int>(run_positions[warp_tile_offset + swizzle_xor_stride32(run_idx)]);
+              const int next_head_pos =
+                static_cast<int>(run_positions[warp_tile_offset + swizzle_xor_stride32(run_idx + 1)]);
+              d_unique[global_run_idx] = tile_keys[next_head_pos - 1 + skip_elems];
+              d_counts[global_run_idx] = next_head_pos - head_pos;
+            }
+            const int run_idx = chunk_base + lane_id;
+            if (run_idx < full_runs)
             {
               const OffT global_run_idx = global_runs_before_warp_tile + run_idx;
               const int head_pos = static_cast<int>(run_positions[warp_tile_offset + swizzle_xor_stride32(run_idx)]);
-              d_unique[global_run_idx] = tile_keys[head_pos + skip_elems]; // gather the run's key at its head position
-              if (run_idx + 1 < warp_tile_run_count)
-              {
-                // within-warp delta (next head - this head); the last run is fixed separately
-                const int run_length =
-                  static_cast<int>(run_positions[warp_tile_offset + swizzle_xor_stride32(run_idx + 1)]) - head_pos;
-                d_counts[global_run_idx] = run_length;
-              }
+              const int next_head_pos =
+                static_cast<int>(run_positions[warp_tile_offset + swizzle_xor_stride32(run_idx + 1)]);
+              d_unique[global_run_idx] = tile_keys[next_head_pos - 1 + skip_elems];
+              d_counts[global_run_idx] = next_head_pos - head_pos;
             }
           }
           else
           {
             // vvv regressed case vvv
             const KeyT* tile_keys = d_keys + static_cast<size_t>(tile_id) * tile_size;
+            int chunk_base        = 0;
             _CCCL_PRAGMA_UNROLL(2)
-            for (int run_idx = lane_id; run_idx < warp_tile_run_count; run_idx += detail::warp_threads)
+            for (; chunk_base + detail::warp_threads <= full_runs; chunk_base += detail::warp_threads)
+            {
+              const int run_idx         = chunk_base + lane_id;
+              const OffT global_run_idx = global_runs_before_warp_tile + run_idx;
+              const int head_pos = static_cast<int>(run_positions[warp_tile_offset + swizzle_xor_stride32(run_idx)]);
+              const int next_head_pos =
+                static_cast<int>(run_positions[warp_tile_offset + swizzle_xor_stride32(run_idx + 1)]);
+              d_unique[global_run_idx] = tile_keys[next_head_pos - 1];
+              d_counts[global_run_idx] = next_head_pos - head_pos;
+            }
+            const int run_idx = chunk_base + lane_id;
+            if (run_idx < full_runs)
             {
               const OffT global_run_idx = global_runs_before_warp_tile + run_idx;
               const int head_pos = static_cast<int>(run_positions[warp_tile_offset + swizzle_xor_stride32(run_idx)]);
-              d_unique[global_run_idx] = tile_keys[head_pos];
-              if (run_idx + 1 < warp_tile_run_count)
-              {
-                const int run_length =
-                  static_cast<int>(run_positions[warp_tile_offset + swizzle_xor_stride32(run_idx + 1)]) - head_pos;
-                d_counts[global_run_idx] = run_length;
-              }
+              const int next_head_pos =
+                static_cast<int>(run_positions[warp_tile_offset + swizzle_xor_stride32(run_idx + 1)]);
+              d_unique[global_run_idx] = tile_keys[next_head_pos - 1];
+              d_counts[global_run_idx] = next_head_pos - head_pos;
             }
             // ^^^ regressed case ^^^
           }
@@ -1182,6 +1203,11 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_rle_encode_lookahead_body(
           const int tile_total_runs =
             __shfl_sync(full_mask, lane_runs_before_warp_tile + lane_warp_tile_run_count, compute_warps - 1);
           const unsigned nonempty_warp_tiles_mask = __ballot_sync(full_mask, lane_warp_tile_run_count > 0);
+          // every count this warp closes gets its key written too: a run's key is its LAST element,
+          // which lives in the closing tile's keys (position -1 reads the over-fetched boundary element)
+          const KeyT* bk_tile_keys = keys_staged ? tile_buf + static_cast<size_t>(slot_id) * slot_stride + slot_pad
+                                                 : d_keys + static_cast<size_t>(tile_id) * tile_size;
+          const int bk_key_skip    = keys_staged ? skip_elems : 0;
           // wait for prefixed
           wait_parity(&prefixed[slot_id], key_ring.parity);
           const prefix_t packed_prefix       = prefix_packed[slot_id];
@@ -1198,12 +1224,14 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_rle_encode_lookahead_body(
             if (later_nonempty_warp_tiles)
             {
               const int next_nonempty_warp_tile = lane_id + 1 + __ffs(later_nonempty_warp_tiles) - 1;
-              d_counts[last_run_global_idx] =
-                warp_first_heads[slot_id][next_nonempty_warp_tile] - warp_last_heads[slot_id][lane_id];
+              const int close_pos               = warp_first_heads[slot_id][next_nonempty_warp_tile];
+              d_unique[last_run_global_idx]     = bk_tile_keys[close_pos - 1 + bk_key_skip];
+              d_counts[last_run_global_idx]     = close_pos - warp_last_heads[slot_id][lane_id];
             }
             else if (is_last_tile)
             {
               // if we are the last warptile of the whole input, we end here
+              d_unique[last_run_global_idx] = bk_tile_keys[tile_len - 1 + bk_key_skip];
               d_counts[last_run_global_idx] = tile_len - warp_last_heads[slot_id][lane_id];
             }
             // else: this run is open in this tile, now this became a job for the next tile (see below)
@@ -1217,11 +1245,14 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_rle_encode_lookahead_body(
             // if our tile has a head, i.e. it stops here
             if (any_head && curr_prefix_run_count > 0)
             {
+              // first_head == 0 reads the over-fetched boundary element (the previous tile's last key)
+              d_unique[curr_prefix_run_count - 1] = bk_tile_keys[first_head - 1 + bk_key_skip];
               d_counts[curr_prefix_run_count - 1] = curr_prefix_open_length + first_head;
             }
             // if we are last tile with no head: we have to close it here
             if (is_last_tile && !any_head && curr_prefix_run_count > 0)
             {
+              d_unique[curr_prefix_run_count - 1] = bk_tile_keys[tile_len - 1 + bk_key_skip];
               d_counts[curr_prefix_run_count - 1] = curr_prefix_open_length + tile_len;
             }
             // otherwise, next tile's problem

--- a/cub/test/catch2_test_device_run_length_encode.cu
+++ b/cub/test/catch2_test_device_run_length_encode.cu
@@ -10,6 +10,7 @@
 #include <thrust/sequence.h>
 
 #include <cuda/iterator>
+#include <cuda/std/bit>
 
 #include <algorithm>
 #include <limits>
@@ -616,4 +617,130 @@ CUB_TEST("DeviceRunLengthEncode::Encode handles every input misalignment",
       test_segmented_encode<key_t, int>(3 * tile + 7, -static_cast<int>(tile), elem_offset, 1u);
     }
   }
+}
+
+// equality ignores the payload: all elements of a run compare equal but stay distinguishable, so
+// the encoded unique key shows which element of the run was selected
+struct alignas(8) tagged_key_t
+{
+  int key;
+  int payload;
+
+  friend __host__ __device__ bool operator==(const tagged_key_t& lhs, const tagged_key_t& rhs)
+  {
+    return lhs.key == rhs.key;
+  }
+
+  friend __host__ __device__ bool operator!=(const tagged_key_t& lhs, const tagged_key_t& rhs)
+  {
+    return !(lhs == rhs);
+  }
+};
+
+// the documented contract: the unique key written for each run is the run's last key
+void test_last_key_selection(std::int64_t num_items, int max_seg, unsigned seed)
+{
+  CAPTURE(num_items, max_seg, seed);
+
+  const auto h_ids = generate_segmented_keys<int>(num_items, max_seg, seed);
+  c2h::host_vector<tagged_key_t> h_keys(static_cast<std::size_t>(num_items));
+  for (std::size_t i = 0; i < h_keys.size(); ++i)
+  {
+    h_keys[i] = tagged_key_t{h_ids[i], static_cast<int>(i)};
+  }
+
+  c2h::host_vector<int> ref_ids;
+  c2h::host_vector<int> ref_payloads;
+  c2h::host_vector<int> ref_counts;
+  for (std::int64_t i = 0; i < num_items;)
+  {
+    std::int64_t j = i + 1;
+    while (j < num_items && h_ids[static_cast<std::size_t>(j)] == h_ids[static_cast<std::size_t>(i)])
+    {
+      ++j;
+    }
+    ref_ids.push_back(h_ids[static_cast<std::size_t>(i)]);
+    ref_payloads.push_back(static_cast<int>(j - 1));
+    ref_counts.push_back(static_cast<int>(j - i));
+    i = j;
+  }
+  const auto ref_num_runs = static_cast<int>(ref_ids.size());
+
+  c2h::device_vector<tagged_key_t> d_keys = h_keys;
+  c2h::device_vector<tagged_key_t> d_unique(ref_ids.size(), tagged_key_t{42424242, -1});
+  c2h::device_vector<int> d_counts(ref_counts.size(), 0);
+  c2h::device_vector<int> d_num_runs(1, -1);
+
+  run_length_encode(
+    thrust::raw_pointer_cast(d_keys.data()),
+    thrust::raw_pointer_cast(d_unique.data()),
+    thrust::raw_pointer_cast(d_counts.data()),
+    thrust::raw_pointer_cast(d_num_runs.data()),
+    static_cast<int>(num_items));
+
+  const c2h::host_vector<tagged_key_t> h_unique(d_unique);
+  c2h::host_vector<int> out_ids(h_unique.size());
+  c2h::host_vector<int> out_payloads(h_unique.size());
+  for (std::size_t i = 0; i < h_unique.size(); ++i)
+  {
+    out_ids[i]      = h_unique[i].key;
+    out_payloads[i] = h_unique[i].payload;
+  }
+
+  REQUIRE(d_num_runs.front() == ref_num_runs);
+  REQUIRE(out_ids == ref_ids);
+  REQUIRE(out_payloads == ref_payloads);
+  REQUIRE(c2h::host_vector<int>(d_counts) == ref_counts);
+}
+
+CUB_TEST("DeviceRunLengthEncode::Encode writes the last key of each run", "[device][run_length_encode]", CUB_SMALL)
+{
+  constexpr std::int64_t tile      = segment_grid_tile_size(sizeof(tagged_key_t));
+  constexpr std::int64_t warp_tile = tile / 8;
+
+  test_last_key_selection(1, 0, 1u); // a single element
+  test_last_key_selection(tile, -static_cast<int>(tile), 1u); // one run per tile
+  test_last_key_selection(3 * tile + 7, 2, 1u); // dense, partial tail tile
+  test_last_key_selection(3 * tile + 7, 2, 42u);
+  test_last_key_selection(3 * tile + 7, 300, 1u); // mixed lengths crossing tile boundaries
+  test_last_key_selection(3 * tile + 7, 300, 42u);
+  test_last_key_selection(64 * tile + 7, 7, 1u); // run count per warp-tile straddles capacity
+  test_last_key_selection(64 * tile, -static_cast<int>(tile + 1), 1u); // head drifts through every in-tile offset
+  test_last_key_selection(64 * tile, -static_cast<int>(warp_tile + 1), 1u); // head drifts through warp-tile offsets
+  test_last_key_selection(64 * tile, 0, 1u); // one run over the whole input
+}
+
+CUB_TEST("DeviceRunLengthEncode::Encode selects the last key among equal negative and positive zeros",
+         "[device][run_length_encode]",
+         CUB_SMALL)
+{
+  // -0.0f == 0.0f, so each zero run reports the bit pattern of its last element
+  const c2h::host_vector<float> h_keys{-0.0f, -0.0f, 0.0f, 1.0f, 0.0f, -0.0f, 2.0f, -0.0f, 0.0f};
+  const c2h::host_vector<float> ref_unique{0.0f, 1.0f, -0.0f, 2.0f, 0.0f};
+  const c2h::host_vector<int> ref_counts{3, 1, 2, 1, 2};
+
+  c2h::device_vector<float> d_keys = h_keys;
+  c2h::device_vector<float> d_unique(ref_unique.size(), 42.0f);
+  c2h::device_vector<int> d_counts(ref_counts.size(), 0);
+  c2h::device_vector<int> d_num_runs(1, -1);
+
+  run_length_encode(
+    thrust::raw_pointer_cast(d_keys.data()),
+    thrust::raw_pointer_cast(d_unique.data()),
+    thrust::raw_pointer_cast(d_counts.data()),
+    thrust::raw_pointer_cast(d_num_runs.data()),
+    static_cast<int>(h_keys.size()));
+
+  const c2h::host_vector<float> h_unique(d_unique);
+  c2h::host_vector<int> out_bits(h_unique.size());
+  c2h::host_vector<int> ref_bits(ref_unique.size());
+  for (std::size_t i = 0; i < h_unique.size(); ++i)
+  {
+    out_bits[i] = cuda::std::bit_cast<int>(h_unique[i]);
+    ref_bits[i] = cuda::std::bit_cast<int>(ref_unique[i]);
+  }
+
+  REQUIRE(d_num_runs.front() == static_cast<int>(ref_unique.size()));
+  REQUIRE(out_bits == ref_bits);
+  REQUIRE(c2h::host_vector<int>(d_counts) == ref_counts);
 }


### PR DESCRIPTION
Closes https://github.com/NVIDIA/cccl/issues/10962

The lookahead kernel introduced in #9699 writes the first key of each run, which matches what the documentation said but not what the shipped lookback kernel does. The docs were wrong the same way they were for ReduceByKey. This PR changes the lookahead kernel to write the last key and fixes the documentation.

The semantic change is that a run's key is now the element before the next run's head instead of the element at its own head. A run whose end is not locally visible (warp tile edge, tile edge, end of input) now gets its key from the bookkeeper alongside the count
.

Performance on B200: for most it is neutral, the worst case showed ~1% regression.

The new test verifies that Encode writes the last key of each run using keys that compare equal but are bitwise distinguishable.