### PR TITLE
Add the CUTLASS backend for cuda.coop

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -724,6 +724,11 @@ jobs:
   test_py_examples: { name: "Test cuda.cccl.examples",     gpu: true,  needs: 'build_py_wheel', force_producer_ctk: "pybuild", invoke: { prefix: 'test_cuda_cccl_examples'} }
   test_py_stf:      { name: "Test cuda.stf._experimental", gpu: true,  needs: 'build_py_stf_wheel', force_producer_ctk: "pybuild", invoke: { prefix: 'test_cuda_stf'} }
   test_py_coop_host: { name: "Test cuda.coop (host)", gpu: false, needs: 'build', invoke: { prefix: 'test'} }
+  # CUTLASS jobs are ready for manual overrides, but stay unscheduled until
+  # nvidia-cutlass-dsl>=4.8 is available from the public package index.
+  test_py_coop_cutlass_host: { name: "Test cuda.coop CUTLASS (host)", gpu: false, needs: 'build', invoke: { prefix: 'test', args: '-stage cutlass-host'} }
+  test_py_coop_cutlass_gpu: { name: "Test cuda.coop CUTLASS (GPU)", gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-stage cutlass-gpu'} }
+  test_py_coop_cutlass_final_link: { name: "Test cuda.coop CUTLASS final link", gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-stage cutlass-final-link'} }
 
   # Run jobs for 'target' project (ci/util/build_and_test_targets.sh):
   run_cpu: { gpu: false }

--- a/ci/test_cuda_coop_python.sh
+++ b/ci/test_cuda_coop_python.sh
@@ -52,8 +52,17 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+needs_cuda_toolkit=false
+needs_gpu=false
 case "$stage" in
   contracts)
+    ;;
+  cutlass-host)
+    needs_cuda_toolkit=true
+    ;;
+  cutlass-gpu | cutlass-final-link)
+    needs_cuda_toolkit=true
+    needs_gpu=true
     ;;
   *)
     echo "Error: unknown cuda.coop test stage '$stage'" >&2
@@ -64,6 +73,14 @@ esac
 
 # shellcheck source=ci/pyenv_helper.sh
 source "$ci_dir/pyenv_helper.sh"
+
+if [[ "$needs_cuda_toolkit" == true ]]; then
+  if ! command -v nvcc >/dev/null 2>&1; then
+    echo "Error: cuda.coop stage '$stage' requires nvcc on PATH" >&2
+    exit 1
+  fi
+  pin_cuda_toolkit "${ctk_mode}"
+fi
 
 setup_python_env "${py_version}" ".cccl-coop-test-venv"
 
@@ -84,7 +101,22 @@ fi
 
 cd "$repo_root/python/cuda_coop/tests"
 
-python -m pip install "${wheels[0]}[test]"
+case "$stage" in
+  contracts)
+    python -m pip install "${wheels[0]}[test]"
+    ;;
+  cutlass-host | cutlass-gpu | cutlass-final-link)
+    if [[ "$cuda_major_version" != "13" ]]; then
+      echo "Error: CUTLASS stages currently require CUDA 13" >&2
+      exit 1
+    fi
+    python -m pip install "${wheels[0]}[test,cutlass]" torch
+    ;;
+  *)
+    echo "Error: unhandled cuda.coop test stage '$stage'" >&2
+    exit 1
+    ;;
+esac
 
 python -m pip check
 python -I - <<'PY'
@@ -108,4 +140,58 @@ paths = resolve_include_paths(
 assert paths.origin == "cuda-coop wheel header bundle"
 PY
 
-python -m pytest -v contracts/ packaging/
+if [[ "$needs_gpu" == true ]]; then
+  nvidia-smi \
+    --query-gpu=name,compute_cap,driver_version \
+    --format=csv,noheader
+fi
+
+case "$stage" in
+  contracts)
+    python -m pytest -v contracts/ packaging/
+    ;;
+  cutlass-host)
+    python - <<'PY'
+import importlib.metadata
+
+import cutlass.cute  # noqa: F401
+
+print(f"nvidia-cutlass-dsl={importlib.metadata.version('nvidia-cutlass-dsl')}")
+PY
+    python -m pytest -v \
+      backends/cutlass/unit/ \
+      backends/cutlass/compile/
+    ;;
+  cutlass-gpu | cutlass-final-link)
+    python - <<'PY'
+import importlib.metadata
+
+import cutlass.cute as cute
+import torch
+
+if not callable(getattr(cute, "_get_launch_facts", None)):
+    raise SystemExit("CUTLASS DSL does not provide launch-facts support")
+if not torch.cuda.is_available():
+    raise SystemExit("PyTorch cannot access an NVIDIA GPU")
+print(f"nvidia-cutlass-dsl={importlib.metadata.version('nvidia-cutlass-dsl')}")
+PY
+    if [[ "$stage" == "cutlass-gpu" ]]; then
+      unset CUDA_COOP_CUTLASS_FINAL_LINK_TEST
+      python -m pytest -v backends/cutlass/runtime/
+    else
+      export CUDA_COOP_CUTLASS_FINAL_LINK_TEST=1
+      unset CUDA_COOP_CUTLASS_PROVIDER_CCCL_ROOT
+      unset CUDA_COOP_CCCL_ROOT
+      python -m pytest -v \
+        backends/cutlass/runtime/test_group_hierarchy.py::test_local_physical_and_exhaustive_mapped_groups_runtime \
+        backends/cutlass/runtime/test_group_hierarchy.py::test_non_exhaustive_mapped_group_membership_runtime \
+        backends/cutlass/runtime/test_data_movement.py::test_block_and_warp_data_movement_match_independent_oracles \
+        backends/cutlass/runtime/test_data_movement.py::test_fixed_capacity_storage_reaches_block_load_and_store \
+        backends/cutlass/runtime/test_reduce_scan.py::test_reduce_scan_group_routes_match_independent_oracles
+    fi
+    ;;
+  *)
+    echo "Error: unhandled cuda.coop test stage '$stage'" >&2
+    exit 1
+    ;;
+esac

--- a/cudax/include/cuda/experimental/__coop/reduce.cuh
+++ b/cudax/include/cuda/experimental/__coop/reduce.cuh
@@ -88,6 +88,8 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, ::cuda::std::size_t _N
 
   const auto __warp_rank_in_block = __group.rank(block);
   const auto __result = _WarpReduce{__scratch.__warp_reduce_[__warp_rank_in_block]}.Reduce(__thread_data, __red_fn);
+  // CUB requires a collective barrier before its temporary storage is reused.
+  __group.sync_aligned();
   if constexpr (_Broadcasted)
   {
     return ::cuda::device::warp_shuffle_idx(__result, 0).data;
@@ -121,6 +123,9 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np,
   __shared__ _Scratch __scratch;
 
   const auto __result = _BlockReduce{__scratch.__block_reduce_}.Reduce(__thread_data, __red_fn);
+  // Finish every CUB access before changing the active union member or
+  // starting a consecutive reduction.
+  __group.sync_aligned();
   if constexpr (_Broadcasted)
   {
     if (gpu_thread.is_root_rank(__group))
@@ -128,7 +133,9 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np,
       __scratch.__bcast_ = __result;
     }
     __group.sync_aligned();
-    return __scratch.__bcast_;
+    const auto __broadcast_result = __scratch.__bcast_;
+    __group.sync_aligned();
+    return __broadcast_result;
   }
   else
   {
@@ -213,6 +220,15 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np,
                      // Wait until all threads are done reading the result.
                      __group.sync_aligned();
                    }
+                   else
+                   {
+                     // This function-local scratch can next be reused only by
+                     // another invocation, whose leading cluster barrier orders
+                     // all other blocks. Keep the root block together until its
+                     // root warp is done; revisit this when scratch is supplied
+                     // by the caller.
+                     this_block{__group.hierarchy()}.sync_aligned();
+                   }
                  }))
 
     if constexpr (_Broadcasted)
@@ -287,6 +303,9 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np,
   }
   else
   {
+    // The root block must finish reading the grid partials before another
+    // reduction can overwrite them.
+    __group.sync_aligned();
     return __result;
   }
 }
@@ -331,9 +350,24 @@ _CCCL_REQUIRES(::cuda::std::is_same_v<warp_level, typename _Group::unit_type>
 [[nodiscard]] _CCCL_DEVICE_API auto
 __reduce_impl(::cuda::std::bool_constant<_Broadcasted>, _Group __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
 {
+  using _MappingResult = typename _Group::__mapping_result_type;
+
   constexpr auto __nwarps_in_group = warp.static_count(__group);
   static_assert(__nwarps_in_group != ::cuda::std::dynamic_extent,
                 "cuda::coop::reduce requires the group to have statically known size");
+  static_assert(_MappingResult::is_always_contiguous(),
+                "cuda::coop::reduce requires contiguous warp mappings within a block");
+  this_block __block{__group.hierarchy()};
+  constexpr auto __static_nwarps_in_block = warp.static_count(__block);
+  // Nested virtual groups report group ranks and counts relative to their
+  // parent group, so size the scratch from the physical block. Static block
+  // extents keep this allocation tight. A fully dynamic block reserves one
+  // slot for every physical group that could exist under CUDA's architectural
+  // limit of 32 warps.
+  constexpr auto __max_nwarps_in_block =
+    (__static_nwarps_in_block != ::cuda::std::dynamic_extent) ? __static_nwarps_in_block : ::cuda::std::size_t{32};
+  constexpr auto __ngroups =
+    (__nwarps_in_group < __max_nwarps_in_block) ? (__max_nwarps_in_block / __nwarps_in_group) : ::cuda::std::size_t{1};
 
   using _WarpReduce = ::cub::WarpReduce<_Tp>;
   struct _AdditionalScratch
@@ -347,15 +381,25 @@ __reduce_impl(::cuda::std::bool_constant<_Broadcasted>, _Group __group, _Tp (&__
     typename _WarpReduce::TempStorage __warp_reduce_[__nwarps_in_group];
     _AdditionalScratch __additional_;
   };
-  __shared__ _Scratch __scratch;
+  __shared__ _Scratch __scratch[__ngroups];
 
-  const auto __partial = _WarpReduce{__scratch.__warp_reduce_[warp.rank(__group)]}.Reduce(__thread_data, __red_fn);
+  // Derive a block-global identity from the first physical warp in this
+  // contiguous group. Parent-local group ranks are not unique for nested
+  // virtual groups under sibling mapped groups.
+  const auto& __mapping_result = __group.__mapping_result();
+  const auto __first_warp      = __mapping_result.is_valid() ? warp.rank(__block) - __mapping_result.unit_rank() : 0u;
+  const auto __scratch_index   = __first_warp / __nwarps_in_group;
+  _CCCL_ASSERT(__scratch_index < __ngroups, "mapped group scratch index is out of bounds");
+  auto& __group_scratch = __scratch[__scratch_index];
+
+  const auto __partial =
+    _WarpReduce{__group_scratch.__warp_reduce_[warp.rank(__group)]}.Reduce(__thread_data, __red_fn);
   __group.sync_aligned();
 
   this_warp __warp{__group.hierarchy()};
   if (gpu_thread.is_root_rank(__warp))
   {
-    __scratch.__additional_.__partials_[warp.rank(__group)] = __partial;
+    __group_scratch.__additional_.__partials_[warp.rank(__group)] = __partial;
   }
   __group.sync_aligned();
 
@@ -363,19 +407,26 @@ __reduce_impl(::cuda::std::bool_constant<_Broadcasted>, _Group __group, _Tp (&__
   if (warp.is_root_rank(__group))
   {
     const auto __value = (gpu_thread.rank(__warp) < __nwarps_in_group)
-                         ? __scratch.__additional_.__partials_[gpu_thread.rank(__warp)]
+                         ? __group_scratch.__additional_.__partials_[gpu_thread.rank(__warp)]
                          : ::cuda::identity_element<_RedFn, _Tp>();
-    __result           = _WarpReduce{__scratch.__warp_reduce_[0]}.Reduce(__value, __red_fn);
+    __result           = _WarpReduce{__group_scratch.__warp_reduce_[0]}.Reduce(__value, __red_fn);
   }
+  // CUB requires a collective barrier before its temporary storage is reused.
+  // This also keeps every member from starting a consecutive reduction while
+  // the root warp is still consuming this group's scratch.
+  __group.sync_aligned();
 
   if constexpr (_Broadcasted)
   {
     if (gpu_thread.is_root_rank(__group))
     {
-      __scratch.__additional_.__bcast_ = __result;
+      __group_scratch.__additional_.__bcast_ = __result;
     }
     __group.sync_aligned();
-    return __scratch.__additional_.__bcast_;
+    const auto __broadcast_result = __group_scratch.__additional_.__bcast_;
+    // Finish every read before a consecutive reduction overwrites the union.
+    __group.sync_aligned();
+    return __broadcast_result;
   }
   else
   {

--- a/cudax/include/cuda/experimental/__group/fwd.cuh
+++ b/cudax/include/cuda/experimental/__group/fwd.cuh
@@ -21,9 +21,13 @@
 #  pragma system_header
 #endif // no system header
 
-// Q: Do we want to enable this by default, or do we want the user to define some macro to get the interoperability with
-//    cooperative groups?
-#if __has_include(<cooperative_groups.h>)
+// Internal hook for embedded compilation environments that cannot consume
+// cooperative_groups.h. Define it consistently for every translation unit in
+// a program, before any cudax group header, to suppress cooperative-groups
+// includes and conversion overloads.
+#if defined(_CUDAX_DISABLE_COOPERATIVE_GROUPS_INTEROP)
+#  define _CCCL_HAS_COOPERATIVE_GROUPS() 0
+#elif __has_include(<cooperative_groups.h>)
 #  define _CCCL_HAS_COOPERATIVE_GROUPS() 1
 #else // ^^^ has cooperative groups ^^^ / vvv no cooperative groups vvv
 #  define _CCCL_HAS_COOPERATIVE_GROUPS() 0

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -183,6 +183,9 @@ cudax_add_catch2_test(test_target group.implicit_hierarchy
 cudax_add_catch2_test(test_target group.segmented_algorithm
     group/segmented_algorithm.cu
 )
+cudax_add_catch2_test(test_target group.no_cooperative_groups_interop
+    group/no_cooperative_groups_interop.cu
+)
 cudax_add_catch2_test(test_target group.this_group
     group/this_group.cu
 )

--- a/cudax/test/coop/reduce/this_block.cu
+++ b/cudax/test/coop/reduce/this_block.cu
@@ -71,6 +71,37 @@ struct ReduceKernel
   }
 };
 
+template <bool Broadcasted>
+struct ConsecutiveReduceKernel
+{
+  template <class Config>
+  __device__ void operator()(Config config, int* d_out)
+  {
+    cudax::this_block block{config};
+    int thread_data[1] = {1};
+
+    if constexpr (Broadcasted)
+    {
+      const auto first = cudax::coop::reduce(cudax::broadcasted, block, thread_data, cuda::std::plus<>{});
+      thread_data[0] += 2;
+      const auto second = cudax::coop::reduce(cudax::broadcasted, block, thread_data, cuda::std::plus<>{});
+      d_out[cuda::gpu_thread.rank_as<int>(block)] = first + second;
+    }
+    else
+    {
+      const auto first = cudax::coop::reduce(block, thread_data, cuda::std::plus<>{});
+      thread_data[0] += 2;
+      const auto second = cudax::coop::reduce(block, thread_data, cuda::std::plus<>{});
+      REQUIRE(first.has_value() == cuda::gpu_thread.is_root_rank(block));
+      REQUIRE(second.has_value() == cuda::gpu_thread.is_root_rank(block));
+      if (first.has_value() && second.has_value())
+      {
+        *d_out = *first + *second;
+      }
+    }
+  }
+};
+
 /***********************************************************************************************************************
  * Type list definition
  **********************************************************************************************************************/
@@ -220,4 +251,21 @@ C2H_TEST("reduce/this_block Broadcasted", "[reduce][this_block]", integral_type_
     run_reduce_kernel(stream, block_size_t{}, num_items, d_in, d_out, reduce_op, cuda::std::true_type{});
     verify_results(c2h::host_vector<value_t>(block_size_t::value, reference_result), c2h::host_vector<value_t>(d_out));
   }
+}
+
+C2H_TEST("reduce/this_block handles consecutive reductions", "[reduce][this_block]")
+{
+  constexpr int block_size = 128;
+  constexpr int expected   = 4 * block_size;
+  cuda::stream stream{cuda::devices[0]};
+  const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<block_size>());
+  c2h::device_vector<int> d_result(1);
+  c2h::device_vector<int> d_broadcast(block_size);
+
+  cuda::launch(stream, config, ConsecutiveReduceKernel<false>{}, thrust::raw_pointer_cast(d_result.data()));
+  cuda::launch(stream, config, ConsecutiveReduceKernel<true>{}, thrust::raw_pointer_cast(d_broadcast.data()));
+  stream.sync();
+
+  verify_results(expected, c2h::host_vector<int>(d_result)[0]);
+  verify_results(c2h::host_vector<int>(block_size, expected), c2h::host_vector<int>(d_broadcast));
 }

--- a/cudax/test/coop/reduce/this_cluster.cu
+++ b/cudax/test/coop/reduce/this_cluster.cu
@@ -70,6 +70,37 @@ struct ReduceKernel
   }
 };
 
+template <bool Broadcasted>
+struct ConsecutiveReduceKernel
+{
+  template <class Config>
+  __device__ void operator()(Config config, int* d_out)
+  {
+    cudax::this_cluster cluster{config};
+    int thread_data[1] = {1};
+
+    if constexpr (Broadcasted)
+    {
+      const auto first = cudax::coop::reduce(cudax::broadcasted, cluster, thread_data, cuda::std::plus<>{});
+      thread_data[0] += 2;
+      const auto second = cudax::coop::reduce(cudax::broadcasted, cluster, thread_data, cuda::std::plus<>{});
+      d_out[cuda::gpu_thread.rank_as<int>(cluster)] = first + second;
+    }
+    else
+    {
+      const auto first = cudax::coop::reduce(cluster, thread_data, cuda::std::plus<>{});
+      thread_data[0] += 2;
+      const auto second = cudax::coop::reduce(cluster, thread_data, cuda::std::plus<>{});
+      REQUIRE(first.has_value() == cuda::gpu_thread.is_root_rank(cluster));
+      REQUIRE(second.has_value() == cuda::gpu_thread.is_root_rank(cluster));
+      if (first.has_value() && second.has_value())
+      {
+        *d_out = *first + *second;
+      }
+    }
+  }
+};
+
 /***********************************************************************************************************************
  * Type list definition
  **********************************************************************************************************************/
@@ -239,4 +270,29 @@ C2H_TEST("reduce/this_cluster Broadcasted", "[reduce][this_cluster]", integral_t
     verify_results(c2h::host_vector<value_t>(cluster_size_t::value * block_size, reference_result),
                    c2h::host_vector<value_t>(d_out));
   }
+}
+
+C2H_TEST("reduce/this_cluster handles consecutive reductions", "[reduce][this_cluster]")
+{
+  const auto device = cuda::devices[0];
+  if (cuda::device_attributes::compute_capability_major(device) < 9)
+  {
+    return;
+  }
+
+  constexpr int cluster_size = 2;
+  constexpr int group_size   = cluster_size * block_size;
+  constexpr int expected     = 4 * group_size;
+  cuda::stream stream{device};
+  const auto config =
+    cuda::make_config(cuda::grid_dims<1>(), cuda::cluster_dims<cluster_size>(), cuda::block_dims<block_size>());
+  c2h::device_vector<int> d_result(1);
+  c2h::device_vector<int> d_broadcast(group_size);
+
+  cuda::launch(stream, config, ConsecutiveReduceKernel<false>{}, thrust::raw_pointer_cast(d_result.data()));
+  cuda::launch(stream, config, ConsecutiveReduceKernel<true>{}, thrust::raw_pointer_cast(d_broadcast.data()));
+  stream.sync();
+
+  verify_results(expected, c2h::host_vector<int>(d_result)[0]);
+  verify_results(c2h::host_vector<int>(group_size, expected), c2h::host_vector<int>(d_broadcast));
 }

--- a/cudax/test/coop/reduce/this_grid.cu
+++ b/cudax/test/coop/reduce/this_grid.cu
@@ -71,6 +71,37 @@ struct ReduceKernel
   }
 };
 
+template <bool Broadcasted>
+struct ConsecutiveReduceKernel
+{
+  template <class Config>
+  __device__ void operator()(Config config, int* d_out)
+  {
+    cudax::this_grid grid{config};
+    int thread_data[1] = {1};
+
+    if constexpr (Broadcasted)
+    {
+      const auto first = cudax::coop::reduce(cudax::broadcasted, grid, thread_data, cuda::std::plus<>{});
+      thread_data[0] += 2;
+      const auto second = cudax::coop::reduce(cudax::broadcasted, grid, thread_data, cuda::std::plus<>{});
+      d_out[cuda::gpu_thread.rank_as<int>(grid)] = first + second;
+    }
+    else
+    {
+      const auto first = cudax::coop::reduce(grid, thread_data, cuda::std::plus<>{});
+      thread_data[0] += 2;
+      const auto second = cudax::coop::reduce(grid, thread_data, cuda::std::plus<>{});
+      REQUIRE(first.has_value() == cuda::gpu_thread.is_root_rank(grid));
+      REQUIRE(second.has_value() == cuda::gpu_thread.is_root_rank(grid));
+      if (first.has_value() && second.has_value())
+      {
+        *d_out = *first + *second;
+      }
+    }
+  }
+};
+
 /***********************************************************************************************************************
  * Type list definition
  **********************************************************************************************************************/
@@ -249,4 +280,33 @@ C2H_TEST("reduce/this_grid Broadcasted", "[reduce][this_grid]", integral_type_li
     verify_results(c2h::host_vector<value_t>(grid_size_t::value * cluster_size * block_size, reference_result),
                    c2h::host_vector<value_t>(d_out));
   }
+}
+
+C2H_TEST("reduce/this_grid handles consecutive reductions", "[reduce][this_grid]")
+{
+  const auto device = cuda::devices[0];
+  if (cuda::device_attributes::compute_capability_major(device) < 9)
+  {
+    return;
+  }
+
+  // Multiple clusters are required to exercise reuse of grid partials.
+  constexpr int grid_size  = 12;
+  constexpr int group_size = grid_size * cluster_size * block_size;
+  constexpr int expected   = 4 * group_size;
+  cuda::stream stream{device};
+  const auto config = cuda::make_config(
+    cuda::grid_dims<grid_size>(),
+    cuda::cluster_dims<cluster_size>(),
+    cuda::block_dims<block_size>(),
+    cuda::cooperative_launch{});
+  c2h::device_vector<int> d_result(1);
+  c2h::device_vector<int> d_broadcast(group_size);
+
+  cuda::launch(stream, config, ConsecutiveReduceKernel<false>{}, thrust::raw_pointer_cast(d_result.data()));
+  cuda::launch(stream, config, ConsecutiveReduceKernel<true>{}, thrust::raw_pointer_cast(d_broadcast.data()));
+  stream.sync();
+
+  verify_results(expected, c2h::host_vector<int>(d_result)[0]);
+  verify_results(c2h::host_vector<int>(group_size, expected), c2h::host_vector<int>(d_broadcast));
 }

--- a/cudax/test/coop/reduce/this_warp.cu
+++ b/cudax/test/coop/reduce/this_warp.cu
@@ -68,6 +68,37 @@ struct ReduceKernel
   }
 };
 
+template <bool Broadcasted>
+struct ConsecutiveReduceKernel
+{
+  template <class Config>
+  __device__ void operator()(Config config, int* d_out)
+  {
+    cudax::this_warp warp{config};
+    int thread_data[1] = {1};
+
+    if constexpr (Broadcasted)
+    {
+      const auto first = cudax::coop::reduce(cudax::broadcasted, warp, thread_data, cuda::std::plus<>{});
+      thread_data[0] += 2;
+      const auto second = cudax::coop::reduce(cudax::broadcasted, warp, thread_data, cuda::std::plus<>{});
+      d_out[cuda::gpu_thread.rank_as<int>(warp)] = first + second;
+    }
+    else
+    {
+      const auto first = cudax::coop::reduce(warp, thread_data, cuda::std::plus<>{});
+      thread_data[0] += 2;
+      const auto second = cudax::coop::reduce(warp, thread_data, cuda::std::plus<>{});
+      REQUIRE(first.has_value() == cuda::gpu_thread.is_root_rank(warp));
+      REQUIRE(second.has_value() == cuda::gpu_thread.is_root_rank(warp));
+      if (first.has_value() && second.has_value())
+      {
+        *d_out = *first + *second;
+      }
+    }
+  }
+};
+
 /***********************************************************************************************************************
  * Type list definition
  **********************************************************************************************************************/
@@ -210,4 +241,20 @@ C2H_TEST("reduce/this_warp Broadcasted", "[reduce][this_warp]", integral_type_li
     run_reduce_kernel(stream, num_items, d_in, d_out, reduce_op, cuda::std::true_type{});
     verify_results(c2h::host_vector<value_t>(warp_size, reference_result), c2h::host_vector<value_t>(d_out));
   }
+}
+
+C2H_TEST("reduce/this_warp handles consecutive reductions", "[reduce][this_warp]")
+{
+  constexpr int expected = 4 * warp_size;
+  cuda::stream stream{cuda::devices[0]};
+  const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<warp_size>());
+  c2h::device_vector<int> d_result(1);
+  c2h::device_vector<int> d_broadcast(warp_size);
+
+  cuda::launch(stream, config, ConsecutiveReduceKernel<false>{}, thrust::raw_pointer_cast(d_result.data()));
+  cuda::launch(stream, config, ConsecutiveReduceKernel<true>{}, thrust::raw_pointer_cast(d_broadcast.data()));
+  stream.sync();
+
+  verify_results(expected, c2h::host_vector<int>(d_result)[0]);
+  verify_results(c2h::host_vector<int>(warp_size, expected), c2h::host_vector<int>(d_broadcast));
 }

--- a/cudax/test/coop/reduce/warps_within_block.cu
+++ b/cudax/test/coop/reduce/warps_within_block.cu
@@ -27,8 +27,9 @@
 #include <c2h/generators.h>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-constexpr int nwarps_in_group = 3;
-constexpr int warp_size       = 32;
+constexpr int nwarps_in_group   = 3;
+constexpr int warp_size         = 32;
+constexpr int multi_group_count = 2;
 
 /***********************************************************************************************************************
  * Thread Reduce Wrapper Kernels
@@ -81,6 +82,92 @@ struct ReduceKernel
       {
         *d_out = result.value();
       }
+    }
+  }
+};
+
+template <bool Broadcasted, bool Exhaustive>
+struct MultiGroupReduceKernel
+{
+  template <class Config>
+  __device__ void operator()(Config config, const int* d_in, int* d_out)
+  {
+    cudax::this_block block{config};
+
+    using Barriers = cuda::barrier<cuda::thread_scope_block>[multi_group_count];
+    __shared__ cuda::std::aligned_storage_t<sizeof(Barriers), alignof(Barriers)> barriers_storage;
+    auto& barriers = reinterpret_cast<Barriers&>(barriers_storage);
+
+    cudax::group group{
+      cuda::warp, block, cudax::group_by<nwarps_in_group, Exhaustive>{}, cudax::barrier_synchronizer{barriers}};
+
+    if (!cuda::gpu_thread.is_part_of(group))
+    {
+      return;
+    }
+
+    int thread_data[1] = {d_in[cuda::gpu_thread.rank_as<int>(block)]};
+    if constexpr (Broadcasted)
+    {
+      const auto result = cudax::coop::reduce(cudax::broadcasted, group, thread_data, cuda::std::plus<>{});
+      d_out[cuda::gpu_thread.rank_as<int>(block)] = result;
+    }
+    else
+    {
+      const auto result = cudax::coop::reduce(group, thread_data, cuda::std::plus<>{});
+      REQUIRE(result.has_value() == cuda::gpu_thread.is_root_rank(group));
+      if (result.has_value())
+      {
+        d_out[group.template rank_as<int>(block)] = *result;
+      }
+    }
+  }
+};
+
+template <bool Broadcasted, class Group, class Block>
+__device__ void run_nested_group_reduce(const Group& group, const Block& block, int (&thread_data)[1], int* d_out)
+{
+  if constexpr (Broadcasted)
+  {
+    const auto first = cudax::coop::reduce(cudax::broadcasted, group, thread_data, cuda::std::plus<>{});
+    ++thread_data[0];
+    const auto second = cudax::coop::reduce(cudax::broadcasted, group, thread_data, cuda::std::plus<>{});
+    d_out[cuda::gpu_thread.rank_as<int>(block)] = first + second;
+  }
+  else
+  {
+    const auto first = cudax::coop::reduce(group, thread_data, cuda::std::plus<>{});
+    ++thread_data[0];
+    const auto second = cudax::coop::reduce(group, thread_data, cuda::std::plus<>{});
+    REQUIRE(first.has_value() == cuda::gpu_thread.is_root_rank(group));
+    REQUIRE(second.has_value() == cuda::gpu_thread.is_root_rank(group));
+    if (first.has_value() && second.has_value())
+    {
+      d_out[cuda::warp.rank(block) / 2] = *first + *second;
+    }
+  }
+}
+
+template <bool Broadcasted, bool UseGroupView>
+struct NestedMultiGroupReduceKernel
+{
+  template <class Config>
+  __device__ void operator()(Config config, const int* d_in, int* d_out)
+  {
+    cudax::this_block block{config};
+
+    cudax::group parent{cuda::warp, block, cudax::group_by<4>{}, cudax::level_synchronizer{}};
+    cudax::virtual_group child{cuda::warp, parent, cudax::group_by<2>{}};
+    cudax::group_view child_view{child};
+
+    int thread_data[1] = {d_in[cuda::gpu_thread.rank_as<int>(block)]};
+    if constexpr (UseGroupView)
+    {
+      run_nested_group_reduce<Broadcasted>(child_view, block, thread_data, d_out);
+    }
+    else
+    {
+      run_nested_group_reduce<Broadcasted>(child, block, thread_data, d_out);
     }
   }
 };
@@ -154,6 +241,101 @@ void run_reduce_kernel(
       FAIL("Unsupported number of items");
   }
   stream.sync();
+}
+
+template <bool Broadcasted, bool Exhaustive, bool DynamicExtents = false>
+void run_multi_group_reduce_kernel(cuda::stream_ref stream)
+{
+  constexpr int nwarps_in_block = multi_group_count * nwarps_in_group + (Exhaustive ? 0 : 1);
+  constexpr int block_size      = nwarps_in_block * warp_size;
+  constexpr int group_size      = nwarps_in_group * warp_size;
+  constexpr int output_size     = Broadcasted ? multi_group_count * group_size : multi_group_count;
+
+  c2h::host_vector<int> h_in(block_size);
+  for (int i = 0; i < block_size; ++i)
+  {
+    h_in[i] = i + 1;
+  }
+
+  c2h::device_vector<int> d_in(h_in);
+  c2h::device_vector<int> d_out(output_size);
+  const auto in_ptr  = thrust::raw_pointer_cast(d_in.data());
+  const auto out_ptr = thrust::raw_pointer_cast(d_out.data());
+  if constexpr (DynamicExtents)
+  {
+    // Run-time block dimensions leave the mapped-group count dynamic, so the
+    // reduce falls back to its bounded per-block scratch array.
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims(block_size));
+    cuda::launch(stream, config, MultiGroupReduceKernel<Broadcasted, Exhaustive>{}, in_ptr, out_ptr);
+  }
+  else
+  {
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<block_size>());
+    cuda::launch(stream, config, MultiGroupReduceKernel<Broadcasted, Exhaustive>{}, in_ptr, out_ptr);
+  }
+  stream.sync();
+
+  const c2h::host_vector<int> h_out = d_out;
+  for (int group_rank = 0; group_rank < multi_group_count; ++group_rank)
+  {
+    const auto group_begin = h_in.begin() + group_rank * group_size;
+    const auto expected    = cuda::std::accumulate(group_begin, group_begin + group_size, 0, cuda::std::plus<>{});
+    if constexpr (Broadcasted)
+    {
+      for (int rank = 0; rank < group_size; ++rank)
+      {
+        REQUIRE(h_out[group_rank * group_size + rank] == expected);
+      }
+    }
+    else
+    {
+      REQUIRE(h_out[group_rank] == expected);
+    }
+  }
+}
+
+template <bool Broadcasted, bool UseGroupView>
+void run_nested_multi_group_reduce_kernel(cuda::stream_ref stream)
+{
+  constexpr int nwarps_in_block = 8;
+  constexpr int block_size      = nwarps_in_block * warp_size;
+  constexpr int child_warps     = 2;
+  constexpr int child_size      = child_warps * warp_size;
+  constexpr int child_count     = nwarps_in_block / child_warps;
+  constexpr int output_size     = Broadcasted ? block_size : child_count;
+
+  c2h::host_vector<int> h_in(block_size);
+  for (int i = 0; i < block_size; ++i)
+  {
+    h_in[i] = i + 1;
+  }
+
+  c2h::device_vector<int> d_in(h_in);
+  c2h::device_vector<int> d_out(output_size);
+  const auto in_ptr  = thrust::raw_pointer_cast(d_in.data());
+  const auto out_ptr = thrust::raw_pointer_cast(d_out.data());
+  const auto config  = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims(block_size));
+  cuda::launch(stream, config, NestedMultiGroupReduceKernel<Broadcasted, UseGroupView>{}, in_ptr, out_ptr);
+  stream.sync();
+
+  const c2h::host_vector<int> h_out = d_out;
+  for (int child_rank = 0; child_rank < child_count; ++child_rank)
+  {
+    const auto child_begin    = h_in.begin() + child_rank * child_size;
+    const auto first_expected = cuda::std::accumulate(child_begin, child_begin + child_size, 0, cuda::std::plus<>{});
+    const auto expected       = 2 * first_expected + child_size;
+    if constexpr (Broadcasted)
+    {
+      for (int rank = 0; rank < child_size; ++rank)
+      {
+        REQUIRE(h_out[child_rank * child_size + rank] == expected);
+      }
+    }
+    else
+    {
+      REQUIRE(h_out[child_rank] == expected);
+    }
+  }
 }
 
 constexpr int max_size  = 4;
@@ -231,4 +413,34 @@ C2H_TEST("reduce/warps_within_block Broadcasted", "[reduce][warps_within_block]"
     verify_results(c2h::host_vector<value_t>(nwarps_in_group * warp_size, reference_result),
                    c2h::host_vector<value_t>(d_out));
   }
+}
+
+C2H_TEST("reduce/warps_within_block isolates scratch across mapped groups", "[reduce][warps_within_block]")
+{
+  cuda::stream stream{cuda::devices[0]};
+
+  run_multi_group_reduce_kernel<false, true>(stream);
+  run_multi_group_reduce_kernel<true, true>(stream);
+  run_multi_group_reduce_kernel<false, false>(stream);
+  run_multi_group_reduce_kernel<true, false>(stream);
+}
+
+C2H_TEST("reduce/warps_within_block isolates scratch with run-time extents", "[reduce][warps_within_block]")
+{
+  cuda::stream stream{cuda::devices[0]};
+
+  run_multi_group_reduce_kernel<false, true, true>(stream);
+  run_multi_group_reduce_kernel<true, true, true>(stream);
+  run_multi_group_reduce_kernel<false, false, true>(stream);
+  run_multi_group_reduce_kernel<true, false, true>(stream);
+}
+
+C2H_TEST("reduce/warps_within_block isolates nested mapped-group scratch", "[reduce][warps_within_block]")
+{
+  cuda::stream stream{cuda::devices[0]};
+
+  run_nested_multi_group_reduce_kernel<false, false>(stream);
+  run_nested_multi_group_reduce_kernel<true, false>(stream);
+  run_nested_multi_group_reduce_kernel<false, true>(stream);
+  run_nested_multi_group_reduce_kernel<true, true>(stream);
 }

--- a/cudax/test/group/no_cooperative_groups_interop.cu
+++ b/cudax/test/group/no_cooperative_groups_interop.cu
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#define _CUDAX_DISABLE_COOPERATIVE_GROUPS_INTEROP
+
+#include <cuda/experimental/coop.cuh>
+#include <cuda/experimental/group.cuh>
+
+#include <c2h/catch2_test_helper.h>
+
+C2H_TEST("cooperative-groups interop can be disabled", "[group]")
+{
+  STATIC_REQUIRE(!_CCCL_HAS_COOPERATIVE_GROUPS());
+}

--- a/docs/python/coop.rst
+++ b/docs/python/coop.rst
@@ -27,8 +27,11 @@ arguments and ``count`` is the runtime number of valid tile items:
 
 The compiler integration supplies launch facts such as the block dimensions;
 they are not repeated in the operation calls. Importing :mod:`cuda.coop`
-remains compiler-free; a compatible compiler context activates its backend
-when a collective is traced. The initial portable contract covers:
+succeeds without a compiler backend. By default, it also probes for an
+installed compatible CUTLASS DSL and activates it when found. Set
+``CUDA_COOP_DISABLE_AUTO_DSL_REGISTRATION=1`` before the import to skip
+automatic compiler probing and register integrations explicitly. The initial
+portable contract covers:
 
 * load and store; and
 * reduce, sum, and inclusive or exclusive scans.

--- a/python/cuda_coop/README.md
+++ b/python/cuda_coop/README.md
@@ -2,7 +2,7 @@
 
 `cuda.coop` provides cooperative CUDA primitives for Python kernel DSLs. Its
 portable API describes CUDA thread groups, per-thread data, temporary storage,
-and collectives without importing a compiler at module load time.
+and collectives through a backend-neutral root namespace.
 
 Inside a kernel body, where `source`, `destination`, and `count` are kernel
 arguments:
@@ -23,8 +23,12 @@ The initial common surface includes load/store and reduce/scan. Compatible
 compiler integrations lower the same root calls in their compiler contexts.
 
 These functions are compile-time kernel constructs. Importing `cuda.coop`
-succeeds without a compiler backend. A backend-dependent call outside a
-compatible compiler context reports a structured context error.
+succeeds without a compiler backend. By default, the import also probes for an
+installed compatible CUTLASS DSL and activates it when found. Set
+`CUDA_COOP_DISABLE_AUTO_DSL_REGISTRATION=1` before importing `cuda.coop` to
+skip automatic compiler probing and register integrations explicitly. A
+backend-dependent call outside a compatible compiler context reports a
+structured context error.
 
 See the [CCCL documentation](https://nvidia.github.io/cccl/python.html) for the
 supported signatures and examples.

--- a/python/cuda_coop/cuda/coop/__init__.py
+++ b/python/cuda_coop/cuda/coop/__init__.py
@@ -32,3 +32,10 @@ def __dir__() -> list[str]:
     """Return only the documented backend-neutral completion surface."""
 
     return sorted(__all__)
+
+
+if _portable_exports:
+    from ._core._auto_registration import _auto_register_known_dsls
+
+    _auto_register_known_dsls()
+    del _auto_register_known_dsls

--- a/python/cuda_coop/cuda/coop/_core/_auto_registration.py
+++ b/python/cuda_coop/cuda/coop/_core/_auto_registration.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Connect the portable ``cuda.coop`` API to compatible Python kernel DSLs.
+
+Importing ``cuda.coop`` probes an explicit allowlist of separately installed
+DSL integrations. Each probe verifies the compiler capabilities that its
+adapter needs before installing compiler-owned activation. Set
+``CUDA_COOP_DISABLE_AUTO_DSL_REGISTRATION`` to a truthy value to skip every
+automatic probe and register backends explicitly instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import os
+import sys
+import warnings
+from collections.abc import Callable
+from dataclasses import dataclass
+from types import ModuleType
+
+_DISABLE_ENV = "CUDA_COOP_DISABLE_AUTO_DSL_REGISTRATION"
+_FALSE_ENV_VALUES = frozenset({"", "0", "false", "no", "off"})
+_WARNING_PREFIX = "cuda.coop automatic DSL registration:"
+
+# Keep this an explicit allowlist so installing an unrelated compiler package
+# cannot change the cuda.coop root import.
+_AUTO_DSL_CANDIDATES = ("cutlass",)
+
+
+class CudaCoopAutoRegistrationWarning(UserWarning):
+    """A detected optional DSL could not activate the portable API."""
+
+
+class _BackendUnavailable(ImportError):
+    """The optional backend's top-level runtime is genuinely absent."""
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    display_name: str
+    runtime_module: str
+    distributions: tuple[str, ...]
+    install_hint: str
+    activate: Callable[[], ModuleType]
+
+
+def _auto_registration_disabled(value: str | None = None) -> bool:
+    """Return whether automatic probing is disabled by the environment."""
+
+    if value is None:
+        value = os.environ.get(_DISABLE_ENV)
+    if value is None:
+        return False
+    return value.strip().lower() not in _FALSE_ENV_VALUES
+
+
+def _import_optional(module_name: str, *, top_level: str) -> ModuleType:
+    """Import one optional module and distinguish absence from breakage."""
+
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as error:
+        if getattr(error, "name", None) == top_level:
+            raise _BackendUnavailable(top_level) from error
+        raise
+
+
+def _activate_cutlass() -> ModuleType:
+    """Let the qualified CUTLASS adapter validate and register its hooks."""
+
+    _import_optional("cutlass.cutlass_dsl", top_level="cutlass")
+
+    # cuda.coop.cutlass registers the common-root fallback as its final import
+    # action, after validation, compiler-hook setup, and wrapper construction.
+    return importlib.import_module("cuda.coop.cutlass")
+
+
+_CANDIDATES = {
+    "cutlass": _Candidate(
+        display_name="CUTLASS",
+        runtime_module="cutlass",
+        distributions=("nvidia-cutlass-dsl",),
+        install_hint="cuda-coop[cutlass]",
+        activate=_activate_cutlass,
+    ),
+}
+
+
+def _detected_version(candidate: _Candidate) -> str | None:
+    runtime = sys.modules.get(candidate.runtime_module)
+    version = getattr(runtime, "__version__", None)
+    if isinstance(version, str) and version:
+        return version
+    for distribution in candidate.distributions:
+        try:
+            return importlib.metadata.version(distribution)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return None
+
+
+def _remove_failed_backend_modules(prefix: str, before: frozenset[str]) -> None:
+    for module_name in tuple(sys.modules):
+        if (
+            module_name == prefix or module_name.startswith(f"{prefix}.")
+        ) and module_name not in before:
+            sys.modules.pop(module_name, None)
+
+
+def _warn_incompatible(candidate: _Candidate, error: Exception) -> None:
+    version = _detected_version(candidate)
+    detected = f" (detected version {version})" if version is not None else ""
+    reason = str(error).strip() or type(error).__name__
+    missing = getattr(error, "name", None)
+    if isinstance(missing, str) and missing and missing not in reason:
+        reason = f"dependency {missing!r} failed to import: {reason}"
+    warnings.warn(
+        f"{_WARNING_PREFIX} {candidate.display_name}{detected} was detected "
+        f"but was not enabled because {reason}. The cuda.coop root import "
+        "continued and other DSL backends were unaffected. Install a compatible "
+        f"{candidate.install_hint}. "
+        f"Set {_DISABLE_ENV}=1 to disable automatic DSL probing.",
+        CudaCoopAutoRegistrationWarning,
+        stacklevel=2,
+    )
+
+
+def _auto_register_known_dsls() -> tuple[str, ...]:
+    """Enable each compatible known DSL without coupling their failures."""
+
+    if _auto_registration_disabled():
+        return ()
+
+    registered = []
+    for name in _AUTO_DSL_CANDIDATES:
+        candidate = _CANDIDATES[name]
+        package_prefix = f"cuda.coop.{name}"
+        if package_prefix in sys.modules:
+            registered.append(name)
+            continue
+        before = frozenset(sys.modules)
+        try:
+            candidate.activate()
+        except _BackendUnavailable:
+            _remove_failed_backend_modules(package_prefix, before)
+        except Exception as error:
+            _remove_failed_backend_modules(package_prefix, before)
+            _warn_incompatible(candidate, error)
+        else:
+            registered.append(name)
+    return tuple(registered)
+
+
+__all__: list[str] = []

--- a/python/cuda_coop/cuda/coop/_core/_symbols.py
+++ b/python/cuda_coop/cuda/coop/_core/_symbols.py
@@ -9,29 +9,134 @@ from __future__ import annotations
 import dataclasses
 import dis
 import hashlib
+import inspect
 import math
+import os
 import re
+import sys
+import sysconfig
 from collections import defaultdict
+from collections.abc import Mapping, Sequence
 from enum import Enum
-from functools import partial
+from functools import cache, partial
 from types import CodeType, ModuleType
-from typing import Any, Mapping
+from typing import Any
 
 _ADDRESS_IN_REPR = re.compile(r"(?<= at )0x[0-9a-fA-F]+")
+_MISSING = object()
+_PY_TPFLAGS_HEAPTYPE = 1 << 9
+_TYPE_METADATA_NAMES = frozenset(
+    {
+        "__dict__",
+        "__classcell__",
+        "__doc__",
+        "__firstlineno__",
+        "__module__",
+        "__qualname__",
+        "__static_attributes__",
+        "__weakref__",
+    }
+)
+
+
+@cache
+def _python_library_paths() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    paths = sysconfig.get_paths()
+
+    def normalized(*names: str) -> tuple[str, ...]:
+        return tuple(
+            dict.fromkeys(
+                os.path.realpath(path)
+                for name in names
+                if isinstance((path := paths.get(name)), str) and path
+            )
+        )
+
+    return normalized("stdlib", "platstdlib"), normalized("purelib", "platlib")
+
+
+def _path_is_within(path: str, directory: str) -> bool:
+    try:
+        return os.path.commonpath((path, directory)) == directory
+    except ValueError:
+        return False
+
+
+def _is_verified_standard_library_module(module_name: Any) -> bool:
+    if not isinstance(module_name, str) or not module_name:
+        return False
+
+    module_root = module_name.partition(".")[0]
+    stdlib_module_names = getattr(sys, "stdlib_module_names", frozenset())
+    if (
+        module_root not in stdlib_module_names
+        and module_root not in sys.builtin_module_names
+    ):
+        return False
+
+    module = sys.modules.get(module_name)
+    if not isinstance(module, ModuleType):
+        return False
+
+    spec = getattr(module, "__spec__", None)
+    origin = getattr(spec, "origin", None)
+    if origin in {"built-in", "frozen"}:
+        return True
+
+    source_path = origin if isinstance(origin, str) else None
+    if not source_path or source_path in {"namespace", "unknown"}:
+        source_path = getattr(module, "__file__", None)
+    if not isinstance(source_path, str) or not source_path:
+        return False
+
+    source_path = os.path.realpath(source_path)
+    stdlib_paths, package_paths = _python_library_paths()
+    return any(_path_is_within(source_path, path) for path in stdlib_paths) and not any(
+        _path_is_within(source_path, path) for path in package_paths
+    )
+
+
+def _is_verified_standard_library_definition(value: Any) -> bool:
+    module_name = _defined_module_name(value)
+    if not _is_verified_standard_library_module(module_name):
+        return False
+    qualified_name = getattr(value, "__qualname__", None)
+    if not isinstance(qualified_name, str) or "<locals>" in qualified_name:
+        return False
+    resolved: Any = sys.modules[module_name]
+    for name in qualified_name.split("."):
+        try:
+            resolved = inspect.getattr_static(resolved, name)
+        except AttributeError:
+            return False
+    return resolved is value
+
+
+def _is_closure_sequence(value: Any) -> bool:
+    return isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    )
+
+
+def _defined_module_name(value: Any) -> str | None:
+    module_name = getattr(value, "__module__", None)
+    return module_name if isinstance(module_name, str) else None
 
 
 @dataclasses.dataclass
 class _TokenState:
     active: dict[int, int] = dataclasses.field(default_factory=dict)
+    completed: dict[tuple[str, int], tuple[Any, Any]] = dataclasses.field(
+        default_factory=dict
+    )
+    cycle_hits: int = 0
 
 
 def _code_token(code: CodeType, state: _TokenState) -> tuple[Any, ...]:
     constants = tuple(
-        (
-            _code_token(value, state)
-            if isinstance(value, CodeType)
-            else _semantic_token(value, state)
-        )
+        _code_token(value, state)
+        if isinstance(value, CodeType)
+        else _semantic_token(value, state)
         for value in code.co_consts
     )
     return (
@@ -51,11 +156,14 @@ def _code_token(code: CodeType, state: _TokenState) -> tuple[Any, ...]:
 def _object_state_token(
     value: Any,
     state: _TokenState,
+    *,
+    dependency_values: bool = False,
 ) -> tuple[Any, ...] | None:
+    tokenize = _dependency_token if dependency_values else _semantic_token
     object_state: list[tuple[str, Any]] = []
     attributes = getattr(value, "__dict__", None)
     if attributes:
-        object_state.append(("__dict__", _semantic_token(attributes, state)))
+        object_state.append(("__dict__", tokenize(attributes, state)))
 
     seen_slots: set[str] = set()
     for cls in type(value).__mro__:
@@ -77,25 +185,253 @@ def _object_state_token(
                 slot_value = getattr(value, storage_name)
             except AttributeError:
                 continue
-            token = (
-                ("self",) if slot_value is value else _semantic_token(slot_value, state)
-            )
+            token = ("self",) if slot_value is value else tokenize(slot_value, state)
             object_state.append((storage_name, token))
 
     return tuple(object_state) if object_state else None
 
 
-def _referenced_global_names(code: CodeType) -> tuple[str, ...]:
-    names = {
-        instruction.argval
-        for instruction in dis.get_instructions(code)
-        if instruction.opname in {"LOAD_GLOBAL", "LOAD_NAME"}
-        and isinstance(instruction.argval, str)
-    }
-    for constant in code.co_consts:
-        if isinstance(constant, CodeType):
-            names.update(_referenced_global_names(constant))
-    return tuple(sorted(names))
+def _referenced_paths_token(
+    code: CodeType,
+    namespace: Mapping[str, Any],
+    state: _TokenState,
+    *,
+    load_opnames: frozenset[str],
+    include_nested: bool,
+) -> tuple[tuple[tuple[str, ...], Any], ...]:
+    paths: set[tuple[str, ...]] = set()
+
+    def collect_paths(current: CodeType) -> None:
+        instructions = tuple(dis.get_instructions(current))
+        for index, instruction in enumerate(instructions):
+            if instruction.opname not in load_opnames or not isinstance(
+                instruction.argval, str
+            ):
+                continue
+            path = [instruction.argval]
+            paths.add(tuple(path))
+            for attribute in instructions[index + 1 :]:
+                if attribute.opname not in {"LOAD_ATTR", "LOAD_METHOD"}:
+                    break
+                if not isinstance(attribute.argval, str):
+                    break
+                path.append(attribute.argval)
+                paths.add(tuple(path))
+        if include_nested:
+            for constant in current.co_consts:
+                if isinstance(constant, CodeType):
+                    collect_paths(constant)
+
+    collect_paths(code)
+    dependencies: list[tuple[tuple[str, ...], Any]] = []
+    for path in sorted(paths):
+        if path[0] not in namespace:
+            continue
+        value = namespace[path[0]]
+        resolved = True
+        for attribute in path[1:]:
+            try:
+                value = inspect.getattr_static(value, attribute)
+            except AttributeError:
+                resolved = False
+                break
+        token = (
+            _dependency_token(value, state)
+            if resolved
+            else ("unresolved-attribute", path)
+        )
+        dependencies.append((path, token))
+    return tuple(dependencies)
+
+
+def _referenced_globals_token(
+    code: CodeType,
+    namespace: Mapping[str, Any] | None,
+    state: _TokenState,
+) -> tuple[tuple[tuple[str, ...], Any], ...]:
+    if namespace is None:
+        return ()
+    return _referenced_paths_token(
+        code,
+        namespace,
+        state,
+        load_opnames=frozenset(
+            {"LOAD_FROM_DICT_OR_GLOBALS", "LOAD_GLOBAL", "LOAD_NAME"}
+        ),
+        include_nested=True,
+    )
+
+
+def _referenced_closure_token(
+    code: CodeType,
+    closure_values: Mapping[str, Any],
+    state: _TokenState,
+) -> tuple[tuple[tuple[str, ...], Any], ...]:
+    return _referenced_paths_token(
+        code,
+        closure_values,
+        state,
+        load_opnames=frozenset({"LOAD_DEREF"}),
+        include_nested=True,
+    )
+
+
+def _type_reference_token(value: type, state: _TokenState) -> Any:
+    module_name = _defined_module_name(value)
+    type_flags = getattr(value, "__flags__", None)
+    is_static_type = (
+        isinstance(type_flags, int) and not type_flags & _PY_TPFLAGS_HEAPTYPE
+    )
+    if _is_verified_standard_library_definition(value) or (
+        is_static_type and _is_verified_standard_library_module(module_name)
+    ):
+        return "type", module_name, getattr(value, "__qualname__", value.__name__)
+    return _type_dependency_token(value, state)
+
+
+def _descriptor_token(value: Any, state: _TokenState) -> Any:
+    if isinstance(value, staticmethod):
+        return "staticmethod", _semantic_token(value.__func__, state)
+    if isinstance(value, classmethod):
+        return "classmethod", _semantic_token(value.__func__, state)
+    if isinstance(value, property):
+        return (
+            "property",
+            _semantic_token(value.fget, state),
+            _semantic_token(value.fset, state),
+            _semantic_token(value.fdel, state),
+        )
+    descriptor_type = type(value)
+    if descriptor_type.__module__ != "builtins" and any(
+        name in base.__dict__
+        for base in descriptor_type.__mro__
+        for name in ("__get__", "__set__", "__delete__")
+    ):
+        return (
+            "descriptor",
+            _type_reference_token(descriptor_type, state),
+            _semantic_token(value, state),
+        )
+    return _semantic_token(value, state)
+
+
+def _type_dependency_token(value: type, state: _TokenState) -> Any:
+    value_id = id(value)
+    if value_id in state.active:
+        state.cycle_hits += 1
+        return _cycle_token(value, len(state.active) - state.active[value_id])
+
+    memo_key = ("type-dependency", value_id)
+    completed = state.completed.get(memo_key)
+    if completed is not None:
+        return completed[1]
+
+    state.active[value_id] = len(state.active)
+    cycle_hits_before = state.cycle_hits
+    try:
+        members = tuple(
+            (name, _dependency_token(member, state))
+            for name, member in sorted(vars(value).items())
+            if name not in _TYPE_METADATA_NAMES
+        )
+        bases = tuple(_type_reference_token(base, state) for base in value.__bases__)
+        metaclass = type(value)
+        metaclass_token = _type_reference_token(metaclass, state)
+        token = (
+            "type-dependency",
+            _defined_module_name(value),
+            getattr(value, "__qualname__", value.__name__),
+            metaclass_token,
+            bases,
+            members,
+        )
+    finally:
+        del state.active[value_id]
+
+    if state.cycle_hits == cycle_hits_before:
+        state.completed[memo_key] = (value, token)
+    return token
+
+
+def _dependency_token(value: Any, state: _TokenState) -> Any:
+    if isinstance(value, type):
+        return _type_reference_token(value, state)
+    if not (
+        isinstance(value, (Mapping, tuple, list, set, frozenset))
+        or (dataclasses.is_dataclass(value) and not isinstance(value, type))
+    ):
+        return _descriptor_token(value, state)
+
+    value_id = id(value)
+    if value_id in state.active:
+        state.cycle_hits += 1
+        return _cycle_token(value, len(state.active) - state.active[value_id])
+
+    memo_key = ("dependency-value", value_id)
+    completed = state.completed.get(memo_key)
+    if completed is not None:
+        return completed[1]
+
+    state.active[value_id] = len(state.active)
+    cycle_hits_before = state.cycle_hits
+    try:
+        if isinstance(value, Mapping):
+            items = [
+                (_dependency_token(key, state), _dependency_token(item, state))
+                for key, item in value.items()
+            ]
+            token = (
+                "mapping",
+                _container_kind(value),
+                _container_state_token(
+                    value,
+                    state,
+                    dependency_values=True,
+                ),
+                tuple(sorted(items, key=lambda item: repr(item[0]))),
+            )
+        elif isinstance(value, (tuple, list)):
+            token = (
+                "sequence",
+                _container_kind(value),
+                _container_state_token(
+                    value,
+                    state,
+                    dependency_values=True,
+                ),
+                tuple(_dependency_token(item, state) for item in value),
+            )
+        elif isinstance(value, (set, frozenset)):
+            token = (
+                "set",
+                _container_kind(value),
+                _container_state_token(
+                    value,
+                    state,
+                    dependency_values=True,
+                ),
+                tuple(
+                    sorted(
+                        (_dependency_token(item, state) for item in value),
+                        key=repr,
+                    )
+                ),
+            )
+        else:
+            token = (
+                type(value).__module__,
+                type(value).__qualname__,
+                tuple(
+                    (field.name, _dependency_token(getattr(value, field.name), state))
+                    for field in dataclasses.fields(value)
+                ),
+            )
+    finally:
+        del state.active[value_id]
+
+    if state.cycle_hits == cycle_hits_before:
+        state.completed[memo_key] = (value, token)
+    return token
 
 
 def _callable_token(value: Any, state: _TokenState) -> tuple[Any, ...]:
@@ -103,65 +439,138 @@ def _callable_token(value: Any, state: _TokenState) -> tuple[Any, ...]:
         return (
             "partial",
             _semantic_token(value.func, state),
-            _semantic_token(value.args, state),
-            _semantic_token(value.keywords, state),
+            _dependency_token(value.args, state),
+            _dependency_token(value.keywords, state),
         )
 
-    code = getattr(value, "__code__", None)
-    global_namespace = getattr(value, "__globals__", None)
-    callable_definition = value
-    callable_state = None
+    function_like = inspect.isfunction(value) or inspect.ismethod(value)
+    module_name = _defined_module_name(value)
+    qualified_name = getattr(value, "__qualname__", type(value).__qualname__)
+    if inspect.isfunction(value) and _is_verified_standard_library_definition(value):
+        return "callable-reference", module_name, qualified_name
+
+    callable_state = _object_state_token(value, state, dependency_values=True)
+    malformed_attributes: list[tuple[str, Any]] = []
+    implementation = value
+    exposed_code = getattr(implementation, "__code__", _MISSING)
+    exposed_namespace = getattr(implementation, "__globals__", _MISSING)
+    exposed_closure = getattr(implementation, "__closure__", _MISSING)
+    if exposed_code is not _MISSING and not isinstance(exposed_code, CodeType):
+        malformed_attributes.append(
+            ("__code__", _dependency_token(exposed_code, state))
+        )
+    code = exposed_code if isinstance(exposed_code, CodeType) else None
+    exposed_object_code = code is not None and not function_like
+    object_call = _MISSING
+    if exposed_object_code:
+        try:
+            object_call = inspect.getattr_static(type(value), "__call__")
+        except AttributeError:
+            pass
     if code is None:
-        call = getattr(value, "__call__", None)
-        code = getattr(call, "__code__", None)
-        global_namespace = getattr(call, "__globals__", None)
-        callable_definition = call
-        callable_state = _object_state_token(value, state)
+        if exposed_namespace is not _MISSING and not isinstance(
+            exposed_namespace, Mapping
+        ):
+            malformed_attributes.append(
+                ("__globals__", _dependency_token(exposed_namespace, state))
+            )
+        if (
+            exposed_closure is not _MISSING
+            and exposed_closure is not None
+            and not _is_closure_sequence(exposed_closure)
+        ):
+            malformed_attributes.append(
+                ("__closure__", _dependency_token(exposed_closure, state))
+            )
+        implementation = getattr(value, "__call__", _MISSING)
+        implementation_code = getattr(implementation, "__code__", _MISSING)
+        if implementation_code is not _MISSING and not isinstance(
+            implementation_code, CodeType
+        ):
+            malformed_attributes.append(
+                (
+                    "__call__.__code__",
+                    _dependency_token(implementation_code, state),
+                )
+            )
+        code = (
+            implementation_code if isinstance(implementation_code, CodeType) else None
+        )
+        namespace_value = getattr(implementation, "__globals__", _MISSING)
+        closure_value = getattr(implementation, "__closure__", _MISSING)
+        attribute_prefix = "__call__."
+    else:
+        namespace_value = exposed_namespace
+        closure_value = exposed_closure
+        attribute_prefix = ""
+
+    if isinstance(namespace_value, Mapping):
+        namespace: Mapping[str, Any] | None = namespace_value
+    else:
+        namespace = None
+        if namespace_value is not _MISSING:
+            malformed_attributes.append(
+                (
+                    f"{attribute_prefix}__globals__",
+                    _dependency_token(namespace_value, state),
+                )
+            )
 
     digest = hashlib.sha256()
     if code is not None:
         digest.update(
             repr(_code_token(code, state)).encode("utf-8", errors="backslashreplace")
         )
-        if isinstance(global_namespace, Mapping):
-            global_tokens = []
-            for name in _referenced_global_names(code):
-                if name not in global_namespace:
-                    continue
-                global_value = global_namespace[name]
-                token = (
-                    ("module", global_value.__name__)
-                    if isinstance(global_value, ModuleType)
-                    else _semantic_token(global_value, state)
-                )
-                global_tokens.append((name, token))
-            digest.update(
-                repr(tuple(global_tokens)).encode("utf-8", errors="backslashreplace")
+        digest.update(
+            repr(_referenced_globals_token(code, namespace, state)).encode(
+                "utf-8", errors="backslashreplace"
             )
+        )
     digest.update(
         repr(
-            _semantic_token(
-                getattr(callable_definition, "__defaults__", None),
-                state,
-            )
+            _dependency_token(getattr(implementation, "__defaults__", None), state)
         ).encode("utf-8", errors="backslashreplace")
     )
     digest.update(
         repr(
-            _semantic_token(
-                getattr(callable_definition, "__kwdefaults__", None),
-                state,
-            )
+            _dependency_token(getattr(implementation, "__kwdefaults__", None), state)
         ).encode("utf-8", errors="backslashreplace")
     )
-    closure = getattr(callable_definition, "__closure__", None) or ()
-    for cell in closure:
+    if closure_value is None or closure_value is _MISSING:
+        closure: Sequence[Any] = ()
+    elif _is_closure_sequence(closure_value):
+        closure = closure_value
+    else:
+        closure = ()
+        malformed_attributes.append(
+            (
+                f"{attribute_prefix}__closure__",
+                _dependency_token(closure_value, state),
+            )
+        )
+    closure_values: dict[str, Any] = {}
+    freevar_names = getattr(code, "co_freevars", ())
+    # Wrappers can expose mismatched code and closure metadata. Hash every cell
+    # and resolve attribute paths only for name/value pairs that are available.
+    for index, cell in enumerate(closure):
+        name = freevar_names[index] if index < len(freevar_names) else None
         try:
             cell_value = cell.cell_contents
         except ValueError:
             cell_value = "<empty>"
+        except AttributeError:
+            cell_value = cell
+        else:
+            if name is not None:
+                closure_values[name] = cell_value
         digest.update(
-            repr(_semantic_token(cell_value, state)).encode(
+            repr(_dependency_token(cell_value, state)).encode(
+                "utf-8", errors="backslashreplace"
+            )
+        )
+    if code is not None:
+        digest.update(
+            repr(_referenced_closure_token(code, closure_values, state)).encode(
                 "utf-8", errors="backslashreplace"
             )
         )
@@ -170,7 +579,11 @@ def _callable_token(value: Any, state: _TokenState) -> tuple[Any, ...]:
         if isinstance(bound_self, ModuleType):
             bound_self_token = ("module", bound_self.__name__)
         else:
-            object_state = _object_state_token(bound_self, state)
+            object_state = _object_state_token(
+                bound_self,
+                state,
+                dependency_values=True,
+            )
             bound_self_token = (
                 type(bound_self).__module__,
                 type(bound_self).__qualname__,
@@ -179,11 +592,21 @@ def _callable_token(value: Any, state: _TokenState) -> tuple[Any, ...]:
         digest.update(repr(bound_self_token).encode("utf-8", errors="backslashreplace"))
     if callable_state is not None:
         digest.update(repr(callable_state).encode("utf-8", errors="backslashreplace"))
+    if object_call is not _MISSING:
+        digest.update(
+            repr(_descriptor_token(object_call, state)).encode(
+                "utf-8", errors="backslashreplace"
+            )
+        )
+    if malformed_attributes:
+        digest.update(
+            repr(tuple(malformed_attributes)).encode("utf-8", errors="backslashreplace")
+        )
 
     return (
         "callable",
-        getattr(value, "__module__", type(value).__module__),
-        getattr(value, "__qualname__", type(value).__qualname__),
+        module_name,
+        qualified_name,
         digest.hexdigest()[:20],
     )
 
@@ -197,21 +620,29 @@ def _cycle_token(value: Any, back_reference_depth: int) -> tuple[str, str, str, 
     )
 
 
-def _container_kind(value: Any) -> tuple[str, str]:
-    return type(value).__module__, type(value).__qualname__
+def _container_kind(value: Any) -> tuple[str | None, str]:
+    return _defined_module_name(type(value)), type(value).__qualname__
 
 
 def _container_state_token(
     value: Any,
     state: _TokenState,
+    *,
+    dependency_values: bool = False,
 ) -> tuple[tuple[str, Any], ...] | None:
-    container_state = list(_object_state_token(value, state) or ())
+    tokenize = _dependency_token if dependency_values else _semantic_token
+    container_state = list(
+        _object_state_token(
+            value,
+            state,
+            dependency_values=dependency_values,
+        )
+        or ()
+    )
     if isinstance(value, defaultdict):
         default_factory = value.default_factory
         default_factory_token = (
-            ("self",)
-            if default_factory is value
-            else _semantic_token(default_factory, state)
+            ("self",) if default_factory is value else tokenize(default_factory, state)
         )
         container_state.append(("default_factory", default_factory_token))
     return tuple(container_state) if container_state else None
@@ -226,37 +657,44 @@ def _semantic_token(value: Any, state: _TokenState) -> Any:
         return "float", value.hex()
     if value is None or isinstance(value, (bool, int, str, bytes)):
         return value
+    if isinstance(value, ModuleType):
+        return "module", value.__name__
     if isinstance(value, type):
-        return "type", value.__module__, value.__qualname__
+        return "type", _defined_module_name(value), value.__qualname__
 
     value_id = id(value)
     if value_id in state.active:
+        state.cycle_hits += 1
         return _cycle_token(value, len(state.active) - state.active[value_id])
+
+    memo_key = ("value", value_id)
+    completed = state.completed.get(memo_key)
+    if completed is not None:
+        return completed[1]
+
     state.active[value_id] = len(state.active)
+    cycle_hits_before = state.cycle_hits
     try:
         if isinstance(value, Mapping):
             items = [
-                (
-                    _semantic_token(key, state),
-                    _semantic_token(item, state),
-                )
+                (_semantic_token(key, state), _semantic_token(item, state))
                 for key, item in value.items()
             ]
-            return (
+            token = (
                 "mapping",
                 _container_kind(value),
                 _container_state_token(value, state),
                 tuple(sorted(items, key=lambda item: repr(item[0]))),
             )
-        if isinstance(value, (tuple, list)):
-            return (
+        elif isinstance(value, (tuple, list)):
+            token = (
                 "sequence",
                 _container_kind(value),
                 _container_state_token(value, state),
                 tuple(_semantic_token(item, state) for item in value),
             )
-        if isinstance(value, (set, frozenset)):
-            return (
+        elif isinstance(value, (set, frozenset)):
+            token = (
                 "set",
                 _container_kind(value),
                 _container_state_token(value, state),
@@ -267,32 +705,38 @@ def _semantic_token(value: Any, state: _TokenState) -> Any:
                     )
                 ),
             )
-        if dataclasses.is_dataclass(value) and not isinstance(value, type):
-            return (
+        elif dataclasses.is_dataclass(value) and not isinstance(value, type):
+            token = (
                 type(value).__module__,
                 type(value).__qualname__,
                 tuple(
-                    (
-                        field.name,
-                        _semantic_token(getattr(value, field.name), state),
-                    )
+                    (field.name, _semantic_token(getattr(value, field.name), state))
                     for field in dataclasses.fields(value)
                 ),
             )
-        if callable(value):
-            return _callable_token(value, state)
-
-        attributes = _object_state_token(value, state)
-        if attributes is not None:
-            return (
-                type(value).__module__,
-                type(value).__qualname__,
-                attributes,
-            )
-        stable_repr = _ADDRESS_IN_REPR.sub("0x?", repr(value))
-        return type(value).__module__, type(value).__qualname__, stable_repr
+        elif callable(value):
+            token = _callable_token(value, state)
+        else:
+            attributes = _object_state_token(value, state)
+            if attributes is not None:
+                token = (
+                    type(value).__module__,
+                    type(value).__qualname__,
+                    attributes,
+                )
+            else:
+                stable_repr = _ADDRESS_IN_REPR.sub("0x?", repr(value))
+                token = (
+                    type(value).__module__,
+                    type(value).__qualname__,
+                    stable_repr,
+                )
     finally:
         del state.active[value_id]
+
+    if state.cycle_hits == cycle_hits_before:
+        state.completed[memo_key] = (value, token)
+    return token
 
 
 def semantic_token(value: Any) -> Any:

--- a/python/cuda_coop/cuda/coop/_headers/_identity.py
+++ b/python/cuda_coop/cuda/coop/_headers/_identity.py
@@ -1,0 +1,327 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Provenance-based identities for ordered compiler include roots."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import subprocess
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class HeaderIdentityError(RuntimeError):
+    """Raised when an include root cannot be fingerprinted safely."""
+
+
+@dataclass(frozen=True)
+class IncludeRootIdentity:
+    """Identity and provenance for one resolved include root."""
+
+    path: str
+    method: str
+    digest: str
+    duration_ns: int
+
+
+@dataclass(frozen=True)
+class IncludeDirsIdentity:
+    """Ordered identity of every CCCL and CUDA include root."""
+
+    roots: tuple[IncludeRootIdentity, ...]
+    digest: str
+    recursive_walks: int
+    duration_ns: int
+
+
+def _find_git_root(root: Path) -> Path | None:
+    for candidate in (root, *root.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", "--literal-pathspecs", "-C", str(repo), *args],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _git_include_root_identities(
+    repo: Path,
+    roots: tuple[Path, ...],
+) -> dict[Path, str]:
+    relatives = tuple(root.relative_to(repo) for root in roots)
+    pathspecs = tuple(
+        "." if not relative.parts else relative.as_posix() for relative in relatives
+    )
+    status = _run_git(
+        repo,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+        "--ignored=matching",
+        "--ignore-submodules=none",
+        "--",
+        *pathspecs,
+    )
+    if status.returncode != 0 or status.stdout:
+        return {}
+
+    index_entries = _run_git(repo, "ls-files", "-v", "-z", "--", *pathspecs)
+    if index_entries.returncode != 0 or not index_entries.stdout:
+        return {}
+    for entry in index_entries.stdout.split(b"\0"):
+        if entry and entry[:1] != b"H":
+            # `S` marks skip-worktree; lowercase marks assume-unchanged.
+            return {}
+
+    staged_entries = _run_git(repo, "ls-files", "--stage", "-z", "--", *pathspecs)
+    if staged_entries.returncode != 0 or not staged_entries.stdout:
+        return {}
+    symlinked_roots: set[Path] = set()
+    for entry in staged_entries.stdout.split(b"\0"):
+        if not entry:
+            continue
+        metadata, separator, path = entry.partition(b"\t")
+        fields = metadata.split()
+        if separator != b"\t" or len(fields) != 3 or fields[2] != b"0":
+            return {}
+        if fields[0] != b"120000":
+            continue
+        tracked_path = path.decode("utf-8", errors="surrogateescape")
+        for root, relative in zip(roots, relatives):
+            relative_path = relative.as_posix()
+            if (
+                not relative.parts
+                or tracked_path == relative_path
+                or tracked_path.startswith(f"{relative_path}/")
+            ):
+                symlinked_roots.add(root)
+
+    result: dict[Path, str] = {}
+    non_root_relatives = tuple(relative for relative in relatives if relative.parts)
+    tree_oids: dict[str, bytes] = {}
+    if non_root_relatives:
+        tree = _run_git(
+            repo,
+            "ls-tree",
+            "-d",
+            "-z",
+            "HEAD",
+            "--",
+            *(relative.as_posix() for relative in non_root_relatives),
+        )
+        if tree.returncode != 0:
+            return {}
+        for record in tree.stdout.split(b"\0"):
+            if not record:
+                continue
+            metadata, separator, path = record.partition(b"\t")
+            fields = metadata.split()
+            if separator != b"\t" or len(fields) != 3 or fields[1] != b"tree":
+                return {}
+            tree_oids[path.decode("utf-8", errors="surrogateescape")] = fields[2]
+
+    repository_tree: bytes | None = None
+    if any(not relative.parts for relative in relatives):
+        tree = _run_git(repo, "rev-parse", "--verify", "HEAD^{tree}")
+        if tree.returncode != 0:
+            return {}
+        repository_tree = tree.stdout.strip()
+
+    for root, relative in zip(roots, relatives):
+        tree_oid = (
+            repository_tree
+            if not relative.parts
+            else tree_oids.get(relative.as_posix())
+        )
+        if (
+            tree_oid is None
+            or len(tree_oid) not in (40, 64)
+            or re.fullmatch(rb"[0-9a-f]+", tree_oid) is None
+        ):
+            return {}
+        if root in symlinked_roots:
+            continue
+        digest = hashlib.sha256()
+        digest.update(b"git-tree-v1\0")
+        digest.update(tree_oid)
+        result[root] = digest.hexdigest()
+    return result
+
+
+def _recursive_include_root_identity(root: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"recursive-content-v2\0")
+
+    def update_path(relative: Path) -> None:
+        encoded = relative.as_posix().encode("utf-8", errors="surrogateescape")
+        digest.update(str(len(encoded)).encode("ascii"))
+        digest.update(b":")
+        digest.update(encoded)
+        digest.update(b"\0")
+
+    def hash_file(path: Path) -> None:
+        with path.open("rb") as header:
+            while chunk := header.read(1024 * 1024):
+                digest.update(chunk)
+        digest.update(b"\0")
+
+    def visit(
+        directory: Path,
+        relative: Path,
+        ancestors: frozenset[Path],
+    ) -> None:
+        resolved_directory = directory.resolve()
+        if resolved_directory in ancestors:
+            digest.update(b"directory-cycle\0")
+            return
+        ancestors = ancestors | {resolved_directory}
+        with os.scandir(directory) as scanned:
+            entries = sorted(scanned, key=lambda entry: os.fsencode(entry.name))
+        for entry in entries:
+            if entry.name in {".git", "__pycache__"}:
+                continue
+            entry_path = Path(entry.path)
+            entry_relative = relative / entry.name
+            update_path(entry_relative)
+            if entry.is_symlink():
+                digest.update(b"symlink\0")
+                target = os.readlink(entry.path)
+                digest.update(
+                    target.encode("utf-8", errors="surrogateescape")
+                    if isinstance(target, str)
+                    else target
+                )
+                digest.update(b"\0")
+                try:
+                    target_path = entry_path.resolve(strict=True)
+                except OSError:
+                    digest.update(b"broken\0")
+                    continue
+                if target_path.is_dir():
+                    digest.update(b"target-directory\0")
+                    visit(target_path, entry_relative, ancestors)
+                elif target_path.is_file():
+                    digest.update(b"target-file\0")
+                    hash_file(target_path)
+                else:
+                    raise HeaderIdentityError(
+                        f"Unsupported special include path: {target_path}"
+                    )
+            elif entry.is_dir(follow_symlinks=False):
+                digest.update(b"directory\0")
+                visit(entry_path, entry_relative, ancestors)
+            elif entry.is_file(follow_symlinks=False):
+                digest.update(b"file\0")
+                hash_file(entry_path)
+            else:
+                raise HeaderIdentityError(
+                    f"Unsupported special include path: {entry_path}"
+                )
+
+    visit(root, Path(), frozenset())
+    return digest.hexdigest()
+
+
+def include_dirs_identity(include_dirs: Iterable[str]) -> IncludeDirsIdentity:
+    started_ns = time.perf_counter_ns()
+    resolved_roots = tuple(
+        Path(include_dir).expanduser().resolve() for include_dir in include_dirs
+    )
+    for root in resolved_roots:
+        if not root.is_dir():
+            raise HeaderIdentityError(
+                f"Provider include path is not a directory: {root}"
+            )
+    if not resolved_roots:
+        digest = hashlib.sha256(b"ordered-include-roots-v2\0none").hexdigest()
+        return IncludeDirsIdentity(
+            roots=(),
+            digest=digest,
+            recursive_walks=0,
+            duration_ns=max(0, time.perf_counter_ns() - started_ns),
+        )
+
+    root_durations_ns = dict.fromkeys(resolved_roots, 0)
+    roots_by_repo: dict[Path, list[Path]] = {}
+    for root in resolved_roots:
+        if (repo := _find_git_root(root)) is not None:
+            roots_by_repo.setdefault(repo, []).append(root)
+    git_identities: dict[Path, str] = {}
+    for repo, roots in roots_by_repo.items():
+        git_started_ns = time.perf_counter_ns()
+        try:
+            identities = _git_include_root_identities(repo, tuple(roots))
+        except OSError:
+            identities = {}
+        git_identities.update(identities)
+        git_duration_ns = max(0, time.perf_counter_ns() - git_started_ns)
+        per_root_duration_ns = git_duration_ns // len(roots)
+        for root in roots:
+            root_durations_ns[root] += per_root_duration_ns
+
+    identities: list[IncludeRootIdentity] = []
+    recursive_walks = 0
+    for root in resolved_roots:
+        method = "git-tree"
+        root_digest = git_identities.get(root)
+        if root_digest is None:
+            method = "recursive-content"
+            recursive_walks += 1
+            recursive_started_ns = time.perf_counter_ns()
+            try:
+                root_digest = _recursive_include_root_identity(root)
+            except OSError as exc:
+                raise HeaderIdentityError(
+                    f"Failed fingerprinting provider include path: {root}"
+                ) from exc
+            root_durations_ns[root] += max(
+                0,
+                time.perf_counter_ns() - recursive_started_ns,
+            )
+        identities.append(
+            IncludeRootIdentity(
+                path=str(root),
+                method=method,
+                digest=root_digest,
+                duration_ns=root_durations_ns[root],
+            )
+        )
+
+    digest = hashlib.sha256()
+    digest.update(b"ordered-include-roots-v2\0")
+    for index, identity in enumerate(identities):
+        digest.update(str(index).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(identity.path.encode("utf-8", errors="surrogateescape"))
+        digest.update(b"\0")
+        digest.update(identity.method.encode("ascii"))
+        digest.update(b"\0")
+        digest.update(identity.digest.encode("ascii"))
+        digest.update(b"\0")
+    return IncludeDirsIdentity(
+        roots=tuple(identities),
+        digest=digest.hexdigest(),
+        recursive_walks=recursive_walks,
+        duration_ns=max(0, time.perf_counter_ns() - started_ns),
+    )
+
+
+__all__ = [
+    "HeaderIdentityError",
+    "IncludeDirsIdentity",
+    "IncludeRootIdentity",
+    "include_dirs_identity",
+]

--- a/python/cuda_coop/cuda/coop/_headers/_toolkit.py
+++ b/python/cuda_coop/cuda/coop/_headers/_toolkit.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Keep process-wide CUDA compiler libraries aligned with resolved headers.
+
+NVRTC must match the selected CUDA headers exactly. nvJitLink consumes the
+NVRTC-produced LTO-IR, so it may be a newer minor release, but it must have the
+same major version and cannot be older than the headers.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import re
+import threading
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+_CUDART_VERSION = re.compile(r"^\s*#\s*define\s+CUDART_VERSION\s+(\d+)", re.MULTILINE)
+_PRELOAD_LOCK = threading.RLock()
+_EXACT_LIBRARY_HANDLES: dict[str, object] = {}
+
+
+@dataclass(frozen=True)
+class ToolkitCompilerLibraries:
+    """Actual process libraries and expected version for one CUDA header set."""
+
+    nvrtc_path: str
+    nvjitlink_path: str
+    toolkit_version: tuple[int, int] | None
+
+
+def _cuda_include_dirs(
+    include_dirs: Iterable[str | os.PathLike[str]],
+) -> tuple[Path, ...]:
+    return tuple(
+        path
+        for raw_path in include_dirs
+        if (path := Path(raw_path).expanduser().resolve())
+        .joinpath("cuda_runtime_api.h")
+        .is_file()
+    )
+
+
+def _toolkit_version(
+    cuda_include_dirs: tuple[Path, ...],
+) -> tuple[int, int] | None:
+    versions: set[tuple[int, int]] = set()
+    for include_dir in cuda_include_dirs:
+        header = include_dir / "cuda_runtime_api.h"
+        try:
+            contents = header.read_text(encoding="utf-8")
+        except UnicodeError as exc:
+            raise RuntimeError(
+                f"failed decoding CUDA Toolkit version header: {header}"
+            ) from exc
+        match = _CUDART_VERSION.search(contents)
+        if match is None:
+            continue
+        encoded = int(match.group(1))
+        versions.add((encoded // 1000, (encoded % 1000) // 10))
+    if len(versions) > 1:
+        rendered = ", ".join(f"{major}.{minor}" for major, minor in sorted(versions))
+        raise RuntimeError(
+            f"resolved CUDA include directories disagree on Toolkit version: {rendered}"
+        )
+    return next(iter(versions), None)
+
+
+def _library_dirs(cuda_include_dirs: tuple[Path, ...]) -> tuple[Path, ...]:
+    result: list[Path] = []
+    for include_dir in cuda_include_dirs:
+        for name in ("lib", "lib64", "bin"):
+            candidate = include_dir.parent / name
+            if candidate.is_dir() and candidate not in result:
+                result.append(candidate)
+    return tuple(result)
+
+
+def _library_names(kind: str, major: int) -> tuple[str, ...]:
+    if os.name == "nt":
+        version = major * 10
+        if kind == "nvrtc":
+            return (f"nvrtc64_{version}_0.dll",)
+        return (f"nvJitLink_{version}_0.dll",)
+    if kind == "nvrtc":
+        return (f"libnvrtc.so.{major}",)
+    return (f"libnvJitLink.so.{major}",)
+
+
+def _preload_exact_library(
+    kind: str,
+    *,
+    major: int,
+    library_dirs: tuple[Path, ...],
+) -> str | None:
+    """Load an exact toolkit candidate while ``_PRELOAD_LOCK`` is held."""
+
+    failures: list[tuple[Path, OSError]] = []
+    for library_dir in library_dirs:
+        for name in _library_names(kind, major):
+            candidate = library_dir / name
+            if not candidate.is_file():
+                continue
+            exact_path = os.path.realpath(candidate)
+            if exact_path in _EXACT_LIBRARY_HANDLES:
+                return exact_path
+            try:
+                handle = ctypes.CDLL(
+                    str(candidate),
+                    mode=getattr(ctypes, "RTLD_GLOBAL", 0),
+                )
+            except OSError as exc:
+                failures.append((candidate, exc))
+                continue
+            _EXACT_LIBRARY_HANDLES[exact_path] = handle
+            return exact_path
+    if failures:
+        rendered = "; ".join(f"{candidate}: {error}" for candidate, error in failures)
+        raise RuntimeError(
+            f"failed loading all resolved CUDA Toolkit {kind} candidates: {rendered}"
+        ) from failures[-1][1]
+    return None
+
+
+def _nvjitlink_version(path: str) -> tuple[int, int]:
+    """Query a loaded nvJitLink while ``_PRELOAD_LOCK`` is held."""
+
+    exact_path = os.path.realpath(path)
+    if exact_path not in _EXACT_LIBRARY_HANDLES:
+        try:
+            handle = ctypes.CDLL(
+                exact_path,
+                mode=getattr(ctypes, "RTLD_GLOBAL", 0),
+            )
+        except OSError as exc:
+            raise RuntimeError(
+                f"unable to load nvJitLink for version validation: {exact_path}"
+            ) from exc
+        _EXACT_LIBRARY_HANDLES[exact_path] = handle
+    handle = _EXACT_LIBRARY_HANDLES[exact_path]
+    try:
+        version = getattr(handle, "nvJitLinkVersion")
+    except AttributeError as exc:
+        raise RuntimeError(
+            f"loaded nvJitLink does not export nvJitLinkVersion: {exact_path}"
+        ) from exc
+    version.argtypes = (
+        ctypes.POINTER(ctypes.c_uint),
+        ctypes.POINTER(ctypes.c_uint),
+    )
+    version.restype = ctypes.c_int
+    major = ctypes.c_uint()
+    minor = ctypes.c_uint()
+    result = version(ctypes.byref(major), ctypes.byref(minor))
+    if result != 0:
+        raise RuntimeError(
+            f"nvJitLinkVersion failed with result {result}: {exact_path}"
+        )
+    return major.value, minor.value
+
+
+def preload_toolkit_compiler_libraries(
+    include_dirs: Iterable[str | os.PathLike[str]],
+) -> ToolkitCompilerLibraries:
+    """Preload and identify NVRTC/nvJitLink for resolved CUDA headers."""
+
+    from cuda.pathfinder import load_nvidia_dynamic_lib
+
+    cuda_include_dirs = _cuda_include_dirs(include_dirs)
+    toolkit_version = _toolkit_version(cuda_include_dirs)
+    library_dirs = _library_dirs(cuda_include_dirs)
+    exact_paths: dict[str, str | None] = {"nvrtc": None, "nvJitLink": None}
+
+    with _PRELOAD_LOCK:
+        if toolkit_version is not None:
+            major = toolkit_version[0]
+            for kind in exact_paths:
+                exact_paths[kind] = _preload_exact_library(
+                    kind,
+                    major=major,
+                    library_dirs=library_dirs,
+                )
+
+        loaded = {
+            kind: load_nvidia_dynamic_lib(kind) for kind in ("nvrtc", "nvJitLink")
+        }
+
+        actual_paths = {
+            kind: os.path.realpath(result.abs_path) for kind, result in loaded.items()
+        }
+        for kind, exact_path in exact_paths.items():
+            if exact_path is not None and actual_paths[kind] != exact_path:
+                raise RuntimeError(
+                    f"resolved CUDA headers expect {exact_path}, but the process uses "
+                    f"{actual_paths[kind]} for {kind}"
+                )
+
+        libraries = ToolkitCompilerLibraries(
+            nvrtc_path=actual_paths["nvrtc"],
+            nvjitlink_path=actual_paths["nvJitLink"],
+            toolkit_version=toolkit_version,
+        )
+        if toolkit_version is not None:
+            validate_nvjitlink_version(
+                libraries,
+                _nvjitlink_version(libraries.nvjitlink_path),
+            )
+        return libraries
+
+
+def validate_nvrtc_version(
+    libraries: ToolkitCompilerLibraries,
+    actual_version: tuple[int, int],
+) -> None:
+    """Require NVRTC to match the selected CUDA headers exactly."""
+
+    expected = libraries.toolkit_version
+    if expected is None or actual_version == expected:
+        return
+    raise RuntimeError(
+        "resolved CUDA headers report Toolkit "
+        f"{expected[0]}.{expected[1]}, but loaded NVRTC "
+        f"{libraries.nvrtc_path} reports {actual_version[0]}.{actual_version[1]}"
+    )
+
+
+def validate_nvjitlink_version(
+    libraries: ToolkitCompilerLibraries,
+    actual_version: tuple[int, int],
+) -> None:
+    """Require nvJitLink to be the same major as the headers and no older."""
+
+    expected = libraries.toolkit_version
+    if expected is None or (
+        actual_version[0] == expected[0] and actual_version[1] >= expected[1]
+    ):
+        return
+    raise RuntimeError(
+        "resolved CUDA headers report Toolkit "
+        f"{expected[0]}.{expected[1]}, but loaded nvJitLink "
+        f"{libraries.nvjitlink_path} reports {actual_version[0]}.{actual_version[1]}; "
+        "nvJitLink must use the same major release and be no older than the headers"
+    )
+
+
+__all__ = [
+    "ToolkitCompilerLibraries",
+    "preload_toolkit_compiler_libraries",
+    "validate_nvjitlink_version",
+    "validate_nvrtc_version",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/__init__.py
+++ b/python/cuda_coop/cuda/coop/cutlass/__init__.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CUTLASS-backed group-first cooperative primitives."""
+
+import importlib as _importlib
+
+from cuda.coop._core.api._dispatch import _register_qualified_backend
+
+from ._compiler import register_trace_context as _register_trace_context
+from ._compiler._runtime import (
+    validate_cutlass_runtime as _validate_cutlass_runtime,
+)
+from ._group_load_store import load, store
+from ._group_reduce import reduce, sum
+from ._group_scan import (
+    exclusive_scan,
+    exclusive_sum,
+    inclusive_scan,
+    inclusive_sum,
+    scan,
+)
+from ._thread_data import (
+    ThreadData,
+    ThreadDataLoadSource,
+    ThreadDataSource,
+    ThreadDataTensorMetadata,
+)
+from ._thread_group import (
+    Hierarchy,
+    ThreadGroup,
+    ThreadHierarchy,
+    this_block,
+    this_cluster,
+    this_grid,
+    this_thread,
+    this_warp,
+)
+
+_validate_cutlass_runtime()
+_register_trace_context()
+
+__all__ = [
+    "Hierarchy",
+    "TempStorage",
+    "ThreadData",
+    "ThreadDataLoadSource",
+    "ThreadDataSource",
+    "ThreadDataTensorMetadata",
+    "ThreadGroup",
+    "ThreadHierarchy",
+    "exclusive_scan",
+    "exclusive_sum",
+    "inclusive_scan",
+    "inclusive_sum",
+    "load",
+    "reduce",
+    "scan",
+    "store",
+    "sum",
+    "this_block",
+    "this_cluster",
+    "this_grid",
+    "this_thread",
+    "this_warp",
+]
+
+
+def __getattr__(name: str):
+    if name == "TempStorage":
+        module = _importlib.import_module(f"{__name__}._temp_storage")
+        value = module.TempStorage
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
+
+_register_qualified_backend(__name__)

--- a/python/cuda_coop/cuda/coop/cutlass/__init__.pyi
+++ b/python/cuda_coop/cuda/coop/cutlass/__init__.pyi
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CUTLASS-qualified cooperative primitives and payload helpers."""
+
+from ._group_load_store import load, store
+from ._group_reduce import reduce, sum
+from ._group_scan import (
+    exclusive_scan,
+    exclusive_sum,
+    inclusive_scan,
+    inclusive_sum,
+    scan,
+)
+from ._temp_storage import TempStorage
+from ._thread_data import (
+    ThreadData,
+    ThreadDataLoadSource,
+    ThreadDataSource,
+    ThreadDataTensorMetadata,
+)
+from ._thread_group import (
+    Hierarchy,
+    ThreadGroup,
+    ThreadHierarchy,
+    this_block,
+    this_cluster,
+    this_grid,
+    this_thread,
+    this_warp,
+)
+
+__all__ = [
+    "Hierarchy",
+    "TempStorage",
+    "ThreadData",
+    "ThreadDataLoadSource",
+    "ThreadDataSource",
+    "ThreadDataTensorMetadata",
+    "ThreadGroup",
+    "ThreadHierarchy",
+    "exclusive_scan",
+    "exclusive_sum",
+    "inclusive_scan",
+    "inclusive_sum",
+    "load",
+    "reduce",
+    "scan",
+    "store",
+    "sum",
+    "this_block",
+    "this_cluster",
+    "this_grid",
+    "this_thread",
+    "this_warp",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/__init__.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CUTLASS compiler activation and provider lifecycle machinery.
+
+Semantic frontends and family lowerers deliberately live outside this package.
+Importing it activates only the lightweight trace-context integration; bundle
+compilation, caching, and final linking remain lazy until a primitive is used.
+"""
+
+from ._activation import register_trace_context, trace_context
+
+__all__ = ["register_trace_context", "trace_context"]

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_activation.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_activation.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Lightweight CUTLASS trace-context activation for qualified imports."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+
+from cuda.coop._core.api._dispatch import _compiler_scope
+
+from ._runtime import (
+    CutlassRuntimeDependencyError,
+    validate_cutlass_runtime,
+)
+
+_BACKEND_MODULE = "cuda.coop.cutlass"
+_DISPATCHER_ATTR = "_cuda_coop_cutlass_trace_context_dispatcher"
+_TARGET_ATTR = "_cuda_coop_cutlass_trace_context_target"
+
+
+@contextmanager
+def trace_context(compiler: object, function_name: str) -> Iterator[None]:
+    """Select CUTLASS while its compiler processes one kernel function."""
+
+    del compiler, function_name
+    with _compiler_scope(_BACKEND_MODULE):
+        yield
+
+
+def _trace_context_dispatcher(
+    compiler: object,
+    function_name: str,
+) -> AbstractContextManager[None]:
+    dsl = validate_cutlass_runtime().dsl_type._get_dsl()
+    target = getattr(dsl, _TARGET_ATTR)
+    return target(compiler, function_name)
+
+
+def register_trace_context() -> None:
+    """Register common-root activation directly with the CUTLASS compiler."""
+
+    runtime = validate_cutlass_runtime()
+    dsl = runtime.dsl_type._get_dsl()
+    register = getattr(dsl, "register_trace_context_factory", None)
+    if not callable(register):
+        raise CutlassRuntimeDependencyError(
+            "backend-runtime-incompatible",
+            "cuda.coop.cutlass requires callable "
+            "register_trace_context_factory() support.",
+            missing_capabilities=(
+                "cutlass.cutlass_dsl.CuTeDSL.register_trace_context_factory",
+            ),
+        )
+    if getattr(dsl, _DISPATCHER_ATTR, None) is None:
+        register(_trace_context_dispatcher)
+        setattr(dsl, _DISPATCHER_ATTR, _trace_context_dispatcher)
+    setattr(dsl, _TARGET_ATTR, trace_context)
+
+
+__all__ = ["register_trace_context", "trace_context"]

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_bundle.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_bundle.py
@@ -1,0 +1,449 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Resolve generated CUTLASS providers through the compiler lifecycle.
+
+This module owns phase telemetry and orchestration across target selection,
+cache, Clang, and NVRTC services. Those services own
+their implementation details and artifact state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import time
+from collections.abc import Callable, Hashable, Iterable
+from pathlib import Path
+
+from cutlass._mlir import ir
+from cutlass.base_dsl.common import DSLRuntimeError
+
+from cuda.coop._headers import HeaderResolutionError, resolve_include_paths
+
+from . import _cache, _clang, _nvrtc
+from ._bundle_contract import (
+    RESOLUTION_ROUTE_CLANG,
+    RESOLUTION_ROUTE_DISK,
+    RESOLUTION_ROUTE_MEMORY,
+    RESOLUTION_ROUTE_NVRTC,
+    BundleCompilation,
+    BundleTelemetry,
+    LayoutProbe,
+    _prepare_layout_probes,
+    bundle_compiler_options,
+    include_dirs_identity,
+    make_bundle_cache_identity,
+    make_bundle_identity,
+)
+from ._target import BUNDLE_FORMAT_ENV
+
+_cache_support = _cache
+_clang_support = _clang
+_nvrtc_support = _nvrtc
+
+DUMP_DIR_ENV = "CUDA_COOP_CUTLASS_PROVIDER_DUMP_DIR"
+CCCL_ROOT_ENV = "CUDA_COOP_CUTLASS_PROVIDER_CCCL_ROOT"
+COMMON_CCCL_ROOT_ENV = "CUDA_COOP_CCCL_ROOT"
+LINK_LIBRARIES_ATTR = "link-libraries"
+
+
+_ROUTE_COUNTS: dict[str, int] = {}
+_PHASE_COUNTS: dict[str, int] = {}
+_PHASE_TIMINGS_NS: dict[str, int] = {}
+_UNKNOWN_COMPILER_PROCESS_NONCE = os.urandom(8).hex()
+
+
+def _unknown_compiler_process_token() -> str:
+    return f"unknown-{os.getpid()}-{_UNKNOWN_COMPILER_PROCESS_NONCE}"
+
+
+def append_link_library_attr(module: ir.Module, path: str) -> None:
+    for op in module.body.operations:
+        if op.name != "gpu.module":
+            continue
+        existing: set[str] = set()
+        if LINK_LIBRARIES_ATTR in op.attributes:
+            existing.update(
+                attr.value
+                for attr in op.attributes[LINK_LIBRARIES_ATTR]
+                if getattr(attr, "value", "")
+            )
+        existing.add(path)
+        op.attributes[LINK_LIBRARIES_ATTR] = ir.ArrayAttr.get(
+            [ir.StringAttr.get(x) for x in sorted(existing)]
+        )
+
+
+def maybe_dump_source(source: str, source_hash: str) -> None:
+    dump_dir = os.environ.get(DUMP_DIR_ENV)
+    if not dump_dir:
+        return
+    dump_dir = os.path.abspath(os.path.expanduser(dump_dir))
+    os.makedirs(dump_dir, exist_ok=True)
+    path = os.path.join(dump_dir, f"cuda_coop_cutlass_bundle_{source_hash}.cpp")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(source)
+
+
+def required_cccl_headers(
+    source: str,
+    *,
+    registered_headers: Callable[[], dict[str, str]],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                relative_path
+                for include, relative_path in registered_headers().items()
+                if include in source
+            }
+        )
+    )
+
+
+def cccl_include_dirs(
+    required_headers: tuple[str, ...],
+    *,
+    scope: str,
+    provider_dir: str,
+) -> list[str]:
+    if not required_headers:
+        return []
+
+    try:
+        paths = resolve_include_paths(
+            start=Path(provider_dir),
+            configured_roots=(
+                os.environ.get(CCCL_ROOT_ENV),
+                os.environ.get(COMMON_CCCL_ROOT_ENV),
+            ),
+            required_headers=required_headers,
+        )
+    except HeaderResolutionError as exc:
+        raise DSLRuntimeError(
+            f"{scope} provider could not resolve its CCCL headers.",
+            cause=exc,
+        ) from exc
+    return [str(path) for path in paths.as_tuple()]
+
+
+def _bundle_compilation(
+    cached: _cache_support._CachedBundle,
+    key_to_expression: dict[Hashable, str],
+) -> BundleCompilation:
+    _cache_support.add_managed_bundle_path(cached.path)
+    return BundleCompilation(
+        path=cached.path,
+        layouts={
+            key: cached.layouts_by_expression[expression]
+            for key, expression in key_to_expression.items()
+        },
+    )
+
+
+def _finish_phase(
+    phase_timings_ns: dict[str, int],
+    phase: str,
+    started_ns: int,
+) -> None:
+    elapsed_ns = max(0, time.perf_counter_ns() - started_ns)
+    phase_timings_ns[phase] = phase_timings_ns.get(phase, 0) + elapsed_ns
+
+
+def _finish_bundle_resolution(
+    *,
+    cached: _cache_support._CachedBundle,
+    route: str,
+    key_to_expression: dict[Hashable, str],
+    phase_timings_ns: dict[str, int],
+    resolution_started_ns: int,
+) -> BundleCompilation:
+    _finish_phase(phase_timings_ns, "total", resolution_started_ns)
+    with _cache_support._STATE_LOCK:
+        _ROUTE_COUNTS[route] = _ROUTE_COUNTS.get(route, 0) + 1
+        for phase, duration_ns in phase_timings_ns.items():
+            _PHASE_COUNTS[phase] = _PHASE_COUNTS.get(phase, 0) + 1
+            _PHASE_TIMINGS_NS[phase] = _PHASE_TIMINGS_NS.get(phase, 0) + duration_ns
+    return _bundle_compilation(cached, key_to_expression)
+
+
+def _compile_bundle_source(
+    source: str,
+    *,
+    layout_probes: Iterable[LayoutProbe],
+    scope: str,
+    provider_dir: str,
+    registered_headers: Callable[[], dict[str, str]],
+    select_bundle_format: Callable[[], str],
+    resolve_nvrtc_sm_arch: Callable[[], str],
+    resolve_nvrtc_arch: Callable[[], str],
+    which: Callable[[str], str | None] = shutil.which,
+) -> BundleCompilation:
+    resolution_started_ns = time.perf_counter_ns()
+    phase_timings_ns: dict[str, int] = {}
+    phase_started_ns = time.perf_counter_ns()
+    prepared_probes = _prepare_layout_probes(source, layout_probes)
+    source = prepared_probes.source
+    source_hash = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    _finish_phase(phase_timings_ns, "prepare", phase_started_ns)
+
+    phase_started_ns = time.perf_counter_ns()
+    bundle_format = select_bundle_format()
+    if prepared_probes.expressions and bundle_format != "ltoir":
+        raise DSLRuntimeError(
+            f"{scope} provider layout metadata requires an NVRTC LTO-IR bundle; "
+            f"set {BUNDLE_FORMAT_ENV}=ltoir."
+        )
+    bundle_sm_arch = resolve_nvrtc_sm_arch()
+    if bundle_format == "bc":
+        bundle_arch = "nvptx64"
+    else:
+        bundle_arch = resolve_nvrtc_arch()
+    _finish_phase(phase_timings_ns, "target", phase_started_ns)
+
+    compiler_options = bundle_compiler_options(
+        bundle_format,
+        bundle_arch,
+        bundle_sm_arch=bundle_sm_arch,
+    )
+    identity = make_bundle_identity(
+        source_hash=source_hash,
+        bundle_format=bundle_format,
+        bundle_arch=bundle_arch,
+        bundle_sm_arch=bundle_sm_arch,
+        compiler_options=compiler_options,
+        layout_expressions=prepared_probes.expressions,
+    )
+    phase_started_ns = time.perf_counter_ns()
+    include_dirs = cccl_include_dirs(
+        required_cccl_headers(source, registered_headers=registered_headers),
+        scope=scope,
+        provider_dir=provider_dir,
+    )
+    _finish_phase(phase_timings_ns, "header_resolution", phase_started_ns)
+    if bundle_format == "ltoir":
+        _nvrtc_support.preload_toolkit_nvrtc(include_dirs)
+
+    phase_started_ns = time.perf_counter_ns()
+    include_identity = include_dirs_identity(include_dirs)
+    include_key = include_identity.digest
+    _finish_phase(phase_timings_ns, "header_fingerprint", phase_started_ns)
+    for root_identity in include_identity.roots:
+        phase = f"header_identity_{root_identity.method.replace('-', '_')}"
+        phase_timings_ns[phase] = (
+            phase_timings_ns.get(phase, 0) + root_identity.duration_ns
+        )
+    clangxx: str | None = None
+    clang_version: str | None = None
+    if bundle_format == "ltoir":
+        nvrtc_version_tuple = _nvrtc_support.get_version_tuple()
+        nvrtc_version = (
+            None
+            if nvrtc_version_tuple is None
+            else f"{nvrtc_version_tuple[0]}.{nvrtc_version_tuple[1]}"
+        )
+        cache_compiler_version = (
+            nvrtc_version
+            if nvrtc_version is not None
+            else _unknown_compiler_process_token()
+        )
+    else:
+        nvrtc_version = None
+        clangxx, clang_version, cache_compiler_version = (
+            _clang_support.resolve_clang_compiler(which)
+        )
+    cache_identity = make_bundle_cache_identity(
+        identity,
+        include_key=include_key,
+        producer_compiler_version=cache_compiler_version,
+    )
+
+    # Source inspection is independent of JIT compilation. Keep the dump useful
+    # even when this process or a previous process already populated the cache.
+    phase_started_ns = time.perf_counter_ns()
+    maybe_dump_source(source, source_hash)
+    _finish_phase(phase_timings_ns, "source_dump", phase_started_ns)
+
+    phase_started_ns = time.perf_counter_ns()
+    cached = _cache_support.memory_cached_bundle(cache_identity.cache_key)
+    memory_hit = cached is not None
+    _finish_phase(phase_timings_ns, "memory_cache", phase_started_ns)
+    if memory_hit:
+        assert cached is not None
+        return _finish_bundle_resolution(
+            cached=cached,
+            route=RESOLUTION_ROUTE_MEMORY,
+            key_to_expression=prepared_probes.key_to_expression,
+            phase_timings_ns=phase_timings_ns,
+            resolution_started_ns=resolution_started_ns,
+        )
+
+    phase_started_ns = time.perf_counter_ns()
+    cache_dir = _cache_support.ensure_cache_dir(scope)
+    output_path = os.path.join(
+        cache_dir,
+        f"{cache_identity.artifact_stem}.{bundle_format}",
+    )
+    lock_started_ns = time.perf_counter_ns()
+    with _cache_support.artifact_lock(output_path, scope=scope):
+        _finish_phase(phase_timings_ns, "artifact_lock", lock_started_ns)
+
+        # A thread or process may have populated the artifact while this caller
+        # waited for the per-artifact lock.
+        phase_started_ns = time.perf_counter_ns()
+        cached = _cache_support.memory_cached_bundle(cache_identity.cache_key)
+        memory_hit = cached is not None
+        _finish_phase(phase_timings_ns, "memory_cache_after_lock", phase_started_ns)
+        if memory_hit:
+            assert cached is not None
+            return _finish_bundle_resolution(
+                cached=cached,
+                route=RESOLUTION_ROUTE_MEMORY,
+                key_to_expression=prepared_probes.key_to_expression,
+                phase_timings_ns=phase_timings_ns,
+                resolution_started_ns=resolution_started_ns,
+            )
+
+        phase_started_ns = time.perf_counter_ns()
+        cached = None
+        if os.path.exists(output_path):
+            cached = _cache_support._load_bundle_metadata(
+                output_path,
+                prepared_probes.expressions,
+                cache_identity,
+            )
+        _finish_phase(phase_timings_ns, "disk_cache", phase_started_ns)
+        if cached is not None:
+            _cache_support.store_memory_bundle(cache_identity.cache_key, cached)
+            return _finish_bundle_resolution(
+                cached=cached,
+                route=RESOLUTION_ROUTE_DISK,
+                key_to_expression=prepared_probes.key_to_expression,
+                phase_timings_ns=phase_timings_ns,
+                resolution_started_ns=resolution_started_ns,
+            )
+
+        phase_started_ns = time.perf_counter_ns()
+        if bundle_format == "bc":
+            cached = _clang_support.compile_bundle(
+                source,
+                output_path=output_path,
+                cache_dir=cache_dir,
+                cache_identity=cache_identity,
+                compiler_options=compiler_options,
+                include_dirs=include_dirs,
+                scope=scope,
+                clangxx=clangxx,
+                clang_version=clang_version,
+            )
+            route = RESOLUTION_ROUTE_CLANG
+        else:
+            cached = _nvrtc_support.compile_bundle(
+                source,
+                output_path=output_path,
+                cache_identity=cache_identity,
+                compiler_options=compiler_options,
+                include_dirs=include_dirs,
+                prepared_probes=prepared_probes,
+                nvrtc_version=nvrtc_version,
+                scope=scope,
+            )
+            route = RESOLUTION_ROUTE_NVRTC
+        _cache_support.store_memory_bundle(cache_identity.cache_key, cached)
+        _cache_support.record_compilation()
+    _finish_phase(phase_timings_ns, "compiler", phase_started_ns)
+    return _finish_bundle_resolution(
+        cached=cached,
+        route=route,
+        key_to_expression=prepared_probes.key_to_expression,
+        phase_timings_ns=phase_timings_ns,
+        resolution_started_ns=resolution_started_ns,
+    )
+
+
+def compile_bundle_source(
+    source: str,
+    *,
+    scope: str,
+    provider_dir: str,
+    registered_headers: Callable[[], dict[str, str]],
+    select_bundle_format: Callable[[], str],
+    resolve_nvrtc_sm_arch: Callable[[], str],
+    resolve_nvrtc_arch: Callable[[], str],
+    which: Callable[[str], str | None] = shutil.which,
+) -> str:
+    """Compile a provider bundle and return its linkable artifact path."""
+
+    return _compile_bundle_source(
+        source,
+        layout_probes=(),
+        scope=scope,
+        provider_dir=provider_dir,
+        registered_headers=registered_headers,
+        select_bundle_format=select_bundle_format,
+        resolve_nvrtc_sm_arch=resolve_nvrtc_sm_arch,
+        resolve_nvrtc_arch=resolve_nvrtc_arch,
+        which=which,
+    ).path
+
+
+def compile_bundle_source_with_layouts(
+    source: str,
+    *,
+    layout_probes: Iterable[LayoutProbe],
+    scope: str,
+    provider_dir: str,
+    registered_headers: Callable[[], dict[str, str]],
+    select_bundle_format: Callable[[], str],
+    resolve_nvrtc_sm_arch: Callable[[], str],
+    resolve_nvrtc_arch: Callable[[], str],
+    which: Callable[[str], str | None] = shutil.which,
+) -> BundleCompilation:
+    """Compile one LTO-IR bundle and recover exact layouts from that program."""
+
+    return _compile_bundle_source(
+        source,
+        layout_probes=layout_probes,
+        scope=scope,
+        provider_dir=provider_dir,
+        registered_headers=registered_headers,
+        select_bundle_format=select_bundle_format,
+        resolve_nvrtc_sm_arch=resolve_nvrtc_sm_arch,
+        resolve_nvrtc_arch=resolve_nvrtc_arch,
+        which=which,
+    )
+
+
+def reset_compile_state() -> None:
+    """Reset orchestration, cache, and NVRTC counters together."""
+
+    with _cache_support._STATE_LOCK:
+        _cache_support.reset_compile_state()
+        _nvrtc_support.reset_compile_state()
+        _ROUTE_COUNTS.clear()
+        _PHASE_COUNTS.clear()
+        _PHASE_TIMINGS_NS.clear()
+
+
+def get_compile_counter() -> int:
+    return _cache_support.get_compile_counter()
+
+
+def get_nvrtc_compile_program_counter() -> int:
+    return _nvrtc_support.get_compile_program_counter()
+
+
+def managed_bundle_paths() -> frozenset[str]:
+    return _cache_support.managed_bundle_paths()
+
+
+def get_bundle_telemetry() -> BundleTelemetry:
+    with _cache_support._STATE_LOCK:
+        return BundleTelemetry(
+            route_counts=dict(_ROUTE_COUNTS),
+            phase_counts=dict(_PHASE_COUNTS),
+            phase_timings_ns=dict(_PHASE_TIMINGS_NS),
+        )

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_bundle_contract.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_bundle_contract.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+"""Stable bundle identities, schemas, and layout contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from collections.abc import Hashable, Iterable, Mapping
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from cutlass.base_dsl.common import DSLRuntimeError
+
+from cuda.coop._headers._identity import (
+    HeaderIdentityError,
+    IncludeDirsIdentity,
+    include_dirs_identity,
+)
+
+_resolve_include_dirs_identity = include_dirs_identity
+
+if os.name == "nt":
+    pass
+else:
+    pass
+
+NVVM_VERSION_OPT = b"-nvvm-version=nvvm-latest"
+
+BUNDLE_CACHE_SCHEMA_VERSION = 3
+
+PROVIDER_BUNDLE_ABI_VERSION = 1
+
+BUNDLE_METADATA_VERSION = 2
+
+LAYOUT_METADATA_VERSION = BUNDLE_METADATA_VERSION
+
+RESOLUTION_ROUTE_MEMORY = "memory"
+
+RESOLUTION_ROUTE_DISK = "disk"
+
+RESOLUTION_ROUTE_CLANG = "clang"
+
+RESOLUTION_ROUTE_NVRTC = "nvrtc"
+
+
+@dataclass(frozen=True)
+class LayoutProbe:
+    """C++ constant expressions whose values describe one storage layout."""
+
+    key: Hashable
+    size_expression: str
+    alignment_expression: str
+
+
+@dataclass(frozen=True)
+class StorageLayout:
+    size_in_bytes: int
+    alignment: int
+
+
+@dataclass(frozen=True)
+class BundleCompilation:
+    path: str
+    layouts: dict[Hashable, StorageLayout]
+
+
+@dataclass(frozen=True)
+class BundleIdentity:
+    """Portable identity for one provider source and compilation contract."""
+
+    provider_abi_version: int
+    source_hash: str
+    bundle_format: str
+    bundle_arch: str
+    bundle_sm_arch: str
+    compiler_options: tuple[str, ...]
+    layout_expressions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BundleCacheIdentity:
+    """Mutable-header identity used only by the existing JIT cache."""
+
+    schema_version: int
+    bundle: BundleIdentity
+    include_key: str
+    producer_compiler_version: str
+
+    @property
+    def contract_digest(self) -> str:
+        payload = {
+            "bundle": asdict(self.bundle),
+            "include_key": self.include_key,
+            "producer_compiler_version": self.producer_compiler_version,
+            "schema_version": self.schema_version,
+        }
+        return hashlib.sha256(
+            json.dumps(
+                payload,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+
+    @property
+    def cache_key(self) -> str:
+        return f"v{self.schema_version}:{self.contract_digest}"
+
+    @property
+    def artifact_stem(self) -> str:
+        return f"bundle_v{self.schema_version}_{self.contract_digest}"
+
+
+@dataclass(frozen=True)
+class BundleTelemetry:
+    """Internal snapshot of provider resolution counts and phase timings."""
+
+    route_counts: Mapping[str, int]
+    phase_counts: Mapping[str, int]
+    phase_timings_ns: Mapping[str, int]
+
+
+@dataclass(frozen=True)
+class _PreparedLayoutProbes:
+    source: str
+    expressions: tuple[str, ...]
+    key_to_expression: dict[Hashable, str]
+    symbol: str
+
+
+def include_dirs_identity(include_dirs: list[str]) -> IncludeDirsIdentity:
+    try:
+        return _resolve_include_dirs_identity(include_dirs)
+    except HeaderIdentityError as exc:
+        raise DSLRuntimeError(
+            "Failed fingerprinting provider include paths.",
+            cause=exc,
+        ) from exc
+
+
+def include_dirs_cache_key(include_dirs: list[str]) -> str:
+    return include_dirs_identity(include_dirs).digest
+
+
+def bundle_compiler_options(
+    bundle_format: str,
+    bundle_arch: str,
+    *,
+    bundle_sm_arch: str | None = None,
+) -> tuple[str, ...]:
+    if bundle_format == "bc":
+        if not bundle_sm_arch:
+            raise ValueError("LLVM bitcode compilation requires an SM architecture")
+        return (
+            "--target=nvptx64-nvidia-cuda",
+            f"-march={bundle_sm_arch}",
+            "-std=c++17",
+            "-O3",
+            "-emit-llvm",
+            "-c",
+        )
+    return (
+        "--std=c++17",
+        "--relocatable-device-code=true",
+        "-default-device",
+        NVVM_VERSION_OPT.decode("ascii"),
+        f"--gpu-architecture={bundle_arch}",
+        "-dlto",
+    )
+
+
+def make_bundle_identity(
+    *,
+    source_hash: str,
+    bundle_format: str,
+    bundle_arch: str,
+    bundle_sm_arch: str,
+    compiler_options: tuple[str, ...],
+    layout_expressions: tuple[str, ...],
+) -> BundleIdentity:
+    return BundleIdentity(
+        provider_abi_version=PROVIDER_BUNDLE_ABI_VERSION,
+        source_hash=source_hash,
+        bundle_format=bundle_format,
+        bundle_arch=bundle_arch,
+        bundle_sm_arch=bundle_sm_arch,
+        compiler_options=compiler_options,
+        layout_expressions=layout_expressions,
+    )
+
+
+def make_bundle_cache_identity(
+    bundle: BundleIdentity,
+    *,
+    include_key: str,
+    producer_compiler_version: str,
+) -> BundleCacheIdentity:
+    return BundleCacheIdentity(
+        schema_version=BUNDLE_CACHE_SCHEMA_VERSION,
+        bundle=bundle,
+        include_key=include_key,
+        producer_compiler_version=producer_compiler_version,
+    )
+
+
+def _prepare_layout_probes(
+    source: str,
+    layout_probes: Iterable[LayoutProbe],
+) -> _PreparedLayoutProbes:
+    probes_by_key: dict[Hashable, tuple[str, str]] = {}
+    for probe in layout_probes:
+        if not isinstance(probe, LayoutProbe):
+            raise TypeError("layout_probes must contain LayoutProbe values")
+        try:
+            hash(probe.key)
+        except TypeError as exc:
+            raise TypeError("layout probe keys must be hashable") from exc
+        size_expression = probe.size_expression.strip()
+        alignment_expression = probe.alignment_expression.strip()
+        if not size_expression or not alignment_expression:
+            raise ValueError("layout probe expressions must be non-empty")
+        expressions = (size_expression, alignment_expression)
+        existing = probes_by_key.get(probe.key)
+        if existing is not None and existing != expressions:
+            raise ValueError(f"conflicting layout probes for key {probe.key!r}")
+        probes_by_key[probe.key] = expressions
+
+    if not probes_by_key:
+        return _PreparedLayoutProbes(
+            source=source,
+            expressions=(),
+            key_to_expression={},
+            symbol="",
+        )
+
+    unique_probes = sorted(set(probes_by_key.values()))
+    probe_digest = hashlib.sha256(
+        json.dumps(
+            {
+                "version": LAYOUT_METADATA_VERSION,
+                "probes": unique_probes,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    symbol = f"cuda_coop_layout_probe_{probe_digest}"
+    source = (
+        f"{source.rstrip()}\n\n"
+        "template <unsigned long long Size, unsigned long long Alignment>\n"
+        f"__device__ unsigned char {symbol} = 0;\n"
+    )
+    expression_by_probe = {
+        probe: f"&{symbol}<({probe[0]}), ({probe[1]})>" for probe in unique_probes
+    }
+    key_to_expression = {
+        key: expression_by_probe[probe] for key, probe in probes_by_key.items()
+    }
+    return _PreparedLayoutProbes(
+        source=source,
+        expressions=tuple(sorted(expression_by_probe.values())),
+        key_to_expression=key_to_expression,
+        symbol=symbol,
+    )
+
+
+def _validate_storage_layout(
+    size_in_bytes: Any,
+    alignment: Any,
+    *,
+    description: str,
+) -> StorageLayout:
+    if (
+        not isinstance(size_in_bytes, int)
+        or isinstance(size_in_bytes, bool)
+        or not isinstance(alignment, int)
+        or isinstance(alignment, bool)
+        or size_in_bytes <= 0
+        or alignment <= 0
+        or alignment & (alignment - 1)
+        or size_in_bytes % alignment != 0
+    ):
+        raise ValueError(
+            f"Invalid storage layout for {description}: "
+            f"size={size_in_bytes!r}, alignment={alignment!r}."
+        )
+    return StorageLayout(size_in_bytes=size_in_bytes, alignment=alignment)
+
+
+def _decode_layout_probe_name(
+    lowered_name: bytes | str,
+    *,
+    symbol: str,
+    expression: str,
+) -> StorageLayout:
+    if isinstance(lowered_name, bytes):
+        lowered_name = lowered_name.decode("utf-8", errors="strict")
+    lowered_name = lowered_name.rstrip("\0")
+    match = re.fullmatch(
+        rf"_Z{len(symbol)}{re.escape(symbol)}ILy([0-9]+)ELy([0-9]+)EE",
+        lowered_name,
+    )
+    if match is None:
+        raise ValueError(
+            "NVRTC returned an unexpected lowered layout-probe name for "
+            f"{expression!r}: {lowered_name!r}."
+        )
+    return _validate_storage_layout(
+        int(match.group(1)),
+        int(match.group(2)),
+        description=expression,
+    )

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_cache.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_cache.py
@@ -1,0 +1,413 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+"""Provider artifact cache paths, atomic I/O, and metadata validation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+import tempfile
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+from cutlass.base_dsl.common import DSLRuntimeError
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
+
+from ._bundle_contract import (
+    BUNDLE_METADATA_VERSION,
+    BundleCacheIdentity,
+    StorageLayout,
+    _validate_storage_layout,
+)
+
+CACHE_DIR_ENV = "CUDA_COOP_CUTLASS_PROVIDER_CACHE_DIR"
+
+_SOURCE_CACHE: dict[str, _CachedBundle] = {}
+_MANAGED_BUNDLE_PATHS: set[str] = set()
+_COMPILE_COUNTER = 0
+_STATE_LOCK = threading.RLock()
+_ARTIFACT_LOCKS: dict[str, threading.RLock] = {}
+_ACTIVE_ARTIFACT_LOCK_FDS: set[int] = set()
+
+
+@dataclass(frozen=True)
+class _CachedBundle:
+    path: str
+    layouts_by_expression: dict[str, StorageLayout]
+    producer_compiler: str | None = None
+    producer_compiler_version: str | None = None
+    producer_toolkit_version: str | None = None
+    artifact_size: int | None = None
+    artifact_sha256: str | None = None
+
+
+def _acquire_state_lock_before_fork() -> None:
+    _STATE_LOCK.acquire()
+
+
+def _release_state_lock_after_fork() -> None:
+    _STATE_LOCK.release()
+
+
+def _reset_locks_after_fork() -> None:
+    global _ACTIVE_ARTIFACT_LOCK_FDS, _ARTIFACT_LOCKS, _STATE_LOCK
+    for descriptor in _ACTIVE_ARTIFACT_LOCK_FDS:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+    _ACTIVE_ARTIFACT_LOCK_FDS = set()
+    _STATE_LOCK = threading.RLock()
+    _ARTIFACT_LOCKS = {}
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(
+        before=_acquire_state_lock_before_fork,
+        after_in_parent=_release_state_lock_after_fork,
+        after_in_child=_reset_locks_after_fork,
+    )
+
+
+def _local_artifact_lock(path: str) -> threading.RLock:
+    real_path = os.path.realpath(path)
+    with _STATE_LOCK:
+        return _ARTIFACT_LOCKS.setdefault(real_path, threading.RLock())
+
+
+def _close_artifact_lock_descriptor(descriptor: int) -> None:
+    with _STATE_LOCK:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        finally:
+            _ACTIVE_ARTIFACT_LOCK_FDS.discard(descriptor)
+
+
+@contextmanager
+def artifact_lock(path: str, *, scope: str):
+    """Serialize one cache artifact across threads and processes."""
+
+    lock_path = f"{path}.lock"
+    local_lock = _local_artifact_lock(path)
+    with local_lock:
+        flags = os.O_CREAT | os.O_RDWR
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor_owner_pid = os.getpid()
+        descriptor: int | None = None
+        try:
+            with _STATE_LOCK:
+                descriptor = os.open(lock_path, flags, 0o600)
+                _ACTIVE_ARTIFACT_LOCK_FDS.add(descriptor)
+            lock_stat = os.fstat(descriptor)
+            if not stat.S_ISREG(lock_stat.st_mode):
+                raise OSError("provider artifact lock is not a regular file")
+            getuid = getattr(os, "getuid", None)
+            if getuid is not None and lock_stat.st_uid != getuid():
+                raise OSError("provider artifact lock is not owned by this user")
+            if os.name == "nt":
+                if lock_stat.st_size == 0:
+                    os.write(descriptor, b"\0")
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+            else:
+                fcntl.flock(descriptor, fcntl.LOCK_EX)
+        except OSError as exc:
+            if descriptor is not None and os.getpid() == descriptor_owner_pid:
+                _close_artifact_lock_descriptor(descriptor)
+            raise DSLRuntimeError(
+                f"Failed locking {scope} provider cache artifact.",
+                cause=exc,
+            ) from exc
+        assert descriptor is not None
+        try:
+            yield
+        finally:
+            if os.getpid() == descriptor_owner_pid:
+                try:
+                    if os.name == "nt":
+                        os.lseek(descriptor, 0, os.SEEK_SET)
+                        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+                    else:
+                        fcntl.flock(descriptor, fcntl.LOCK_UN)
+                except OSError:
+                    pass
+                _close_artifact_lock_descriptor(descriptor)
+
+
+def memory_cached_bundle(cache_key: str) -> _CachedBundle | None:
+    with _STATE_LOCK:
+        cached = _SOURCE_CACHE.get(cache_key)
+    if cached is None:
+        return None
+    if _cached_artifact_is_valid(cached):
+        return cached
+    with _STATE_LOCK:
+        if _SOURCE_CACHE.get(cache_key) is cached:
+            _SOURCE_CACHE.pop(cache_key, None)
+    return None
+
+
+def store_memory_bundle(cache_key: str, cached: _CachedBundle) -> None:
+    with _STATE_LOCK:
+        _SOURCE_CACHE[cache_key] = cached
+
+
+def record_compilation() -> None:
+    global _COMPILE_COUNTER
+    with _STATE_LOCK:
+        _COMPILE_COUNTER += 1
+
+
+def reset_compile_state() -> None:
+    global _COMPILE_COUNTER
+    with _STATE_LOCK:
+        _COMPILE_COUNTER = 0
+        _SOURCE_CACHE.clear()
+
+
+def get_compile_counter() -> int:
+    with _STATE_LOCK:
+        return _COMPILE_COUNTER
+
+
+def add_managed_bundle_path(path: str) -> None:
+    with _STATE_LOCK:
+        _MANAGED_BUNDLE_PATHS.add(os.path.realpath(path))
+
+
+def managed_bundle_paths() -> frozenset[str]:
+    with _STATE_LOCK:
+        return frozenset(_MANAGED_BUNDLE_PATHS)
+
+
+def _cache_dir_name() -> str:
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:
+        return "cuda_coop_cutlass_provider"
+    return f"cuda_coop_cutlass_provider_{getuid()}"
+
+
+_CACHE_DIR = os.path.join(tempfile.gettempdir(), _cache_dir_name())
+
+
+def configured_cache_dir() -> str:
+    cache_dir = os.environ.get(CACHE_DIR_ENV)
+    if cache_dir:
+        return os.path.abspath(os.path.expanduser(cache_dir))
+    return _CACHE_DIR
+
+
+def ensure_cache_dir(scope: str) -> str:
+    cache_dir = configured_cache_dir()
+    try:
+        os.makedirs(cache_dir, mode=0o700, exist_ok=True)
+        cache_stat = os.lstat(cache_dir)
+        if stat.S_ISLNK(cache_stat.st_mode) or not stat.S_ISDIR(cache_stat.st_mode):
+            raise DSLRuntimeError(
+                f"{scope} provider cache path is not a real directory."
+            )
+        getuid = getattr(os, "getuid", None)
+        if getuid is not None and cache_stat.st_uid != getuid():
+            raise DSLRuntimeError(
+                f"{scope} provider cache directory is not owned by this user."
+            )
+        if stat.S_IMODE(cache_stat.st_mode) != 0o700:
+            os.chmod(cache_dir, 0o700)
+    except OSError as exc:
+        raise DSLRuntimeError(
+            f"Failed preparing {scope} provider cache directory.",
+            cause=exc,
+        ) from exc
+    return cache_dir
+
+
+def write_binary_atomic(path: str, blob: bytes | bytearray, *, scope: str) -> None:
+    cache_dir = ensure_cache_dir(scope)
+    temp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=cache_dir,
+            prefix=".bundle-",
+            delete=False,
+        ) as f:
+            temp_path = f.name
+            f.write(blob)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(temp_path, path)
+    except OSError as exc:
+        if temp_path:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+        raise DSLRuntimeError(
+            f"Failed writing {scope} provider cache artifact.",
+            cause=exc,
+        ) from exc
+
+
+def write_text_atomic(path: str, text: str, *, scope: str) -> None:
+    write_binary_atomic(path, text.encode("utf-8"), scope=scope)
+
+
+def _layout_metadata_path(output_path: str) -> str:
+    return f"{output_path}.layouts.json"
+
+
+def _optional_metadata_string(value: Any) -> str | None:
+    if value is None or isinstance(value, str):
+        return value
+    raise ValueError("invalid provider producer metadata")
+
+
+def _cached_artifact_is_valid(cached: _CachedBundle) -> bool:
+    if (
+        cached.artifact_size is None
+        or cached.artifact_size <= 0
+        or cached.artifact_sha256 is None
+    ):
+        return False
+    try:
+        output_stat = os.lstat(cached.path)
+        if (
+            not stat.S_ISREG(output_stat.st_mode)
+            or output_stat.st_size != cached.artifact_size
+        ):
+            return False
+        artifact_digest = hashlib.sha256()
+        with open(cached.path, "rb") as artifact_file:
+            while chunk := artifact_file.read(1024 * 1024):
+                artifact_digest.update(chunk)
+    except OSError:
+        return False
+    return artifact_digest.hexdigest() == cached.artifact_sha256
+
+
+def _load_bundle_metadata(
+    output_path: str,
+    expressions: tuple[str, ...],
+    cache_identity: BundleCacheIdentity,
+) -> _CachedBundle | None:
+    metadata_path = _layout_metadata_path(output_path)
+    try:
+        metadata_stat = os.lstat(metadata_path)
+        if not stat.S_ISREG(metadata_stat.st_mode):
+            return None
+        with open(metadata_path, encoding="utf-8") as metadata_file:
+            payload = json.load(metadata_file)
+        if (
+            not isinstance(payload, dict)
+            or payload.get("version") != BUNDLE_METADATA_VERSION
+            or payload.get("cache_key") != cache_identity.cache_key
+        ):
+            return None
+
+        artifact = payload.get("artifact")
+        if not isinstance(artifact, dict):
+            return None
+        artifact_size = artifact.get("size")
+        artifact_sha256 = artifact.get("sha256")
+        if (
+            not isinstance(artifact_size, int)
+            or isinstance(artifact_size, bool)
+            or artifact_size <= 0
+            or not isinstance(artifact_sha256, str)
+            or re.fullmatch(r"[0-9a-f]{64}", artifact_sha256) is None
+        ):
+            return None
+        output_stat = os.lstat(output_path)
+        if (
+            not stat.S_ISREG(output_stat.st_mode)
+            or output_stat.st_size != artifact_size
+        ):
+            return None
+        artifact_digest = hashlib.sha256()
+        with open(output_path, "rb") as artifact_file:
+            while chunk := artifact_file.read(1024 * 1024):
+                artifact_digest.update(chunk)
+        if artifact_digest.hexdigest() != artifact_sha256:
+            return None
+
+        serialized_layouts = payload.get("layouts")
+        if not isinstance(serialized_layouts, dict) or set(serialized_layouts) != set(
+            expressions
+        ):
+            return None
+        layouts = {}
+        for expression in expressions:
+            serialized_layout = serialized_layouts[expression]
+            if not isinstance(serialized_layout, list) or len(serialized_layout) != 2:
+                return None
+            layouts[expression] = _validate_storage_layout(
+                serialized_layout[0],
+                serialized_layout[1],
+                description=expression,
+            )
+
+        producer = payload.get("producer")
+        if not isinstance(producer, dict):
+            return None
+        return _CachedBundle(
+            path=output_path,
+            layouts_by_expression=layouts,
+            producer_compiler=_optional_metadata_string(producer.get("compiler")),
+            producer_compiler_version=_optional_metadata_string(
+                producer.get("compiler_version")
+            ),
+            producer_toolkit_version=_optional_metadata_string(
+                producer.get("toolkit_version")
+            ),
+            artifact_size=artifact_size,
+            artifact_sha256=artifact_sha256,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def _write_bundle_metadata(
+    output_path: str,
+    artifact_blob: bytes | bytearray,
+    cached: _CachedBundle,
+    cache_identity: BundleCacheIdentity,
+    *,
+    scope: str,
+) -> None:
+    payload = {
+        "version": BUNDLE_METADATA_VERSION,
+        "cache_key": cache_identity.cache_key,
+        "artifact": {
+            "size": len(artifact_blob),
+            "sha256": hashlib.sha256(artifact_blob).hexdigest(),
+        },
+        "producer": {
+            "compiler": cached.producer_compiler,
+            "compiler_version": cached.producer_compiler_version,
+            "toolkit_version": cached.producer_toolkit_version,
+        },
+        "layouts": {
+            expression: [layout.size_in_bytes, layout.alignment]
+            for expression, layout in cached.layouts_by_expression.items()
+        },
+    }
+    write_text_atomic(
+        _layout_metadata_path(output_path),
+        json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n",
+        scope=scope,
+    )

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_call_context.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_call_context.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Transactional per-call state shared by CUTLASS family lowerers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+
+from .._temp_storage import TempStorageBase
+from .._thread_data import ThreadData
+
+
+@dataclass(frozen=True)
+class SinglePhaseContext:
+    thread_data: ThreadData | None
+    temp_storage: TempStorageBase | None
+
+
+_ACTIVE_SINGLE_PHASE_CONTEXT: ContextVar[SinglePhaseContext | None] = ContextVar(
+    "cuda_coop_cutlass_active_single_phase_context",
+    default=None,
+)
+
+
+@contextmanager
+def activate_single_phase_context(context: SinglePhaseContext):
+    token = _ACTIVE_SINGLE_PHASE_CONTEXT.set(context)
+    try:
+        yield
+    finally:
+        _ACTIVE_SINGLE_PHASE_CONTEXT.reset(token)
+
+
+def get_active_single_phase_context() -> SinglePhaseContext | None:
+    return _ACTIVE_SINGLE_PHASE_CONTEXT.get()
+
+
+@contextmanager
+def single_phase_transaction(
+    single_phase_context: SinglePhaseContext,
+    *,
+    snapshot_provider_session: Callable[[], Any],
+    restore_provider_session: Callable[[Any], None],
+) -> Iterator[None]:
+    """Roll back scratch planning and provider registration on failure."""
+
+    temp_storage = single_phase_context.temp_storage
+    temp_storage_snapshot = (
+        temp_storage._snapshot_uses() if temp_storage is not None else None
+    )
+    provider_session_snapshot = snapshot_provider_session()
+    try:
+        yield
+    except Exception:
+        if temp_storage is not None and temp_storage_snapshot is not None:
+            temp_storage._restore_uses(temp_storage_snapshot)
+        restore_provider_session(provider_session_snapshot)
+        raise

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_clang.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_clang.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+"""Host Clang discovery for the optional LLVM-bitcode route."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import tempfile
+from collections.abc import Callable
+
+from cutlass.base_dsl.common import DSLRuntimeError
+
+from ._bundle_contract import BundleCacheIdentity
+from ._cache import (
+    _CachedBundle,
+    _write_bundle_metadata,
+    write_binary_atomic,
+    write_text_atomic,
+)
+
+CLANGXX_ENV = "CUDA_COOP_CUTLASS_PROVIDER_CLANGXX"
+
+CLANGXX_TIMEOUT_SECONDS = 60
+
+
+def resolve_clang_compiler(
+    which: Callable[[str], str | None],
+) -> tuple[str | None, str | None, str]:
+    configured = os.environ.get(CLANGXX_ENV)
+    clangxx = which(configured) if configured else which("clang++")
+    if not clangxx:
+        return None, None, "clang-not-found"
+    real_clangxx = os.path.realpath(clangxx)
+    try:
+        completed = subprocess.run(
+            [clangxx, "--version"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=5,
+        )
+        version = completed.stdout.splitlines()[0].strip()
+    except (OSError, subprocess.SubprocessError, IndexError):
+        version = None
+    digest = hashlib.sha256()
+    digest.update(real_clangxx.encode("utf-8", errors="surrogateescape"))
+    digest.update(b"\0")
+    digest.update((version or "unknown").encode("utf-8", errors="replace"))
+    return clangxx, version, f"clang-{digest.hexdigest()[:16]}"
+
+
+def compile_bundle(
+    source: str,
+    *,
+    output_path: str,
+    cache_dir: str,
+    cache_identity: BundleCacheIdentity,
+    compiler_options: tuple[str, ...],
+    include_dirs: list[str],
+    scope: str,
+    clangxx: str | None,
+    clang_version: str | None,
+) -> _CachedBundle:
+    """Compile one provider source to cached LLVM bitcode."""
+
+    if not clangxx:
+        raise DSLRuntimeError(
+            f"Failed compiling {scope} provider shim to LLVM bitcode.",
+            cause=RuntimeError("clang++ not found in PATH"),
+        )
+    try:
+        with tempfile.TemporaryDirectory(
+            dir=cache_dir,
+            prefix=".bundle-",
+        ) as temp_dir:
+            source_path = os.path.join(temp_dir, "bundle.cpp")
+            write_text_atomic(source_path, source, scope=scope)
+            temporary_output_path = os.path.join(temp_dir, "bundle.bc")
+            cmd = [
+                clangxx,
+                *compiler_options,
+                *[f"-I{path}" for path in include_dirs],
+                source_path,
+                "-o",
+                temporary_output_path,
+            ]
+            subprocess.run(
+                cmd,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=CLANGXX_TIMEOUT_SECONDS,
+            )
+            with open(temporary_output_path, "rb") as artifact_file:
+                artifact_blob = artifact_file.read()
+    except subprocess.CalledProcessError as exc:
+        raise DSLRuntimeError(
+            f"Failed compiling {scope} provider shim to LLVM bitcode.",
+            cause=RuntimeError(exc.stderr.strip()),
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise DSLRuntimeError(
+            f"Timed out compiling {scope} provider shim to LLVM bitcode.",
+            cause=exc,
+        ) from exc
+    except OSError as exc:
+        raise DSLRuntimeError(
+            f"Failed writing {scope} provider LLVM bitcode artifact.",
+            cause=exc,
+        ) from exc
+    if not artifact_blob:
+        raise DSLRuntimeError(
+            f"Clang produced an empty LLVM bitcode artifact for {scope} provider shim."
+        )
+
+    cached = _CachedBundle(
+        path=output_path,
+        layouts_by_expression={},
+        producer_compiler="clang++",
+        producer_compiler_version=clang_version,
+        artifact_size=len(artifact_blob),
+        artifact_sha256=hashlib.sha256(artifact_blob).hexdigest(),
+    )
+    write_binary_atomic(output_path, artifact_blob, scope=scope)
+    _write_bundle_metadata(
+        output_path,
+        artifact_blob,
+        cached,
+        cache_identity,
+        scope=scope,
+    )
+    return cached

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_finalize.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_finalize.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Finalize traced CUTLASS provider requests into one linkable bundle."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Any
+
+from cutlass.base_dsl.common import DSLRuntimeError
+
+from . import _bundle, _cache, _rendering, _state, _storage, _target, _types
+from ._types import ROOT_SCOPE
+
+_provider_bundle_support = _bundle
+_provider_cache_support = _cache
+_provider_rendering = _rendering
+_provider_state = _state
+_provider_storage = _storage
+_provider_target_support = _target
+_provider_types = _types
+
+_PROVIDER_DIR = os.path.dirname(os.path.dirname(__file__))
+
+
+def _get_cute_dsl():
+    return _provider_state._get_cute_dsl()
+
+
+def _remove_managed_bundle_link_options(dsl: Any) -> None:
+    """Keep persistent CUTLASS compile options from relinking prior bundles."""
+
+    managed_paths = _provider_cache_support.managed_bundle_paths()
+    if not managed_paths:
+        return
+    try:
+        from cutlass.base_dsl.compiler import LinkLibraries
+
+        options = dsl.compile_options.options
+        try:
+            option = options[LinkLibraries]
+        except KeyError:
+            return
+        paths = [path for path in str(option.value).split(",") if path]
+    except (AttributeError, ImportError, TypeError) as exc:
+        raise DSLRuntimeError(
+            f"{ROOT_SCOPE} provider requires a CUTLASS DSL with mutable "
+            "link-library compile options.",
+            cause=exc,
+        ) from exc
+
+    filtered_paths = [
+        path for path in paths if os.path.realpath(path) not in managed_paths
+    ]
+    if filtered_paths != paths:
+        options[LinkLibraries] = LinkLibraries(",".join(filtered_paths))
+
+
+def _configured_gpu_arch() -> str:
+    return _provider_target_support.configured_gpu_arch(_get_cute_dsl)
+
+
+def _resolve_nvrtc_arch() -> str:
+    return _provider_target_support.resolve_nvrtc_arch(
+        ROOT_SCOPE,
+        _configured_gpu_arch,
+    )
+
+
+def _resolve_nvrtc_sm_arch() -> str:
+    return _provider_target_support.resolve_nvrtc_sm_arch(
+        ROOT_SCOPE,
+        _configured_gpu_arch,
+    )
+
+
+def _select_bundle_format() -> str:
+    return _provider_target_support.select_bundle_format(ROOT_SCOPE)
+
+
+def _compile_bundle_source(source: str) -> str:
+    return _provider_bundle_support.compile_bundle_source(
+        source,
+        scope=ROOT_SCOPE,
+        provider_dir=_PROVIDER_DIR,
+        registered_headers=_provider_rendering.registered_bundle_headers,
+        select_bundle_format=_select_bundle_format,
+        resolve_nvrtc_sm_arch=_resolve_nvrtc_sm_arch,
+        resolve_nvrtc_arch=_resolve_nvrtc_arch,
+        which=shutil.which,
+    )
+
+
+def _compile_bundle_source_with_layouts(
+    source: str,
+    probes: dict[object, _provider_types.ScratchLayoutProbe],
+) -> _provider_bundle_support.BundleCompilation:
+    return _provider_bundle_support.compile_bundle_source_with_layouts(
+        source,
+        layout_probes=(
+            _provider_bundle_support.LayoutProbe(
+                key=key,
+                size_expression=probe.size_expression,
+                alignment_expression=probe.alignment_expression,
+            )
+            for key, probe in probes.items()
+        ),
+        scope=ROOT_SCOPE,
+        provider_dir=_PROVIDER_DIR,
+        registered_headers=_provider_rendering.registered_bundle_headers,
+        select_bundle_format=_select_bundle_format,
+        resolve_nvrtc_sm_arch=_resolve_nvrtc_sm_arch,
+        resolve_nvrtc_arch=_resolve_nvrtc_arch,
+        which=shutil.which,
+    )
+
+
+def _reject_unregistered_request(request: Any) -> list[str]:
+    kind = getattr(request, "kind", type(request).__name__)
+    raise ValueError(f"CUTLASS provider request {kind!r} has no renderer")
+
+
+def _render_bundle_source(requests: list[Any]) -> str:
+    return _provider_rendering.render_bundle_source(
+        requests,
+        scope=ROOT_SCOPE,
+        render_local_request=_reject_unregistered_request,
+    )
+
+
+def _trace_finalize_hook(dsl: Any, module: Any, function_name: str) -> None:
+    compile_options = dsl.compile_options
+    session = _provider_state.lookup_bundle_session(compile_options)
+    _remove_managed_bundle_link_options(dsl)
+    del dsl, function_name
+    if session is None or not session.belongs_to_trace_module(
+        getattr(module, "operation", module)
+    ):
+        return
+    session = _provider_state.pop_bundle_session(compile_options)
+    if session is None or session.is_empty():
+        return
+
+    requests = session.request_list()
+    events = session.deferred_temp_storage_event_list()
+    probes = _provider_rendering.bundle_scratch_layout_probes(requests)
+    missing_probe_keys = {
+        event.requirement_key for event in events if event.requirement_key not in probes
+    }
+    if missing_probe_keys:
+        raise DSLRuntimeError(
+            "Deferred TempStorage events have no registered exact-layout probe: "
+            f"{sorted(map(repr, missing_probe_keys))}"
+        )
+
+    source = _render_bundle_source(requests)
+    if probes:
+        compilation = _compile_bundle_source_with_layouts(source, probes)
+        bundle_path = compilation.path
+        layouts = {
+            key: _provider_types.ScratchLayout(
+                size_in_bytes=layout.size_in_bytes,
+                alignment=layout.alignment,
+            )
+            for key, layout in compilation.layouts.items()
+        }
+    else:
+        bundle_path = _compile_bundle_source(source)
+        layouts = {}
+
+    plans = _provider_storage.plan_deferred_temp_storage_events(events, layouts)
+    _provider_storage.materialize_deferred_temp_storage_plans(plans)
+    _provider_bundle_support.append_link_library_attr(module, bundle_path)
+
+
+_provider_state.register_bundle_finalizer(
+    _trace_finalize_hook,
+    scope=ROOT_SCOPE,
+)
+
+__all__: tuple[str, ...] = ()

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_launch.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_launch.py
@@ -1,0 +1,723 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Trace-time launch-fact inference for CUTLASS family lowerers."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any, TypedDict
+
+from ..._core.launch import LaunchFactOrigin, LaunchFacts, merge_launch_facts
+from .._thread_data import _normalize_index_int
+
+LAUNCH_METADATA_KEYS = ("launch_metadata", "launch_meta", "launch", "launch_config")
+LAUNCH_THREAD_COUNT_KEYS = ("threads_per_block", "block", "block_dim")
+
+LaunchDimension = int | tuple[int, ...] | list[int]
+
+
+class CutlassLaunchMetadata(TypedDict, total=False):
+    """Static launch facts accepted by CUTLASS group-first primitives."""
+
+    threads_per_block: LaunchDimension
+    block: LaunchDimension
+    block_dim: LaunchDimension
+    block_x: int
+    block_y: int
+    block_z: int
+    block_dim_x: int
+    block_dim_y: int
+    block_dim_z: int
+    grid: LaunchDimension
+    grid_dim: LaunchDimension
+    grid_x: int
+    grid_y: int
+    grid_z: int
+    grid_dim_x: int
+    grid_dim_y: int
+    grid_dim_z: int
+    cluster: LaunchDimension
+    cluster_dim: LaunchDimension
+    cluster_x: int
+    cluster_y: int
+    cluster_z: int
+    cluster_dim_x: int
+    cluster_dim_y: int
+    cluster_dim_z: int
+    cooperative_launch: bool
+    cluster_launch: bool
+
+
+def _normalize_static_int(value: Any) -> int | None:
+    try:
+        return _normalize_index_int(value)
+    except Exception:
+        return None
+
+
+def resolve_block_threads(
+    scope: str,
+    primitive_name: str,
+    *,
+    threads_per_block: Any,
+    dim: Any,
+) -> Any:
+    if threads_per_block is not None:
+        threads_per_block = require_static_block_dim(
+            scope,
+            primitive_name,
+            "threads_per_block",
+            threads_per_block,
+        )
+    if dim is not None:
+        dim = require_static_block_dim(scope, primitive_name, "dim", dim)
+    if threads_per_block is not None and dim is not None:
+        if normalize_block_dim(threads_per_block) != normalize_block_dim(dim):
+            raise TypeError(
+                f"{scope}.{primitive_name} got conflicting threads_per_block and dim"
+            )
+    return threads_per_block if threads_per_block is not None else dim
+
+
+def is_block_dim_sequence(value: Any) -> bool:
+    return isinstance(value, (tuple, list)) and len(value) > 0
+
+
+def block_dim_product(value: Any) -> int | None:
+    if is_block_dim_sequence(value):
+        if len(value) > 3:
+            return None
+        threads = 1
+        for dim in value:
+            dim = _normalize_static_int(dim)
+            if dim is None or dim <= 0:
+                return None
+            threads *= dim
+        return threads
+    value = _normalize_static_int(value)
+    if value is not None and value > 0:
+        return value
+    return None
+
+
+def normalize_block_dim(value: Any) -> tuple[int, int, int] | None:
+    """Try to parse a block shape, returning ``None`` instead of raising.
+
+    This tolerant helper is for optional backend metadata. Core descriptor
+    construction uses strict ``normalize_thread_dim`` validation instead.
+    """
+
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (tuple, list)):
+        if not value or len(value) > 3:
+            return None
+        dims = tuple(_normalize_static_int(dim) for dim in value)
+        if any(dim is None or dim <= 0 for dim in dims):
+            return None
+        return (*dims, *((1,) * (3 - len(dims))))  # type: ignore[return-value]
+    dim = _normalize_static_int(value)
+    if dim is None or dim <= 0:
+        return None
+    return dim, 1, 1
+
+
+def block_dim_from_launch_metadata(metadata: Any) -> tuple[int, int, int] | None:
+    """Extract an exact static block shape from normalized launch metadata."""
+
+    if not isinstance(metadata, Mapping):
+        return None
+
+    if "threads_per_block" in metadata:
+        return normalize_block_dim(metadata["threads_per_block"])
+
+    for key in ("block", "block_dim"):
+        if key in metadata:
+            return normalize_block_dim(metadata[key])
+
+    for prefix in ("block", "block_dim"):
+        keys = tuple(f"{prefix}_{suffix}" for suffix in ("x", "y", "z"))
+        present = tuple(key in metadata for key in keys)
+        if not any(present):
+            continue
+        if not all(present):
+            return None
+        return normalize_block_dim(tuple(metadata[key] for key in keys))
+
+    return None
+
+
+def _launch_metadata_dim_candidates(
+    metadata: Mapping[str, Any],
+    aliases: tuple[str, ...],
+) -> tuple[tuple[str, tuple[int, int, int]], ...]:
+    candidates: list[tuple[str, tuple[int, int, int]]] = []
+    for alias in aliases:
+        if alias in metadata:
+            dimension = normalize_block_dim(metadata[alias])
+            if dimension is None:
+                raise ValueError(
+                    f"launch metadata {alias!r} must be a complete static shape"
+                )
+            candidates.append((alias, dimension))
+
+        axis_keys = tuple(f"{alias}_{axis}" for axis in ("x", "y", "z"))
+        present = tuple(key in metadata for key in axis_keys)
+        if not any(present):
+            continue
+        if not all(present):
+            raise ValueError(
+                f"launch metadata {alias!r} axis form requires x, y, and z"
+            )
+        dimension = normalize_block_dim(tuple(metadata[key] for key in axis_keys))
+        if dimension is None:
+            raise ValueError(
+                f"launch metadata {alias!r} axis form must be a static shape"
+            )
+        candidates.append(("/".join(axis_keys), dimension))
+    return tuple(candidates)
+
+
+def launch_facts_from_launch_metadata(
+    metadata: Mapping[str, Any],
+    *,
+    source: str = "launch_metadata",
+) -> LaunchFacts:
+    """Extract exact launch facts while reconciling all recognized aliases."""
+
+    if not isinstance(metadata, Mapping):
+        raise TypeError("launch metadata must be a mapping")
+
+    facts: list[LaunchFacts] = []
+    for field_name, aliases in (
+        ("exact_block_dim", ("threads_per_block", "block", "block_dim")),
+        ("exact_grid_dim", ("grid", "grid_dim")),
+        ("exact_cluster_dim", ("cluster", "cluster_dim")),
+    ):
+        for alias, dimension in _launch_metadata_dim_candidates(metadata, aliases):
+            facts.append(
+                LaunchFacts(
+                    **{field_name: dimension},
+                    provenance=LaunchFactOrigin(
+                        fact=field_name,
+                        source=source,
+                        detail=alias,
+                    ),
+                )
+            )
+
+    for field_name in ("cooperative_launch", "cluster_launch"):
+        if field_name not in metadata:
+            continue
+        value = metadata[field_name]
+        if not isinstance(value, bool):
+            raise TypeError(f"launch metadata {field_name!r} must be a bool")
+        facts.append(
+            LaunchFacts(
+                **{field_name: value},
+                provenance=LaunchFactOrigin(
+                    fact=field_name,
+                    source=source,
+                    detail=field_name,
+                ),
+            )
+        )
+
+    return merge_launch_facts(*facts)
+
+
+def block_dim_from_nvvm_thread_attr(attr: Any) -> tuple[int, int, int] | None:
+    """Parse a static block shape from an NVVM reqntid/maxntid attribute."""
+
+    attr_text = str(attr)
+    match = re.search(r":\s*([0-9,\s-]+)\s*>", attr_text)
+    if not match:
+        return None
+    parts = tuple(
+        int(part.strip()) for part in match.group(1).split(",") if part.strip()
+    )
+    return normalize_block_dim(parts)
+
+
+def launch_facts_from_cutlass_api(
+    facts: Any,
+    *,
+    detail: str = "cute._get_launch_facts()",
+) -> LaunchFacts:
+    """Normalize launch facts returned by CUTLASS's private provider hook."""
+
+    normalized: list[LaunchFacts] = []
+    for field_name in (
+        "exact_block_dim",
+        "exact_grid_dim",
+        "exact_cluster_dim",
+    ):
+        raw_value = getattr(facts, field_name, None)
+        if raw_value is None:
+            continue
+        dimension = normalize_block_dim(raw_value)
+        if dimension is None:
+            raise ValueError(
+                f"{detail} field {field_name!r} does not contain a valid static shape"
+            )
+        normalized.append(
+            LaunchFacts(
+                **{field_name: dimension},
+                provenance=LaunchFactOrigin(
+                    fact=field_name,
+                    source="cutlass_provider_api",
+                    detail=detail,
+                    verified=True,
+                ),
+            )
+        )
+
+    for field_name in ("cooperative_launch", "cluster_launch"):
+        value = getattr(facts, field_name, None)
+        if value is None:
+            continue
+        if not isinstance(value, bool):
+            raise ValueError(f"{detail} field {field_name!r} must be a bool")
+        normalized.append(
+            LaunchFacts(
+                **{field_name: value},
+                provenance=LaunchFactOrigin(
+                    fact=field_name,
+                    source="cutlass_provider_api",
+                    detail=detail,
+                    verified=True,
+                ),
+            )
+        )
+    return merge_launch_facts(*normalized)
+
+
+def block_dim_from_kernel_op(
+    current_op: Any,
+    *,
+    allow_maxntid: bool,
+) -> tuple[int, int, int] | None:
+    """Read block dimensions from a kernel op and its ancestors.
+
+    ``reqntid`` is an exact launch requirement and always takes precedence.
+    ``maxntid`` is only an upper bound, so callers that require an exact shape
+    must leave ``allow_maxntid`` disabled.
+    """
+
+    ops = []
+    op = current_op
+    while op is not None:
+        ops.append(op)
+        op = getattr(op, "parent_op", None) or getattr(op, "parent", None)
+
+    attribute_groups = [("nvvm.reqntid", "reqntid")]
+    if allow_maxntid:
+        attribute_groups.append(("nvvm.maxntid", "maxntid"))
+
+    for keys in attribute_groups:
+        for op in ops:
+            attrs = getattr(op, "attributes", None)
+            if attrs is None:
+                continue
+            for key in keys:
+                try:
+                    attr = attrs[key]
+                except Exception:
+                    continue
+                block_dim = block_dim_from_nvvm_thread_attr(attr)
+                if block_dim is not None:
+                    return block_dim
+    return None
+
+
+def launch_facts_from_kernel_op(current_op: Any) -> LaunchFacts:
+    """Extract ``reqntid`` exact and ``maxntid`` upper-bound fallback facts."""
+
+    facts: list[LaunchFacts] = []
+    op = current_op
+    depth = 0
+    while op is not None:
+        attrs = getattr(op, "attributes", None)
+        if attrs is not None:
+            for field_name, keys in (
+                ("exact_block_dim", ("nvvm.reqntid", "reqntid")),
+                ("max_block_dim", ("nvvm.maxntid", "maxntid")),
+            ):
+                for key in keys:
+                    try:
+                        attr = attrs[key]
+                    except Exception:
+                        continue
+                    block_dim = block_dim_from_nvvm_thread_attr(attr)
+                    if block_dim is None:
+                        if field_name == "max_block_dim":
+                            continue
+                        raise ValueError(
+                            f"kernel attribute {key!r} does not contain a valid "
+                            "static thread shape"
+                        )
+                    facts.append(
+                        LaunchFacts(
+                            **{field_name: block_dim},
+                            provenance=LaunchFactOrigin(
+                                fact=field_name,
+                                source="kernel_attribute",
+                                detail=f"{key}@ancestor[{depth}]",
+                                verified=field_name == "exact_block_dim",
+                            ),
+                        )
+                    )
+        op = getattr(op, "parent_op", None) or getattr(op, "parent", None)
+        depth += 1
+    return merge_launch_facts(*facts)
+
+
+def current_kernel_block_dim(
+    *,
+    allow_maxntid: bool = False,
+) -> tuple[int, int, int] | None:
+    """Read exact block dimensions, or an allowed upper bound, from the kernel."""
+
+    facts = current_kernel_launch_facts()
+    if facts.exact_block_dim is not None:
+        return facts.exact_block_dim
+    if allow_maxntid:
+        return facts.max_block_dim
+    return None
+
+
+def current_kernel_launch_facts() -> LaunchFacts:
+    """Read launch facts from the active CUTLASS MLIR insertion point."""
+
+    try:
+        from cutlass._mlir import ir
+
+        current_ip = ir.InsertionPoint.current
+    except Exception:
+        return LaunchFacts()
+    if current_ip is None or current_ip.block is None:
+        return LaunchFacts()
+    kernel_facts = launch_facts_from_kernel_op(current_ip.block.owner)
+    try:
+        from cutlass import cute
+
+        get_launch_facts = getattr(cute, "_get_launch_facts", None)
+        if callable(get_launch_facts):
+            try:
+                provider_facts = launch_facts_from_cutlass_api(get_launch_facts())
+            except Exception as exc:
+                if "launch facts are unavailable" not in str(exc):
+                    raise
+            else:
+                return merge_launch_facts(provider_facts, kernel_facts)
+    except ImportError:
+        pass
+    return kernel_facts
+
+
+def infer_launch_facts(
+    kwargs: Mapping[str, Any],
+    *,
+    scope: str,
+    primitive_name: str,
+) -> LaunchFacts:
+    """Merge exact call metadata with current kernel attributes."""
+
+    present = tuple(
+        key for key in LAUNCH_METADATA_KEYS if key in kwargs and kwargs[key] is not None
+    )
+    if len(present) > 1:
+        names = ", ".join(present)
+        raise TypeError(
+            f"{scope}.{primitive_name} got multiple launch metadata aliases: {names}"
+        )
+    facts = [current_kernel_launch_facts()]
+    for key in present:
+        facts.append(
+            launch_facts_from_launch_metadata(
+                kwargs[key],
+                source=f"call_argument:{key}",
+            )
+        )
+    return merge_launch_facts(*facts)
+
+
+def infer_block_dim(
+    kwargs: Mapping[str, Any],
+    *,
+    scope: str,
+    primitive_name: str,
+) -> tuple[int, int, int]:
+    """Infer the current static block shape from call or kernel metadata."""
+
+    present = tuple(
+        key for key in LAUNCH_METADATA_KEYS if key in kwargs and kwargs[key] is not None
+    )
+    facts = infer_launch_facts(
+        kwargs,
+        scope=scope,
+        primitive_name=primitive_name,
+    )
+    if facts.exact_block_dim is not None:
+        return facts.exact_block_dim
+    if present:
+        raise ValueError(
+            f"{scope}.{primitive_name} requires launch metadata with a complete "
+            "static block shape"
+        )
+
+    raise ValueError(
+        f"{scope}.{primitive_name} requires launch metadata or kernel "
+        "reqntid attributes to infer the exact block dimensions"
+    )
+
+
+def require_static_block_dim(
+    scope: str,
+    primitive_name: str,
+    arg_name: str,
+    value: Any,
+) -> Any:
+    if is_block_dim_sequence(value):
+        dims = tuple(_normalize_static_int(dim) for dim in value)
+        if len(dims) > 3:
+            raise TypeError(
+                f"{scope}.{primitive_name} {arg_name} must have at most 3 dimensions"
+            )
+        if not dims or any(dim is None or dim <= 0 for dim in dims):
+            raise TypeError(
+                f"{scope}.{primitive_name} {arg_name} must be a compile-time "
+                "positive int or tuple/list of positive ints"
+            )
+        return dims
+    value = _normalize_static_int(value)
+    if value is None or value <= 0:
+        raise TypeError(
+            f"{scope}.{primitive_name} {arg_name} must be a compile-time "
+            "positive int or tuple/list of positive ints"
+        )
+    return value
+
+
+def resolve_threads_in_warp(
+    scope: str,
+    primitive_name: str,
+    value: Any,
+) -> int:
+    value = _normalize_static_int(value)
+    if value is None:
+        raise TypeError(f"{scope}.{primitive_name} threads_in_warp must be an int")
+    if value <= 0:
+        raise ValueError(f"{scope}.{primitive_name} threads_in_warp must be positive")
+    if value > 32:
+        raise ValueError(f"{scope}.{primitive_name} threads_in_warp must be <= 32")
+    if value & (value - 1):
+        raise ValueError(
+            f"{scope}.{primitive_name} threads_in_warp must be a power of two"
+        )
+    return value
+
+
+def metadata_thread_count(metadata: Mapping[str, Any]) -> int | None:
+    if "threads_per_block" in metadata:
+        return block_dim_product(metadata["threads_per_block"])
+    for key in LAUNCH_THREAD_COUNT_KEYS[1:]:
+        if key in metadata:
+            return block_dim_product(metadata[key])
+    return None
+
+
+def validate_metadata_thread_count(
+    scope: str,
+    primitive_name: str,
+    metadata: Mapping[str, Any],
+) -> tuple[int | None, list[str]]:
+    existing_thread_keys = [
+        name for name in LAUNCH_THREAD_COUNT_KEYS if name in metadata
+    ]
+    if len(existing_thread_keys) > 1:
+        names = ", ".join(existing_thread_keys)
+        raise TypeError(
+            f"{scope}.{primitive_name} launch metadata has multiple "
+            f"thread-count keys: {names}"
+        )
+    existing_count = metadata_thread_count(metadata)
+    if existing_thread_keys and existing_count is None:
+        names = ", ".join(existing_thread_keys)
+        raise TypeError(
+            f"{scope}.{primitive_name} launch metadata has "
+            f"invalid thread-count key(s): {names}"
+        )
+    return existing_count, existing_thread_keys
+
+
+def pop_launch_metadata(kwargs: dict[str, Any]) -> dict[str, Any]:
+    launch_kwargs: dict[str, Any] = {}
+    for key in LAUNCH_METADATA_KEYS:
+        if key in kwargs:
+            launch_kwargs[key] = kwargs.pop(key)
+    return launch_kwargs
+
+
+def bind_block_launch_metadata(
+    scope: str,
+    primitive_name: str,
+    kwargs: dict[str, Any],
+    *,
+    threads_per_block: Any,
+) -> None:
+    present = [
+        name
+        for name in LAUNCH_METADATA_KEYS
+        if name in kwargs and kwargs[name] is not None
+    ]
+    if len(present) > 1:
+        names = ", ".join(present)
+        raise TypeError(
+            f"{scope}.{primitive_name} got multiple launch metadata aliases: {names}"
+        )
+
+    if not present:
+        if threads_per_block is None:
+            return
+        requested_count = block_dim_product(threads_per_block)
+        metadata_key = (
+            "block" if is_block_dim_sequence(threads_per_block) else "threads_per_block"
+        )
+        metadata_value = (
+            tuple(threads_per_block)
+            if is_block_dim_sequence(threads_per_block)
+            else threads_per_block
+        )
+        kwargs["launch_metadata"] = {metadata_key: metadata_value}
+        return
+
+    key = present[0]
+    metadata = kwargs[key]
+    if threads_per_block is None:
+        if isinstance(metadata, Mapping):
+            validate_metadata_thread_count(scope, primitive_name, metadata)
+        return
+
+    if not isinstance(metadata, Mapping):
+        raise TypeError(
+            f"{scope}.{primitive_name} launch metadata must "
+            "be a mapping when threads_per_block or dim is also provided"
+        )
+
+    requested_count = block_dim_product(threads_per_block)
+    metadata_key = (
+        "block" if is_block_dim_sequence(threads_per_block) else "threads_per_block"
+    )
+    metadata_value = (
+        tuple(threads_per_block)
+        if is_block_dim_sequence(threads_per_block)
+        else threads_per_block
+    )
+    existing_count, existing_thread_keys = validate_metadata_thread_count(
+        scope,
+        primitive_name,
+        metadata,
+    )
+    if (
+        requested_count is not None
+        and existing_count is not None
+        and existing_count != requested_count
+    ):
+        raise TypeError(
+            f"{scope}.{primitive_name} got conflicting "
+            "launch metadata and threads_per_block"
+        )
+    merged = dict(metadata)
+    block_candidates = _launch_metadata_dim_candidates(
+        metadata,
+        ("threads_per_block", "block", "block_dim"),
+    )
+    exact_dimensions = tuple(
+        dimension
+        for candidate, dimension in block_candidates
+        if "/" in candidate or is_block_dim_sequence(metadata.get(candidate))
+    )
+    if exact_dimensions and any(
+        dimension != exact_dimensions[0] for dimension in exact_dimensions[1:]
+    ):
+        raise TypeError(
+            f"{scope}.{primitive_name} got conflicting launch metadata block shapes"
+        )
+    if exact_dimensions and block_dim_product(exact_dimensions[0]) != requested_count:
+        raise TypeError(
+            f"{scope}.{primitive_name} got conflicting "
+            "launch metadata and threads_per_block"
+        )
+    requested_dimension = normalize_block_dim(threads_per_block)
+    assert requested_dimension is not None
+    if (
+        is_block_dim_sequence(threads_per_block)
+        and exact_dimensions
+        and exact_dimensions[0] != requested_dimension
+    ):
+        raise TypeError(
+            f"{scope}.{primitive_name} got conflicting "
+            "launch metadata and threads_per_block shapes"
+        )
+
+    precise_dimension = (
+        exact_dimensions[0]
+        if exact_dimensions
+        else requested_dimension
+        if is_block_dim_sequence(threads_per_block)
+        else None
+    )
+    if existing_thread_keys and precise_dimension is not None:
+        existing_key = existing_thread_keys[0]
+        if not is_block_dim_sequence(metadata[existing_key]):
+            merged[existing_key] = precise_dimension
+    if block_candidates:
+        kwargs[key] = merged
+        return
+    merged[metadata_key] = metadata_value
+    kwargs[key] = merged
+
+
+def bind_block_launch_kwargs(
+    scope: str,
+    primitive_name: str,
+    kwargs: dict[str, Any],
+    *,
+    threads_per_block: Any = None,
+    dim: Any = None,
+) -> dict[str, Any]:
+    bound = dict(kwargs)
+    resolved_threads = resolve_block_threads(
+        scope,
+        primitive_name,
+        threads_per_block=threads_per_block,
+        dim=dim,
+    )
+    bind_block_launch_metadata(
+        scope,
+        primitive_name,
+        bound,
+        threads_per_block=resolved_threads,
+    )
+    return bound
+
+
+def normalize_block_launch_kwargs(
+    scope: str,
+    primitive_name: str,
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    bound = dict(kwargs)
+    threads_per_block = bound.pop("threads_per_block", None)
+    dim = bound.pop("dim", None)
+    return bind_block_launch_kwargs(
+        scope,
+        primitive_name,
+        bound,
+        threads_per_block=threads_per_block,
+        dim=dim,
+    )

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_nvrtc.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_nvrtc.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Compile CUTLASS provider bundles with NVRTC."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Iterable
+from typing import Any
+
+from cutlass.base_dsl.common import DSLRuntimeError
+
+import cuda.bindings.nvrtc as cuda_nvrtc
+from cuda.coop._headers._toolkit import (
+    preload_toolkit_compiler_libraries,
+    validate_nvrtc_version,
+)
+
+from . import _cache as _cache_support
+from ._bundle_contract import (
+    BundleCacheIdentity,
+    _decode_layout_probe_name,
+    _PreparedLayoutProbes,
+)
+from ._cache import (
+    _CachedBundle,
+    _write_bundle_metadata,
+    write_binary_atomic,
+)
+
+_COMPILE_PROGRAM_COUNTER = 0
+
+
+def get_program_log(program: Any) -> str:
+    err, log_size = cuda_nvrtc.nvrtcGetProgramLogSize(program)
+    if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS or log_size <= 0:
+        return ""
+    log = bytearray(log_size)
+    err = cuda_nvrtc.nvrtcGetProgramLog(program, log)[0]
+    if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+        return ""
+    return bytes(log).decode("utf-8", errors="replace").strip("\x00").strip()
+
+
+def version_tuple(nvrtc: Any) -> tuple[int, int] | None:
+    """Return the loaded NVRTC major/minor version when queryable."""
+
+    version = getattr(nvrtc, "nvrtcVersion", None)
+    if not callable(version):
+        return None
+    try:
+        err, major, minor = version()
+        parsed_version = int(major), int(minor)
+    except (TypeError, ValueError):
+        return None
+    if err != nvrtc.nvrtcResult.NVRTC_SUCCESS:
+        return None
+    return parsed_version
+
+
+def get_version_tuple() -> tuple[int, int] | None:
+    return version_tuple(cuda_nvrtc)
+
+
+def get_version() -> str | None:
+    loaded_version = get_version_tuple()
+    if loaded_version is None:
+        return None
+    return f"{loaded_version[0]}.{loaded_version[1]}"
+
+
+def preload_toolkit_nvrtc(include_dirs: Iterable[str]) -> None:
+    """Load the toolkit NVRTC selected by the resolved CUDA headers."""
+
+    try:
+        libraries = preload_toolkit_compiler_libraries(include_dirs)
+        actual_version = get_version_tuple()
+        if actual_version is None:
+            raise RuntimeError("loaded NVRTC did not report its version")
+        validate_nvrtc_version(libraries, actual_version)
+    except (OSError, RuntimeError) as exc:
+        raise DSLRuntimeError(
+            "Failed aligning provider NVRTC with the resolved CUDA headers.",
+            cause=exc,
+        ) from exc
+
+
+def include_options(include_dirs: list[str]) -> list[bytes]:
+    """Encode NVRTC include options with the platform filesystem codec."""
+
+    return [os.fsencode(f"-I{path}") for path in include_dirs]
+
+
+def compile_bundle(
+    source: str,
+    *,
+    output_path: str,
+    cache_identity: BundleCacheIdentity,
+    compiler_options: tuple[str, ...],
+    include_dirs: list[str],
+    prepared_probes: _PreparedLayoutProbes,
+    nvrtc_version: str | None,
+    scope: str,
+) -> _CachedBundle:
+    """Compile one provider source to cached NVRTC LTO-IR."""
+
+    global _COMPILE_PROGRAM_COUNTER
+
+    source_bytes = source.encode("utf-8")
+    options = [
+        *(option.encode("ascii") for option in compiler_options),
+        *include_options(include_dirs),
+    ]
+    err, program = cuda_nvrtc.nvrtcCreateProgram(
+        source_bytes,
+        b"cuda_coop_cutlass_bundle.cu",
+        0,
+        [],
+        [],
+    )
+    if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+        raise DSLRuntimeError(
+            f"Failed creating NVRTC program for {scope} provider bundle."
+        )
+
+    try:
+        encoded_expressions = tuple(
+            expression.encode("utf-8") for expression in prepared_probes.expressions
+        )
+        for expression in encoded_expressions:
+            result = cuda_nvrtc.nvrtcAddNameExpression(program, expression)
+            err = result[0] if isinstance(result, tuple) else result
+            if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+                raise DSLRuntimeError(
+                    f"Failed registering an NVRTC layout probe for {scope} "
+                    "provider bundle."
+                )
+
+        err = cuda_nvrtc.nvrtcCompileProgram(program, len(options), options)[0]
+        if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+            raise DSLRuntimeError(
+                f"Failed compiling {scope} provider shim to LTO-IR.",
+                cause=RuntimeError(get_program_log(program)),
+            )
+        with _cache_support._STATE_LOCK:
+            _COMPILE_PROGRAM_COUNTER += 1
+
+        layouts_by_expression = {}
+        for expression, encoded_expression in zip(
+            prepared_probes.expressions,
+            encoded_expressions,
+        ):
+            err, lowered_name = cuda_nvrtc.nvrtcGetLoweredName(
+                program,
+                encoded_expression,
+            )
+            if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+                raise DSLRuntimeError(
+                    f"Failed retrieving an NVRTC layout probe for {scope} "
+                    "provider bundle."
+                )
+            layouts_by_expression[expression] = _decode_layout_probe_name(
+                lowered_name,
+                symbol=prepared_probes.symbol,
+                expression=expression,
+            )
+
+        err, blob_size = cuda_nvrtc.nvrtcGetLTOIRSize(program)
+        if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+            raise DSLRuntimeError(
+                f"Failed querying NVRTC LTO-IR size for {scope} provider shim."
+            )
+        if blob_size <= 0:
+            raise DSLRuntimeError(
+                f"NVRTC produced an empty LTO-IR artifact for {scope} provider shim."
+            )
+        artifact_blob = bytearray(blob_size)
+        err = cuda_nvrtc.nvrtcGetLTOIR(program, artifact_blob)[0]
+        if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+            raise DSLRuntimeError(
+                f"Failed retrieving NVRTC LTO-IR for {scope} provider shim."
+            )
+    finally:
+        cuda_nvrtc.nvrtcDestroyProgram(program)
+
+    cached = _CachedBundle(
+        path=output_path,
+        layouts_by_expression=layouts_by_expression,
+        producer_compiler="nvrtc",
+        producer_compiler_version=nvrtc_version,
+        artifact_size=len(artifact_blob),
+        artifact_sha256=hashlib.sha256(artifact_blob).hexdigest(),
+    )
+    write_binary_atomic(output_path, artifact_blob, scope=scope)
+    _write_bundle_metadata(
+        output_path,
+        artifact_blob,
+        cached,
+        cache_identity,
+        scope=scope,
+    )
+    return cached
+
+
+def reset_compile_state() -> None:
+    global _COMPILE_PROGRAM_COUNTER
+    with _cache_support._STATE_LOCK:
+        _COMPILE_PROGRAM_COUNTER = 0
+
+
+def get_compile_program_counter() -> int:
+    with _cache_support._STATE_LOCK:
+        return _COMPILE_PROGRAM_COUNTER

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_rendering.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_rendering.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+"""Canonical request registration and generated C++ rendering."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Hashable, Iterable
+from typing import Any
+
+from ._types import BundleRenderer, ScratchLayoutProbe
+
+_FEATURE_DEFINE_RE = re.compile(r"^#define\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s|\(|$)")
+
+_BUNDLE_RENDERERS: dict[str, BundleRenderer] = {}
+
+
+def register_bundle_renderer(
+    kind: str,
+    *,
+    render: Callable[[Any], list[str]],
+    include_lines: tuple[str, ...] = (),
+    cccl_headers: tuple[tuple[str, str], ...] = (),
+    scratch_layout_probe: Callable[[Any], ScratchLayoutProbe | None] | None = None,
+) -> None:
+    """Register an internal non-block request renderer with the shared bundle JIT."""
+    if not kind:
+        raise ValueError("kind must be a non-empty string")
+    if not callable(render):
+        raise TypeError("render must be callable")
+    if scratch_layout_probe is not None and not callable(scratch_layout_probe):
+        raise TypeError("scratch_layout_probe must be callable or None")
+    if kind in _BUNDLE_RENDERERS:
+        raise ValueError(f"bundle renderer {kind!r} is already registered")
+    _BUNDLE_RENDERERS[kind] = BundleRenderer(
+        include_lines=tuple(include_lines),
+        cccl_headers=tuple(cccl_headers),
+        render=render,
+        scratch_layout_probe=scratch_layout_probe,
+    )
+
+
+def bundle_renderer_for(request: Any) -> BundleRenderer | None:
+    return _BUNDLE_RENDERERS.get(getattr(request, "kind", ""))
+
+
+def canonical_bundle_requests(requests: Iterable[Any]) -> tuple[Any, ...]:
+    """Return one deterministic request per provider symbol."""
+
+    requests_by_symbol: dict[str, Any] = {}
+    for request in requests:
+        symbol = getattr(request, "symbol_name", None)
+        if not isinstance(symbol, str) or not symbol:
+            raise ValueError("provider bundle requests require a non-empty symbol_name")
+        existing = requests_by_symbol.get(symbol)
+        if existing is not None and existing != request:
+            raise ValueError(
+                f"provider symbol {symbol!r} maps to conflicting bundle requests"
+            )
+        requests_by_symbol[symbol] = request
+    return tuple(requests_by_symbol[symbol] for symbol in sorted(requests_by_symbol))
+
+
+def canonical_bundle_preamble_lines(lines: Iterable[str]) -> tuple[str, ...]:
+    """Canonicalize feature definitions before all other preamble lines."""
+
+    feature_definitions: dict[str, str] = {}
+    other_lines: set[str] = set()
+    for line in lines:
+        if not line:
+            continue
+        if line.startswith("#define "):
+            match = _FEATURE_DEFINE_RE.match(line)
+            if match is None:
+                raise ValueError(f"invalid provider feature definition: {line!r}")
+            name = match.group(1)
+            existing = feature_definitions.get(name)
+            if existing is not None and existing != line:
+                raise ValueError(
+                    f"provider feature {name!r} has conflicting definitions"
+                )
+            feature_definitions[name] = line
+        else:
+            other_lines.add(line)
+    return (
+        *(feature_definitions[name] for name in sorted(feature_definitions)),
+        *sorted(other_lines),
+    )
+
+
+def bundle_include_lines(requests: Iterable[Any]) -> list[str]:
+    include_lines: list[str] = []
+    for request in canonical_bundle_requests(requests):
+        renderer = bundle_renderer_for(request)
+        if renderer is not None:
+            include_lines.extend(renderer.include_lines)
+    return list(canonical_bundle_preamble_lines(include_lines))
+
+
+def registered_bundle_headers() -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for kind in sorted(_BUNDLE_RENDERERS):
+        renderer = _BUNDLE_RENDERERS[kind]
+        for include, relative_path in sorted(renderer.cccl_headers):
+            existing = headers.get(include)
+            if existing is not None and existing != relative_path:
+                raise ValueError(
+                    f"provider include {include!r} maps to conflicting CCCL headers"
+                )
+            headers[include] = relative_path
+    return {include: headers[include] for include in sorted(headers)}
+
+
+def bundle_scratch_layout_probes(
+    requests: list[Any],
+) -> dict[Hashable, ScratchLayoutProbe]:
+    """Collect exact-layout probes registered by provider request renderers."""
+
+    probes: dict[Hashable, ScratchLayoutProbe] = {}
+    for request in canonical_bundle_requests(requests):
+        renderer = bundle_renderer_for(request)
+        if renderer is None or renderer.scratch_layout_probe is None:
+            continue
+        probe = renderer.scratch_layout_probe(request)
+        if probe is None:
+            continue
+        try:
+            hash(probe.requirement_key)
+        except TypeError as exc:
+            raise TypeError("scratch requirement keys must be hashable") from exc
+        existing = probes.get(probe.requirement_key)
+        if existing is not None and existing != probe:
+            raise ValueError(
+                "scratch requirement key maps to conflicting NVRTC layout probes"
+            )
+        probes[probe.requirement_key] = probe
+    return probes
+
+
+def make_scratch_layout_probe(
+    requirement_key: Hashable,
+    cpp_type: str,
+) -> ScratchLayoutProbe:
+    """Describe a name expression for the exact layout of ``cpp_type``."""
+
+    if not cpp_type:
+        raise ValueError("scratch layout probe requires a non-empty C++ type")
+    return ScratchLayoutProbe(
+        requirement_key=requirement_key,
+        size_expression=f"sizeof({cpp_type})",
+        alignment_expression=f"alignof({cpp_type})",
+    )
+
+
+def bundle_source_preamble_lines(
+    include_lines: list[str] | tuple[str, ...] = (),
+) -> list[str]:
+    return [
+        *[line for line in include_lines if line],
+        'extern "C" {',
+        "static inline unsigned int cuda_coop_cutlass_logical_warp_mask(",
+        "    unsigned int logical_width) {",
+        "  if (logical_width >= 32u) {",
+        "    return 0xffffffffu;",
+        "  }",
+        "  unsigned int lane;",
+        '  asm("mov.u32 %0, %%laneid;" : "=r"(lane));',
+        "  unsigned int first_lane = (lane / logical_width) * logical_width;",
+        "  return ((1u << logical_width) - 1u) << first_lane;",
+        "}",
+        "static inline void cuda_coop_cutlass_warp_sync(unsigned int logical_width) {",
+        "  unsigned int mask =",
+        "      cuda_coop_cutlass_logical_warp_mask(logical_width);",
+        '  asm volatile("bar.warp.sync %0;" :: "r"(mask) : "memory");',
+        "}",
+        "static inline void cuda_coop_cutlass_block_sync() {",
+        '  asm volatile("bar.sync 0;" ::: "memory");',
+        "}",
+        "static inline unsigned int cuda_coop_cutlass_tid_x() {",
+        "  unsigned int tid;",
+        '  asm("mov.u32 %0, %%tid.x;" : "=r"(tid));',
+        "  return tid;",
+        "}",
+        "static inline unsigned int cuda_coop_cutlass_tid_y() {",
+        "  unsigned int tid;",
+        '  asm("mov.u32 %0, %%tid.y;" : "=r"(tid));',
+        "  return tid;",
+        "}",
+        "static inline unsigned int cuda_coop_cutlass_tid_z() {",
+        "  unsigned int tid;",
+        '  asm("mov.u32 %0, %%tid.z;" : "=r"(tid));',
+        "  return tid;",
+        "}",
+        "static inline unsigned int cuda_coop_cutlass_ntid_x() {",
+        "  unsigned int ntid;",
+        '  asm("mov.u32 %0, %%ntid.x;" : "=r"(ntid));',
+        "  return ntid;",
+        "}",
+        "static inline unsigned int cuda_coop_cutlass_ntid_y() {",
+        "  unsigned int ntid;",
+        '  asm("mov.u32 %0, %%ntid.y;" : "=r"(ntid));',
+        "  return ntid;",
+        "}",
+        "static inline unsigned int cuda_coop_cutlass_ntid_z() {",
+        "  unsigned int ntid;",
+        '  asm("mov.u32 %0, %%ntid.z;" : "=r"(ntid));',
+        "  return ntid;",
+        "}",
+        "static inline unsigned int cuda_coop_cutlass_linear_tid() {",
+        "  unsigned int tidx = cuda_coop_cutlass_tid_x();",
+        "  unsigned int tidy = cuda_coop_cutlass_tid_y();",
+        "  unsigned int tidz = cuda_coop_cutlass_tid_z();",
+        "  unsigned int ntx = cuda_coop_cutlass_ntid_x();",
+        "  unsigned int nty = cuda_coop_cutlass_ntid_y();",
+        "  return tidx + ntx * (tidy + nty * tidz);",
+        "}",
+        "static inline int cuda_coop_cutlass_group_threads() {",
+        (
+            "  int group_threads = "
+            "(int)(cuda_coop_cutlass_ntid_x() * cuda_coop_cutlass_ntid_y() * "
+            "cuda_coop_cutlass_ntid_z());"
+        ),
+        "  if (group_threads <= 0) {",
+        "    group_threads = 1;",
+        "  }",
+        "  return group_threads;",
+        "}",
+        "static inline void* cuda_coop_cutlass_shared_ptr(",
+        "    unsigned int shared_addr) {",
+        "  unsigned long long shared_addr_u64 =",
+        "      static_cast<unsigned long long>(shared_addr);",
+        "  unsigned long long generic_addr;",
+        '  asm("cvta.shared.u64 %0, %1;" : "=l"(generic_addr) : "l"(shared_addr_u64));',
+        "  return reinterpret_cast<void*>(generic_addr);",
+        "}",
+    ]
+
+
+def render_bundle_source(
+    requests: list[Any],
+    *,
+    scope: str,
+    include_lines: list[str] | tuple[str, ...] = (),
+    multi_item_kinds: frozenset[str] = frozenset(),
+    render_local_request: Callable[[Any], list[str]],
+) -> str:
+    """Render a CuTe provider bundle with provider-specific local requests.
+
+    Providers pass their extra include lines, the request kinds that support
+    multi-item ``ThreadData``, and a ``render_local_request`` callback for
+    requests that are not handled by registered shared renderers. The callback
+    must return C++ source lines for supported local request kinds and raise for
+    unsupported kinds.
+    """
+    requests = list(canonical_bundle_requests(requests))
+    preamble_lines = canonical_bundle_preamble_lines(
+        [
+            *include_lines,
+            *bundle_include_lines(requests),
+        ]
+    )
+    lines = bundle_source_preamble_lines(preamble_lines)
+
+    for request in requests:
+        if bundle_renderer_for(request) is not None:
+            continue
+        if request.items_per_thread != 1 and request.kind not in multi_item_kinds:
+            raise NotImplementedError(
+                f"{scope} provider does not yet support multi-item "
+                "ThreadData shims; use items_per_thread=1"
+            )
+
+    for request in requests:
+        external_renderer = bundle_renderer_for(request)
+        if external_renderer is not None:
+            lines.extend(external_renderer.render(request))
+            continue
+        lines.extend(render_local_request(request))
+
+    lines.append("}")
+    return "\n".join(lines) + "\n"

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_runtime.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_runtime.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Validate and diagnose the separately installed CUTLASS DSL runtime."""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import importlib.metadata
+from collections.abc import Callable
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Any
+
+_MINIMUM_RUNTIME_VERSION = "4.8"
+_RUNTIME_EXTRA = "cuda-coop[cutlass]"
+_RUNTIME_DISTRIBUTIONS = ("nvidia-cutlass-dsl",)
+_RUNTIME_MODULES = (
+    "cutlass.cutlass_dsl",
+    "cutlass.cute",
+    "cutlass.base_dsl.compiler",
+)
+
+
+class CutlassRuntimeDependencyError(ImportError):
+    """Structured failure to load a qualified CUTLASS backend."""
+
+    def __init__(
+        self,
+        reason_code: str,
+        message: str,
+        *,
+        cause: BaseException | None = None,
+        **details: Any,
+    ) -> None:
+        super().__init__(message)
+        self.backend = "cutlass"
+        self.reason_code = reason_code
+        self.details = details
+        if cause is not None:
+            self.__cause__ = cause
+
+
+@dataclass(frozen=True)
+class CutlassRuntime:
+    """Validated CUTLASS modules and compiler type used by ``cuda.coop``."""
+
+    cutlass_dsl: ModuleType
+    cute: ModuleType
+    compiler: ModuleType
+    dsl_type: type
+
+
+def _runtime_requirement() -> str:
+    version = None
+    distribution = None
+    for candidate in _RUNTIME_DISTRIBUTIONS:
+        try:
+            version = importlib.metadata.version(candidate)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+        distribution = candidate
+        break
+
+    detected = "no CUTLASS DSL distribution was detected"
+    if isinstance(version, str) and version:
+        detected = f"detected {distribution}=={version}"
+    return (
+        f"{detected}; the public package floor is nvidia-cutlass-dsl>="
+        f"{_MINIMUM_RUNTIME_VERSION}. Install '{_RUNTIME_EXTRA}'."
+    )
+
+
+def _runtime_import_error(error: ImportError) -> CutlassRuntimeDependencyError:
+    missing = getattr(error, "name", None)
+    if missing == "cutlass":
+        return CutlassRuntimeDependencyError(
+            "backend-runtime-missing",
+            "cuda.coop.cutlass requires a compatible CUTLASS DSL runtime. "
+            f"{_runtime_requirement()}",
+            cause=error,
+            missing=missing,
+        )
+    if isinstance(missing, str) and any(
+        missing == module_name or missing.startswith(f"{module_name}.")
+        for module_name in _RUNTIME_MODULES
+    ):
+        return CutlassRuntimeDependencyError(
+            "conflicting-backend-runtime",
+            "cuda.coop.cutlass found a package named 'cutlass', but it does not "
+            "provide the complete CUTLASS DSL compiler runtime; missing "
+            f"{missing!r}. Remove the conflicting package. "
+            f"{_runtime_requirement()}",
+            cause=error,
+            missing=missing,
+        )
+    return CutlassRuntimeDependencyError(
+        "transitive-runtime-import-failed",
+        "cuda.coop.cutlass found the CUTLASS DSL runtime, but importing it "
+        "failed at dependency "
+        f"{missing!r}. {_runtime_requirement()}",
+        cause=error,
+        missing=missing,
+    )
+
+
+def _missing_capabilities(
+    cutlass_dsl: ModuleType,
+    cute: ModuleType,
+    compiler: ModuleType,
+) -> tuple[str, ...]:
+    dsl_type = getattr(cutlass_dsl, "CuTeDSL", None)
+    missing: list[str] = []
+    if not isinstance(dsl_type, type):
+        missing.append("cutlass.cutlass_dsl.CuTeDSL")
+    else:
+        for name in (
+            "_get_dsl",
+            "register_trace_context_factory",
+            "register_trace_finalize_hook",
+        ):
+            if not callable(getattr(dsl_type, name, None)):
+                missing.append(f"cutlass.cutlass_dsl.CuTeDSL.{name}")
+
+    if not callable(getattr(cute, "_get_launch_facts", None)):
+        missing.append("cutlass.cute._get_launch_facts")
+
+    link_libraries = getattr(compiler, "LinkLibraries", None)
+    if not callable(link_libraries):
+        missing.append("cutlass.base_dsl.compiler.LinkLibraries")
+    elif getattr(link_libraries, "_option_name", None) != "link-libraries":
+        missing.append(
+            "cutlass.base_dsl.compiler.LinkLibraries._option_name=link-libraries"
+        )
+
+    if not callable(getattr(compiler, "GPUArch", None)):
+        missing.append("cutlass.base_dsl.compiler.GPUArch")
+    return tuple(missing)
+
+
+@functools.lru_cache(maxsize=1)
+def validate_cutlass_runtime() -> CutlassRuntime:
+    """Return CUTLASS modules with the capabilities required by ``cuda.coop``."""
+
+    try:
+        cutlass_dsl = importlib.import_module("cutlass.cutlass_dsl")
+        cute = importlib.import_module("cutlass.cute")
+        compiler = importlib.import_module("cutlass.base_dsl.compiler")
+    except ImportError as error:
+        raise _runtime_import_error(error) from error
+    except Exception as error:
+        raise CutlassRuntimeDependencyError(
+            "transitive-runtime-import-failed",
+            "cuda.coop.cutlass found the CUTLASS DSL runtime, but importing it "
+            "failed with "
+            f"{type(error).__name__}. "
+            f"{_runtime_requirement()}",
+            cause=error,
+            exception_type=type(error).__name__,
+        ) from error
+
+    missing_capabilities = _missing_capabilities(cutlass_dsl, cute, compiler)
+    if missing_capabilities:
+        raise CutlassRuntimeDependencyError(
+            "backend-runtime-incompatible",
+            "cuda.coop.cutlass requires CUTLASS trace contexts, trace "
+            "finalization, exact launch facts, architecture selection, and "
+            "link-library merging; missing: "
+            + ", ".join(missing_capabilities)
+            + f". {_runtime_requirement()}",
+            missing_capabilities=missing_capabilities,
+        )
+
+    return CutlassRuntime(
+        cutlass_dsl=cutlass_dsl,
+        cute=cute,
+        compiler=compiler,
+        dsl_type=cutlass_dsl.CuTeDSL,
+    )
+
+
+def raise_for_missing_cutlass_runtime(error: ImportError) -> None:
+    missing = getattr(error, "name", None)
+    if not isinstance(missing, str):
+        return
+    if missing == "cutlass" or missing.startswith("cutlass."):
+        translated = _runtime_import_error(error)
+        raise translated from error
+
+
+def guard_cutlass_runtime(function: Callable[..., Any]) -> Callable[..., Any]:
+    """Translate CUTLASS import failures from lazily imported provider modules."""
+
+    @functools.wraps(function)
+    def guarded(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return function(*args, **kwargs)
+        except ImportError as error:
+            raise_for_missing_cutlass_runtime(error)
+            raise
+
+    return guarded
+
+
+__all__ = [
+    "CutlassRuntime",
+    "CutlassRuntimeDependencyError",
+    "guard_cutlass_runtime",
+    "raise_for_missing_cutlass_runtime",
+    "validate_cutlass_runtime",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_state.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_state.py
@@ -1,0 +1,701 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+"""Per-trace provider sessions, finalizer activation, and scalar identity."""
+
+from __future__ import annotations
+
+import importlib
+import threading
+import weakref
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from cutlass.base_dsl.common import DSLRuntimeError
+from cutlass.base_dsl.typing import (
+    Float32,
+    Float64,
+    Int32,
+    Int64,
+    Uint32,
+    Uint64,
+)
+
+from cuda.coop._core.api._dispatch import _common_root_operation_name
+from cuda.coop._core.dtype_policy import validate_portable_numeric_dtype_name
+
+from .._value_metadata import (
+    ValueGroupMetadata,
+    register_scalar_metadata_lookup,
+)
+from ._rendering import canonical_bundle_requests
+from ._types import (
+    ORDINARY_PROVIDER_TYPES,
+    PROVIDER_TYPE_NAMES,
+    TYPE_SPECS,
+    DeferredTempStorageEvent,
+    supported_names,
+)
+
+
+@dataclass(frozen=True)
+class _ScalarResultTypeEntry:
+    value_type: type
+    value_ref: weakref.ReferenceType[Any] | None
+    strong_ref: Any | None = None
+    group_metadata: ValueGroupMetadata | None = None
+
+
+_SESSION_SCOPE = "cuda.coop.cutlass"
+
+_TRACE_HOOK_DISPATCHER_ATTR = "_cuda_coop_cutlass_provider_trace_finalize_dispatcher"
+
+_TRACE_HOOK_TARGET_ATTR = "_cuda_coop_cutlass_provider_trace_finalize_hook"
+
+_BUILTIN_SCALAR_VALUE_TYPES = (bool, int, float, complex, str)
+
+_BUNDLE_FINALIZER: Callable[[Any, Any, str], None] | None = None
+
+_COMPILE_OPTIONS_UNSET = object()
+
+_STATE_LOCK = threading.RLock()
+
+_SCALAR_RESULT_TYPES: dict[tuple[int, type], _ScalarResultTypeEntry] = {}
+
+_SESSIONS: weakref.WeakKeyDictionary[Any, BundleSession] = weakref.WeakKeyDictionary()
+
+_ID_SESSIONS: dict[int, tuple[weakref.ReferenceType[Any], BundleSession, Any]] = {}
+
+
+class BundleSession:
+    def __init__(self, trace_module_op: Any | None = None) -> None:
+        self._lock = threading.RLock()
+        self.trace_module_op = trace_module_op
+        self.requests: set[Any] = set()
+        self.temp_storage_bindings: weakref.WeakKeyDictionary[Any, Any] = (
+            weakref.WeakKeyDictionary()
+        )
+        self.scalar_result_type_entries: dict[
+            tuple[int, type], _ScalarResultTypeEntry
+        ] = {}
+        self.deferred_temp_storage_events: list[DeferredTempStorageEvent] = []
+
+    def close(self) -> None:
+        try:
+            with _STATE_LOCK:
+                _clear_scalar_result_types_for_session_locked(self)
+        except Exception:
+            pass
+
+    def __del__(self) -> None:
+        self.close()
+
+    def add(self, request: Any) -> None:
+        with self._lock:
+            self.requests.add(request)
+
+    def add_scalar_result_type_entry(
+        self,
+        key: tuple[int, type],
+        entry: _ScalarResultTypeEntry,
+    ) -> None:
+        with self._lock:
+            self.scalar_result_type_entries[key] = entry
+
+    def add_deferred_temp_storage_event(
+        self,
+        event: DeferredTempStorageEvent,
+    ) -> None:
+        with self._lock:
+            self.deferred_temp_storage_events.append(event)
+
+    def is_empty(self) -> bool:
+        with self._lock:
+            return not self.requests and not self.deferred_temp_storage_events
+
+    def snapshot(self):
+        with self._lock:
+            return (
+                self.trace_module_op,
+                set(self.requests),
+                dict(self.temp_storage_bindings),
+                dict(self.scalar_result_type_entries),
+                list(self.deferred_temp_storage_events),
+            )
+
+    def restore(self, snapshot) -> None:
+        if len(snapshot) == 3:
+            requests, temp_storage_bindings, scalar_result_type_entries = snapshot
+            deferred_temp_storage_events = []
+            trace_module_op = self.trace_module_op
+        elif len(snapshot) == 4:
+            (
+                requests,
+                temp_storage_bindings,
+                scalar_result_type_entries,
+                deferred_temp_storage_events,
+            ) = snapshot
+            trace_module_op = self.trace_module_op
+        else:
+            (
+                trace_module_op,
+                requests,
+                temp_storage_bindings,
+                scalar_result_type_entries,
+                deferred_temp_storage_events,
+            ) = snapshot
+        restored_entries = dict(scalar_result_type_entries)
+        with _STATE_LOCK, self._lock:
+            for key, entry in self.scalar_result_type_entries.items():
+                if key in restored_entries:
+                    continue
+                if _SCALAR_RESULT_TYPES.get(key) is entry:
+                    _SCALAR_RESULT_TYPES.pop(key, None)
+            for key, entry in restored_entries.items():
+                _SCALAR_RESULT_TYPES[key] = entry
+            self.requests = set(requests)
+            self.trace_module_op = trace_module_op
+            self.temp_storage_bindings = weakref.WeakKeyDictionary(
+                temp_storage_bindings
+            )
+            self.scalar_result_type_entries = restored_entries
+            self.deferred_temp_storage_events = list(deferred_temp_storage_events)
+
+    def get_temp_storage_binding(self, temp_storage: Any) -> Any | None:
+        with self._lock:
+            return self.temp_storage_bindings.get(temp_storage)
+
+    def set_temp_storage_binding(self, temp_storage: Any, binding: Any) -> None:
+        with self._lock:
+            self.temp_storage_bindings[temp_storage] = binding
+
+    def request_list(self) -> list[Any]:
+        with self._lock:
+            return list(canonical_bundle_requests(self.requests))
+
+    def deferred_temp_storage_event_list(self) -> list[DeferredTempStorageEvent]:
+        with self._lock:
+            return list(self.deferred_temp_storage_events)
+
+    def belongs_to_trace_module(self, trace_module_op: Any) -> bool:
+        with self._lock:
+            return self.trace_module_op is None or _same_mlir_operation(
+                self.trace_module_op,
+                trace_module_op,
+            )
+
+    def bind_trace_module(self, trace_module_op: Any) -> bool:
+        with self._lock:
+            if self.trace_module_op is None:
+                self.trace_module_op = trace_module_op
+                return True
+            return _same_mlir_operation(self.trace_module_op, trace_module_op)
+
+    def scalar_result_type_entry_items(
+        self,
+    ) -> list[tuple[tuple[int, type], _ScalarResultTypeEntry]]:
+        with self._lock:
+            return list(self.scalar_result_type_entries.items())
+
+    def scalar_result_type_key_list(self) -> list[tuple[int, type]]:
+        with self._lock:
+            return list(self.scalar_result_type_entries)
+
+    def clear_scalar_result_type_keys(self) -> None:
+        with self._lock:
+            self.scalar_result_type_entries.clear()
+
+
+def register_bundle_finalizer(
+    finalizer: Callable[[Any, Any, str], None],
+    *,
+    scope: str = _SESSION_SCOPE,
+) -> None:
+    if not callable(finalizer):
+        raise TypeError("finalizer must be callable")
+    global _BUNDLE_FINALIZER, _SESSION_SCOPE
+    with _STATE_LOCK:
+        _BUNDLE_FINALIZER = finalizer
+        _SESSION_SCOPE = scope
+
+
+def _ensure_bundle_finalizer() -> Callable[[Any, Any, str], None]:
+    if _BUNDLE_FINALIZER is None:
+        importlib.import_module(f"{__package__}._finalize")
+    if _BUNDLE_FINALIZER is None:
+        raise DSLRuntimeError(
+            f"{_SESSION_SCOPE} provider has no cooperative bundle finalizer."
+        )
+    return _BUNDLE_FINALIZER
+
+
+def _get_cute_dsl():
+    from cutlass.cute import _dsl as cute_dsl
+
+    return cute_dsl.CuTeDSL._get_dsl()
+
+
+def _trace_finalize_dispatcher(dsl, module, function_name) -> None:
+    hook = getattr(dsl, _TRACE_HOOK_TARGET_ATTR, None)
+    if hook is not None:
+        hook(dsl, module, function_name)
+
+
+def ensure_trace_hook_registered(
+    *,
+    finalizer: Callable[[Any, Any, str], None] | None = None,
+    scope: str | None = None,
+    get_cute_dsl: Callable[[], Any] | None = None,
+) -> None:
+    if finalizer is None:
+        finalizer = _ensure_bundle_finalizer()
+        scope = _SESSION_SCOPE if scope is None else scope
+    else:
+        scope = _SESSION_SCOPE if scope is None else scope
+        with _STATE_LOCK:
+            needs_registration = (
+                _BUNDLE_FINALIZER is not finalizer or _SESSION_SCOPE != scope
+            )
+        if needs_registration:
+            register_bundle_finalizer(finalizer, scope=scope)
+
+    dsl = _get_cute_dsl() if get_cute_dsl is None else get_cute_dsl()
+    with _STATE_LOCK:
+        if getattr(dsl, _TRACE_HOOK_DISPATCHER_ATTR, None) is None:
+            register_hook = getattr(dsl, "register_trace_finalize_hook", None)
+            if register_hook is None:
+                raise DSLRuntimeError(
+                    f"{scope} provider requires CuTe DSL trace-finalize hook "
+                    "support so generated cooperative-primitive bundles can be "
+                    "linked into the compiled kernel. Install a compatible "
+                    "CUTLASS DSL runtime with register_trace_finalize_hook and "
+                    "link-libraries support."
+                )
+            register_hook(_trace_finalize_dispatcher)
+            setattr(
+                dsl,
+                _TRACE_HOOK_DISPATCHER_ATTR,
+                _trace_finalize_dispatcher,
+            )
+        setattr(dsl, _TRACE_HOOK_TARGET_ATTR, finalizer)
+        dsl._cuda_coop_cutlass_provider_trace_hook_registered = True
+
+
+def _ensure_trace_hook_registered() -> None:
+    ensure_trace_hook_registered()
+
+
+def lookup_bundle_session(compile_options: Any) -> BundleSession | None:
+    with _STATE_LOCK:
+        try:
+            return _SESSIONS.get(compile_options)
+        except TypeError:
+            key = id(compile_options)
+            entry = _ID_SESSIONS.get(key)
+            if entry is None:
+                return None
+            compile_options_ref, session, _finalizer = entry
+            if compile_options_ref() is compile_options:
+                return session
+            _ID_SESSIONS.pop(key, None)
+            return None
+
+
+def _drop_id_session(key: int) -> None:
+    with _STATE_LOCK:
+        entry = _ID_SESSIONS.pop(key, None)
+        if entry is not None:
+            entry[1].close()
+
+
+def _clear_scalar_result_types_for_session_locked(session: BundleSession) -> None:
+    for key, entry in session.scalar_result_type_entry_items():
+        if _SCALAR_RESULT_TYPES.get(key) is entry:
+            _SCALAR_RESULT_TYPES.pop(key, None)
+    session.clear_scalar_result_type_keys()
+
+
+def set_bundle_session(compile_options: Any, session: BundleSession) -> None:
+    with _STATE_LOCK:
+        try:
+            _SESSIONS[compile_options] = session
+        except TypeError:
+            try:
+                compile_options_ref = weakref.ref(compile_options)
+            except TypeError as exc:
+                raise DSLRuntimeError(
+                    f"{_SESSION_SCOPE} provider compile_options must be "
+                    "hashable or weak-referenceable."
+                ) from exc
+            key = id(compile_options)
+            finalizer = weakref.finalize(compile_options, _drop_id_session, key)
+            _ID_SESSIONS[key] = (compile_options_ref, session, finalizer)
+
+
+def pop_bundle_session(compile_options: Any) -> BundleSession | None:
+    with _STATE_LOCK:
+        try:
+            session = _SESSIONS.pop(compile_options, None)
+            if session is not None:
+                session.close()
+            return session
+        except TypeError:
+            entry = _ID_SESSIONS.pop(id(compile_options), None)
+            if entry is None:
+                return None
+            compile_options_ref, session, finalizer = entry
+            if finalizer.alive:
+                finalizer.detach()
+            if compile_options_ref() is compile_options:
+                session.close()
+                return session
+            return None
+
+
+def _same_mlir_operation(lhs: Any, rhs: Any) -> bool:
+    lhs = getattr(lhs, "operation", lhs)
+    rhs = getattr(rhs, "operation", rhs)
+    if lhs is rhs:
+        return True
+    try:
+        result = lhs == rhs
+    except Exception:
+        return False
+    return isinstance(result, bool) and result
+
+
+def _active_trace_module_op() -> Any | None:
+    try:
+        from cutlass._mlir import ir
+
+        current_ip = ir.InsertionPoint.current
+        op = None if current_ip is None else current_ip.block.owner
+    except Exception:
+        return None
+
+    while op is not None:
+        operation = getattr(op, "operation", op)
+        if str(getattr(operation, "name", "")) == "builtin.module":
+            return operation
+        op = getattr(operation, "parent", None)
+    return None
+
+
+def get_or_create_bundle_session(
+    compile_options: Any,
+    *,
+    trace_module_op: Any | None = None,
+) -> BundleSession:
+    with _STATE_LOCK:
+        session = lookup_bundle_session(compile_options)
+        if session is not None and trace_module_op is not None:
+            if not session.bind_trace_module(trace_module_op):
+                pop_bundle_session(compile_options)
+                session = None
+        if session is None:
+            session = BundleSession(trace_module_op=trace_module_op)
+            set_bundle_session(compile_options, session)
+        return session
+
+
+def active_bundle_session() -> BundleSession:
+    _ensure_trace_hook_registered()
+    compile_options = _get_cute_dsl().compile_options
+    return get_or_create_bundle_session(
+        compile_options,
+        trace_module_op=_active_trace_module_op(),
+    )
+
+
+def snapshot_active_session_state_for(*, get_cute_dsl: Callable[[], Any]):
+    compile_options = get_cute_dsl().compile_options
+    session = lookup_bundle_session(compile_options)
+    trace_module_op = _active_trace_module_op()
+    if (
+        session is not None
+        and trace_module_op is not None
+        and not session.belongs_to_trace_module(trace_module_op)
+    ):
+        pop_bundle_session(compile_options)
+        session = None
+    if session is None:
+        return compile_options, None
+    return compile_options, session.snapshot()
+
+
+def snapshot_active_session_state():
+    return snapshot_active_session_state_for(get_cute_dsl=_get_cute_dsl)
+
+
+def restore_active_session_state_for(
+    snapshot,
+    *,
+    get_cute_dsl: Callable[[], Any],
+) -> None:
+    current_compile_options = get_cute_dsl().compile_options
+    if snapshot is None:
+        pop_bundle_session(current_compile_options)
+        return
+
+    compile_options, session_snapshot = snapshot
+    if current_compile_options is not compile_options:
+        pop_bundle_session(current_compile_options)
+    if session_snapshot is None:
+        pop_bundle_session(compile_options)
+        return
+
+    session = lookup_bundle_session(compile_options)
+    if session is None:
+        session = BundleSession()
+        set_bundle_session(compile_options, session)
+    session.restore(session_snapshot)
+
+
+def restore_active_session_state(snapshot) -> None:
+    restore_active_session_state_for(snapshot, get_cute_dsl=_get_cute_dsl)
+
+
+def register_request(request: Any) -> None:
+    active_bundle_session().add(request)
+
+
+def canonical_dsl_type(
+    value: Any,
+    *,
+    scope: str = _SESSION_SCOPE,
+    root_scope: str = _SESSION_SCOPE,
+) -> type:
+    if isinstance(value, type) and value in TYPE_SPECS:
+        return value
+
+    if isinstance(value, np.dtype):
+        ordinary_type = ORDINARY_PROVIDER_TYPES.get(value.type)
+        if ordinary_type is not None:
+            return ordinary_type
+
+    if isinstance(value, type):
+        ordinary_type = ORDINARY_PROVIDER_TYPES.get(value)
+        if ordinary_type is not None:
+            return ordinary_type
+
+    value_type = type(value)
+    ordinary_type = ORDINARY_PROVIDER_TYPES.get(value_type)
+    if ordinary_type is not None:
+        return ordinary_type
+    if value_type in TYPE_SPECS:
+        return value_type
+
+    dsl_dtype = getattr(value, "dtype", None)
+    if isinstance(dsl_dtype, type) and dsl_dtype in TYPE_SPECS:
+        return dsl_dtype
+
+    scalar_result_key = _scalar_result_type_key(value)
+    with _STATE_LOCK:
+        remembered_entry = _SCALAR_RESULT_TYPES.get(scalar_result_key)
+    if remembered_entry is not None:
+        remembered_value = (
+            remembered_entry.strong_ref
+            if remembered_entry.value_ref is None
+            else remembered_entry.value_ref()
+        )
+        if remembered_value is value and remembered_entry.value_type in TYPE_SPECS:
+            return remembered_entry.value_type
+
+    mlir_type = getattr(value, "type", None)
+    if mlir_type is None:
+        return value_type
+
+    ty_str = str(mlir_type)
+    signed = getattr(value, "signed", None)
+    is_float = bool(getattr(value, "is_float", False))
+
+    if is_float:
+        if ty_str == "f32":
+            return Float32
+        if ty_str == "f64":
+            return Float64
+        return value_type
+
+    if ty_str in {"i32", "i64"} and signed is None:
+        raise TypeError(
+            f"{scope} provider cannot infer integer signedness; "
+            f"pass a {root_scope}.ThreadData value, a CUDA DSL typing class, "
+            "or a value with signed=True/False"
+        )
+    if ty_str == "i32":
+        return Int32 if signed is True else Uint32
+    if ty_str == "i64":
+        return Int64 if signed is True else Uint64
+    return value_type
+
+
+def _validate_common_root_numeric_dtype(
+    value: Any,
+    *,
+    operation: str | None = None,
+) -> type:
+    """Validate one CUTLASS value only while it crosses the common root."""
+
+    value_type = canonical_dsl_type(value)
+    if operation is None:
+        operation = _common_root_operation_name()
+    if operation is None:
+        return value_type
+    dtype_name = PROVIDER_TYPE_NAMES.get(value_type, "unsupported")
+    validate_portable_numeric_dtype_name(dtype_name, operation=operation)
+    return value_type
+
+
+def _scalar_result_type_key(value: Any) -> tuple[int, type]:
+    return id(value), type(value)
+
+
+def _forget_scalar_result_type(
+    key: tuple[int, type],
+    value_ref: weakref.ReferenceType[Any],
+) -> None:
+    with _STATE_LOCK:
+        entry = _SCALAR_RESULT_TYPES.get(key)
+        if entry is not None and entry.value_ref is value_ref:
+            _SCALAR_RESULT_TYPES.pop(key, None)
+
+
+def remember_scalar_result_type(
+    value: Any,
+    value_type: type,
+    *,
+    scope: str = _SESSION_SCOPE,
+    compile_options: Any = _COMPILE_OPTIONS_UNSET,
+    compile_options_getter: Callable[[], Any] | None = None,
+    group_metadata: ValueGroupMetadata | None = None,
+) -> Any:
+    if value_type not in TYPE_SPECS:
+        return value
+    if type(value) in _BUILTIN_SCALAR_VALUE_TYPES:
+        if group_metadata is not None:
+            raise RuntimeError(
+                f"{scope} provider cannot attach group metadata to an interned "
+                "builtin scalar result"
+            )
+        return value
+
+    key = _scalar_result_type_key(value)
+    with _STATE_LOCK:
+        value_ref: weakref.ReferenceType[Any] | None
+        strong_ref: Any | None = None
+        finalizer = None
+        try:
+            value_ref = weakref.ref(value)
+            finalizer = weakref.finalize(
+                value,
+                _forget_scalar_result_type,
+                key,
+                value_ref,
+            )
+        except TypeError:
+            value_ref = None
+            strong_ref = value
+        else:
+            if value_ref() is not value:
+                if finalizer is not None:
+                    finalizer.detach()
+                return value
+
+        try:
+            if compile_options is _COMPILE_OPTIONS_UNSET:
+                if compile_options_getter is None:
+                    compile_options = _get_cute_dsl().compile_options
+                else:
+                    compile_options = compile_options_getter()
+            session = lookup_bundle_session(compile_options)
+        except Exception:
+            session = None
+        if strong_ref is not None and session is None:
+            raise RuntimeError(
+                f"{scope} provider cannot remember a "
+                "non-weakrefable scalar result type without an active bundle session"
+            )
+
+        entry = _ScalarResultTypeEntry(
+            value_type,
+            value_ref,
+            strong_ref,
+            group_metadata,
+        )
+        _SCALAR_RESULT_TYPES[key] = entry
+        if session is not None:
+            session.add_scalar_result_type_entry(key, entry)
+        if finalizer is not None:
+            finalizer.atexit = False
+    return value
+
+
+def scalar_result_group_metadata(value: Any) -> ValueGroupMetadata | None:
+    key = _scalar_result_type_key(value)
+    with _STATE_LOCK:
+        entry = _SCALAR_RESULT_TYPES.get(key)
+    if entry is None:
+        return None
+    remembered_value = (
+        entry.strong_ref if entry.value_ref is None else entry.value_ref()
+    )
+    if remembered_value is not value:
+        return None
+    return entry.group_metadata
+
+
+register_scalar_metadata_lookup(scalar_result_group_metadata)
+
+
+def resolve_provider_type(
+    value: Any,
+    *,
+    allowed: frozenset[type],
+    feature: str,
+    root_scope: str,
+    namespace: str,
+    canonical_type: Callable[[Any], type],
+) -> type:
+    value_type = canonical_type(value)
+    operation = _common_root_operation_name()
+    if operation is not None:
+        dtype_name = PROVIDER_TYPE_NAMES.get(value_type, "unsupported")
+        validate_portable_numeric_dtype_name(dtype_name, operation=operation)
+    if value_type not in TYPE_SPECS or value_type not in allowed:
+        raise NotImplementedError(
+            f"{root_scope}.{namespace} provider {feature} currently supports "
+            f"{supported_names(allowed)} only"
+        )
+    return value_type
+
+
+def make_provider_type_resolver(
+    *,
+    scope: str,
+    root_scope: str,
+    namespace: str,
+) -> Callable[..., type]:
+    def resolve_type(
+        value: Any,
+        *,
+        allowed: frozenset[type],
+        feature: str,
+    ) -> type:
+        return resolve_provider_type(
+            value,
+            allowed=allowed,
+            feature=feature,
+            root_scope=root_scope,
+            namespace=namespace,
+            canonical_type=lambda value: canonical_dsl_type(
+                value,
+                scope=scope,
+                root_scope=root_scope,
+            ),
+        )
+
+    return resolve_type

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_storage.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_storage.py
@@ -1,0 +1,457 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+"""Deferred and explicit shared-memory storage materialization."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable, Mapping
+from dataclasses import dataclass
+from typing import Any, NoReturn
+
+from cutlass.base_dsl.common import DSLRuntimeError
+from cutlass.base_dsl.typing import (
+    Int32,
+    Uint8,
+    Uint32,
+)
+
+from ._state import _SESSION_SCOPE, BundleSession, active_bundle_session
+from ._types import (
+    DeferredTempStorageBinding,
+    DeferredTempStorageEvent,
+    DeferredTempStoragePlan,
+    ScratchLayout,
+)
+
+
+def _deferred_temp_storage_capability_error(
+    cause: Exception | None = None,
+) -> NoReturn:
+    raise DSLRuntimeError(
+        f"{_SESSION_SCOPE} deferred TempStorage requires "
+        "a CUTLASS DSL with trace finalization, SmemAllocator, and MLIR value "
+        "replacement support. Install a compatible CUTLASS DSL runtime.",
+        cause=cause,
+    )
+
+
+def _active_cuda_kernel_op() -> Any:
+    try:
+        from cutlass._mlir import ir
+
+        current_ip = ir.InsertionPoint.current
+    except Exception as exc:
+        raise DSLRuntimeError(
+            f"{_SESSION_SCOPE} deferred TempStorage requires an active CuTe "
+            "kernel trace."
+        ) from exc
+
+    if current_ip is None or current_ip.block is None:
+        raise DSLRuntimeError(
+            f"{_SESSION_SCOPE} deferred TempStorage requires an active CuTe "
+            "kernel trace."
+        )
+
+    op = current_ip.block.owner
+    while op is not None:
+        operation = getattr(op, "operation", op)
+        if getattr(operation, "name", None) == "cuda.kernel":
+            return operation
+        op = getattr(op, "parent_op", None) or getattr(op, "parent", None)
+
+    raise DSLRuntimeError(
+        f"{_SESSION_SCOPE} deferred TempStorage could not find the enclosing "
+        "cuda.kernel operation."
+    )
+
+
+def _cuda_kernel_name(kernel_op: Any) -> str:
+    try:
+        return str(kernel_op.attributes["sym_name"])
+    except Exception:
+        return f"cuda.kernel@{id(kernel_op):x}"
+
+
+def _fresh_i32_placeholder() -> Any:
+    from cutlass._mlir.dialects import arith
+    from cutlass.cutlass_dsl import T
+
+    return arith.constant(T.i32(), 0)
+
+
+def register_deferred_temp_storage_event(
+    temp_storage: Any,
+    *,
+    primitive_name: str,
+    requirement_key: Hashable,
+    active_session_getter: Callable[[], BundleSession] = active_bundle_session,
+) -> tuple[Any, Any, Any]:
+    """Emit fresh ABI placeholders and record one deferred scratch use."""
+
+    if not getattr(temp_storage, "is_deferred", False):
+        raise ValueError("deferred scratch registration requires deferred TempStorage")
+    try:
+        hash(requirement_key)
+    except TypeError as exc:
+        raise TypeError("scratch requirement keys must be hashable") from exc
+
+    session = active_session_getter()
+    kernel_op = _active_cuda_kernel_op()
+    smem_addr_placeholder = _fresh_i32_placeholder()
+    size_placeholder = _fresh_i32_placeholder()
+    try:
+        location = str(smem_addr_placeholder.owner.location)
+    except Exception:
+        location = "unknown location"
+
+    session.add_deferred_temp_storage_event(
+        DeferredTempStorageEvent(
+            kernel_op=kernel_op,
+            kernel_name=_cuda_kernel_name(kernel_op),
+            temp_storage=temp_storage,
+            primitive_name=primitive_name,
+            requirement_key=requirement_key,
+            sharing=temp_storage.sharing,
+            auto_sync=temp_storage.auto_sync,
+            capacity_size_in_bytes=temp_storage.capacity_size_in_bytes,
+            capacity_alignment=temp_storage.alignment,
+            smem_addr_placeholder=smem_addr_placeholder,
+            size_placeholder=size_placeholder,
+            location=location,
+        )
+    )
+    return (
+        Uint32(smem_addr_placeholder),
+        Int32(size_placeholder),
+        Int32(1 if temp_storage.auto_sync else 0),
+    )
+
+
+def _align_up(value: int, alignment: int) -> int:
+    remainder = value % alignment
+    return value if remainder == 0 else value + alignment - remainder
+
+
+def plan_deferred_temp_storage_events(
+    events: list[DeferredTempStorageEvent],
+    layouts: Mapping[Hashable, ScratchLayout],
+) -> tuple[DeferredTempStoragePlan, ...]:
+    """Resolve exact kernel-local storage plans without mutating MLIR."""
+
+    grouped: dict[tuple[Any, int], list[DeferredTempStorageEvent]] = {}
+    for event in events:
+        grouped.setdefault(
+            (event.kernel_op, id(event.temp_storage)),
+            [],
+        ).append(event)
+
+    plans: list[DeferredTempStoragePlan] = []
+    for group_events in grouped.values():
+        first = group_events[0]
+        for event in group_events[1:]:
+            if (
+                event.sharing != first.sharing
+                or event.auto_sync != first.auto_sync
+                or event.capacity_size_in_bytes != first.capacity_size_in_bytes
+                or event.capacity_alignment != first.capacity_alignment
+            ):
+                raise DSLRuntimeError(
+                    "Deferred TempStorage configuration changed during tracing "
+                    f"for {first.kernel_name} ({event.location})."
+                )
+        event_layouts = []
+        for event in group_events:
+            layout = layouts.get(event.requirement_key)
+            if layout is None:
+                raise DSLRuntimeError(
+                    "No exact C++ scratch layout was registered for "
+                    f"{event.primitive_name} ({event.location})."
+                )
+            event_layouts.append((event, layout))
+
+        required_plan_alignment = max(layout.alignment for _, layout in event_layouts)
+        if first.sharing == "shared":
+            planned_size = max(layout.size_in_bytes for _, layout in event_layouts)
+            planned_bindings = tuple(
+                (event, 0, planned_size, required_plan_alignment)
+                for event, _ in event_layouts
+            )
+        else:
+            planned_size = 0
+            exclusive_bindings = []
+            for event, layout in event_layouts:
+                offset = _align_up(planned_size, layout.alignment)
+                exclusive_bindings.append(
+                    (event, offset, layout.size_in_bytes, layout.alignment)
+                )
+                planned_size = offset + layout.size_in_bytes
+            planned_bindings = tuple(exclusive_bindings)
+
+        capacity_size = first.capacity_size_in_bytes
+        if capacity_size is not None and capacity_size < planned_size:
+            raise DSLRuntimeError(
+                "Deferred TempStorage capacity is smaller than its resolved plan "
+                f"in {first.kernel_name} ({capacity_size} < {planned_size})."
+            )
+        resolved_size_in_bytes = (
+            capacity_size if capacity_size is not None else planned_size
+        )
+        if first.capacity_alignment is None:
+            plan_alignment = required_plan_alignment
+        else:
+            if first.capacity_alignment < required_plan_alignment:
+                raise DSLRuntimeError(
+                    "Deferred TempStorage alignment is weaker than its resolved "
+                    f"plan in {first.kernel_name}."
+                )
+            plan_alignment = first.capacity_alignment
+
+        bindings = tuple(
+            DeferredTempStorageBinding(
+                event=event,
+                byte_offset_in_bytes=offset,
+                size_in_bytes=(
+                    binding_size_in_bytes
+                    if first.sharing == "exclusive"
+                    else resolved_size_in_bytes
+                ),
+                alignment=(
+                    binding_alignment
+                    if first.sharing == "exclusive"
+                    else plan_alignment
+                ),
+            )
+            for event, offset, binding_size_in_bytes, binding_alignment in (
+                planned_bindings
+            )
+        )
+        plans.append(
+            DeferredTempStoragePlan(
+                kernel_op=first.kernel_op,
+                kernel_name=first.kernel_name,
+                temp_storage=first.temp_storage,
+                size_in_bytes=resolved_size_in_bytes,
+                alignment=plan_alignment,
+                bindings=bindings,
+            )
+        )
+    return tuple(plans)
+
+
+def _replace_all_uses(old_value: Any, new_value: Any) -> None:
+    for method_name in ("replace_all_uses_with", "replaceAllUsesWith"):
+        replace = getattr(old_value, method_name, None)
+        if replace is None:
+            continue
+        try:
+            replace(new_value)
+            return
+        except Exception:
+            continue
+    _deferred_temp_storage_capability_error()
+
+
+def materialize_deferred_temp_storage_plans(
+    plans: tuple[DeferredTempStoragePlan, ...],
+) -> None:
+    """Insert planned allocations and backpatch every recorded ABI operand."""
+
+    if not plans:
+        return
+
+    try:
+        from cutlass._mlir import ir
+        from cutlass._mlir.dialects import arith, llvm
+        from cutlass.cute.typing import Pointer
+        from cutlass.cutlass_dsl import T
+        from cutlass.memory import SmemAllocator
+    except (AttributeError, ImportError) as exc:
+        _deferred_temp_storage_capability_error(exc)
+
+    required_capabilities = (
+        getattr(ir.InsertionPoint, "at_block_begin", None),
+        getattr(SmemAllocator, "allocate", None),
+        getattr(Pointer, "to_llvm_ptr", None),
+        getattr(arith, "constant", None),
+        getattr(arith, "addi", None),
+        getattr(llvm, "ptrtoint", None),
+    )
+    if not all(callable(capability) for capability in required_capabilities):
+        _deferred_temp_storage_capability_error()
+
+    kernel_groups: dict[Any, tuple[Any, list[DeferredTempStoragePlan]]] = {}
+    for plan in plans:
+        try:
+            entry_block = plan.kernel_op.regions[0].blocks[0]
+        except Exception as exc:
+            raise DSLRuntimeError(
+                "Deferred TempStorage could not locate the entry block for "
+                f"{plan.kernel_name}."
+            ) from exc
+        kernel_key = plan.kernel_op
+        existing_group = kernel_groups.get(kernel_key)
+        if existing_group is None:
+            kernel_groups[kernel_key] = (entry_block, [plan])
+        else:
+            existing_group[1].append(plan)
+        for binding in plan.bindings:
+            for placeholder in (
+                binding.event.smem_addr_placeholder,
+                binding.event.size_placeholder,
+            ):
+                if not any(
+                    callable(getattr(placeholder, method_name, None))
+                    for method_name in ("replace_all_uses_with", "replaceAllUsesWith")
+                ):
+                    _deferred_temp_storage_capability_error()
+
+    for entry_block, kernel_plans in kernel_groups.values():
+        with ir.InsertionPoint.at_block_begin(entry_block):
+            allocator = SmemAllocator()
+            for plan in kernel_plans:
+                smem_ptr = allocator.allocate(
+                    plan.size_in_bytes,
+                    plan.alignment,
+                )
+                base_addr = llvm.ptrtoint(T.i32(), smem_ptr.to_llvm_ptr())
+                for binding in plan.bindings:
+                    smem_addr = base_addr
+                    if binding.byte_offset_in_bytes:
+                        offset = arith.constant(
+                            T.i32(),
+                            binding.byte_offset_in_bytes,
+                        )
+                        smem_addr = arith.addi(base_addr, offset)
+                    size = arith.constant(T.i32(), binding.size_in_bytes)
+                    _replace_all_uses(
+                        binding.event.smem_addr_placeholder,
+                        smem_addr,
+                    )
+                    _replace_all_uses(binding.event.size_placeholder, size)
+
+
+@dataclass(frozen=True)
+class _TempStorageBinding:
+    smem_addr_u32: Any
+    size_in_bytes: int
+    alignment: int
+    auto_sync: bool
+
+
+def materialize_temp_storage_binding(
+    temp_storage: Any,
+    *,
+    scope: str = _SESSION_SCOPE,
+    active_session_getter: Callable[[], BundleSession] = active_bundle_session,
+    implicit_alignment: int = 8,
+) -> _TempStorageBinding:
+    session = active_session_getter()
+    size_in_bytes = (
+        temp_storage.capacity_size_in_bytes
+        if temp_storage.capacity_size_in_bytes is not None
+        else temp_storage.required_size_in_bytes
+    )
+    alignment = (
+        temp_storage.alignment
+        if temp_storage.alignment is not None
+        else max(implicit_alignment, temp_storage.required_alignment)
+    )
+
+    binding = session.get_temp_storage_binding(temp_storage)
+    # Primitive temp-storage requirements are discovered before provider
+    # materialization. If a binding has already been allocated, growing it here
+    # would leave earlier FFI call sites pointing at an undersized allocation.
+    if (
+        binding is not None
+        and binding.size_in_bytes >= size_in_bytes
+        and binding.alignment >= alignment
+        and binding.auto_sync == temp_storage.auto_sync
+    ):
+        return binding
+    if binding is not None:
+        raise RuntimeError(
+            f"{scope}.TempStorage requirements changed after shared-memory "
+            "materialization; record all primitive uses before requesting "
+            "provider storage"
+        )
+
+    binding = _TempStorageBinding(
+        smem_addr_u32=_allocate_smem_addr_u32(size_in_bytes, alignment),
+        size_in_bytes=size_in_bytes,
+        alignment=alignment,
+        auto_sync=temp_storage.auto_sync,
+    )
+    session.set_temp_storage_binding(temp_storage, binding)
+    return binding
+
+
+def _allocate_smem_addr_u32(size_in_bytes: int, alignment: int) -> Any:
+    if size_in_bytes <= 0:
+        return Uint32(0)
+
+    from cutlass._mlir.dialects import llvm
+    from cutlass.cute.arch import smem as cute_smem
+    from cutlass.cutlass_dsl import T
+
+    smem_ptr = cute_smem.alloc_smem(Uint8, size_in_bytes, alignment)
+    # Carry shared-space address (u32) through ABI. Shims recover a usable
+    # generic pointer via cvta.shared before doing typed accesses.
+    return Uint32(llvm.ptrtoint(T.i32(), smem_ptr.to_llvm_ptr()))
+
+
+def temp_storage_ffi_args_for_size(
+    size_in_bytes: int,
+    alignment: int,
+    *,
+    auto_sync: bool = True,
+) -> tuple[Any, Any, Any]:
+    return (
+        _allocate_smem_addr_u32(size_in_bytes, alignment),
+        Int32(size_in_bytes),
+        Int32(1 if auto_sync else 0),
+    )
+
+
+def temp_storage_ffi_args(
+    primitive_name: str,
+    *,
+    scope: str = _SESSION_SCOPE,
+    active_session_getter: Callable[[], BundleSession] = active_bundle_session,
+    implicit_alignment: int = 8,
+) -> tuple[Any, Any, Any]:
+    from ._call_context import get_active_single_phase_context
+
+    context = get_active_single_phase_context()
+    temp_storage = context.temp_storage if context is not None else None
+    if temp_storage is None:
+        return (Uint32(0), Int32(0), Int32(1))
+    if getattr(temp_storage, "is_deferred", False):
+        raise NotImplementedError(
+            f"{scope}.{primitive_name} does not support inferred TempStorage; "
+            "pass a fixed-capacity TempStorage or None"
+        )
+
+    binding = materialize_temp_storage_binding(
+        temp_storage,
+        scope=scope,
+        active_session_getter=active_session_getter,
+        implicit_alignment=implicit_alignment,
+    )
+    primitive_slice = temp_storage.slice_for_latest_use(primitive_name)
+    if primitive_slice is None or primitive_slice.size_in_bytes <= 0:
+        return (Uint32(0), Int32(0), Int32(1 if binding.auto_sync else 0))
+
+    smem_addr_arg = binding.smem_addr_u32
+    slice_size_in_bytes = primitive_slice.size_in_bytes
+    if temp_storage.sharing == "shared":
+        slice_size_in_bytes = binding.size_in_bytes
+    if primitive_slice.byte_offset_in_bytes != 0:
+        smem_addr_arg = smem_addr_arg + Uint32(primitive_slice.byte_offset_in_bytes)
+    return (
+        smem_addr_arg,
+        Int32(slice_size_in_bytes),
+        Int32(1 if binding.auto_sync else 0),
+    )

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_target.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_target.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Select the target and artifact format for CUTLASS provider compilation.
+
+This module translates CUTLASS launch configuration into the exact NVRTC or
+Clang target used by bundle orchestration. It does not compile or cache an
+artifact.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from typing import Any
+
+from cutlass.base_dsl.common import DSLRuntimeError
+from cutlass.base_dsl.compiler import GPUArch
+
+BUNDLE_FORMAT_ENV = "CUDA_COOP_CUTLASS_PROVIDER_BUNDLE_FORMAT"
+
+
+def configured_gpu_arch(get_cute_dsl: Callable[[], Any]) -> str:
+    dsl = get_cute_dsl()
+    compile_options = getattr(dsl, "compile_options", None)
+    options = getattr(compile_options, "options", None)
+    option = None
+    if options is not None:
+        if hasattr(options, "get"):
+            option = options.get(GPUArch)
+        else:
+            try:
+                option = options[GPUArch]
+            except (KeyError, TypeError):
+                option = None
+    option_arch = getattr(option, "value", None)
+    if option_arch is not None:
+        arch = str(option_arch).strip()
+        if arch:
+            return arch
+    environment_arch = getattr(getattr(dsl, "envar", None), "arch", None)
+    return "" if environment_arch is None else str(environment_arch).strip()
+
+
+def _is_numeric_arch(arch: str) -> bool:
+    if arch.isdigit():
+        return True
+    return bool(arch and arch[-1] in ("a", "f") and arch[:-1].isdigit())
+
+
+def _configured_arch_suffix(scope: str, arch: str) -> str:
+    original = arch
+    for prefix in ("compute_", "compute", "sm_", "sm"):
+        if arch.startswith(prefix):
+            arch = arch[len(prefix) :]
+            break
+    if _is_numeric_arch(arch):
+        return arch
+    raise DSLRuntimeError(
+        f"Invalid configured CUDA arch {original!r} for {scope} provider; "
+        "expected digits with an optional 'a' or 'f' suffix, optionally "
+        "prefixed by 'sm' or 'compute'."
+    )
+
+
+def resolve_nvrtc_arch(
+    scope: str,
+    configured_arch: Callable[[], str],
+) -> str:
+    """Return the ``compute_*`` target for NVRTC LTO-IR compilation."""
+
+    arch = configured_arch()
+    if arch:
+        return f"compute_{_configured_arch_suffix(scope, arch)}"
+
+    from cutlass.base_dsl.runtime import cuda as cuda_runtime
+
+    major, minor = cuda_runtime.get_compute_capability_major_minor()
+    if major is None or minor is None:
+        raise DSLRuntimeError(
+            f"Unable to resolve CUDA arch for {scope} provider NVRTC bundle "
+            "compilation."
+        )
+    return f"compute_{major}{minor}"
+
+
+def resolve_nvrtc_sm_arch(
+    scope: str,
+    configured_arch: Callable[[], str],
+) -> str:
+    """Return the ``sm_*`` target used for final linking."""
+
+    arch = configured_arch()
+    if arch:
+        return f"sm_{_configured_arch_suffix(scope, arch)}"
+
+    from cutlass.base_dsl.runtime import cuda as cuda_runtime
+
+    major, minor = cuda_runtime.get_compute_capability_major_minor()
+    if major is None or minor is None:
+        raise DSLRuntimeError(
+            f"Unable to resolve CUDA arch for {scope} provider NVRTC bundle "
+            "compilation."
+        )
+    return f"sm_{major}{minor}"
+
+
+def select_bundle_format(scope: str) -> str:
+    """Return the configured provider artifact format."""
+
+    bundle_format = os.environ.get(BUNDLE_FORMAT_ENV, "auto").strip().lower()
+    if bundle_format == "bc":
+        return "bc"
+    if bundle_format in ("lto", "ltoir"):
+        return "ltoir"
+    if bundle_format == "cubin":
+        raise DSLRuntimeError(
+            f"Unsupported {BUNDLE_FORMAT_ENV} value: {bundle_format!r}. "
+            f"{scope} external provider shims require LTO-IR or LLVM bitcode."
+        )
+    if bundle_format != "auto":
+        raise DSLRuntimeError(
+            f"Unsupported {BUNDLE_FORMAT_ENV} value: {bundle_format!r}. "
+            "Use auto/bc/ltoir."
+        )
+    return "ltoir"

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_types.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_types.py
@@ -1,0 +1,617 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+"""Compiler value models, dtype policy, and operation normalization."""
+
+from __future__ import annotations
+
+import math
+import operator
+from collections.abc import Callable, Hashable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from cutlass.base_dsl.typing import (
+    Float32,
+    Float64,
+    Int32,
+    Int64,
+    Uint8,
+    Uint32,
+    Uint64,
+)
+
+from .._thread_data import ThreadData
+
+ROOT_SCOPE = "cuda.coop.cutlass"
+
+_SUPPORTED_OPS_TEXT = "sum, multiplies, min, max, bit_and, bit_or, and bit_xor"
+
+_REDUCE_OP_ALIASES = {
+    None: "sum",
+    "+": "sum",
+    "sum": "sum",
+    "add": "sum",
+    "plus": "sum",
+    "*": "multiplies",
+    "mul": "multiplies",
+    "multiply": "multiplies",
+    "multiplies": "multiplies",
+    "min": "min",
+    "minimum": "min",
+    "max": "max",
+    "maximum": "max",
+    "&": "bit_and",
+    "bit_and": "bit_and",
+    "|": "bit_or",
+    "bit_or": "bit_or",
+    "^": "bit_xor",
+    "bit_xor": "bit_xor",
+}
+
+_CALLABLE_REDUCE_OP_ALIASES = {
+    operator.add: "sum",
+    operator.mul: "multiplies",
+    operator.and_: "bit_and",
+    operator.or_: "bit_or",
+    operator.xor: "bit_xor",
+}
+
+_CALLABLE_REDUCE_OP_NAME_ALIASES = {
+    ("_operator", "add"): "sum",
+    ("_operator", "mul"): "multiplies",
+    ("_operator", "and_"): "bit_and",
+    ("_operator", "or_"): "bit_or",
+    ("_operator", "xor"): "bit_xor",
+    ("operator", "add"): "sum",
+    ("operator", "mul"): "multiplies",
+    ("operator", "and_"): "bit_and",
+    ("operator", "or_"): "bit_or",
+    ("operator", "xor"): "bit_xor",
+    ("numpy", "add"): "sum",
+    ("numpy", "multiply"): "multiplies",
+    ("numpy", "minimum"): "min",
+    ("numpy", "maximum"): "max",
+    ("numpy", "bitwise_and"): "bit_and",
+    ("numpy", "bitwise_or"): "bit_or",
+    ("numpy", "bitwise_xor"): "bit_xor",
+}
+
+
+def merge_payload(
+    scope: str,
+    primitive_name: str,
+    structural_payload: dict[str, Any],
+    extra_kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    if "payload" in extra_kwargs:
+        raise TypeError(f"{scope}.{primitive_name} does not accept a payload selector")
+    reserved = structural_payload.keys() & extra_kwargs.keys()
+    if reserved:
+        reserved_names = ", ".join(sorted(reserved))
+        raise TypeError(
+            f"{scope}.{primitive_name} got reserved keyword argument(s): "
+            f"{reserved_names}"
+        )
+
+    payload = dict(structural_payload)
+    payload.update(extra_kwargs)
+    return payload
+
+
+def normalize_reduce_op(
+    binary_op: Any,
+    *,
+    scope: str,
+    primitive_name: str = "reduce",
+) -> str:
+    try:
+        return _REDUCE_OP_ALIASES[binary_op]
+    except (KeyError, TypeError):
+        pass
+
+    try:
+        return _CALLABLE_REDUCE_OP_ALIASES[binary_op]
+    except (KeyError, TypeError):
+        pass
+
+    if callable(binary_op):
+        module = getattr(binary_op, "__module__", "")
+        name = getattr(binary_op, "__name__", "")
+        try:
+            return _CALLABLE_REDUCE_OP_NAME_ALIASES[(module, name)]
+        except KeyError:
+            pass
+
+    raise NotImplementedError(
+        f"{scope}.{primitive_name} currently supports {_SUPPORTED_OPS_TEXT} reductions"
+    )
+
+
+def normalize_scan_op(
+    scan_op: Any,
+    *,
+    scope: str,
+    primitive_name: str = "scan",
+) -> str:
+    try:
+        return normalize_reduce_op(
+            scan_op,
+            scope=scope,
+            primitive_name=primitive_name,
+        )
+    except NotImplementedError as exc:
+        raise NotImplementedError(
+            f"{scope}.{primitive_name} currently supports {_SUPPORTED_OPS_TEXT} scans"
+        ) from exc
+
+
+def validate_no_extra_args(
+    scope: str,
+    primitive_name: str,
+    *,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    expected: str,
+    allowed_kwargs: Iterable[str] = (),
+) -> None:
+    if args:
+        raise TypeError(f"{scope}.{primitive_name} {expected}")
+
+    unexpected_kwargs = kwargs.keys() - set(allowed_kwargs)
+    if unexpected_kwargs:
+        unexpected = ", ".join(sorted(unexpected_kwargs))
+        raise TypeError(
+            f"{scope}.{primitive_name} {expected}; got unexpected keyword "
+            f"argument(s): {unexpected}"
+        )
+
+
+@dataclass(frozen=True)
+class TypeSpec:
+    cpp_type: str
+    token: str
+    width_bits: int
+    zero_literal: str
+
+
+@dataclass(frozen=True)
+class BundleRenderer:
+    include_lines: tuple[str, ...]
+    cccl_headers: tuple[tuple[str, str], ...]
+    render: Callable[[Any], list[str]]
+    scratch_layout_probe: Callable[[Any], ScratchLayoutProbe | None] | None = None
+
+
+@dataclass(frozen=True)
+class ScratchLayout:
+    """Exact C++ temporary-storage layout for one specialization."""
+
+    size_in_bytes: int
+    alignment: int
+
+
+@dataclass(frozen=True)
+class ScratchLayoutProbe:
+    """C++ constant expressions for one exact scratch layout."""
+
+    requirement_key: Hashable
+    size_expression: str
+    alignment_expression: str
+
+
+@dataclass(frozen=True)
+class DeferredTempStorageEvent:
+    """One traced cooperative call whose scratch operands need finalization."""
+
+    kernel_op: Any
+    kernel_name: str
+    temp_storage: Any
+    primitive_name: str
+    requirement_key: Hashable
+    sharing: str
+    auto_sync: bool
+    capacity_size_in_bytes: int | None
+    capacity_alignment: int | None
+    smem_addr_placeholder: Any
+    size_placeholder: Any
+    location: str
+
+
+@dataclass(frozen=True)
+class DeferredTempStorageBinding:
+    """Resolved per-call scratch slice within a deferred storage plan."""
+
+    event: DeferredTempStorageEvent
+    byte_offset_in_bytes: int
+    size_in_bytes: int
+    alignment: int
+
+
+@dataclass(frozen=True)
+class DeferredTempStoragePlan:
+    """One kernel-local allocation for one TempStorage identity."""
+
+    kernel_op: Any
+    kernel_name: str
+    temp_storage: Any
+    size_in_bytes: int
+    alignment: int
+    bindings: tuple[DeferredTempStorageBinding, ...]
+
+
+TYPE_SPECS: dict[type, TypeSpec] = {
+    Uint8: TypeSpec(
+        cpp_type="unsigned char",
+        token="u8",
+        width_bits=8,
+        zero_literal="0u",
+    ),
+    Int32: TypeSpec(
+        cpp_type="int",
+        token="i32",
+        width_bits=32,
+        zero_literal="0",
+    ),
+    Uint32: TypeSpec(
+        cpp_type="unsigned int",
+        token="u32",
+        width_bits=32,
+        zero_literal="0u",
+    ),
+    Int64: TypeSpec(
+        cpp_type="long long",
+        token="i64",
+        width_bits=64,
+        zero_literal="0ll",
+    ),
+    Uint64: TypeSpec(
+        cpp_type="unsigned long long",
+        token="u64",
+        width_bits=64,
+        zero_literal="0ull",
+    ),
+    Float32: TypeSpec(
+        cpp_type="float",
+        token="f32",
+        width_bits=32,
+        zero_literal="0.0f",
+    ),
+    Float64: TypeSpec(
+        cpp_type="double",
+        token="f64",
+        width_bits=64,
+        zero_literal="0.0",
+    ),
+}
+
+SCAN_REDUCE_TYPES = frozenset(TYPE_SPECS.keys())
+
+INTEGER_VALUE_TYPES = frozenset({Uint8, Int32, Uint32, Int64, Uint64})
+
+ALL_PROVIDER_TYPES = frozenset(TYPE_SPECS.keys())
+
+ORDINARY_PROVIDER_TYPES = {
+    int: Int32,
+    float: Float32,
+    np.uint8: Uint8,
+    np.int32: Int32,
+    np.uint32: Uint32,
+    np.int64: Int64,
+    np.uint64: Uint64,
+    np.float32: Float32,
+    np.float64: Float64,
+}
+
+PROVIDER_TYPE_NAMES = {
+    Uint8: "uint8",
+    Int32: "int32",
+    Uint32: "uint32",
+    Int64: "int64",
+    Uint64: "uint64",
+    Float32: "float32",
+    Float64: "float64",
+}
+
+_INTEGER_TYPE_TOKENS = frozenset({"u8", "i32", "u32", "i64", "u64"})
+
+_FLOAT_TYPE_TOKENS = frozenset({"f32", "f64"})
+
+_NOT_PLAIN_SCALAR = object()
+
+
+def supported_names(types: frozenset[type]) -> str:
+    return "/".join(sorted(t.__name__ for t in types))
+
+
+def coerce_plain_scalar(
+    value: Any,
+    value_type: type,
+    *,
+    name: str,
+    scope: str,
+    allow_nonfinite: bool,
+    convert: bool = True,
+) -> Any:
+    """Validate and optionally convert an exact Python numeric literal."""
+
+    token = TYPE_SPECS[value_type].token
+    if type(value) is int:
+        if token not in _INTEGER_TYPE_TOKENS:
+            raise TypeError(
+                f"{scope}.{name} dtype does not match {value_type.__name__}"
+            )
+        bits = int(token.lstrip("iu"))
+        lower = 0 if token.startswith("u") else -(1 << (bits - 1))
+        upper = (1 << bits) - 1 if token.startswith("u") else (1 << (bits - 1)) - 1
+        if not lower <= value <= upper:
+            raise ValueError(
+                f"{scope}.{name}={value} is not representable in {value_type.__name__}"
+            )
+        return value_type(value) if convert else value
+    if type(value) is float:
+        if token not in _FLOAT_TYPE_TOKENS:
+            raise TypeError(
+                f"{scope}.{name} dtype does not match {value_type.__name__}"
+            )
+        if not allow_nonfinite and not math.isfinite(value):
+            raise ValueError(f"{scope}.{name} must be finite")
+        numpy_type = np.float32 if token == "f32" else np.float64
+        limit = float(np.finfo(numpy_type).max)
+        if math.isfinite(value) and abs(value) > limit:
+            raise ValueError(
+                f"{scope}.{name}={value} is not representable in {value_type.__name__}"
+            )
+        return value_type(value) if convert else value
+    return _NOT_PLAIN_SCALAR
+
+
+def validate_scan_reduce_op_for_type(
+    op: str,
+    value_type: type,
+    *,
+    root_scope: str,
+    feature: str,
+    namespace: str = "block",
+) -> None:
+    if op.startswith("bit_") and value_type not in INTEGER_VALUE_TYPES:
+        operation = "reductions" if feature == "reduce" else "operations"
+        raise TypeError(
+            f"{root_scope}.{namespace}.{feature} bitwise {operation} require "
+            "an integral type"
+        )
+
+
+def reduce_op_expr(op: str, lhs: str, rhs: str) -> str:
+    if op == "sum":
+        return f"{lhs} + {rhs}"
+    if op == "multiplies":
+        return f"{lhs} * {rhs}"
+    if op == "min":
+        return f"(({rhs}) < ({lhs}) ? ({rhs}) : ({lhs}))"
+    if op == "max":
+        return f"(({rhs}) > ({lhs}) ? ({rhs}) : ({lhs}))"
+    if op == "bit_and":
+        return f"{lhs} & {rhs}"
+    if op == "bit_or":
+        return f"{lhs} | {rhs}"
+    if op == "bit_xor":
+        return f"{lhs} ^ {rhs}"
+    raise NotImplementedError(f"Unsupported reduce op: {op}")
+
+
+def cub_op_expr(op: str) -> str:
+    if op == "sum":
+        return "::cuda::std::plus<>{}"
+    if op == "multiplies":
+        return "::cuda::std::multiplies<>{}"
+    if op == "min":
+        return "::cuda::minimum<>{}"
+    if op == "max":
+        return "::cuda::maximum<>{}"
+    if op == "bit_and":
+        return "::cuda::std::bit_and<>{}"
+    if op == "bit_or":
+        return "::cuda::std::bit_or<>{}"
+    if op == "bit_xor":
+        return "::cuda::std::bit_xor<>{}"
+    raise NotImplementedError(f"Unsupported CUB op: {op}")
+
+
+def as_int32(value: Any) -> Any:
+    if isinstance(value, Int32):
+        return value
+    return Int32(value)
+
+
+def as_valid_items_arg(value: Any, *, scope: str) -> Any:
+    if value is None:
+        return Int32(-1)
+    if isinstance(value, Int32):
+        return value
+    try:
+        return Int32(value)
+    except Exception as exc:
+        raise TypeError(f"{scope} valid_items must be convertible to Int32") from exc
+
+
+def type_size_bytes(value_type: type) -> int:
+    return max(1, (TYPE_SPECS[value_type].width_bits + 7) // 8)
+
+
+def coerce_scan_initial_value(
+    *,
+    initial_value: Any,
+    value_type: type,
+    root_scope: str,
+    feature: str,
+    namespace: str,
+) -> Any:
+    if isinstance(initial_value, value_type):
+        return initial_value
+    try:
+        return value_type(initial_value)
+    except Exception as exc:
+        raise TypeError(
+            f"{root_scope}.{namespace}.{feature} initial_value cannot be converted to "
+            f"{value_type.__name__}"
+        ) from exc
+
+
+def resolve_thread_data_value_type(
+    value: ThreadData,
+    *,
+    allowed: frozenset[type],
+    feature: str,
+    scope: str,
+    resolve_type: Callable[..., type],
+    supported_types: frozenset[type] = ALL_PROVIDER_TYPES,
+) -> tuple[type, tuple[Any, ...]]:
+    values = value.values(feature)
+    if value.dtype is not None:
+        value_type = resolve_type(value.dtype, allowed=allowed, feature=feature)
+        converted: list[Any] = []
+        for idx, item in enumerate(values):
+            plain_item = coerce_plain_scalar(
+                item,
+                value_type,
+                name=f"{feature} ThreadData item {idx}",
+                scope=scope,
+                allow_nonfinite=True,
+            )
+            if plain_item is not _NOT_PLAIN_SCALAR:
+                converted.append(plain_item)
+                continue
+            try:
+                item_type = resolve_type(
+                    item,
+                    allowed=supported_types,
+                    feature=feature,
+                )
+            except TypeError as exc:
+                if _signless_integer_item_matches_dtype(item, value_type):
+                    converted.append(item)
+                    continue
+                raise TypeError(
+                    f"{scope}.{feature} ThreadData item {idx} type "
+                    "cannot be reconciled with declared dtype"
+                ) from exc
+            except NotImplementedError as exc:
+                raise TypeError(
+                    f"{scope}.{feature} ThreadData item {idx} type "
+                    "cannot be reconciled with declared dtype"
+                ) from exc
+            if item_type is not value_type:
+                raise TypeError(
+                    f"{scope}.{feature} ThreadData dtype does not match "
+                    "initialized item types"
+                )
+            converted.append(item)
+        return value_type, tuple(converted)
+
+    value_type = resolve_type(values[0], allowed=allowed, feature=feature)
+    for item in values[1:]:
+        item_type = resolve_type(item, allowed=allowed, feature=feature)
+        if item_type is not value_type:
+            raise TypeError(
+                f"{scope}.{feature} ThreadData requires homogeneous item types"
+            )
+    return value_type, values
+
+
+def _signless_integer_item_matches_dtype(item: Any, value_type: type) -> bool:
+    if value_type not in {Uint8, Int32, Uint32, Int64, Uint64}:
+        return False
+    if getattr(item, "signed", None) is not None:
+        return False
+    mlir_type = getattr(item, "type", None)
+    if mlir_type is None:
+        return False
+    return str(mlir_type) == f"i{TYPE_SPECS[value_type].width_bits}"
+
+
+def resolve_thread_data_pair_types(
+    *,
+    key: Any,
+    value: Any,
+    allowed_key_types: frozenset[type],
+    allowed_value_types: frozenset[type],
+    feature: str,
+    scope: str,
+    resolve_type: Callable[..., type],
+) -> tuple[type, tuple[Any, ...], ThreadData, type, tuple[Any, ...], ThreadData]:
+    if isinstance(key, ThreadData) or isinstance(value, ThreadData):
+        if not isinstance(key, ThreadData) or not isinstance(value, ThreadData):
+            raise TypeError(
+                f"{scope}.{feature} requires both key and value to be "
+                "ThreadData when one argument uses ThreadData"
+            )
+        if key.items_per_thread != value.items_per_thread:
+            raise ValueError(
+                f"{scope}.{feature} requires matching "
+                "ThreadData.items_per_thread for key and value"
+            )
+
+    if not isinstance(key, ThreadData) or not isinstance(value, ThreadData):
+        raise TypeError(
+            f"{scope}.{feature} internal ThreadData path requires "
+            "ThreadData key/value inputs"
+        )
+
+    key_type, key_values = resolve_thread_data_value_type(
+        key,
+        allowed=allowed_key_types,
+        feature=feature,
+        scope=scope,
+        resolve_type=resolve_type,
+    )
+    value_type, value_values = resolve_thread_data_value_type(
+        value,
+        allowed=allowed_value_types,
+        feature=feature,
+        scope=scope,
+        resolve_type=resolve_type,
+    )
+    return key_type, key_values, key, value_type, value_values, value
+
+
+def validate_thread_data_output(
+    *,
+    output: Any,
+    expected_items_per_thread: int,
+    resolved_dtype: type,
+    scope: str,
+    primitive_name: str,
+    output_name: str,
+    resolve_type: Callable[..., type],
+    assigned_dtype: Any | None = None,
+    type_label: str = "ThreadData",
+    item_count_message: str | None = None,
+) -> ThreadData | None:
+    if output is None:
+        return None
+    if not isinstance(output, ThreadData):
+        raise TypeError(f"{scope}.{primitive_name} {output_name} must be {type_label}")
+    if output.items_per_thread != expected_items_per_thread:
+        if item_count_message is None:
+            item_count_message = (
+                f"{scope}.{primitive_name} {output_name} must have "
+                f"items_per_thread={expected_items_per_thread}"
+            )
+        raise ValueError(item_count_message)
+    if output.dtype is not None:
+        resolve_type(
+            output.dtype,
+            allowed=frozenset({resolved_dtype}),
+            feature=primitive_name,
+        )
+    else:
+        output.dtype = resolved_dtype if assigned_dtype is None else assigned_dtype
+    return output
+
+
+def thread_data_output_dtype(value: ThreadData, value_type: type) -> Any:
+    return value.dtype if value.dtype is not None else value_type

--- a/python/cuda_coop/cuda/coop/cutlass/_group_load_store.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_group_load_store.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CUTLASS group-first CUB load and store entrypoints."""
+
+from __future__ import annotations
+
+import math
+from numbers import Integral, Real
+from typing import Any
+
+from cuda.coop._core import (
+    ArgumentBinding,
+    GroupLoadStoreAlgorithm,
+    LaunchFacts,
+    ResultVisibility,
+)
+
+from ._thread_data import ThreadData, _coerce_thread_payload
+from ._thread_group import (
+    ThreadGroup,
+    _require_complete_warp_partition,
+    _resolve_collective_group_from_launch,
+)
+from ._value_metadata import (
+    attach_thread_data_metadata,
+    metadata_for_group,
+    validate_operand_domains,
+)
+
+_SCOPE = __name__.rsplit(".", 1)[0]
+_MAX_STATIC_OFFSET = (1 << 63) - 1
+
+
+def _normalize_algorithm(algorithm: Any) -> GroupLoadStoreAlgorithm:
+    token = getattr(algorithm, "value", algorithm)
+    if isinstance(token, str):
+        token = token.lower().replace("-", "_")
+    try:
+        return GroupLoadStoreAlgorithm(token)
+    except (TypeError, ValueError) as exc:
+        choices = ", ".join(item.value for item in GroupLoadStoreAlgorithm)
+        raise ValueError(
+            f"{_SCOPE}.load/store algorithm must be one of {choices}"
+        ) from exc
+
+
+def _is_boolean(value: Any) -> bool:
+    if isinstance(value, bool):
+        return True
+    try:
+        import numpy as np
+    except ImportError:
+        pass
+    else:
+        if isinstance(value, np.bool_):
+            return True
+    from cutlass.base_dsl.typing import Boolean
+
+    return isinstance(value, Boolean)
+
+
+def _classify_integer_binding(value: Any, *, name: str) -> ArgumentBinding:
+    if value is None:
+        return ArgumentBinding.omitted()
+    if _is_boolean(value):
+        raise TypeError(f"{_SCOPE}.load/store {name} must be an integer")
+    if isinstance(value, Integral):
+        normalized = int(value)
+        if name == "offset" and normalized < 0:
+            raise ValueError(f"{_SCOPE}.load/store offset must be non-negative")
+        if name == "offset" and normalized > _MAX_STATIC_OFFSET:
+            raise ValueError(
+                f"{_SCOPE}.load/store offset must fit a signed 64-bit integer"
+            )
+        return ArgumentBinding.static(normalized)
+    from cutlass.base_dsl.typing import Integer
+
+    if isinstance(value, Integer):
+        return ArgumentBinding.runtime()
+    raise TypeError(
+        f"{_SCOPE}.load/store {name} must be an integer, not {type(value).__name__}"
+    )
+
+
+def _classify_oob_default(value: Any) -> ArgumentBinding:
+    if value is None:
+        return ArgumentBinding.omitted()
+    if _is_boolean(value):
+        raise TypeError(f"{_SCOPE}.load oob_default must be numeric, not boolean")
+    if isinstance(value, Integral):
+        return ArgumentBinding.static(int(value))
+    if isinstance(value, Real):
+        normalized = float(value)
+        if not math.isfinite(normalized):
+            raise ValueError(f"{_SCOPE}.load oob_default must be finite")
+        return ArgumentBinding.static(normalized)
+    from cutlass.base_dsl.typing import Numeric
+
+    if isinstance(value, Numeric):
+        return ArgumentBinding.runtime()
+    raise TypeError(
+        f"{_SCOPE}.load oob_default must be a numeric scalar, not "
+        f"{type(value).__name__}"
+    )
+
+
+def _validate_group(group: ThreadGroup, *, primitive_name: str) -> None:
+    if not isinstance(group, ThreadGroup):
+        raise TypeError(f"{_SCOPE}.{primitive_name} group must be a ThreadGroup")
+    if group.kind not in {"block", "warp", "threads_within_warp"}:
+        raise NotImplementedError(
+            f"{_SCOPE}.{primitive_name} supports complete physical block, "
+            "physical-warp, and logical-warp groups only"
+        )
+
+
+def _launch_and_resolve_group(
+    group: ThreadGroup,
+    *,
+    primitive_name: str,
+) -> tuple[LaunchFacts, ThreadGroup]:
+    from ._compiler._launch import infer_launch_facts
+
+    launch = infer_launch_facts(
+        {},
+        scope=_SCOPE,
+        primitive_name=primitive_name,
+    )
+    if not launch.is_verified("exact_block_dim"):
+        raise NotImplementedError(
+            f"{_SCOPE}.{primitive_name} requires exact block dimensions from "
+            "verified compiler launch facts"
+        )
+    resolved = _resolve_collective_group_from_launch(
+        group,
+        launch,
+        feature=primitive_name,
+    )
+    assert resolved.hierarchy is not None
+    _require_complete_warp_partition(
+        resolved,
+        feature=primitive_name,
+        exact_block_dim=resolved.hierarchy.block_dim,
+    )
+    return launch, resolved
+
+
+def load(
+    group: ThreadGroup,
+    source: Any,
+    output: ThreadData,
+    /,
+    *,
+    algorithm: Any = "direct",
+    valid_items: Any = None,
+    oob_default: Any = None,
+    offset: Any = None,
+    temp_storage: Any = None,
+) -> ThreadData:
+    """Collectively load one block, physical-warp, or logical-warp tile.
+
+    ``group`` always names the participating threads explicitly.
+    ``output`` is returned after being populated. Its ``items_per_thread`` is
+    the sole source of the CUB item count. ``source`` must expose a contiguous
+    pointer-backed CUTLASS tensor or ``cutlass.Array`` view whose origin is the
+    start of the current block tile. Physical warps automatically advance that
+    origin by one warp tile per warp in the CTA.
+    """
+
+    _validate_group(group, primitive_name="load")
+    if not isinstance(output, ThreadData):
+        raise TypeError(f"{_SCOPE}.load output must be ThreadData")
+    valid_items_binding = _classify_integer_binding(
+        valid_items,
+        name="valid_items",
+    )
+    oob_default_binding = _classify_oob_default(oob_default)
+    if oob_default is not None and valid_items is None:
+        raise TypeError(f"{_SCOPE}.load oob_default requires valid_items")
+    offset_binding = _classify_integer_binding(offset, name="offset")
+    launch, resolved_group = _launch_and_resolve_group(
+        group,
+        primitive_name="load",
+    )
+
+    from ._lowering import _load_store as _provider
+
+    result = _provider.provider_load(
+        group=resolved_group,
+        launch=launch,
+        source=source,
+        output=output,
+        algorithm=_normalize_algorithm(algorithm),
+        valid_items=valid_items,
+        valid_items_binding=valid_items_binding,
+        oob_default=oob_default,
+        oob_default_binding=oob_default_binding,
+        offset=offset,
+        offset_binding=offset_binding,
+        temp_storage=temp_storage,
+    )
+    return attach_thread_data_metadata(
+        result,
+        metadata_for_group(
+            resolved_group,
+            visibility=ResultVisibility.PER_MEMBER,
+        ),
+    )
+
+
+def store(
+    group: ThreadGroup,
+    destination: Any,
+    value: Any,
+    /,
+    *,
+    algorithm: Any = "direct",
+    valid_items: Any = None,
+    offset: Any = None,
+    temp_storage: Any = None,
+) -> None:
+    """Collectively store one value or register tile through CUB.
+
+    A scalar is one item per group member. ``ThreadData``, an rmem tensor, or
+    ``TensorSSA`` supplies its own item count. ``group`` always names the
+    participating threads explicitly.
+    """
+
+    _validate_group(group, primitive_name="store")
+    value = _coerce_thread_payload(
+        value,
+        scope=_SCOPE,
+        primitive_name="store",
+        arg_name="value",
+        common_root_payload_kind="scalar_or_thread_data",
+    )
+    valid_items_binding = _classify_integer_binding(
+        valid_items,
+        name="valid_items",
+    )
+    offset_binding = _classify_integer_binding(offset, name="offset")
+    launch, resolved_group = _launch_and_resolve_group(
+        group,
+        primitive_name="store",
+    )
+    validate_operand_domains(
+        resolved_group,
+        {"value": value},
+        scope=_SCOPE,
+        primitive_name="store",
+    )
+
+    from ._lowering import _load_store as _provider
+
+    _provider.provider_store(
+        group=resolved_group,
+        launch=launch,
+        destination=destination,
+        value=value,
+        algorithm=_normalize_algorithm(algorithm),
+        valid_items=valid_items,
+        valid_items_binding=valid_items_binding,
+        offset=offset,
+        offset_binding=offset_binding,
+        temp_storage=temp_storage,
+    )
+
+
+__all__ = ["load", "store"]

--- a/python/cuda_coop/cuda/coop/cutlass/_group_load_store.pyi
+++ b/python/cuda_coop/cuda/coop/cutlass/_group_load_store.pyi
@@ -1,0 +1,125 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Typing declarations for qualified CUTLASS load and store."""
+
+from __future__ import annotations
+
+from typing import overload
+
+from .._typing import (
+    BlockLoadStoreAlgorithm,
+    IntegerValue,
+    PortableNumericScalar,
+    PortableThreadDataLike,
+    ValidItems,
+    WarpLoadStoreAlgorithm,
+)
+from ._temp_storage import TempStorage
+from ._thread_data import CutlassTensorSample, CutlassTensorSSASample, ThreadData
+from ._thread_group import BlockGroup, WarpGroup
+from ._typing import CutlassNumericT
+
+@overload
+def load(
+    group: BlockGroup,
+    source: object,
+    output: ThreadData[CutlassNumericT],
+    /,
+    *,
+    algorithm: BlockLoadStoreAlgorithm = "direct",
+    valid_items: ValidItems | None = None,
+    oob_default: None = None,
+    offset: IntegerValue | None = None,
+    temp_storage: TempStorage | None = None,
+) -> ThreadData[CutlassNumericT]:
+    """Populate and return ``output`` with a block tile."""
+
+@overload
+def load(
+    group: BlockGroup,
+    source: object,
+    output: ThreadData[CutlassNumericT],
+    /,
+    *,
+    algorithm: BlockLoadStoreAlgorithm = "direct",
+    valid_items: ValidItems,
+    oob_default: CutlassNumericT,
+    offset: IntegerValue | None = None,
+    temp_storage: TempStorage | None = None,
+) -> ThreadData[CutlassNumericT]:
+    """Populate a partial block tile and fill invalid items."""
+
+@overload
+def load(
+    group: WarpGroup,
+    source: object,
+    output: ThreadData[CutlassNumericT],
+    /,
+    *,
+    algorithm: WarpLoadStoreAlgorithm = "direct",
+    valid_items: ValidItems | None = None,
+    oob_default: None = None,
+    offset: IntegerValue | None = None,
+    temp_storage: None = None,
+) -> ThreadData[CutlassNumericT]:
+    """Populate and return ``output`` with a physical- or logical-warp tile."""
+
+@overload
+def load(
+    group: WarpGroup,
+    source: object,
+    output: ThreadData[CutlassNumericT],
+    /,
+    *,
+    algorithm: WarpLoadStoreAlgorithm = "direct",
+    valid_items: ValidItems,
+    oob_default: CutlassNumericT,
+    offset: IntegerValue | None = None,
+    temp_storage: None = None,
+) -> ThreadData[CutlassNumericT]:
+    """Populate a partial physical- or logical-warp tile and fill invalid items."""
+
+@overload
+def store(
+    group: BlockGroup,
+    destination: object,
+    value: (
+        PortableNumericScalar
+        | PortableThreadDataLike
+        | CutlassTensorSample
+        | CutlassTensorSSASample
+    ),
+    /,
+    *,
+    algorithm: BlockLoadStoreAlgorithm = "direct",
+    valid_items: ValidItems | None = None,
+    offset: IntegerValue | None = None,
+    temp_storage: TempStorage | None = None,
+) -> None:
+    """Store a scalar or register payload across a block through CUB."""
+
+@overload
+def store(
+    group: WarpGroup,
+    destination: object,
+    value: (
+        PortableNumericScalar
+        | PortableThreadDataLike
+        | CutlassTensorSample
+        | CutlassTensorSSASample
+    ),
+    /,
+    *,
+    algorithm: WarpLoadStoreAlgorithm = "direct",
+    valid_items: ValidItems | None = None,
+    offset: IntegerValue | None = None,
+    temp_storage: None = None,
+) -> None:
+    """Store a scalar or register payload across a physical or logical warp."""
+
+__all__ = [
+    "load",
+    "store",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_group_reduce.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_group_reduce.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CUTLASS group-first reduction entrypoint."""
+
+from __future__ import annotations
+
+from numbers import Integral
+from typing import Any
+
+from cuda.coop._core import (
+    ArgumentBinding,
+)
+from cuda.coop._core.block import BlockReduceAlgorithm
+
+from ._thread_data import _coerce_thread_payload
+from ._thread_group import ThreadGroup
+
+_SCOPE = __name__.rsplit(".", 1)[0]
+
+_REDUCE_OPERATOR_CPP = {
+    "multiplies": "::cuda::std::multiplies<T>",
+    "min": "::cuda::minimum<T>",
+    "max": "::cuda::maximum<T>",
+    "bit_and": "::cuda::std::bit_and<T>",
+    "bit_or": "::cuda::std::bit_or<T>",
+    "bit_xor": "::cuda::std::bit_xor<T>",
+}
+
+_BLOCK_REDUCE_ALGORITHM_ALIASES = {
+    "raking_commutative_only": BlockReduceAlgorithm.RAKING_COMMUTATIVE_ONLY,
+    "raking": BlockReduceAlgorithm.RAKING,
+    "warp_reductions": BlockReduceAlgorithm.WARP_REDUCTIONS,
+    "warp_reductions_nondeterministic": (
+        BlockReduceAlgorithm.WARP_REDUCTIONS_NONDETERMINISTIC
+    ),
+}
+
+
+def _normalize_reduce_op(binary_op: Any) -> str:
+    from ._compiler._types import normalize_reduce_op
+
+    return normalize_reduce_op(binary_op, scope=_SCOPE)
+
+
+def _is_boolean_control(value: Any) -> bool:
+    if isinstance(value, bool):
+        return True
+    try:
+        import numpy as np
+    except ImportError:
+        pass
+    else:
+        if isinstance(value, np.bool_):
+            return True
+    try:
+        from cutlass.base_dsl.typing import Boolean
+    except ImportError:
+        return False
+    return isinstance(value, Boolean)
+
+
+def _classify_valid_items(valid_items: Any) -> ArgumentBinding:
+    if valid_items is None:
+        return ArgumentBinding.omitted()
+    if _is_boolean_control(valid_items):
+        raise TypeError(f"{_SCOPE}.reduce valid_items must be an integer")
+    if isinstance(valid_items, Integral):
+        return ArgumentBinding.static(int(valid_items))
+    from cutlass.base_dsl.typing import Integer
+
+    if isinstance(valid_items, Integer):
+        return ArgumentBinding.runtime()
+    raise TypeError(f"{_SCOPE}.reduce valid_items must be an integer")
+
+
+def _normalize_block_reduce_algorithm(algorithm: Any) -> Any:
+    if _is_boolean_control(algorithm):
+        raise TypeError(f"{_SCOPE}.reduce algorithm must not be boolean")
+    if isinstance(algorithm, str):
+        return _BLOCK_REDUCE_ALGORITHM_ALIASES.get(algorithm, algorithm)
+    return algorithm
+
+
+def _validate_group_for_reduce(group: ThreadGroup) -> None:
+    if not isinstance(group, ThreadGroup):
+        raise TypeError(f"{_SCOPE}.reduce group must be a ThreadGroup")
+    if group.kind == "grid":
+        raise NotImplementedError(f"{_SCOPE}.reduce does not support grid groups")
+
+
+def _reduce(
+    group: ThreadGroup,
+    value: Any,
+    /,
+    *,
+    binary_op: Any = None,
+    broadcast: bool = True,
+    valid_items: Any = None,
+    algorithm: Any = None,
+) -> Any:
+    """Reduce values across a CUDA thread group with CUDAX or direct CUB.
+
+    ``group`` always names the participating threads explicitly.
+    Full-group reductions use CUDAX and may be broadcast to every member or
+    returned only at rank zero. ``valid_items`` and explicit block ``algorithm``
+    selectors use direct CUB and therefore require ``broadcast=False``.
+
+    With ``broadcast=False``, only group rank zero has a defined result; other
+    members receive an implementation placeholder and must not consume it.
+    Every group member must still invoke the collective in converged control
+    flow; root-only result ownership never means root-only participation.
+    ``valid_items`` counts the first contributing group members, not the total
+    items inside ``ThreadData``, and is therefore supported only for scalar
+    operands. It changes which members contribute, not which members call the
+    collective. Its valid range is ``1 <= valid_items <= group.static_size``.
+    Static counts are checked while tracing. A runtime count is a uniform caller
+    precondition and is passed directly to CUB without a device-side range
+    check.
+
+    Register-resident CuTe tensor fragments and ``TensorSSA`` values are
+    adapted to ``ThreadData`` directly without another global/shared-memory
+    load or bulk copy. Values that are already thread-local do not require an
+    intervening ``coop.load`` call.
+
+    Supported block algorithm names are ``raking_commutative_only``, ``raking``,
+    and ``warp_reductions``. The nondeterministic CUB specialization is excluded
+    because its current implementation is addition-specific. All direct CUB
+    routes return a value defined only at the group root.
+    """
+
+    from ._compiler._launch import infer_launch_facts
+
+    _validate_group_for_reduce(group)
+    if not isinstance(broadcast, bool):
+        raise TypeError(f"{_SCOPE}.reduce broadcast must be a bool")
+    op = _normalize_reduce_op(binary_op)
+    valid_items_binding = _classify_valid_items(valid_items)
+    algorithm = _normalize_block_reduce_algorithm(algorithm)
+    value = _coerce_thread_payload(
+        value,
+        scope=_SCOPE,
+        primitive_name="reduce",
+        arg_name="value",
+        common_root_payload_kind="scalar_or_thread_data",
+    )
+    launch = infer_launch_facts(
+        {},
+        scope=_SCOPE,
+        primitive_name="reduce",
+    )
+    from ._lowering import _reduce as _provider
+
+    return _provider.provider_reduce(
+        group=group,
+        launch=launch,
+        value=value,
+        op=op,
+        broadcast=broadcast,
+        valid_items=valid_items,
+        valid_items_binding=valid_items_binding,
+        algorithm=algorithm,
+    )
+
+
+def reduce(
+    group: ThreadGroup,
+    value: Any,
+    /,
+    *,
+    binary_op: Any = None,
+    broadcast: bool = True,
+    valid_items: Any = None,
+    algorithm: Any = None,
+) -> Any:
+    """Reduce values across a CUDA thread group with CUDAX or direct CUB."""
+
+    return _reduce(
+        group,
+        value,
+        binary_op=binary_op,
+        broadcast=broadcast,
+        valid_items=valid_items,
+        algorithm=algorithm,
+    )
+
+
+def sum(
+    group: ThreadGroup,
+    value: Any,
+    /,
+    *,
+    broadcast: bool = True,
+    valid_items: Any = None,
+    algorithm: Any = None,
+) -> Any:
+    """Sum values across a CUDA thread group."""
+
+    return _reduce(
+        group,
+        value,
+        binary_op=None,
+        broadcast=broadcast,
+        valid_items=valid_items,
+        algorithm=algorithm,
+    )
+
+
+__all__ = ["reduce", "sum"]

--- a/python/cuda_coop/cuda/coop/cutlass/_group_reduce.pyi
+++ b/python/cuda_coop/cuda/coop/cutlass/_group_reduce.pyi
@@ -1,0 +1,231 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Typing declarations for qualified CUTLASS reductions."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, overload
+
+from .._typing import ReduceAlgorithm, ReduceOperator, ValidItems
+from ._thread_data import CutlassTensorSample, CutlassTensorSSASample, ThreadData
+from ._thread_group import BlockGroup, ReductionGroup, WarpGroup
+from ._typing import CutlassNumericT, ScalarValueT
+
+@overload
+def reduce(
+    group: ReductionGroup,
+    value: ThreadData[CutlassNumericT],
+    /,
+    *,
+    binary_op: ReduceOperator | None = None,
+    broadcast: bool = True,
+    valid_items: None = None,
+    algorithm: None = None,
+) -> CutlassNumericT:
+    """Reduce a full-group register payload and preserve its element type."""
+
+@overload
+def reduce(
+    group: ReductionGroup,
+    value: ScalarValueT,
+    /,
+    *,
+    binary_op: ReduceOperator | None = None,
+    broadcast: bool = True,
+    valid_items: None = None,
+    algorithm: None = None,
+) -> ScalarValueT:
+    """Reduce full-group CUTLASS scalars while preserving their static type."""
+
+@overload
+def reduce(
+    group: BlockGroup,
+    value: ThreadData[CutlassNumericT],
+    /,
+    *,
+    binary_op: ReduceOperator | None = None,
+    broadcast: Literal[False],
+    valid_items: None = None,
+    algorithm: ReduceAlgorithm,
+) -> CutlassNumericT:
+    """Reduce a register payload with an explicit CUB block algorithm."""
+
+@overload
+def reduce(
+    group: BlockGroup,
+    value: CutlassTensorSample | CutlassTensorSSASample,
+    /,
+    *,
+    binary_op: ReduceOperator | None = None,
+    broadcast: Literal[False],
+    valid_items: None = None,
+    algorithm: ReduceAlgorithm,
+) -> Any:
+    """Reduce a CUTLASS register tensor with an explicit block algorithm."""
+
+@overload
+def reduce(
+    group: BlockGroup,
+    value: ScalarValueT,
+    /,
+    *,
+    binary_op: ReduceOperator | None = None,
+    broadcast: Literal[False],
+    valid_items: ValidItems,
+    algorithm: ReduceAlgorithm | None = None,
+) -> ScalarValueT:
+    """Reduce a scalar through direct CUB BlockReduce at the block root.
+
+    ``valid_items`` accepts Python, NumPy, and structural compiler integers.
+    """
+
+@overload
+def reduce(
+    group: BlockGroup,
+    value: ScalarValueT,
+    /,
+    *,
+    binary_op: ReduceOperator | None = None,
+    broadcast: Literal[False],
+    valid_items: None = None,
+    algorithm: ReduceAlgorithm,
+) -> ScalarValueT:
+    """Reduce a scalar with an explicit direct CUB BlockReduce algorithm."""
+
+@overload
+def reduce(
+    group: WarpGroup,
+    value: ScalarValueT,
+    /,
+    *,
+    binary_op: ReduceOperator | None = None,
+    broadcast: Literal[False],
+    valid_items: ValidItems,
+    algorithm: None = None,
+) -> ScalarValueT:
+    """Reduce a valid scalar prefix through direct CUB WarpReduce.
+
+    ``valid_items`` accepts Python, NumPy, and structural compiler integers.
+    """
+
+@overload
+def reduce(
+    group: ReductionGroup,
+    value: CutlassTensorSample | CutlassTensorSSASample,
+    /,
+    *,
+    binary_op: ReduceOperator | None = None,
+    broadcast: bool = True,
+    valid_items: None = None,
+    algorithm: None = None,
+) -> Any:
+    """Reduce a CUTLASS register tensor; its external element type is unknown."""
+
+@overload
+def sum(
+    group: ReductionGroup,
+    value: ThreadData[CutlassNumericT],
+    /,
+    *,
+    broadcast: bool = True,
+    valid_items: None = None,
+    algorithm: None = None,
+) -> CutlassNumericT:
+    """Sum a full-group register payload and preserve its element type."""
+
+@overload
+def sum(
+    group: ReductionGroup,
+    value: ScalarValueT,
+    /,
+    *,
+    broadcast: bool = True,
+    valid_items: None = None,
+    algorithm: None = None,
+) -> ScalarValueT:
+    """Sum full-group CUTLASS scalars while preserving their static type."""
+
+@overload
+def sum(
+    group: BlockGroup,
+    value: ThreadData[CutlassNumericT],
+    /,
+    *,
+    broadcast: Literal[False],
+    valid_items: None = None,
+    algorithm: ReduceAlgorithm,
+) -> CutlassNumericT:
+    """Sum a register payload with an explicit CUB block algorithm."""
+
+@overload
+def sum(
+    group: BlockGroup,
+    value: CutlassTensorSample | CutlassTensorSSASample,
+    /,
+    *,
+    broadcast: Literal[False],
+    valid_items: None = None,
+    algorithm: ReduceAlgorithm,
+) -> Any:
+    """Sum a CUTLASS register tensor with an explicit block algorithm."""
+
+@overload
+def sum(
+    group: BlockGroup,
+    value: ScalarValueT,
+    /,
+    *,
+    broadcast: Literal[False],
+    valid_items: ValidItems,
+    algorithm: ReduceAlgorithm | None = None,
+) -> ScalarValueT:
+    """Sum a scalar through direct CUB BlockReduce at the block root.
+
+    ``valid_items`` accepts Python, NumPy, and structural compiler integers.
+    """
+
+@overload
+def sum(
+    group: BlockGroup,
+    value: ScalarValueT,
+    /,
+    *,
+    broadcast: Literal[False],
+    valid_items: None = None,
+    algorithm: ReduceAlgorithm,
+) -> ScalarValueT:
+    """Sum a scalar with an explicit direct CUB BlockReduce algorithm."""
+
+@overload
+def sum(
+    group: WarpGroup,
+    value: ScalarValueT,
+    /,
+    *,
+    broadcast: Literal[False],
+    valid_items: ValidItems,
+    algorithm: None = None,
+) -> ScalarValueT:
+    """Sum a valid scalar prefix through direct CUB WarpReduce.
+
+    ``valid_items`` accepts Python, NumPy, and structural compiler integers.
+    """
+
+@overload
+def sum(
+    group: ReductionGroup,
+    value: CutlassTensorSample | CutlassTensorSSASample,
+    /,
+    *,
+    broadcast: bool = True,
+    valid_items: None = None,
+    algorithm: None = None,
+) -> Any:
+    """Sum a CUTLASS register tensor; its external element type is unknown."""
+
+__all__ = [
+    "reduce",
+    "sum",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_group_scan.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_group_scan.py
@@ -1,0 +1,328 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CUTLASS group-first scan entrypoint."""
+
+from __future__ import annotations
+
+from numbers import Integral
+from typing import Any
+
+from cuda.coop._core import (
+    ArgumentBinding,
+    ScanMode,
+)
+from cuda.coop._core.block import BlockScanAlgorithm
+
+from ._thread_data import _coerce_thread_payload
+from ._thread_group import (
+    ThreadGroup,
+    _require_complete_warp_partition,
+    _resolve_collective_group_from_launch,
+)
+
+_SCOPE = __name__.rsplit(".", 1)[0]
+
+_SCAN_OPERATOR_CPP = {
+    "sum": "::cuda::std::plus<T>",
+    "multiplies": "::cuda::std::multiplies<T>",
+    "min": "::cuda::minimum<T>",
+    "max": "::cuda::maximum<T>",
+    "bit_and": "::cuda::std::bit_and<T>",
+    "bit_or": "::cuda::std::bit_or<T>",
+    "bit_xor": "::cuda::std::bit_xor<T>",
+}
+
+_BLOCK_SCAN_ALGORITHM_ALIASES = {
+    "raking": BlockScanAlgorithm.RAKING,
+    "raking_memoize": BlockScanAlgorithm.RAKING_MEMOIZE,
+    "warp_scans": BlockScanAlgorithm.WARP_SCANS,
+}
+
+
+def _normalize_scan_op(scan_op: Any) -> str:
+    from ._compiler._types import normalize_scan_op
+
+    return normalize_scan_op(scan_op, scope=_SCOPE)
+
+
+def _normalize_scan_mode(mode: Any) -> str:
+    from ._group_reduce import _is_boolean_control
+
+    if _is_boolean_control(mode):
+        raise TypeError(f"{_SCOPE}.scan mode must not be boolean")
+    try:
+        return ScanMode(mode).value
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{_SCOPE}.scan mode must be 'exclusive' or 'inclusive'"
+        ) from exc
+
+
+def _normalize_block_scan_algorithm(algorithm: Any) -> Any:
+    from ._group_reduce import _is_boolean_control
+
+    if _is_boolean_control(algorithm):
+        raise TypeError(f"{_SCOPE}.scan algorithm must not be boolean")
+    if isinstance(algorithm, str):
+        return _BLOCK_SCAN_ALGORITHM_ALIASES.get(algorithm, algorithm)
+    return algorithm
+
+
+def _validate_group_for_scan(group: ThreadGroup) -> None:
+    if group.kind not in {"block", "warp", "threads_within_warp"}:
+        raise NotImplementedError(
+            f"{_SCOPE}.scan currently lowers CUB scans only for this_block "
+            "and physical or logical warp groups"
+        )
+
+
+def _classify_valid_items(valid_items: Any) -> ArgumentBinding:
+    if valid_items is None:
+        return ArgumentBinding.omitted()
+    from ._group_reduce import _is_boolean_control
+
+    if _is_boolean_control(valid_items):
+        raise TypeError(f"{_SCOPE}.scan valid_items must be an integer")
+    if isinstance(valid_items, Integral):
+        return ArgumentBinding.static(int(valid_items))
+    from cutlass.base_dsl.typing import Integer
+
+    if isinstance(valid_items, Integer):
+        return ArgumentBinding.runtime()
+    raise TypeError(f"{_SCOPE}.scan valid_items must be an integer")
+
+
+def _scan(
+    group: ThreadGroup,
+    value: Any,
+    /,
+    *,
+    mode: str = "exclusive",
+    scan_op: Any = None,
+    initial_value: Any = None,
+    algorithm: Any = None,
+    aggregate_output: Any = None,
+    valid_items: Any = None,
+    temp_storage: Any = None,
+) -> Any:
+    """Internal implementation for the public group-first scan entrypoints."""
+
+    from ._compiler._launch import infer_launch_facts
+
+    if not isinstance(group, ThreadGroup):
+        raise TypeError(f"{_SCOPE}.scan group must be a ThreadGroup")
+
+    value = _coerce_thread_payload(
+        value,
+        scope=_SCOPE,
+        primitive_name="scan",
+        arg_name="value",
+        common_root_payload_kind="scalar_or_thread_data",
+    )
+
+    mode = _normalize_scan_mode(mode)
+    op = _normalize_scan_op(scan_op)
+    algorithm = _normalize_block_scan_algorithm(algorithm)
+    _classify_valid_items(valid_items)
+    if mode == ScanMode.INCLUSIVE.value and initial_value is not None:
+        raise ValueError(
+            f"{_SCOPE}.scan initial_value is not supported for inclusive scans"
+        )
+    if mode == ScanMode.EXCLUSIVE.value and op != "sum" and initial_value is None:
+        raise ValueError(
+            f"{_SCOPE}.scan requires initial_value for non-default exclusive scans"
+        )
+
+    _validate_group_for_scan(group)
+    launch = infer_launch_facts(
+        {},
+        scope=_SCOPE,
+        primitive_name="scan",
+    )
+    validated_group = _resolve_collective_group_from_launch(
+        group,
+        launch,
+        feature="scan",
+    )
+    assert validated_group.hierarchy is not None
+    _require_complete_warp_partition(
+        validated_group,
+        feature="scan",
+        exact_block_dim=validated_group.hierarchy.block_dim,
+    )
+
+    from ._lowering import _scan as _provider
+
+    return _provider.provider_scan(
+        group=group,
+        launch=launch,
+        value=value,
+        mode=mode,
+        op=op,
+        initial_value=initial_value,
+        algorithm=algorithm,
+        aggregate_output=aggregate_output,
+        valid_items=valid_items,
+        temp_storage=temp_storage,
+    )
+
+
+def scan(
+    group: ThreadGroup,
+    value: Any,
+    /,
+    *,
+    mode: str = "exclusive",
+    scan_op: Any = None,
+    initial_value: Any = None,
+    algorithm: Any = None,
+    temp_storage: Any = None,
+    valid_items: Any = None,
+    aggregate_output: Any = None,
+) -> Any:
+    """Scan values across a complete CUDA block, physical warp, or logical warp.
+
+    ``group`` always names the participating threads explicitly.
+    Block scans accept scalars, ``ThreadData``, rmem tensors, and ``TensorSSA``.
+    Physical- and logical-warp scans are scalar-per-lane. The default operator is sum;
+    non-default exclusive scans require ``initial_value``. Inclusive scans do
+    not accept an initial value. Explicit ``algorithm`` selectors apply only
+    to block scans and accept ``raking``, ``raking_memoize``, or ``warp_scans``.
+    ``warp_scans`` requires a block size that is a multiple of 32 threads.
+    A runtime ``initial_value`` must be uniform across every group member.
+    ``valid_items`` selects a leading partial logical warp and is accepted only
+    for physical or logical warp groups. ``aggregate_output`` receives the
+    reduction of the input values and excludes ``initial_value``.
+
+    Every group member must invoke the collective in converged control flow.
+    ``coop.TempStorage()`` requests inferred caller-owned scratch for block
+    scans. Fixed-capacity storage uses the supplied allocation and validates
+    its capacity and alignment in the generated CUB shim. Shared storage
+    inserts the reuse barrier by default; ``auto_sync=False`` leaves
+    synchronization to the caller. Warp scans use implementation-owned scratch.
+    """
+
+    return _scan(
+        group,
+        value,
+        mode=mode,
+        scan_op=scan_op,
+        initial_value=initial_value,
+        algorithm=algorithm,
+        aggregate_output=aggregate_output,
+        valid_items=valid_items,
+        temp_storage=temp_storage,
+    )
+
+
+def exclusive_sum(
+    group: ThreadGroup,
+    value: Any,
+    /,
+    *,
+    algorithm: Any = None,
+    temp_storage: Any = None,
+    aggregate_output: Any = None,
+) -> Any:
+    """Return an exclusive sum across a block, physical warp, or logical warp."""
+
+    return _scan(
+        group,
+        value,
+        mode="exclusive",
+        scan_op=None,
+        initial_value=None,
+        algorithm=algorithm,
+        aggregate_output=aggregate_output,
+        valid_items=None,
+        temp_storage=temp_storage,
+    )
+
+
+def inclusive_sum(
+    group: ThreadGroup,
+    value: Any,
+    /,
+    *,
+    algorithm: Any = None,
+    temp_storage: Any = None,
+    valid_items: Any = None,
+    aggregate_output: Any = None,
+) -> Any:
+    """Return an inclusive sum across a block, physical warp, or logical warp."""
+
+    return _scan(
+        group,
+        value,
+        mode="inclusive",
+        scan_op=None,
+        initial_value=None,
+        algorithm=algorithm,
+        aggregate_output=aggregate_output,
+        valid_items=valid_items,
+        temp_storage=temp_storage,
+    )
+
+
+def exclusive_scan(
+    group: ThreadGroup,
+    value: Any,
+    /,
+    *,
+    scan_op: Any = None,
+    initial_value: Any = None,
+    algorithm: Any = None,
+    temp_storage: Any = None,
+    valid_items: Any = None,
+    aggregate_output: Any = None,
+) -> Any:
+    """Return an exclusive scan using a supported built-in operator."""
+
+    return _scan(
+        group,
+        value,
+        mode="exclusive",
+        scan_op=scan_op,
+        initial_value=initial_value,
+        algorithm=algorithm,
+        aggregate_output=aggregate_output,
+        valid_items=valid_items,
+        temp_storage=temp_storage,
+    )
+
+
+def inclusive_scan(
+    group: ThreadGroup,
+    value: Any,
+    /,
+    *,
+    scan_op: Any = None,
+    algorithm: Any = None,
+    temp_storage: Any = None,
+    valid_items: Any = None,
+    aggregate_output: Any = None,
+) -> Any:
+    """Return an inclusive scan using a supported built-in operator."""
+
+    return _scan(
+        group,
+        value,
+        mode="inclusive",
+        scan_op=scan_op,
+        initial_value=None,
+        algorithm=algorithm,
+        aggregate_output=aggregate_output,
+        valid_items=valid_items,
+        temp_storage=temp_storage,
+    )
+
+
+__all__ = [
+    "exclusive_scan",
+    "exclusive_sum",
+    "inclusive_scan",
+    "inclusive_sum",
+    "scan",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_group_scan.pyi
+++ b/python/cuda_coop/cuda/coop/cutlass/_group_scan.pyi
@@ -1,0 +1,567 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Typing declarations for qualified CUTLASS scans."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, overload
+
+from .._typing import (
+    NonSumScanOperator,
+    PortableNumericScalar,
+    ScanAlgorithm,
+    ScanOperator,
+    SumScanOperator,
+    ValidItems,
+)
+from ._temp_storage import TempStorage
+from ._thread_data import CutlassTensorSample, CutlassTensorSSASample, ThreadData
+from ._thread_group import BlockGroup, WarpGroup
+from ._typing import CutlassNumericT, ScalarT
+
+@overload
+def scan(
+    group: BlockGroup,
+    value: ThreadData[CutlassNumericT],
+    /,
+    *,
+    mode: Literal["exclusive"] = "exclusive",
+    scan_op: SumScanOperator | None = None,
+    initial_value: PortableNumericScalar | None = None,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[CutlassNumericT]:
+    """Return block-exclusive sums without mutating the input payload."""
+
+@overload
+def scan(
+    group: BlockGroup,
+    value: ThreadData[CutlassNumericT],
+    /,
+    *,
+    mode: Literal["exclusive"] = "exclusive",
+    scan_op: NonSumScanOperator,
+    initial_value: PortableNumericScalar,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[CutlassNumericT]:
+    """Return non-sum block prefixes from a required initial value."""
+
+@overload
+def scan(
+    group: BlockGroup,
+    value: ThreadData[CutlassNumericT],
+    /,
+    *,
+    mode: Literal["inclusive"],
+    scan_op: ScanOperator | None = None,
+    initial_value: None = None,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[CutlassNumericT]:
+    """Return block-inclusive prefixes without mutating the input payload."""
+
+@overload
+def scan(
+    group: BlockGroup,
+    value: CutlassTensorSample | CutlassTensorSSASample,
+    /,
+    *,
+    mode: Literal["exclusive"] = "exclusive",
+    scan_op: SumScanOperator | None = None,
+    initial_value: PortableNumericScalar | None = None,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[Any]:
+    """Return block-exclusive sums for a CUTLASS register tensor.
+
+    ``group`` is a complete block and ``value`` is an rmem ``Tensor`` or
+    ``TensorSSA`` with a static item count. ``mode`` selects exclusive output;
+    ``scan_op`` selects sum and ``initial_value`` optionally supplies its
+    initial value. ``algorithm`` selects the block implementation and
+    ``temp_storage`` supplies scratch. ``valid_items`` must remain ``None``;
+    ``aggregate_output`` receives the input aggregate. The compiler validates
+    the element dtype; static analysis represents the
+    returned ``ThreadData`` element type as ``Any``.
+    """
+
+@overload
+def scan(
+    group: BlockGroup,
+    value: CutlassTensorSample | CutlassTensorSSASample,
+    /,
+    *,
+    mode: Literal["exclusive"] = "exclusive",
+    scan_op: NonSumScanOperator,
+    initial_value: PortableNumericScalar,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[Any]:
+    """Return non-sum block prefixes for a CUTLASS register tensor.
+
+    ``group`` is a complete block and ``value`` is an rmem ``Tensor`` or
+    ``TensorSSA`` with a static item count. ``mode`` selects exclusive output;
+    ``scan_op`` selects a non-sum operation and ``initial_value`` supplies its
+    required initial value. ``algorithm`` selects the block implementation,
+    ``temp_storage`` supplies scratch. ``valid_items`` must remain ``None``;
+    ``aggregate_output`` receives the input aggregate. The compiler validates
+    the element dtype; static analysis represents the returned ``ThreadData``
+    element type as ``Any``.
+    """
+
+@overload
+def scan(
+    group: BlockGroup,
+    value: CutlassTensorSample | CutlassTensorSSASample,
+    /,
+    *,
+    mode: Literal["inclusive"],
+    scan_op: ScanOperator | None = None,
+    initial_value: None = None,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[Any]:
+    """Return block-inclusive prefixes for a CUTLASS register tensor.
+
+    ``group`` is a complete block and ``value`` is an rmem ``Tensor`` or
+    ``TensorSSA`` with a static item count. ``mode`` selects inclusive output;
+    ``scan_op`` selects the built-in operation and ``initial_value`` must remain
+    absent. ``algorithm`` selects the block implementation and ``temp_storage``
+    supplies scratch. ``valid_items`` must remain ``None``;
+    ``aggregate_output`` receives the input aggregate. The compiler validates
+    the element dtype; static analysis represents the
+    returned ``ThreadData`` element type as ``Any``.
+    """
+
+@overload
+def scan(
+    group: BlockGroup,
+    value: ScalarT,
+    /,
+    *,
+    mode: Literal["exclusive"] = "exclusive",
+    scan_op: SumScanOperator | None = None,
+    initial_value: PortableNumericScalar | None = None,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Block-exclusive sum a CUTLASS scalar from an optional initial value."""
+
+@overload
+def scan(
+    group: BlockGroup,
+    value: ScalarT,
+    /,
+    *,
+    mode: Literal["exclusive"] = "exclusive",
+    scan_op: NonSumScanOperator,
+    initial_value: PortableNumericScalar,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Block-exclusive scan a CUTLASS scalar with a non-sum initial value."""
+
+@overload
+def scan(
+    group: BlockGroup,
+    value: ScalarT,
+    /,
+    *,
+    mode: Literal["inclusive"],
+    scan_op: ScanOperator | None = None,
+    initial_value: None = None,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Block-inclusive scan a portable or structural CUTLASS scalar."""
+
+@overload
+def scan(
+    group: WarpGroup,
+    value: ScalarT,
+    /,
+    *,
+    mode: Literal["exclusive"] = "exclusive",
+    scan_op: SumScanOperator | None = None,
+    initial_value: PortableNumericScalar | None = None,
+    algorithm: None = None,
+    temp_storage: None = None,
+    valid_items: ValidItems | None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Warp-group-exclusive sum a scalar from an optional initial value."""
+
+@overload
+def scan(
+    group: WarpGroup,
+    value: ScalarT,
+    /,
+    *,
+    mode: Literal["exclusive"] = "exclusive",
+    scan_op: NonSumScanOperator,
+    initial_value: PortableNumericScalar,
+    algorithm: None = None,
+    temp_storage: None = None,
+    valid_items: ValidItems | None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Warp-group-exclusive scan with a required non-sum initial value."""
+
+@overload
+def scan(
+    group: WarpGroup,
+    value: ScalarT,
+    /,
+    *,
+    mode: Literal["inclusive"],
+    scan_op: ScanOperator | None = None,
+    initial_value: None = None,
+    algorithm: None = None,
+    temp_storage: None = None,
+    valid_items: ValidItems | None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Warp-group-inclusive scan a scalar without an initial value."""
+
+@overload
+def exclusive_sum(
+    group: BlockGroup,
+    value: ThreadData[CutlassNumericT],
+    /,
+    *,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[CutlassNumericT]:
+    """Return block-exclusive sums with the input payload shape."""
+
+@overload
+def exclusive_sum(
+    group: BlockGroup,
+    value: CutlassTensorSample | CutlassTensorSSASample,
+    /,
+    *,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[Any]:
+    """Return block-exclusive sums for a CUTLASS register tensor.
+
+    ``group`` is a complete block and ``value`` supplies a static rmem or SSA
+    register payload. ``algorithm`` selects the block implementation and
+    ``temp_storage`` supplies scratch. ``aggregate_output`` receives the input
+    aggregate. The compiler validates the element dtype; the external dtype
+    remains ``Any`` to static analysis.
+    """
+
+@overload
+def exclusive_sum(
+    group: BlockGroup,
+    value: ScalarT,
+    /,
+    *,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Preserve a scalar type through block-exclusive sum."""
+
+@overload
+def exclusive_sum(
+    group: WarpGroup,
+    value: ScalarT,
+    /,
+    *,
+    algorithm: None = None,
+    temp_storage: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Preserve a scalar type through physical- or logical-warp exclusive sum."""
+
+@overload
+def inclusive_sum(
+    group: BlockGroup,
+    value: ThreadData[CutlassNumericT],
+    /,
+    *,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[CutlassNumericT]:
+    """Return block-inclusive sums with the input payload shape."""
+
+@overload
+def inclusive_sum(
+    group: BlockGroup,
+    value: CutlassTensorSample | CutlassTensorSSASample,
+    /,
+    *,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[Any]:
+    """Return block-inclusive sums for a CUTLASS register tensor.
+
+    ``group`` is a complete block and ``value`` supplies a static rmem or SSA
+    register payload. ``algorithm`` selects the block implementation and
+    ``temp_storage`` supplies scratch. ``valid_items`` must remain ``None``;
+    ``aggregate_output`` receives the input aggregate. The compiler validates
+    the element dtype; the external dtype remains ``Any`` to static analysis.
+    """
+
+@overload
+def inclusive_sum(
+    group: BlockGroup,
+    value: ScalarT,
+    /,
+    *,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Preserve a scalar type through block-inclusive sum."""
+
+@overload
+def inclusive_sum(
+    group: WarpGroup,
+    value: ScalarT,
+    /,
+    *,
+    algorithm: None = None,
+    temp_storage: None = None,
+    valid_items: ValidItems | None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Preserve a scalar type through physical- or logical-warp inclusive sum."""
+
+@overload
+def exclusive_scan(
+    group: BlockGroup,
+    value: ThreadData[CutlassNumericT],
+    /,
+    *,
+    scan_op: SumScanOperator | None = None,
+    initial_value: PortableNumericScalar | None = None,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[CutlassNumericT]:
+    """Return block-exclusive sums with the input payload shape."""
+
+@overload
+def exclusive_scan(
+    group: BlockGroup,
+    value: ThreadData[CutlassNumericT],
+    /,
+    *,
+    scan_op: NonSumScanOperator,
+    initial_value: PortableNumericScalar,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[CutlassNumericT]:
+    """Return non-sum block prefixes from a required initial value."""
+
+@overload
+def exclusive_scan(
+    group: BlockGroup,
+    value: CutlassTensorSample | CutlassTensorSSASample,
+    /,
+    *,
+    scan_op: SumScanOperator | None = None,
+    initial_value: PortableNumericScalar | None = None,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[Any]:
+    """Return block-exclusive sums for a CUTLASS register tensor.
+
+    ``group`` is a complete block and ``value`` supplies a static rmem or SSA
+    register payload. ``scan_op`` selects sum and ``initial_value`` optionally
+    supplies its initial value, ``algorithm`` selects the block implementation,
+    and ``temp_storage`` supplies scratch. ``valid_items`` must remain ``None``;
+    ``aggregate_output`` receives the input aggregate. The compiler validates
+    the element dtype; the external dtype remains ``Any`` to static analysis.
+    """
+
+@overload
+def exclusive_scan(
+    group: BlockGroup,
+    value: CutlassTensorSample | CutlassTensorSSASample,
+    /,
+    *,
+    scan_op: NonSumScanOperator,
+    initial_value: PortableNumericScalar,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[Any]:
+    """Return non-sum block prefixes for a CUTLASS register tensor.
+
+    ``group`` is a complete block and ``value`` supplies a static rmem or SSA
+    register payload. ``scan_op`` selects the operation and ``initial_value``
+    supplies its required initial value, ``algorithm`` selects the block
+    implementation, and ``temp_storage`` supplies scratch. ``valid_items``
+    must remain ``None``; ``aggregate_output`` receives the
+    input aggregate. The compiler validates the element dtype; the
+    external dtype remains ``Any`` to static analysis.
+    """
+
+@overload
+def exclusive_scan(
+    group: BlockGroup,
+    value: ScalarT,
+    /,
+    *,
+    scan_op: SumScanOperator | None = None,
+    initial_value: PortableNumericScalar | None = None,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Block-exclusive sum a scalar from an optional initial value."""
+
+@overload
+def exclusive_scan(
+    group: BlockGroup,
+    value: ScalarT,
+    /,
+    *,
+    scan_op: NonSumScanOperator,
+    initial_value: PortableNumericScalar,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Block-exclusive scan a scalar with a required non-sum initial value."""
+
+@overload
+def exclusive_scan(
+    group: WarpGroup,
+    value: ScalarT,
+    /,
+    *,
+    scan_op: SumScanOperator | None = None,
+    initial_value: PortableNumericScalar | None = None,
+    algorithm: None = None,
+    temp_storage: None = None,
+    valid_items: ValidItems | None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Warp-group-exclusive sum a scalar from an optional initial value."""
+
+@overload
+def exclusive_scan(
+    group: WarpGroup,
+    value: ScalarT,
+    /,
+    *,
+    scan_op: NonSumScanOperator,
+    initial_value: PortableNumericScalar,
+    algorithm: None = None,
+    temp_storage: None = None,
+    valid_items: ValidItems | None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Warp-group-exclusive scan with a required non-sum initial value."""
+
+@overload
+def inclusive_scan(
+    group: BlockGroup,
+    value: ThreadData[CutlassNumericT],
+    /,
+    *,
+    scan_op: ScanOperator | None = None,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[CutlassNumericT]:
+    """Return block-inclusive prefixes with the input payload shape."""
+
+@overload
+def inclusive_scan(
+    group: BlockGroup,
+    value: CutlassTensorSample | CutlassTensorSSASample,
+    /,
+    *,
+    scan_op: ScanOperator | None = None,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ThreadData[Any]:
+    """Return block-inclusive prefixes for a CUTLASS register tensor.
+
+    ``group`` is a complete block and ``value`` supplies a static rmem or SSA
+    register payload. ``scan_op`` selects the built-in operation, ``algorithm``
+    selects the block implementation and ``temp_storage`` supplies scratch.
+    ``valid_items`` must remain ``None``; ``aggregate_output`` receives the
+    input aggregate. The compiler validates the
+    element dtype; the external dtype remains ``Any`` to static analysis.
+    """
+
+@overload
+def inclusive_scan(
+    group: BlockGroup,
+    value: ScalarT,
+    /,
+    *,
+    scan_op: ScanOperator | None = None,
+    algorithm: ScanAlgorithm | None = None,
+    temp_storage: TempStorage | None = None,
+    valid_items: None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Preserve a scalar type through block-inclusive Scan."""
+
+@overload
+def inclusive_scan(
+    group: WarpGroup,
+    value: ScalarT,
+    /,
+    *,
+    scan_op: ScanOperator | None = None,
+    algorithm: None = None,
+    temp_storage: None = None,
+    valid_items: ValidItems | None = None,
+    aggregate_output: ThreadData | None = None,
+) -> ScalarT:
+    """Preserve a scalar type through physical- or logical-warp inclusive Scan."""
+
+__all__ = [
+    "exclusive_scan",
+    "exclusive_sum",
+    "inclusive_scan",
+    "inclusive_sum",
+    "scan",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_lowering/__init__.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_lowering/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CUTLASS family lowerers and generated-provider renderers.
+
+Each module translates one public ``_group_<family>`` contract into CUTLASS,
+CUB, or CUDAX compiler operations. Public modules import these lowerers lazily
+so importing :mod:`cuda.coop.cutlass` does not activate compiler machinery.
+"""
+
+__all__: tuple[str, ...] = ()

--- a/python/cuda_coop/cuda/coop/cutlass/_lowering/_core.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_lowering/_core.py
@@ -1,0 +1,1205 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Lower shared-core algorithm specs into public-CUB CUTLASS shims."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from cutlass._mlir.dialects import llvm
+from cutlass.base_dsl.typing import Int8, Int32, Int64, Uint8, Uint32
+
+from cuda.coop._core import (
+    INT8,
+    INT32,
+    INT64,
+    UINT8,
+    AlgorithmSpec,
+    Array,
+    BuiltinDType,
+    Constant,
+    CoreBackendAdapter,
+    CxxFunction,
+    CxxOperator,
+    Dependency,
+    GroupLoweringPlan,
+    GroupLoweringTarget,
+    Pointer,
+    PointerOffset,
+    PythonOperator,
+    Reference,
+    StatefulOperator,
+    StorageOwnership,
+    SynchronizationScope,
+    TempStorageParameter,
+    Value,
+    lower_method_parameters,
+)
+
+from .._compiler import _rendering as _provider_rendering
+from .._compiler._types import TYPE_SPECS
+
+_ROOT_SCOPE = "cuda.coop.cutlass"
+
+
+@dataclasses.dataclass(frozen=True)
+class CutlassAbiParameter:
+    """One flattened FFI parameter in a generated CUTLASS provider shim."""
+
+    logical_name: str
+    cpp_name: str
+    cpp_type: str
+    ffi_type: Any | None
+    source: str
+    item_index: int | None = None
+    is_pointer: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
+class CutlassLoweredParameter:
+    """C++ wrapper fragments for one shared-core method parameter."""
+
+    name: str
+    call_expression: str | None
+    abi_parameters: tuple[CutlassAbiParameter, ...] = ()
+    declarations: tuple[str, ...] = ()
+    epilogue: tuple[str, ...] = ()
+    is_temp_storage: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
+class CutlassArrayInputTransform:
+    """Adapt one flattened input array before invoking the CUB collective."""
+
+    source_dtype: Any
+    cpp_expression: str
+
+    def __post_init__(self) -> None:
+        if "{value}" not in self.cpp_expression:
+            raise ValueError("CUTLASS input transforms require a {value} placeholder")
+
+
+@dataclasses.dataclass(frozen=True)
+class CutlassRuntimeIntRange:
+    """Inclusive and optional relational policy for a runtime ``int``."""
+
+    logical_name: str
+    minimum: int
+    maximum: int
+    clamp: bool = False
+    modulus: int | None = None
+    less_than_parameter: str | None = None
+
+    def __post_init__(self) -> None:
+        if (
+            not self.logical_name
+            or self.logical_name[0].isdigit()
+            or not self.logical_name.replace("_", "a").isalnum()
+        ):
+            raise ValueError("CUTLASS runtime range requires a C identifier")
+        if any(
+            not isinstance(bound, int) or isinstance(bound, bool)
+            for bound in (self.minimum, self.maximum)
+        ):
+            raise TypeError("CUTLASS runtime range bounds must be integers")
+        if self.minimum > self.maximum:
+            raise ValueError("CUTLASS runtime range minimum exceeds maximum")
+        if not isinstance(self.clamp, bool):
+            raise TypeError("CUTLASS runtime range clamp must be a bool")
+        if self.less_than_parameter is not None:
+            if (
+                not self.less_than_parameter
+                or self.less_than_parameter[0].isdigit()
+                or not self.less_than_parameter.replace("_", "a").isalnum()
+            ):
+                raise ValueError(
+                    "CUTLASS runtime range relation requires a C identifier"
+                )
+            if self.less_than_parameter == self.logical_name:
+                raise ValueError(
+                    "CUTLASS runtime range relation requires distinct parameters"
+                )
+            if self.clamp or self.modulus is not None:
+                raise ValueError(
+                    "CUTLASS runtime range relations cannot clamp or normalize"
+                )
+        if self.modulus is not None:
+            if (
+                not isinstance(self.modulus, int)
+                or isinstance(self.modulus, bool)
+                or self.modulus < 1
+            ):
+                raise TypeError("CUTLASS runtime range modulus must be positive int")
+            if self.clamp:
+                raise ValueError("CUTLASS runtime range cannot clamp and normalize")
+            if self.minimum != 0 or self.maximum != self.modulus - 1:
+                raise ValueError(
+                    "CUTLASS modulo range must span zero through modulus minus one"
+                )
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class CutlassCoreArtifact:
+    """Plan-owned, runtime-value-free description of one CUB wrapper."""
+
+    plan: GroupLoweringPlan
+    specialization: AlgorithmSpec
+    parameters: tuple[CutlassLoweredParameter, ...]
+    kind: str
+    symbol_name: str
+    method_index: int = 0
+    input_transforms: tuple[tuple[str, CutlassArrayInputTransform], ...] = ()
+    output_initializers: tuple[tuple[str, str], ...] = ()
+    output_value_initializers: tuple[tuple[str, str], ...] = ()
+    runtime_int_ranges: tuple[CutlassRuntimeIntRange, ...] = ()
+    external_scratch: bool = False
+
+    @property
+    def _base_semantic_key(self) -> tuple[Any, ...]:
+        assert self.plan.artifact_key is not None
+        return (
+            self.plan.artifact_key,
+            self.kind,
+            self.method_index,
+            self.input_transforms,
+            self.output_initializers,
+            self.output_value_initializers,
+            self.runtime_int_ranges,
+        )
+
+    @property
+    def semantic_key(self) -> tuple[Any, ...]:
+        if not self.external_scratch:
+            return self._base_semantic_key
+        return "external_scratch", self._base_semantic_key
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, CutlassCoreArtifact):
+            return NotImplemented
+        return self.semantic_key == other.semantic_key
+
+    def __hash__(self) -> int:
+        return hash(self.semantic_key)
+
+    @property
+    def items_per_thread(self) -> int:
+        value = self.specialization.template_arguments.get("ITEMS_PER_THREAD", 1)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ValueError("ITEMS_PER_THREAD must be a positive integer")
+        return value
+
+    @property
+    def abi_parameters(self) -> tuple[CutlassAbiParameter, ...]:
+        return tuple(
+            abi_parameter
+            for parameter in self.parameters
+            for abi_parameter in parameter.abi_parameters
+        )
+
+    @property
+    def ffi_param_types(self) -> tuple[Any, ...]:
+        parameter_types = tuple(
+            llvm.PointerType.get(0) if parameter.is_pointer else parameter.ffi_type
+            for parameter in self.abi_parameters
+        )
+        if self.external_scratch:
+            return *parameter_types, Uint32, Int32, Int32
+        return parameter_types
+
+    def bind_ffi_arguments(
+        self,
+        runtime_values: Mapping[str, Any],
+        output_values: Mapping[str, Any],
+        *,
+        scratch_values: Sequence[Any] = (),
+    ) -> tuple[Any, ...]:
+        """Flatten logical runtime values in the generated ABI order."""
+
+        arguments = []
+        for parameter in self.abi_parameters:
+            values = output_values if parameter.source == "output" else runtime_values
+            if parameter.logical_name not in values:
+                raise KeyError(
+                    f"missing {parameter.source} value for {parameter.logical_name!r}"
+                )
+            value = values[parameter.logical_name]
+            if parameter.item_index is not None:
+                if not isinstance(value, Sequence):
+                    raise TypeError(
+                        f"{parameter.logical_name} must be a sequence for an "
+                        "array parameter"
+                    )
+                try:
+                    value = value[parameter.item_index]
+                except IndexError as exc:
+                    raise ValueError(
+                        f"{parameter.logical_name} does not contain enough items"
+                    ) from exc
+            arguments.append(value)
+        scratch_values = tuple(scratch_values)
+        expected_scratch_values = 3 if self.external_scratch else 0
+        if len(scratch_values) != expected_scratch_values:
+            raise ValueError(
+                "CUTLASS core artifact expected "
+                f"{expected_scratch_values} scratch ABI values, got "
+                f"{len(scratch_values)}"
+            )
+        return *arguments, *scratch_values
+
+    @property
+    def scratch_requirement_key(self) -> tuple[Any, ...]:
+        """Identity of the instantiated CUB class whose layout is required."""
+
+        if not self.external_scratch:
+            raise ValueError("implementation-owned artifacts have no scratch probe")
+        provenance = self.plan.provenance
+        if provenance is None or provenance.library != "CUB":
+            raise ValueError("external core scratch requires public-CUB provenance")
+        adapter = CutlassCoreAdapter()
+        return (
+            "cub_temp_storage_layout",
+            self.specialization.struct_name,
+            tuple(
+                (name, _render_template_argument(adapter, value))
+                for name, value in self.specialization.ordered_template_arguments
+            ),
+        )
+
+    @property
+    def scratch_cpp_type(self) -> str:
+        """Fully instantiated public-CUB temporary-storage type."""
+
+        provenance = self.plan.provenance
+        if provenance is None or provenance.library != "CUB":
+            raise ValueError("external core scratch requires public-CUB provenance")
+        cpp_class = provenance.cpp_class
+        if not cpp_class.startswith("::"):
+            cpp_class = f"::{cpp_class}"
+        adapter = CutlassCoreAdapter()
+        template_arguments = ", ".join(
+            _render_template_argument(adapter, value)
+            for _, value in self.specialization.ordered_template_arguments
+        )
+        return f"typename {cpp_class}<{template_arguments}>::TempStorage"
+
+
+class CutlassCoreAdapter(CoreBackendAdapter):
+    """Render backend-neutral descriptors through the CUTLASS bundle JIT."""
+
+    _BUILTIN_DTYPES = {
+        INT8: Int8,
+        UINT8: Uint8,
+        INT32: Int32,
+        INT64: Int64,
+    }
+    _BUILTIN_CPP_TYPES = {
+        Int8: "signed char",
+        Uint8: "unsigned char",
+        Int32: "int",
+        Int64: "long long",
+    }
+
+    def normalize_dtype(self, dtype: Any) -> Any:
+        if isinstance(dtype, BuiltinDType):
+            try:
+                return self._BUILTIN_DTYPES[dtype]
+            except KeyError as exc:
+                raise TypeError(f"unsupported core dtype {dtype.name!r}") from exc
+        return dtype
+
+    def cpp_type(self, dtype: Any) -> str:
+        dtype = self.normalize_dtype(dtype)
+        if dtype in TYPE_SPECS:
+            return TYPE_SPECS[dtype].cpp_type
+        try:
+            return self._BUILTIN_CPP_TYPES[dtype]
+        except KeyError as exc:
+            raise TypeError(f"unsupported CUTLASS dtype {dtype!r}") from exc
+
+    def _resolve(self, value: Any, specialization: AlgorithmSpec) -> Any:
+        if isinstance(value, (Dependency, Constant)):
+            value = value.resolve(specialization.template_arguments)
+        return value
+
+    def _resolved_dtype(self, value: Any, specialization: AlgorithmSpec) -> Any:
+        return self.normalize_dtype(self._resolve(value, specialization))
+
+    @staticmethod
+    def _name(parameter: Any) -> str:
+        name = getattr(parameter, "name", None)
+        if not isinstance(name, str) or not name:
+            raise ValueError("CUTLASS core parameters require stable names")
+        return name
+
+    @staticmethod
+    def _output_pointer(name: str, cpp_type: str) -> CutlassAbiParameter:
+        return CutlassAbiParameter(
+            logical_name=name,
+            cpp_name=f"{name}_result",
+            cpp_type=f"{cpp_type}*",
+            ffi_type=None,
+            source="output",
+            is_pointer=True,
+        )
+
+    def lower_parameter(
+        self,
+        parameter: Any,
+        *,
+        specialization: AlgorithmSpec,
+    ) -> CutlassLoweredParameter:
+        if isinstance(parameter, Array):
+            name = self._name(parameter)
+            dtype = self._resolved_dtype(parameter.dtype, specialization)
+            cpp_type = self.cpp_type(dtype)
+            size = self._resolve(parameter.size, specialization)
+            if not isinstance(size, int) or isinstance(size, bool) or size < 1:
+                raise ValueError(f"{name} array extent must be a positive integer")
+            abi_parameters = []
+            declarations = []
+            epilogue = []
+            if not parameter.is_output or parameter.is_inout:
+                abi_parameters.extend(
+                    CutlassAbiParameter(
+                        logical_name=name,
+                        cpp_name=f"{name}_{index}",
+                        cpp_type=cpp_type,
+                        ffi_type=dtype,
+                        source="runtime",
+                        item_index=index,
+                    )
+                    for index in range(size)
+                )
+                values = ", ".join(f"{name}_{index}" for index in range(size))
+                declarations.append(f"  {cpp_type} {name}[{size}] = {{{values}}};")
+            else:
+                declarations.append(f"  {cpp_type} {name}[{size}];")
+            if parameter.is_output or parameter.is_inout:
+                abi_parameters.append(self._output_pointer(name, cpp_type))
+                epilogue.extend(
+                    f"  {name}_result[{index}] = {name}[{index}];"
+                    for index in range(size)
+                )
+            return CutlassLoweredParameter(
+                name=name,
+                call_expression=name,
+                abi_parameters=tuple(abi_parameters),
+                declarations=tuple(declarations),
+                epilogue=tuple(epilogue),
+            )
+
+        if isinstance(parameter, PointerOffset):
+            name = self._name(parameter)
+            dtype = self._resolved_dtype(parameter.dtype, specialization)
+            cpp_type = self.cpp_type(dtype)
+            return CutlassLoweredParameter(
+                name=name,
+                call_expression=name,
+                abi_parameters=(
+                    CutlassAbiParameter(
+                        logical_name=name,
+                        cpp_name=name,
+                        cpp_type=cpp_type,
+                        ffi_type=dtype,
+                        source="runtime",
+                    ),
+                ),
+            )
+
+        if isinstance(parameter, Pointer):
+            name = self._name(parameter)
+            dtype = self._resolved_dtype(parameter.dtype, specialization)
+            cpp_type = self.cpp_type(dtype)
+            qualifiers = " __restrict__" if parameter.restrict else ""
+            expression = f"*{name}" if parameter.deref_on_call else name
+            if getattr(parameter, "is_inout", False):
+                raise NotImplementedError(
+                    "CUTLASS core pointer parameters do not support inout values"
+                )
+            return CutlassLoweredParameter(
+                name=name,
+                call_expression=expression,
+                abi_parameters=(
+                    CutlassAbiParameter(
+                        logical_name=name,
+                        cpp_name=name,
+                        cpp_type=f"{cpp_type}*{qualifiers}",
+                        ffi_type=None,
+                        source="output" if parameter.is_output else "runtime",
+                        is_pointer=True,
+                    ),
+                ),
+            )
+
+        if isinstance(parameter, (Reference, Value)):
+            name = self._name(parameter)
+            dtype = self._resolved_dtype(parameter.dtype, specialization)
+            cpp_type = self.cpp_type(dtype)
+            abi_parameters = []
+            declarations = []
+            epilogue = []
+            if parameter.is_output or parameter.is_inout:
+                input_name = f"{name}_input"
+                if parameter.is_inout:
+                    abi_parameters.append(
+                        CutlassAbiParameter(
+                            logical_name=name,
+                            cpp_name=input_name,
+                            cpp_type=cpp_type,
+                            ffi_type=dtype,
+                            source="runtime",
+                        )
+                    )
+                    declarations.append(f"  {cpp_type} {name} = {input_name};")
+                else:
+                    declarations.append(f"  {cpp_type} {name}{{}};")
+                abi_parameters.append(self._output_pointer(name, cpp_type))
+                epilogue.append(f"  *{name}_result = {name};")
+            else:
+                abi_parameters.append(
+                    CutlassAbiParameter(
+                        logical_name=name,
+                        cpp_name=name,
+                        cpp_type=cpp_type,
+                        ffi_type=dtype,
+                        source="runtime",
+                    )
+                )
+            return CutlassLoweredParameter(
+                name=name,
+                call_expression=name,
+                abi_parameters=tuple(abi_parameters),
+                declarations=tuple(declarations),
+                epilogue=tuple(epilogue),
+            )
+
+        if isinstance(parameter, CxxFunction):
+            name = self._name(parameter)
+            cpp = parameter.cpp
+            if isinstance(parameter.dtype, Dependency):
+                dtype = self._resolved_dtype(parameter.dtype, specialization)
+                cpp = cpp.replace(
+                    f"<{parameter.dtype.name}>",
+                    f"<{self.cpp_type(dtype)}>",
+                )
+            return CutlassLoweredParameter(name=name, call_expression=cpp)
+
+        raise TypeError(f"unsupported CUTLASS core parameter {parameter!r}")
+
+    def lower_cxx_operator(
+        self,
+        operator: Any,
+        *,
+        specialization: AlgorithmSpec,
+    ) -> CutlassLoweredParameter:
+        if not isinstance(operator, CxxOperator):
+            raise TypeError(f"expected CxxOperator, got {operator!r}")
+        name = self._name(operator)
+        cpp = operator.cpp
+        if isinstance(operator.dtype, Dependency):
+            dtype = self._resolved_dtype(operator.dtype, specialization)
+            cpp = cpp.replace(
+                f"<{operator.dtype.name}>",
+                f"<{self.cpp_type(dtype)}>",
+            )
+        return CutlassLoweredParameter(
+            name=name,
+            call_expression=f"{cpp}{{}}",
+        )
+
+    def lower_python_operator(
+        self,
+        operator: Any,
+        *,
+        specialization: AlgorithmSpec,
+    ) -> CutlassLoweredParameter:
+        del specialization
+        if not isinstance(operator, PythonOperator):
+            raise TypeError(f"expected PythonOperator, got {operator!r}")
+        raise NotImplementedError(
+            "CUTLASS public-CUB lowering does not support Python operators"
+        )
+
+    def lower_stateful_operator(
+        self,
+        operator: Any,
+        *,
+        specialization: AlgorithmSpec,
+    ) -> CutlassLoweredParameter:
+        del specialization
+        if not isinstance(operator, StatefulOperator):
+            raise TypeError(f"expected StatefulOperator, got {operator!r}")
+        raise NotImplementedError(
+            "CUTLASS public-CUB lowering does not support stateful Python operators"
+        )
+
+    def lower_temp_storage(
+        self,
+        parameter: TempStorageParameter,
+        *,
+        specialization: AlgorithmSpec,
+    ) -> CutlassLoweredParameter:
+        del specialization
+        return CutlassLoweredParameter(
+            name=self._name(parameter),
+            call_expression=None,
+            is_temp_storage=True,
+        )
+
+    def materialize(
+        self,
+        specialization: AlgorithmSpec,
+        *,
+        plan: GroupLoweringPlan,
+        kind: str,
+        symbol_name: str | None = None,
+        method_index: int = 0,
+        input_transforms: Mapping[str, CutlassArrayInputTransform] | None = None,
+        output_initializers: Mapping[str, str] | Sequence[tuple[str, str]] = (),
+        output_value_initializers: Mapping[str, str] | None = None,
+        runtime_int_ranges: Sequence[CutlassRuntimeIntRange] = (),
+        external_scratch: bool = False,
+        **kwargs: Any,
+    ) -> CutlassCoreArtifact:
+        if kwargs:
+            unexpected = ", ".join(sorted(kwargs))
+            raise TypeError(f"unexpected CUTLASS materialization options: {unexpected}")
+        plan.require_supported()
+        if plan.target not in {
+            GroupLoweringTarget.CUB_BLOCK,
+            GroupLoweringTarget.CUB_WARP,
+        }:
+            raise ValueError("CUTLASS core artifacts require a CUB lowering plan")
+        if not isinstance(plan.implementation, AlgorithmSpec):
+            raise TypeError("CUTLASS core artifacts require an AlgorithmSpec")
+        if plan.implementation.semantic_key != specialization.semantic_key:
+            raise ValueError("CUTLASS specialization does not match its plan")
+        if not isinstance(external_scratch, bool):
+            raise TypeError("external_scratch must be a bool")
+        expected_storage_ownership = (
+            StorageOwnership.CALLER
+            if external_scratch
+            else StorageOwnership.IMPLEMENTATION
+        )
+        if plan.temp_storage is None or (
+            plan.temp_storage.ownership is not expected_storage_ownership
+        ):
+            raise ValueError(
+                "CUTLASS core artifact storage ownership does not match its "
+                "external-scratch mode"
+            )
+        if external_scratch:
+            temp_storage = plan.temp_storage
+            if plan.target is not GroupLoweringTarget.CUB_BLOCK:
+                raise ValueError("external CUTLASS core scratch is block-scoped only")
+            if (
+                temp_storage.address_space != "shared"
+                or temp_storage.instances != 1
+                or temp_storage.instance_index != "cta"
+                or not temp_storage.exact_layout_required
+            ):
+                raise ValueError(
+                    "external CUTLASS core scratch requires exact caller-owned "
+                    "CTA shared storage"
+                )
+        if not isinstance(kind, str) or not kind:
+            raise ValueError("CUTLASS core artifact kind must not be empty")
+        if method_index < 0:
+            raise ValueError("CUTLASS method_index is out of range")
+        try:
+            method = specialization.parameters[method_index]
+        except IndexError as exc:
+            raise ValueError("CUTLASS method_index is out of range") from exc
+        if isinstance(output_initializers, Mapping):
+            if output_value_initializers is not None:
+                raise ValueError(
+                    "output initializers may be supplied either as value mappings "
+                    "or copy pairs, not both"
+                )
+            output_value_initializers = output_initializers
+            output_initializers = ()
+        output_initializers = tuple(tuple(pair) for pair in output_initializers)
+        if any(
+            len(pair) != 2
+            or not isinstance(pair[0], str)
+            or not isinstance(pair[1], str)
+            for pair in output_initializers
+        ):
+            raise TypeError(
+                "CUTLASS output initializers must be (output, input) name pairs"
+            )
+        output_names = [output_name for output_name, _ in output_initializers]
+        if len(output_names) != len(set(output_names)):
+            raise ValueError("CUTLASS output initializer targets must be unique")
+        method_by_name = {
+            getattr(parameter, "name", None): parameter for parameter in method
+        }
+        normalized_runtime_int_ranges = tuple(runtime_int_ranges)
+        if any(
+            not isinstance(runtime_range, CutlassRuntimeIntRange)
+            for runtime_range in normalized_runtime_int_ranges
+        ):
+            raise TypeError(
+                "CUTLASS runtime int ranges must contain CutlassRuntimeIntRange values"
+            )
+        range_names = [
+            runtime_range.logical_name
+            for runtime_range in normalized_runtime_int_ranges
+        ]
+        if len(range_names) != len(set(range_names)):
+            raise ValueError("CUTLASS runtime int range parameters must be unique")
+        for runtime_range in normalized_runtime_int_ranges:
+            descriptor = method_by_name.get(runtime_range.logical_name)
+            if not isinstance(descriptor, (Reference, Value)) or getattr(
+                descriptor,
+                "is_output",
+                False,
+            ):
+                raise ValueError(
+                    "CUTLASS runtime int ranges must name input scalar parameters"
+                )
+            if (
+                self.cpp_type(self._resolved_dtype(descriptor.dtype, specialization))
+                != "int"
+            ):
+                raise TypeError("CUTLASS runtime int ranges require int parameters")
+            relation_name = runtime_range.less_than_parameter
+            if relation_name is not None:
+                relation_descriptor = method_by_name.get(relation_name)
+                if not isinstance(relation_descriptor, (Reference, Value)) or getattr(
+                    relation_descriptor,
+                    "is_output",
+                    False,
+                ):
+                    raise ValueError(
+                        "CUTLASS runtime int range relations must name input "
+                        "scalar parameters"
+                    )
+                if (
+                    self.cpp_type(
+                        self._resolved_dtype(
+                            relation_descriptor.dtype,
+                            specialization,
+                        )
+                    )
+                    != "int"
+                ):
+                    raise TypeError(
+                        "CUTLASS runtime int range relations require int parameters"
+                    )
+        for output_name, input_name in output_initializers:
+            if output_name not in method_by_name or input_name not in method_by_name:
+                raise ValueError(
+                    "CUTLASS output initializers must name method parameters"
+                )
+            if not getattr(method_by_name[output_name], "is_output", False):
+                raise ValueError(
+                    f"CUTLASS output initializer target {output_name!r} is not output"
+                )
+            input_parameter = method_by_name[input_name]
+            if getattr(input_parameter, "is_output", False) and not getattr(
+                input_parameter,
+                "is_inout",
+                False,
+            ):
+                raise ValueError(
+                    f"CUTLASS output initializer source {input_name!r} is output-only"
+                )
+        parameters = lower_method_parameters(
+            self,
+            specialization,
+            method,
+            include_temp_storage=True,
+        )
+        normalized_input_transforms = tuple(
+            sorted((input_transforms or {}).items(), key=lambda item: item[0])
+        )
+        normalized_output_value_initializers = tuple(
+            sorted((output_value_initializers or {}).items(), key=lambda item: item[0])
+        )
+        parameters = self._apply_parameter_adapters(
+            specialization,
+            method,
+            parameters,
+            input_transforms=dict(normalized_input_transforms),
+            output_initializers=dict(normalized_output_value_initializers),
+        )
+        if sum(parameter.is_temp_storage for parameter in parameters) != 1:
+            raise ValueError(
+                "CUTLASS public-CUB wrappers require exactly one TempStorage parameter"
+            )
+        generated_symbol = symbol_name is None
+        if generated_symbol:
+            digest = hashlib.sha256(
+                repr(
+                    (
+                        plan.artifact_key,
+                        kind,
+                        method_index,
+                        normalized_input_transforms,
+                        output_initializers,
+                        normalized_output_value_initializers,
+                        normalized_runtime_int_ranges,
+                    )
+                ).encode("utf-8", errors="backslashreplace")
+            ).hexdigest()[:16]
+            symbol_name = (
+                f"cuda_coop_cutlass_{specialization.c_name}_"
+                f"{specialization.method_name.lower()}_{digest}"
+            )
+        external_suffix = "_external_scratch"
+        if external_scratch and symbol_name.endswith(external_suffix):
+            symbol_name = symbol_name[: -len(external_suffix)]
+        if (
+            method_index
+            and (external_scratch or not generated_symbol)
+            and not symbol_name.endswith(f"_m{method_index}")
+        ):
+            symbol_name = f"{symbol_name}_m{method_index}"
+        if external_scratch:
+            symbol_name = f"{symbol_name}{external_suffix}"
+        return CutlassCoreArtifact(
+            plan=plan,
+            specialization=specialization,
+            parameters=parameters,
+            kind=kind,
+            symbol_name=symbol_name,
+            method_index=method_index,
+            output_initializers=output_initializers,
+            input_transforms=normalized_input_transforms,
+            output_value_initializers=normalized_output_value_initializers,
+            runtime_int_ranges=normalized_runtime_int_ranges,
+            external_scratch=external_scratch,
+        )
+
+    def _apply_parameter_adapters(
+        self,
+        specialization: AlgorithmSpec,
+        method: tuple[Any, ...],
+        parameters: tuple[CutlassLoweredParameter, ...],
+        *,
+        input_transforms: Mapping[str, CutlassArrayInputTransform],
+        output_initializers: Mapping[str, str],
+    ) -> tuple[CutlassLoweredParameter, ...]:
+        remaining_transforms = dict(input_transforms)
+        remaining_initializers = dict(output_initializers)
+        adapted = []
+        for descriptor, lowered in zip(method, parameters, strict=True):
+            transform = remaining_transforms.pop(lowered.name, None)
+            initializer = remaining_initializers.pop(lowered.name, None)
+            if transform is not None:
+                if not isinstance(descriptor, Array) or descriptor.is_output:
+                    raise TypeError(
+                        f"CUTLASS input transform {lowered.name!r} requires an "
+                        "input-only Array parameter"
+                    )
+                source_dtype = self.normalize_dtype(transform.source_dtype)
+                source_cpp_type = self.cpp_type(source_dtype)
+                target_dtype = self._resolved_dtype(descriptor.dtype, specialization)
+                target_cpp_type = self.cpp_type(target_dtype)
+                size = self._resolve(descriptor.size, specialization)
+                if not isinstance(size, int) or isinstance(size, bool) or size < 1:
+                    raise ValueError(
+                        f"{lowered.name} array extent must be a positive integer"
+                    )
+                abi_parameters = tuple(
+                    CutlassAbiParameter(
+                        logical_name=lowered.name,
+                        cpp_name=f"{lowered.name}_{index}",
+                        cpp_type=source_cpp_type,
+                        ffi_type=source_dtype,
+                        source="runtime",
+                        item_index=index,
+                    )
+                    for index in range(size)
+                )
+                values = ", ".join(
+                    transform.cpp_expression.format(value=f"{lowered.name}_{index}")
+                    for index in range(size)
+                )
+                lowered = dataclasses.replace(
+                    lowered,
+                    abi_parameters=abi_parameters,
+                    declarations=(
+                        f"  {target_cpp_type} {lowered.name}[{size}] = {{{values}}};",
+                    ),
+                )
+            if initializer is not None:
+                if (
+                    not isinstance(descriptor, Array)
+                    or not descriptor.is_output
+                    or descriptor.is_inout
+                ):
+                    raise TypeError(
+                        f"CUTLASS output initializer {lowered.name!r} requires "
+                        "an output-only Array parameter"
+                    )
+                dtype = self._resolved_dtype(descriptor.dtype, specialization)
+                cpp_type = self.cpp_type(dtype)
+                size = self._resolve(descriptor.size, specialization)
+                if not isinstance(size, int) or isinstance(size, bool) or size < 1:
+                    raise ValueError(
+                        f"{lowered.name} array extent must be a positive integer"
+                    )
+                values = ", ".join(initializer for _ in range(size))
+                lowered = dataclasses.replace(
+                    lowered,
+                    declarations=(
+                        f"  {cpp_type} {lowered.name}[{size}] = {{{values}}};",
+                    ),
+                )
+            adapted.append(lowered)
+        if remaining_transforms:
+            names = ", ".join(sorted(remaining_transforms))
+            raise ValueError(f"unknown CUTLASS input transform parameter(s): {names}")
+        if remaining_initializers:
+            names = ", ".join(sorted(remaining_initializers))
+            raise ValueError(
+                f"unknown CUTLASS output initializer parameter(s): {names}"
+            )
+        return tuple(adapted)
+
+
+def with_caller_owned_core_temp_storage(
+    plan: GroupLoweringPlan,
+) -> GroupLoweringPlan:
+    """Return a block-CUB plan whose exact scratch is supplied by the caller."""
+
+    if plan.target is not GroupLoweringTarget.CUB_BLOCK:
+        raise ValueError("external CUTLASS core scratch is block-scoped only")
+    temp_storage = plan.temp_storage
+    if temp_storage is None:
+        raise ValueError("CUTLASS core plan requires a temporary-storage contract")
+    return dataclasses.replace(
+        plan,
+        temp_storage=dataclasses.replace(
+            temp_storage,
+            ownership=StorageOwnership.CALLER,
+            address_space="shared",
+            cpp_type="typename implementation_type::TempStorage",
+            instances=1,
+            instance_index="cta",
+            exact_layout_required=True,
+        ),
+    )
+
+
+def _render_template_argument(adapter: CutlassCoreAdapter, value: Any) -> str:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, str):
+        return value
+    return adapter.cpp_type(value)
+
+
+def _render_type_definitions(artifact: CutlassCoreArtifact) -> list[str]:
+    lines = []
+    for definition in artifact.specialization.type_definitions:
+        digest = (
+            hashlib.sha256(
+                repr(definition.semantic_key).encode("utf-8", errors="backslashreplace")
+            )
+            .hexdigest()[:16]
+            .upper()
+        )
+        guard = f"CUDA_COOP_CUTLASS_TYPE_{digest}"
+        lines.extend(
+            [
+                f"#ifndef {guard}",
+                f"#define {guard}",
+                *definition.code.splitlines(),
+                "#endif",
+            ]
+        )
+    return lines
+
+
+def _storage_lines(artifact: CutlassCoreArtifact) -> tuple[list[str], str]:
+    if artifact.external_scratch:
+        return (
+            [
+                "  constexpr unsigned long long required_temp_bytes =",
+                "      (unsigned long long)sizeof(typename implementation_type::TempStorage);",
+                "  constexpr unsigned long long required_temp_alignment =",
+                "      (unsigned long long)alignof(typename implementation_type::TempStorage);",
+                "  if (temp_storage_bytes <= 0 ||",
+                "      (unsigned long long)temp_storage_bytes < required_temp_bytes ||",
+                "      ((unsigned long long)temp_storage_smem_addr &",
+                "       (required_temp_alignment - 1ull)) != 0ull) {",
+                '    asm volatile("trap;");',
+                "  }",
+                "  void* temp_storage_ptr =",
+                "      cuda_coop_cutlass_shared_ptr(temp_storage_smem_addr);",
+                "  auto* storage_ptr = reinterpret_cast<",
+                "      typename implementation_type::TempStorage*>(temp_storage_ptr);",
+            ],
+            "*storage_ptr",
+        )
+    if artifact.plan.target is GroupLoweringTarget.CUB_BLOCK:
+        return (
+            ["  __shared__ typename implementation_type::TempStorage storage;"],
+            "storage",
+        )
+    participation = artifact.plan.participation
+    if participation is None or participation.exact_block_dim is None:
+        raise ValueError("CUB warp artifacts require exact block dimensions")
+    x, y, z = participation.exact_block_dim
+    block_threads = x * y * z
+    resolved_group = artifact.plan.resolved_group
+    if resolved_group.kind == "warp":
+        logical_width = 32
+    elif resolved_group.kind == "threads_within_warp":
+        logical_width = resolved_group.static_size
+        assert logical_width is not None
+    else:
+        raise ValueError("CUB warp artifacts require a warp group")
+    if block_threads < logical_width or block_threads % logical_width != 0:
+        raise ValueError("CUB warp artifacts require complete logical-warp partitions")
+    instances = block_threads // logical_width
+    return (
+        [
+            "  __shared__ typename implementation_type::TempStorage "
+            f"storage[{instances}];",
+            "  unsigned int storage_instance =",
+            f"      cuda_coop_cutlass_linear_tid() / {logical_width}u;",
+        ],
+        "storage[storage_instance]",
+    )
+
+
+def _storage_reuse_barrier(artifact: CutlassCoreArtifact) -> str | None:
+    synchronization = artifact.plan.synchronization
+    if synchronization is None:
+        raise ValueError("CUTLASS core artifacts require synchronization metadata")
+    barrier = synchronization.storage_reuse_barrier
+    if barrier is SynchronizationScope.BLOCK:
+        return "  cuda_coop_cutlass_block_sync();"
+    if barrier is SynchronizationScope.WARP:
+        group = artifact.plan.resolved_group
+        logical_width = 32 if group.kind == "warp" else group.static_size
+        if group.kind not in {"warp", "threads_within_warp"} or not isinstance(
+            logical_width,
+            int,
+        ):
+            raise ValueError("CUTLASS warp barrier requires a static warp group")
+        return f"  cuda_coop_cutlass_warp_sync({logical_width}u);"
+    if barrier is SynchronizationScope.NONE:
+        return None
+    raise ValueError("CUTLASS core artifact has an unsupported storage barrier")
+
+
+def _render_output_initializers(
+    adapter: CutlassCoreAdapter,
+    artifact: CutlassCoreArtifact,
+) -> list[str]:
+    method = artifact.specialization.parameters[artifact.method_index]
+    method_by_name = {
+        getattr(parameter, "name", None): parameter for parameter in method
+    }
+    lines = []
+    for output_name, input_name in artifact.output_initializers:
+        output_parameter = method_by_name[output_name]
+        input_parameter = method_by_name[input_name]
+        if isinstance(output_parameter, Array) and isinstance(input_parameter, Array):
+            output_size = adapter._resolve(
+                output_parameter.size,
+                artifact.specialization,
+            )
+            input_size = adapter._resolve(
+                input_parameter.size,
+                artifact.specialization,
+            )
+            if output_size != input_size:
+                raise ValueError("CUTLASS array output initializer extents must match")
+            lines.extend(
+                f"  {output_name}[{index}] = {input_name}[{index}];"
+                for index in range(output_size)
+            )
+            continue
+        if isinstance(output_parameter, (Reference, Value)) and isinstance(
+            input_parameter,
+            (Reference, Value),
+        ):
+            lines.append(f"  {output_name} = {input_name};")
+            continue
+        raise TypeError(
+            "CUTLASS output initializers require matching scalar or array parameters"
+        )
+    return lines
+
+
+def _render_runtime_int_ranges(artifact: CutlassCoreArtifact) -> list[str]:
+    lines = []
+    for runtime_range in artifact.runtime_int_ranges:
+        name = runtime_range.logical_name
+        if runtime_range.modulus is not None:
+            lines.extend(
+                (
+                    f"  if ({name} < 0) {{",
+                    '    asm volatile("trap;");',
+                    "  }",
+                    f"  {name} %= {runtime_range.modulus};",
+                )
+            )
+        elif runtime_range.clamp:
+            lines.extend(
+                (
+                    f"  if ({name} < {runtime_range.minimum}) {{",
+                    f"    {name} = {runtime_range.minimum};",
+                    f"  }} else if ({name} > {runtime_range.maximum}) {{",
+                    f"    {name} = {runtime_range.maximum};",
+                    "  }",
+                )
+            )
+        else:
+            lines.extend(
+                (
+                    f"  if ({name} < {runtime_range.minimum} || "
+                    f"{name} > {runtime_range.maximum}) {{",
+                    '    asm volatile("trap;");',
+                    "  }",
+                )
+            )
+    for runtime_range in artifact.runtime_int_ranges:
+        relation_name = runtime_range.less_than_parameter
+        if relation_name is not None:
+            lines.extend(
+                (
+                    f"  if ({runtime_range.logical_name} >= {relation_name}) {{",
+                    '    asm volatile("trap;");',
+                    "  }",
+                )
+            )
+    return lines
+
+
+def render_cutlass_core_artifact(artifact: CutlassCoreArtifact) -> list[str]:
+    """Render one typed wrapper containing exactly one public-CUB call."""
+
+    adapter = CutlassCoreAdapter()
+    # Re-materialization validation keeps stale or manually forged requests from
+    # bypassing the plan/spec invariant at source-generation time.
+    validated = adapter.materialize(
+        artifact.specialization,
+        plan=artifact.plan,
+        kind=artifact.kind,
+        symbol_name=artifact.symbol_name,
+        method_index=artifact.method_index,
+        input_transforms=dict(artifact.input_transforms),
+        output_initializers=artifact.output_initializers,
+        output_value_initializers=dict(artifact.output_value_initializers),
+        runtime_int_ranges=artifact.runtime_int_ranges,
+        external_scratch=artifact.external_scratch,
+    )
+    abi_parameters = validated.abi_parameters
+    signature_parameters = [
+        f"{parameter.cpp_type} {parameter.cpp_name}" for parameter in abi_parameters
+    ]
+    if validated.external_scratch:
+        signature_parameters.extend(
+            (
+                "unsigned int temp_storage_smem_addr",
+                "int temp_storage_bytes",
+                "int temp_storage_auto_sync",
+            )
+        )
+    signature = ", ".join(signature_parameters)
+    template_arguments = ", ".join(
+        _render_template_argument(adapter, value)
+        for _, value in validated.specialization.ordered_template_arguments
+    )
+    provenance = validated.plan.provenance
+    if provenance is None or provenance.library != "CUB":
+        raise ValueError("CUTLASS core artifacts require public-CUB provenance")
+    cpp_class = provenance.cpp_class
+    if not cpp_class.startswith("::"):
+        cpp_class = f"::{cpp_class}"
+    storage_lines, storage_expression = _storage_lines(validated)
+    declarations = [
+        line for parameter in validated.parameters for line in parameter.declarations
+    ]
+    output_initializers = _render_output_initializers(adapter, validated)
+    runtime_int_ranges = _render_runtime_int_ranges(validated)
+    call_arguments = [
+        parameter.call_expression
+        for parameter in validated.parameters
+        if parameter.call_expression is not None
+    ]
+    epilogue = [
+        line for parameter in validated.parameters for line in parameter.epilogue
+    ]
+    barrier = _storage_reuse_barrier(validated)
+    barrier_lines = []
+    if barrier is not None:
+        if validated.external_scratch:
+            barrier_lines = [
+                "  if (temp_storage_auto_sync != 0) {",
+                f"  {barrier}",
+                "  }",
+            ]
+        else:
+            barrier_lines = [barrier]
+    type_definitions = _render_type_definitions(validated)
+    linkage_safe_definitions = (
+        ["}", *type_definitions, 'extern "C" {'] if type_definitions else []
+    )
+    return [
+        *linkage_safe_definitions,
+        f"void {validated.symbol_name}({signature}) {{",
+        f"  using implementation_type = {cpp_class}<{template_arguments}>;",
+        *storage_lines,
+        *declarations,
+        *output_initializers,
+        *runtime_int_ranges,
+        f"  implementation_type({storage_expression})."
+        f"{validated.specialization.method_name}("
+        f"{', '.join(call_arguments)});",
+        *barrier_lines,
+        *epilogue,
+        "}",
+    ]
+
+
+def register_cutlass_core_renderer(
+    kind: str,
+    *,
+    includes: tuple[str, ...],
+) -> None:
+    """Register the shared renderer for one AlgorithmSpec include family."""
+
+    # Shared-core CxxOperator descriptors use cuda::std function objects. Keep
+    # that dependency at the reusable renderer boundary instead of relying on
+    # a primitive header to include it transitively.
+    includes = tuple(dict.fromkeys((*includes, "cuda/std/functional")))
+    include_lines = tuple(f"#include <{include}>" for include in includes)
+    _provider_rendering.register_bundle_renderer(
+        kind,
+        render=render_cutlass_core_artifact,
+        include_lines=include_lines,
+        cccl_headers=tuple((f"#include <{include}>", include) for include in includes),
+        scratch_layout_probe=lambda artifact: (
+            _provider_rendering.make_scratch_layout_probe(
+                artifact.scratch_requirement_key,
+                artifact.scratch_cpp_type,
+            )
+            if artifact.external_scratch
+            else None
+        ),
+    )
+
+
+__all__ = [
+    "CutlassAbiParameter",
+    "CutlassArrayInputTransform",
+    "CutlassCoreAdapter",
+    "CutlassCoreArtifact",
+    "CutlassLoweredParameter",
+    "register_cutlass_core_renderer",
+    "render_cutlass_core_artifact",
+    "with_caller_owned_core_temp_storage",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_lowering/_load_store.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_lowering/_load_store.py
@@ -1,0 +1,1202 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Plan-driven public-CUB provider renderer for group Load and Store."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import math
+from numbers import Integral, Real
+from typing import Any
+
+from cutlass import cute as _cute
+from cutlass._mlir.dialects import llvm
+from cutlass.base_dsl.typing import Int32, Int64, Uint32
+from cutlass.cute.ffi import ffi
+
+from cuda.coop._core import (
+    AlgorithmSpec,
+    ArgumentBinding,
+    BindingKind,
+    GroupLoadStoreAlgorithm,
+    GroupLoadStoreKind,
+    GroupLoadStoreSemantics,
+    GroupLoweringPlan,
+    GroupLoweringTarget,
+    LaunchFacts,
+    StorageOwnership,
+    SynchronizationScope,
+    make_group_primitive_call,
+    plan_group_primitive,
+)
+
+from .._compiler import _rendering, _state, _storage, _types
+from .._compiler._call_context import get_active_single_phase_context
+from .._compiler._types import ALL_PROVIDER_TYPES, TYPE_SPECS
+from .._prims import is_cutlass_array_operand
+from .._thread_data import ThreadData
+from .._thread_group import ThreadGroup
+from ._load_store_layout import contiguous_layout_reason, static_layout_elements
+from ._symbols import block_dim_token as _block_dim_token
+
+_provider_rendering = _rendering
+_provider_state = _state
+_provider_storage = _storage
+_provider_types = _types
+
+_ROOT_SCOPE = "cuda.coop.cutlass"
+_MAX_STATIC_OFFSET = (1 << 63) - 1
+_LLVM_LOCAL_ADDRESS_SPACE = 5
+
+
+def _normalize_algorithm(algorithm: Any) -> GroupLoadStoreAlgorithm:
+    token = getattr(algorithm, "value", algorithm)
+    if isinstance(token, str):
+        token = token.lower().replace("-", "_")
+    try:
+        return GroupLoadStoreAlgorithm(token)
+    except (TypeError, ValueError) as exc:
+        choices = ", ".join(item.value for item in GroupLoadStoreAlgorithm)
+        raise ValueError(
+            f"{_ROOT_SCOPE}.load/store algorithm must be one of {choices}"
+        ) from exc
+
+
+def _make_group_load_store_plan(
+    *,
+    group: ThreadGroup,
+    launch: LaunchFacts,
+    kind: GroupLoadStoreKind,
+    dtype: Any,
+    items_per_thread: int,
+    algorithm: Any,
+    valid_items: ArgumentBinding,
+    oob_default: ArgumentBinding,
+    offset: ArgumentBinding,
+    source: str = "cutlass_root",
+) -> GroupLoweringPlan:
+    """Build the canonical shared-core plan for group Load or Store."""
+
+    operation = GroupLoadStoreSemantics(
+        kind=kind,
+        dtype=dtype,
+        items_per_thread=items_per_thread,
+        algorithm=_normalize_algorithm(algorithm),
+        valid_items=valid_items,
+        oob_default=oob_default,
+        offset=offset,
+    )
+    call = make_group_primitive_call(group, operation, source=source)
+    return plan_group_primitive(call, launch)
+
+
+def _validate_binding_payload(
+    binding: ArgumentBinding,
+    value: Any,
+    *,
+    name: str,
+) -> None:
+    if binding.kind is BindingKind.OMITTED:
+        if value is not None:
+            raise ValueError(f"omitted {name} binding cannot carry a value")
+        return
+    if binding.kind is BindingKind.RUNTIME:
+        if value is None:
+            raise ValueError(f"runtime {name} binding requires a value")
+        return
+    if value != binding.value:
+        raise ValueError(f"static {name} value does not match its binding")
+
+
+def _validate_plan(
+    plan: GroupLoweringPlan,
+    *,
+    value_type: type,
+    kind: GroupLoadStoreKind,
+    external_scratch: bool,
+) -> GroupLoadStoreSemantics:
+    plan.require_supported()
+    if plan.target not in {
+        GroupLoweringTarget.CUB_BLOCK,
+        GroupLoweringTarget.CUB_WARP,
+    }:
+        raise ValueError("group load/store request requires a CUB lowering plan")
+    if not isinstance(plan.implementation, AlgorithmSpec):
+        raise TypeError("group load/store request requires an AlgorithmSpec")
+    operation = plan.call.operation
+    if not isinstance(operation, GroupLoadStoreSemantics):
+        raise TypeError("group load/store request requires load/store semantics")
+    if operation.kind is not kind:
+        raise ValueError("group load/store request kind does not match its plan")
+    if operation.dtype is not value_type:
+        raise ValueError("group load/store request dtype does not match its plan")
+    if operation.valid_items.kind is BindingKind.STATIC:
+        valid_items = operation.valid_items.value
+        if isinstance(valid_items, bool) or not isinstance(valid_items, Integral):
+            raise TypeError("static group load/store valid_items must be an integer")
+        group_size = plan.resolved_group.static_size
+        assert group_size is not None
+        tile_items = group_size * operation.items_per_thread
+        if not 0 <= valid_items <= tile_items:
+            raise ValueError(
+                "static group load/store valid_items must be between zero and "
+                f"the group tile size ({tile_items})"
+            )
+    if operation.offset.kind is BindingKind.STATIC:
+        offset = operation.offset.value
+        if isinstance(offset, bool) or not isinstance(offset, Integral):
+            raise TypeError("static group load/store offset must be an integer")
+        if offset < 0:
+            raise ValueError("static group load/store offset must be non-negative")
+        if offset > _MAX_STATIC_OFFSET:
+            raise ValueError(
+                "static group load/store offset must fit a signed 64-bit integer"
+            )
+    if operation.oob_default.kind is BindingKind.STATIC:
+        _validate_static_oob_default(operation.oob_default.value, value_type)
+
+    expected_target = (
+        GroupLoweringTarget.CUB_BLOCK
+        if plan.resolved_group.kind == "block"
+        else GroupLoweringTarget.CUB_WARP
+    )
+    if plan.target is not expected_target:
+        raise ValueError("group load/store target does not match its group")
+    implementation = plan.implementation
+    expected_struct = (
+        f"Block{kind.value.title()}"
+        if expected_target is GroupLoweringTarget.CUB_BLOCK
+        else f"Warp{kind.value.title()}"
+    )
+    if implementation.struct_name != expected_struct:
+        raise ValueError("group load/store implementation does not match its plan")
+    if implementation.method_name != kind.value.title():
+        raise ValueError("group load/store method does not match its plan")
+    template_arguments = implementation.template_arguments
+    if template_arguments.get("T") is not value_type:
+        raise ValueError("group load/store template dtype does not match its plan")
+    if template_arguments.get("ITEMS_PER_THREAD") != operation.items_per_thread:
+        raise ValueError("group load/store item count does not match its plan")
+    if expected_target is GroupLoweringTarget.CUB_WARP:
+        if template_arguments.get("LOGICAL_WARP_THREADS") != (
+            plan.resolved_group.static_size
+        ):
+            raise ValueError("group WarpLoad/Store width does not match its plan")
+    else:
+        participation = plan.participation
+        if participation is None:
+            raise ValueError("group BlockLoad/Store requires participation metadata")
+        expected_dims = (
+            template_arguments.get("BLOCK_DIM_X"),
+            template_arguments.get("BLOCK_DIM_Y"),
+            template_arguments.get("BLOCK_DIM_Z"),
+        )
+        if expected_dims != participation.exact_block_dim:
+            raise ValueError("group BlockLoad/Store dimensions do not match its plan")
+
+    temp_storage = plan.temp_storage
+    if temp_storage is None:
+        raise ValueError("group load/store requires a temporary-storage contract")
+    expected_ownership = (
+        StorageOwnership.CALLER if external_scratch else StorageOwnership.IMPLEMENTATION
+    )
+    if temp_storage.ownership is not expected_ownership:
+        raise ValueError("group load/store storage ownership does not match request")
+    if external_scratch:
+        if plan.target is not GroupLoweringTarget.CUB_BLOCK:
+            raise ValueError("deferred CUB Load/Store scratch is block-scoped only")
+        if (
+            temp_storage.address_space != "shared"
+            or temp_storage.instances != 1
+            or temp_storage.instance_index != "cta"
+            or not temp_storage.exact_layout_required
+        ):
+            raise ValueError(
+                "deferred CUB BlockLoad/Store requires exact caller-owned "
+                "shared storage"
+            )
+    if kind is GroupLoadStoreKind.LOAD:
+        if plan.result is None or plan.result.result_items_per_thread != (
+            operation.items_per_thread
+        ):
+            raise ValueError("group Load result does not match its item count")
+    elif plan.result is not None:
+        raise ValueError("group Store must not expose a result contract")
+    return operation
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class _CubLoadStoreRequest:
+    plan: GroupLoweringPlan
+    value_type: type
+    external_scratch: bool = False
+    kind: str = "cub_group_load_store"
+
+    def __post_init__(self) -> None:
+        _validate_plan(
+            self.plan,
+            value_type=self.value_type,
+            kind=self.operation_kind,
+            external_scratch=self.external_scratch,
+        )
+
+    @property
+    def operation(self) -> GroupLoadStoreSemantics:
+        operation = self.plan.call.operation
+        if not isinstance(operation, GroupLoadStoreSemantics):
+            raise TypeError("group load/store request requires load/store semantics")
+        return operation
+
+    @property
+    def operation_kind(self) -> GroupLoadStoreKind:
+        operation = self.plan.call.operation
+        if not isinstance(operation, GroupLoadStoreSemantics):
+            raise TypeError("group load/store request requires load/store semantics")
+        return operation.kind
+
+    @property
+    def implementation(self) -> AlgorithmSpec:
+        implementation = self.plan.implementation
+        if not isinstance(implementation, AlgorithmSpec):
+            raise TypeError("group load/store request requires an AlgorithmSpec")
+        return implementation
+
+    @property
+    def block_dim(self) -> tuple[int, int, int]:
+        participation = self.plan.participation
+        if participation is None or participation.exact_block_dim is None:
+            raise ValueError("group load/store request requires exact block dimensions")
+        return participation.exact_block_dim
+
+    @property
+    def semantic_key(self) -> tuple[Any, ...]:
+        assert self.plan.artifact_key is not None
+        if not self.external_scratch:
+            return self.plan.artifact_key
+        return "external_scratch", self.plan.artifact_key
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _CubLoadStoreRequest):
+            return NotImplemented
+        return self.semantic_key == other.semantic_key
+
+    def __hash__(self) -> int:
+        return hash(self.semantic_key)
+
+    @property
+    def symbol_name(self) -> str:
+        signature_plan = self.plan
+        if self.external_scratch:
+            assert self.plan.temp_storage is not None
+            signature_plan = dataclasses.replace(
+                self.plan,
+                temp_storage=dataclasses.replace(
+                    self.plan.temp_storage,
+                    ownership=StorageOwnership.IMPLEMENTATION,
+                    address_space=None,
+                    cpp_type=None,
+                    instances=None,
+                    instance_index=None,
+                    exact_layout_required=False,
+                ),
+            )
+        assert signature_plan.artifact_key is not None
+        signature = hashlib.sha256(
+            repr(signature_plan.artifact_key).encode()
+        ).hexdigest()[:12]
+        symbol = (
+            "cuda_coop_cutlass_cub_"
+            f"{self.operation_kind.value}_{self.plan.resolved_group.kind}_"
+            f"{_block_dim_token(self.block_dim)}_"
+            f"{self.operation.algorithm.value}_"
+            f"{TYPE_SPECS[self.value_type].token}_"
+            f"x{self.operation.items_per_thread}_{signature}"
+        )
+        if self.external_scratch:
+            return f"{symbol}_external_scratch"
+        return symbol
+
+    @property
+    def scratch_requirement_key(self) -> tuple[Any, ...]:
+        return (
+            "cub_temp_storage_layout",
+            self.implementation.struct_name,
+            tuple(
+                (name, _render_template_argument(self, name, value))
+                for name, value in self.implementation.ordered_template_arguments
+            ),
+        )
+
+    @property
+    def scratch_cpp_type(self) -> str:
+        template_arguments = ", ".join(
+            _render_template_argument(self, name, value)
+            for name, value in self.implementation.ordered_template_arguments
+        )
+        return (
+            f"typename ::cub::{self.implementation.struct_name}<"
+            f"{template_arguments}>::TempStorage"
+        )
+
+
+def _render_template_argument(
+    request: _CubLoadStoreRequest,
+    name: str,
+    value: Any,
+) -> str:
+    if name == "T":
+        if value is not request.value_type:
+            raise ValueError("group load/store template dtype does not match request")
+        return TYPE_SPECS[value].cpp_type
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, str):
+        return value
+    raise TypeError(f"cannot render load/store template argument {name}={value!r}")
+
+
+def _cpp_oob_literal(request: _CubLoadStoreRequest) -> str:
+    value = getattr(request.operation.oob_default.value, "value", None)
+    if value is None:
+        value = request.operation.oob_default.value
+    cpp_type = TYPE_SPECS[request.value_type].cpp_type
+    if isinstance(value, bool):
+        literal = "true" if value else "false"
+    elif isinstance(value, Integral):
+        literal = str(value)
+    elif isinstance(value, Real) and math.isfinite(float(value)):
+        literal = repr(float(value))
+    else:
+        raise TypeError("static oob_default must be a finite scalar literal")
+    return f"static_cast<{cpp_type}>({literal})"
+
+
+def _binding_expr(
+    request: _CubLoadStoreRequest,
+    binding: ArgumentBinding,
+    *,
+    runtime_name: str,
+    oob_default: bool = False,
+) -> str | None:
+    if binding.kind is BindingKind.OMITTED:
+        return None
+    if binding.kind is BindingKind.RUNTIME:
+        return runtime_name
+    if oob_default:
+        return _cpp_oob_literal(request)
+    return str(binding.value)
+
+
+def _storage_reuse_barrier_line(request: _CubLoadStoreRequest) -> str:
+    synchronization = request.plan.synchronization
+    if synchronization is None:
+        raise ValueError("group load/store requires a synchronization contract")
+    if synchronization.storage_reuse_barrier is SynchronizationScope.BLOCK:
+        return "  cuda_coop_cutlass_block_sync();"
+    if synchronization.storage_reuse_barrier is SynchronizationScope.WARP:
+        implementation = request.plan.implementation
+        assert isinstance(implementation, AlgorithmSpec)
+        logical_width = implementation.template_arguments.get("LOGICAL_WARP_THREADS")
+        if not isinstance(logical_width, int) or logical_width < 1:
+            raise ValueError("Warp load/store plan requires a logical warp width")
+        return f"  cuda_coop_cutlass_warp_sync({logical_width}u);"
+    raise ValueError("group load/store requires a block or warp reuse barrier")
+
+
+def _render_cub_load_store(request: _CubLoadStoreRequest) -> list[str]:
+    request.__post_init__()
+    operation = request.operation
+    implementation = request.implementation
+    spec = TYPE_SPECS[request.value_type]
+    template_arguments = ", ".join(
+        _render_template_argument(request, name, value)
+        for name, value in implementation.ordered_template_arguments
+    )
+    is_load = operation.kind is GroupLoadStoreKind.LOAD
+    params = [f"{'const ' if is_load else ''}{spec.cpp_type}* base"]
+    if not is_load:
+        params.extend(
+            f"{spec.cpp_type} item{index}"
+            for index in range(operation.items_per_thread)
+        )
+    if operation.valid_items.kind is BindingKind.RUNTIME:
+        params.append("int valid_items")
+    if operation.oob_default.kind is BindingKind.RUNTIME:
+        params.append(f"{spec.cpp_type} oob_default")
+    if operation.offset.kind is BindingKind.RUNTIME:
+        params.append("long long offset")
+    if request.external_scratch:
+        params.extend(
+            (
+                "unsigned int temp_storage_smem_addr",
+                "int temp_storage_bytes",
+                "int temp_storage_auto_sync",
+            )
+        )
+    if is_load:
+        params.append(f"{spec.cpp_type}* result_items")
+
+    storage = "storage"
+    storage_lines = ["  __shared__ typename implementation_type::TempStorage storage;"]
+    tile_pointer_lines: list[str] = []
+    if request.external_scratch:
+        storage_lines = [
+            "  constexpr unsigned long long required_temp_bytes =",
+            "      (unsigned long long)sizeof(typename implementation_type::TempStorage);",
+            "  constexpr unsigned long long required_temp_alignment =",
+            "      (unsigned long long)alignof(typename implementation_type::TempStorage);",
+            "  if (temp_storage_bytes <= 0 ||",
+            "      (unsigned long long)temp_storage_bytes < required_temp_bytes ||",
+            "      ((unsigned long long)temp_storage_smem_addr &",
+            "       (required_temp_alignment - 1ull)) != 0ull) {",
+            '    asm volatile("trap;");',
+            "  }",
+            "  void* temp_storage_ptr =",
+            "      cuda_coop_cutlass_shared_ptr(temp_storage_smem_addr);",
+            "  auto* storage_ptr = reinterpret_cast<",
+            "      typename implementation_type::TempStorage*>(temp_storage_ptr);",
+        ]
+        storage = "*storage_ptr"
+    elif request.plan.target is GroupLoweringTarget.CUB_WARP:
+        block_threads = math.prod(request.block_dim)
+        logical_width = implementation.template_arguments.get("LOGICAL_WARP_THREADS")
+        if not isinstance(logical_width, int) or logical_width < 1:
+            raise ValueError(
+                "group WarpLoad/Store requires a static logical warp width"
+            )
+        if block_threads < logical_width or block_threads % logical_width != 0:
+            raise ValueError("group WarpLoad/Store requires complete logical warps")
+        storage_lines = [
+            "  __shared__ typename implementation_type::TempStorage "
+            f"storage[{block_threads // logical_width}];",
+            "  unsigned int storage_instance =",
+            f"      cuda_coop_cutlass_linear_tid() / {logical_width}u;",
+        ]
+        storage = "storage[storage_instance]"
+        tile_pointer_lines = [
+            "  tile_ptr += static_cast<long long>(storage_instance) * "
+            f"{logical_width * operation.items_per_thread}ll;"
+        ]
+
+    offset_expr = _binding_expr(
+        request,
+        operation.offset,
+        runtime_name="offset",
+    )
+    pointer_type = f"{'const ' if is_load else ''}{spec.cpp_type}*"
+    pointer_lines = []
+    if operation.offset.kind is BindingKind.RUNTIME:
+        pointer_lines.extend(
+            (
+                "  if (offset < 0) {",
+                '    asm volatile("trap;");',
+                "  }",
+            )
+        )
+    pointer_lines.append(f"  {pointer_type} tile_ptr = base;")
+    if offset_expr is not None:
+        pointer_lines.append(f"  tile_ptr += {offset_expr};")
+    pointer_lines.extend(tile_pointer_lines)
+
+    if is_load:
+        item_lines = [f"  {spec.cpp_type} items[{operation.items_per_thread}] = {{}};"]
+    else:
+        values = ", ".join(
+            f"item{index}" for index in range(operation.items_per_thread)
+        )
+        item_lines = [
+            f"  {spec.cpp_type} items[{operation.items_per_thread}] = {{{values}}};"
+        ]
+    call_arguments = ["tile_ptr", "items"]
+    valid_items_expr = _binding_expr(
+        request,
+        operation.valid_items,
+        runtime_name="valid_items",
+    )
+    if valid_items_expr is not None:
+        call_arguments.append(valid_items_expr)
+    oob_default_expr = _binding_expr(
+        request,
+        operation.oob_default,
+        runtime_name="oob_default",
+        oob_default=True,
+    )
+    if oob_default_expr is not None:
+        call_arguments.append(oob_default_expr)
+
+    output_lines = []
+    if is_load:
+        output_lines = [
+            f"  result_items[{index}] = items[{index}];"
+            for index in range(operation.items_per_thread)
+        ]
+    barrier = _storage_reuse_barrier_line(request)
+    barrier_lines = [barrier]
+    if request.external_scratch:
+        barrier_lines = [
+            "  if (temp_storage_auto_sync != 0) {",
+            f"  {barrier}",
+            "  }",
+        ]
+    return [
+        f"void {request.symbol_name}({', '.join(params)}) {{",
+        f"  using implementation_type = ::cub::{implementation.struct_name}<"
+        f"{template_arguments}>;",
+        *storage_lines,
+        *pointer_lines,
+        *item_lines,
+        f"  implementation_type({storage}).{implementation.method_name}("
+        f"{', '.join(call_arguments)});",
+        *barrier_lines,
+        *output_lines,
+        "}",
+    ]
+
+
+def _cub_load_store_scratch_layout_probe(
+    request: _CubLoadStoreRequest,
+) -> _provider_types.ScratchLayoutProbe | None:
+    if not request.external_scratch:
+        return None
+    return _provider_rendering.make_scratch_layout_probe(
+        request.scratch_requirement_key,
+        request.scratch_cpp_type,
+    )
+
+
+def _register_renderer() -> None:
+    _provider_rendering.register_bundle_renderer(
+        "cub_group_load_store",
+        render=_render_cub_load_store,
+        include_lines=(
+            "#include <cub/block/block_load.cuh>",
+            "#include <cub/block/block_store.cuh>",
+            "#include <cub/warp/warp_load.cuh>",
+            "#include <cub/warp/warp_store.cuh>",
+        ),
+        cccl_headers=(
+            ("#include <cub/block/block_load.cuh>", "cub/block/block_load.cuh"),
+            ("#include <cub/block/block_store.cuh>", "cub/block/block_store.cuh"),
+            ("#include <cub/warp/warp_load.cuh>", "cub/warp/warp_load.cuh"),
+            ("#include <cub/warp/warp_store.cuh>", "cub/warp/warp_store.cuh"),
+        ),
+        scratch_layout_probe=_cub_load_store_scratch_layout_probe,
+    )
+
+
+_register_renderer()
+
+_resolve_type = _provider_state.make_provider_type_resolver(
+    scope=_ROOT_SCOPE,
+    root_scope=_ROOT_SCOPE,
+    namespace="thread_group",
+)
+
+
+def _memory_dtype(value: Any) -> Any:
+    for name in ("element_type", "dtype", "_dtype"):
+        dtype = getattr(value, name, None)
+        if dtype is not None:
+            return dtype
+    iterator = getattr(value, "iterator", None)
+    return getattr(iterator, "dtype", None)
+
+
+@dataclasses.dataclass(frozen=True)
+class _ContiguousMemoryProof:
+    pointer: Any
+    available_elements: int | None
+
+
+def _is_local_memory_space(value: Any) -> bool:
+    try:
+        if int(value) == _LLVM_LOCAL_ADDRESS_SPACE:
+            return True
+    except Exception:
+        pass
+    try:
+        name = str(getattr(value, "name", value)).strip().lower()
+    except Exception:
+        return False
+    return name in {"local", "local_memory", "rmem"}
+
+
+def _uses_local_memory(value: Any) -> bool:
+    candidates = [value]
+    for name in ("iterator", "pointer", "ptr", "_pointer", "_ptr"):
+        try:
+            candidate = getattr(value, name)
+        except Exception:
+            continue
+        if candidate is not None:
+            candidates.append(candidate)
+    for candidate in candidates:
+        for name in ("memspace", "space", "address_space"):
+            try:
+                memory_space = getattr(candidate, name)
+            except Exception:
+                continue
+            if _is_local_memory_space(memory_space):
+                return True
+    return False
+
+
+def _try_raw_memory_pointer(value: Any) -> Any | None:
+    candidates = [value]
+    data_ptr = getattr(value, "data_ptr", None)
+    if callable(data_ptr):
+        try:
+            candidates.append(data_ptr())
+        except Exception:
+            pass
+    for name in ("iterator", "pointer", "ptr", "_pointer", "_ptr"):
+        try:
+            candidate = getattr(value, name)
+        except (AttributeError, TypeError):
+            continue
+        if candidate is not None:
+            candidates.append(candidate)
+
+    for candidate in candidates:
+        to_llvm_ptr = getattr(candidate, "to_llvm_ptr", None)
+        if callable(to_llvm_ptr):
+            pointer = to_llvm_ptr()
+        else:
+            pointer = getattr(candidate, "llvm_ptr", None)
+        if pointer is None:
+            continue
+        try:
+            pointer_type = llvm.PointerType(pointer.type)
+        except Exception:
+            continue
+        if pointer_type.address_space == _LLVM_LOCAL_ADDRESS_SPACE:
+            return None
+        if pointer_type.address_space != 0:
+            pointer = llvm.addrspacecast(llvm.PointerType.get(0), pointer)
+        return pointer
+
+    return None
+
+
+def _contiguous_memory_proof(
+    value: Any,
+    *,
+    primitive_name: str,
+) -> tuple[_ContiguousMemoryProof | None, str]:
+    """Classify raw-pointer eligibility without registering a provider request."""
+
+    layout_reason = contiguous_layout_reason(value)
+    if layout_reason is not None:
+        return None, layout_reason
+    if _uses_local_memory(value):
+        return None, "uses register/local memory instead of a collective base pointer"
+    pointer = _try_raw_memory_pointer(value)
+    if pointer is None:
+        return None, "does not expose a raw iterator/pointer"
+    return (
+        _ContiguousMemoryProof(pointer, static_layout_elements(value)),
+        "raw pointer and compact layout proven",
+    )
+
+
+def _memory_pointer(
+    value: Any,
+    *,
+    primitive_name: str,
+    required_elements: int | None = None,
+) -> Any:
+    proof, reason = _contiguous_memory_proof(
+        value,
+        primitive_name=primitive_name,
+    )
+    if proof is not None:
+        if (
+            required_elements is not None
+            and proof.available_elements is not None
+            and required_elements > proof.available_elements
+        ):
+            raise ValueError(
+                f"{_ROOT_SCOPE}.{primitive_name} requires {required_elements} "
+                "elements after applying its static offset, group instances, "
+                f"and valid_items, but the operand provides "
+                f"{proof.available_elements}"
+            )
+        return proof.pointer
+
+    operand = "cutlass.Array" if is_cutlass_array_operand(value) else "tensor"
+    raise NotImplementedError(
+        f"{_ROOT_SCOPE}.{primitive_name} {operand} must prove a raw contiguous "
+        f"iterator/pointer for CUB collective lowering; {reason}"
+    )
+
+
+def _resolve_memory_type(value: Any, *, primitive_name: str) -> type:
+    dtype = _memory_dtype(value)
+    if dtype is None:
+        raise TypeError(
+            f"{_ROOT_SCOPE}.{primitive_name} memory operand must expose element_type "
+            "or dtype"
+        )
+    return _resolve_type(
+        dtype,
+        allowed=ALL_PROVIDER_TYPES,
+        feature=primitive_name,
+    )
+
+
+def _validate_static_oob_default(value: Any, value_type: type) -> None:
+    plain_value = _provider_types.coerce_plain_scalar(
+        value,
+        value_type,
+        name="load oob_default",
+        scope=_ROOT_SCOPE,
+        allow_nonfinite=False,
+        convert=False,
+    )
+    if plain_value is not _provider_types._NOT_PLAIN_SCALAR:
+        return
+    try:
+        actual_type = _resolve_type(
+            value,
+            allowed=ALL_PROVIDER_TYPES,
+            feature="load",
+        )
+    except (TypeError, NotImplementedError) as exc:
+        raise TypeError(
+            f"{_ROOT_SCOPE}.load oob_default must match the memory dtype"
+        ) from exc
+    if actual_type is not value_type:
+        raise TypeError(f"{_ROOT_SCOPE}.load oob_default must match the memory dtype")
+    scalar_value = getattr(value, "value", value)
+    if isinstance(scalar_value, bool) or not isinstance(
+        scalar_value,
+        (Integral, Real),
+    ):
+        raise TypeError(
+            f"{_ROOT_SCOPE}.load oob_default must be a finite scalar literal"
+        )
+    if isinstance(scalar_value, Real) and not math.isfinite(float(scalar_value)):
+        raise ValueError(f"{_ROOT_SCOPE}.load oob_default must be finite")
+
+
+def _coerce_runtime_oob_default(value: Any, value_type: type) -> Any:
+    if isinstance(value, value_type):
+        return value
+    raise TypeError(
+        f"{_ROOT_SCOPE}.load runtime oob_default must match the memory dtype "
+        f"{value_type.__name__}"
+    )
+
+
+def _runtime_binding_args(
+    operation: GroupLoadStoreSemantics,
+    *,
+    value_type: type,
+    valid_items: Any,
+    oob_default: Any,
+    offset: Any,
+) -> tuple[list[type], list[Any]]:
+    param_types: list[type] = []
+    args: list[Any] = []
+    if operation.valid_items.kind is BindingKind.RUNTIME:
+        param_types.append(Int32)
+        args.append(_provider_types.as_valid_items_arg(valid_items, scope=_ROOT_SCOPE))
+    if operation.oob_default.kind is BindingKind.RUNTIME:
+        param_types.append(value_type)
+        args.append(_coerce_runtime_oob_default(oob_default, value_type))
+    if operation.offset.kind is BindingKind.RUNTIME:
+        param_types.append(Int64)
+        try:
+            args.append(offset if isinstance(offset, Int64) else Int64(offset))
+        except Exception as exc:
+            raise TypeError(
+                f"{_ROOT_SCOPE}.load/store offset must be convertible to Int64"
+            ) from exc
+    return param_types, args
+
+
+def _temp_storage_for_load_store(
+    *,
+    group: ThreadGroup,
+    explicit_temp_storage: Any,
+    primitive_name: str,
+) -> Any | None:
+    context = get_active_single_phase_context()
+    context_storage = context.temp_storage if context is not None else None
+    if (
+        explicit_temp_storage is not None
+        and context_storage is not None
+        and explicit_temp_storage is not context_storage
+    ):
+        raise ValueError(
+            f"{_ROOT_SCOPE}.{primitive_name} received two TempStorage objects"
+        )
+    temp_storage = (
+        explicit_temp_storage if explicit_temp_storage is not None else context_storage
+    )
+    if temp_storage is None:
+        return None
+
+    from .._temp_storage import TempStorage
+
+    if not isinstance(temp_storage, TempStorage):
+        raise TypeError(
+            f"{_ROOT_SCOPE}.{primitive_name} temp_storage must be "
+            f"{_ROOT_SCOPE}.TempStorage"
+        )
+    if group.kind != "block":
+        raise ValueError(
+            f"{_ROOT_SCOPE}.{primitive_name} TempStorage is supported only for "
+            "block groups"
+        )
+    if not temp_storage.is_deferred and temp_storage.sharing == "exclusive":
+        raise ValueError(
+            f"{_ROOT_SCOPE}.{primitive_name} fixed-capacity TempStorage does not "
+            "support sharing='exclusive'; use sharing='shared' or deferred "
+            "storage"
+        )
+    return temp_storage
+
+
+def _external_scratch_args(
+    temp_storage: Any,
+    *,
+    primitive_name: str,
+    requirement_key: Any,
+) -> tuple[Any, Any, Any]:
+    if temp_storage.is_deferred:
+        return _provider_storage.register_deferred_temp_storage_event(
+            temp_storage,
+            primitive_name=primitive_name,
+            requirement_key=requirement_key,
+        )
+
+    # The generated CUB shim checks this capacity and address against its exact
+    # TempStorage size and alignment before using the caller-owned allocation.
+    binding = _provider_storage.materialize_temp_storage_binding(
+        temp_storage,
+        scope=_ROOT_SCOPE,
+        implicit_alignment=16,
+    )
+    return (
+        binding.smem_addr_u32,
+        Int32(binding.size_in_bytes),
+        Int32(1 if binding.auto_sync else 0),
+    )
+
+
+def _with_caller_owned_load_store_storage(
+    plan: GroupLoweringPlan,
+) -> GroupLoweringPlan:
+    temp_storage = plan.temp_storage
+    if temp_storage is None:
+        raise ValueError("group load/store requires a temporary-storage contract")
+    return dataclasses.replace(
+        plan,
+        temp_storage=dataclasses.replace(
+            temp_storage,
+            ownership=StorageOwnership.CALLER,
+            address_space="shared",
+            cpp_type="typename implementation_type::TempStorage",
+            instances=1,
+            instance_index="cta",
+            exact_layout_required=True,
+        ),
+    )
+
+
+def _make_request(
+    *,
+    group: ThreadGroup,
+    launch: LaunchFacts,
+    kind: GroupLoadStoreKind,
+    value_type: type,
+    items_per_thread: int,
+    algorithm: Any,
+    valid_items_binding: ArgumentBinding,
+    oob_default_binding: ArgumentBinding,
+    offset_binding: ArgumentBinding,
+    external_scratch: bool,
+) -> _CubLoadStoreRequest:
+    plan = _make_group_load_store_plan(
+        group=group,
+        launch=launch,
+        kind=kind,
+        dtype=value_type,
+        items_per_thread=items_per_thread,
+        algorithm=algorithm,
+        valid_items=valid_items_binding,
+        oob_default=oob_default_binding,
+        offset=offset_binding,
+        source="cutlass_group_load_store_provider",
+    ).require_supported()
+    if external_scratch:
+        plan = _with_caller_owned_load_store_storage(plan)
+    return _CubLoadStoreRequest(
+        plan=plan,
+        value_type=value_type,
+        external_scratch=external_scratch,
+    )
+
+
+def _required_static_elements(request: _CubLoadStoreRequest) -> int | None:
+    """Return the largest statically reachable operand prefix."""
+
+    operation = request.operation
+    if (
+        operation.valid_items.kind is BindingKind.RUNTIME
+        or operation.offset.kind is BindingKind.RUNTIME
+    ):
+        return None
+
+    group_size = request.plan.resolved_group.static_size
+    if group_size is None:
+        raise ValueError("group load/store request requires a static group size")
+    tile_items = group_size * operation.items_per_thread
+    valid_items = (
+        tile_items
+        if operation.valid_items.kind is BindingKind.OMITTED
+        else int(operation.valid_items.value)
+    )
+    offset = (
+        0
+        if operation.offset.kind is BindingKind.OMITTED
+        else int(operation.offset.value)
+    )
+
+    group_instances = 1
+    if request.plan.target is GroupLoweringTarget.CUB_WARP:
+        block_threads = math.prod(request.block_dim)
+        group_instances, remainder = divmod(block_threads, group_size)
+        if remainder or group_instances < 1:
+            raise ValueError("group WarpLoad/Store requires complete group instances")
+    return offset + (group_instances - 1) * tile_items + valid_items
+
+
+def provider_load(
+    *,
+    group: ThreadGroup,
+    launch: LaunchFacts,
+    source: Any,
+    output: ThreadData,
+    algorithm: GroupLoadStoreAlgorithm,
+    valid_items: Any,
+    valid_items_binding: ArgumentBinding,
+    oob_default: Any,
+    oob_default_binding: ArgumentBinding,
+    offset: Any,
+    offset_binding: ArgumentBinding,
+    temp_storage: Any = None,
+) -> ThreadData:
+    """Materialize one CUB BlockLoad or physical WarpLoad call."""
+
+    if not isinstance(output, ThreadData):
+        raise TypeError(f"{_ROOT_SCOPE}.load output must be ThreadData")
+    _validate_binding_payload(
+        valid_items_binding,
+        valid_items,
+        name="valid_items",
+    )
+    _validate_binding_payload(
+        oob_default_binding,
+        oob_default,
+        name="oob_default",
+    )
+    _validate_binding_payload(offset_binding, offset, name="offset")
+    value_type = _resolve_memory_type(source, primitive_name="load")
+    if output.dtype is not None:
+        output_type = _resolve_type(
+            output.dtype,
+            allowed=ALL_PROVIDER_TYPES,
+            feature="load",
+        )
+        if output_type is not value_type:
+            raise TypeError(f"{_ROOT_SCOPE}.load source dtype does not match output")
+    external_temp_storage = _temp_storage_for_load_store(
+        group=group,
+        explicit_temp_storage=temp_storage,
+        primitive_name="load",
+    )
+    request = _make_request(
+        group=group,
+        launch=launch,
+        kind=GroupLoadStoreKind.LOAD,
+        value_type=value_type,
+        items_per_thread=output.items_per_thread,
+        algorithm=algorithm,
+        valid_items_binding=valid_items_binding,
+        oob_default_binding=oob_default_binding,
+        offset_binding=offset_binding,
+        external_scratch=external_temp_storage is not None,
+    )
+    source_pointer = _memory_pointer(
+        source,
+        primitive_name="load",
+        required_elements=_required_static_elements(request),
+    )
+    runtime_types, runtime_args = _runtime_binding_args(
+        request.operation,
+        value_type=value_type,
+        valid_items=valid_items,
+        oob_default=oob_default,
+        offset=offset,
+    )
+    result_tensor = _cute.make_rmem_tensor(output.items_per_thread, value_type)
+    session_snapshot = (
+        _provider_state.snapshot_active_session_state()
+        if external_temp_storage is not None
+        else None
+    )
+    try:
+        _provider_state.register_request(request)
+        scratch_args: tuple[Any, ...] = ()
+        scratch_param_types: list[type] = []
+        if external_temp_storage is not None:
+            scratch_args = _external_scratch_args(
+                external_temp_storage,
+                primitive_name="load",
+                requirement_key=request.scratch_requirement_key,
+            )
+            scratch_param_types = [Uint32, Int32, Int32]
+        ffi(
+            name=request.symbol_name,
+            params_types=[
+                llvm.PointerType.get(0),
+                *runtime_types,
+                *scratch_param_types,
+                llvm.PointerType.get(0),
+            ],
+            return_type=None,
+        )(
+            source_pointer,
+            *runtime_args,
+            *scratch_args,
+            result_tensor.iterator.llvm_ptr,
+        )
+        if output.dtype is None:
+            output.dtype = value_type
+        for index in range(output.items_per_thread):
+            output[index] = result_tensor[index]
+        return output
+    except Exception:
+        if session_snapshot is not None:
+            _provider_state.restore_active_session_state(session_snapshot)
+        raise
+
+
+def provider_store(
+    *,
+    group: ThreadGroup,
+    launch: LaunchFacts,
+    destination: Any,
+    value: Any,
+    algorithm: GroupLoadStoreAlgorithm,
+    valid_items: Any,
+    valid_items_binding: ArgumentBinding,
+    offset: Any,
+    offset_binding: ArgumentBinding,
+    temp_storage: Any = None,
+) -> None:
+    """Materialize one CUB BlockStore or physical WarpStore call."""
+
+    _validate_binding_payload(
+        valid_items_binding,
+        valid_items,
+        name="valid_items",
+    )
+    _validate_binding_payload(offset_binding, offset, name="offset")
+    if isinstance(value, ThreadData):
+        value_type, values = _provider_types.resolve_thread_data_value_type(
+            value,
+            allowed=ALL_PROVIDER_TYPES,
+            feature="store",
+            scope=_ROOT_SCOPE,
+            resolve_type=_resolve_type,
+        )
+        values = tuple(values)
+    else:
+        value_type = _resolve_type(
+            value,
+            allowed=ALL_PROVIDER_TYPES,
+            feature="store",
+        )
+        values = (value,)
+    destination_type = _resolve_memory_type(destination, primitive_name="store")
+    if destination_type is not value_type:
+        raise TypeError(
+            f"{_ROOT_SCOPE}.store destination dtype does not match value dtype"
+        )
+    external_temp_storage = _temp_storage_for_load_store(
+        group=group,
+        explicit_temp_storage=temp_storage,
+        primitive_name="store",
+    )
+    request = _make_request(
+        group=group,
+        launch=launch,
+        kind=GroupLoadStoreKind.STORE,
+        value_type=value_type,
+        items_per_thread=len(values),
+        algorithm=algorithm,
+        valid_items_binding=valid_items_binding,
+        oob_default_binding=ArgumentBinding.omitted(),
+        offset_binding=offset_binding,
+        external_scratch=external_temp_storage is not None,
+    )
+    destination_pointer = _memory_pointer(
+        destination,
+        primitive_name="store",
+        required_elements=_required_static_elements(request),
+    )
+    runtime_types, runtime_args = _runtime_binding_args(
+        request.operation,
+        value_type=value_type,
+        valid_items=valid_items,
+        oob_default=None,
+        offset=offset,
+    )
+    session_snapshot = (
+        _provider_state.snapshot_active_session_state()
+        if external_temp_storage is not None
+        else None
+    )
+    try:
+        _provider_state.register_request(request)
+        scratch_args: tuple[Any, ...] = ()
+        scratch_param_types: list[type] = []
+        if external_temp_storage is not None:
+            scratch_args = _external_scratch_args(
+                external_temp_storage,
+                primitive_name="store",
+                requirement_key=request.scratch_requirement_key,
+            )
+            scratch_param_types = [Uint32, Int32, Int32]
+        ffi(
+            name=request.symbol_name,
+            params_types=[
+                llvm.PointerType.get(0),
+                *([value_type] * len(values)),
+                *runtime_types,
+                *scratch_param_types,
+            ],
+            return_type=None,
+        )(
+            destination_pointer,
+            *values,
+            *runtime_args,
+            *scratch_args,
+        )
+    except Exception:
+        if session_snapshot is not None:
+            _provider_state.restore_active_session_state(session_snapshot)
+        raise
+
+
+__all__ = [
+    "_CubLoadStoreRequest",
+    "provider_load",
+    "provider_store",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_lowering/_load_store_layout.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_lowering/_load_store_layout.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Static layout proofs shared by CUTLASS load and store providers."""
+
+from __future__ import annotations
+
+from math import prod
+from typing import Any
+
+
+def _optional_attr(value: Any, name: str) -> Any:
+    try:
+        return getattr(value, name, None)
+    except Exception:
+        return None
+
+
+def _static_layout_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        normalized = value.__index__()
+    except Exception:
+        return None
+    if isinstance(normalized, bool):
+        return None
+    return int(normalized)
+
+
+def _layout_leaf_pairs(
+    shape: Any,
+    strides: Any,
+) -> tuple[tuple[Any, Any], ...] | None:
+    """Flatten congruent shape/stride trees into scalar leaf pairs."""
+
+    shape_is_tree = isinstance(shape, (tuple, list))
+    strides_is_tree = isinstance(strides, (tuple, list))
+    if shape_is_tree != strides_is_tree:
+        return None
+    if not shape_is_tree:
+        return ((shape, strides),)
+    if len(shape) != len(strides):
+        return None
+
+    leaves: list[tuple[Any, Any]] = []
+    for shape_child, strides_child in zip(shape, strides):
+        child_leaves = _layout_leaf_pairs(shape_child, strides_child)
+        if child_leaves is None:
+            return None
+        leaves.extend(child_leaves)
+    return tuple(leaves)
+
+
+def _layout_leaves(value: Any) -> tuple[tuple[Any, Any], ...] | None:
+    shape = _optional_attr(value, "shape")
+    strides = _optional_attr(value, "strides")
+    if strides is None:
+        strides = _optional_attr(value, "stride")
+    if shape is None or strides is None:
+        return None
+    return _layout_leaf_pairs(shape, strides)
+
+
+def static_layout_elements(value: Any) -> int | None:
+    """Return a statically known layout capacity, when metadata proves one."""
+
+    leaves = _layout_leaves(value)
+    if leaves is None:
+        return None
+    extents = tuple(_static_layout_int(extent) for extent, _ in leaves)
+    if any(extent is None or extent <= 0 for extent in extents):
+        return None
+    return prod(int(extent) for extent in extents)
+
+
+def contiguous_layout_reason(value: Any) -> str | None:
+    """Return why an operand is not statically compact, or ``None``."""
+
+    shape = _optional_attr(value, "shape")
+    strides_value = _optional_attr(value, "strides")
+    if strides_value is None:
+        strides_value = _optional_attr(value, "stride")
+    if shape is None and strides_value is None:
+        if callable(_optional_attr(value, "to_llvm_ptr")):
+            return None
+        return "has no inspectable shape/stride contract"
+    if shape is None or strides_value is None:
+        return "does not expose both shape and stride metadata"
+    leaves = _layout_leaf_pairs(shape, strides_value)
+    if leaves is None:
+        return "has incongruent shape and stride layouts"
+
+    static_shape = tuple(_static_layout_int(extent) for extent, _ in leaves)
+    static_strides = tuple(_static_layout_int(stride) for _, stride in leaves)
+    if any(value is None for value in (*static_shape, *static_strides)):
+        return "is not statically provable as compact"
+    normalized_shape = tuple(int(extent) for extent in static_shape)
+    normalized_strides = tuple(int(stride) for stride in static_strides)
+    if any(extent <= 0 for extent in normalized_shape):
+        return "has a non-positive static extent"
+    if any(
+        stride <= 0
+        for stride, extent in zip(normalized_strides, normalized_shape)
+        if extent != 1
+    ):
+        return "has a non-positive static stride"
+
+    expected_stride = 1
+    for stride, extent in sorted(
+        zip(normalized_strides, normalized_shape),
+        key=lambda entry: entry[0],
+    ):
+        if extent == 1:
+            continue
+        if stride != expected_stride:
+            return "is not a compact contiguous layout"
+        expected_stride *= extent
+    return None

--- a/python/cuda_coop/cuda/coop/cutlass/_lowering/_reduce.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_lowering/_reduce.py
@@ -1,0 +1,744 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Plan-driven CUDAX/CUB provider renderer for CUTLASS group reductions."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+from numbers import Integral
+from typing import Any
+
+from cutlass.base_dsl.typing import Int32
+from cutlass.cute.ffi import ffi
+
+from cuda.coop._core import (
+    AlgorithmSpec,
+    ArgumentBinding,
+    BindingKind,
+    CudaxCallDescription,
+    CudaxReturnKind,
+    CxxOperator,
+    Dependency,
+    GroupLoweringPlan,
+    GroupLoweringTarget,
+    GroupReduceSemantics,
+    LaunchFacts,
+    ReduceOperation,
+    ReduceValueKind,
+    SynchronizationScope,
+    make_group_primitive_call,
+    make_reduce_semantics,
+    plan_group_primitive,
+)
+from cuda.coop._core.block import BlockReduceAlgorithm
+
+from .._compiler import _rendering, _state, _types
+from .._compiler._types import SCAN_REDUCE_TYPES, TYPE_SPECS
+from .._thread_data import ThreadData
+from .._thread_group import (
+    ThreadGroup,
+    render_group_decl_lines,
+    render_hierarchy_decl,
+)
+from .._value_metadata import metadata_for_group, validate_operand_domains
+
+_provider_rendering = _rendering
+_provider_state = _state
+_provider_types = _types
+
+_ROOT_SCOPE = "cuda.coop.cutlass"
+_GRID_REDUCE_UNAVAILABLE = f"{_ROOT_SCOPE}.reduce does not support grid groups"
+_REDUCE_OPERATOR_CPP = {
+    "multiplies": "::cuda::std::multiplies<T>",
+    "min": "::cuda::minimum<T>",
+    "max": "::cuda::maximum<T>",
+    "bit_and": "::cuda::std::bit_and<T>",
+    "bit_or": "::cuda::std::bit_or<T>",
+    "bit_xor": "::cuda::std::bit_xor<T>",
+}
+
+
+def _is_boolean_control(value: Any) -> bool:
+    if isinstance(value, bool):
+        return True
+    try:
+        import numpy as np
+    except ImportError:
+        pass
+    else:
+        if isinstance(value, np.bool_):
+            return True
+    try:
+        from cutlass.base_dsl.typing import Boolean
+    except ImportError:
+        return False
+    return isinstance(value, Boolean)
+
+
+def _classify_valid_items(valid_items: Any) -> ArgumentBinding:
+    if valid_items is None:
+        return ArgumentBinding.omitted()
+    if _is_boolean_control(valid_items):
+        raise TypeError(f"{_ROOT_SCOPE}.reduce valid_items must be an integer")
+    if isinstance(valid_items, Integral):
+        return ArgumentBinding.static(int(valid_items))
+    from cutlass.base_dsl.typing import Integer
+
+    if isinstance(valid_items, Integer):
+        return ArgumentBinding.runtime()
+    raise TypeError(f"{_ROOT_SCOPE}.reduce valid_items must be an integer")
+
+
+def _make_group_reduce_plan(
+    *,
+    group: ThreadGroup,
+    launch: LaunchFacts,
+    dtype: Any,
+    value_kind: ReduceValueKind,
+    items_per_thread: int,
+    op: str,
+    broadcast: bool,
+    valid_items: ArgumentBinding | None = None,
+    algorithm: Any = None,
+    source: str = "cutlass_root",
+) -> GroupLoweringPlan:
+    """Build the canonical shared-core plan for one CUTLASS reduction."""
+
+    reduce_operator = None
+    operation = ReduceOperation.SUM
+    if op != "sum":
+        try:
+            cpp = _REDUCE_OPERATOR_CPP[op]
+        except KeyError as exc:
+            raise NotImplementedError(
+                f"unsupported group reduce operator {op!r}"
+            ) from exc
+        operation = ReduceOperation.REDUCE
+        reduce_operator = CxxOperator(
+            cpp=cpp,
+            dtype=Dependency("T"),
+            name="binary_op",
+        )
+    if valid_items is None:
+        valid_items = ArgumentBinding.omitted()
+    primitive = make_reduce_semantics(
+        dtype=dtype,
+        operation=operation,
+        value_kind=value_kind,
+        items_per_thread=items_per_thread,
+        reduce_operator=reduce_operator,
+        valid_items=valid_items,
+    )
+    call = make_group_primitive_call(
+        group,
+        GroupReduceSemantics(
+            primitive=primitive,
+            broadcast=broadcast,
+            cub_algorithm=algorithm,
+        ),
+        source=source,
+    )
+    return plan_group_primitive(call, launch)
+
+
+def _validate_valid_items_payload(
+    binding: ArgumentBinding,
+    value: Any,
+) -> None:
+    if binding.kind is BindingKind.OMITTED:
+        if value is not None:
+            raise ValueError("omitted valid_items binding cannot carry a value")
+        return
+    if binding.kind is BindingKind.RUNTIME:
+        if value is None:
+            raise ValueError("runtime valid_items binding requires a value")
+        return
+    if value != binding.value:
+        raise ValueError("static valid_items value does not match its binding")
+
+
+def _validate_reduce_request_plan(
+    plan: GroupLoweringPlan,
+    *,
+    op: str,
+    value_type: type,
+) -> GroupReduceSemantics:
+    operation = plan.call.operation
+    if not isinstance(operation, GroupReduceSemantics):
+        raise TypeError("group reduce request requires reduce semantics")
+    if operation.dtype is not value_type:
+        raise ValueError("group reduce request dtype does not match its plan")
+    expected_operation = ReduceOperation.SUM if op == "sum" else ReduceOperation.REDUCE
+    if operation.operation is not expected_operation:
+        raise ValueError("group reduce request operator does not match its plan")
+    if expected_operation is ReduceOperation.REDUCE:
+        expected_cpp = _REDUCE_OPERATOR_CPP.get(op)
+        if expected_cpp is None or operation.reduce_operator is None:
+            raise ValueError("group reduce request operator does not match its plan")
+        if operation.reduce_operator.cpp != expected_cpp:
+            raise ValueError("group reduce request operator does not match its plan")
+    return operation
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class _CudaxReduceRequest:
+    plan: GroupLoweringPlan
+    op: str
+    value_type: type
+    kind: str = "cudax_reduce"
+
+    def __post_init__(self) -> None:
+        self.plan.require_supported()
+        if self.plan.target is not GroupLoweringTarget.CUDAX_GROUP:
+            raise ValueError("cudax reduce request requires a CUDAX_GROUP plan")
+        if self.plan.resolved_group.kind == "grid":
+            raise NotImplementedError(_GRID_REDUCE_UNAVAILABLE)
+        if not isinstance(self.plan.implementation, CudaxCallDescription):
+            raise TypeError("cudax reduce request requires a CUDAX call description")
+        operation = _validate_reduce_request_plan(
+            self.plan,
+            op=self.op,
+            value_type=self.value_type,
+        )
+        expected_overload = "broadcasted" if operation.broadcast else "root_only"
+        expected_return = (
+            CudaxReturnKind.VALUE
+            if operation.broadcast
+            else CudaxReturnKind.OPTIONAL_VALUE
+        )
+        if (
+            self.plan.implementation.overload != expected_overload
+            or self.plan.implementation.return_kind is not expected_return
+        ):
+            raise ValueError("cudax reduce request result mode does not match its plan")
+
+    @property
+    def semantic_key(self) -> tuple[Any, ...]:
+        assert self.plan.artifact_key is not None
+        return self.plan.artifact_key
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _CudaxReduceRequest):
+            return NotImplemented
+        return self.semantic_key == other.semantic_key
+
+    def __hash__(self) -> int:
+        return hash(self.semantic_key)
+
+    @property
+    def group(self) -> ThreadGroup:
+        return self.plan.resolved_group
+
+    @property
+    def items_per_thread(self) -> int:
+        return self.plan.call.operation.items_per_thread
+
+    @property
+    def broadcast(self) -> bool:
+        return self.plan.call.operation.broadcast
+
+    @property
+    def _arity_suffix(self) -> str:
+        if self.plan.call.operation.primitive.value_kind is ReduceValueKind.ARRAY:
+            return f"_x{self.items_per_thread}"
+        return ""
+
+    @property
+    def _block_suffix(self) -> str:
+        return self.group.symbol_suffix
+
+    @property
+    def _result_mode_suffix(self) -> str:
+        return "" if self.broadcast else "_root"
+
+    @property
+    def symbol_name(self) -> str:
+        signature = hashlib.sha256(
+            repr(self.semantic_key).encode("utf-8", errors="backslashreplace")
+        ).hexdigest()[:12]
+        return (
+            "cuda_coop_cutlass_cudax_reduce_"
+            f"{self._block_suffix}_{self.op}_"
+            f"{TYPE_SPECS[self.value_type].token}{self._arity_suffix}"
+            f"{self._result_mode_suffix}_{signature}"
+        )
+
+
+def _storage_reuse_barrier_line(plan: GroupLoweringPlan) -> str:
+    synchronization = plan.synchronization
+    if synchronization is None:
+        raise ValueError("Reduce plan requires a synchronization contract")
+    if synchronization.storage_reuse_barrier is SynchronizationScope.BLOCK:
+        return "  cuda_coop_cutlass_block_sync();"
+    if synchronization.storage_reuse_barrier is SynchronizationScope.WARP:
+        if plan.target is GroupLoweringTarget.CUB_WARP:
+            _, logical_width = _warp_instances(plan)
+        else:
+            group = plan.resolved_group
+            logical_width = 32 if group.kind == "warp" else group.static_size
+            if group.kind not in {"warp", "threads_within_warp"} or not isinstance(
+                logical_width,
+                int,
+            ):
+                raise ValueError("Reduce plan requires a static warp group")
+        return f"  cuda_coop_cutlass_warp_sync({logical_width}u);"
+    if synchronization.storage_reuse_barrier is SynchronizationScope.GROUP:
+        return "  group.sync_aligned();"
+    if synchronization.storage_reuse_barrier is SynchronizationScope.NONE:
+        return ""
+    raise ValueError("Reduce plan requires a storage reuse barrier")
+
+
+def _render_group_prelude(group: ThreadGroup) -> list[str]:
+    if group.hierarchy.implicit:
+        assert group.mapping is None
+        hierarchy = "::cuda::experimental::implicit_hierarchy()"
+        return [f"  ::cuda::experimental::this_{group.kind} group{{{hierarchy}}};"]
+    return [
+        *render_hierarchy_decl(group.hierarchy),
+        *render_group_decl_lines(group),
+    ]
+
+
+def _render_cudax_reduce(request: _CudaxReduceRequest) -> list[str]:
+    if request.items_per_thread <= 0:
+        raise ValueError("cudax reduce items_per_thread must be positive")
+    implementation = request.plan.implementation
+    assert isinstance(implementation, CudaxCallDescription)
+    runtime_parameters = tuple(
+        parameter.name
+        for parameter in implementation.parameters
+        if parameter.kind.value == "runtime"
+    )
+    expected_parameters = tuple(
+        f"item{index}" for index in range(request.items_per_thread)
+    )
+    if runtime_parameters != expected_parameters:
+        raise ValueError(
+            "cudax reduce runtime ABI does not match the shared lowering plan"
+        )
+
+    spec = TYPE_SPECS[request.value_type]
+    params = [f"{spec.cpp_type} item{idx}" for idx in range(request.items_per_thread)]
+    values = ", ".join(f"item{idx}" for idx in range(request.items_per_thread))
+    lines = [
+        f"{spec.cpp_type} {request.symbol_name}({', '.join(params)}) {{",
+        *_render_group_prelude(request.group),
+        *(
+            [
+                "  if (!::cuda::gpu_thread.is_part_of(group)) {",
+                f"    return {spec.cpp_type}{{}};",
+                "  }",
+            ]
+            if request.group.mapping is not None
+            and request.group.complete_membership is False
+            else []
+        ),
+        f"  {spec.cpp_type} thread_data[{request.items_per_thread}] = {{{values}}};",
+    ]
+    barrier_line = _storage_reuse_barrier_line(request.plan)
+    if request.broadcast:
+        lines.extend(
+            [
+                "  auto reduced = ::cuda::experimental::coop::reduce(",
+                "      ::cuda::experimental::broadcasted, group, thread_data,",
+                f"      {_provider_types.cub_op_expr(request.op)});",
+                f"  {spec.cpp_type} result = reduced;",
+                *([barrier_line] if barrier_line else []),
+                "  return result;",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "  auto reduced = ::cuda::experimental::coop::reduce(",
+                "      group, thread_data, "
+                f"{_provider_types.cub_op_expr(request.op)});",
+                f"  {spec.cpp_type} result = reduced.value_or({spec.cpp_type}{{}});",
+                *([barrier_line] if barrier_line else []),
+                "  return result;",
+            ]
+        )
+    lines.append("}")
+    return lines
+
+
+_BLOCK_ALGORITHM_TOKENS = {
+    BlockReduceAlgorithm.RAKING_COMMUTATIVE_ONLY: "raking_commutative",
+    BlockReduceAlgorithm.RAKING: "raking",
+    BlockReduceAlgorithm.WARP_REDUCTIONS: "warp_reductions",
+    BlockReduceAlgorithm.WARP_REDUCTIONS_NONDETERMINISTIC: "nondeterministic",
+}
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class _CubReduceRequest:
+    plan: GroupLoweringPlan
+    op: str
+    value_type: type
+    kind: str = "cub_group_reduce"
+
+    def __post_init__(self) -> None:
+        self.plan.require_supported()
+        if self.plan.target not in {
+            GroupLoweringTarget.CUB_BLOCK,
+            GroupLoweringTarget.CUB_WARP,
+        }:
+            raise ValueError("CUB reduce request requires a CUB lowering plan")
+        if not isinstance(self.plan.implementation, AlgorithmSpec):
+            raise TypeError("CUB reduce request requires an AlgorithmSpec")
+        _validate_reduce_request_plan(
+            self.plan,
+            op=self.op,
+            value_type=self.value_type,
+        )
+
+    @property
+    def semantic_key(self) -> tuple[Any, ...]:
+        assert self.plan.artifact_key is not None
+        return self.plan.artifact_key
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _CubReduceRequest):
+            return NotImplemented
+        return self.semantic_key == other.semantic_key
+
+    def __hash__(self) -> int:
+        return hash(self.semantic_key)
+
+    @property
+    def group(self) -> ThreadGroup:
+        return self.plan.resolved_group
+
+    @property
+    def operation(self) -> GroupReduceSemantics:
+        operation = self.plan.call.operation
+        assert isinstance(operation, GroupReduceSemantics)
+        return operation
+
+    @property
+    def items_per_thread(self) -> int:
+        return self.operation.items_per_thread
+
+    @property
+    def valid_items_suffix(self) -> str:
+        binding = self.operation.valid_items
+        if binding.kind is BindingKind.OMITTED:
+            return "full"
+        if binding.kind is BindingKind.RUNTIME:
+            return "valid_r"
+        return f"valid_s{binding.value}"
+
+    @property
+    def algorithm_suffix(self) -> str:
+        if self.plan.target is GroupLoweringTarget.CUB_WARP:
+            return "warp"
+        algorithm = self.operation.cub_algorithm or BlockReduceAlgorithm.WARP_REDUCTIONS
+        return _BLOCK_ALGORITHM_TOKENS[algorithm]
+
+    @property
+    def symbol_name(self) -> str:
+        arity = (
+            f"_x{self.items_per_thread}"
+            if self.operation.primitive.value_kind is ReduceValueKind.ARRAY
+            else ""
+        )
+        signature = hashlib.sha256(repr(self.semantic_key).encode()).hexdigest()[:12]
+        return (
+            "cuda_coop_cutlass_cub_reduce_"
+            f"{self.group.symbol_suffix}_{self.op}_"
+            f"{TYPE_SPECS[self.value_type].token}{arity}_"
+            f"{self.algorithm_suffix}_{self.valid_items_suffix}_{signature}"
+        )
+
+
+def _render_cub_template_argument(
+    request: _CubReduceRequest,
+    name: str,
+    value: Any,
+) -> str:
+    if name == "T":
+        if value is not request.value_type:
+            raise ValueError("CUB reduce template dtype does not match its request")
+        return TYPE_SPECS[request.value_type].cpp_type
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, str):
+        return value
+    raise TypeError(f"cannot render CUB reduce template argument {name}={value!r}")
+
+
+def _warp_instances(plan: GroupLoweringPlan) -> tuple[int, int]:
+    participation = plan.participation
+    if participation is None:
+        raise ValueError("WarpReduce plan requires a participation contract")
+    block_dim = participation.exact_block_dim
+    block_threads = block_dim[0] * block_dim[1] * block_dim[2]
+    implementation = plan.implementation
+    assert isinstance(implementation, AlgorithmSpec)
+    logical_width = implementation.template_arguments.get("VIRTUAL_WARP_THREADS")
+    if not isinstance(logical_width, int) or logical_width < 1:
+        raise ValueError("WarpReduce plan requires a static logical warp width")
+    if block_threads < logical_width or block_threads % logical_width != 0:
+        raise ValueError("WarpReduce plan requires complete logical warps")
+    return block_threads // logical_width, logical_width
+
+
+def _render_cub_reduce(request: _CubReduceRequest) -> list[str]:
+    implementation = request.plan.implementation
+    assert isinstance(implementation, AlgorithmSpec)
+    spec = TYPE_SPECS[request.value_type]
+    template_arguments = ", ".join(
+        _render_cub_template_argument(request, name, value)
+        for name, value in implementation.ordered_template_arguments
+    )
+    runtime_valid_items = request.operation.valid_items.kind is BindingKind.RUNTIME
+    params = [
+        *(f"{spec.cpp_type} item{index}" for index in range(request.items_per_thread)),
+        *(["int valid_items"] if runtime_valid_items else []),
+    ]
+    input_name = "item0"
+    input_lines: list[str] = []
+    if request.operation.primitive.value_kind is ReduceValueKind.ARRAY:
+        values = ", ".join(f"item{index}" for index in range(request.items_per_thread))
+        input_name = "thread_data"
+        input_lines.append(
+            f"  {spec.cpp_type} thread_data[{request.items_per_thread}] = {{{values}}};"
+        )
+
+    call_arguments = [input_name]
+    if request.operation.operation is ReduceOperation.REDUCE:
+        call_arguments.append(_provider_types.cub_op_expr(request.op))
+    if runtime_valid_items:
+        call_arguments.append("valid_items")
+    elif request.operation.valid_items.kind is BindingKind.STATIC:
+        call_arguments.append(str(request.operation.valid_items.value))
+
+    storage = "storage"
+    storage_lines = ["  __shared__ typename implementation_type::TempStorage storage;"]
+    if request.plan.target is GroupLoweringTarget.CUB_WARP:
+        instances, logical_width = _warp_instances(request.plan)
+        storage_lines = [
+            "  __shared__ typename implementation_type::TempStorage "
+            f"storage[{instances}];",
+            "  unsigned int storage_instance =",
+            f"      cuda_coop_cutlass_linear_tid() / {logical_width}u;",
+        ]
+        storage = "storage[storage_instance]"
+
+    barrier_line = _storage_reuse_barrier_line(request.plan)
+
+    return [
+        f"{spec.cpp_type} {request.symbol_name}({', '.join(params)}) {{",
+        f"  using implementation_type = ::cub::{implementation.struct_name}<"
+        f"{template_arguments}>;",
+        *storage_lines,
+        *input_lines,
+        f"  {spec.cpp_type} result = implementation_type({storage})."
+        f"{implementation.method_name}({', '.join(call_arguments)});",
+        barrier_line,
+        "  return result;",
+        "}",
+    ]
+
+
+def _register_renderer() -> None:
+    _provider_rendering.register_bundle_renderer(
+        "cudax_reduce",
+        render=_render_cudax_reduce,
+        include_lines=(
+            "#define _CUDAX_ENABLE_GROUP_FEATURES_IN_LIBCUDACXX",
+            "#define _CUDAX_DISABLE_COOPERATIVE_GROUPS_INTEROP",
+            "#include <cuda/barrier>",
+            "#include <cuda/devices>",
+            "#include <cuda/functional>",
+            "#include <cuda/hierarchy>",
+            "#include <cuda/std/functional>",
+            "#include <cuda/std/type_traits>",
+            "#include <cuda/experimental/coop.cuh>",
+            "#include <cuda/experimental/group.cuh>",
+        ),
+        cccl_headers=(
+            ("#include <cuda/experimental/coop.cuh>", "cuda/experimental/coop.cuh"),
+            ("#include <cuda/experimental/group.cuh>", "cuda/experimental/group.cuh"),
+        ),
+    )
+    _provider_rendering.register_bundle_renderer(
+        "cub_group_reduce",
+        render=_render_cub_reduce,
+        include_lines=(
+            "#include <cuda/functional>",
+            "#include <cuda/std/functional>",
+            "#include <cub/block/block_reduce.cuh>",
+            "#include <cub/warp/warp_reduce.cuh>",
+        ),
+        cccl_headers=(
+            ("#include <cub/block/block_reduce.cuh>", "cub/block/block_reduce.cuh"),
+            ("#include <cub/warp/warp_reduce.cuh>", "cub/warp/warp_reduce.cuh"),
+        ),
+    )
+
+
+_register_renderer()
+
+_resolve_type = _provider_state.make_provider_type_resolver(
+    scope=_ROOT_SCOPE,
+    root_scope=_ROOT_SCOPE,
+    namespace="thread_group",
+)
+
+
+def _validate_op_for_type(op: str, value_type: type) -> None:
+    _provider_types.validate_scan_reduce_op_for_type(
+        op,
+        value_type,
+        root_scope=_ROOT_SCOPE,
+        feature="reduce",
+        namespace="thread_group",
+    )
+
+
+def _register_request(request: _CudaxReduceRequest | _CubReduceRequest) -> None:
+    _provider_state.register_request(request)
+
+
+def _remember_scalar_result_type(
+    value: Any,
+    value_type: type,
+    *,
+    plan: GroupLoweringPlan,
+) -> Any:
+    assert plan.result is not None
+    return _provider_state.remember_scalar_result_type(
+        value,
+        value_type,
+        scope=_ROOT_SCOPE,
+        compile_options_getter=lambda: _provider_state._get_cute_dsl().compile_options,
+        group_metadata=metadata_for_group(
+            plan.resolved_group,
+            visibility=plan.result.visibility,
+        ),
+    )
+
+
+def provider_reduce(
+    *,
+    group: ThreadGroup,
+    launch: LaunchFacts | None = None,
+    value: Any,
+    op: str = "sum",
+    broadcast: bool = True,
+    valid_items: Any = None,
+    valid_items_binding: ArgumentBinding | None = None,
+    algorithm: Any = None,
+) -> Any:
+    if not isinstance(group, ThreadGroup):
+        raise TypeError(f"{_ROOT_SCOPE}.reduce group must be a ThreadGroup")
+    if not isinstance(broadcast, bool):
+        raise TypeError(f"{_ROOT_SCOPE}.reduce broadcast must be a bool")
+    if launch is None:
+        if group.hierarchy is None or group.hierarchy.block_dim is None:
+            raise TypeError("group reduce provider requires exact launch facts")
+        launch = LaunchFacts(exact_block_dim=group.hierarchy.block_dim)
+    if valid_items_binding is None:
+        valid_items_binding = _classify_valid_items(valid_items)
+    _validate_valid_items_payload(valid_items_binding, valid_items)
+
+    def materialize(
+        *,
+        value_type: type,
+        value_kind: ReduceValueKind,
+        values: tuple[Any, ...],
+    ) -> Any:
+        plan = _make_group_reduce_plan(
+            group=group,
+            launch=launch,
+            dtype=value_type,
+            value_kind=value_kind,
+            items_per_thread=len(values),
+            op=op,
+            broadcast=broadcast,
+            valid_items=valid_items_binding,
+            algorithm=algorithm,
+            source="cutlass_group_reduce_provider",
+        ).require_supported()
+        validate_operand_domains(
+            plan.resolved_group,
+            {"value": value},
+            scope=_ROOT_SCOPE,
+            primitive_name="reduce",
+        )
+        if plan.target is GroupLoweringTarget.CUDAX_GROUP:
+            request: _CudaxReduceRequest | _CubReduceRequest = _CudaxReduceRequest(
+                plan=plan,
+                op=op,
+                value_type=value_type,
+            )
+        elif plan.target in {
+            GroupLoweringTarget.CUB_BLOCK,
+            GroupLoweringTarget.CUB_WARP,
+        }:
+            request = _CubReduceRequest(
+                plan=plan,
+                op=op,
+                value_type=value_type,
+            )
+        else:
+            raise AssertionError("supported group Reduce plan has no provider target")
+
+        runtime_valid_items = valid_items_binding.kind is BindingKind.RUNTIME
+        runtime_valid_args = (
+            [_provider_types.as_valid_items_arg(valid_items, scope=_ROOT_SCOPE)]
+            if runtime_valid_items
+            else []
+        )
+        _register_request(request)
+        result = ffi(
+            name=request.symbol_name,
+            params_types=[
+                *([value_type] * len(values)),
+                *([Int32] if runtime_valid_items else []),
+            ],
+            return_type=value_type,
+        )(
+            *values,
+            *runtime_valid_args,
+        )
+        return _remember_scalar_result_type(result, value_type, plan=plan)
+
+    if isinstance(value, ThreadData):
+        value_type, values = _provider_types.resolve_thread_data_value_type(
+            value,
+            allowed=SCAN_REDUCE_TYPES,
+            feature="reduce",
+            scope=_ROOT_SCOPE,
+            resolve_type=_resolve_type,
+        )
+        _validate_op_for_type(op, value_type)
+        return materialize(
+            value_type=value_type,
+            value_kind=ReduceValueKind.ARRAY,
+            values=tuple(values),
+        )
+
+    value_type = _resolve_type(
+        value,
+        allowed=SCAN_REDUCE_TYPES,
+        feature="reduce",
+    )
+    _validate_op_for_type(op, value_type)
+    return materialize(
+        value_type=value_type,
+        value_kind=ReduceValueKind.SCALAR,
+        values=(value,),
+    )
+
+
+__all__ = [
+    "_CudaxReduceRequest",
+    "_CubReduceRequest",
+    "provider_reduce",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_lowering/_scan.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_lowering/_scan.py
@@ -1,0 +1,1038 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Plan-driven CUB provider renderer for CUTLASS group scans."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+from numbers import Integral
+from typing import Any
+
+from cutlass import cute as _cute
+from cutlass._mlir.dialects import llvm
+from cutlass.base_dsl.typing import Int32, Uint32
+from cutlass.cute.ffi import ffi
+
+from cuda.coop._core import (
+    AlgorithmSpec,
+    ArgumentBinding,
+    BindingKind,
+    CxxOperator,
+    Dependency,
+    GroupLoweringPlan,
+    GroupLoweringTarget,
+    GroupScanSemantics,
+    LaunchFacts,
+    Reference,
+    ScanMode,
+    ScanValueKind,
+    StorageOwnership,
+    SynchronizationScope,
+    make_group_primitive_call,
+    make_scan_semantics,
+    plan_group_primitive,
+)
+from cuda.coop._core.block import BlockScanAlgorithm
+
+from .._compiler import _rendering, _state, _storage, _types
+from .._compiler._call_context import get_active_single_phase_context
+from .._compiler._types import SCAN_REDUCE_TYPES, TYPE_SPECS
+from .._thread_data import ThreadData
+from .._thread_group import ThreadGroup
+from .._value_metadata import (
+    attach_thread_data_metadata,
+    metadata_for_group,
+    validate_operand_domains,
+)
+
+_provider_rendering = _rendering
+_provider_state = _state
+_provider_storage = _storage
+_provider_types = _types
+
+_ROOT_SCOPE = "cuda.coop.cutlass"
+
+_BLOCK_ALGORITHM_TOKENS = {
+    BlockScanAlgorithm.RAKING.value: "raking",
+    BlockScanAlgorithm.RAKING_MEMOIZE.value: "raking_memoize",
+    BlockScanAlgorithm.WARP_SCANS.value: "warp_scans",
+}
+_SCAN_OPERATOR_CPP = {
+    "sum": "::cuda::std::plus<T>",
+    "multiplies": "::cuda::std::multiplies<T>",
+    "min": "::cuda::minimum<T>",
+    "max": "::cuda::maximum<T>",
+    "bit_and": "::cuda::std::bit_and<T>",
+    "bit_or": "::cuda::std::bit_or<T>",
+    "bit_xor": "::cuda::std::bit_xor<T>",
+}
+
+
+def _is_boolean_control(value: Any) -> bool:
+    if isinstance(value, bool):
+        return True
+    try:
+        import numpy as np
+    except ImportError:
+        pass
+    else:
+        if isinstance(value, np.bool_):
+            return True
+    try:
+        from cutlass.base_dsl.typing import Boolean
+    except ImportError:
+        return False
+    return isinstance(value, Boolean)
+
+
+def _normalize_scan_mode(mode: Any) -> str:
+    if _is_boolean_control(mode):
+        raise TypeError(f"{_ROOT_SCOPE}.scan mode must not be boolean")
+    try:
+        return ScanMode(mode).value
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{_ROOT_SCOPE}.scan mode must be 'exclusive' or 'inclusive'"
+        ) from exc
+
+
+def _classify_valid_items(valid_items: Any) -> ArgumentBinding:
+    if valid_items is None:
+        return ArgumentBinding.omitted()
+    if _is_boolean_control(valid_items):
+        raise TypeError(f"{_ROOT_SCOPE}.scan valid_items must be an integer")
+    if isinstance(valid_items, Integral):
+        return ArgumentBinding.static(int(valid_items))
+    from cutlass.base_dsl.typing import Integer
+
+    if isinstance(valid_items, Integer):
+        return ArgumentBinding.runtime()
+    raise TypeError(f"{_ROOT_SCOPE}.scan valid_items must be an integer")
+
+
+def _make_group_scan_plan(
+    *,
+    group: ThreadGroup,
+    launch: LaunchFacts,
+    dtype: Any,
+    value_kind: ScanValueKind,
+    items_per_thread: int,
+    mode: str,
+    op: str,
+    initial_value: Any = None,
+    aggregate: bool = False,
+    valid_items: Any = None,
+    algorithm: Any = None,
+    source: str = "cutlass_root",
+) -> GroupLoweringPlan:
+    """Build the canonical shared-core plan for one CUTLASS scan."""
+
+    mode = _normalize_scan_mode(mode)
+    if group.kind == "block" and algorithm is None:
+        algorithm = BlockScanAlgorithm.RAKING
+    if mode == ScanMode.INCLUSIVE.value and initial_value is not None:
+        raise ValueError(
+            f"{_ROOT_SCOPE}.scan initial_value is not supported for inclusive scans"
+        )
+    if mode == ScanMode.EXCLUSIVE.value and op != "sum" and initial_value is None:
+        raise ValueError(
+            f"{_ROOT_SCOPE}.scan requires initial_value for non-default exclusive scans"
+        )
+
+    initial_descriptor = (
+        Reference(Dependency("T"), name="initial_value")
+        if initial_value is not None
+        else None
+    )
+    scan_operator = None
+    if op != "sum" or initial_descriptor is not None:
+        try:
+            cpp = _SCAN_OPERATOR_CPP[op]
+        except KeyError as exc:
+            raise NotImplementedError(
+                f"unsupported group scan operator {op!r}"
+            ) from exc
+        scan_operator = CxxOperator(
+            cpp=cpp,
+            dtype=Dependency("T"),
+            name="scan_op",
+        )
+
+    primitive = make_scan_semantics(
+        dtype=dtype,
+        mode=mode,
+        value_kind=value_kind,
+        items_per_thread=items_per_thread,
+        scan_operator=scan_operator,
+        initial_value=initial_descriptor,
+        aggregate=aggregate,
+    )
+    call = make_group_primitive_call(
+        group,
+        GroupScanSemantics(
+            primitive=primitive,
+            cub_algorithm=algorithm,
+            valid_items=_classify_valid_items(valid_items),
+        ),
+        source=source,
+    )
+    return plan_group_primitive(call, launch)
+
+
+def _normalize_cpp_operator(cpp: str) -> str:
+    return cpp.strip().replace("<T>", "<>").removesuffix("{}")
+
+
+def _validate_scan_request_plan(
+    plan: GroupLoweringPlan,
+    *,
+    op: str,
+    value_type: type,
+    external_scratch: bool,
+) -> GroupScanSemantics:
+    plan.require_supported()
+    if plan.target not in {
+        GroupLoweringTarget.CUB_BLOCK,
+        GroupLoweringTarget.CUB_WARP,
+    }:
+        raise ValueError("CUB scan request requires a CUB lowering plan")
+    if not isinstance(plan.implementation, AlgorithmSpec):
+        raise TypeError("CUB scan request requires an AlgorithmSpec")
+
+    operation = plan.call.operation
+    if not isinstance(operation, GroupScanSemantics):
+        raise TypeError("group scan request requires scan semantics")
+    if operation.dtype is not value_type:
+        raise ValueError("group scan request dtype does not match its plan")
+
+    scan_operator = operation.scan_operator
+    if scan_operator is None:
+        if op != "sum":
+            raise ValueError("group scan request operator does not match its plan")
+    else:
+        if not isinstance(scan_operator, CxxOperator):
+            raise NotImplementedError(
+                "CUTLASS group scan currently supports built-in C++ operators only"
+            )
+        expected_cpp = _normalize_cpp_operator(_provider_types.cub_op_expr(op))
+        if _normalize_cpp_operator(scan_operator.cpp) != expected_cpp:
+            raise ValueError("group scan request operator does not match its plan")
+
+    initial_value = operation.initial_value
+    if initial_value is not None and not isinstance(initial_value, Reference):
+        raise NotImplementedError(
+            "CUTLASS group scan currently supports runtime initial values only"
+        )
+
+    implementation = plan.implementation
+    expected_target = (
+        GroupLoweringTarget.CUB_BLOCK
+        if plan.resolved_group.kind == "block"
+        else GroupLoweringTarget.CUB_WARP
+    )
+    if plan.target is not expected_target:
+        raise ValueError("CUB scan target does not match its resolved group")
+    expected_struct = (
+        "BlockScan" if plan.target is GroupLoweringTarget.CUB_BLOCK else "WarpScan"
+    )
+    if implementation.struct_name != expected_struct:
+        raise ValueError("CUB scan implementation does not match its group target")
+    expected_prefix = (
+        "Exclusive" if operation.mode is ScanMode.EXCLUSIVE else "Inclusive"
+    )
+    expected_method = (
+        f"{expected_prefix}ScanPartial"
+        if operation.valid_items.kind is not BindingKind.OMITTED
+        else f"{expected_prefix}{'Sum' if scan_operator is None else 'Scan'}"
+    )
+    if implementation.method_name != expected_method:
+        raise ValueError("CUB scan method does not match its plan semantics")
+
+    template_arguments = implementation.template_arguments
+    if template_arguments.get("T") is not value_type:
+        raise ValueError("CUB scan template dtype does not match its request")
+    if operation.operand_kind.value == ScanValueKind.ARRAY.value:
+        if template_arguments.get("ITEMS_PER_THREAD") != operation.items_per_thread:
+            raise ValueError("CUB scan item count does not match its request")
+    elif "ITEMS_PER_THREAD" in template_arguments:
+        raise ValueError("scalar CUB scan plan cannot carry an array item count")
+    participation = plan.participation
+    if participation is None:
+        raise ValueError("CUB scan plan requires a participation contract")
+    block_dim = participation.exact_block_dim
+    if plan.target is GroupLoweringTarget.CUB_BLOCK:
+        expected_dims = (
+            template_arguments.get("BLOCK_DIM_X"),
+            template_arguments.get("BLOCK_DIM_Y"),
+            template_arguments.get("BLOCK_DIM_Z"),
+        )
+        if expected_dims != block_dim:
+            raise ValueError("CUB BlockScan dimensions do not match its plan")
+    else:
+        if operation.operand_kind.value != ScanValueKind.SCALAR.value:
+            raise ValueError("CUB WarpScan request requires a scalar operand")
+        if template_arguments.get("VIRTUAL_WARP_THREADS") != (
+            plan.resolved_group.static_size
+        ):
+            raise ValueError("group WarpScan width does not match its plan")
+
+    temp_storage = plan.temp_storage
+    if temp_storage is None:
+        raise ValueError("CUB scan plan requires a temporary-storage contract")
+    expected_storage_ownership = (
+        StorageOwnership.CALLER if external_scratch else StorageOwnership.IMPLEMENTATION
+    )
+    if temp_storage.ownership is not expected_storage_ownership:
+        raise ValueError("CUB group Scan storage ownership does not match its request")
+    if external_scratch:
+        if plan.target is not GroupLoweringTarget.CUB_BLOCK:
+            raise ValueError("caller-owned CUB Scan scratch is block-scoped only")
+        if (
+            temp_storage.address_space != "shared"
+            or temp_storage.instances != 1
+            or temp_storage.instance_index != "cta"
+            or not temp_storage.exact_layout_required
+        ):
+            raise ValueError("CUB BlockScan requires exact caller-owned shared storage")
+
+    result = plan.result
+    if result is None or result.has_aggregate != operation.aggregate:
+        raise ValueError("CUB scan result contract does not match aggregate semantics")
+    return operation
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class _CubScanRequest:
+    plan: GroupLoweringPlan
+    op: str
+    value_type: type
+    external_scratch: bool = False
+    kind: str = "cub_group_scan"
+
+    def __post_init__(self) -> None:
+        _validate_scan_request_plan(
+            self.plan,
+            op=self.op,
+            value_type=self.value_type,
+            external_scratch=self.external_scratch,
+        )
+
+    @property
+    def semantic_key(self) -> tuple[Any, ...]:
+        assert self.plan.artifact_key is not None
+        if not self.external_scratch:
+            return self.plan.artifact_key
+        return "external_scratch", self.plan.artifact_key
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _CubScanRequest):
+            return NotImplemented
+        return self.semantic_key == other.semantic_key
+
+    def __hash__(self) -> int:
+        return hash(self.semantic_key)
+
+    @property
+    def operation(self) -> GroupScanSemantics:
+        operation = self.plan.call.operation
+        assert isinstance(operation, GroupScanSemantics)
+        return operation
+
+    @property
+    def group(self) -> ThreadGroup:
+        group = self.plan.resolved_group
+        assert isinstance(group, ThreadGroup)
+        return group
+
+    @property
+    def items_per_thread(self) -> int:
+        return self.operation.items_per_thread
+
+    @property
+    def is_array(self) -> bool:
+        return self.operation.primitive.value_kind is ScanValueKind.ARRAY
+
+    @property
+    def has_initial_value(self) -> bool:
+        return self.operation.initial_value is not None
+
+    @property
+    def has_aggregate(self) -> bool:
+        return self.operation.aggregate
+
+    @property
+    def valid_items(self) -> ArgumentBinding:
+        return self.operation.valid_items
+
+    @property
+    def has_valid_items(self) -> bool:
+        return self.valid_items.kind is not BindingKind.OMITTED
+
+    @property
+    def _algorithm_suffix(self) -> str:
+        if self.plan.target is GroupLoweringTarget.CUB_WARP:
+            return "warp"
+        implementation = self.plan.implementation
+        assert isinstance(implementation, AlgorithmSpec)
+        algorithm = implementation.template_arguments.get("ALGORITHM")
+        try:
+            return _BLOCK_ALGORITHM_TOKENS[algorithm]
+        except KeyError as exc:
+            raise ValueError(
+                f"unsupported CUB BlockScan algorithm {algorithm!r}"
+            ) from exc
+
+    @property
+    def symbol_name(self) -> str:
+        implementation = self.plan.implementation
+        assert isinstance(implementation, AlgorithmSpec)
+        value_kind = f"x{self.items_per_thread}" if self.is_array else "scalar"
+        initial = "initial" if self.has_initial_value else "noinit"
+        aggregate = "aggregate" if self.has_aggregate else "value"
+        valid_items = {
+            BindingKind.OMITTED: "all",
+            BindingKind.RUNTIME: "valid_runtime",
+            BindingKind.STATIC: f"valid_{self.valid_items.value}",
+        }[self.valid_items.kind]
+        signature = hashlib.sha256(repr(self.semantic_key).encode()).hexdigest()[:12]
+        symbol = (
+            "cuda_coop_cutlass_cub_scan_"
+            f"{self.group.symbol_suffix}_"
+            f"{implementation.method_name.lower()}_{self.op}_"
+            f"{TYPE_SPECS[self.value_type].token}_{value_kind}_"
+            f"{self._algorithm_suffix}_{initial}_{aggregate}_{valid_items}_"
+            f"{signature}"
+        )
+        if self.external_scratch:
+            return f"{symbol}_external_scratch"
+        return symbol
+
+    @property
+    def scratch_requirement_key(self) -> tuple[Any, ...]:
+        """Identity of the instantiated CUB class whose layout is required."""
+
+        implementation = self.plan.implementation
+        assert isinstance(implementation, AlgorithmSpec)
+        return (
+            "cub_temp_storage_layout",
+            implementation.struct_name,
+            tuple(
+                (name, _render_cub_template_argument(self, name, value))
+                for name, value in implementation.ordered_template_arguments
+            ),
+        )
+
+    @property
+    def scratch_cpp_type(self) -> str:
+        implementation = self.plan.implementation
+        assert isinstance(implementation, AlgorithmSpec)
+        template_arguments = ", ".join(
+            _render_cub_template_argument(self, name, value)
+            for name, value in implementation.ordered_template_arguments
+        )
+        return (
+            f"typename ::cub::{implementation.struct_name}<"
+            f"{template_arguments}>::TempStorage"
+        )
+
+
+def _render_cub_template_argument(
+    request: _CubScanRequest,
+    name: str,
+    value: Any,
+) -> str:
+    if name == "T":
+        if value is not request.value_type:
+            raise ValueError("CUB scan template dtype does not match its request")
+        return TYPE_SPECS[request.value_type].cpp_type
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, str):
+        return value
+    raise TypeError(f"cannot render CUB scan template argument {name}={value!r}")
+
+
+def _storage_reuse_barrier_line(plan: GroupLoweringPlan) -> str:
+    synchronization = plan.synchronization
+    if synchronization is None:
+        raise ValueError("Scan plan requires a synchronization contract")
+    if synchronization.storage_reuse_barrier is SynchronizationScope.BLOCK:
+        return "  cuda_coop_cutlass_block_sync();"
+    if synchronization.storage_reuse_barrier is SynchronizationScope.WARP:
+        _, logical_width = _warp_instances(plan)
+        return f"  cuda_coop_cutlass_warp_sync({logical_width}u);"
+    raise ValueError("Scan plan requires a storage reuse barrier")
+
+
+def _warp_instances(plan: GroupLoweringPlan) -> tuple[int, int]:
+    participation = plan.participation
+    if participation is None:
+        raise ValueError("WarpScan plan requires a participation contract")
+    block_dim = participation.exact_block_dim
+    block_threads = block_dim[0] * block_dim[1] * block_dim[2]
+    implementation = plan.implementation
+    assert isinstance(implementation, AlgorithmSpec)
+    logical_width = implementation.template_arguments.get("VIRTUAL_WARP_THREADS")
+    if not isinstance(logical_width, int) or logical_width < 1:
+        raise ValueError("WarpScan plan requires a static logical warp width")
+    if block_threads < logical_width or block_threads % logical_width != 0:
+        raise ValueError("WarpScan plan requires complete logical warps")
+    return block_threads // logical_width, logical_width
+
+
+def _render_cub_scan(request: _CubScanRequest) -> list[str]:
+    operation = _validate_scan_request_plan(
+        request.plan,
+        op=request.op,
+        value_type=request.value_type,
+        external_scratch=request.external_scratch,
+    )
+    implementation = request.plan.implementation
+    assert isinstance(implementation, AlgorithmSpec)
+    spec = TYPE_SPECS[request.value_type]
+    template_arguments = ", ".join(
+        _render_cub_template_argument(request, name, value)
+        for name, value in implementation.ordered_template_arguments
+    )
+
+    storage = "storage"
+    storage_lines = ["  __shared__ typename implementation_type::TempStorage storage;"]
+    if request.external_scratch:
+        storage_lines = [
+            "  constexpr unsigned long long required_temp_bytes =",
+            "      (unsigned long long)sizeof(typename implementation_type::TempStorage);",
+            "  constexpr unsigned long long required_temp_alignment =",
+            "      (unsigned long long)alignof(typename implementation_type::TempStorage);",
+            "  if (temp_storage_bytes <= 0 ||",
+            "      (unsigned long long)temp_storage_bytes < required_temp_bytes ||",
+            "      ((unsigned long long)temp_storage_smem_addr &",
+            "       (required_temp_alignment - 1ull)) != 0ull) {",
+            '    asm volatile("trap;");',
+            "  }",
+            "  void* temp_storage_ptr =",
+            "      cuda_coop_cutlass_shared_ptr(temp_storage_smem_addr);",
+            "  auto* storage_ptr = reinterpret_cast<",
+            "      typename implementation_type::TempStorage*>(temp_storage_ptr);",
+        ]
+        storage = "*storage_ptr"
+    elif request.plan.target is GroupLoweringTarget.CUB_WARP:
+        instances, logical_width = _warp_instances(request.plan)
+        storage_lines = [
+            "  __shared__ typename implementation_type::TempStorage "
+            f"storage[{instances}];",
+            "  unsigned int storage_instance =",
+            f"      cuda_coop_cutlass_linear_tid() / {logical_width}u;",
+        ]
+        storage = "storage[storage_instance]"
+
+    params: list[str] = []
+    input_lines: list[str] = []
+    output_lines: list[str] = []
+    if request.is_array:
+        params.extend(
+            f"{spec.cpp_type} item{index}" for index in range(request.items_per_thread)
+        )
+        values = ", ".join(f"item{index}" for index in range(request.items_per_thread))
+        input_lines.extend(
+            [
+                f"  {spec.cpp_type} input_items[{request.items_per_thread}] = "
+                f"{{{values}}};",
+                f"  {spec.cpp_type} output_items[{request.items_per_thread}];",
+            ]
+        )
+        call_arguments = ["input_items", "output_items"]
+    else:
+        params.append(f"{spec.cpp_type} value")
+        input_lines.append(f"  {spec.cpp_type} result = value;")
+        call_arguments = ["value", "result"]
+
+    if request.has_initial_value:
+        params.append(f"{spec.cpp_type} initial_value")
+        call_arguments.append("initial_value")
+    if operation.scan_operator is not None or request.has_valid_items:
+        call_arguments.append(_provider_types.cub_op_expr(request.op))
+    if request.valid_items.kind is BindingKind.RUNTIME:
+        params.append("int valid_items")
+        call_arguments.append("valid_items")
+    elif request.valid_items.kind is BindingKind.STATIC:
+        call_arguments.append(str(request.valid_items.value))
+    if request.external_scratch:
+        params.extend(
+            (
+                "unsigned int temp_storage_smem_addr",
+                "int temp_storage_bytes",
+                "int temp_storage_auto_sync",
+            )
+        )
+    if request.has_aggregate:
+        params.append(f"{spec.cpp_type}* aggregate_output")
+        input_lines.append(f"  {spec.cpp_type} aggregate;")
+        call_arguments.append("aggregate")
+    if request.is_array:
+        params.append(f"{spec.cpp_type}* result_items")
+        output_lines.extend(
+            f"  result_items[{index}] = output_items[{index}];"
+            for index in range(request.items_per_thread)
+        )
+    else:
+        output_lines.append("  return result;")
+
+    barrier = _storage_reuse_barrier_line(request.plan)
+    barrier_lines = [barrier]
+    if request.external_scratch:
+        barrier_lines = [
+            "  if (temp_storage_auto_sync != 0) {",
+            f"  {barrier}",
+            "  }",
+        ]
+    aggregate_lines = (
+        ["  *aggregate_output = aggregate;"] if request.has_aggregate else []
+    )
+    return [
+        f"{'void' if request.is_array else spec.cpp_type} "
+        f"{request.symbol_name}({', '.join(params)}) {{",
+        f"  using implementation_type = ::cub::{implementation.struct_name}<"
+        f"{template_arguments}>;",
+        *storage_lines,
+        *input_lines,
+        f"  implementation_type({storage}).{implementation.method_name}("
+        f"{', '.join(call_arguments)});",
+        *barrier_lines,
+        *aggregate_lines,
+        *output_lines,
+        "}",
+    ]
+
+
+def _cub_scan_scratch_layout_probe(
+    request: _CubScanRequest,
+) -> _provider_types.ScratchLayoutProbe | None:
+    if not request.external_scratch:
+        return None
+    return _provider_rendering.make_scratch_layout_probe(
+        request.scratch_requirement_key,
+        request.scratch_cpp_type,
+    )
+
+
+def _register_renderer() -> None:
+    _provider_rendering.register_bundle_renderer(
+        "cub_group_scan",
+        render=_render_cub_scan,
+        include_lines=(
+            "#include <cuda/functional>",
+            "#include <cuda/std/functional>",
+            "#include <cub/block/block_scan.cuh>",
+            "#include <cub/warp/warp_scan.cuh>",
+        ),
+        cccl_headers=(
+            ("#include <cub/block/block_scan.cuh>", "cub/block/block_scan.cuh"),
+            ("#include <cub/warp/warp_scan.cuh>", "cub/warp/warp_scan.cuh"),
+        ),
+        scratch_layout_probe=_cub_scan_scratch_layout_probe,
+    )
+
+
+_register_renderer()
+
+_resolve_type = _provider_state.make_provider_type_resolver(
+    scope=_ROOT_SCOPE,
+    root_scope=_ROOT_SCOPE,
+    namespace="thread_group",
+)
+
+
+def _validate_op_for_type(op: str, value_type: type) -> None:
+    _provider_types.validate_scan_reduce_op_for_type(
+        op,
+        value_type,
+        root_scope=_ROOT_SCOPE,
+        feature="scan",
+        namespace="thread_group",
+    )
+
+
+def _validate_aggregate_output(
+    output: Any,
+    *,
+    value_type: type,
+) -> ThreadData | None:
+    return _provider_types.validate_thread_data_output(
+        output=output,
+        expected_items_per_thread=1,
+        resolved_dtype=value_type,
+        scope=_ROOT_SCOPE,
+        primitive_name="scan",
+        output_name="aggregate_output",
+        resolve_type=_resolve_type,
+        type_label=f"{_ROOT_SCOPE}.ThreadData",
+    )
+
+
+def _make_aggregate_tensor(
+    aggregate_output: ThreadData | None,
+    value_type: type,
+) -> Any | None:
+    if aggregate_output is None:
+        return None
+    return _cute.make_rmem_tensor(1, value_type)
+
+
+def _populate_aggregate_output(
+    aggregate_output: ThreadData | None,
+    aggregate_tensor: Any | None,
+) -> None:
+    if aggregate_output is None:
+        return
+    assert aggregate_tensor is not None
+    aggregate_output[0] = aggregate_tensor[0]
+
+
+def _coerce_initial_value(
+    request: _CubScanRequest,
+    initial_value: Any,
+) -> list[Any]:
+    if not request.has_initial_value:
+        if initial_value is not None:
+            raise ValueError("scan initial value does not match its lowering plan")
+        return []
+    if initial_value is None:
+        raise ValueError("scan lowering plan requires an initial value")
+    return [
+        _provider_types.coerce_scan_initial_value(
+            initial_value=initial_value,
+            value_type=request.value_type,
+            root_scope=_ROOT_SCOPE,
+            feature="scan",
+            namespace="thread_group",
+        )
+    ]
+
+
+def _temp_storage_for_scan(
+    *,
+    group: ThreadGroup,
+    explicit_temp_storage: Any,
+) -> Any | None:
+    context = get_active_single_phase_context()
+    context_storage = context.temp_storage if context is not None else None
+    if (
+        explicit_temp_storage is not None
+        and context_storage is not None
+        and explicit_temp_storage is not context_storage
+    ):
+        raise ValueError(f"{_ROOT_SCOPE}.scan received two TempStorage objects")
+    temp_storage = (
+        explicit_temp_storage if explicit_temp_storage is not None else context_storage
+    )
+    if temp_storage is None:
+        return None
+
+    from .._temp_storage import TempStorage
+
+    if not isinstance(temp_storage, TempStorage):
+        raise TypeError(
+            f"{_ROOT_SCOPE}.scan temp_storage must be {_ROOT_SCOPE}.TempStorage"
+        )
+    if group.kind != "block":
+        raise ValueError(
+            f"{_ROOT_SCOPE}.scan TempStorage is supported only for block groups"
+        )
+    if not temp_storage.is_deferred and temp_storage.sharing == "exclusive":
+        raise ValueError(
+            f"{_ROOT_SCOPE}.scan fixed-capacity TempStorage does not support "
+            "sharing='exclusive'; use sharing='shared' or deferred storage"
+        )
+    return temp_storage
+
+
+def _external_scratch_args(
+    temp_storage: Any,
+    *,
+    requirement_key: Any,
+) -> tuple[Any, Any, Any]:
+    if temp_storage.is_deferred:
+        return _provider_storage.register_deferred_temp_storage_event(
+            temp_storage,
+            primitive_name="scan",
+            requirement_key=requirement_key,
+        )
+
+    binding = _provider_storage.materialize_temp_storage_binding(
+        temp_storage,
+        scope=_ROOT_SCOPE,
+        implicit_alignment=16,
+    )
+    return (
+        binding.smem_addr_u32,
+        Int32(binding.size_in_bytes),
+        Int32(1 if binding.auto_sync else 0),
+    )
+
+
+def _with_caller_owned_scan_storage(plan: GroupLoweringPlan) -> GroupLoweringPlan:
+    temp_storage = plan.temp_storage
+    if temp_storage is None:
+        raise ValueError("CUB scan plan requires a temporary-storage contract")
+    return dataclasses.replace(
+        plan,
+        temp_storage=dataclasses.replace(
+            temp_storage,
+            ownership=StorageOwnership.CALLER,
+            address_space="shared",
+            cpp_type="typename implementation_type::TempStorage",
+            instances=1,
+            instance_index="cta",
+            exact_layout_required=True,
+        ),
+    )
+
+
+def _materialize_scan(
+    *,
+    plan: GroupLoweringPlan,
+    value: Any,
+    values: tuple[Any, ...],
+    value_type: type,
+    op: str,
+    initial_value: Any,
+    aggregate_output: Any,
+    valid_items: Any,
+    external_temp_storage: Any | None,
+) -> Any:
+    request = _CubScanRequest(
+        plan=plan,
+        op=op,
+        value_type=value_type,
+        external_scratch=external_temp_storage is not None,
+    )
+    aggregate_output_td = _validate_aggregate_output(
+        aggregate_output,
+        value_type=value_type,
+    )
+    if request.has_aggregate != (aggregate_output_td is not None):
+        raise ValueError("scan aggregate output does not match its lowering plan")
+
+    initial_args = _coerce_initial_value(request, initial_value)
+    aggregate_tensor = _make_aggregate_tensor(aggregate_output_td, value_type)
+    aggregate_args = (
+        [aggregate_tensor.iterator.llvm_ptr] if aggregate_tensor is not None else []
+    )
+    aggregate_param_types = (
+        [llvm.PointerType.get(0)] if aggregate_tensor is not None else []
+    )
+    if request.valid_items.kind is BindingKind.OMITTED:
+        if valid_items is not None:
+            raise ValueError("scan valid_items does not match its lowering plan")
+        valid_args: list[Any] = []
+        valid_param_types: list[type] = []
+    elif request.valid_items.kind is BindingKind.STATIC:
+        if valid_items != request.valid_items.value:
+            raise ValueError("static scan valid_items does not match its plan")
+        valid_args = []
+        valid_param_types = []
+    else:
+        if valid_items is None:
+            raise ValueError("scan lowering plan requires valid_items")
+        valid_args = [
+            _provider_types.as_valid_items_arg(valid_items, scope=_ROOT_SCOPE)
+        ]
+        valid_param_types = [Int32]
+
+    assert plan.result is not None
+    result_metadata = metadata_for_group(
+        plan.resolved_group,
+        visibility=plan.result.visibility,
+    )
+    session_snapshot = (
+        _provider_state.snapshot_active_session_state()
+        if external_temp_storage is not None
+        else None
+    )
+    try:
+        _provider_state.register_request(request)
+        scratch_args: tuple[Any, ...] = ()
+        scratch_param_types: list[type] = []
+        if external_temp_storage is not None:
+            scratch_addr, scratch_size, scratch_auto_sync = _external_scratch_args(
+                external_temp_storage,
+                requirement_key=request.scratch_requirement_key,
+            )
+            scratch_args = (scratch_addr, scratch_size, scratch_auto_sync)
+            scratch_param_types = [Uint32, Int32, Int32]
+
+        if request.is_array:
+            result_tensor = _cute.make_rmem_tensor(request.items_per_thread, value_type)
+            ffi(
+                name=request.symbol_name,
+                params_types=[
+                    *([value_type] * request.items_per_thread),
+                    *([value_type] if request.has_initial_value else []),
+                    *valid_param_types,
+                    *scratch_param_types,
+                    *aggregate_param_types,
+                    llvm.PointerType.get(0),
+                ],
+                return_type=None,
+            )(
+                *values,
+                *initial_args,
+                *valid_args,
+                *scratch_args,
+                *aggregate_args,
+                result_tensor.iterator.llvm_ptr,
+            )
+            _populate_aggregate_output(aggregate_output_td, aggregate_tensor)
+            assert isinstance(value, ThreadData)
+            return attach_thread_data_metadata(
+                ThreadData.from_values(
+                    *(
+                        result_tensor[index]
+                        for index in range(request.items_per_thread)
+                    ),
+                    dtype=_provider_types.thread_data_output_dtype(
+                        value,
+                        value_type,
+                    ),
+                ),
+                result_metadata,
+            )
+
+        result = ffi(
+            name=request.symbol_name,
+            params_types=[
+                value_type,
+                *([value_type] if request.has_initial_value else []),
+                *valid_param_types,
+                *scratch_param_types,
+                *aggregate_param_types,
+            ],
+            return_type=value_type,
+        )(
+            values[0],
+            *initial_args,
+            *valid_args,
+            *scratch_args,
+            *aggregate_args,
+        )
+        _populate_aggregate_output(aggregate_output_td, aggregate_tensor)
+        return _provider_state.remember_scalar_result_type(
+            result,
+            value_type,
+            scope=_ROOT_SCOPE,
+            compile_options_getter=lambda: (
+                _provider_state._get_cute_dsl().compile_options
+            ),
+            group_metadata=result_metadata,
+        )
+    except Exception:
+        if session_snapshot is not None:
+            _provider_state.restore_active_session_state(session_snapshot)
+        raise
+
+
+def provider_scan(
+    *,
+    group: ThreadGroup,
+    launch: LaunchFacts | None = None,
+    value: Any,
+    mode: str = "exclusive",
+    op: str = "sum",
+    initial_value: Any = None,
+    algorithm: Any = None,
+    aggregate_output: Any = None,
+    valid_items: Any = None,
+    temp_storage: Any = None,
+) -> Any:
+    """Materialize one planner-selected CUB BlockScan or physical WarpScan."""
+
+    if not isinstance(group, ThreadGroup):
+        raise TypeError(f"{_ROOT_SCOPE}.scan group must be a ThreadGroup")
+    if launch is None:
+        if group.hierarchy is None or group.hierarchy.block_dim is None:
+            raise TypeError("group scan provider requires exact launch facts")
+        launch = LaunchFacts(exact_block_dim=group.hierarchy.block_dim)
+    external_temp_storage = _temp_storage_for_scan(
+        group=group,
+        explicit_temp_storage=temp_storage,
+    )
+
+    def materialize(
+        *,
+        value_type: type,
+        value_kind: ScanValueKind,
+        values: tuple[Any, ...],
+    ) -> Any:
+        _validate_op_for_type(op, value_type)
+        plan = _make_group_scan_plan(
+            group=group,
+            launch=launch,
+            dtype=value_type,
+            value_kind=value_kind,
+            items_per_thread=len(values),
+            mode=mode,
+            op=op,
+            initial_value=initial_value,
+            aggregate=aggregate_output is not None,
+            valid_items=valid_items,
+            algorithm=algorithm,
+            source="cutlass_group_scan_provider",
+        ).require_supported()
+        if external_temp_storage is not None:
+            plan = _with_caller_owned_scan_storage(plan)
+        validate_operand_domains(
+            plan.resolved_group,
+            {
+                "value": value,
+                **(
+                    {"initial_value": initial_value}
+                    if initial_value is not None
+                    else {}
+                ),
+                **({"valid_items": valid_items} if valid_items is not None else {}),
+            },
+            scope=_ROOT_SCOPE,
+            primitive_name="scan",
+        )
+        return _materialize_scan(
+            plan=plan,
+            value=value,
+            values=values,
+            value_type=value_type,
+            op=op,
+            initial_value=initial_value,
+            aggregate_output=aggregate_output,
+            valid_items=valid_items,
+            external_temp_storage=external_temp_storage,
+        )
+
+    if isinstance(value, ThreadData):
+        value_type, values = _provider_types.resolve_thread_data_value_type(
+            value,
+            allowed=SCAN_REDUCE_TYPES,
+            feature="scan",
+            scope=_ROOT_SCOPE,
+            resolve_type=_resolve_type,
+        )
+        return materialize(
+            value_type=value_type,
+            value_kind=ScanValueKind.ARRAY,
+            values=tuple(values),
+        )
+
+    value_type = _resolve_type(
+        value,
+        allowed=SCAN_REDUCE_TYPES,
+        feature="scan",
+    )
+    return materialize(
+        value_type=value_type,
+        value_kind=ScanValueKind.SCALAR,
+        values=(value,),
+    )
+
+
+__all__ = ["_CubScanRequest", "provider_scan"]

--- a/python/cuda_coop/cuda/coop/cutlass/_lowering/_symbols.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_lowering/_symbols.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Canonical symbol fragments shared by CUTLASS provider artifacts."""
+
+from __future__ import annotations
+
+
+def block_dim_token(block_dim: tuple[int, int, int]) -> str:
+    """Return the existing provider ABI token for an exact CUDA block shape."""
+
+    x, y, z = block_dim
+    if (y, z) == (1, 1):
+        return f"b{x}"
+    return f"b{x}x{y}x{z}"
+
+
+__all__ = ["block_dim_token"]

--- a/python/cuda_coop/cuda/coop/cutlass/_lowering/_thread_group.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_lowering/_thread_group.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Provider renderer for experimental cudax thread-group query helpers."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from cutlass.cute.ffi import ffi
+
+from .._compiler import _rendering, _state, _types
+from .._thread_group import (
+    ThreadGroup,
+    cpp_level_expr,
+    render_group_decl_lines,
+    render_hierarchy_decl,
+)
+
+_provider_rendering = _rendering
+_provider_state = _state
+_provider_types = _types
+
+_ROOT_SCOPE = "cuda.coop.cutlass"
+
+_QUERY_OPS = frozenset({"rank", "count"})
+_SYNC_OPS = frozenset({"sync", "sync_aligned"})
+_MEMBERSHIP_OP = "is_member"
+_LEVEL_ORDER = {
+    "thread": 0,
+    "warp": 1,
+    "block": 2,
+    "cluster": 3,
+    "grid": 4,
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class _CudaxGroupRequest:
+    group: ThreadGroup
+    op: str
+    level: str = "thread"
+    result_type: type | None = None
+    kind: str = "cudax_group"
+
+    @property
+    def symbol_name(self) -> str:
+        parts = [
+            "cuda_coop_cutlass_cudax_group",
+            self.group.symbol_suffix,
+            self.op,
+        ]
+        if self.op in _QUERY_OPS:
+            parts.append(self.level)
+            parts.append(_provider_types.TYPE_SPECS[self.result_type].token)
+        return "_".join(parts)
+
+
+def _result_type(result_type: type | None) -> type:
+    if result_type is None:
+        return _provider_types.Int32
+    from cuda.coop._core import validate_thread_group_query_dtype
+
+    validate_thread_group_query_dtype(result_type, scope=_ROOT_SCOPE)
+    if result_type not in _provider_types.TYPE_SPECS:
+        raise TypeError(
+            f"{_ROOT_SCOPE}.ThreadGroup query dtype must be one of "
+            f"{_provider_types.supported_names(_provider_types.ALL_PROVIDER_TYPES)}"
+        )
+    return result_type
+
+
+def _validate_query(group: ThreadGroup, op: str, level: str) -> ThreadGroup:
+    if op not in _QUERY_OPS:
+        raise ValueError(f"Unsupported cudax group query op: {op}")
+    from .._thread_group import _validate_query_launch
+
+    return _validate_query_launch(
+        group,
+        feature=f"ThreadGroup.{op}",
+        level=level,
+    )
+
+
+def _validate_sync(group: ThreadGroup, op: str) -> ThreadGroup:
+    if op not in _SYNC_OPS:
+        raise ValueError(f"Unsupported cudax group sync op: {op}")
+    from .._thread_group import _validate_sync_launch
+
+    return _validate_sync_launch(group, feature=f"ThreadGroup.{op}")
+
+
+def _render_group_prelude(group: ThreadGroup) -> list[str]:
+    if group.hierarchy.implicit:
+        assert group.mapping is None
+        hierarchy = "::cuda::experimental::implicit_hierarchy()"
+        return [f"  ::cuda::experimental::this_{group.kind} group{{{hierarchy}}};"]
+    return [
+        *render_hierarchy_decl(group.hierarchy),
+        *render_group_decl_lines(group),
+    ]
+
+
+def _render_query_expr(group: ThreadGroup, op: str, level: str) -> str:
+    level_expr = cpp_level_expr(level)
+    group_level = group.kind if group.mapping is None else group.mapping.parent
+    if group.mapping is None and level == group_level:
+        return "0" if op == "rank" else "1"
+    if group.mapping is not None and level == group.mapping.parent:
+        return f"group.{op}(group_parent)"
+    if _LEVEL_ORDER[level] < _LEVEL_ORDER[group_level]:
+        return f"{level_expr}.{op}(group)"
+    return f"group.{op}({level_expr})"
+
+
+def _render_cudax_group(request: _CudaxGroupRequest) -> list[str]:
+    if request.op in _QUERY_OPS:
+        spec = _provider_types.TYPE_SPECS[request.result_type]
+        return [
+            f"{spec.cpp_type} {request.symbol_name}() {{",
+            *_render_group_prelude(request.group),
+            (
+                f"  return static_cast<{spec.cpp_type}>("
+                f"{_render_query_expr(request.group, request.op, request.level)});"
+            ),
+            "}",
+        ]
+    if request.op in _SYNC_OPS:
+        member = "sync_aligned" if request.op == "sync_aligned" else "sync"
+        return [
+            f"void {request.symbol_name}() {{",
+            *_render_group_prelude(request.group),
+            f"  group.{member}();",
+            "}",
+        ]
+    if request.op == _MEMBERSHIP_OP:
+        return [
+            f"unsigned char {request.symbol_name}() {{",
+            *_render_group_prelude(request.group),
+            "  return ::cuda::gpu_thread.is_part_of(group) ? 1u : 0u;",
+            "}",
+        ]
+    raise ValueError(f"Unsupported cudax group request op: {request.op}")
+
+
+def _register_renderer() -> None:
+    _provider_rendering.register_bundle_renderer(
+        "cudax_group",
+        render=_render_cudax_group,
+        include_lines=(
+            "#define _CUDAX_ENABLE_GROUP_FEATURES_IN_LIBCUDACXX",
+            "#define _CUDAX_DISABLE_COOPERATIVE_GROUPS_INTEROP",
+            "#include <cuda/barrier>",
+            "#include <cuda/devices>",
+            "#include <cuda/hierarchy>",
+            "#include <cuda/std/type_traits>",
+            "#include <cuda/experimental/group.cuh>",
+        ),
+        cccl_headers=(
+            ("#include <cuda/experimental/group.cuh>", "cuda/experimental/group.cuh"),
+        ),
+    )
+
+
+_register_renderer()
+
+
+def provider_group_query(
+    *,
+    group: ThreadGroup,
+    op: str,
+    level: str = "thread",
+    result_type: type | None = None,
+) -> Any:
+    if not isinstance(group, ThreadGroup):
+        raise TypeError(f"{_ROOT_SCOPE}.ThreadGroup query group must be a ThreadGroup")
+    group = _validate_query(group, op, level)
+    resolved_type = _result_type(result_type)
+    request = _CudaxGroupRequest(
+        group=group,
+        op=op,
+        level=level,
+        result_type=resolved_type,
+    )
+    _provider_state.register_request(request)
+    result = ffi(
+        name=request.symbol_name,
+        params_types=[],
+        return_type=resolved_type,
+    )()
+    return _provider_state.remember_scalar_result_type(
+        result,
+        resolved_type,
+        scope=_ROOT_SCOPE,
+        compile_options_getter=lambda: _provider_state._get_cute_dsl().compile_options,
+        group_metadata=_query_group_metadata(group),
+    )
+
+
+def provider_group_sync(
+    *,
+    group: ThreadGroup,
+    aligned: bool,
+) -> None:
+    if not isinstance(group, ThreadGroup):
+        raise TypeError(f"{_ROOT_SCOPE}.ThreadGroup sync group must be a ThreadGroup")
+    op = "sync_aligned" if aligned else "sync"
+    group = _validate_sync(group, op)
+    request = _CudaxGroupRequest(group=group, op=op)
+    _provider_state.register_request(request)
+    ffi(
+        name=request.symbol_name,
+        params_types=[],
+        return_type=None,
+    )()
+
+
+def provider_group_membership(*, group: ThreadGroup) -> Any:
+    if not isinstance(group, ThreadGroup):
+        raise TypeError(
+            f"{_ROOT_SCOPE}.ThreadGroup.is_member group must be a ThreadGroup"
+        )
+    from .._thread_group import _validate_membership_launch
+
+    group = _validate_membership_launch(
+        group,
+        feature="ThreadGroup.is_member",
+    )
+    request = _CudaxGroupRequest(group=group, op=_MEMBERSHIP_OP)
+    _provider_state.register_request(request)
+    return ffi(
+        name=request.symbol_name,
+        params_types=[],
+        return_type=_provider_types.Uint8,
+    )()
+
+
+def _query_group_metadata(group: ThreadGroup) -> Any:
+    from cuda.coop._core import ResultVisibility
+
+    from .._value_metadata import metadata_for_group
+
+    return metadata_for_group(group, visibility=ResultVisibility.PER_MEMBER)
+
+
+__all__ = [
+    "_CudaxGroupRequest",
+    "provider_group_membership",
+    "provider_group_query",
+    "provider_group_sync",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_prims.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_prims.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Import-light probes for public CUTLASS values used by the Prims path."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+
+def is_cutlass_array_operand(value: Any, *, method: str | None = None) -> bool:
+    """Return whether *value* is a public ``cutlass.Array`` operand.
+
+    This local probe never imports CUTLASS itself. It resolves the public class
+    only when another activation path, including default root auto-registration,
+    has already loaded the CUTLASS runtime.
+    """
+    cutlass_module = sys.modules.get("cutlass")
+    array_type = (
+        getattr(cutlass_module, "Array", None) if cutlass_module is not None else None
+    )
+    if not isinstance(array_type, type) or not isinstance(value, array_type):
+        return False
+
+    if method is not None:
+        return callable(getattr(value, method, None))
+
+    return callable(getattr(value, "load", None)) or callable(
+        getattr(value, "store", None)
+    )
+
+
+__all__ = ["is_cutlass_array_operand"]

--- a/python/cuda_coop/cuda/coop/cutlass/_temp_storage.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_temp_storage.py
@@ -1,0 +1,311 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Temporary-storage identity and slice planning for CUTLASS collectives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+_DEFAULT_SCOPE = "cuda.coop.cutlass"
+_TEMP_STORAGE_SHARING_VALUES = frozenset(("shared", "exclusive"))
+
+
+def _align_up(value: int, alignment: int) -> int:
+    if alignment <= 1:
+        return value
+    remainder = value % alignment
+    return value if remainder == 0 else (value + alignment - remainder)
+
+
+@dataclass(frozen=True)
+class TempStorageSlice:
+    byte_offset_in_bytes: int
+    size_in_bytes: int
+    alignment: int
+
+
+def _merge_slice_requirements(
+    existing: TempStorageSlice,
+    *,
+    required_size_in_bytes: int,
+    required_alignment: int,
+) -> TempStorageSlice:
+    next_size = max(existing.size_in_bytes, required_size_in_bytes)
+    next_alignment = max(existing.alignment, required_alignment)
+    return TempStorageSlice(
+        byte_offset_in_bytes=existing.byte_offset_in_bytes,
+        size_in_bytes=next_size,
+        alignment=next_alignment,
+    )
+
+
+def _plan_next_slice(
+    planned_size_in_bytes: int,
+    *,
+    required_size_in_bytes: int,
+    required_alignment: int,
+) -> TempStorageSlice:
+    offset = _align_up(planned_size_in_bytes, required_alignment)
+    return TempStorageSlice(
+        byte_offset_in_bytes=offset,
+        size_in_bytes=required_size_in_bytes,
+        alignment=required_alignment,
+    )
+
+
+def _plan_primitive_slice(
+    primitive_slices: dict[str, TempStorageSlice],
+    primitive_name: str,
+    *,
+    sharing: str,
+    planned_size_in_bytes: int,
+    required_size_in_bytes: int,
+    required_alignment: int,
+) -> tuple[TempStorageSlice, int]:
+    if sharing == "exclusive":
+        planned = _plan_next_slice(
+            planned_size_in_bytes,
+            required_size_in_bytes=required_size_in_bytes,
+            required_alignment=required_alignment,
+        )
+        next_size = (
+            planned_size_in_bytes
+            if required_size_in_bytes == 0
+            else planned.byte_offset_in_bytes + planned.size_in_bytes
+        )
+        return planned, next_size
+
+    current = primitive_slices.get(primitive_name)
+    if current is not None:
+        merged = _merge_slice_requirements(
+            current,
+            required_size_in_bytes=required_size_in_bytes,
+            required_alignment=required_alignment,
+        )
+        return merged, max(
+            planned_size_in_bytes,
+            merged.size_in_bytes,
+        )
+
+    planned = TempStorageSlice(
+        byte_offset_in_bytes=0,
+        size_in_bytes=required_size_in_bytes,
+        alignment=required_alignment,
+    )
+    return planned, max(planned_size_in_bytes, planned.size_in_bytes)
+
+
+@dataclass(frozen=True)
+class TempStorageUse:
+    primitive_name: str
+    required_size_in_bytes: int
+    required_alignment: int
+    byte_offset_in_bytes: int
+
+
+class TempStorageBase:
+    """Explicit shared-memory scratch planner for CuTe collectives."""
+
+    scope = _DEFAULT_SCOPE
+
+    def __init__(
+        self,
+        size_in_bytes: int | None = None,
+        alignment: int | None = None,
+        auto_sync: bool | None = None,
+        sharing: Literal["shared", "exclusive"] = "shared",
+    ):
+        deferred = size_in_bytes is None
+        if size_in_bytes is not None:
+            if not isinstance(size_in_bytes, int) or isinstance(size_in_bytes, bool):
+                raise TypeError("TempStorage size_in_bytes must be an integer or None.")
+            if size_in_bytes <= 0:
+                raise ValueError(
+                    "TempStorage size_in_bytes must be a positive integer."
+                )
+
+        if alignment is not None:
+            if not isinstance(alignment, int) or isinstance(alignment, bool):
+                raise TypeError("TempStorage alignment must be an integer or None.")
+            if alignment <= 0:
+                raise ValueError("TempStorage alignment must be a positive integer.")
+            if alignment & (alignment - 1):
+                raise ValueError("TempStorage alignment must be a power of 2.")
+
+        if not isinstance(sharing, str):
+            raise TypeError(
+                "TempStorage sharing must be a string: 'shared' or 'exclusive'."
+            )
+        sharing_value = sharing.strip().lower()
+        if sharing_value not in _TEMP_STORAGE_SHARING_VALUES:
+            raise ValueError("TempStorage sharing must be 'shared' or 'exclusive'.")
+
+        if auto_sync is not None and not isinstance(auto_sync, bool):
+            raise TypeError("TempStorage auto_sync must be None/True/False.")
+        if sharing_value == "exclusive" and auto_sync is True:
+            raise ValueError(
+                "TempStorage with sharing='exclusive' does not support auto_sync=True."
+            )
+        self.size_in_bytes = size_in_bytes
+        self.alignment = alignment
+        self.sharing = sharing_value
+        self.auto_sync = (
+            False
+            if sharing_value == "exclusive"
+            else (True if auto_sync is None else auto_sync)
+        )
+        self._deferred = deferred
+        self._required_size_in_bytes = 0
+        self._required_alignment = 1
+        self._uses: list[TempStorageUse] = []
+        self._primitive_slices: dict[str, TempStorageSlice] = {}
+        self._planned_size_in_bytes = 0
+
+    def record_use(
+        self,
+        primitive_name: str,
+        *,
+        required_size_in_bytes: int = 0,
+        required_alignment: int = 1,
+    ) -> TempStorageUse:
+        if not isinstance(required_size_in_bytes, int) or isinstance(
+            required_size_in_bytes, bool
+        ):
+            raise TypeError("required_size_in_bytes must be an integer")
+        if required_size_in_bytes < 0:
+            raise ValueError("required_size_in_bytes must be >= 0")
+        if not isinstance(required_alignment, int) or isinstance(
+            required_alignment, bool
+        ):
+            raise TypeError("required_alignment must be an integer")
+        if required_alignment <= 0:
+            raise ValueError("required_alignment must be > 0")
+        if required_alignment & (required_alignment - 1):
+            raise ValueError("required_alignment must be a power of two")
+
+        if (
+            self.size_in_bytes is not None
+            and self.size_in_bytes < required_size_in_bytes
+        ):
+            raise ValueError(
+                "TempStorage size_in_bytes is smaller than required by primitive "
+                f"use ({self.size_in_bytes} < {required_size_in_bytes})"
+            )
+        if self.alignment is not None and self.alignment < required_alignment:
+            raise ValueError(
+                "TempStorage alignment is smaller than required by primitive use "
+                f"({self.alignment} < {required_alignment})"
+            )
+
+        slice_plan, next_planned_size = _plan_primitive_slice(
+            self._primitive_slices,
+            primitive_name,
+            sharing=self.sharing,
+            planned_size_in_bytes=self._planned_size_in_bytes,
+            required_size_in_bytes=required_size_in_bytes,
+            required_alignment=required_alignment,
+        )
+        if self.size_in_bytes is not None and self.size_in_bytes < next_planned_size:
+            raise ValueError(
+                "TempStorage size_in_bytes is smaller than the cumulative planned "
+                "primitive uses "
+                f"({self.size_in_bytes} < {next_planned_size})"
+            )
+        self._primitive_slices[primitive_name] = slice_plan
+        self._planned_size_in_bytes = next_planned_size
+
+        self._required_size_in_bytes = max(
+            self._required_size_in_bytes, required_size_in_bytes
+        )
+        self._required_alignment = max(self._required_alignment, required_alignment)
+        use = TempStorageUse(
+            primitive_name=primitive_name,
+            required_size_in_bytes=required_size_in_bytes,
+            required_alignment=required_alignment,
+            byte_offset_in_bytes=slice_plan.byte_offset_in_bytes,
+        )
+        self._uses.append(use)
+        return use
+
+    @property
+    def uses(self) -> tuple[TempStorageUse, ...]:
+        return tuple(self._uses)
+
+    @property
+    def is_deferred(self) -> bool:
+        """Whether this storage is finalized after whole-kernel tracing."""
+
+        return self._deferred
+
+    @property
+    def required_size_in_bytes(self) -> int:
+        return self._planned_size_in_bytes
+
+    @property
+    def capacity_size_in_bytes(self) -> int | None:
+        return self.size_in_bytes
+
+    @property
+    def required_alignment(self) -> int:
+        return (
+            self.alignment if self.alignment is not None else self._required_alignment
+        )
+
+    def reset_uses(self) -> None:
+        self._required_size_in_bytes = 0
+        self._required_alignment = 1
+        self._uses.clear()
+        self._primitive_slices.clear()
+        self._planned_size_in_bytes = 0
+
+    def _snapshot_uses(self):
+        return (
+            self._required_size_in_bytes,
+            self._required_alignment,
+            list(self._uses),
+            dict(self._primitive_slices),
+            self._planned_size_in_bytes,
+        )
+
+    def _restore_uses(self, snapshot) -> None:
+        (
+            self._required_size_in_bytes,
+            self._required_alignment,
+            uses,
+            primitive_slices,
+            self._planned_size_in_bytes,
+        ) = snapshot
+        self._uses = list(uses)
+        self._primitive_slices = dict(primitive_slices)
+
+    def slice_for_primitive(self, primitive_name: str) -> TempStorageSlice | None:
+        return self._primitive_slices.get(primitive_name)
+
+    def slice_for_latest_use(self, primitive_name: str) -> TempStorageSlice | None:
+        if not self._uses or self._uses[-1].primitive_name != primitive_name:
+            return None
+        use = self._uses[-1]
+        return TempStorageSlice(
+            byte_offset_in_bytes=use.byte_offset_in_bytes,
+            size_in_bytes=use.required_size_in_bytes,
+            alignment=use.required_alignment,
+        )
+
+
+class TempStorage(TempStorageBase):
+    """Identity-scoped scratch planner for CUTLASS block collectives."""
+
+    scope = "cuda.coop.cutlass"
+
+    def sync(self) -> None:
+        """Synchronize the threads that may reuse this block scratch."""
+
+        from ._thread_group import this_block
+
+        this_block().sync()
+
+
+__all__ = ["TempStorage"]

--- a/python/cuda_coop/cuda/coop/cutlass/_temp_storage.pyi
+++ b/python/cuda_coop/cuda/coop/cutlass/_temp_storage.pyi
@@ -1,0 +1,41 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Typing declarations for explicit CUTLASS temporary storage."""
+
+from .._typing import TempStorageSharing
+
+class TempStorage:
+    """Explicit CUTLASS shared-memory scratch planner."""
+
+    size_in_bytes: int | None
+    alignment: int | None
+    auto_sync: bool
+    sharing: TempStorageSharing
+
+    def __init__(
+        self,
+        size_in_bytes: int | None = None,
+        alignment: int | None = None,
+        auto_sync: bool | None = None,
+        sharing: TempStorageSharing = "shared",
+    ) -> None:
+        """Configure scratch capacity, alignment, synchronization, and sharing."""
+
+    @property
+    def required_size_in_bytes(self) -> int:
+        """Return scratch bytes required by recorded collective uses."""
+
+    @property
+    def capacity_size_in_bytes(self) -> int | None:
+        """Return the explicit capacity, or ``None`` for deferred storage."""
+
+    @property
+    def required_alignment(self) -> int:
+        """Return the strongest alignment required by recorded uses."""
+
+    def sync(self) -> None:
+        """Synchronize threads that may reuse this scratch allocation."""
+
+__all__ = ["TempStorage"]

--- a/python/cuda_coop/cuda/coop/cutlass/_thread_data.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_thread_data.py
@@ -1,0 +1,960 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Register-resident per-thread payloads for CUTLASS collectives.
+
+``ThreadData`` is a public semantic type. Compiler-specific validation remains
+lazy so constructing or inspecting the type does not activate provider code.
+"""
+
+from __future__ import annotations
+
+import inspect as _inspect
+import operator as _operator
+from collections.abc import Callable, Iterator
+from copy import deepcopy as _deepcopy
+from typing import Any, Literal, Protocol
+
+from ._prims import is_cutlass_array_operand as _is_cutlass_array_operand
+from ._value_metadata import (
+    merge_value_metadata,
+    thread_data_metadata,
+    value_group_metadata,
+)
+
+_merge_group_metadata = merge_value_metadata
+_thread_data_metadata = thread_data_metadata
+_value_group_metadata = value_group_metadata
+
+_ROOT_SCOPE = "cuda.coop.cutlass"
+_UNSET = object()
+_THREAD_DATA_LOAD_ATTR = "__cuda_coop_thread_data_load__"
+_MEMORY_PROTOCOL_ATTRS = (
+    "__array_interface__",
+    "__cuda_array_interface__",
+    "__dlpack__",
+    "__dlpack_device__",
+)
+_COMMON_ROOT_OPERATION_FAMILIES = {
+    "reduce": frozenset({"reduce", "sum"}),
+    "scan": frozenset(
+        {
+            "scan",
+            "exclusive_sum",
+            "inclusive_sum",
+            "exclusive_scan",
+            "inclusive_scan",
+        }
+    ),
+}
+
+
+class ThreadDataLoadSource(Protocol):
+    """Producer capability that loads one payload into per-thread registers.
+
+    Implementations own the storage-specific copy policy and expose it through
+    this trace-time hook.
+    """
+
+    def __cuda_coop_thread_data_load__(self) -> Any:
+        """Return a register payload that :meth:`ThreadData.load` can adapt."""
+        ...
+
+
+class ThreadDataTensorMetadata(Protocol):
+    """Static shape and dtype used to reconstruct a CuTe ``TensorSSA``."""
+
+    @property
+    def shape(self) -> Any:
+        """Static shape of the target register payload."""
+        ...
+
+    @property
+    def dtype(self) -> Any:
+        """Element type of the target register payload."""
+        ...
+
+
+class ThreadDataSource(
+    ThreadDataLoadSource,
+    ThreadDataTensorMetadata,
+    Protocol,
+):
+    """Producer source that supports loading and TensorSSA reconstruction."""
+
+
+def _normalize_index_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        normalized = _operator.index(value)
+    except Exception:
+        return None
+    if isinstance(normalized, bool):
+        return None
+    return int(normalized)
+
+
+def _normalize_group_width(value: Any) -> int | None:
+    try:
+        normalized = _normalize_index_int(value)
+    except Exception:
+        return None
+    if normalized is not None and normalized > 0:
+        return normalized
+    return None
+
+
+def _get_optional_metadata_attr(value: Any, attr_name: str) -> Any:
+    try:
+        return getattr(value, attr_name, None)
+    except Exception:
+        return None
+
+
+def _first_optional_metadata_attr(value: Any, attr_names: tuple[str, ...]) -> Any:
+    for attr_name in attr_names:
+        candidate = _get_optional_metadata_attr(value, attr_name)
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _require_like_metadata_attr(value: Any, attr_name: str, *, source: str) -> Any:
+    try:
+        metadata = getattr(value, attr_name)
+    except Exception as exc:
+        raise TypeError(
+            f"{source} like= source must expose accessible {attr_name} metadata"
+        ) from exc
+    if metadata is None:
+        raise TypeError(
+            f"{source} like= source must expose non-None {attr_name} metadata"
+        )
+    return metadata
+
+
+def _infer_1d_static_extent(shape: Any) -> int | None:
+    inferred = _normalize_group_width(shape)
+    if inferred is not None:
+        return inferred
+    if isinstance(shape, (tuple, list)) and len(shape) == 1:
+        return _normalize_group_width(shape[0])
+    return None
+
+
+def _infer_static_extent(shape: Any) -> int | None:
+    inferred = _normalize_group_width(shape)
+    if inferred is not None:
+        return inferred
+    if not isinstance(shape, (tuple, list)) or len(shape) == 0:
+        return None
+
+    extent = 1
+    for dimension in shape:
+        inferred = _infer_static_extent(dimension)
+        if inferred is None:
+            return None
+        extent *= inferred
+    return extent
+
+
+def _infer_fragment_items_per_thread(
+    fragment: Any,
+    *,
+    allow_nested: bool = True,
+) -> int | None:
+    infer_extent = _infer_static_extent if allow_nested else _infer_1d_static_extent
+
+    # Prefer explicit tensor-like shape metadata when available.
+    for attr_name in ("shape",):
+        candidate = _get_optional_metadata_attr(fragment, attr_name)
+        inferred = infer_extent(candidate)
+        if inferred is not None:
+            return inferred
+
+    # Fall back to layout/type metadata for tensor-like fragments.
+    layout = _get_optional_metadata_attr(fragment, "layout")
+    if layout is not None:
+        inferred = infer_extent(_get_optional_metadata_attr(layout, "shape"))
+        if inferred is not None:
+            return inferred
+
+    fragment_type = _get_optional_metadata_attr(fragment, "type")
+    if fragment_type is not None:
+        inferred = infer_extent(_get_optional_metadata_attr(fragment_type, "shape"))
+        if inferred is not None:
+            return inferred
+
+    return None
+
+
+def _infer_vector_items_per_thread(vector: Any) -> int | None:
+    numel = _get_optional_metadata_attr(vector, "numel")
+    if callable(numel):
+        try:
+            inferred = _normalize_group_width(numel())
+        except Exception:
+            inferred = None
+        if inferred is not None:
+            return inferred
+
+    inferred = _infer_fragment_items_per_thread(vector, allow_nested=False)
+    if inferred is not None:
+        return inferred
+
+    candidate = _get_optional_metadata_attr(vector, "_shape")
+    return _infer_1d_static_extent(candidate)
+
+
+def _is_register_fragment(value: Any) -> bool:
+    try:
+        memspace = getattr(value, "memspace", None)
+    except Exception:
+        return False
+    return _is_register_memory_space(memspace)
+
+
+def _is_register_memory_space(memspace: Any) -> bool:
+    register_spaces = []
+    try:
+        from cutlass import AddressSpace as CutlassAddressSpace
+
+        register_spaces.append(CutlassAddressSpace.rmem)
+    except Exception:
+        pass
+    try:
+        from cutlass._mlir.dialects.cute import AddressSpace as CuteAddressSpace
+
+        register_spaces.append(CuteAddressSpace.rmem)
+    except Exception:
+        pass
+
+    for register_space in register_spaces:
+        try:
+            if memspace == register_space:
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _has_memory_space(value: Any) -> bool:
+    for attr_name in ("memspace", "space"):
+        try:
+            attr = getattr(value, attr_name, None)
+        except Exception:
+            try:
+                _inspect.getattr_static(value, attr_name)
+            except AttributeError:
+                continue
+            return True
+        if attr is not None:
+            return True
+    return False
+
+
+def _has_memory_protocol(value: Any) -> bool:
+    for attr_name in _MEMORY_PROTOCOL_ATTRS:
+        try:
+            _inspect.getattr_static(value, attr_name)
+        except AttributeError:
+            pass
+        else:
+            return True
+
+        try:
+            attr = getattr(value, attr_name, None)
+        except Exception:
+            return True
+        if attr is not None:
+            return True
+    return False
+
+
+def _is_memory_backed_payload(value: Any) -> bool:
+    return (
+        _is_cutlass_array_payload(value)
+        or _has_memory_space(value)
+        or _has_memory_protocol(value)
+    )
+
+
+def _is_cutlass_array_payload(value: Any) -> bool:
+    return _is_cutlass_array_operand(value)
+
+
+def _is_cutlass_dsl_dtype(dtype: Any) -> bool:
+    return isinstance(dtype, type) and dtype.__module__ == "cutlass.base_dsl.typing"
+
+
+def _is_ordinary_scalar_dtype(dtype: Any) -> bool:
+    if any(dtype is candidate for candidate in (bool, int, float, complex)):
+        return True
+    if not isinstance(dtype, type) or dtype.__module__.split(".", 1)[0] != "numpy":
+        return False
+
+    # NumPy is not a base dependency of cuda-coop.  Import it only when the
+    # caller has already supplied a NumPy-owned scalar type so importing the
+    # qualified CUTLASS namespace remains dependency-light.
+    try:
+        import numpy as np
+    except ImportError:
+        return False
+    return issubclass(dtype, np.generic)
+
+
+def _coerce_payload_values_to_dtype(
+    values: tuple[Any, ...],
+    dtype: Any,
+    *,
+    source: str,
+) -> tuple[Any, ...]:
+    if not (_is_cutlass_dsl_dtype(dtype) or _is_ordinary_scalar_dtype(dtype)):
+        return values
+
+    coerced = []
+    for idx, value in enumerate(values):
+        if value is _UNSET:
+            coerced.append(value)
+            continue
+        try:
+            if isinstance(value, dtype):
+                coerced.append(value)
+            else:
+                coerced.append(dtype(value))
+        except Exception as exc:
+            raise TypeError(
+                f"{source} dtype cannot be applied to payload item {idx}"
+            ) from exc
+    return tuple(coerced)
+
+
+def _validate_items_per_thread(value: Any) -> int:
+    normalized = _normalize_index_int(value)
+    if normalized is None:
+        raise TypeError("items_per_thread must be an integer")
+    if normalized <= 0:
+        raise ValueError("items_per_thread must be a positive integer")
+    return normalized
+
+
+def _resolve_items_per_thread(
+    *,
+    explicit: Any,
+    infer: Callable[[], int | None],
+    source: str,
+    missing_message: str,
+) -> int:
+    explicit = None if explicit is None else _validate_items_per_thread(explicit)
+    inferred = infer()
+    if explicit is None:
+        if inferred is not None:
+            return inferred
+        raise ValueError(missing_message)
+    if inferred is not None and explicit != inferred:
+        raise ValueError(
+            f"{source} items_per_thread does not match payload item count "
+            f"({explicit} != {inferred})"
+        )
+    return explicit
+
+
+def _resolve_export_shape(
+    shape: Any,
+    *,
+    items_per_thread: int,
+    source: str,
+) -> Any:
+    if shape is None:
+        return (items_per_thread,)
+    inferred = _infer_static_extent(shape)
+    if inferred is None:
+        raise ValueError(f"{source} shape must be positive and fully static")
+    if inferred != items_per_thread:
+        raise ValueError(
+            f"{source} shape must contain exactly items_per_thread elements "
+            f"({inferred} != {items_per_thread})"
+        )
+    return shape
+
+
+def _resolve_export_dtype(dtype: Any, *, fallback: Any, source: str) -> Any:
+    dtype = fallback if dtype is None else dtype
+    if dtype is None:
+        raise TypeError(f"{source} requires dtype when ThreadData.dtype is not set")
+    try:
+        from cutlass.base_dsl.typing import Numeric
+    except Exception as exc:
+        raise TypeError(f"{source} requires a CUTLASS Numeric dtype") from exc
+    if not isinstance(dtype, type) or not issubclass(dtype, Numeric):
+        raise TypeError(f"{source} dtype must be a CUTLASS Numeric type")
+    return dtype
+
+
+def _validate_export_domain(value: ThreadData, *, source: str) -> None:
+    metadata = _thread_data_metadata(value)
+    if metadata is not None and metadata.defined_domain.constraints:
+        raise ValueError(
+            f"{source} requires ThreadData values defined for all calling threads; "
+            "root-only and incomplete-group results must remain ThreadData"
+        )
+
+
+class ThreadData:
+    """Per-thread register payload used by CUTLASS cooperative primitives.
+
+    ``ThreadData`` carries the number of logical items owned by each thread,
+    optional dtype metadata, and the per-item register values traced by a
+    CUTLASS DSL kernel. Block- and warp-group primitives infer
+    ``items_per_thread`` from this object, so users specify the item count once
+    when constructing the payload.
+    """
+
+    def __init__(
+        self,
+        items_per_thread: int,
+        dtype: Any = None,
+        *,
+        values: tuple[Any, ...] | list[Any] | None = None,
+    ):
+        items_per_thread = _validate_items_per_thread(items_per_thread)
+
+        from cuda.coop._core.api._dispatch import _common_root_operation_name
+
+        common_root = _common_root_operation_name() == "ThreadData"
+        if dtype is not None and common_root:
+            from ._compiler._state import _validate_common_root_numeric_dtype
+
+            _validate_common_root_numeric_dtype(dtype, operation="ThreadData")
+
+        if values is not None:
+            if not isinstance(values, (tuple, list)):
+                raise TypeError("values must be a tuple/list when provided")
+            if len(values) != items_per_thread:
+                raise ValueError(
+                    "values length must match items_per_thread "
+                    f"({len(values)} != {items_per_thread})"
+                )
+
+        self.items_per_thread = items_per_thread
+        self.dtype = dtype
+        self._values = (
+            list(values)
+            if values is not None
+            else [_UNSET for _ in range(self.items_per_thread)]
+        )
+        self._common_root = common_root
+        self._item_group_metadata = [
+            _value_group_metadata(value) for value in self._values
+        ]
+        self._refresh_group_metadata()
+
+    @classmethod
+    def from_values(cls, *values: Any, dtype: Any = None) -> ThreadData:
+        if len(values) == 0:
+            raise ValueError("ThreadData.from_values requires at least one value")
+        return cls(len(values), dtype=dtype, values=list(values))
+
+    @classmethod
+    def from_fn(
+        cls,
+        items_per_thread: int,
+        fn: Callable[[int], Any],
+        *,
+        dtype: Any = None,
+    ) -> ThreadData:
+        """Build ThreadData by calling ``fn(item_idx)`` for each item."""
+        items_per_thread = _validate_items_per_thread(items_per_thread)
+        if not callable(fn):
+            raise TypeError("ThreadData.from_fn requires a callable")
+
+        values = []
+        for item_idx in range(items_per_thread):
+            try:
+                values.append(fn(item_idx))
+            except Exception as exc:
+                raise TypeError(
+                    f"ThreadData.from_fn callable failed for item {item_idx}"
+                ) from exc
+        values = _coerce_payload_values_to_dtype(
+            tuple(values),
+            dtype,
+            source="ThreadData.from_fn",
+        )
+        return cls.from_values(*values, dtype=dtype)
+
+    @classmethod
+    def from_register_tensor(
+        cls,
+        fragment: Any,
+        *,
+        items_per_thread: int | None = None,
+        dtype: Any = None,
+    ) -> ThreadData:
+        """
+        Build ThreadData from a per-thread register-backed CuTe tensor fragment.
+
+        This bridge is intentionally strict: it only accepts rmem fragments so users
+        cannot accidentally pass global/shared tensors as cooperative thread payload.
+        Passing an explicit CUTLASS DSL dtype casts the extracted register values
+        to that dtype.
+        """
+        try:
+            memspace = getattr(fragment, "memspace", None)
+        except Exception as exc:
+            raise TypeError(
+                "ThreadData.from_register_tensor requires a register-memory "
+                "(rmem) CuTe tensor fragment"
+            ) from exc
+        if not _is_register_memory_space(memspace):
+            raise TypeError(
+                "ThreadData.from_register_tensor requires a register-memory "
+                "(rmem) CuTe tensor fragment"
+            )
+
+        items_per_thread = _resolve_items_per_thread(
+            explicit=items_per_thread,
+            infer=lambda: _infer_fragment_items_per_thread(fragment),
+            source="ThreadData.from_register_tensor",
+            missing_message=(
+                "ThreadData.from_register_tensor could not infer items_per_thread "
+                "from fragment shape; pass items_per_thread explicitly"
+            ),
+        )
+
+        if dtype is None:
+            dtype = _get_optional_metadata_attr(fragment, "element_type")
+
+        values = tuple(fragment[idx] for idx in range(items_per_thread))
+        values = _coerce_payload_values_to_dtype(
+            values,
+            dtype,
+            source="ThreadData.from_register_tensor",
+        )
+        return cls.from_values(*values, dtype=dtype)
+
+    @classmethod
+    def from_vector(
+        cls,
+        vector: Any,
+        *,
+        items_per_thread: int | None = None,
+        dtype: Any = None,
+    ) -> ThreadData:
+        """
+        Build ThreadData from a register vector-like object.
+
+        This bridge accepts CuTe ``TensorSSA`` values and CUTLASS register
+        vectors that expose a static item count through ``numel()`` or 1-D shape
+        metadata and support integer indexing for each per-thread item.
+        """
+        if _is_memory_backed_payload(vector):
+            raise TypeError(
+                "ThreadData.from_vector requires a CUTLASS vector-like "
+                "per-thread payload; use ThreadData.from_register_tensor for "
+                "CuTe register fragments, or a group-first load for cutlass.Array "
+                "values and memory tensors"
+            )
+
+        items_per_thread = _resolve_items_per_thread(
+            explicit=items_per_thread,
+            infer=lambda: _infer_vector_items_per_thread(vector),
+            source="ThreadData.from_vector",
+            missing_message=(
+                "ThreadData.from_vector could not infer items_per_thread "
+                "from vector shape; pass items_per_thread explicitly"
+            ),
+        )
+
+        if dtype is None:
+            dtype = _first_optional_metadata_attr(
+                vector,
+                ("dtype", "_dtype", "element_type"),
+            )
+
+        try:
+            values = tuple(vector[idx] for idx in range(items_per_thread))
+        except Exception as exc:
+            raise TypeError(
+                "ThreadData.from_vector requires integer-indexable vector items"
+            ) from exc
+        values = _coerce_payload_values_to_dtype(
+            values,
+            dtype,
+            source="ThreadData.from_vector",
+        )
+        return cls.from_values(*values, dtype=dtype)
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: Any,
+        *,
+        items_per_thread: int | None = None,
+        dtype: Any = None,
+    ) -> ThreadData:
+        """
+        Build ThreadData from a backend-specific per-thread register payload.
+
+        This is the common CUTLASS-root bridge for payloads that are already
+        thread-local: CuTe register-memory fragments are adapted through
+        :meth:`from_register_tensor`, while CuTe ``TensorSSA`` and CUTLASS
+        vector-like values are adapted through :meth:`from_vector`.
+        Memory-backed tensors and arrays remain outside this boundary; use
+        group-first load/store helpers to move them into per-thread registers
+        first.
+        """
+        if isinstance(payload, cls):
+            if items_per_thread is not None:
+                items_per_thread = _validate_items_per_thread(items_per_thread)
+                if payload.items_per_thread != items_per_thread:
+                    raise ValueError(
+                        "ThreadData.from_payload items_per_thread does not match "
+                        "payload.items_per_thread"
+                    )
+            if dtype is None or payload.dtype == dtype:
+                return payload
+            if payload.dtype is not None:
+                raise TypeError("ThreadData.from_payload dtype does not match payload")
+            if payload._common_root:
+                from ._compiler._state import _validate_common_root_numeric_dtype
+
+                _validate_common_root_numeric_dtype(
+                    dtype,
+                    operation="ThreadData",
+                )
+            values = _coerce_payload_values_to_dtype(
+                tuple(payload._values),
+                dtype,
+                source="ThreadData.from_payload",
+            )
+            result = cls(payload.items_per_thread, dtype=dtype, values=values)
+            result = payload._preserve_common_root(result)
+            return payload._preserve_group_metadata(result)
+
+        if _is_register_fragment(payload):
+            return cls.from_register_tensor(
+                payload,
+                items_per_thread=items_per_thread,
+                dtype=dtype,
+            )
+        if _is_memory_backed_payload(payload):
+            raise TypeError(
+                "ThreadData.from_payload requires a per-thread register payload; "
+                "use ThreadData.from_register_tensor for CuTe register fragments, "
+                "or a group-first load for cutlass.Array values and memory tensors"
+            )
+        return cls.from_vector(
+            payload,
+            items_per_thread=items_per_thread,
+            dtype=dtype,
+        )
+
+    @classmethod
+    def load(
+        cls,
+        source: ThreadDataLoadSource,
+        *,
+        items_per_thread: int | None = None,
+        dtype: Any = None,
+    ) -> ThreadData:
+        """Load a producer-owned source into per-thread registers.
+
+        The source must explicitly implement the private
+        ``__cuda_coop_thread_data_load__`` tracing hook. The producer owns any
+        required tensor-memory-to-register copy, including its copy atom,
+        thread partition, readiness, and lifetime. The hook must return either
+        ``ThreadData`` or a statically sized per-thread register payload
+        accepted by :meth:`from_payload`. The hook is invoked exactly once by
+        each call during DSL tracing; a single-use producer source is
+        responsible for rejecting a second call.
+
+        Bare memory-backed tensors are intentionally not interpreted here:
+        their address space and shape do not provide enough information to
+        safely select or schedule a register load.
+
+        ``items_per_thread`` and ``dtype`` are optional static constraints on
+        the returned register payload, matching :meth:`from_payload`.
+        """
+
+        if items_per_thread is not None:
+            items_per_thread = _validate_items_per_thread(items_per_thread)
+        source_type = type(source).__name__
+        try:
+            _inspect.getattr_static(source, _THREAD_DATA_LOAD_ATTR)
+        except AttributeError:
+            if _is_memory_backed_payload(source):
+                raise TypeError(
+                    f"ThreadData.load source {source_type} requires a producer-provided "
+                    f"{_THREAD_DATA_LOAD_ATTR} hook; bare memory-backed tensors "
+                    "including TMEM do not carry the copy atom, thread partition, "
+                    "readiness, and lifetime needed for a safe register load"
+                ) from None
+            raise TypeError(
+                "ThreadData.load requires source to define the producer-provided "
+                f"{_THREAD_DATA_LOAD_ATTR} hook; got {source_type}"
+            ) from None
+
+        try:
+            load_payload = getattr(source, _THREAD_DATA_LOAD_ATTR)
+        except Exception as exc:
+            raise TypeError(
+                f"ThreadData.load could not access {source_type}'s producer-provided "
+                f"{_THREAD_DATA_LOAD_ATTR} hook"
+            ) from exc
+        if not callable(load_payload):
+            raise TypeError(
+                f"ThreadData.load source {source_type} requires the producer-provided "
+                f"{_THREAD_DATA_LOAD_ATTR} hook to be callable"
+            )
+
+        payload = load_payload()
+        payload_type = type(payload).__name__
+
+        try:
+            return cls.from_payload(
+                payload,
+                items_per_thread=items_per_thread,
+                dtype=dtype,
+            )
+        except TypeError as exc:
+            raise TypeError(
+                f"ThreadData.load hook on {source_type} returned {payload_type}; "
+                "expected ThreadData or a statically sized per-thread register "
+                f"payload: {exc}"
+            ) from exc
+        except ValueError as exc:
+            raise ValueError(
+                f"ThreadData.load hook on {source_type} returned {payload_type}; "
+                "expected ThreadData or a statically sized per-thread register "
+                f"payload: {exc}"
+            ) from exc
+
+    def to_tensor_ssa(
+        self,
+        *,
+        dtype: Any = None,
+        shape: Any = None,
+        like: ThreadDataTensorMetadata | None = None,
+    ) -> Any:
+        """Materialize this payload as a register-only CuTe ``TensorSSA``.
+
+        The default shape is ``(items_per_thread,)``. An explicit shape may be
+        nested, but it must be positive, fully static, and contain the same
+        number of logical elements. The result preserves ``ThreadData`` flat
+        item order; it does not recover an input fragment's original shape.
+
+        ``like`` supplies missing ``shape`` and ``dtype`` metadata from another
+        static payload or producer capability. Explicit arguments take
+        precedence.
+        """
+
+        source = "ThreadData.to_tensor_ssa"
+        _validate_export_domain(self, source=source)
+        if like is not None:
+            if dtype is None:
+                dtype = _require_like_metadata_attr(
+                    like,
+                    "dtype",
+                    source=source,
+                )
+            if shape is None:
+                shape = _require_like_metadata_attr(
+                    like,
+                    "shape",
+                    source=source,
+                )
+        dtype = _resolve_export_dtype(dtype, fallback=self.dtype, source=source)
+        shape = _resolve_export_shape(
+            shape,
+            items_per_thread=self.items_per_thread,
+            source=source,
+        )
+        values = self.values(source)
+
+        import cutlass.cute as _cute
+        from cutlass import Vector
+
+        vector = Vector.from_elements(values, dtype)
+        return _cute.TensorSSA(vector, shape, dtype)
+
+    def to_register_tensor(
+        self,
+        *,
+        dtype: Any = None,
+        shape: Any = None,
+    ) -> Any:
+        """Materialize this payload as a fresh mutable CuTe rmem tensor.
+
+        This creates addressable register-memory storage and stores a newly
+        assembled ``TensorSSA`` into it. It does not alias this ``ThreadData``
+        object, and code generation may still spill register storage locally.
+        """
+
+        ssa = self.to_tensor_ssa(dtype=dtype, shape=shape)
+
+        from cutlass import cute as _cute
+
+        result = _cute.make_rmem_tensor_like(ssa)
+        result.store(ssa)
+        return result
+
+    def __len__(self) -> int:
+        return self.items_per_thread
+
+    def __getitem__(self, idx: int) -> Any:
+        return self._values[idx]
+
+    def __setitem__(self, idx: int, value: Any) -> None:
+        if self._common_root:
+            from ._compiler._state import _validate_common_root_numeric_dtype
+
+            _validate_common_root_numeric_dtype(value, operation="ThreadData")
+        item_metadata = _value_group_metadata(value)
+        self._values[idx] = value
+        self._item_group_metadata[idx] = item_metadata
+        self._refresh_group_metadata()
+
+    def _refresh_group_metadata(self) -> None:
+        self._group_metadata = _merge_group_metadata(self._item_group_metadata)
+
+    def _set_group_metadata(self, metadata: Any) -> None:
+        self._item_group_metadata = [metadata] * self.items_per_thread
+        self._group_metadata = metadata
+
+    def _preserve_group_metadata(self, result: ThreadData) -> ThreadData:
+        result._item_group_metadata = list(self._item_group_metadata)
+        result._refresh_group_metadata()
+        return result
+
+    def _preserve_common_root(self, result: ThreadData) -> ThreadData:
+        result._common_root = self._common_root
+        return result
+
+    def __copy__(self) -> ThreadData:
+        result = ThreadData(
+            self.items_per_thread,
+            dtype=self.dtype,
+            values=list(self._values),
+        )
+        result = self._preserve_common_root(result)
+        return self._preserve_group_metadata(result)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> ThreadData:
+        result = ThreadData(
+            self.items_per_thread,
+            dtype=_deepcopy(self.dtype, memo),
+            values=_deepcopy(self._values, memo),
+        )
+        result = self._preserve_common_root(result)
+        memo[id(self)] = result
+        return self._preserve_group_metadata(result)
+
+    def _require_values(self, primitive_name: str | None) -> list[Any]:
+        missing = [idx for idx, value in enumerate(self._values) if value is _UNSET]
+        if missing:
+            context = (
+                "ThreadData iteration"
+                if primitive_name is None
+                else f"{_ROOT_SCOPE}.{primitive_name}"
+            )
+            raise ValueError(
+                f"{context} requires ThreadData values to be initialized before use; "
+                "missing index(es): " + ", ".join(str(i) for i in missing)
+            )
+        return self._values
+
+    def values(self, primitive_name: str) -> tuple[Any, ...]:
+        return tuple(self._require_values(primitive_name))
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._require_values(None))
+
+    def _new_uninitialized(self, *, dtype: Any = None) -> ThreadData:
+        resolved_dtype = self.dtype if dtype is None else dtype
+        if self._common_root and resolved_dtype is not None:
+            from ._compiler._state import _validate_common_root_numeric_dtype
+
+            _validate_common_root_numeric_dtype(
+                resolved_dtype,
+                operation="ThreadData",
+            )
+        result = ThreadData(
+            self.items_per_thread,
+            dtype=resolved_dtype,
+        )
+        return self._preserve_common_root(result)
+
+
+def _is_thread_payload_candidate(value: Any) -> bool:
+    if _is_register_fragment(value) or _is_memory_backed_payload(value):
+        return True
+    # A callable numel() is the stable TensorSSA/vector recognition hook even
+    # when it reports an invalid or non-static extent. Keep recognition
+    # separate from successful extent inference so malformed register vectors
+    # produce the same targeted conversion error as malformed rmem fragments
+    # instead of falling through as scalar operands.
+    if callable(_get_optional_metadata_attr(value, "numel")):
+        return True
+    return _infer_vector_items_per_thread(value) is not None
+
+
+def _coerce_thread_payload(
+    value: Any,
+    *,
+    scope: str,
+    primitive_name: str,
+    arg_name: str,
+    common_root_payload_kind: Literal[
+        "thread_data",
+        "scalar_or_thread_data",
+    ]
+    | None = None,
+) -> Any:
+    """Adapt a backend register payload without widening the common contract."""
+
+    if common_root_payload_kind is not None:
+        from cuda.coop._core.api._dispatch import _common_root_operation_name
+
+        common_operation = _common_root_operation_name()
+        family = _COMMON_ROOT_OPERATION_FAMILIES.get(
+            primitive_name,
+            frozenset({primitive_name}),
+        )
+        if common_operation in family:
+            assert common_operation is not None
+            if common_root_payload_kind == "thread_data":
+                if not isinstance(value, ThreadData):
+                    raise TypeError(
+                        f"cuda.coop.{common_operation} requires a fixed-size "
+                        f"ThreadData {arg_name} payload in the portable API; use "
+                        "cuda.coop.cutlass for backend-qualified scalar or "
+                        "register payload support"
+                    )
+            elif common_root_payload_kind == "scalar_or_thread_data":
+                if not isinstance(value, ThreadData) and _is_thread_payload_candidate(
+                    value
+                ):
+                    raise TypeError(
+                        f"cuda.coop.{common_operation} accepts only a scalar or "
+                        f"fixed-size ThreadData {arg_name} payload in the portable API; "
+                        "use cuda.coop.cutlass for backend-qualified register "
+                        "payload support"
+                    )
+            else:  # pragma: no cover - the annotation defines the private contract.
+                raise ValueError(
+                    "common_root_payload_kind must be 'thread_data' or "
+                    "'scalar_or_thread_data'"
+                )
+
+    if isinstance(value, ThreadData) or not _is_thread_payload_candidate(value):
+        return value
+    try:
+        return ThreadData.from_payload(value)
+    except Exception as exc:
+        raise TypeError(
+            f"{scope}.{primitive_name} could not auto-convert "
+            f"'{arg_name}' payload to ThreadData: {exc}"
+        ) from exc

--- a/python/cuda_coop/cuda/coop/cutlass/_thread_data.pyi
+++ b/python/cuda_coop/cuda/coop/cutlass/_thread_data.pyi
@@ -1,0 +1,544 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Typing declarations for CUTLASS per-thread register payloads."""
+
+from collections.abc import Callable, Iterator
+from typing import Any, Generic, Protocol, TypeAlias, overload
+
+import numpy as np
+from typing_extensions import TypeVar
+
+from .._typing import ThreadDataLike
+
+_ItemT = TypeVar("_ItemT", default=Any)
+_SourceT_co = TypeVar("_SourceT_co", covariant=True)
+_ValueT = TypeVar("_ValueT")
+_OrdinaryNumericScalar: TypeAlias = (
+    int
+    | float
+    | np.uint8
+    | np.int32
+    | np.uint32
+    | np.int64
+    | np.uint64
+    | np.float32
+    | np.float64
+)
+_DtypeT = TypeVar("_DtypeT", bound=_OrdinaryNumericScalar)
+
+class _CutlassNumericDtype(Protocol):
+    """Structural metadata carried by a CUTLASS ``Numeric`` dtype class."""
+
+    width: int
+
+class CutlassTensorSample(Protocol):
+    """Structural view of one CUTLASS register-memory Tensor."""
+
+    @property
+    def element_type(self) -> object: ...
+    @property
+    def shape(self) -> object: ...
+    @property
+    def memspace(self) -> object: ...
+    def __getitem__(self, index: int, /) -> Any:
+        """Return one register value."""
+    def load(self) -> object:
+        """Load this register-memory tensor as an immutable value."""
+
+class CutlassTensorSSASample(Protocol):
+    """Structural view of one CUTLASS immutable register TensorSSA."""
+
+    @property
+    def dtype(self) -> object: ...
+    @property
+    def shape(self) -> object: ...
+    def __getitem__(self, index: int, /) -> Any:
+        """Return one register value."""
+    def ir_value(self) -> object:
+        """Return this immutable register tensor's compiler IR value."""
+
+class _ThreadDataVectorSource(Protocol[_SourceT_co]):
+    """Integer-indexable register payload accepted by ``ThreadData``."""
+
+    def __getitem__(self, index: int, /) -> _SourceT_co:
+        """Return one register value."""
+
+class _ThreadDataSizedVectorSource(
+    _ThreadDataVectorSource[_SourceT_co],
+    Protocol[_SourceT_co],
+):
+    """Indexable register payload with a statically inferable shape."""
+
+    @property
+    def shape(self) -> object:
+        """Return static payload-shape metadata."""
+
+class _ThreadDataNumelVectorSource(
+    _ThreadDataVectorSource[_SourceT_co],
+    Protocol[_SourceT_co],
+):
+    """Indexable register payload with a statically inferable element count."""
+
+    def numel(self) -> object:
+        """Return the trace-static payload item count."""
+
+_ThreadDataStaticallySizedVectorSource: TypeAlias = (
+    _ThreadDataSizedVectorSource[_SourceT_co]
+    | _ThreadDataNumelVectorSource[_SourceT_co]
+)
+
+class _ThreadDataReadOnlyView(
+    _ThreadDataVectorSource[_SourceT_co],
+    Protocol[_SourceT_co],
+):
+    """Read-only payload view returned by covariant load sources."""
+
+    @property
+    def items_per_thread(self) -> int:
+        """Return the static number of register values."""
+
+class _ThreadDataRegisterTensorSource(
+    _ThreadDataVectorSource[_SourceT_co],
+    Protocol[_SourceT_co],
+):
+    """Integer-indexable register-memory tensor accepted by ``ThreadData``."""
+
+    @property
+    def memspace(self) -> object:
+        """Return the tensor memory-space token."""
+
+class _ThreadDataSizedRegisterTensorSource(
+    _ThreadDataRegisterTensorSource[_SourceT_co],
+    _ThreadDataSizedVectorSource[_SourceT_co],
+    Protocol[_SourceT_co],
+):
+    """Register-memory tensor with a statically inferable shape."""
+
+class ThreadDataLoadSource(Protocol[_SourceT_co]):
+    """Producer of a payload whose static extent can be inferred."""
+
+    def __cuda_coop_thread_data_load__(
+        self,
+    ) -> (
+        _ThreadDataReadOnlyView[_SourceT_co]
+        | _ThreadDataStaticallySizedVectorSource[_SourceT_co]
+    ):
+        """Return one producer-owned register payload exactly once."""
+
+class _ThreadDataIndexableLoadSource(Protocol[_SourceT_co]):
+    """Producer of an indexable payload requiring an explicit item count."""
+
+    def __cuda_coop_thread_data_load__(
+        self,
+    ) -> ThreadData[_SourceT_co] | _ThreadDataVectorSource[_SourceT_co]:
+        """Return one producer-owned register payload exactly once."""
+
+class ThreadDataTensorMetadata(Protocol):
+    """Static shape and dtype used to reconstruct a CUTLASS register tensor."""
+
+    @property
+    def shape(self) -> object:
+        """Return the static register-payload shape."""
+
+    @property
+    def dtype(self) -> object:
+        """Return the CUTLASS element-type token."""
+
+class ThreadDataSource(
+    ThreadDataLoadSource[_SourceT_co],
+    ThreadDataTensorMetadata,
+    Protocol[_SourceT_co],
+):
+    """Producer supporting both register loading and tensor reconstruction."""
+
+class ThreadData(ThreadDataLike[_ItemT], Generic[_ItemT]):
+    """Generic CUTLASS per-thread register payload.
+
+    Python, NumPy, compiler, and user-defined register values preserve their
+    item type through construction and indexing. Unknown external dtype tokens
+    can be annotated as ``Any`` when no more precise type is available.
+
+    The container is broader than the group-first collectives: each operation
+    separately restricts payloads to the numeric, ordered-key, or integer-key
+    family implemented by its CUTLASS provider.
+
+    Python's type system treats ``bool`` as a subtype of ``int``, so static
+    checking cannot exclude it from these overloads. CUTLASS rejects Boolean
+    payload dtypes and values when it validates a traced primitive.
+    """
+
+    items_per_thread: int
+    dtype: object | None
+
+    @overload
+    def __init__(
+        self,
+        items_per_thread: int,
+        dtype: type[_ItemT],
+        *,
+        values: tuple[_ItemT, ...] | list[_ItemT] | None = None,
+    ) -> None:
+        """Construct typed register storage with optional initial values."""
+    @overload
+    def __init__(
+        self,
+        items_per_thread: int,
+        dtype: None = None,
+        *,
+        values: tuple[_ItemT, ...] | list[_ItemT] | None = None,
+    ) -> None:
+        """Construct storage whose item type is inferred from initial values."""
+
+    @classmethod
+    def from_values(
+        cls,
+        first: _ValueT,
+        *rest: _ValueT,
+        dtype: type[Any] | None = None,
+    ) -> ThreadData[_ValueT]:
+        """Preserve the value type; ``dtype`` records metadata without casting."""
+
+    @overload
+    @classmethod
+    def from_fn(
+        cls,
+        items_per_thread: int,
+        fn: Callable[[int], object],
+        *,
+        dtype: type[_DtypeT],
+    ) -> ThreadData[_DtypeT]:
+        """Cast results to ``dtype``; an opaque ``Any`` dtype yields ``Any``."""
+    @overload
+    @classmethod
+    def from_fn(
+        cls,
+        items_per_thread: int,
+        fn: Callable[[int], _ValueT],
+        *,
+        dtype: None = None,
+    ) -> ThreadData[_ValueT]:
+        """Infer the item type from ``fn`` when no dtype cast is requested."""
+    @overload
+    @classmethod
+    def from_fn(
+        cls,
+        items_per_thread: int,
+        fn: Callable[[int], object],
+        *,
+        dtype: object,
+    ) -> ThreadData[Any]:
+        """Accept opaque dtype metadata whose resulting item type is unknown."""
+
+    @overload
+    @classmethod
+    def from_register_tensor(
+        cls,
+        fragment: _ThreadDataSizedRegisterTensorSource[Any],
+        *,
+        items_per_thread: int | None = None,
+        dtype: type[_DtypeT],
+    ) -> ThreadData[_DtypeT]:
+        """Cast a shaped register tensor to the explicit CUTLASS dtype."""
+    @overload
+    @classmethod
+    def from_register_tensor(
+        cls,
+        fragment: _ThreadDataRegisterTensorSource[Any],
+        *,
+        items_per_thread: int,
+        dtype: type[_DtypeT],
+    ) -> ThreadData[_DtypeT]:
+        """Cast an explicitly sized register tensor to ``dtype``."""
+    @overload
+    @classmethod
+    def from_register_tensor(
+        cls,
+        fragment: _ThreadDataSizedRegisterTensorSource[_ValueT],
+        *,
+        items_per_thread: int | None = None,
+        dtype: None = None,
+    ) -> ThreadData[_ValueT]:
+        """Adapt a shaped register tensor and preserve its item type."""
+    @overload
+    @classmethod
+    def from_register_tensor(
+        cls,
+        fragment: _ThreadDataRegisterTensorSource[_ValueT],
+        *,
+        items_per_thread: int,
+        dtype: None = None,
+    ) -> ThreadData[_ValueT]:
+        """Adapt an indexable register tensor using an explicit item count."""
+    @overload
+    @classmethod
+    def from_register_tensor(
+        cls,
+        fragment: _ThreadDataSizedRegisterTensorSource[Any],
+        *,
+        items_per_thread: int | None = None,
+        dtype: object,
+    ) -> ThreadData[Any]:
+        """Adapt a shaped register tensor with opaque dtype metadata."""
+    @overload
+    @classmethod
+    def from_register_tensor(
+        cls,
+        fragment: _ThreadDataRegisterTensorSource[Any],
+        *,
+        items_per_thread: int,
+        dtype: object,
+    ) -> ThreadData[Any]:
+        """Adapt an explicitly sized tensor with opaque dtype metadata."""
+
+    @overload
+    @classmethod
+    def from_vector(
+        cls,
+        vector: _ThreadDataStaticallySizedVectorSource[Any],
+        *,
+        items_per_thread: int | None = None,
+        dtype: type[_DtypeT],
+    ) -> ThreadData[_DtypeT]:
+        """Cast a statically sized register vector to the explicit dtype."""
+    @overload
+    @classmethod
+    def from_vector(
+        cls,
+        vector: _ThreadDataVectorSource[Any],
+        *,
+        items_per_thread: int,
+        dtype: type[_DtypeT],
+    ) -> ThreadData[_DtypeT]:
+        """Cast an explicitly sized register vector to ``dtype``."""
+    @overload
+    @classmethod
+    def from_vector(
+        cls,
+        vector: _ThreadDataStaticallySizedVectorSource[_ValueT],
+        *,
+        items_per_thread: int | None = None,
+        dtype: None = None,
+    ) -> ThreadData[_ValueT]:
+        """Adapt a statically sized register vector and preserve its item type."""
+    @overload
+    @classmethod
+    def from_vector(
+        cls,
+        vector: _ThreadDataVectorSource[_ValueT],
+        *,
+        items_per_thread: int,
+        dtype: None = None,
+    ) -> ThreadData[_ValueT]:
+        """Adapt an indexable register vector using an explicit item count."""
+    @overload
+    @classmethod
+    def from_vector(
+        cls,
+        vector: _ThreadDataStaticallySizedVectorSource[Any],
+        *,
+        items_per_thread: int | None = None,
+        dtype: object,
+    ) -> ThreadData[Any]:
+        """Adapt a statically sized vector with opaque dtype metadata."""
+    @overload
+    @classmethod
+    def from_vector(
+        cls,
+        vector: _ThreadDataVectorSource[Any],
+        *,
+        items_per_thread: int,
+        dtype: object,
+    ) -> ThreadData[Any]:
+        """Adapt an explicitly sized vector with opaque dtype metadata."""
+
+    @overload
+    @classmethod
+    def from_payload(
+        cls,
+        payload: ThreadData[Any],
+        *,
+        items_per_thread: int | None = None,
+        dtype: type[_DtypeT],
+    ) -> ThreadData[_DtypeT]:
+        """Constrain or cast an existing payload to the explicit dtype."""
+    @overload
+    @classmethod
+    def from_payload(
+        cls,
+        payload: _ThreadDataStaticallySizedVectorSource[Any],
+        *,
+        items_per_thread: int | None = None,
+        dtype: type[_DtypeT],
+    ) -> ThreadData[_DtypeT]:
+        """Cast a statically sized backend payload to the explicit dtype."""
+    @overload
+    @classmethod
+    def from_payload(
+        cls,
+        payload: _ThreadDataVectorSource[Any],
+        *,
+        items_per_thread: int,
+        dtype: type[_DtypeT],
+    ) -> ThreadData[_DtypeT]:
+        """Cast an explicitly sized backend payload to ``dtype``."""
+    @overload
+    @classmethod
+    def from_payload(
+        cls,
+        payload: ThreadData[_ValueT],
+        *,
+        items_per_thread: int | None = None,
+        dtype: None = None,
+    ) -> ThreadData[_ValueT]:
+        """Preserve the item type of an existing CUTLASS payload."""
+    @overload
+    @classmethod
+    def from_payload(
+        cls,
+        payload: _ThreadDataStaticallySizedVectorSource[_ValueT],
+        *,
+        items_per_thread: int | None = None,
+        dtype: None = None,
+    ) -> ThreadData[_ValueT]:
+        """Adapt a statically sized backend payload and preserve its item type."""
+    @overload
+    @classmethod
+    def from_payload(
+        cls,
+        payload: _ThreadDataVectorSource[_ValueT],
+        *,
+        items_per_thread: int,
+        dtype: None = None,
+    ) -> ThreadData[_ValueT]:
+        """Adapt an indexable payload using an explicit item count."""
+    @overload
+    @classmethod
+    def from_payload(
+        cls,
+        payload: ThreadData[Any],
+        *,
+        items_per_thread: int | None = None,
+        dtype: object,
+    ) -> ThreadData[Any]:
+        """Constrain an existing payload with opaque dtype metadata."""
+    @overload
+    @classmethod
+    def from_payload(
+        cls,
+        payload: _ThreadDataStaticallySizedVectorSource[Any],
+        *,
+        items_per_thread: int | None = None,
+        dtype: object,
+    ) -> ThreadData[Any]:
+        """Adapt a statically sized payload with opaque dtype metadata."""
+    @overload
+    @classmethod
+    def from_payload(
+        cls,
+        payload: _ThreadDataVectorSource[Any],
+        *,
+        items_per_thread: int,
+        dtype: object,
+    ) -> ThreadData[Any]:
+        """Adapt an explicitly sized payload with opaque dtype metadata."""
+
+    @overload
+    @classmethod
+    def load(
+        cls,
+        source: ThreadDataLoadSource[Any],
+        *,
+        items_per_thread: int | None = None,
+        dtype: type[_DtypeT],
+    ) -> ThreadData[_DtypeT]:
+        """Load and cast a statically sized producer payload to ``dtype``."""
+    @overload
+    @classmethod
+    def load(
+        cls,
+        source: _ThreadDataIndexableLoadSource[Any],
+        *,
+        items_per_thread: int,
+        dtype: type[_DtypeT],
+    ) -> ThreadData[_DtypeT]:
+        """Load and cast an explicitly sized producer payload to ``dtype``."""
+    @overload
+    @classmethod
+    def load(
+        cls,
+        source: ThreadDataLoadSource[_ValueT],
+        *,
+        items_per_thread: int | None = None,
+        dtype: None = None,
+    ) -> ThreadData[_ValueT]:
+        """Load registers and preserve the producer's declared item type."""
+    @overload
+    @classmethod
+    def load(
+        cls,
+        source: _ThreadDataIndexableLoadSource[_ValueT],
+        *,
+        items_per_thread: int,
+        dtype: None = None,
+    ) -> ThreadData[_ValueT]:
+        """Load an indexable producer payload using an explicit item count."""
+    @overload
+    @classmethod
+    def load(
+        cls,
+        source: ThreadDataLoadSource[Any],
+        *,
+        items_per_thread: int | None = None,
+        dtype: object,
+    ) -> ThreadData[Any]:
+        """Load a statically sized producer using opaque dtype metadata."""
+    @overload
+    @classmethod
+    def load(
+        cls,
+        source: _ThreadDataIndexableLoadSource[Any],
+        *,
+        items_per_thread: int,
+        dtype: object,
+    ) -> ThreadData[Any]:
+        """Load an explicitly sized producer using opaque dtype metadata."""
+    def to_tensor_ssa(
+        self,
+        *,
+        dtype: type[_CutlassNumericDtype] | None = None,
+        shape: object = None,
+        like: ThreadDataTensorMetadata | None = None,
+    ) -> CutlassTensorSSASample:
+        """Materialize this payload as a register-only CUTLASS TensorSSA."""
+
+    def to_register_tensor(
+        self,
+        *,
+        dtype: type[_CutlassNumericDtype] | None = None,
+        shape: object = None,
+    ) -> CutlassTensorSample:
+        """Materialize this payload as a fresh mutable register tensor."""
+
+    def values(self, primitive_name: str) -> tuple[_ItemT, ...]:
+        """Return initialized register values for one primitive."""
+
+    def __len__(self) -> int:
+        """Return ``items_per_thread``."""
+
+    def __iter__(self) -> Iterator[_ItemT]:
+        """Iterate initialized register values."""
+
+    def __getitem__(self, index: int, /) -> _ItemT:
+        """Return one register value."""
+
+    def __setitem__(self, index: int, value: _ItemT, /) -> None:
+        """Replace one register value."""
+
+__all__ = [
+    "ThreadData",
+    "ThreadDataLoadSource",
+    "ThreadDataSource",
+    "ThreadDataTensorMetadata",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_thread_group.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_thread_group.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CUTLASS bindings for shared CUDA thread-hierarchy descriptors."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cuda.coop._core import (
+    COMPLETE_WARP_GROUP_KINDS,
+    PHYSICAL_GROUP_KINDS,
+    LaunchFacts,
+    ThreadHierarchy,
+    UnsupportedReasonCode,
+    cpp_level_expr,
+    make_thread_group,
+    normalize_thread_level,
+    render_group_decl,
+    render_group_decl_lines,
+    render_hierarchy_decl,
+    resolve_thread_group,
+)
+from cuda.coop._core.thread_group import ThreadGroup as PortableThreadGroup
+
+_ROOT_SCOPE = __name__.rsplit(".", 1)[0]
+Hierarchy = ThreadHierarchy
+
+
+class ThreadGroup(PortableThreadGroup):
+    """Shared group descriptor with CUTLASS provider operations attached."""
+
+    def rank(self, level: str = "thread") -> Any:
+        """Return this group's rank relative to another hierarchy level."""
+
+        return self.rank_as(None, level)
+
+    def count(self, level: str = "thread") -> Any:
+        """Return this group's count relative to another hierarchy level."""
+
+        return self.count_as(None, level)
+
+    def rank_as(self, dtype: Any = None, level: str = "thread") -> Any:
+        level = normalize_thread_level(
+            level,
+            scope=_ROOT_SCOPE,
+            feature="ThreadGroup.rank",
+        )
+        group = _validate_query_launch(
+            self,
+            feature="ThreadGroup.rank",
+            level=level,
+        )
+        from ._lowering import _thread_group as _provider
+
+        return _provider.provider_group_query(
+            group=group,
+            op="rank",
+            level=level,
+            result_type=dtype,
+        )
+
+    def count_as(self, dtype: Any = None, level: str = "thread") -> Any:
+        level = normalize_thread_level(
+            level,
+            scope=_ROOT_SCOPE,
+            feature="ThreadGroup.count",
+        )
+        group = _validate_query_launch(
+            self,
+            feature="ThreadGroup.count",
+            level=level,
+        )
+        from ._lowering import _thread_group as _provider
+
+        return _provider.provider_group_query(
+            group=group,
+            op="count",
+            level=level,
+            result_type=dtype,
+        )
+
+    def sync(self) -> None:
+        group = _validate_sync_launch(self, feature="ThreadGroup.sync")
+        from ._lowering import _thread_group as _provider
+
+        _provider.provider_group_sync(group=group, aligned=False)
+
+    def sync_aligned(self) -> None:
+        group = _validate_sync_launch(self, feature="ThreadGroup.sync_aligned")
+        from ._lowering import _thread_group as _provider
+
+        _provider.provider_group_sync(group=group, aligned=True)
+
+    def group_by(
+        self,
+        count: int,
+        *,
+        exhaustive: bool = True,
+    ) -> ThreadGroup:
+        return super().group_by(count, exhaustive=exhaustive)
+
+    def is_member(self) -> Any:
+        """Return whether the current thread belongs to this group."""
+
+        group = _validate_membership_launch(
+            self,
+            feature="ThreadGroup.is_member",
+        )
+        from ._lowering import _thread_group as _provider
+
+        return _provider.provider_group_membership(group=group)
+
+
+def _require_complete_warp_partition(
+    group: ThreadGroup,
+    *,
+    feature: str,
+    exact_block_dim: tuple[int, int, int] | None = None,
+) -> None:
+    """Reject warp collectives whose enclosing CTA may have a partial warp."""
+
+    if group.kind not in COMPLETE_WARP_GROUP_KINDS:
+        return
+    assert group.hierarchy is not None
+    block_threads = group.hierarchy.block_thread_count
+    if exact_block_dim is not None:
+        exact_threads = 1
+        for dim in exact_block_dim:
+            exact_threads *= dim
+        block_threads = exact_threads
+    if block_threads is None:
+        raise NotImplementedError(
+            f"{_ROOT_SCOPE}.{feature} requires exact enclosing block dimensions "
+            "to prove complete 32-thread physical-warp participation"
+        )
+    if block_threads % 32 != 0:
+        raise NotImplementedError(
+            f"{_ROOT_SCOPE}.{feature} requires every physical warp in the "
+            f"enclosing CTA to be complete; got {block_threads} block threads"
+        )
+
+
+def _require_resolved_group(
+    group: ThreadGroup,
+    *,
+    feature: str,
+    through_level: str | None = None,
+    allow_unresolved_current: bool = False,
+) -> tuple[ThreadGroup, Any]:
+    """Resolve one group from the active CUTLASS launch facts."""
+
+    from ._compiler._launch import current_kernel_launch_facts
+
+    launch = current_kernel_launch_facts()
+    resolution = resolve_thread_group(
+        group,
+        launch,
+        through_level=through_level,
+    )
+    if (
+        resolution.unsupported is not None
+        and allow_unresolved_current
+        and group.is_current
+        and group.mapping is None
+    ):
+        return group, launch
+    try:
+        resolved = resolution.require_supported()
+    except NotImplementedError as exc:
+        raise NotImplementedError(f"{_ROOT_SCOPE}.{feature} {exc}") from exc
+    return resolved, launch
+
+
+def _collective_group_resolution_error(
+    group: ThreadGroup,
+    *,
+    feature: str,
+) -> str:
+    if group.is_static:
+        return (
+            f"{_ROOT_SCOPE}.{feature} could not prove that the resolved group "
+            "hierarchy matches the exact kernel launch; requires exact block "
+            "dimensions from verified compiler launch facts"
+        )
+    return (
+        f"{_ROOT_SCOPE}.{feature} could not infer static block dimensions from "
+        "verified compiler launch facts; requires exact block dimensions; "
+        "attach reqntid to the kernel"
+    )
+
+
+def _resolve_collective_group_from_launch(
+    group: ThreadGroup,
+    launch: LaunchFacts,
+    *,
+    feature: str,
+) -> ThreadGroup:
+    """Resolve a collective group from launch facts established by its frontend."""
+
+    resolution = resolve_thread_group(group, launch)
+    if (
+        resolution.unsupported is not None
+        and resolution.unsupported.code is UnsupportedReasonCode.MISSING_EXACT_BLOCK_DIM
+    ):
+        raise NotImplementedError(
+            _collective_group_resolution_error(group, feature=feature)
+        )
+    try:
+        resolved = resolution.require_supported()
+    except NotImplementedError as exc:
+        raise NotImplementedError(f"{_ROOT_SCOPE}.{feature} {exc}") from exc
+    assert resolved.hierarchy is not None
+    return resolved.with_hierarchy(
+        resolved.hierarchy,
+        source="validated_launch" if group.is_static else "inferred_launch",
+    )
+
+
+def _validate_sync_launch(group: ThreadGroup, *, feature: str) -> ThreadGroup:
+    """Resolve and validate the launch capabilities needed for synchronization."""
+
+    if group.kind == "grid" and group.source == "common_root":
+        raise NotImplementedError(
+            f"cuda.coop.{feature} grid synchronization is unavailable through "
+            "the portable API; use cuda.coop.cutlass.this_grid() under a "
+            "verified cooperative launch"
+        )
+    if group.hierarchy.block_thread_count is not None:
+        _require_complete_warp_partition(group, feature=feature)
+    resolved, launch = _require_resolved_group(
+        group,
+        feature=feature,
+        allow_unresolved_current=group.kind in {"thread", "block"},
+    )
+    if resolved.kind == "grid" and (
+        launch.cooperative_launch is not True
+        or not launch.is_verified("cooperative_launch")
+    ):
+        raise NotImplementedError(
+            f"{_ROOT_SCOPE}.{feature} grid synchronization requires verified "
+            "cooperative launch capability"
+        )
+    return resolved
+
+
+def _validate_query_launch(
+    group: ThreadGroup,
+    *,
+    feature: str,
+    level: str,
+) -> ThreadGroup:
+    """Resolve source and enclosing target hierarchy for a rank/count query."""
+
+    resolved, _ = _require_resolved_group(
+        group,
+        feature=feature,
+        through_level=level,
+        allow_unresolved_current=(
+            group.kind in {"thread", "block"} and level in {"thread", "block"}
+        ),
+    )
+    return resolved
+
+
+def _validate_membership_launch(group: ThreadGroup, *, feature: str) -> ThreadGroup:
+    """Resolve the group before materializing a membership predicate."""
+
+    resolved, _ = _require_resolved_group(
+        group,
+        feature=feature,
+        allow_unresolved_current=group.kind in PHYSICAL_GROUP_KINDS,
+    )
+    return resolved
+
+
+def _make_group(kind: str) -> ThreadGroup:
+    return make_thread_group(
+        kind,
+        group_type=ThreadGroup,
+        scope=_ROOT_SCOPE,
+    )
+
+
+def this_thread() -> ThreadGroup:
+    """Describe the current thread."""
+
+    return _make_group("thread")
+
+
+def this_warp() -> ThreadGroup:
+    """Describe the current physical warp."""
+
+    return _make_group("warp")
+
+
+def this_block() -> ThreadGroup:
+    """Describe the current CTA."""
+
+    return _make_group("block")
+
+
+def this_cluster() -> ThreadGroup:
+    """Describe the current cluster where the launch can represent it."""
+
+    return _make_group("cluster")
+
+
+def this_grid() -> ThreadGroup:
+    """Describe the current grid where the launch can represent it."""
+
+    return _make_group("grid")
+
+
+__all__ = [
+    "Hierarchy",
+    "ThreadGroup",
+    "ThreadHierarchy",
+    "cpp_level_expr",
+    "render_group_decl",
+    "render_group_decl_lines",
+    "render_hierarchy_decl",
+    "this_block",
+    "this_cluster",
+    "this_grid",
+    "this_thread",
+    "this_warp",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_thread_group.pyi
+++ b/python/cuda_coop/cuda/coop/cutlass/_thread_group.pyi
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Typing declarations for CUTLASS thread-hierarchy descriptors."""
+
+from typing import Any, Generic, Literal, TypeAlias, overload
+
+from typing_extensions import TypeVar
+
+from .. import ThreadHierarchy
+from .._core.api.thread_group import ThreadGroup as PortableThreadGroup
+from .._typing import CompilerIntegerLike, ThreadGroupKind, ThreadLevel
+from ._typing import ScalarT
+
+_GroupKindT_co = TypeVar(
+    "_GroupKindT_co",
+    bound=ThreadGroupKind,
+    covariant=True,
+    default=ThreadGroupKind,
+)
+
+Hierarchy = ThreadHierarchy
+
+class ThreadGroup(
+    PortableThreadGroup[_GroupKindT_co],
+    Generic[_GroupKindT_co],
+):
+    """Common CUDA group descriptor with CUTLASS lowering methods."""
+
+    def rank(self, level: ThreadLevel = "thread") -> CompilerIntegerLike:
+        """Return this group's rank as a CUTLASS ``Int32`` scalar."""
+
+    def count(self, level: ThreadLevel = "thread") -> CompilerIntegerLike:
+        """Return this group's count as a CUTLASS ``Int32`` scalar."""
+
+    @overload
+    def rank_as(self, dtype: type[ScalarT], level: ThreadLevel = "thread") -> ScalarT:
+        """Convert rank to a portable or structural CUTLASS numeric dtype."""
+
+    @overload
+    def rank_as(self, dtype: None = None, level: ThreadLevel = "thread") -> Any:
+        """Omit dtype or use an ``Any``-typed external CUTLASS dtype token."""
+
+    @overload
+    def count_as(self, dtype: type[ScalarT], level: ThreadLevel = "thread") -> ScalarT:
+        """Convert count to a portable or structural CUTLASS numeric dtype."""
+
+    @overload
+    def count_as(self, dtype: None = None, level: ThreadLevel = "thread") -> Any:
+        """Omit dtype or use an ``Any``-typed external CUTLASS dtype token."""
+
+    def sync(self) -> None:
+        """Synchronize participating members.
+
+        Grid synchronization requires a compiler-verified cooperative launch.
+        """
+
+    def sync_aligned(self) -> None:
+        """Synchronize an aligned group in converged control flow.
+
+        Grid synchronization requires a compiler-verified cooperative launch.
+        """
+
+    @overload
+    def group_by(
+        self: ThreadGroup[Literal["warp"]],
+        count: int,
+        *,
+        exhaustive: bool = True,
+    ) -> ThreadGroup[Literal["threads_within_warp"]]:
+        """Partition a physical warp into groups of threads."""
+
+    @overload
+    def group_by(
+        self: ThreadGroup[Literal["block"]],
+        count: int,
+        *,
+        exhaustive: bool = True,
+    ) -> ThreadGroup[Literal["warps_within_block"]]:
+        """Partition a block into groups of physical warps."""
+
+    def is_member(self) -> CompilerIntegerLike:
+        """Return a CUTLASS ``Uint8`` membership flag for the current thread."""
+
+MemoryGroup: TypeAlias = ThreadGroup[Literal["warp", "threads_within_warp", "block"]]
+ReductionGroup: TypeAlias = ThreadGroup[
+    Literal[
+        "thread",
+        "warp",
+        "threads_within_warp",
+        "warps_within_block",
+        "block",
+        "cluster",
+    ]
+]
+BlockGroup: TypeAlias = ThreadGroup[Literal["block"]]
+WarpGroup: TypeAlias = ThreadGroup[Literal["warp", "threads_within_warp"]]
+
+def this_thread() -> ThreadGroup[Literal["thread"]]:
+    """Describe the current thread."""
+
+def this_warp() -> ThreadGroup[Literal["warp"]]:
+    """Describe the current complete physical warp."""
+
+def this_block() -> ThreadGroup[Literal["block"]]:
+    """Describe the current CUDA thread block."""
+
+def this_cluster() -> ThreadGroup[Literal["cluster"]]:
+    """Describe the current thread-block cluster."""
+
+def this_grid() -> ThreadGroup[Literal["grid"]]:
+    """Describe the current grid."""
+
+__all__ = [
+    "Hierarchy",
+    "ThreadGroup",
+    "ThreadHierarchy",
+    "this_block",
+    "this_cluster",
+    "this_grid",
+    "this_thread",
+    "this_warp",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_typing.pyi
+++ b/python/cuda_coop/cuda/coop/cutlass/_typing.pyi
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Private scalar typing shared by CUTLASS primitive families."""
+
+from typing import TypeAlias
+
+from typing_extensions import TypeVar
+
+from .._typing import PortableNumericScalar
+
+ScalarT = TypeVar("ScalarT", bound=PortableNumericScalar)
+CutlassNumericT = TypeVar("CutlassNumericT", bound=PortableNumericScalar)
+ScalarValueT = TypeVar("ScalarValueT", bound=PortableNumericScalar)
+
+CutlassOrderedItem: TypeAlias = PortableNumericScalar
+CutlassPairValueT = TypeVar("CutlassPairValueT", bound=CutlassOrderedItem)

--- a/python/cuda_coop/cuda/coop/cutlass/_value_metadata.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_value_metadata.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Compile-time value-availability metadata for cooperative operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from cuda.coop._core import ResultVisibility, ThreadGroup
+
+_SCALAR_METADATA_LOOKUP: Callable[[Any], ValueGroupMetadata | None] | None = None
+
+
+class DefinedThreadDomainKind(str, Enum):
+    MEMBERS = "members"
+    ROOTS = "roots"
+
+
+@dataclass(frozen=True, eq=False)
+class ResolvedGroupIdentity:
+    """The semantic identity and lineage of a resolved static group."""
+
+    group: ThreadGroup
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.group, ThreadGroup):
+            raise TypeError("ResolvedGroupIdentity group must be a ThreadGroup")
+        if not self.group.is_static:
+            raise ValueError("ResolvedGroupIdentity requires a static resolved group")
+
+    @property
+    def semantic_key(self) -> tuple[Any, ...]:
+        return self.group.semantic_key
+
+    @property
+    def lineage_keys(self) -> tuple[tuple[Any, ...], ...]:
+        keys = []
+        group: ThreadGroup | None = self.group
+        while group is not None:
+            keys.append(group.semantic_key)
+            group = group.parent
+        return tuple(keys)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ResolvedGroupIdentity):
+            return NotImplemented
+        return self.semantic_key == other.semantic_key
+
+    def __hash__(self) -> int:
+        return hash(self.semantic_key)
+
+
+@dataclass(frozen=True)
+class DefinedThreadConstraint:
+    kind: DefinedThreadDomainKind
+    group_key: tuple[Any, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "kind", DefinedThreadDomainKind(self.kind))
+        if not self.group_key:
+            raise ValueError("defined-thread constraint requires a group key")
+
+
+@dataclass(frozen=True)
+class DefinedThreadDomain:
+    """Intersection of constraints describing where a value is defined."""
+
+    constraints: frozenset[DefinedThreadConstraint] = frozenset()
+
+    def __post_init__(self) -> None:
+        constraints = frozenset(self.constraints)
+        if any(
+            not isinstance(constraint, DefinedThreadConstraint)
+            for constraint in constraints
+        ):
+            raise TypeError(
+                "DefinedThreadDomain constraints must be DefinedThreadConstraint"
+            )
+        object.__setattr__(self, "constraints", constraints)
+
+    @classmethod
+    def all_callers(cls) -> DefinedThreadDomain:
+        return cls()
+
+    @classmethod
+    def members(cls, group: ResolvedGroupIdentity) -> DefinedThreadDomain:
+        return cls(
+            frozenset(
+                {
+                    DefinedThreadConstraint(
+                        DefinedThreadDomainKind.MEMBERS,
+                        group.semantic_key,
+                    )
+                }
+            )
+        )
+
+    @classmethod
+    def roots(cls, group: ResolvedGroupIdentity) -> DefinedThreadDomain:
+        return cls(
+            frozenset(
+                {
+                    DefinedThreadConstraint(
+                        DefinedThreadDomainKind.ROOTS,
+                        group.semantic_key,
+                    )
+                }
+            )
+        )
+
+    def intersect(self, other: DefinedThreadDomain) -> DefinedThreadDomain:
+        if not isinstance(other, DefinedThreadDomain):
+            raise TypeError("defined-thread domains can intersect only each other")
+        return DefinedThreadDomain(self.constraints | other.constraints)
+
+    @property
+    def contains_roots_only(self) -> bool:
+        return any(
+            constraint.kind is DefinedThreadDomainKind.ROOTS
+            for constraint in self.constraints
+        )
+
+    def covers(self, target: ResolvedGroupIdentity) -> bool:
+        lineage = frozenset(target.lineage_keys)
+        for constraint in self.constraints:
+            if constraint.kind is DefinedThreadDomainKind.ROOTS:
+                return False
+            if constraint.group_key not in lineage:
+                return False
+        return True
+
+
+@dataclass(frozen=True)
+class ValueGroupMetadata:
+    """Compile-time facts describing where a value is available."""
+
+    defined_domain: DefinedThreadDomain
+    visibility: ResultVisibility
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.defined_domain, DefinedThreadDomain):
+            raise TypeError("defined_domain must be a DefinedThreadDomain")
+        object.__setattr__(self, "visibility", ResultVisibility(self.visibility))
+
+
+def metadata_for_group(
+    group: ThreadGroup,
+    *,
+    visibility: ResultVisibility,
+) -> ValueGroupMetadata:
+    visibility = ResultVisibility(visibility)
+    if visibility is ResultVisibility.GROUP_ROOT:
+        domain = DefinedThreadDomain.roots(ResolvedGroupIdentity(group))
+    elif group.complete_membership is False:
+        domain = DefinedThreadDomain.members(ResolvedGroupIdentity(group))
+    else:
+        domain = DefinedThreadDomain.all_callers()
+    return ValueGroupMetadata(domain, visibility)
+
+
+def merge_value_metadata(
+    metadata: Iterable[ValueGroupMetadata | None],
+) -> ValueGroupMetadata | None:
+    values = tuple(value for value in metadata if value is not None)
+    if not values:
+        return None
+    domain = DefinedThreadDomain.all_callers()
+    for value in values:
+        domain = domain.intersect(value.defined_domain)
+    if domain.contains_roots_only:
+        visibility = ResultVisibility.GROUP_ROOT
+    elif any(value.visibility is ResultVisibility.PER_MEMBER for value in values):
+        visibility = ResultVisibility.PER_MEMBER
+    else:
+        visibility = ResultVisibility.ALL_MEMBERS
+    return ValueGroupMetadata(domain, visibility)
+
+
+def attach_thread_data_metadata(value: Any, metadata: ValueGroupMetadata | None) -> Any:
+    if metadata is not None and not isinstance(metadata, ValueGroupMetadata):
+        raise TypeError("thread-data metadata must be ValueGroupMetadata or None")
+    setter = getattr(value, "_set_group_metadata", None)
+    if callable(setter):
+        setter(metadata)
+    else:
+        value._group_metadata = metadata
+    return value
+
+
+def thread_data_metadata(value: Any) -> ValueGroupMetadata | None:
+    metadata = getattr(value, "_group_metadata", None)
+    return metadata if isinstance(metadata, ValueGroupMetadata) else None
+
+
+def register_scalar_metadata_lookup(
+    lookup: Callable[[Any], ValueGroupMetadata | None],
+) -> None:
+    if not callable(lookup):
+        raise TypeError("scalar metadata lookup must be callable")
+    global _SCALAR_METADATA_LOOKUP
+    _SCALAR_METADATA_LOOKUP = lookup
+
+
+def value_group_metadata(value: Any) -> ValueGroupMetadata | None:
+    metadata = thread_data_metadata(value)
+    if metadata is not None or _SCALAR_METADATA_LOOKUP is None:
+        return metadata
+    scalar_metadata = _SCALAR_METADATA_LOOKUP(value)
+    return scalar_metadata if isinstance(scalar_metadata, ValueGroupMetadata) else None
+
+
+def validate_operand_domains(
+    group: ThreadGroup,
+    operands: dict[str, Any],
+    *,
+    scope: str,
+    primitive_name: str,
+) -> None:
+    """Prove every tagged operand is defined for all target participants."""
+
+    target = ResolvedGroupIdentity(group)
+    for name, value in operands.items():
+        metadata = value_group_metadata(value)
+        if metadata is None:
+            continue
+        if metadata.defined_domain.contains_roots_only:
+            raise ValueError(
+                f"{scope}.{primitive_name} operand {name!r} is defined only at "
+                "group roots; use broadcast=True or consume it under rank-0 "
+                "control flow with non-cooperative scalar operations"
+            )
+        if not metadata.defined_domain.covers(target):
+            raise ValueError(
+                f"{scope}.{primitive_name} operand {name!r} is not defined for "
+                f"every member of target group {group.symbol_suffix}; pass a "
+                "compatible group or rebuild the value for the wider domain"
+            )
+
+
+__all__ = [
+    "DefinedThreadConstraint",
+    "DefinedThreadDomain",
+    "DefinedThreadDomainKind",
+    "ResolvedGroupIdentity",
+    "ValueGroupMetadata",
+    "attach_thread_data_metadata",
+    "merge_value_metadata",
+    "metadata_for_group",
+    "register_scalar_metadata_lookup",
+    "thread_data_metadata",
+    "validate_operand_domains",
+    "value_group_metadata",
+]

--- a/python/cuda_coop/pyproject.toml
+++ b/python/cuda_coop/pyproject.toml
@@ -35,6 +35,11 @@ dynamic = ["version"]
 readme = { file = "README.md", content-type = "text/markdown" }
 
 [project.optional-dependencies]
+cutlass = [
+  "cuda-bindings>=13.0.0,<14.0.0",
+  "cuda-toolkit[nvrtc,nvjitlink,cudart,nvcc,nvvm]>=13.0.0,<14.0.0",
+  "nvidia-cutlass-dsl[cu13]>=4.8,<5",
+]
 test = [
   "mypy",
   "numpy",
@@ -119,6 +124,9 @@ known-first-party = [
   "cuda.coop._core.block",
   "cuda.coop._core.group",
   "cuda.coop._core.warp",
+  "cuda.coop.cutlass",
+  "cuda.coop.cutlass._compiler",
+  "cuda.coop.cutlass._lowering",
 ]
 
 [tool.pytest.ini_options]

--- a/python/cuda_coop/tests/backends/__init__.py
+++ b/python/cuda_coop/tests/backends/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/python/cuda_coop/tests/backends/cutlass/__init__.py
+++ b/python/cuda_coop/tests/backends/cutlass/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/python/cuda_coop/tests/backends/cutlass/compile/__init__.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/python/cuda_coop/tests/backends/cutlass/compile/test_data_movement.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/test_data_movement.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cuda import coop
+
+from ....support.paths import REPO_ROOT
+
+cute = pytest.importorskip("cutlass.cute")
+runtime = pytest.importorskip("cutlass.cute.runtime")
+Int32 = pytest.importorskip("cutlass.base_dsl.typing").Int32
+cutlass_coop = pytest.importorskip("cuda.coop.cutlass")
+
+pytestmark = [pytest.mark.backend_cutlass, pytest.mark.compile]
+
+_THREADS = 64
+_ITEMS_PER_THREAD = 2
+_TILE_ITEMS = _THREADS * _ITEMS_PER_THREAD
+_OUTPUT_SEGMENTS = 2
+
+
+@cute.kernel
+def _data_movement_kernel(values: cute.Tensor, output: cute.Tensor):
+    block = coop.this_block()
+    common_items = coop.ThreadData(_ITEMS_PER_THREAD)
+    common_loaded = coop.load(block, values, common_items)
+    coop.store(block, output, common_loaded)
+
+    qualified_block = cutlass_coop.this_block()
+    qualified_items = cutlass_coop.ThreadData(_ITEMS_PER_THREAD, dtype=Int32)
+    qualified_loaded = cutlass_coop.load(
+        qualified_block,
+        values,
+        qualified_items,
+        algorithm="striped",
+        offset=_TILE_ITEMS,
+    )
+    cutlass_coop.store(
+        qualified_block,
+        output,
+        qualified_loaded,
+        algorithm="striped",
+        offset=_TILE_ITEMS,
+    )
+
+
+@cute.jit
+def _run_data_movement(values: cute.Tensor, output: cute.Tensor):
+    _data_movement_kernel(values, output).launch(
+        grid=(1, 1, 1),
+        block=(_THREADS, 1, 1),
+    )
+
+
+def test_common_and_qualified_data_movement_compile_together(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache_dir = tmp_path / "provider-cache"
+    dump_dir = tmp_path / "provider-dump"
+    dump_dir.mkdir()
+    monkeypatch.setenv("CUDA_COOP_CUTLASS_PROVIDER_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("CUDA_COOP_CUTLASS_PROVIDER_DUMP_DIR", str(dump_dir))
+    monkeypatch.setenv("CUDA_COOP_CUTLASS_PROVIDER_BUNDLE_FORMAT", "ltoir")
+    monkeypatch.setenv("CUDA_COOP_CUTLASS_PROVIDER_CCCL_ROOT", str(REPO_ROOT))
+
+    fake_values = runtime.make_fake_compact_tensor(Int32, (2 * _TILE_ITEMS,))
+    fake_output = runtime.make_fake_compact_tensor(
+        Int32,
+        (_OUTPUT_SEGMENTS * _TILE_ITEMS,),
+    )
+    compiled = cute.compile(_run_data_movement, fake_values, fake_output)
+
+    assert callable(compiled)
+    artifacts = tuple(cache_dir.glob("*.ltoir"))
+    assert len(artifacts) == 1
+    assert artifacts[0].stat().st_size > 0
+
+    sources = tuple(dump_dir.glob("cuda_coop_cutlass_bundle_*.cpp"))
+    assert len(sources) == 1
+    source = sources[0].read_text(encoding="utf-8")
+    for header in (
+        "cub/block/block_load.cuh",
+        "cub/block/block_store.cuh",
+    ):
+        assert f"#include <{header}>" in source
+    for symbol_fragment in (
+        "cuda_coop_cutlass_cub_load_block_b64_direct_i32_x2_",
+        "cuda_coop_cutlass_cub_load_block_b64_striped_i32_x2_",
+        "cuda_coop_cutlass_cub_store_block_b64_direct_i32_x2_",
+        "cuda_coop_cutlass_cub_store_block_b64_striped_i32_x2_",
+    ):
+        assert symbol_fragment in source

--- a/python/cuda_coop/tests/backends/cutlass/compile/test_provider_bundle_identity.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/test_provider_bundle_identity.py
@@ -1,0 +1,308 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("cutlass")
+
+import cuda.coop.cutlass._compiler._bundle as provider_bundle
+import cuda.coop.cutlass._compiler._bundle_contract as provider_contract
+import cuda.coop.cutlass._compiler._rendering as provider_rendering
+import cuda.coop.cutlass._compiler._types as provider_types
+
+
+@dataclass(frozen=True)
+class _Request:
+    symbol_name: str
+    body: str
+    kind: str = "test"
+    items_per_thread: int = 1
+
+
+def _render(requests, include_lines):
+    return provider_rendering.render_bundle_source(
+        requests,
+        scope="cuda.coop.cutlass",
+        include_lines=include_lines,
+        render_local_request=lambda request: [
+            f"void {request.symbol_name}() {{ {request.body}; }}"
+        ],
+    )
+
+
+def test_bundle_source_is_independent_of_request_and_preamble_permutations():
+    requests = (
+        _Request("cuda_coop_z", "int z = 0"),
+        _Request("cuda_coop_a", "int a = 0"),
+    )
+    preamble = (
+        "#include <z.cuh>",
+        "#define FEATURE_Z",
+        "#include <a.cuh>",
+        "#define FEATURE_A",
+    )
+    expected = _render(requests, preamble)
+    assert _render((requests[0], requests[0], requests[1]), preamble) == expected
+
+    for request_order in itertools.permutations(requests):
+        for preamble_order in itertools.permutations(preamble):
+            assert _render(request_order, preamble_order) == expected
+
+    assert expected.index("#define FEATURE_A") < expected.index("#define FEATURE_Z")
+    assert expected.index("#define FEATURE_Z") < expected.index("#include <a.cuh>")
+    assert expected.index("#include <a.cuh>") < expected.index("#include <z.cuh>")
+    assert expected.index("void cuda_coop_a") < expected.index("void cuda_coop_z")
+
+
+def test_bundle_source_rejects_conflicting_symbols_and_features():
+    with pytest.raises(ValueError, match="conflicting bundle requests"):
+        _render(
+            (
+                _Request("cuda_coop_conflict", "int first = 0"),
+                _Request("cuda_coop_conflict", "int second = 0"),
+            ),
+            (),
+        )
+
+    with pytest.raises(ValueError, match="conflicting definitions"):
+        _render(
+            (_Request("cuda_coop_ok", "int value = 0"),),
+            ("#define FEATURE 1", "#define FEATURE 2"),
+        )
+
+
+def test_bundle_renderer_registration_rejects_duplicate_kinds(monkeypatch):
+    monkeypatch.setattr(provider_rendering, "_BUNDLE_RENDERERS", {})
+
+    def render(_request):
+        return []
+
+    provider_rendering.register_bundle_renderer("duplicate", render=render)
+
+    with pytest.raises(ValueError, match="already registered"):
+        provider_rendering.register_bundle_renderer("duplicate", render=render)
+
+
+def test_registered_headers_are_canonical_and_reject_conflicts(monkeypatch):
+    def render(_request):
+        return []
+
+    renderer_a = provider_types.BundleRenderer(
+        include_lines=(),
+        cccl_headers=(
+            ("#include <z.cuh>", "z.cuh"),
+            ("#include <a.cuh>", "a.cuh"),
+        ),
+        render=render,
+    )
+    renderer_z = provider_types.BundleRenderer(
+        include_lines=(),
+        cccl_headers=(("#include <m.cuh>", "m.cuh"),),
+        render=render,
+    )
+    monkeypatch.setattr(
+        provider_rendering,
+        "_BUNDLE_RENDERERS",
+        {"z-kind": renderer_z, "a-kind": renderer_a},
+    )
+    assert list(provider_rendering.registered_bundle_headers()) == [
+        "#include <a.cuh>",
+        "#include <m.cuh>",
+        "#include <z.cuh>",
+    ]
+
+    conflicting = provider_types.BundleRenderer(
+        include_lines=(),
+        cccl_headers=(("#include <a.cuh>", "different/a.cuh"),),
+        render=render,
+    )
+    monkeypatch.setitem(
+        provider_rendering._BUNDLE_RENDERERS,
+        "conflict",
+        conflicting,
+    )
+    with pytest.raises(ValueError, match="conflicting CCCL headers"):
+        provider_rendering.registered_bundle_headers()
+
+
+def test_required_headers_are_sorted_and_deduplicated():
+    headers = provider_bundle.required_cccl_headers(
+        "#include <z.cuh>\n#include <alias.cuh>\n#include <a.cuh>\n",
+        registered_headers=lambda: {
+            "#include <z.cuh>": "z.cuh",
+            "#include <alias.cuh>": "a.cuh",
+            "#include <a.cuh>": "a.cuh",
+        },
+    )
+    assert headers == ("a.cuh", "z.cuh")
+
+
+def test_bundle_source_is_independent_of_python_hash_seed():
+    script = r"""
+import hashlib
+import os
+from dataclasses import dataclass
+import cuda.coop
+
+cuda.coop.__path__.insert(0, os.environ["CUDA_COOP_SOURCE_PATH"])
+from cuda.coop.cutlass._compiler import _rendering as provider_rendering
+
+@dataclass(frozen=True)
+class Request:
+    symbol_name: str
+    body: str
+    kind: str = "hash_seed_test"
+    items_per_thread: int = 1
+
+requests = list({
+    Request("cuda_coop_z", "int z = 0"),
+    Request("cuda_coop_a", "int a = 0"),
+})
+lines = list({
+    "#include <z.cuh>",
+    "#include <a.cuh>",
+    "#define FEATURE_Z",
+    "#define FEATURE_A",
+})
+source = provider_rendering.render_bundle_source(
+    requests,
+    scope="cuda.coop.cutlass",
+    include_lines=lines,
+    render_local_request=lambda request: [
+        f"void {request.symbol_name}() {{ {request.body}; }}"
+    ],
+)
+print(hashlib.sha256(source.encode()).hexdigest())
+"""
+    digests = []
+    for seed in ("1", "7", "100"):
+        env = os.environ.copy()
+        env["CUDA_COOP_SOURCE_PATH"] = str(
+            Path(provider_rendering.__file__).resolve().parents[2]
+        )
+        env["PYTHONHASHSEED"] = seed
+        result = subprocess.run(
+            [sys.executable, "-B", "-c", script],
+            check=True,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+        digests.append(result.stdout.strip())
+    assert len(set(digests)) == 1
+
+
+def test_bundle_cache_identity_uses_the_full_canonical_contract():
+    source_hash = hashlib.sha256(b"source").hexdigest()
+    compiler_options = provider_contract.bundle_compiler_options(
+        "ltoir",
+        "compute_100a",
+    )
+    identity = provider_contract.make_bundle_identity(
+        source_hash=source_hash,
+        bundle_format="ltoir",
+        bundle_arch="compute_100a",
+        bundle_sm_arch="sm_100a",
+        compiler_options=compiler_options,
+        layout_expressions=("layout-expression",),
+    )
+    cache_identity = provider_contract.make_bundle_cache_identity(
+        identity,
+        include_key="0123456789abcdef",
+        producer_compiler_version="13.0",
+    )
+
+    assert (
+        identity.provider_abi_version
+        == provider_contract.PROVIDER_BUNDLE_ABI_VERSION
+        == 1
+    )
+    assert identity.compiler_options == compiler_options
+    assert identity.layout_expressions == ("layout-expression",)
+    assert (
+        cache_identity.schema_version
+        == provider_contract.BUNDLE_CACHE_SCHEMA_VERSION
+        == 3
+    )
+    expected_payload = {
+        "bundle": asdict(identity),
+        "include_key": "0123456789abcdef",
+        "producer_compiler_version": "13.0",
+        "schema_version": 3,
+    }
+    expected_digest = hashlib.sha256(
+        json.dumps(
+            expected_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    assert cache_identity.contract_digest == expected_digest
+    assert cache_identity.cache_key == f"v3:{expected_digest}"
+    assert cache_identity.artifact_stem == f"bundle_v3_{expected_digest}"
+
+
+def test_bundle_cache_contract_has_no_identity_field_collisions():
+    identity = provider_contract.make_bundle_identity(
+        source_hash=hashlib.sha256(b"source").hexdigest(),
+        bundle_format="ltoir",
+        bundle_arch="compute_100a",
+        bundle_sm_arch="sm_100a",
+        compiler_options=("--std=c++17", "-dlto"),
+        layout_expressions=("layout-expression",),
+    )
+    bundle_variants = (
+        identity,
+        replace(
+            identity,
+            provider_abi_version=identity.provider_abi_version + 1,
+        ),
+        replace(
+            identity,
+            source_hash=hashlib.sha256(b"different-source").hexdigest(),
+        ),
+        replace(identity, bundle_format="bc"),
+        replace(identity, bundle_arch="compute_90"),
+        replace(identity, bundle_sm_arch="sm_90"),
+        replace(
+            identity,
+            compiler_options=(*identity.compiler_options, "--fmad=false"),
+        ),
+        replace(
+            identity,
+            layout_expressions=("different-layout-expression",),
+        ),
+    )
+    cache_identities = tuple(
+        provider_contract.make_bundle_cache_identity(
+            bundle,
+            include_key="headers-a",
+            producer_compiler_version="13.0",
+        )
+        for bundle in bundle_variants
+    )
+    cache_identities += (
+        replace(cache_identities[0], include_key="headers-b"),
+        replace(cache_identities[0], producer_compiler_version="13_0"),
+        replace(cache_identities[0], schema_version=4),
+    )
+
+    assert len({item.contract_digest for item in cache_identities}) == len(
+        cache_identities
+    )
+    assert len({item.cache_key for item in cache_identities}) == len(cache_identities)
+    assert len({item.artifact_stem for item in cache_identities}) == len(
+        cache_identities
+    )

--- a/python/cuda_coop/tests/backends/cutlass/compile/test_provider_bundle_metadata.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/test_provider_bundle_metadata.py
@@ -1,0 +1,544 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("cutlass")
+
+from cutlass.base_dsl.common import DSLRuntimeError
+from cutlass.base_dsl.compiler import GPUArch
+
+import cuda.coop.cutlass._compiler._bundle as provider_bundle
+import cuda.coop.cutlass._compiler._bundle_contract as provider_contract
+import cuda.coop.cutlass._compiler._cache as provider_cache
+import cuda.coop.cutlass._compiler._clang as provider_clang
+import cuda.coop.cutlass._compiler._nvrtc as provider_nvrtc
+import cuda.coop.cutlass._compiler._target as provider_target
+
+
+class _NvrtcResult:
+    NVRTC_SUCCESS = 0
+
+
+class _FakeNvrtc:
+    nvrtcResult = _NvrtcResult
+
+    def __init__(self):
+        self.calls = []
+        self.blob = b"fake-ltoir"
+        self.version = (13, 0)
+
+    def nvrtcVersion(self):
+        return 0, *self.version
+
+    def nvrtcCreateProgram(self, source, name, num_headers, headers, include_names):
+        self.calls.append(("create", source))
+        return 0, object()
+
+    def nvrtcAddNameExpression(self, program, expression):
+        self.calls.append(("add", expression))
+        return (0,)
+
+    def nvrtcCompileProgram(self, program, num_options, options):
+        self.calls.append(("compile", tuple(options)))
+        return (0,)
+
+    def nvrtcGetLoweredName(self, program, expression):
+        self.calls.append(("get_lowered", expression))
+        decoded = expression.decode("utf-8")
+        symbol_match = re.match(r"&([^<]+)<", decoded)
+        assert symbol_match is not None
+        symbol = symbol_match.group(1)
+        if "LargeStorage" in decoded:
+            size_in_bytes, alignment = 40, 8
+        else:
+            size_in_bytes, alignment = 20, 4
+        return (
+            0,
+            f"_Z{len(symbol)}{symbol}ILy{size_in_bytes}ELy{alignment}EE".encode(),
+        )
+
+    def nvrtcGetLTOIRSize(self, program):
+        self.calls.append(("get_ltoir_size",))
+        return 0, len(self.blob)
+
+    def nvrtcGetLTOIR(self, program, blob):
+        self.calls.append(("get_ltoir",))
+        blob[:] = self.blob
+        return (0,)
+
+    def nvrtcDestroyProgram(self, program):
+        self.calls.append(("destroy",))
+        return (0,)
+
+
+def _compile_kwargs():
+    return {
+        "scope": "cuda.coop.cutlass",
+        "provider_dir": provider_bundle.__file__,
+        "registered_headers": dict,
+        "select_bundle_format": lambda: "ltoir",
+        "resolve_nvrtc_sm_arch": lambda: "sm_80",
+        "resolve_nvrtc_arch": lambda: "compute_80",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _isolated_bundle_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        provider_cache.CACHE_DIR_ENV,
+        str(tmp_path / "provider-cache"),
+    )
+    provider_bundle.reset_compile_state()
+    yield
+    provider_bundle.reset_compile_state()
+
+
+def _layout_probes():
+    return (
+        provider_contract.LayoutProbe(
+            key="small-a",
+            size_expression="sizeof(SmallStorage)",
+            alignment_expression="alignof(SmallStorage)",
+        ),
+        provider_contract.LayoutProbe(
+            key="small-b",
+            size_expression="sizeof(SmallStorage)",
+            alignment_expression="alignof(SmallStorage)",
+        ),
+        provider_contract.LayoutProbe(
+            key="large",
+            size_expression="sizeof(LargeStorage)",
+            alignment_expression="alignof(LargeStorage)",
+        ),
+    )
+
+
+@pytest.mark.parametrize("configured_arch", ["sm_103a", "sm_103f"])
+def test_sm103_provider_target_resolvers_preserve_arch_suffix(configured_arch):
+    def configured_gpu_arch():
+        return configured_arch
+
+    assert (
+        provider_target.resolve_nvrtc_sm_arch(
+            "cuda.coop.cutlass",
+            configured_gpu_arch,
+        )
+        == configured_arch
+    )
+    assert provider_target.resolve_nvrtc_arch(
+        "cuda.coop.cutlass",
+        configured_gpu_arch,
+    ) == configured_arch.replace("sm_", "compute_", 1)
+
+
+@pytest.mark.parametrize(
+    ("configured_arch", "compute_arch", "sm_arch"),
+    (
+        ("103", "compute_103", "sm_103"),
+        ("sm103", "compute_103", "sm_103"),
+        ("sm_103a", "compute_103a", "sm_103a"),
+        ("compute103f", "compute_103f", "sm_103f"),
+        ("compute_103a", "compute_103a", "sm_103a"),
+    ),
+)
+def test_provider_target_normalizes_valid_configured_arches(
+    configured_arch,
+    compute_arch,
+    sm_arch,
+):
+    def configured():
+        return configured_arch
+
+    assert (
+        provider_target.resolve_nvrtc_arch("cuda.coop.cutlass", configured)
+        == compute_arch
+    )
+    assert (
+        provider_target.resolve_nvrtc_sm_arch("cuda.coop.cutlass", configured)
+        == sm_arch
+    )
+
+
+@pytest.mark.parametrize("configured_arch", ["sm_", "compute_foo", "103x", "garbage"])
+def test_provider_target_rejects_malformed_configured_arch(configured_arch):
+    from cutlass.base_dsl.common import DSLRuntimeError
+
+    for resolver in (
+        provider_target.resolve_nvrtc_arch,
+        provider_target.resolve_nvrtc_sm_arch,
+    ):
+        with pytest.raises(DSLRuntimeError, match="Invalid configured CUDA arch"):
+            resolver("cuda.coop.cutlass", lambda: configured_arch)
+
+
+@pytest.mark.parametrize(
+    ("environment_arch", "expected_arch"),
+    (("sm_80", "sm_80"), (None, "")),
+)
+def test_configured_gpu_arch_treats_none_as_unset(
+    environment_arch,
+    expected_arch,
+):
+    option = type("Option", (), {"value": None})()
+    compile_options = type("CompileOptions", (), {"options": {GPUArch: option}})()
+    dsl = type(
+        "Dsl",
+        (),
+        {
+            "compile_options": compile_options,
+            "envar": type("Environment", (), {"arch": environment_arch})(),
+        },
+    )()
+
+    assert provider_target.configured_gpu_arch(lambda: dsl) == expected_arch
+
+
+def test_bitcode_compiler_options_require_the_selected_sm_arch():
+    with pytest.raises(ValueError, match="requires an SM architecture"):
+        provider_contract.bundle_compiler_options("bc", "nvptx64")
+
+    assert "-march=sm_80" in provider_contract.bundle_compiler_options(
+        "bc",
+        "nvptx64",
+        bundle_sm_arch="sm_80",
+    )
+
+
+def test_clang_resolution_preserves_the_selected_invocation_path(
+    monkeypatch,
+    tmp_path,
+):
+    real_compiler = tmp_path / "compiler"
+    real_compiler.touch()
+    invocation = tmp_path / "cuda-clang++"
+    invocation.symlink_to(real_compiler)
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        return type("Completed", (), {"stdout": "clang version 20.1\n"})()
+
+    monkeypatch.setenv(provider_clang.CLANGXX_ENV, "cuda-clang++")
+    monkeypatch.setattr(provider_clang.subprocess, "run", run)
+    resolved, version, identity = provider_clang.resolve_clang_compiler(
+        lambda name: str(invocation) if name == "cuda-clang++" else None
+    )
+
+    assert resolved == str(invocation)
+    assert resolved != str(real_compiler)
+    assert version == "clang version 20.1"
+    assert identity.startswith("clang-")
+    assert calls[0][0] == [str(invocation), "--version"]
+
+
+def test_clang_resolution_rejects_a_stale_configured_path(monkeypatch, tmp_path):
+    configured = str(tmp_path / "missing-clang++")
+    looked_up = []
+    monkeypatch.setenv(provider_clang.CLANGXX_ENV, configured)
+
+    resolved = provider_clang.resolve_clang_compiler(
+        lambda name: looked_up.append(name) or None
+    )
+
+    assert looked_up == [configured]
+    assert resolved == (None, None, "clang-not-found")
+
+
+def test_layout_probes_share_one_nvrtc_program(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+
+    compilation = provider_bundle.compile_bundle_source_with_layouts(
+        'extern "C" {}',
+        layout_probes=_layout_probes(),
+        **_compile_kwargs(),
+    )
+
+    assert compilation.layouts == {
+        "small-a": provider_contract.StorageLayout(20, 4),
+        "small-b": provider_contract.StorageLayout(20, 4),
+        "large": provider_contract.StorageLayout(40, 8),
+    }
+    assert compilation.path.endswith(".ltoir")
+    assert provider_bundle.get_nvrtc_compile_program_counter() == 1
+    call_names = [call[0] for call in fake_nvrtc.calls]
+    assert call_names.count("add") == 2
+    assert call_names.count("compile") == 1
+    assert call_names.count("get_lowered") == 2
+    assert max(
+        i for i, name in enumerate(call_names) if name == "add"
+    ) < call_names.index("compile")
+    assert call_names.index("compile") < min(
+        i for i, name in enumerate(call_names) if name == "get_lowered"
+    )
+    compiled_source = fake_nvrtc.calls[0][1].decode("utf-8")
+    assert "template <unsigned long long Size" in compiled_source
+    assert "__device__ unsigned char cuda_coop_layout_probe_" in compiled_source
+
+
+def test_nvrtc_rejects_empty_ltoir_before_retrieval(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    fake_nvrtc.blob = b""
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+
+    with pytest.raises(DSLRuntimeError, match="empty LTO-IR"):
+        provider_bundle.compile_bundle_source(
+            'extern "C" {}',
+            **_compile_kwargs(),
+        )
+
+    assert "get_ltoir" not in [call[0] for call in fake_nvrtc.calls]
+
+
+def test_layout_metadata_survives_an_in_memory_cache_reset(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    first = provider_bundle.compile_bundle_source_with_layouts(
+        'extern "C" {}',
+        layout_probes=_layout_probes(),
+        **_compile_kwargs(),
+    )
+    metadata_path = provider_cache._layout_metadata_path(first.path)
+    with open(metadata_path, encoding="utf-8") as metadata_file:
+        metadata = json.load(metadata_file)
+    assert metadata["version"] == provider_contract.LAYOUT_METADATA_VERSION
+    assert len(metadata["layouts"]) == 2
+
+    provider_bundle.reset_compile_state()
+    second = provider_bundle.compile_bundle_source_with_layouts(
+        'extern "C" {}',
+        layout_probes=_layout_probes(),
+        **_compile_kwargs(),
+    )
+
+    assert second == first
+    assert provider_bundle.get_nvrtc_compile_program_counter() == 0
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 1
+
+
+def test_corrupt_layout_sidecar_is_recompiled(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    first = provider_bundle.compile_bundle_source_with_layouts(
+        'extern "C" {}',
+        layout_probes=_layout_probes(),
+        **_compile_kwargs(),
+    )
+    with open(
+        provider_cache._layout_metadata_path(first.path),
+        "w",
+        encoding="utf-8",
+    ) as metadata_file:
+        metadata_file.write("not-json")
+
+    provider_bundle.reset_compile_state()
+    second = provider_bundle.compile_bundle_source_with_layouts(
+        'extern "C" {}',
+        layout_probes=_layout_probes(),
+        **_compile_kwargs(),
+    )
+
+    assert second == first
+    assert provider_bundle.get_nvrtc_compile_program_counter() == 1
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 2
+
+
+def test_artifact_hash_mismatch_is_recompiled(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    first = provider_bundle.compile_bundle_source_with_layouts(
+        'extern "C" {}',
+        layout_probes=_layout_probes(),
+        **_compile_kwargs(),
+    )
+    Path(first.path).write_bytes(fake_nvrtc.blob[::-1])
+
+    provider_bundle.reset_compile_state()
+    second = provider_bundle.compile_bundle_source_with_layouts(
+        'extern "C" {}',
+        layout_probes=_layout_probes(),
+        **_compile_kwargs(),
+    )
+
+    assert second == first
+    assert provider_bundle.get_nvrtc_compile_program_counter() == 1
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 2
+
+
+def test_zero_byte_in_memory_artifact_is_rejected(tmp_path):
+    artifact_path = tmp_path / "empty.ltoir"
+    artifact_path.write_bytes(b"")
+    cached = provider_cache._CachedBundle(
+        path=str(artifact_path),
+        layouts_by_expression={},
+        artifact_size=0,
+        artifact_sha256=hashlib.sha256(b"").hexdigest(),
+    )
+    provider_cache.store_memory_bundle("empty", cached)
+
+    assert provider_cache.memory_cached_bundle("empty") is None
+
+
+def test_zero_byte_disk_artifact_is_recompiled(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    first = provider_bundle.compile_bundle_source_with_layouts(
+        'extern "C" {}',
+        layout_probes=_layout_probes(),
+        **_compile_kwargs(),
+    )
+    artifact_path = Path(first.path)
+    artifact_path.write_bytes(b"")
+    metadata_path = Path(provider_cache._layout_metadata_path(first.path))
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["artifact"] = {
+        "size": 0,
+        "sha256": hashlib.sha256(b"").hexdigest(),
+    }
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    provider_bundle.reset_compile_state()
+    second = provider_bundle.compile_bundle_source_with_layouts(
+        'extern "C" {}',
+        layout_probes=_layout_probes(),
+        **_compile_kwargs(),
+    )
+
+    assert second == first
+    assert provider_bundle.get_nvrtc_compile_program_counter() == 1
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 2
+
+
+def test_in_memory_artifact_hash_mismatch_is_recompiled(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    first = provider_bundle.compile_bundle_source_with_layouts(
+        'extern "C" {}',
+        layout_probes=_layout_probes(),
+        **_compile_kwargs(),
+    )
+    Path(first.path).write_bytes(fake_nvrtc.blob[::-1])
+
+    second = provider_bundle.compile_bundle_source_with_layouts(
+        'extern "C" {}',
+        layout_probes=_layout_probes(),
+        **_compile_kwargs(),
+    )
+
+    assert second == first
+    assert provider_bundle.get_nvrtc_compile_program_counter() == 2
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 2
+
+
+def test_existing_bundle_api_still_returns_a_path(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+
+    path = provider_bundle.compile_bundle_source(
+        'extern "C" {}',
+        **_compile_kwargs(),
+    )
+
+    assert isinstance(path, str)
+    assert path.endswith(".ltoir")
+    assert not any(call[0] == "add" for call in fake_nvrtc.calls)
+
+
+def test_layout_metadata_rejects_bitcode_without_compiling(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    kwargs = _compile_kwargs()
+    kwargs["select_bundle_format"] = lambda: "bc"
+
+    with pytest.raises(DSLRuntimeError, match="requires an NVRTC LTO-IR bundle"):
+        provider_bundle.compile_bundle_source_with_layouts(
+            'extern "C" {}',
+            layout_probes=_layout_probes(),
+            **kwargs,
+        )
+
+    assert fake_nvrtc.calls == []
+
+
+def test_clang_rejects_a_successful_empty_output(monkeypatch):
+    monkeypatch.setattr(
+        provider_clang,
+        "resolve_clang_compiler",
+        lambda _which: ("clang++", "clang-test", "clang-test"),
+    )
+
+    def run(cmd, **_kwargs):
+        Path(cmd[-1]).touch()
+
+    monkeypatch.setattr(provider_clang.subprocess, "run", run)
+    kwargs = _compile_kwargs()
+    kwargs["select_bundle_format"] = lambda: "bc"
+
+    with pytest.raises(DSLRuntimeError, match="empty LLVM bitcode"):
+        provider_bundle.compile_bundle_source(
+            'extern "C" {}',
+            **kwargs,
+        )
+
+    assert provider_bundle.get_compile_counter() == 0
+
+
+def test_layout_probe_decoder_is_strict():
+    symbol = "cuda_coop_layout_probe_test"
+    expression = f"&{symbol}<(sizeof(Storage)), (alignof(Storage))>"
+
+    assert provider_contract._decode_layout_probe_name(
+        f"_Z{len(symbol)}{symbol}ILy40ELy8EE",
+        symbol=symbol,
+        expression=expression,
+    ) == provider_contract.StorageLayout(40, 8)
+    with pytest.raises(ValueError, match="unexpected lowered layout-probe name"):
+        provider_contract._decode_layout_probe_name(
+            f"_Z{len(symbol)}{symbol}ILy40ELy8ELy2EE",
+            symbol=symbol,
+            expression=expression,
+        )
+    with pytest.raises(ValueError, match="Invalid storage layout"):
+        provider_contract._decode_layout_probe_name(
+            f"_Z{len(symbol)}{symbol}ILy40ELy3EE",
+            symbol=symbol,
+            expression=expression,
+        )
+
+
+def test_real_nvrtc_layout_probe_and_disk_cache():
+    source = """
+struct alignas(8) Storage { unsigned char data[40]; };
+extern "C" __device__ void provider_entry() {}
+"""
+    probe = provider_contract.LayoutProbe(
+        key="storage",
+        size_expression="sizeof(Storage)",
+        alignment_expression="alignof(Storage)",
+    )
+
+    first = provider_bundle.compile_bundle_source_with_layouts(
+        source,
+        layout_probes=(probe,),
+        **_compile_kwargs(),
+    )
+
+    assert first.layouts == {"storage": provider_contract.StorageLayout(40, 8)}
+    assert provider_bundle.get_nvrtc_compile_program_counter() == 1
+
+    provider_bundle.reset_compile_state()
+    second = provider_bundle.compile_bundle_source_with_layouts(
+        source,
+        layout_probes=(probe,),
+        **_compile_kwargs(),
+    )
+
+    assert second == first
+    assert provider_bundle.get_nvrtc_compile_program_counter() == 0

--- a/python/cuda_coop/tests/backends/cutlass/compile/test_provider_bundle_resolution.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/test_provider_bundle_resolution.py
@@ -1,0 +1,673 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import re
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("cutlass")
+
+from cutlass.base_dsl.common import DSLRuntimeError
+
+import cuda.coop.cutlass._compiler._bundle as provider_bundle
+import cuda.coop.cutlass._compiler._bundle_contract as provider_contract
+import cuda.coop.cutlass._compiler._cache as provider_cache
+import cuda.coop.cutlass._compiler._nvrtc as provider_nvrtc
+from cuda.coop._headers import _toolkit
+
+
+def test_include_options_use_filesystem_encoding():
+    include_dir = "/tmp/cuda-coop-\udcff/include"
+
+    assert provider_nvrtc.include_options([include_dir]) == [
+        os.fsencode(f"-I{include_dir}")
+    ]
+
+
+def test_preload_toolkit_nvrtc_wraps_malformed_header_encoding(tmp_path):
+    include_dir = tmp_path / "toolkit" / "include"
+    include_dir.mkdir(parents=True)
+    (include_dir / "cuda_runtime_api.h").write_bytes(b"\xff")
+
+    with pytest.raises(
+        DSLRuntimeError,
+        match="Failed aligning provider NVRTC",
+    ) as error:
+        provider_nvrtc.preload_toolkit_nvrtc([str(include_dir)])
+
+    assert isinstance(error.value.__cause__, RuntimeError)
+    assert isinstance(error.value.__cause__.__cause__, UnicodeDecodeError)
+
+
+class _NvrtcResult:
+    NVRTC_SUCCESS = 0
+
+
+class _FakeNvrtc:
+    nvrtcResult = _NvrtcResult
+
+    def __init__(self):
+        self.calls = []
+        self.blob = b"fake-ltoir"
+        self.version = (13, 0)
+
+    def nvrtcVersion(self):
+        return 0, *self.version
+
+    def nvrtcCreateProgram(self, source, name, num_headers, headers, include_names):
+        self.calls.append(("create", source))
+        return 0, object()
+
+    def nvrtcAddNameExpression(self, program, expression):
+        self.calls.append(("add", expression))
+        return (0,)
+
+    def nvrtcCompileProgram(self, program, num_options, options):
+        self.calls.append(("compile", tuple(options)))
+        return (0,)
+
+    def nvrtcGetLoweredName(self, program, expression):
+        self.calls.append(("get_lowered", expression))
+        decoded = expression.decode("utf-8")
+        symbol_match = re.match(r"&([^<]+)<", decoded)
+        assert symbol_match is not None
+        symbol = symbol_match.group(1)
+        return 0, f"_Z{len(symbol)}{symbol}ILy40ELy8EE".encode()
+
+    def nvrtcGetLTOIRSize(self, program):
+        self.calls.append(("get_ltoir_size",))
+        return 0, len(self.blob)
+
+    def nvrtcGetLTOIR(self, program, blob):
+        self.calls.append(("get_ltoir",))
+        blob[:] = self.blob
+        return (0,)
+
+    def nvrtcDestroyProgram(self, program):
+        self.calls.append(("destroy",))
+        return (0,)
+
+
+def _compile_kwargs():
+    return {
+        "scope": "cuda.coop.cutlass",
+        "provider_dir": provider_bundle.__file__,
+        "registered_headers": dict,
+        "select_bundle_format": lambda: "ltoir",
+        "resolve_nvrtc_sm_arch": lambda: "sm_80",
+        "resolve_nvrtc_arch": lambda: "compute_80",
+    }
+
+
+def _probe():
+    return provider_contract.LayoutProbe(
+        key="storage",
+        size_expression="sizeof(Storage)",
+        alignment_expression="alignof(Storage)",
+    )
+
+
+def test_bitcode_resolution_tracks_the_selected_sm_arch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        provider_bundle._clang_support,
+        "resolve_clang_compiler",
+        lambda which: ("clang++", "clang-test", "clang-test"),
+    )
+
+    def compile_bundle(source, **kwargs):
+        del source
+        calls.append(kwargs)
+        return provider_cache._CachedBundle(
+            path=kwargs["output_path"], layouts_by_expression={}
+        )
+
+    monkeypatch.setattr(
+        provider_bundle._clang_support,
+        "compile_bundle",
+        compile_bundle,
+    )
+    kwargs = _compile_kwargs()
+    kwargs.update(
+        select_bundle_format=lambda: "bc",
+        resolve_nvrtc_sm_arch=lambda: "sm_90",
+        resolve_nvrtc_arch=lambda: (_ for _ in ()).throw(
+            AssertionError("bitcode must not resolve an NVRTC compute target")
+        ),
+    )
+
+    path = provider_bundle.compile_bundle_source('extern "C" {}', **kwargs)
+
+    assert path.endswith(".bc")
+    assert len(calls) == 1
+    assert "-march=sm_90" in calls[0]["compiler_options"]
+    assert calls[0]["cache_identity"].bundle.bundle_sm_arch == "sm_90"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_bundle_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        provider_cache.CACHE_DIR_ENV,
+        str(tmp_path / "provider-cache"),
+    )
+    provider_bundle.reset_compile_state()
+    with _toolkit._PRELOAD_LOCK:
+        _toolkit._EXACT_LIBRARY_HANDLES.clear()
+    yield
+    provider_bundle.reset_compile_state()
+    with _toolkit._PRELOAD_LOCK:
+        _toolkit._EXACT_LIBRARY_HANDLES.clear()
+
+
+def test_configured_cache_dir_creates_missing_parents(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "nested" / "provider" / "cache"
+    monkeypatch.setenv(provider_cache.CACHE_DIR_ENV, str(cache_dir))
+
+    assert provider_cache.ensure_cache_dir("cuda.coop.cutlass") == str(cache_dir)
+    assert cache_dir.is_dir()
+    assert cache_dir.stat().st_mode & 0o777 == 0o700
+
+
+def test_preload_toolkit_nvrtc_checks_lib64_and_ignores_unversioned_files(
+    monkeypatch,
+    tmp_path,
+):
+    include_dir = tmp_path / "toolkit" / "include"
+    lib64_dir = tmp_path / "toolkit" / "lib64"
+    include_dir.mkdir(parents=True)
+    lib64_dir.mkdir()
+    nvrtc = lib64_dir / "libnvrtc.so.13"
+    nvjitlink = lib64_dir / "libnvJitLink.so.13"
+    unversioned = lib64_dir / "libnvrtc.so"
+    for library in (nvrtc, nvjitlink, unversioned):
+        library.touch()
+    (include_dir / "cuda_runtime_api.h").write_text(
+        "#define CUDART_VERSION 13000\n",
+        encoding="utf-8",
+    )
+
+    loaded = []
+    monkeypatch.setattr(
+        "ctypes.CDLL",
+        lambda path, *, mode: loaded.append((path, mode)),
+    )
+    monkeypatch.setattr(
+        "cuda.pathfinder.load_nvidia_dynamic_lib",
+        lambda name: SimpleNamespace(
+            abs_path=str(nvrtc if name == "nvrtc" else nvjitlink)
+        ),
+    )
+    monkeypatch.setattr(_toolkit, "_nvjitlink_version", lambda path: (13, 0))
+    monkeypatch.setattr(provider_nvrtc, "get_version_tuple", lambda: (13, 0))
+
+    provider_nvrtc.preload_toolkit_nvrtc([str(include_dir)])
+
+    assert [Path(path).name for path, _ in loaded] == [
+        "libnvrtc.so.13",
+        "libnvJitLink.so.13",
+    ]
+    with _toolkit._PRELOAD_LOCK:
+        assert len(_toolkit._EXACT_LIBRARY_HANDLES) == 2
+
+
+def test_preload_toolkit_nvrtc_loads_split_library_directories(
+    monkeypatch,
+    tmp_path,
+):
+    first_include = tmp_path / "first" / "include"
+    second_include = tmp_path / "second" / "include"
+    first_lib = tmp_path / "first" / "lib"
+    second_lib = tmp_path / "second" / "lib"
+    for directory in (first_include, second_include, first_lib, second_lib):
+        directory.mkdir(parents=True)
+    for include_dir in (first_include, second_include):
+        (include_dir / "cuda_runtime_api.h").write_text(
+            "#define CUDART_VERSION 13000\n",
+            encoding="utf-8",
+        )
+    nvrtc = first_lib / "libnvrtc.so.13"
+    nvjitlink = second_lib / "libnvJitLink.so.13"
+    nvrtc.touch()
+    nvjitlink.touch()
+
+    loaded = []
+    monkeypatch.setattr(
+        "ctypes.CDLL",
+        lambda path, *, mode: loaded.append((path, mode)),
+    )
+    monkeypatch.setattr(
+        "cuda.pathfinder.load_nvidia_dynamic_lib",
+        lambda name: SimpleNamespace(
+            abs_path=str(nvrtc if name == "nvrtc" else nvjitlink)
+        ),
+    )
+    monkeypatch.setattr(_toolkit, "_nvjitlink_version", lambda path: (13, 0))
+    monkeypatch.setattr(provider_nvrtc, "get_version_tuple", lambda: (13, 0))
+
+    provider_nvrtc.preload_toolkit_nvrtc([str(first_include), str(second_include)])
+
+    assert [Path(path) for path, _ in loaded] == [nvrtc, nvjitlink]
+
+
+def test_preload_toolkit_nvrtc_requires_a_reported_version(monkeypatch):
+    monkeypatch.setattr(
+        provider_nvrtc,
+        "preload_toolkit_compiler_libraries",
+        lambda _include_dirs: SimpleNamespace(
+            nvrtc_path="/toolkit/libnvrtc.so",
+            toolkit_version=(13, 0),
+        ),
+    )
+    monkeypatch.setattr(provider_nvrtc, "get_version_tuple", lambda: None)
+
+    with pytest.raises(
+        DSLRuntimeError,
+        match="Failed aligning provider NVRTC",
+    ) as exc_info:
+        provider_nvrtc.preload_toolkit_nvrtc(("/toolkit/include",))
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert str(exc_info.value.__cause__) == "loaded NVRTC did not report its version"
+
+
+def test_resolution_routes_preserve_nvrtc_memory_and_disk_behavior(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+
+    first = provider_bundle.compile_bundle_source(
+        'extern "C" {}',
+        **_compile_kwargs(),
+    )
+    assert provider_bundle.get_bundle_telemetry().route_counts == {
+        provider_contract.RESOLUTION_ROUTE_NVRTC: 1
+    }
+    second = provider_bundle.compile_bundle_source(
+        'extern "C" {}',
+        **_compile_kwargs(),
+    )
+    assert provider_bundle.get_bundle_telemetry().route_counts == {
+        provider_contract.RESOLUTION_ROUTE_NVRTC: 1,
+        provider_contract.RESOLUTION_ROUTE_MEMORY: 1,
+    }
+    provider_bundle.reset_compile_state()
+    third = provider_bundle.compile_bundle_source(
+        'extern "C" {}',
+        **_compile_kwargs(),
+    )
+
+    assert first == second == third
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 1
+    compile_options = next(call[1] for call in fake_nvrtc.calls if call[0] == "compile")
+    identity_options = tuple(
+        option.encode("ascii")
+        for option in provider_contract.bundle_compiler_options(
+            "ltoir",
+            "compute_80",
+        )
+    )
+    assert compile_options[: len(identity_options)] == identity_options
+
+    telemetry = provider_bundle.get_bundle_telemetry()
+    assert telemetry.route_counts == {provider_contract.RESOLUTION_ROUTE_DISK: 1}
+    assert telemetry.phase_counts["total"] == 1
+    assert "compiler" not in telemetry.phase_counts
+
+
+def test_resolution_telemetry_counts_routes_and_exact_layouts(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+
+    first = provider_bundle.compile_bundle_source_with_layouts(
+        "struct Storage {};",
+        layout_probes=(_probe(),),
+        **_compile_kwargs(),
+    )
+    second = provider_bundle.compile_bundle_source_with_layouts(
+        "struct Storage {};",
+        layout_probes=(_probe(),),
+        **_compile_kwargs(),
+    )
+
+    assert first == second
+    assert first.layouts == {"storage": provider_contract.StorageLayout(40, 8)}
+
+    telemetry = provider_bundle.get_bundle_telemetry()
+    assert telemetry.route_counts == {
+        provider_contract.RESOLUTION_ROUTE_NVRTC: 1,
+        provider_contract.RESOLUTION_ROUTE_MEMORY: 1,
+    }
+    assert telemetry.phase_counts["total"] == 2
+    assert telemetry.phase_counts["compiler"] == 1
+    assert all(value >= 0 for value in telemetry.phase_timings_ns.values())
+
+
+def test_nvrtc_version_changes_mutable_cache_identity(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+
+    first = provider_bundle.compile_bundle_source(
+        'extern "C" {}',
+        **_compile_kwargs(),
+    )
+    fake_nvrtc.version = (13, 1)
+    second = provider_bundle.compile_bundle_source(
+        'extern "C" {}',
+        **_compile_kwargs(),
+    )
+
+    assert first != second
+    assert provider_bundle.get_bundle_telemetry().route_counts == {
+        provider_contract.RESOLUTION_ROUTE_NVRTC: 2
+    }
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 2
+
+
+@pytest.mark.skipif(os.name == "nt", reason="test exercises POSIX file locking")
+def test_artifact_lock_serializes_across_processes(tmp_path):
+    artifact_path = str(tmp_path / "bundle.ltoir")
+    acquired_path = tmp_path / "acquired"
+    source_path = str(Path(provider_bundle.__file__).resolve().parents[4])
+    script = """
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[1])
+from cuda.coop.cutlass._compiler import _cache as provider_cache
+
+with provider_cache.artifact_lock(sys.argv[2], scope="test"):
+    Path(sys.argv[3]).write_text("acquired", encoding="utf-8")
+"""
+
+    with provider_cache.artifact_lock(artifact_path, scope="test"):
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                script,
+                source_path,
+                artifact_path,
+                str(acquired_path),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        with pytest.raises(subprocess.TimeoutExpired):
+            process.wait(timeout=0.2)
+        assert not acquired_path.exists()
+
+    _, stderr = process.communicate(timeout=5)
+    assert process.returncode == 0, stderr
+    assert acquired_path.read_text(encoding="utf-8") == "acquired"
+
+
+def _forked_artifact_lock_worker(
+    artifact_path,
+    inherited_descriptor,
+    inherited_identity,
+    connection,
+):
+    try:
+        descriptor_stat = os.fstat(inherited_descriptor)
+    except OSError:
+        inherited_lock_descriptor = False
+    else:
+        inherited_lock_descriptor = (
+            descriptor_stat.st_dev,
+            descriptor_stat.st_ino,
+        ) == inherited_identity
+    connection.send(("inherited_lock_descriptor", inherited_lock_descriptor))
+    with provider_cache.artifact_lock(artifact_path, scope="test"):
+        connection.send(("acquired", True))
+    connection.close()
+
+
+def _forked_nvrtc_counter_worker(connection):
+    outcome = {}
+
+    def access_counter():
+        try:
+            provider_nvrtc.reset_compile_state()
+            outcome["counter"] = provider_nvrtc.get_compile_program_counter()
+        except Exception as exc:
+            outcome["error"] = repr(exc)
+
+    thread = threading.Thread(target=access_counter, daemon=True)
+    thread.start()
+    thread.join(timeout=2)
+    connection.send(
+        {
+            "completed": not thread.is_alive(),
+            "counter": outcome.get("counter"),
+            "error": outcome.get("error"),
+        }
+    )
+    connection.close()
+
+
+def _forked_unknown_compiler_token_worker(connection):
+    connection.send(provider_bundle._unknown_compiler_process_token())
+    connection.close()
+
+
+def _fork_inside_artifact_lock_worker(artifact_path, connection):
+    report_read, report_write = os.pipe()
+    child_pid = None
+    descriptor = None
+    with provider_cache.artifact_lock(artifact_path, scope="test"):
+        with provider_cache._STATE_LOCK:
+            active_descriptors = tuple(provider_cache._ACTIVE_ARTIFACT_LOCK_FDS)
+        assert len(active_descriptors) == 1
+        descriptor = active_descriptors[0]
+        child_pid = os.fork()
+        if child_pid == 0:
+            os.close(report_read)
+            reused_read, reused_write = os.pipe()
+            if descriptor not in (reused_read, reused_write):
+                os.dup2(reused_read, descriptor)
+
+    assert child_pid is not None
+    assert descriptor is not None
+    if child_pid == 0:
+        try:
+            os.fstat(descriptor)
+        except OSError:
+            os.write(report_write, b"0")
+        else:
+            os.write(report_write, b"1")
+        os._exit(0)
+
+    os.close(report_write)
+    descriptor_survived = os.read(report_read, 1) == b"1"
+    _, child_status = os.waitpid(child_pid, 0)
+    connection.send(
+        {
+            "child_exitcode": os.waitstatus_to_exitcode(child_status),
+            "descriptor_survived": descriptor_survived,
+        }
+    )
+    connection.close()
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork"),
+    reason="test requires POSIX fork state reset",
+)
+@pytest.mark.filterwarnings(
+    "ignore:This process .* is multi-threaded, use of fork.*:DeprecationWarning"
+)
+def test_nvrtc_counter_lock_state_resets_after_fork():
+    context = multiprocessing.get_context("fork")
+    parent_connection, child_connection = context.Pipe(duplex=False)
+    process = context.Process(
+        target=_forked_nvrtc_counter_worker,
+        args=(child_connection,),
+    )
+    process.start()
+    child_connection.close()
+    result = None
+    try:
+        assert parent_connection.poll(5)
+        result = parent_connection.recv()
+        process.join(timeout=5)
+    finally:
+        if process.is_alive():
+            process.terminate()
+        process.join(timeout=5)
+        parent_connection.close()
+
+    assert not process.is_alive()
+    assert process.exitcode == 0
+    assert result == {"completed": True, "counter": 0, "error": None}
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork"),
+    reason="test requires POSIX fork state reset",
+)
+@pytest.mark.filterwarnings(
+    "ignore:This process .* is multi-threaded, use of fork.*:DeprecationWarning"
+)
+def test_unknown_compiler_token_partitions_forked_processes():
+    parent_token = provider_bundle._unknown_compiler_process_token()
+    assert provider_bundle._unknown_compiler_process_token() == parent_token
+
+    context = multiprocessing.get_context("fork")
+    parent_connection, child_connection = context.Pipe(duplex=False)
+    process = context.Process(
+        target=_forked_unknown_compiler_token_worker,
+        args=(child_connection,),
+    )
+    process.start()
+    child_connection.close()
+    child_token = None
+    try:
+        assert parent_connection.poll(5)
+        child_token = parent_connection.recv()
+        process.join(timeout=5)
+    finally:
+        if process.is_alive():
+            process.terminate()
+        process.join(timeout=5)
+        parent_connection.close()
+
+    assert process.exitcode == 0
+    assert child_token != parent_token
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork"),
+    reason="test requires POSIX fork state reset",
+)
+@pytest.mark.filterwarnings(
+    "ignore:This process .* is multi-threaded, use of fork.*:DeprecationWarning"
+)
+def test_artifact_lock_state_resets_after_fork(tmp_path):
+    artifact_path = str(tmp_path / "bundle.ltoir")
+    lock_held = threading.Event()
+    release_lock = threading.Event()
+
+    def hold_artifact_lock():
+        with provider_cache.artifact_lock(artifact_path, scope="test"):
+            lock_held.set()
+            release_lock.wait()
+
+    holder = threading.Thread(target=hold_artifact_lock)
+    holder.start()
+    process = None
+    parent_connection = None
+    child_connection = None
+    try:
+        assert lock_held.wait(timeout=5)
+        with provider_cache._STATE_LOCK:
+            inherited_descriptors = tuple(provider_cache._ACTIVE_ARTIFACT_LOCK_FDS)
+        assert len(inherited_descriptors) == 1
+        inherited_descriptor = inherited_descriptors[0]
+        descriptor_stat = os.fstat(inherited_descriptor)
+        inherited_identity = (
+            descriptor_stat.st_dev,
+            descriptor_stat.st_ino,
+        )
+        context = multiprocessing.get_context("fork")
+        parent_connection, child_connection = context.Pipe(duplex=False)
+        process = context.Process(
+            target=_forked_artifact_lock_worker,
+            args=(
+                artifact_path,
+                inherited_descriptor,
+                inherited_identity,
+                child_connection,
+            ),
+        )
+        process.start()
+        assert parent_connection.poll(5)
+        assert parent_connection.recv() == (
+            "inherited_lock_descriptor",
+            False,
+        )
+        assert not parent_connection.poll(0.2)
+        release_lock.set()
+        assert parent_connection.poll(5)
+        assert parent_connection.recv() == ("acquired", True)
+        process.join(timeout=5)
+    finally:
+        release_lock.set()
+        holder.join(timeout=5)
+        if process is not None and process.is_alive():
+            process.terminate()
+        if process is not None:
+            process.join(timeout=5)
+        if parent_connection is not None:
+            parent_connection.close()
+        if child_connection is not None:
+            child_connection.close()
+
+    assert not holder.is_alive()
+    assert process is not None
+    assert not process.is_alive()
+    assert process.exitcode == 0
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork"),
+    reason="test requires POSIX fork state reset",
+)
+@pytest.mark.filterwarnings(
+    "ignore:This process .* is multi-threaded, use of fork.*:DeprecationWarning"
+)
+def test_artifact_lock_context_ignores_stale_child_descriptor(tmp_path):
+    artifact_path = str(tmp_path / "bundle.ltoir")
+    context = multiprocessing.get_context("fork")
+    parent_connection, child_connection = context.Pipe(duplex=False)
+    process = context.Process(
+        target=_fork_inside_artifact_lock_worker,
+        args=(artifact_path, child_connection),
+    )
+    process.start()
+    try:
+        assert parent_connection.poll(10)
+        result = parent_connection.recv()
+        process.join(timeout=5)
+    finally:
+        if process.is_alive():
+            process.terminate()
+        process.join(timeout=5)
+        parent_connection.close()
+        child_connection.close()
+
+    assert not process.is_alive()
+    assert process.exitcode == 0
+    assert result == {
+        "child_exitcode": 0,
+        "descriptor_survived": True,
+    }

--- a/python/cuda_coop/tests/backends/cutlass/compile/test_provider_finalization.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/test_provider_finalization.py
@@ -1,0 +1,323 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+pytest.importorskip("cutlass")
+
+
+@dataclass(frozen=True)
+class _Request:
+    kind: str = "foundation_test"
+    symbol_name: str = "cuda_coop_foundation_test"
+
+
+def test_provider_requires_trace_finalize_capability():
+    from cutlass.base_dsl.common import DSLRuntimeError
+
+    from cuda.coop.cutlass._compiler import _state
+
+    dsl_without_finalize = type("Dsl", (), {"compile_options": object()})()
+
+    with pytest.raises(
+        DSLRuntimeError,
+        match=r"(?s)trace-finalize hook.*compatible.*CUTLASS DSL runtime",
+    ):
+        _state.ensure_trace_hook_registered(
+            get_cute_dsl=lambda: dsl_without_finalize,
+        )
+
+
+def test_trace_hook_registration_holds_the_state_lock(monkeypatch):
+    from cuda.coop.cutlass._compiler import _state
+
+    class RecordingLock:
+        depth = 0
+
+        def __enter__(self):
+            self.depth += 1
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            del exc_type, exc_value, traceback
+            self.depth -= 1
+
+    lock = RecordingLock()
+    registered = []
+
+    def register_hook(hook):
+        assert lock.depth > 0
+        registered.append(hook)
+
+    dsl = type(
+        "Dsl",
+        (),
+        {
+            "compile_options": object(),
+            "register_trace_finalize_hook": staticmethod(register_hook),
+        },
+    )()
+
+    def finalizer(dsl, module, function_name):
+        del dsl, module, function_name
+
+    monkeypatch.setattr(_state, "_BUNDLE_FINALIZER", finalizer)
+    monkeypatch.setattr(_state, "_SESSION_SCOPE", "cuda.coop.cutlass")
+    monkeypatch.setattr(_state, "_STATE_LOCK", lock)
+
+    _state.ensure_trace_hook_registered(
+        finalizer=finalizer,
+        scope="cuda.coop.cutlass",
+        get_cute_dsl=lambda: dsl,
+    )
+
+    assert registered == [_state._trace_finalize_dispatcher]
+
+
+def test_managed_link_cleanup_accepts_fresh_compile_options(monkeypatch, tmp_path):
+    import cuda.coop.cutlass._compiler._cache as _provider_cache
+    import cuda.coop.cutlass._compiler._finalize as _provider_finalizer
+
+    managed_path = str(tmp_path / "managed.ltoir")
+    monkeypatch.setattr(
+        _provider_cache,
+        "managed_bundle_paths",
+        lambda: frozenset({managed_path}),
+    )
+    dsl = type(
+        "Dsl",
+        (),
+        {"compile_options": type("Options", (), {"options": {}})()},
+    )()
+
+    _provider_finalizer._remove_managed_bundle_link_options(dsl)
+
+    assert dsl.compile_options.options == {}
+
+
+def test_trace_finalizer_compiles_and_links_registered_requests(monkeypatch):
+    import cuda.coop.cutlass._compiler._bundle as _provider_bundle
+    import cuda.coop.cutlass._compiler._finalize as finalizer
+    import cuda.coop.cutlass._compiler._rendering as _rendering
+    import cuda.coop.cutlass._compiler._state as _state
+    import cuda.coop.cutlass._compiler._storage as _storage
+    import cuda.coop.cutlass._compiler._types as _types
+
+    renderer = _types.BundleRenderer(
+        include_lines=(),
+        cccl_headers=(),
+        render=lambda request: [f'extern "C" void {request.symbol_name}() {{}}'],
+    )
+    monkeypatch.setitem(_rendering._BUNDLE_RENDERERS, "foundation_test", renderer)
+
+    compile_options = type("CompileOptions", (), {"options": {}})()
+    dsl = type("Dsl", (), {"compile_options": compile_options})()
+    module = type("Module", (), {"operation": object()})()
+    session = _state.BundleSession(module.operation)
+    session.add(_Request())
+    _state.set_bundle_session(compile_options, session)
+
+    compiled_sources: list[str] = []
+    materialized: list[tuple[object, ...]] = []
+    linked: list[tuple[object, str]] = []
+
+    def compile_source(source: str) -> str:
+        compiled_sources.append(source)
+        return "/tmp/cuda_coop_foundation_test.ltoir"
+
+    monkeypatch.setattr(finalizer, "_compile_bundle_source", compile_source)
+    monkeypatch.setattr(
+        _storage,
+        "materialize_deferred_temp_storage_plans",
+        lambda plans: materialized.append(plans),
+    )
+    monkeypatch.setattr(
+        _provider_bundle,
+        "append_link_library_attr",
+        lambda target, path: linked.append((target, path)),
+    )
+
+    finalizer._trace_finalize_hook(dsl, module, "kernel")
+
+    assert len(compiled_sources) == 1
+    assert "cuda_coop_foundation_test" in compiled_sources[0]
+    assert materialized == [()]
+    assert linked == [(module, "/tmp/cuda_coop_foundation_test.ltoir")]
+    assert _state.lookup_bundle_session(compile_options) is None
+
+
+def test_trace_finalizer_preserves_a_session_for_its_owning_module(monkeypatch):
+    import cuda.coop.cutlass._compiler._bundle as _provider_bundle
+    import cuda.coop.cutlass._compiler._finalize as finalizer
+    import cuda.coop.cutlass._compiler._state as _state
+
+    compile_options = type("CompileOptions", (), {"options": {}})()
+    dsl = type("Dsl", (), {"compile_options": compile_options})()
+    owning_module = type("Module", (), {"operation": object()})()
+    unrelated_module = type("Module", (), {"operation": object()})()
+    session = _state.BundleSession(owning_module.operation)
+    session.add(_Request())
+    _state.set_bundle_session(compile_options, session)
+
+    compiled_sources: list[str] = []
+    linked: list[tuple[object, str]] = []
+    monkeypatch.setattr(
+        finalizer,
+        "_render_bundle_source",
+        lambda requests: f"requests={len(requests)}",
+    )
+    monkeypatch.setattr(
+        finalizer,
+        "_compile_bundle_source",
+        lambda source: compiled_sources.append(source) or "/tmp/provider.ltoir",
+    )
+    monkeypatch.setattr(
+        _provider_bundle,
+        "append_link_library_attr",
+        lambda target, path: linked.append((target, path)),
+    )
+
+    finalizer._trace_finalize_hook(dsl, unrelated_module, "other")
+
+    assert _state.lookup_bundle_session(compile_options) is session
+    assert compiled_sources == []
+    assert linked == []
+
+    finalizer._trace_finalize_hook(dsl, owning_module, "owner")
+
+    assert _state.lookup_bundle_session(compile_options) is None
+    assert compiled_sources == ["requests=1"]
+    assert linked == [(owning_module, "/tmp/provider.ltoir")]
+
+
+def test_provider_session_snapshot_restores_trace_module_binding(monkeypatch):
+    from cuda.coop.cutlass._compiler import _state
+
+    compile_options = type("CompileOptions", (), {"options": {}})()
+    dsl = type("Dsl", (), {"compile_options": compile_options})()
+    trace_module = object()
+    session = _state.BundleSession()
+    _state.set_bundle_session(compile_options, session)
+    monkeypatch.setattr(_state, "_active_trace_module_op", lambda: trace_module)
+
+    snapshot = _state.snapshot_active_session_state_for(get_cute_dsl=lambda: dsl)
+    assert session.trace_module_op is None
+
+    assert session.bind_trace_module(trace_module)
+    session.add(_Request())
+    _state.restore_active_session_state_for(snapshot, get_cute_dsl=lambda: dsl)
+
+    assert session.trace_module_op is None
+    assert session.is_empty()
+
+
+def test_provider_session_snapshot_restores_nonweak_scalar_types():
+    from cutlass.base_dsl.typing import Int32
+
+    from cuda.coop.cutlass._compiler import _state
+
+    class Scalar:
+        __slots__ = ()
+
+    compile_options = type("CompileOptions", (), {"options": {}})()
+    dsl = type("Dsl", (), {"compile_options": compile_options})()
+    value = Scalar()
+    session = _state.BundleSession()
+    _state.set_bundle_session(compile_options, session)
+    _state.remember_scalar_result_type(
+        value,
+        Int32,
+        compile_options=compile_options,
+    )
+    snapshot = _state.snapshot_active_session_state_for(get_cute_dsl=lambda: dsl)
+
+    assert _state.canonical_dsl_type(value) is Int32
+    assert _state.pop_bundle_session(compile_options) is session
+    assert _state.canonical_dsl_type(value) is Scalar
+
+    try:
+        _state.restore_active_session_state_for(snapshot, get_cute_dsl=lambda: dsl)
+        assert _state.lookup_bundle_session(compile_options) is not session
+        assert _state.canonical_dsl_type(value) is Int32
+    finally:
+        _state.pop_bundle_session(compile_options)
+
+
+def test_provider_session_snapshot_rolls_back_weak_scalar_types():
+    from cutlass.base_dsl.typing import Int32
+
+    from cuda.coop._core import ResultVisibility
+    from cuda.coop.cutlass import _value_metadata
+    from cuda.coop.cutlass._compiler import _state
+
+    class Scalar:
+        pass
+
+    compile_options = type("CompileOptions", (), {"options": {}})()
+    dsl = type("Dsl", (), {"compile_options": compile_options})()
+    value = Scalar()
+    metadata = _value_metadata.ValueGroupMetadata(
+        _value_metadata.DefinedThreadDomain.all_callers(),
+        ResultVisibility.PER_MEMBER,
+    )
+    session = _state.BundleSession()
+    _state.set_bundle_session(compile_options, session)
+    snapshot = _state.snapshot_active_session_state_for(get_cute_dsl=lambda: dsl)
+
+    try:
+        _state.remember_scalar_result_type(
+            value,
+            Int32,
+            compile_options=compile_options,
+            group_metadata=metadata,
+        )
+        assert _state.canonical_dsl_type(value) is Int32
+        assert _state.scalar_result_group_metadata(value) is metadata
+
+        _state.restore_active_session_state_for(snapshot, get_cute_dsl=lambda: dsl)
+
+        assert _state.canonical_dsl_type(value) is Scalar
+        assert _state.scalar_result_group_metadata(value) is None
+    finally:
+        _state.pop_bundle_session(compile_options)
+
+
+@pytest.mark.parametrize("snapshot_has_state", [False, True])
+def test_provider_session_restore_closes_a_switched_compile_options_session(
+    snapshot_has_state,
+):
+    from cuda.coop.cutlass._compiler import _state
+
+    compile_options_a = type("CompileOptions", (), {"options": {}})()
+    compile_options_b = type("CompileOptions", (), {"options": {}})()
+    dsl = type("Dsl", (), {"compile_options": compile_options_a})()
+    session_a = None
+    if snapshot_has_state:
+        session_a = _state.BundleSession()
+        session_a.add(_Request())
+        _state.set_bundle_session(compile_options_a, session_a)
+    snapshot = _state.snapshot_active_session_state_for(get_cute_dsl=lambda: dsl)
+
+    dsl.compile_options = compile_options_b
+    session_b = _state.BundleSession()
+    session_b.add(_Request(symbol_name="cuda_coop_switched_options"))
+    _state.set_bundle_session(compile_options_b, session_b)
+
+    try:
+        _state.restore_active_session_state_for(snapshot, get_cute_dsl=lambda: dsl)
+
+        assert _state.lookup_bundle_session(compile_options_b) is None
+        restored_a = _state.lookup_bundle_session(compile_options_a)
+        if snapshot_has_state:
+            assert restored_a is session_a
+            assert restored_a.request_list() == [_Request()]
+        else:
+            assert restored_a is None
+    finally:
+        _state.pop_bundle_session(compile_options_a)
+        _state.pop_bundle_session(compile_options_b)

--- a/python/cuda_coop/tests/backends/cutlass/compile/test_provider_source_dump.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/test_provider_source_dump.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+pytest.importorskip("cutlass")
+
+import cuda.coop.cutlass._compiler._bundle as _provider_bundle
+import cuda.coop.cutlass._compiler._bundle_contract as _provider_contract
+import cuda.coop.cutlass._compiler._cache as _provider_cache
+import cuda.coop.cutlass._compiler._nvrtc as _provider_nvrtc
+
+
+def test_provider_source_dump_survives_compile_cache_hit(tmp_path, monkeypatch):
+    source = 'extern "C" __device__ int cuda_coop_cutlass_probe() { return 1; }\n'
+    source_hash = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    identity = _provider_contract.make_bundle_identity(
+        source_hash=source_hash,
+        bundle_format="ltoir",
+        bundle_arch="compute_80",
+        bundle_sm_arch="sm_80",
+        compiler_options=_provider_contract.bundle_compiler_options(
+            "ltoir",
+            "compute_80",
+        ),
+        layout_expressions=(),
+    )
+    cache_identity = _provider_contract.make_bundle_cache_identity(
+        identity,
+        include_key=_provider_contract.include_dirs_cache_key([]),
+        producer_compiler_version=(
+            _provider_nvrtc.get_version()
+            or _provider_bundle._UNKNOWN_COMPILER_PROCESS_TOKEN
+        ),
+    )
+    cached_artifact = tmp_path / "cached.ltoir"
+    cached_artifact.write_bytes(b"cached")
+    dump_dir = tmp_path / "source"
+
+    monkeypatch.setenv(
+        "CUDA_COOP_CUTLASS_PROVIDER_DUMP_DIR",
+        str(dump_dir),
+    )
+    _provider_bundle.reset_compile_state()
+    monkeypatch.setitem(
+        _provider_cache._SOURCE_CACHE,
+        cache_identity.cache_key,
+        _provider_cache._CachedBundle(
+            path=str(cached_artifact),
+            layouts_by_expression={},
+            artifact_size=len(b"cached"),
+            artifact_sha256=hashlib.sha256(b"cached").hexdigest(),
+        ),
+    )
+
+    result = _provider_bundle.compile_bundle_source(
+        source,
+        scope="test",
+        provider_dir=str(tmp_path),
+        registered_headers=dict,
+        select_bundle_format=lambda: "ltoir",
+        resolve_nvrtc_sm_arch=lambda: "sm_80",
+        resolve_nvrtc_arch=lambda: "compute_80",
+    )
+
+    assert result == str(cached_artifact)
+    dumped = dump_dir / f"cuda_coop_cutlass_bundle_{source_hash}.cpp"
+    assert dumped.read_text(encoding="utf-8") == source

--- a/python/cuda_coop/tests/backends/cutlass/compile/test_reduce_scan.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/test_reduce_scan.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cuda import coop
+
+from ....support.paths import REPO_ROOT
+
+cute = pytest.importorskip("cutlass.cute")
+runtime = pytest.importorskip("cutlass.cute.runtime")
+Int32 = pytest.importorskip("cutlass.base_dsl.typing").Int32
+cutlass_coop = pytest.importorskip("cuda.coop.cutlass")
+
+pytestmark = [pytest.mark.backend_cutlass, pytest.mark.compile]
+
+_THREADS = 64
+_ITEMS_PER_THREAD = 2
+_TILE_ITEMS = _THREADS * _ITEMS_PER_THREAD
+
+
+@cute.kernel
+def _reduce_scan_kernel(values: cute.Tensor, output: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    block = coop.this_block()
+    items = coop.ThreadData(_ITEMS_PER_THREAD)
+    items[0] = values[tidx * _ITEMS_PER_THREAD]
+    items[1] = values[tidx * _ITEMS_PER_THREAD + 1]
+
+    full_sum = coop.sum(block, items)
+    inclusive = coop.inclusive_sum(block, items)
+    output[tidx * _ITEMS_PER_THREAD] = inclusive[0]
+    output[tidx * _ITEMS_PER_THREAD + 1] = inclusive[1]
+
+    qualified_block = cutlass_coop.this_block()
+    qualified_items = cutlass_coop.ThreadData.from_values(
+        items[0],
+        items[1],
+        dtype=Int32,
+    )
+    fixed_storage = cutlass_coop.TempStorage(4096, alignment=16)
+    aggregate = cutlass_coop.ThreadData(1, dtype=Int32)
+    exclusive = cutlass_coop.exclusive_sum(
+        qualified_block,
+        qualified_items,
+        temp_storage=fixed_storage,
+        aggregate_output=aggregate,
+    )
+    output[_TILE_ITEMS + tidx * _ITEMS_PER_THREAD] = exclusive[0]
+    output[_TILE_ITEMS + tidx * _ITEMS_PER_THREAD + 1] = exclusive[1]
+
+    direct_items_sum = cutlass_coop.sum(
+        qualified_block,
+        qualified_items,
+        broadcast=False,
+        algorithm="raking",
+    )
+    mapped_sum = cutlass_coop.sum(
+        qualified_block.group_by(1),
+        values[tidx],
+    )
+    logical = coop.this_warp().group_by(8)
+    partial_sum = coop.sum(
+        logical,
+        values[tidx],
+        broadcast=False,
+        valid_items=7,
+    )
+    if tidx == 0:
+        output[2 * _TILE_ITEMS] = full_sum
+        output[2 * _TILE_ITEMS + 1] = direct_items_sum
+        output[2 * _TILE_ITEMS + 2] = aggregate[0]
+    output[2 * _TILE_ITEMS + 3 + tidx] = mapped_sum
+    if tidx % 8 == 0:
+        output[3 * _TILE_ITEMS + tidx] = partial_sum
+
+
+@cute.jit
+def _run_reduce_scan(values: cute.Tensor, output: cute.Tensor):
+    _reduce_scan_kernel(values, output).launch(
+        grid=(1, 1, 1),
+        block=(_THREADS, 1, 1),
+    )
+
+
+def test_common_and_qualified_reduce_scan_compile_together(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache_dir = tmp_path / "provider-cache"
+    dump_dir = tmp_path / "provider-dump"
+    dump_dir.mkdir()
+    monkeypatch.setenv("CUDA_COOP_CUTLASS_PROVIDER_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("CUDA_COOP_CUTLASS_PROVIDER_DUMP_DIR", str(dump_dir))
+    monkeypatch.setenv("CUDA_COOP_CUTLASS_PROVIDER_BUNDLE_FORMAT", "ltoir")
+    monkeypatch.setenv("CUDA_COOP_CUTLASS_PROVIDER_CCCL_ROOT", str(REPO_ROOT))
+
+    fake_values = runtime.make_fake_compact_tensor(Int32, (_TILE_ITEMS,))
+    fake_output = runtime.make_fake_compact_tensor(Int32, (4 * _TILE_ITEMS,))
+    compiled = cute.compile(_run_reduce_scan, fake_values, fake_output)
+
+    assert callable(compiled)
+    artifacts = tuple(cache_dir.glob("*.ltoir"))
+    assert len(artifacts) == 1
+    assert artifacts[0].stat().st_size > 0
+
+    sources = tuple(dump_dir.glob("cuda_coop_cutlass_bundle_*.cpp"))
+    assert len(sources) == 1
+    source = sources[0].read_text(encoding="utf-8")
+    assert "#define _CUDAX_DISABLE_COOPERATIVE_GROUPS_INTEROP" in source
+    for header in (
+        "cuda/experimental/coop.cuh",
+        "cub/block/block_reduce.cuh",
+        "cub/block/block_scan.cuh",
+        "cub/warp/warp_reduce.cuh",
+    ):
+        assert f"#include <{header}>" in source
+    for symbol_fragment in (
+        "cuda_coop_cutlass_cudax_reduce_block_b64_sum_i32_x2",
+        "cuda_coop_cutlass_cudax_reduce_warps_within_block_1_all_b64_sum_i32",
+        "cuda_coop_cutlass_cub_reduce_block_b64_sum_i32_x2_raking_full",
+        "cuda_coop_cutlass_cub_reduce_threads_within_warp_8_all_b64_sum_i32",
+        "cuda_coop_cutlass_cub_scan_block_b64_exclusivesum_sum_i32_x2",
+        "cuda_coop_cutlass_cub_scan_block_b64_inclusivesum_sum_i32_x2",
+    ):
+        assert symbol_fragment in source
+    assert "temp_storage_bytes < required_temp_bytes" in source

--- a/python/cuda_coop/tests/backends/cutlass/compile/test_thread_groups.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/test_thread_groups.py
@@ -1,0 +1,301 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+import pytest
+
+import cuda.coop
+
+from ....support.paths import PACKAGE_ROOT
+
+SOURCE_ROOT = PACKAGE_ROOT
+_COOP_SOURCE_PATH = str(SOURCE_ROOT / "cuda" / "coop")
+cuda.coop.__path__ = [
+    _COOP_SOURCE_PATH,
+    *(entry for entry in cuda.coop.__path__ if entry != _COOP_SOURCE_PATH),
+]
+
+
+def _verified_grid_facts(*, exact_block_dim=64):
+    from cuda.coop._core import LaunchFactOrigin, LaunchFacts
+
+    return LaunchFacts(
+        exact_block_dim=exact_block_dim,
+        exact_grid_dim=(8, 2, 1),
+        exact_cluster_dim=(2, 1, 1),
+        cooperative_launch=True,
+        cluster_launch=True,
+        provenance=(
+            LaunchFactOrigin(
+                "cooperative_launch",
+                "test_launch_config",
+                verified=True,
+            ),
+            LaunchFactOrigin(
+                "cluster_launch",
+                "test_launch_config",
+                verified=True,
+            ),
+        ),
+    )
+
+
+def test_generic_finalizer_uses_registered_group_renderer():
+    import cuda.coop.cutlass as coop
+    import cuda.coop.cutlass._compiler._finalize as _provider_finalizer
+    import cuda.coop.cutlass._compiler._state as provider_state
+    from cuda.coop.cutlass._lowering import _thread_group as _thread_group_provider
+
+    request = _thread_group_provider._CudaxGroupRequest(
+        group=coop.this_block(),
+        op="sync",
+    )
+    source = _provider_finalizer._render_bundle_source([request])
+
+    assert f"void {request.symbol_name}()" in source
+    assert "#define _CUDAX_DISABLE_COOPERATIVE_GROUPS_INTEROP" in source
+    assert (
+        "::cuda::experimental::this_block "
+        "group{::cuda::experimental::implicit_hierarchy()};"
+    ) in source
+    assert provider_state._ensure_bundle_finalizer() is (
+        _provider_finalizer._trace_finalize_hook
+    )
+
+
+def test_group_query_rendering_covers_static_hierarchy_and_mappings():
+    pytest.importorskip("cutlass.cute.ffi")
+    from cutlass.base_dsl.typing import Int32
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop._core import resolve_thread_group
+    from cuda.coop.cutlass._lowering import _thread_group as provider
+
+    facts = _verified_grid_facts()
+    thread = resolve_thread_group(
+        coop.this_thread(),
+        facts,
+        through_level="grid",
+    ).require_supported()
+    grid = resolve_thread_group(
+        coop.this_grid(),
+        facts,
+    ).require_supported()
+    mapped = resolve_thread_group(
+        coop.this_warp().group_by(12, exhaustive=False),
+        facts,
+        through_level="warp",
+    ).require_supported()
+
+    thread_source = "\n".join(
+        provider._render_cudax_group(
+            provider._CudaxGroupRequest(
+                group=thread,
+                op="rank",
+                level="grid",
+                result_type=Int32,
+            )
+        )
+    )
+    grid_thread_source = "\n".join(
+        provider._render_cudax_group(
+            provider._CudaxGroupRequest(
+                group=grid,
+                op="count",
+                level="thread",
+                result_type=Int32,
+            )
+        )
+    )
+    grid_self_source = "\n".join(
+        provider._render_cudax_group(
+            provider._CudaxGroupRequest(
+                group=grid,
+                op="count",
+                level="grid",
+                result_type=Int32,
+            )
+        )
+    )
+    mapped_source = "\n".join(
+        provider._render_cudax_group(
+            provider._CudaxGroupRequest(
+                group=mapped,
+                op="rank",
+                level="warp",
+                result_type=Int32,
+            )
+        )
+    )
+    mapped_count_source = "\n".join(
+        provider._render_cudax_group(
+            provider._CudaxGroupRequest(
+                group=mapped,
+                op="count",
+                level="warp",
+                result_type=Int32,
+            )
+        )
+    )
+
+    assert "group.rank(::cuda::grid)" in thread_source
+    assert "::cuda::gpu_thread.count(group)" in grid_thread_source
+    assert "return static_cast<int>(1);" in grid_self_source
+    assert "group.rank(group_parent)" in mapped_source
+    assert "group.count(group_parent)" in mapped_count_source
+    assert "group_by<12, false>" in mapped_source
+
+
+@pytest.mark.parametrize("kind", ("thread", "warp", "block", "cluster", "grid"))
+def test_current_physical_group_rendering_uses_implicit_hierarchy(kind):
+    pytest.importorskip("cutlass.cute.ffi")
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop.cutlass._lowering import _thread_group as provider
+
+    group = getattr(coop, f"this_{kind}")()
+    source = "\n".join(
+        provider._render_cudax_group(
+            provider._CudaxGroupRequest(group=group, op="is_member")
+        )
+    )
+
+    assert (
+        f"::cuda::experimental::this_{kind} "
+        "group{::cuda::experimental::implicit_hierarchy()};"
+    ) in source
+    assert "group{}" not in source
+
+
+def test_implicit_current_block_operations_allow_empty_launch_facts(monkeypatch):
+    pytest.importorskip("cutlass.cute.ffi")
+    from cutlass.base_dsl.typing import Int32
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop._core import LaunchFacts
+    from cuda.coop.cutlass import _thread_group
+    from cuda.coop.cutlass._compiler import _launch
+    from cuda.coop.cutlass._lowering import _thread_group as provider
+
+    monkeypatch.setattr(_launch, "current_kernel_launch_facts", LaunchFacts)
+    block = coop.this_block()
+
+    assert (
+        _thread_group._validate_sync_launch(
+            block,
+            feature="ThreadGroup.sync",
+        )
+        is block
+    )
+    assert (
+        _thread_group._validate_query_launch(
+            block,
+            feature="ThreadGroup.rank",
+            level="thread",
+        )
+        is block
+    )
+    with pytest.raises(NotImplementedError, match="exact block dimensions"):
+        _thread_group._validate_query_launch(
+            coop.this_warp(),
+            feature="ThreadGroup.rank",
+            level="thread",
+        )
+    for group in (coop.this_thread(), coop.this_block()):
+        with pytest.raises(NotImplementedError, match="exact block dimensions"):
+            _thread_group._validate_query_launch(
+                group,
+                feature="ThreadGroup.rank",
+                level="warp",
+            )
+    for request in (
+        provider._CudaxGroupRequest(group=block, op="sync"),
+        provider._CudaxGroupRequest(
+            group=block,
+            op="rank",
+            level="thread",
+            result_type=Int32,
+        ),
+        provider._CudaxGroupRequest(group=block, op="is_member"),
+    ):
+        source = "\n".join(provider._render_cudax_group(request))
+        assert (
+            "::cuda::experimental::this_block "
+            "group{::cuda::experimental::implicit_hierarchy()};"
+        ) in source
+        assert "::cuda::hierarchy" not in source
+
+    monkeypatch.setattr(
+        _launch,
+        "current_kernel_launch_facts",
+        lambda: _verified_grid_facts(exact_block_dim=48),
+    )
+    with pytest.raises(NotImplementedError, match="complete 32-thread warps"):
+        _thread_group._validate_query_launch(
+            coop.this_warp(),
+            feature="ThreadGroup.count",
+            level="thread",
+        )
+    for group in (coop.this_thread(), coop.this_block(), coop.this_grid()):
+        with pytest.raises(NotImplementedError, match="every physical warp"):
+            _thread_group._validate_query_launch(
+                group,
+                feature="ThreadGroup.count",
+                level="warp",
+            )
+
+    monkeypatch.setattr(
+        _launch,
+        "current_kernel_launch_facts",
+        _verified_grid_facts,
+    )
+    for group in (coop.this_thread(), coop.this_block(), coop.this_grid()):
+        resolved = _thread_group._validate_query_launch(
+            group,
+            feature="ThreadGroup.count",
+            level="warp",
+        )
+        assert resolved.hierarchy.block_thread_count == 64
+
+
+def test_empty_launch_facts_allow_current_physical_but_reject_mapped_groups(
+    monkeypatch,
+):
+    pytest.importorskip("cutlass.cute.ffi")
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop._core import LaunchFacts
+    from cuda.coop.cutlass import _thread_group
+    from cuda.coop.cutlass._compiler import _launch
+
+    monkeypatch.setattr(_launch, "current_kernel_launch_facts", LaunchFacts)
+
+    for current_physical in (
+        coop.this_thread(),
+        coop.this_warp(),
+        coop.this_block(),
+        coop.this_cluster(),
+        coop.this_grid(),
+    ):
+        assert (
+            _thread_group._validate_membership_launch(
+                current_physical,
+                feature="ThreadGroup.is_member",
+            )
+            is current_physical
+        )
+
+    current = coop.this_block()
+    assert (
+        _thread_group._validate_sync_launch(
+            current,
+            feature="ThreadGroup.sync",
+        )
+        is current
+    )
+    with pytest.raises(NotImplementedError, match="exact block dimensions"):
+        _thread_group._validate_membership_launch(
+            coop.this_block().group_by(2),
+            feature="ThreadGroup.is_member",
+        )

--- a/python/cuda_coop/tests/backends/cutlass/runtime/__init__.py
+++ b/python/cuda_coop/tests/backends/cutlass/runtime/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/python/cuda_coop/tests/backends/cutlass/runtime/test_data_movement.py
+++ b/python/cuda_coop/tests/backends/cutlass/runtime/test_data_movement.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from ....support.paths import REPO_ROOT
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+runtime = pytest.importorskip("cutlass.cute.runtime")
+torch = pytest.importorskip("torch")
+
+if not torch.cuda.is_available():
+    pytest.skip("requires a CUDA-capable PyTorch runtime", allow_module_level=True)
+
+coop = pytest.importorskip("cuda.coop.cutlass")
+
+from_dlpack = runtime.from_dlpack
+
+pytestmark = [
+    pytest.mark.backend_cutlass,
+    pytest.mark.runtime,
+    pytest.mark.gpu,
+]
+
+_BLOCK_THREADS = 64
+_WARP_THREADS = 32
+_ITEMS_PER_THREAD = 2
+_TILE_ITEMS = _BLOCK_THREADS * _ITEMS_PER_THREAD
+_OUTPUT_SEGMENTS = 4
+_PARTIAL_BLOCK_ITEMS = 95
+_PARTIAL_WARP_ITEMS = 41
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _isolated_provider_cache(tmp_path_factory):
+    cache_dir = tmp_path_factory.mktemp("cuda-coop-cutlass-movement-runtime")
+    env_values = {
+        "CUDA_COOP_CUTLASS_PROVIDER_BUNDLE_FORMAT": "ltoir",
+        "CUDA_COOP_CUTLASS_PROVIDER_CACHE_DIR": os.fspath(cache_dir),
+    }
+    if os.environ.get("CUDA_COOP_CUTLASS_FINAL_LINK_TEST") != "1":
+        env_values["CUDA_COOP_CUTLASS_PROVIDER_CCCL_ROOT"] = os.fspath(REPO_ROOT)
+    original = {name: os.environ.get(name) for name in env_values}
+    os.environ.update(env_values)
+    try:
+        yield
+    finally:
+        for name, value in original.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+@cute.kernel
+def _data_movement_kernel(values: cute.Tensor, output: cute.Tensor):
+    block = coop.this_block()
+    block_items = coop.ThreadData(_ITEMS_PER_THREAD)
+    loaded_block = coop.load(block, values, block_items)
+    coop.store(block, output, loaded_block)
+
+    warp = coop.this_warp()
+    warp_items = coop.ThreadData(_ITEMS_PER_THREAD)
+    loaded_warp = coop.load(warp, values, warp_items)
+    coop.store(warp, output, loaded_warp, offset=_TILE_ITEMS)
+
+    partial_block_items = coop.ThreadData(_ITEMS_PER_THREAD)
+    partial_block = coop.load(
+        block,
+        values,
+        partial_block_items,
+        valid_items=_PARTIAL_BLOCK_ITEMS,
+    )
+    coop.store(block, output, partial_block, offset=2 * _TILE_ITEMS)
+
+    partial_warp_items = coop.ThreadData(_ITEMS_PER_THREAD)
+    partial_warp = coop.load(
+        warp,
+        values,
+        partial_warp_items,
+        valid_items=_PARTIAL_WARP_ITEMS,
+    )
+    coop.store(warp, output, partial_warp, offset=3 * _TILE_ITEMS)
+
+
+@cute.jit
+def _run_data_movement(values: cute.Tensor, output: cute.Tensor):
+    _data_movement_kernel(values, output).launch(
+        grid=(1, 1, 1),
+        block=(_BLOCK_THREADS, 1, 1),
+    )
+
+
+@cute.kernel
+def _fixed_storage_kernel(values: cute.Tensor, output: cute.Tensor):
+    block = coop.this_block()
+    storage = coop.TempStorage(4096, alignment=16)
+    items = coop.ThreadData(_ITEMS_PER_THREAD)
+    loaded = coop.load(block, values, items, temp_storage=storage)
+    coop.store(block, output, loaded, temp_storage=storage)
+
+
+@cute.jit
+def _run_fixed_storage(values: cute.Tensor, output: cute.Tensor):
+    _fixed_storage_kernel(values, output).launch(
+        grid=(1, 1, 1),
+        block=(_BLOCK_THREADS, 1, 1),
+    )
+
+
+def test_block_and_warp_data_movement_match_independent_oracles() -> None:
+    cutlass.cuda.initialize_cuda_context()
+    values_host = torch.arange(_TILE_ITEMS, dtype=torch.int32)
+    values = values_host.cuda()
+    output = torch.full(
+        (_OUTPUT_SEGMENTS * _TILE_ITEMS,),
+        -1,
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    _run_data_movement(from_dlpack(values), from_dlpack(output))
+    torch.cuda.synchronize()
+    segments = output.cpu().reshape(_OUTPUT_SEGMENTS, _TILE_ITEMS)
+
+    torch.testing.assert_close(segments[0], values_host, atol=0, rtol=0)
+    torch.testing.assert_close(segments[1], values_host, atol=0, rtol=0)
+    torch.testing.assert_close(
+        segments[2, :_PARTIAL_BLOCK_ITEMS],
+        values_host[:_PARTIAL_BLOCK_ITEMS],
+        atol=0,
+        rtol=0,
+    )
+    for begin in range(0, _TILE_ITEMS, _WARP_THREADS * _ITEMS_PER_THREAD):
+        torch.testing.assert_close(
+            segments[
+                3,
+                begin : begin + _PARTIAL_WARP_ITEMS,
+            ],
+            values_host[begin : begin + _PARTIAL_WARP_ITEMS],
+            atol=0,
+            rtol=0,
+        )
+
+
+def test_fixed_capacity_storage_reaches_block_load_and_store() -> None:
+    cutlass.cuda.initialize_cuda_context()
+    values_host = torch.arange(_TILE_ITEMS, dtype=torch.int32)
+    values = values_host.cuda()
+    output = torch.full_like(values, -1)
+
+    _run_fixed_storage(from_dlpack(values), from_dlpack(output))
+    torch.cuda.synchronize()
+    torch.testing.assert_close(output.cpu(), values_host, atol=0, rtol=0)

--- a/python/cuda_coop/tests/backends/cutlass/runtime/test_group_hierarchy.py
+++ b/python/cuda_coop/tests/backends/cutlass/runtime/test_group_hierarchy.py
@@ -1,0 +1,298 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from ....support.paths import REPO_ROOT
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+runtime = pytest.importorskip("cutlass.cute.runtime")
+torch = pytest.importorskip("torch")
+
+if not callable(getattr(cute, "_get_launch_facts", None)):
+    pytest.skip(
+        "requires CUTLASS DSL launch-facts support",
+        allow_module_level=True,
+    )
+if not torch.cuda.is_available():
+    pytest.skip(
+        "requires a CUDA-capable PyTorch runtime",
+        allow_module_level=True,
+    )
+
+coop = pytest.importorskip("cuda.coop.cutlass")
+
+from_dlpack = runtime.from_dlpack
+
+pytestmark = [
+    pytest.mark.backend_cutlass,
+    pytest.mark.runtime,
+    pytest.mark.gpu,
+]
+
+_LOCAL_BLOCK_THREADS = 128
+_LOCAL_QUERY_FIELDS = 15
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _isolated_provider_cache(tmp_path_factory):
+    cache_dir = tmp_path_factory.mktemp("cuda-coop-cutlass-group-runtime")
+    env_values = {
+        "CUDA_COOP_CUTLASS_PROVIDER_BUNDLE_FORMAT": "ltoir",
+        "CUDA_COOP_CUTLASS_PROVIDER_CACHE_DIR": os.fspath(cache_dir),
+    }
+    if os.environ.get("CUDA_COOP_CUTLASS_FINAL_LINK_TEST") != "1":
+        env_values["CUDA_COOP_CUTLASS_PROVIDER_CCCL_ROOT"] = os.fspath(REPO_ROOT)
+    original = {name: os.environ.get(name) for name in env_values}
+    os.environ.update(env_values)
+    try:
+        yield
+    finally:
+        for name, value in original.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+@cute.kernel
+def _local_groups_kernel(query_out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    thread = coop.this_thread()
+    warp = coop.this_warp()
+    block = coop.this_block()
+    lanes = warp.group_by(8)
+    warps = block.group_by(2)
+
+    thread.sync()
+    warp.sync_aligned()
+    lanes.sync()
+    warps.sync_aligned()
+    block.sync()
+
+    query_out[0 * _LOCAL_BLOCK_THREADS + tidx] = thread.rank("block")
+    query_out[1 * _LOCAL_BLOCK_THREADS + tidx] = thread.count("thread")
+    query_out[2 * _LOCAL_BLOCK_THREADS + tidx] = warp.rank("thread")
+    query_out[3 * _LOCAL_BLOCK_THREADS + tidx] = warp.count("block")
+    query_out[4 * _LOCAL_BLOCK_THREADS + tidx] = block.rank("thread")
+    query_out[5 * _LOCAL_BLOCK_THREADS + tidx] = block.count("grid")
+    query_out[6 * _LOCAL_BLOCK_THREADS + tidx] = lanes.rank("thread")
+    query_out[7 * _LOCAL_BLOCK_THREADS + tidx] = lanes.count("warp")
+    query_out[8 * _LOCAL_BLOCK_THREADS + tidx] = warps.rank("warp")
+    query_out[9 * _LOCAL_BLOCK_THREADS + tidx] = warps.count("thread")
+    query_out[10 * _LOCAL_BLOCK_THREADS + tidx] = thread.is_member()
+    query_out[11 * _LOCAL_BLOCK_THREADS + tidx] = warp.is_member()
+    query_out[12 * _LOCAL_BLOCK_THREADS + tidx] = block.is_member()
+    query_out[13 * _LOCAL_BLOCK_THREADS + tidx] = lanes.is_member()
+    query_out[14 * _LOCAL_BLOCK_THREADS + tidx] = warps.is_member()
+
+
+@cute.jit
+def _run_local_groups(query_out: cute.Tensor):
+    _local_groups_kernel(query_out).launch(
+        grid=(1, 1, 1),
+        block=(_LOCAL_BLOCK_THREADS, 1, 1),
+    )
+
+
+_REMAINDER_BLOCK_THREADS = 224
+_REMAINDER_FIELDS = 2
+
+
+@cute.kernel
+def _remainder_groups_kernel(membership_out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    lanes = coop.this_warp().group_by(12, exhaustive=False)
+    warps = coop.this_block().group_by(3, exhaustive=False)
+
+    membership_out[0 * _REMAINDER_BLOCK_THREADS + tidx] = lanes.is_member()
+    membership_out[1 * _REMAINDER_BLOCK_THREADS + tidx] = warps.is_member()
+
+
+@cute.jit
+def _run_remainder_groups(membership_out: cute.Tensor):
+    _remainder_groups_kernel(membership_out).launch(
+        grid=(1, 1, 1),
+        block=(_REMAINDER_BLOCK_THREADS, 1, 1),
+    )
+
+
+_WIDE_GROUP_BLOCK_THREADS = 64
+_WIDE_GROUP_BLOCKS = 2
+_WIDE_GROUP_THREADS = _WIDE_GROUP_BLOCK_THREADS * _WIDE_GROUP_BLOCKS
+_WIDE_QUERY_FIELDS = 3
+
+
+@cute.kernel
+def _cluster_group_kernel(query_out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+    index = bidx * _WIDE_GROUP_BLOCK_THREADS + tidx
+    cluster = coop.this_cluster()
+
+    cluster.sync_aligned()
+    query_out[0 * _WIDE_GROUP_THREADS + index] = cluster.rank("block")
+    query_out[1 * _WIDE_GROUP_THREADS + index] = cluster.count("grid")
+    query_out[2 * _WIDE_GROUP_THREADS + index] = cluster.is_member()
+
+
+@cute.jit
+def _run_cluster_group(query_out: cute.Tensor):
+    _cluster_group_kernel(query_out).launch(
+        grid=(_WIDE_GROUP_BLOCKS, 1, 1),
+        block=(_WIDE_GROUP_BLOCK_THREADS, 1, 1),
+        cluster=(_WIDE_GROUP_BLOCKS, 1, 1),
+    )
+
+
+@cute.kernel
+def _grid_group_kernel(query_out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+    index = bidx * _WIDE_GROUP_BLOCK_THREADS + tidx
+    grid = coop.this_grid()
+
+    grid.sync()
+    grid.sync_aligned()
+    query_out[0 * _WIDE_GROUP_THREADS + index] = grid.rank("block")
+    query_out[1 * _WIDE_GROUP_THREADS + index] = grid.count("thread")
+    query_out[2 * _WIDE_GROUP_THREADS + index] = grid.is_member()
+
+
+@cute.jit
+def _run_grid_group(query_out: cute.Tensor):
+    _grid_group_kernel(query_out).launch(
+        grid=(_WIDE_GROUP_BLOCKS, 1, 1),
+        block=(_WIDE_GROUP_BLOCK_THREADS, 1, 1),
+        cooperative=True,
+    )
+
+
+def _expected_wide_queries(*, cluster: bool) -> torch.Tensor:
+    return torch.stack(
+        (
+            torch.arange(_WIDE_GROUP_BLOCKS, dtype=torch.int32).repeat_interleave(
+                _WIDE_GROUP_BLOCK_THREADS
+            ),
+            torch.full(
+                (_WIDE_GROUP_THREADS,),
+                1 if cluster else _WIDE_GROUP_THREADS,
+                dtype=torch.int32,
+            ),
+            torch.ones((_WIDE_GROUP_THREADS,), dtype=torch.int32),
+        )
+    )
+
+
+def test_local_physical_and_exhaustive_mapped_groups_runtime():
+    cutlass.cuda.initialize_cuda_context()
+
+    query_out = torch.empty(
+        (_LOCAL_QUERY_FIELDS * _LOCAL_BLOCK_THREADS,),
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    _run_local_groups(from_dlpack(query_out))
+    torch.cuda.synchronize()
+
+    tidx = torch.arange(_LOCAL_BLOCK_THREADS, dtype=torch.int32)
+    lane = tidx % 32
+    expected_queries = torch.stack(
+        (
+            tidx,
+            torch.ones_like(tidx),
+            lane,
+            torch.full_like(tidx, 4),
+            tidx,
+            torch.ones_like(tidx),
+            lane % 8,
+            torch.full_like(tidx, 4),
+            (tidx % 64) // 32,
+            torch.full_like(tidx, 64),
+            *([torch.ones_like(tidx)] * 5),
+        )
+    )
+    torch.testing.assert_close(
+        query_out.cpu().reshape(_LOCAL_QUERY_FIELDS, _LOCAL_BLOCK_THREADS),
+        expected_queries,
+        atol=0,
+        rtol=0,
+    )
+
+
+def test_non_exhaustive_mapped_group_membership_runtime():
+    cutlass.cuda.initialize_cuda_context()
+
+    membership_out = torch.empty(
+        (_REMAINDER_FIELDS * _REMAINDER_BLOCK_THREADS,),
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    _run_remainder_groups(from_dlpack(membership_out))
+    torch.cuda.synchronize()
+
+    expected_membership = torch.zeros(
+        (_REMAINDER_FIELDS, _REMAINDER_BLOCK_THREADS),
+        dtype=torch.int32,
+    )
+    for index in range(_REMAINDER_BLOCK_THREADS):
+        lane = index % 32
+        warp = index // 32
+        if lane < 24:
+            expected_membership[0, index] = 1
+        if warp < 6:
+            expected_membership[1, index] = 1
+
+    torch.testing.assert_close(
+        membership_out.cpu().reshape(_REMAINDER_FIELDS, _REMAINDER_BLOCK_THREADS),
+        expected_membership,
+        atol=0,
+        rtol=0,
+    )
+
+
+def test_cluster_group_runtime():
+    if torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("thread-block clusters require compute capability 9.0 or newer")
+
+    cutlass.cuda.initialize_cuda_context()
+    query_out = torch.empty(
+        (_WIDE_QUERY_FIELDS * _WIDE_GROUP_THREADS,),
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    _run_cluster_group(from_dlpack(query_out))
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        query_out.cpu().reshape(_WIDE_QUERY_FIELDS, _WIDE_GROUP_THREADS),
+        _expected_wide_queries(cluster=True),
+        atol=0,
+        rtol=0,
+    )
+
+
+def test_cooperative_grid_group_runtime():
+    cutlass.cuda.initialize_cuda_context()
+    query_out = torch.empty(
+        (_WIDE_QUERY_FIELDS * _WIDE_GROUP_THREADS,),
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    _run_grid_group(from_dlpack(query_out))
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        query_out.cpu().reshape(_WIDE_QUERY_FIELDS, _WIDE_GROUP_THREADS),
+        _expected_wide_queries(cluster=False),
+        atol=0,
+        rtol=0,
+    )

--- a/python/cuda_coop/tests/backends/cutlass/runtime/test_reduce_scan.py
+++ b/python/cuda_coop/tests/backends/cutlass/runtime/test_reduce_scan.py
@@ -1,0 +1,390 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from cuda import coop as common_coop
+
+from ....support.paths import REPO_ROOT
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+runtime = pytest.importorskip("cutlass.cute.runtime")
+torch = pytest.importorskip("torch")
+
+if not torch.cuda.is_available():
+    pytest.skip("requires a CUDA-capable PyTorch runtime", allow_module_level=True)
+
+coop = pytest.importorskip("cuda.coop.cutlass")
+
+from_dlpack = runtime.from_dlpack
+Int32 = pytest.importorskip("cutlass.base_dsl.typing").Int32
+
+pytestmark = [
+    pytest.mark.backend_cutlass,
+    pytest.mark.runtime,
+    pytest.mark.gpu,
+]
+
+_BLOCK_THREADS = 64
+_ITEMS_PER_THREAD = 2
+_TILE_ITEMS = _BLOCK_THREADS * _ITEMS_PER_THREAD
+_SEGMENTS = 15
+_SENTINEL = -999
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _isolated_provider_cache(tmp_path_factory):
+    cache_dir = tmp_path_factory.mktemp("cuda-coop-cutlass-reduce-scan-runtime")
+    env_values = {
+        "CUDA_COOP_CUTLASS_PROVIDER_BUNDLE_FORMAT": "ltoir",
+        "CUDA_COOP_CUTLASS_PROVIDER_CACHE_DIR": os.fspath(cache_dir),
+    }
+    if os.environ.get("CUDA_COOP_CUTLASS_FINAL_LINK_TEST") != "1":
+        env_values["CUDA_COOP_CUTLASS_PROVIDER_CCCL_ROOT"] = os.fspath(REPO_ROOT)
+    original = {name: os.environ.get(name) for name in env_values}
+    os.environ.update(env_values)
+    try:
+        yield
+    finally:
+        for name, value in original.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _store_items(output: cute.Tensor, segment: int, items) -> None:
+    tidx, _, _ = cute.arch.thread_idx()
+    offset = segment * _TILE_ITEMS + tidx * _ITEMS_PER_THREAD
+    output[offset] = items[0]
+    output[offset + 1] = items[1]
+
+
+def _store_scalar(output: cute.Tensor, segment: int, value) -> None:
+    tidx, _, _ = cute.arch.thread_idx()
+    output[segment * _TILE_ITEMS + tidx] = value
+
+
+@cute.kernel
+def _reduce_scan_kernel(values: cute.Tensor, output: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    block = common_coop.this_block()
+    items = common_coop.ThreadData(_ITEMS_PER_THREAD)
+    items[0] = values[tidx * _ITEMS_PER_THREAD]
+    items[1] = values[tidx * _ITEMS_PER_THREAD + 1]
+
+    fixed_storage = coop.TempStorage(4096, alignment=16)
+    block_aggregate = coop.ThreadData(1, dtype=Int32)
+    exclusive = coop.exclusive_sum(
+        coop.this_block(),
+        items,
+        temp_storage=fixed_storage,
+        aggregate_output=block_aggregate,
+    )
+    inclusive = common_coop.inclusive_sum(block, items)
+    full_sum = common_coop.sum(block, items)
+    direct_items_sum = coop.sum(
+        coop.this_block(),
+        items,
+        broadcast=False,
+        algorithm="raking",
+    )
+    partial_block_sum = common_coop.sum(
+        block,
+        values[tidx],
+        broadcast=False,
+        valid_items=47,
+        algorithm="raking",
+    )
+
+    thread_sum = coop.sum(coop.this_thread(), values[tidx])
+    warp_sum = coop.sum(coop.this_warp(), values[tidx])
+    mapped_sum = coop.sum(coop.this_block().group_by(1), values[tidx])
+    logical = coop.this_warp().group_by(8)
+    logical_sum = coop.sum(logical, values[tidx])
+    logical_partial_sum = common_coop.sum(
+        logical,
+        values[tidx],
+        broadcast=False,
+        valid_items=5,
+    )
+    logical_aggregate = coop.ThreadData(1, dtype=Int32)
+    logical_scan = coop.inclusive_sum(
+        logical,
+        values[tidx],
+        valid_items=5,
+        aggregate_output=logical_aggregate,
+    )
+    logical_exclusive = coop.exclusive_scan(
+        logical,
+        values[tidx],
+        scan_op="sum",
+        initial_value=Int32(0),
+        valid_items=5,
+    )
+
+    # Read the input payload only after both scans to verify non-mutation.
+    _store_items(output, 0, items)
+    _store_items(output, 1, exclusive)
+    _store_items(output, 2, inclusive)
+    _store_scalar(output, 3, full_sum)
+    _store_scalar(output, 4, mapped_sum)
+    _store_scalar(output, 6, logical_scan)
+    _store_scalar(output, 7, logical_aggregate[0])
+    _store_scalar(output, 8, block_aggregate[0])
+    _store_scalar(output, 11, logical_exclusive)
+    _store_scalar(output, 12, thread_sum)
+    _store_scalar(output, 13, warp_sum)
+    _store_scalar(output, 14, logical_sum)
+    if tidx == 0:
+        output[9 * _TILE_ITEMS] = direct_items_sum
+        output[10 * _TILE_ITEMS] = partial_block_sum
+    if tidx % 8 == 0:
+        output[5 * _TILE_ITEMS + tidx] = logical_partial_sum
+
+
+@cute.jit
+def _run_reduce_scan(values: cute.Tensor, output: cute.Tensor):
+    _reduce_scan_kernel(values, output).launch(
+        grid=(1, 1, 1),
+        block=(_BLOCK_THREADS, 1, 1),
+    )
+
+
+def test_reduce_scan_group_routes_match_independent_oracles() -> None:
+    cutlass.cuda.initialize_cuda_context()
+    values_host = (torch.arange(_TILE_ITEMS, dtype=torch.int32) * 17 % 97) - 48
+    values = values_host.cuda()
+    output = torch.full(
+        (_SEGMENTS * _TILE_ITEMS,),
+        _SENTINEL,
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    _run_reduce_scan(from_dlpack(values), from_dlpack(output))
+    torch.cuda.synchronize()
+    segments = output.cpu().reshape(_SEGMENTS, _TILE_ITEMS)
+
+    inclusive = torch.cumsum(values_host.to(torch.int64), dim=0).to(torch.int32)
+    exclusive = inclusive - values_host
+    torch.testing.assert_close(segments[0], values_host, atol=0, rtol=0)
+    torch.testing.assert_close(segments[1], exclusive, atol=0, rtol=0)
+    torch.testing.assert_close(segments[2], inclusive, atol=0, rtol=0)
+
+    total = int(values_host.sum())
+    torch.testing.assert_close(
+        segments[3, :_BLOCK_THREADS],
+        torch.full((_BLOCK_THREADS,), total, dtype=torch.int32),
+        atol=0,
+        rtol=0,
+    )
+    warp_values = values_host[:_BLOCK_THREADS].reshape(2, 32)
+    mapped_expected = warp_values.sum(dim=1).to(torch.int32).repeat_interleave(32)
+    torch.testing.assert_close(
+        segments[4, :_BLOCK_THREADS],
+        mapped_expected,
+        atol=0,
+        rtol=0,
+    )
+
+    for begin in range(0, _BLOCK_THREADS, 8):
+        group = values_host[begin : begin + 8]
+        valid = group[:5]
+        assert segments[5, begin].item() == int(valid.sum())
+        torch.testing.assert_close(
+            segments[6, begin : begin + 5],
+            torch.cumsum(valid.to(torch.int64), dim=0).to(torch.int32),
+            atol=0,
+            rtol=0,
+        )
+        torch.testing.assert_close(
+            segments[11, begin : begin + 5],
+            (torch.cumsum(valid.to(torch.int64), dim=0) - valid.to(torch.int64)).to(
+                torch.int32
+            ),
+            atol=0,
+            rtol=0,
+        )
+        torch.testing.assert_close(
+            segments[6, begin + 5 : begin + 8],
+            group[5:8],
+            atol=0,
+            rtol=0,
+        )
+        torch.testing.assert_close(
+            segments[11, begin + 5 : begin + 8],
+            group[5:8],
+            atol=0,
+            rtol=0,
+        )
+        assert segments[7, begin].item() == int(valid.sum())
+
+    torch.testing.assert_close(
+        segments[8, :_BLOCK_THREADS],
+        torch.full((_BLOCK_THREADS,), total, dtype=torch.int32),
+        atol=0,
+        rtol=0,
+    )
+    assert segments[9, 0].item() == total
+    assert segments[10, 0].item() == int(values_host[:47].sum())
+    torch.testing.assert_close(
+        segments[12, :_BLOCK_THREADS],
+        values_host[:_BLOCK_THREADS],
+        atol=0,
+        rtol=0,
+    )
+    torch.testing.assert_close(
+        segments[13, :_BLOCK_THREADS],
+        warp_values.sum(dim=1).to(torch.int32).repeat_interleave(32),
+        atol=0,
+        rtol=0,
+    )
+    torch.testing.assert_close(
+        segments[14, :_BLOCK_THREADS],
+        values_host[:_BLOCK_THREADS]
+        .reshape(8, 8)
+        .sum(dim=1)
+        .to(torch.int32)
+        .repeat_interleave(8),
+        atol=0,
+        rtol=0,
+    )
+
+
+@cute.kernel
+def _register_tensor_reduce_kernel(values: cute.Tensor, output: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    fragment = cute.make_rmem_tensor((_ITEMS_PER_THREAD,), Int32)
+    fragment[0] = values[tidx * _ITEMS_PER_THREAD]
+    fragment[1] = values[tidx * _ITEMS_PER_THREAD + 1]
+
+    tensor_sum = coop.sum(
+        coop.this_block(),
+        fragment,
+        broadcast=False,
+        algorithm="raking",
+    )
+    tensor_ssa_max = coop.reduce(
+        coop.this_block(),
+        fragment.load(),
+        binary_op="max",
+        broadcast=False,
+        algorithm="raking",
+    )
+    if tidx == 0:
+        output[0] = tensor_sum
+        output[1] = tensor_ssa_max
+
+
+@cute.jit
+def _run_register_tensor_reduce(values: cute.Tensor, output: cute.Tensor):
+    _register_tensor_reduce_kernel(values, output).launch(
+        grid=(1, 1, 1),
+        block=(_BLOCK_THREADS, 1, 1),
+    )
+
+
+def test_reduce_accepts_real_rmem_tensor_and_tensor_ssa_payloads() -> None:
+    cutlass.cuda.initialize_cuda_context()
+    values_host = (torch.arange(_TILE_ITEMS, dtype=torch.int32) * 13 % 101) - 50
+    values = values_host.cuda()
+    output = torch.full((2,), _SENTINEL, dtype=torch.int32, device="cuda")
+
+    _run_register_tensor_reduce(from_dlpack(values), from_dlpack(output))
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        output.cpu(),
+        torch.tensor(
+            [int(values_host.sum()), int(values_host.max())],
+            dtype=torch.int32,
+        ),
+        atol=0,
+        rtol=0,
+    )
+
+
+@cute.kernel
+def _non_power_of_two_warp_reduce_kernel(values: cute.Tensor, output: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    group = coop.this_warp().group_by(12, exhaustive=False)
+    reduced = coop.sum(group, values[tidx], broadcast=False)
+    lane = tidx % 32
+    if lane == 0 or lane == 12:
+        output[(tidx // 32) * 2 + lane // 12] = reduced
+
+
+@cute.jit
+def _run_non_power_of_two_warp_reduce(
+    values: cute.Tensor,
+    output: cute.Tensor,
+):
+    _non_power_of_two_warp_reduce_kernel(values, output).launch(
+        grid=(1, 1, 1),
+        block=(_BLOCK_THREADS, 1, 1),
+    )
+
+
+def test_non_power_of_two_warp_reduce_uses_stable_membership_masks() -> None:
+    cutlass.cuda.initialize_cuda_context()
+    values_host = torch.arange(_BLOCK_THREADS, dtype=torch.int32) - 19
+    values = values_host.cuda()
+    output = torch.full((4,), _SENTINEL, dtype=torch.int32, device="cuda")
+
+    _run_non_power_of_two_warp_reduce(from_dlpack(values), from_dlpack(output))
+    torch.cuda.synchronize()
+
+    expected = torch.tensor(
+        [
+            int(values_host[0:12].sum()),
+            int(values_host[12:24].sum()),
+            int(values_host[32:44].sum()),
+            int(values_host[44:56].sum()),
+        ],
+        dtype=torch.int32,
+    )
+    torch.testing.assert_close(output.cpu(), expected, atol=0, rtol=0)
+
+
+@cute.kernel
+def _cluster_reduce_kernel(values: cute.Tensor, output: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+    index = bidx * _BLOCK_THREADS + tidx
+    output[index] = coop.sum(coop.this_cluster(), values[index])
+
+
+@cute.jit
+def _run_cluster_reduce(values: cute.Tensor, output: cute.Tensor):
+    _cluster_reduce_kernel(values, output).launch(
+        grid=(2, 1, 1),
+        block=(_BLOCK_THREADS, 1, 1),
+        cluster=(2, 1, 1),
+    )
+
+
+def test_cluster_reduce_broadcasts_across_cluster_members() -> None:
+    if torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("thread-block clusters require compute capability 9.0 or newer")
+
+    cutlass.cuda.initialize_cuda_context()
+    values_host = torch.arange(2 * _BLOCK_THREADS, dtype=torch.int32) - 41
+    values = values_host.cuda()
+    output = torch.empty_like(values)
+
+    _run_cluster_reduce(from_dlpack(values), from_dlpack(output))
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        output.cpu(),
+        torch.full_like(values_host, int(values_host.sum())),
+        atol=0,
+        rtol=0,
+    )

--- a/python/cuda_coop/tests/backends/cutlass/support/__init__.py
+++ b/python/cuda_coop/tests/backends/cutlass/support/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Shared helpers for CUTLASS backend tests."""

--- a/python/cuda_coop/tests/backends/cutlass/support/_subprocess.py
+++ b/python/cuda_coop/tests/backends/cutlass/support/_subprocess.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Isolated Python runners for CUTLASS host-contract tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from ....support.paths import PACKAGE_ROOT
+
+_CUTLASS_RUNTIME_STUB = """
+import sys as _cuda_coop_test_sys
+import types as _cuda_coop_test_types
+import importlib as _cuda_coop_test_importlib
+
+_cuda_coop_test_cutlass = _cuda_coop_test_types.ModuleType("cutlass")
+_cuda_coop_test_cutlass.__path__ = []
+_cuda_coop_test_dsl = _cuda_coop_test_types.ModuleType("cutlass.cutlass_dsl")
+
+class _CudaCoopTestCuTeDSL:
+    _instance = None
+
+    @classmethod
+    def _get_dsl(cls):
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def __init__(self):
+        self.trace_context_factories = []
+
+    def register_trace_context_factory(self, factory):
+        if factory not in self.trace_context_factories:
+            self.trace_context_factories.append(factory)
+
+    def register_trace_finalize_hook(self, hook):
+        self.trace_finalize_hook = hook
+
+_cuda_coop_test_dsl.CuTeDSL = _CudaCoopTestCuTeDSL
+_cuda_coop_test_cute = _cuda_coop_test_types.ModuleType("cutlass.cute")
+_cuda_coop_test_cute._get_launch_facts = lambda: {}
+_cuda_coop_test_base_dsl = _cuda_coop_test_types.ModuleType("cutlass.base_dsl")
+_cuda_coop_test_base_dsl.__path__ = []
+_cuda_coop_test_compiler = _cuda_coop_test_types.ModuleType(
+    "cutlass.base_dsl.compiler"
+)
+_cuda_coop_test_compiler.LinkLibraries = type(
+    "LinkLibraries",
+    (),
+    {"_option_name": "link-libraries"},
+)
+_cuda_coop_test_compiler.GPUArch = type("GPUArch", (), {})
+_cuda_coop_test_cutlass.cutlass_dsl = _cuda_coop_test_dsl
+_cuda_coop_test_cutlass.cute = _cuda_coop_test_cute
+_cuda_coop_test_cutlass.base_dsl = _cuda_coop_test_base_dsl
+_cuda_coop_test_base_dsl.compiler = _cuda_coop_test_compiler
+_cuda_coop_test_sys.modules["cutlass"] = _cuda_coop_test_cutlass
+_cuda_coop_test_sys.modules["cutlass.cutlass_dsl"] = _cuda_coop_test_dsl
+_cuda_coop_test_sys.modules["cutlass.cute"] = _cuda_coop_test_cute
+_cuda_coop_test_sys.modules["cutlass.base_dsl"] = _cuda_coop_test_base_dsl
+_cuda_coop_test_sys.modules[
+    "cutlass.base_dsl.compiler"
+] = _cuda_coop_test_compiler
+_cuda_coop_test_real_import_module = _cuda_coop_test_importlib.import_module
+
+def _cuda_coop_test_import_module(name, package=None):
+    if name == "cutlass.cutlass_dsl":
+        module = _cuda_coop_test_sys.modules.get(name)
+        if module is None:
+            module = _cuda_coop_test_types.ModuleType(name)
+            _cuda_coop_test_sys.modules[name] = module
+        parent = _cuda_coop_test_sys.modules.get("cutlass")
+        if parent is not None:
+            parent.cutlass_dsl = module
+        return module
+    return _cuda_coop_test_real_import_module(name, package)
+
+_cuda_coop_test_importlib.import_module = _cuda_coop_test_import_module
+"""
+
+
+def run_python_with_source(script: str) -> subprocess.CompletedProcess[str]:
+    """Run ``script`` against this checkout without importing site packages."""
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PACKAGE_ROOT)
+    return subprocess.run(
+        [sys.executable, "-S", "-B", "-c", _CUTLASS_RUNTIME_STUB + script],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+def run_python_with_source_and_site(
+    script: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``script`` with this checkout and the active environment packages."""
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PACKAGE_ROOT)
+    return subprocess.run(
+        [sys.executable, "-B", "-c", script],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )

--- a/python/cuda_coop/tests/backends/cutlass/unit/__init__.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/python/cuda_coop/tests/backends/cutlass/unit/test_data_movement.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/test_data_movement.py
@@ -1,0 +1,552 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+
+def _provider_dependencies():
+    pytest.importorskip("cutlass")
+    pytest.importorskip("cutlass.cute.ffi")
+
+
+def _launch_facts(block_dim=64):
+    from cuda.coop._core import LaunchFactOrigin, LaunchFacts
+
+    return LaunchFacts(
+        exact_block_dim=block_dim,
+        provenance=LaunchFactOrigin(
+            "exact_block_dim",
+            "test_kernel",
+            verified=True,
+        ),
+    )
+
+
+def test_public_data_movement_exports_and_signatures():
+    _provider_dependencies()
+
+    import cuda.coop.cutlass as coop
+
+    expected_modules = {
+        "load": "cuda.coop.cutlass._group_load_store",
+        "store": "cuda.coop.cutlass._group_load_store",
+    }
+    for name, module in expected_modules.items():
+        assert name in coop.__all__
+        assert getattr(coop, name).__module__ == module
+        assert all(
+            not parameter.startswith("_")
+            for parameter in inspect.signature(getattr(coop, name)).parameters
+        )
+
+
+def test_frontends_delegate_resolved_groups_and_plans(monkeypatch):
+    _provider_dependencies()
+    from cutlass.base_dsl.typing import Int32
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop.cutlass._compiler import _launch
+    from cuda.coop.cutlass._lowering import _load_store as load_store_provider
+
+    monkeypatch.setattr(_launch, "current_kernel_launch_facts", _launch_facts)
+    calls = []
+    monkeypatch.setattr(
+        load_store_provider,
+        "provider_load",
+        lambda **payload: calls.append(("load", payload)) or payload["output"],
+    )
+    monkeypatch.setattr(
+        load_store_provider,
+        "provider_store",
+        lambda **payload: calls.append(("store", payload)),
+    )
+
+    block = coop.this_block()
+    output = coop.ThreadData(2, dtype=Int32)
+    items = coop.ThreadData.from_values(Int32(1), Int32(2), dtype=Int32)
+    assert coop.load(block, object(), output, valid_items=17, offset=4) is output
+    coop.store(block, object(), items, algorithm="striped")
+    assert [name for name, _ in calls] == ["load", "store"]
+    for _, payload in calls:
+        group = payload["group"]
+        assert group.hierarchy.block_dim == (64, 1, 1)
+        assert group is not block
+
+
+def test_load_store_plans_bindings_rendering_and_layout_proofs():
+    _provider_dependencies()
+    from cutlass.base_dsl.typing import Float32, Int32
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop._core import ArgumentBinding, GroupLoadStoreKind, LaunchFacts
+    from cuda.coop.cutlass import _group_load_store as frontend
+    from cuda.coop.cutlass._lowering import _load_store as provider
+    from cuda.coop.cutlass._lowering._load_store_layout import (
+        contiguous_layout_reason,
+        static_layout_elements,
+    )
+
+    block_plan = provider._make_group_load_store_plan(
+        group=coop.this_block(),
+        launch=LaunchFacts(exact_block_dim=64),
+        kind=GroupLoadStoreKind.LOAD,
+        dtype=Int32,
+        items_per_thread=2,
+        algorithm="striped",
+        valid_items=ArgumentBinding.runtime(),
+        oob_default=ArgumentBinding.static(0),
+        offset=ArgumentBinding.static(4),
+    ).require_supported()
+    block_request = provider._CubLoadStoreRequest(block_plan, Int32)
+    block_source = "\n".join(provider._render_cub_load_store(block_request))
+    assert "::cub::BlockLoad<int, 64, 2, ::cub::BLOCK_LOAD_STRIPED" in block_source
+    assert "const int* base, int valid_items, int* result_items" in block_source
+    assert "tile_ptr += 4;" in block_source
+    assert ".Load(tile_ptr, items, valid_items, static_cast<int>(0));" in block_source
+    assert "cuda_coop_cutlass_block_sync();" in block_source
+
+    partial_block_plan = provider._make_group_load_store_plan(
+        group=coop.this_block(),
+        launch=LaunchFacts(exact_block_dim=64),
+        kind=GroupLoadStoreKind.LOAD,
+        dtype=Int32,
+        items_per_thread=2,
+        algorithm="striped",
+        valid_items=ArgumentBinding.runtime(),
+        oob_default=ArgumentBinding.omitted(),
+        offset=ArgumentBinding.static(4),
+    ).require_supported()
+    partial_block_source = "\n".join(
+        provider._render_cub_load_store(
+            provider._CubLoadStoreRequest(partial_block_plan, Int32)
+        )
+    )
+    assert "int items[2] = {};" in partial_block_source
+    assert ".Load(tile_ptr, items, valid_items);" in partial_block_source
+
+    partial_warp_plan = provider._make_group_load_store_plan(
+        group=coop.this_warp().group_by(8),
+        launch=LaunchFacts(exact_block_dim=64),
+        kind=GroupLoadStoreKind.LOAD,
+        dtype=Int32,
+        items_per_thread=2,
+        algorithm="striped",
+        valid_items=ArgumentBinding.static(5),
+        oob_default=ArgumentBinding.omitted(),
+        offset=ArgumentBinding.omitted(),
+    ).require_supported()
+    partial_warp_source = "\n".join(
+        provider._render_cub_load_store(
+            provider._CubLoadStoreRequest(partial_warp_plan, Int32)
+        )
+    )
+    assert "int items[2] = {};" in partial_warp_source
+    assert ".Load(tile_ptr, items, 5);" in partial_warp_source
+
+    warp_plan = provider._make_group_load_store_plan(
+        group=coop.this_warp(),
+        launch=LaunchFacts(exact_block_dim=64),
+        kind=GroupLoadStoreKind.STORE,
+        dtype=Float32,
+        items_per_thread=3,
+        algorithm="transpose",
+        valid_items=ArgumentBinding.omitted(),
+        oob_default=ArgumentBinding.omitted(),
+        offset=ArgumentBinding.runtime(),
+    ).require_supported()
+    warp_request = provider._CubLoadStoreRequest(warp_plan, Float32)
+    warp_source = "\n".join(provider._render_cub_load_store(warp_request))
+    assert "::cub::WarpStore<float, 3, ::cub::WARP_STORE_TRANSPOSE, 32>" in warp_source
+    assert "storage[2]" in warp_source
+    assert "storage_instance) * 96ll" in warp_source
+    assert "cuda_coop_cutlass_warp_sync(32u);" in warp_source
+    assert "if (offset < 0)" in warp_source
+    assert warp_source.index("if (offset < 0)") < warp_source.index(
+        "tile_ptr += offset;"
+    )
+
+    assert frontend._classify_integer_binding(3, name="offset") == (
+        ArgumentBinding.static(3)
+    )
+    assert frontend._classify_oob_default(1.25) == ArgumentBinding.static(1.25)
+    assert frontend._classify_oob_default(Float32(1.25)) == (ArgumentBinding.runtime())
+
+    import numpy as np
+
+    numpy_integer = frontend._classify_oob_default(np.int64(7))
+    numpy_float = frontend._classify_oob_default(np.float32(1.25))
+    assert numpy_integer == ArgumentBinding.static(7)
+    assert numpy_float == ArgumentBinding.static(1.25)
+    assert type(numpy_integer.value) is int
+    assert type(numpy_float.value) is float
+    with pytest.raises(TypeError, match="must be an integer"):
+        frontend._classify_integer_binding(True, name="valid_items")
+    with pytest.raises(ValueError, match="non-negative"):
+        frontend._classify_integer_binding(-1, name="offset")
+
+    class Layout:
+        def __init__(self, shape, stride):
+            self.shape = shape
+            self.stride = stride
+
+    compact = Layout(((8, 4), 2), ((1, 8), 32))
+    assert static_layout_elements(compact) == 64
+    assert contiguous_layout_reason(compact) is None
+    scalar = Layout((), ())
+    assert static_layout_elements(scalar) == 1
+    assert contiguous_layout_reason(scalar) is None
+    singleton_mode = Layout((1, 8), (0, 1))
+    assert static_layout_elements(singleton_mode) == 8
+    assert contiguous_layout_reason(singleton_mode) is None
+    assert "not a compact" in contiguous_layout_reason(Layout((8, 4, 2), (12, 3, 1)))
+    assert "incongruent" in contiguous_layout_reason(Layout(((8, 4), 2), (1, 8)))
+
+
+def test_deferred_load_store_requests_do_not_collide():
+    _provider_dependencies()
+    from cutlass.base_dsl.typing import Int32
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop._core import (
+        ArgumentBinding,
+        GroupLoadStoreKind,
+        LaunchFacts,
+        StorageOwnership,
+    )
+    from cuda.coop.cutlass._lowering import _load_store as provider
+
+    plan = provider._make_group_load_store_plan(
+        group=coop.this_block(),
+        launch=LaunchFacts(exact_block_dim=64),
+        kind=GroupLoadStoreKind.LOAD,
+        dtype=Int32,
+        items_per_thread=4,
+        algorithm="transpose",
+        valid_items=ArgumentBinding.omitted(),
+        oob_default=ArgumentBinding.omitted(),
+        offset=ArgumentBinding.omitted(),
+    ).require_supported()
+    assert plan.temp_storage is not None
+    caller_owned = dataclasses.replace(
+        plan,
+        temp_storage=dataclasses.replace(
+            plan.temp_storage,
+            ownership=StorageOwnership.CALLER,
+            address_space="shared",
+            cpp_type="typename implementation_type::TempStorage",
+            instances=1,
+            instance_index="cta",
+            exact_layout_required=True,
+        ),
+    )
+    owned = provider._CubLoadStoreRequest(plan, Int32)
+    deferred = provider._CubLoadStoreRequest(
+        caller_owned,
+        Int32,
+        external_scratch=True,
+    )
+    assert owned != deferred
+    assert owned.symbol_name != deferred.symbol_name
+    assert deferred.symbol_name == f"{owned.symbol_name}_external_scratch"
+    assert provider._cub_load_store_scratch_layout_probe(owned) is None
+    probe = provider._cub_load_store_scratch_layout_probe(deferred)
+    assert probe is not None
+    assert probe.requirement_key == deferred.scratch_requirement_key
+
+
+def test_core_output_initializers_require_a_readable_source():
+    _provider_dependencies()
+    from cutlass.base_dsl.typing import Int32
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop._core import (
+        ArgumentBinding,
+        Array,
+        Dependency,
+        GroupLoadStoreKind,
+        LaunchFacts,
+        TempStorageParameter,
+    )
+    from cuda.coop.cutlass._lowering import _load_store as provider
+    from cuda.coop.cutlass._lowering._core import CutlassCoreAdapter
+
+    plan = provider._make_group_load_store_plan(
+        group=coop.this_block(),
+        launch=LaunchFacts(exact_block_dim=64),
+        kind=GroupLoadStoreKind.LOAD,
+        dtype=Int32,
+        items_per_thread=2,
+        algorithm="striped",
+        valid_items=ArgumentBinding.omitted(),
+        oob_default=ArgumentBinding.omitted(),
+        offset=ArgumentBinding.omitted(),
+    ).require_supported()
+
+    def specialization_with_source(*, is_output: bool, is_inout: bool = False):
+        parameters = (
+            (
+                TempStorageParameter(),
+                Array(
+                    Dependency("T"),
+                    Dependency("ITEMS_PER_THREAD"),
+                    name="src",
+                    is_output=is_output,
+                    is_inout=is_inout,
+                ),
+                Array(
+                    Dependency("T"),
+                    Dependency("ITEMS_PER_THREAD"),
+                    name="dst",
+                    is_output=True,
+                ),
+            ),
+        )
+        algorithm = dataclasses.replace(
+            plan.implementation.algorithm,
+            parameters=parameters,
+        )
+        return dataclasses.replace(plan.implementation, algorithm=algorithm)
+
+    output_only = specialization_with_source(is_output=True)
+    with pytest.raises(ValueError, match="source 'src' is output-only"):
+        CutlassCoreAdapter().materialize(
+            output_only,
+            plan=dataclasses.replace(plan, implementation=output_only),
+            kind="output_initializer_test",
+            output_initializers=(("dst", "src"),),
+        )
+
+    inout = specialization_with_source(is_output=True, is_inout=True)
+    artifact = CutlassCoreAdapter().materialize(
+        inout,
+        plan=dataclasses.replace(plan, implementation=inout),
+        kind="output_initializer_test",
+        output_initializers=(("dst", "src"),),
+    )
+    assert artifact.output_initializers == (("dst", "src"),)
+
+
+def test_core_artifact_identity_includes_renderer_kind_and_method_index():
+    _provider_dependencies()
+    from cutlass.base_dsl.typing import Int32
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop._core import ArgumentBinding, GroupLoadStoreKind, LaunchFacts
+    from cuda.coop.cutlass._compiler._rendering import canonical_bundle_requests
+    from cuda.coop.cutlass._lowering import _load_store as provider
+    from cuda.coop.cutlass._lowering._core import CutlassCoreAdapter
+
+    plan = provider._make_group_load_store_plan(
+        group=coop.this_block(),
+        launch=LaunchFacts(exact_block_dim=64),
+        kind=GroupLoadStoreKind.LOAD,
+        dtype=Int32,
+        items_per_thread=2,
+        algorithm="striped",
+        valid_items=ArgumentBinding.omitted(),
+        oob_default=ArgumentBinding.omitted(),
+        offset=ArgumentBinding.omitted(),
+    ).require_supported()
+    adapter = CutlassCoreAdapter()
+
+    first = adapter.materialize(
+        plan.implementation,
+        plan=plan,
+        kind="first_renderer",
+    )
+    second = adapter.materialize(
+        plan.implementation,
+        plan=plan,
+        kind="second_renderer",
+    )
+    assert first.semantic_key != second.semantic_key
+    assert first.symbol_name != second.symbol_name
+
+    first = dataclasses.replace(first, symbol_name="shared_symbol")
+    second = dataclasses.replace(second, symbol_name="shared_symbol")
+    with pytest.raises(ValueError, match="conflicting bundle requests"):
+        canonical_bundle_requests((first, second))
+
+    with pytest.raises(ValueError, match="method_index is out of range"):
+        adapter.materialize(
+            plan.implementation,
+            plan=plan,
+            kind="negative_method",
+            method_index=-1,
+        )
+
+
+def test_load_store_rejects_register_and_local_address_space_pointers(monkeypatch):
+    _provider_dependencies()
+    from cutlass import AddressSpace
+
+    from cuda.coop.cutlass._lowering import _load_store as provider
+
+    class FakePointer:
+        def __init__(self, address_space):
+            self.type = SimpleNamespace(address_space=address_space)
+
+    class Operand:
+        shape = (1,)
+        stride = (1,)
+
+        def __init__(self, address_space, *, memspace=None):
+            self.iterator = SimpleNamespace(llvm_ptr=FakePointer(address_space))
+            if memspace is not None:
+                self.memspace = memspace
+
+    class FakePointerType:
+        def __new__(cls, pointer_type):
+            return pointer_type
+
+        @staticmethod
+        def get(address_space):
+            return SimpleNamespace(address_space=address_space)
+
+    monkeypatch.setattr(provider.llvm, "PointerType", FakePointerType)
+    monkeypatch.setattr(
+        provider.llvm,
+        "addrspacecast",
+        lambda pointer_type, pointer: (pointer_type, pointer),
+    )
+
+    proof, reason = provider._contiguous_memory_proof(
+        Operand(0, memspace=AddressSpace.rmem),
+        primitive_name="load",
+    )
+    assert proof is None
+    assert "register/local memory" in reason
+
+    proof, _ = provider._contiguous_memory_proof(
+        Operand(5),
+        primitive_name="load",
+    )
+    assert proof is None
+
+    for address_space, memspace in (
+        (1, AddressSpace.gmem),
+        (3, AddressSpace.smem),
+    ):
+        proof, reason = provider._contiguous_memory_proof(
+            Operand(address_space, memspace=memspace),
+            primitive_name="load",
+        )
+        assert proof is not None, reason
+
+
+def test_fixed_load_store_storage_is_forwarded_and_scoped(monkeypatch):
+    _provider_dependencies()
+    from cutlass.base_dsl.typing import Int32
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop.cutlass._compiler import _storage as provider_storage
+    from cuda.coop.cutlass._lowering import _load_store as provider
+
+    storage = coop.TempStorage(4096, alignment=16, auto_sync=False)
+    assert (
+        provider._temp_storage_for_load_store(
+            group=coop.this_block(),
+            explicit_temp_storage=storage,
+            primitive_name="load",
+        )
+        is storage
+    )
+    for warp_storage in (storage, coop.TempStorage()):
+        with pytest.raises(ValueError, match="only for block groups"):
+            provider._temp_storage_for_load_store(
+                group=coop.this_warp(),
+                explicit_temp_storage=warp_storage,
+                primitive_name="load",
+            )
+    with pytest.raises(ValueError, match="sharing='exclusive'"):
+        provider._temp_storage_for_load_store(
+            group=coop.this_block(),
+            explicit_temp_storage=coop.TempStorage(4096, sharing="exclusive"),
+            primitive_name="store",
+        )
+
+    monkeypatch.setattr(
+        provider_storage,
+        "materialize_temp_storage_binding",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            smem_addr_u32="shared-address",
+            size_in_bytes=4096,
+            auto_sync=False,
+        ),
+    )
+    assert provider._external_scratch_args(
+        storage,
+        primitive_name="load",
+        requirement_key=("load", "int32"),
+    ) == ("shared-address", Int32(4096), Int32(0))
+
+
+class _FakeTensor:
+    class _Iterator:
+        llvm_ptr = object()
+
+    iterator = _Iterator()
+
+    def __getitem__(self, index):
+        return index
+
+
+def test_deferred_load_failure_rolls_back_provider_session(monkeypatch):
+    _provider_dependencies()
+    from cutlass.base_dsl.typing import Int32
+
+    import cuda.coop.cutlass as coop
+    import cuda.coop.cutlass._compiler._state as provider_state
+    import cuda.coop.cutlass._compiler._storage as provider_storage
+    from cuda.coop._core import ArgumentBinding, GroupLoadStoreAlgorithm, LaunchFacts
+    from cuda.coop.cutlass._lowering import _load_store as provider
+
+    storage = coop.TempStorage()
+    snapshot = object()
+    restored = []
+    monkeypatch.setattr(provider, "_resolve_memory_type", lambda *args, **kwargs: Int32)
+    monkeypatch.setattr(provider, "_memory_pointer", lambda *args, **kwargs: object())
+    monkeypatch.setattr(provider._cute, "make_rmem_tensor", lambda *args: _FakeTensor())
+    monkeypatch.setattr(
+        provider_state, "snapshot_active_session_state", lambda: snapshot
+    )
+    monkeypatch.setattr(provider_state, "restore_active_session_state", restored.append)
+    monkeypatch.setattr(provider_state, "register_request", lambda _request: None)
+    monkeypatch.setattr(
+        provider_storage,
+        "register_deferred_temp_storage_event",
+        lambda *args, **kwargs: (object(), object(), object()),
+    )
+    monkeypatch.setattr(provider.llvm.PointerType, "get", lambda *_args: object())
+
+    def failing_ffi(**_kwargs):
+        def invoke(*_args):
+            raise RuntimeError("forced FFI failure")
+
+        return invoke
+
+    monkeypatch.setattr(provider, "ffi", failing_ffi)
+    with pytest.raises(RuntimeError, match="forced FFI failure"):
+        provider.provider_load(
+            group=coop.this_block(),
+            launch=LaunchFacts(exact_block_dim=64),
+            source=object(),
+            output=coop.ThreadData(4, dtype=Int32),
+            algorithm=GroupLoadStoreAlgorithm.TRANSPOSE,
+            valid_items=None,
+            valid_items_binding=ArgumentBinding.omitted(),
+            oob_default=None,
+            oob_default_binding=ArgumentBinding.omitted(),
+            offset=None,
+            offset_binding=ArgumentBinding.omitted(),
+            temp_storage=storage,
+        )
+
+    assert restored == [snapshot]

--- a/python/cuda_coop/tests/backends/cutlass/unit/test_launch_facts.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/test_launch_facts.py
@@ -1,0 +1,381 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from cuda.coop._core import LaunchFacts
+from cuda.coop.cutlass._compiler import _launch
+
+
+class KernelOp:
+    def __init__(self, attributes, parent_op=None):
+        self.attributes = attributes
+        self.parent_op = parent_op
+
+
+def _install_fake_cutlass(monkeypatch):
+    cutlass = ModuleType("cutlass")
+    cutlass.__path__ = []
+    cute = ModuleType("cutlass.cute")
+    mlir = ModuleType("cutlass._mlir")
+    mlir.__path__ = []
+    ir = ModuleType("cutlass._mlir.ir")
+    cutlass.cute = cute
+    cutlass._mlir = mlir
+    mlir.ir = ir
+    for name, module in (
+        ("cutlass", cutlass),
+        ("cutlass.cute", cute),
+        ("cutlass._mlir", mlir),
+        ("cutlass._mlir.ir", ir),
+    ):
+        monkeypatch.setitem(sys.modules, name, module)
+    return cute, ir
+
+
+def test_launch_metadata_reconciles_all_exact_aliases():
+    facts = _launch.launch_facts_from_launch_metadata(
+        {
+            "threads_per_block": (8, 4),
+            "block_dim": (8, 4, 1),
+            "grid": 9,
+            "cluster_dim_x": 2,
+            "cluster_dim_y": 1,
+            "cluster_dim_z": 1,
+            "cooperative_launch": True,
+            "cluster_launch": True,
+        },
+        source="test_metadata",
+    )
+
+    assert facts.exact_block_dim == (8, 4, 1)
+    assert facts.exact_grid_dim == (9, 1, 1)
+    assert facts.exact_cluster_dim == (2, 1, 1)
+    assert facts.cooperative_launch is True
+    assert facts.cluster_launch is True
+    assert {origin.fact for origin in facts.provenance} == {
+        "exact_block_dim",
+        "exact_grid_dim",
+        "exact_cluster_dim",
+        "cooperative_launch",
+        "cluster_launch",
+    }
+    assert {origin.source for origin in facts.provenance} == {"test_metadata"}
+
+
+def test_launch_metadata_rejects_conflicting_or_partial_shapes():
+    with pytest.raises(ValueError, match="conflicting exact_block_dim"):
+        _launch.launch_facts_from_launch_metadata({"block": 32, "block_dim": 64})
+    with pytest.raises(ValueError, match="requires x, y, and z"):
+        _launch.launch_facts_from_launch_metadata({"block_dim_x": 8, "block_dim_y": 4})
+    with pytest.raises(TypeError, match="must be a bool"):
+        _launch.launch_facts_from_launch_metadata(
+            {"block": 32, "cooperative_launch": 1}
+        )
+
+
+def test_bind_launch_metadata_preserves_the_most_precise_block_shape():
+    kwargs = {"launch_metadata": {"threads_per_block": 128}}
+    _launch.bind_block_launch_metadata(
+        "cuda.coop.cutlass",
+        "load",
+        kwargs,
+        threads_per_block=(32, 4),
+    )
+    assert kwargs["launch_metadata"]["threads_per_block"] == (32, 4, 1)
+    assert _launch.launch_facts_from_launch_metadata(
+        kwargs["launch_metadata"]
+    ).exact_block_dim == (32, 4, 1)
+
+    kwargs = {
+        "launch_metadata": {
+            "threads_per_block": 128,
+            "block_x": 32,
+            "block_y": 4,
+            "block_z": 1,
+        }
+    }
+    _launch.bind_block_launch_metadata(
+        "cuda.coop.cutlass",
+        "load",
+        kwargs,
+        threads_per_block=128,
+    )
+    assert kwargs["launch_metadata"]["threads_per_block"] == (32, 4, 1)
+
+    with pytest.raises(TypeError, match="conflicting.*shapes"):
+        _launch.bind_block_launch_metadata(
+            "cuda.coop.cutlass",
+            "load",
+            {
+                "launch_metadata": {
+                    "block_x": 64,
+                    "block_y": 2,
+                    "block_z": 1,
+                }
+            },
+            threads_per_block=(32, 4),
+        )
+
+
+def test_equivalent_scalar_and_vector_block_aliases_do_not_conflict():
+    assert (
+        _launch.resolve_block_threads(
+            "cuda.coop.cutlass",
+            "load",
+            threads_per_block=32,
+            dim=(32,),
+        )
+        == 32
+    )
+
+
+@pytest.mark.parametrize("argument", ["threads_per_block", "dim"])
+def test_bind_launch_metadata_rejects_more_than_three_block_axes(argument):
+    with pytest.raises(TypeError, match="at most 3 dimensions"):
+        _launch.bind_block_launch_kwargs(
+            "cuda.coop.cutlass",
+            "load",
+            {},
+            **{argument: (2, 2, 2, 2)},
+        )
+
+
+def test_bind_launch_metadata_rejects_more_than_three_metadata_axes():
+    with pytest.raises(TypeError, match="invalid thread-count"):
+        _launch.bind_block_launch_kwargs(
+            "cuda.coop.cutlass",
+            "load",
+            {"launch_metadata": {"block": (2, 2, 2, 2)}},
+        )
+
+
+def test_bind_launch_metadata_ignores_none_aliases():
+    kwargs = {"launch_metadata": None, "launch": None}
+
+    _launch.bind_block_launch_metadata(
+        "cuda.coop.cutlass",
+        "load",
+        kwargs,
+        threads_per_block=None,
+    )
+
+    assert kwargs == {"launch_metadata": None, "launch": None}
+
+
+def test_kernel_attributes_keep_reqntid_and_maxntid_distinct():
+    operation = KernelOp(
+        {
+            "nvvm.reqntid": "attr : 8, 4, 2>",
+            "nvvm.maxntid": "attr : 16, 4, 2>",
+        }
+    )
+    facts = _launch.launch_facts_from_kernel_op(operation)
+
+    assert facts.exact_block_dim == (8, 4, 2)
+    assert facts.max_block_dim == (16, 4, 2)
+    assert [origin.fact for origin in facts.provenance] == [
+        "exact_block_dim",
+        "max_block_dim",
+    ]
+    assert _launch.block_dim_from_kernel_op(
+        operation,
+        allow_maxntid=False,
+    ) == (8, 4, 2)
+
+    max_only = KernelOp({"nvvm.maxntid": "attr : 256>"})
+    max_facts = _launch.launch_facts_from_kernel_op(max_only)
+    assert max_facts.exact_block_dim is None
+    assert max_facts.max_block_dim == (256, 1, 1)
+    assert _launch.block_dim_from_kernel_op(max_only, allow_maxntid=False) is None
+    assert _launch.block_dim_from_kernel_op(
+        max_only,
+        allow_maxntid=True,
+    ) == (256, 1, 1)
+
+
+def test_kernel_attributes_ignore_only_malformed_maxntid():
+    facts = _launch.launch_facts_from_kernel_op(
+        KernelOp(
+            {
+                "nvvm.reqntid": "attr : 32>",
+                "nvvm.maxntid": "malformed",
+            }
+        )
+    )
+
+    assert facts.exact_block_dim == (32, 1, 1)
+    assert facts.max_block_dim is None
+
+    with pytest.raises(ValueError, match="reqntid"):
+        _launch.launch_facts_from_kernel_op(KernelOp({"nvvm.reqntid": "malformed"}))
+
+
+def test_kernel_fallback_ignores_private_cutlass_launch_fact_attributes():
+    operation = KernelOp(
+        {
+            "cutlass_launch_facts": {
+                "exact_block_dim": "array<i64: 64, 1, 1>",
+                "exact_grid_dim": "array<i64: 8, 2, 1>",
+                "exact_cluster_dim": "array<i64: 2, 1, 1>",
+                "cooperative_launch": "true",
+                "cluster_launch": "true",
+            },
+            "nvvm.reqntid": "attr : 64, 1, 1>",
+        }
+    )
+
+    facts = _launch.launch_facts_from_kernel_op(operation)
+
+    assert facts.exact_block_dim == (64, 1, 1)
+    assert facts.exact_grid_dim is None
+    assert facts.exact_cluster_dim is None
+    assert facts.cooperative_launch is None
+    assert facts.cluster_launch is None
+    assert {origin.source for origin in facts.provenance} == {"kernel_attribute"}
+
+
+def test_private_cutlass_launch_facts_api_is_preferred_and_verified():
+    facts = _launch.launch_facts_from_cutlass_api(
+        SimpleNamespace(
+            exact_block_dim=(64, 1, 1),
+            exact_grid_dim=(8, 2, 1),
+            exact_cluster_dim=(2, 1, 1),
+            cooperative_launch=True,
+            cluster_launch=False,
+        )
+    )
+
+    assert facts.exact_block_dim == (64, 1, 1)
+    assert facts.exact_grid_dim == (8, 2, 1)
+    assert facts.exact_cluster_dim == (2, 1, 1)
+    assert facts.cooperative_launch is True
+    assert facts.cluster_launch is False
+    assert {origin.source for origin in facts.provenance} == {"cutlass_provider_api"}
+    assert all(origin.verified for origin in facts.provenance)
+
+
+def test_private_cutlass_launch_facts_api_rejects_invalid_values():
+    with pytest.raises(ValueError, match="exact_block_dim"):
+        _launch.launch_facts_from_cutlass_api(
+            SimpleNamespace(exact_block_dim=(64, 0, 1))
+        )
+    with pytest.raises(ValueError, match="cooperative_launch"):
+        _launch.launch_facts_from_cutlass_api(SimpleNamespace(cooperative_launch=1))
+
+
+def test_current_launch_facts_merge_private_api_with_maxntid(monkeypatch):
+    cute, ir = _install_fake_cutlass(monkeypatch)
+
+    operation = KernelOp({"nvvm.maxntid": "attr : 128>"})
+    monkeypatch.setattr(
+        ir,
+        "InsertionPoint",
+        SimpleNamespace(
+            current=SimpleNamespace(block=SimpleNamespace(owner=operation))
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        cute,
+        "_get_launch_facts",
+        lambda: SimpleNamespace(exact_grid_dim=(8, 1, 1)),
+        raising=False,
+    )
+
+    facts = _launch.current_kernel_launch_facts()
+
+    assert facts.exact_grid_dim == (8, 1, 1)
+    assert facts.max_block_dim == (128, 1, 1)
+    assert {origin.source for origin in facts.provenance} == {
+        "cutlass_provider_api",
+        "kernel_attribute",
+    }
+
+
+def test_current_launch_facts_reject_private_reqntid_conflict(monkeypatch):
+    cute, ir = _install_fake_cutlass(monkeypatch)
+
+    operation = KernelOp({"nvvm.reqntid": "attr : 32>"})
+    monkeypatch.setattr(
+        ir,
+        "InsertionPoint",
+        SimpleNamespace(
+            current=SimpleNamespace(block=SimpleNamespace(owner=operation))
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        cute,
+        "_get_launch_facts",
+        lambda: SimpleNamespace(exact_block_dim=(64, 1, 1)),
+        raising=False,
+    )
+
+    with pytest.raises(ValueError, match="conflicting exact_block_dim"):
+        _launch.current_kernel_launch_facts()
+
+
+def test_current_launch_facts_falls_back_only_when_private_facts_are_unavailable(
+    monkeypatch,
+):
+    cute, ir = _install_fake_cutlass(monkeypatch)
+    operation = KernelOp({"nvvm.reqntid": "attr : 32>"})
+    monkeypatch.setattr(
+        ir,
+        "InsertionPoint",
+        SimpleNamespace(
+            current=SimpleNamespace(block=SimpleNamespace(owner=operation))
+        ),
+        raising=False,
+    )
+
+    def unavailable():
+        raise RuntimeError("launch facts are unavailable on the enclosing kernel")
+
+    monkeypatch.setattr(cute, "_get_launch_facts", unavailable, raising=False)
+
+    facts = _launch.current_kernel_launch_facts()
+
+    assert facts.exact_block_dim == (32, 1, 1)
+    assert {origin.source for origin in facts.provenance} == {"kernel_attribute"}
+
+
+def test_kernel_attributes_reject_conflicting_exact_requirements():
+    operation = KernelOp(
+        {"nvvm.reqntid": "attr : 32>"},
+        KernelOp({"reqntid": "attr : 64>"}),
+    )
+
+    with pytest.raises(ValueError, match="conflicting exact_block_dim"):
+        _launch.launch_facts_from_kernel_op(operation)
+
+    with pytest.raises(ValueError, match="does not contain a valid"):
+        _launch.launch_facts_from_kernel_op(KernelOp({"nvvm.reqntid": "malformed"}))
+
+
+def test_infer_launch_facts_reconciles_call_and_kernel_sources(monkeypatch):
+    monkeypatch.setattr(
+        _launch,
+        "current_kernel_launch_facts",
+        lambda: LaunchFacts(exact_block_dim=(8, 4, 1), max_block_dim=(16, 8, 1)),
+    )
+
+    facts = _launch.infer_launch_facts(
+        {"launch_metadata": {"block": (8, 4)}},
+        scope="cuda.coop.cutlass",
+        primitive_name="scan",
+    )
+    assert facts.exact_block_dim == (8, 4, 1)
+    assert facts.max_block_dim == (16, 8, 1)
+
+    with pytest.raises(ValueError, match="conflicting exact_block_dim"):
+        _launch.infer_launch_facts(
+            {"launch_metadata": {"block": 64}},
+            scope="cuda.coop.cutlass",
+            primitive_name="scan",
+        )

--- a/python/cuda_coop/tests/backends/cutlass/unit/test_public_foundation.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/test_public_foundation.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import textwrap
+
+from ..support import _subprocess
+
+
+def test_cutlass_foundation_exports_current_public_surface():
+    script = textwrap.dedent(
+        """
+        import sys
+
+        import cuda.coop.cutlass as coop
+
+        expected = [
+            "Hierarchy",
+            "TempStorage",
+            "ThreadData",
+            "ThreadDataLoadSource",
+            "ThreadDataSource",
+            "ThreadDataTensorMetadata",
+            "ThreadGroup",
+            "ThreadHierarchy",
+            "exclusive_scan",
+            "exclusive_sum",
+            "inclusive_scan",
+            "inclusive_sum",
+            "load",
+            "reduce",
+            "scan",
+            "store",
+            "sum",
+            "this_block",
+            "this_cluster",
+            "this_grid",
+            "this_thread",
+            "this_warp",
+        ]
+        assert coop.__all__ == expected
+        assert sorted(name for name in dir(coop) if not name.startswith("_")) == expected
+        assert not hasattr(coop, "Payload")
+        assert not hasattr(coop, "aot")
+        assert not hasattr(coop, "_block")
+        assert not hasattr(coop, "_warp")
+        assert "numpy" not in sys.modules
+
+        assert not any(
+            name.startswith("cuda.coop.cutlass._lowering.")
+            for name in sys.modules
+        )
+        assert "cuda.coop.cutlass._compiler._bundle" not in sys.modules
+        assert "cuda.coop.cutlass._compiler._finalize" not in sys.modules
+
+        dsl = _cuda_coop_test_dsl.CuTeDSL._get_dsl()
+        assert len(dsl.trace_context_factories) == 1
+
+        temp_storage_type = coop.TempStorage
+        assert temp_storage_type.__module__ == "cuda.coop.cutlass._temp_storage"
+        assert len(dsl.trace_context_factories) == 1
+        """
+    )
+
+    result = _subprocess.run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_qualified_cutlass_import_reports_missing_runtime():
+    script = textwrap.dedent(
+        """
+        import importlib.abc
+        import os
+        import sys
+
+        os.environ["CUDA_COOP_DISABLE_AUTO_DSL_REGISTRATION"] = "1"
+
+        class BlockCutlassRuntime(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                del path, target
+                if fullname == "cutlass" or fullname.startswith("cutlass."):
+                    raise ImportError("blocked CUTLASS runtime", name=fullname)
+                return None
+
+        sys.meta_path.insert(0, BlockCutlassRuntime())
+
+        from cuda import coop
+
+        assert coop.__name__ == "cuda.coop"
+        assert not any(
+            name == "cutlass" or name.startswith("cutlass.")
+            for name in sys.modules
+        )
+
+        try:
+            import cuda.coop.cutlass  # noqa: F401
+        except ImportError as exc:
+            assert exc.backend == "cutlass"
+            assert exc.reason_code == "backend-runtime-missing"
+            assert exc.details["missing"] == "cutlass"
+            assert isinstance(exc.__cause__, ImportError)
+            message = str(exc)
+            assert "nvidia-cutlass-dsl>=4.8" in message
+            assert "cuda-coop[cutlass]" in message
+        else:
+            raise AssertionError("qualified CUTLASS import unexpectedly succeeded")
+        """
+    )
+
+    result = _subprocess.run_python_with_source_and_site(script)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_qualified_cutlass_import_reports_missing_capabilities():
+    script = textwrap.dedent(
+        """
+        import importlib.metadata
+
+        importlib.metadata.version = lambda distribution: "99.7"
+        _cuda_coop_test_compiler.GPUArch = None
+
+        try:
+            import cuda.coop.cutlass  # noqa: F401
+        except ImportError as exc:
+            assert exc.backend == "cutlass"
+            assert exc.reason_code == "backend-runtime-incompatible"
+            assert exc.details["missing_capabilities"] == (
+                "cutlass.base_dsl.compiler.GPUArch",
+            )
+            message = str(exc)
+            assert "cutlass.base_dsl.compiler.GPUArch" in message
+            assert "detected nvidia-cutlass-dsl==99.7" in message
+        else:
+            raise AssertionError("incompatible CUTLASS import unexpectedly succeeded")
+        """
+    )
+
+    result = _subprocess.run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_lowering_package_stays_lazy():
+    script = textwrap.dedent(
+        """
+        import sys
+
+        import cuda.coop.cutlass._lowering as lowering
+
+        assert lowering.__all__ == ()
+        assert not any(
+            name.startswith("cuda.coop.cutlass._lowering.")
+            for name in sys.modules
+        )
+        assert "cuda.coop.cutlass._compiler._bundle" not in sys.modules
+        assert "cuda.coop.cutlass._compiler._finalize" not in sys.modules
+        """
+    )
+
+    result = _subprocess.run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr

--- a/python/cuda_coop/tests/backends/cutlass/unit/test_reduce_scan.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/test_reduce_scan.py
@@ -1,0 +1,563 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+
+def _provider_dependencies() -> None:
+    pytest.importorskip("cutlass")
+    pytest.importorskip("cutlass.cute.ffi")
+
+
+def _launch_facts(block_dim=64):
+    from cuda.coop._core import LaunchFactOrigin, LaunchFacts
+
+    return LaunchFacts(
+        exact_block_dim=block_dim,
+        exact_grid_dim=(2, 1, 1),
+        exact_cluster_dim=(2, 1, 1),
+        cluster_launch=True,
+        provenance=(LaunchFactOrigin("cluster_launch", "test_kernel", verified=True),),
+    )
+
+
+def test_public_reduce_scan_exports_and_frontends(monkeypatch) -> None:
+    _provider_dependencies()
+    from cutlass.base_dsl.typing import Boolean, Int32
+
+    import cuda.coop.cutlass as coop
+    import cuda.coop.cutlass._lowering._reduce as reduce_provider
+    import cuda.coop.cutlass._lowering._scan as scan_provider
+    from cuda.coop._core import ArgumentBinding
+    from cuda.coop._core.block import BlockReduceAlgorithm
+    from cuda.coop.cutlass._compiler import _launch
+
+    monkeypatch.setattr(_launch, "current_kernel_launch_facts", _launch_facts)
+    reduce_calls = []
+    scan_calls = []
+    monkeypatch.setattr(
+        reduce_provider,
+        "provider_reduce",
+        lambda **payload: reduce_calls.append(payload) or "reduced",
+    )
+    monkeypatch.setattr(
+        scan_provider,
+        "provider_scan",
+        lambda **payload: scan_calls.append(payload) or "scanned",
+    )
+
+    block = coop.this_block()
+    assert (
+        coop.sum(
+            block,
+            Int32(1),
+            broadcast=False,
+            valid_items=47,
+            algorithm="raking",
+        )
+        == "reduced"
+    )
+    assert reduce_calls[-1]["valid_items_binding"] == ArgumentBinding.static(47)
+    assert reduce_calls[-1]["algorithm"] is BlockReduceAlgorithm.RAKING
+    assert (
+        coop.exclusive_scan(
+            block,
+            Int32(1),
+            scan_op="max",
+            initial_value=-2_147_483_648,
+            temp_storage=object(),
+        )
+        == "scanned"
+    )
+    assert scan_calls[-1]["mode"] == "exclusive"
+    assert scan_calls[-1]["op"] == "max"
+
+    expected_modules = {
+        "reduce": "cuda.coop.cutlass._group_reduce",
+        "sum": "cuda.coop.cutlass._group_reduce",
+        "scan": "cuda.coop.cutlass._group_scan",
+        "exclusive_sum": "cuda.coop.cutlass._group_scan",
+        "inclusive_sum": "cuda.coop.cutlass._group_scan",
+        "exclusive_scan": "cuda.coop.cutlass._group_scan",
+        "inclusive_scan": "cuda.coop.cutlass._group_scan",
+    }
+    for name, module in expected_modules.items():
+        function = getattr(coop, name)
+        assert name in coop.__all__
+        assert function.__module__ == module
+        assert all(
+            not parameter.startswith("_")
+            for parameter in inspect.signature(function).parameters
+        )
+
+    for invalid in (True, __import__("numpy").bool_(True), Boolean(True)):
+        with pytest.raises(TypeError, match="must be an integer"):
+            coop.sum(block, Int32(1), broadcast=False, valid_items=invalid)
+        with pytest.raises(TypeError, match="must be an integer"):
+            coop.scan(coop.this_warp(), Int32(1), valid_items=invalid)
+        with pytest.raises(TypeError, match="algorithm must not be boolean"):
+            coop.sum(
+                block,
+                Int32(1),
+                broadcast=False,
+                algorithm=invalid,
+            )
+        with pytest.raises(TypeError, match="algorithm must not be boolean"):
+            coop.scan(block, Int32(1), algorithm=invalid)
+    for invalid in (1.5, object()):
+        with pytest.raises(TypeError, match="must be an integer"):
+            coop.sum(block, Int32(1), broadcast=False, valid_items=invalid)
+        with pytest.raises(TypeError, match="must be an integer"):
+            coop.scan(coop.this_warp(), Int32(1), valid_items=invalid)
+    with pytest.raises(TypeError, match="broadcast must be a bool"):
+        coop.sum(block, Int32(1), broadcast=1)
+    with pytest.raises(NotImplementedError, match="does not support grid"):
+        coop.sum(coop.this_grid(), Int32(1))
+
+
+def test_reduce_plans_cover_cudax_mappings_and_direct_cub() -> None:
+    _provider_dependencies()
+    from cutlass.base_dsl.typing import Int32
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop._core import (
+        ArgumentBinding,
+        GroupLoweringTarget,
+        ReduceValueKind,
+    )
+    from cuda.coop._core.block import BlockReduceAlgorithm
+    from cuda.coop.cutlass._lowering import _reduce as provider
+
+    launch = _launch_facts()
+    groups = (
+        coop.this_thread(),
+        coop.this_warp(),
+        coop.this_warp().group_by(8),
+        coop.this_block().group_by(1),
+        coop.this_block(),
+        coop.this_cluster(),
+    )
+    plans = []
+    for group in groups:
+        plan = provider._make_group_reduce_plan(
+            group=group,
+            launch=launch,
+            dtype=Int32,
+            value_kind=ReduceValueKind.SCALAR,
+            items_per_thread=1,
+            op="sum",
+            broadcast=True,
+        ).require_supported()
+        assert plan.target is GroupLoweringTarget.CUDAX_GROUP
+        plans.append(plan)
+
+    for plan, kind in zip(plans[:2], ("thread", "warp"), strict=True):
+        physical_request = provider._CudaxReduceRequest(
+            plan=plan,
+            op="sum",
+            value_type=Int32,
+        )
+        physical_source = "\n".join(provider._render_cudax_reduce(physical_request))
+        assert "group{}" not in physical_source
+        hierarchy = (
+            "::cuda::experimental::implicit_hierarchy()"
+            if plan.resolved_group.hierarchy.implicit
+            else "hierarchy"
+        )
+        assert (
+            f"::cuda::experimental::this_{kind} group{{{hierarchy}}};"
+        ) in physical_source
+
+    mapped_request = provider._CudaxReduceRequest(
+        plan=plans[3],
+        op="sum",
+        value_type=Int32,
+    )
+    mapped_source = "\n".join(provider._render_cudax_reduce(mapped_request))
+    assert "group_by<1, true>" in mapped_source
+
+    non_power_of_two_plan = provider._make_group_reduce_plan(
+        group=coop.this_warp().group_by(12, exhaustive=False),
+        launch=launch,
+        dtype=Int32,
+        value_kind=ReduceValueKind.SCALAR,
+        items_per_thread=1,
+        op="sum",
+        broadcast=True,
+    ).require_supported()
+    non_power_of_two_source = "\n".join(
+        provider._render_cudax_reduce(
+            provider._CudaxReduceRequest(
+                plan=non_power_of_two_plan,
+                op="sum",
+                value_type=Int32,
+            )
+        )
+    )
+    assert "group_by<12, false>" in non_power_of_two_source
+    assert "cuda_coop_cutlass_warp_sync(12u);" in non_power_of_two_source
+
+    distinct_request = provider._CudaxReduceRequest(
+        plan=provider._make_group_reduce_plan(
+            group=coop.this_thread(),
+            launch=_launch_facts(32),
+            dtype=Int32,
+            value_kind=ReduceValueKind.SCALAR,
+            items_per_thread=1,
+            op="sum",
+            broadcast=True,
+        ).require_supported(),
+        op="sum",
+        value_type=Int32,
+    )
+    physical_request = provider._CudaxReduceRequest(
+        plan=plans[0],
+        op="sum",
+        value_type=Int32,
+    )
+    assert physical_request.group.symbol_suffix == distinct_request.group.symbol_suffix
+    assert physical_request.symbol_name != distinct_request.symbol_name
+    from cuda.coop.cutlass._compiler._state import BundleSession
+
+    session = BundleSession()
+    session.add(physical_request)
+    session.add(distinct_request)
+    assert len(session.request_list()) == 2
+
+    array_plan = provider._make_group_reduce_plan(
+        group=coop.this_block(),
+        launch=launch,
+        dtype=Int32,
+        value_kind=ReduceValueKind.ARRAY,
+        items_per_thread=2,
+        op="sum",
+        broadcast=False,
+        algorithm=BlockReduceAlgorithm.RAKING,
+    ).require_supported()
+    array_request = provider._CubReduceRequest(array_plan, "sum", Int32)
+    array_source = "\n".join(provider._render_cub_reduce(array_request))
+    assert array_plan.target is GroupLoweringTarget.CUB_BLOCK
+    assert "::cub::BlockReduce<int, 64" in array_source
+    assert ".Sum(thread_data)" in array_source
+
+    def logical_request(width: int):
+        plan = provider._make_group_reduce_plan(
+            group=coop.this_warp().group_by(width),
+            launch=launch,
+            dtype=Int32,
+            value_kind=ReduceValueKind.SCALAR,
+            items_per_thread=1,
+            op="sum",
+            broadcast=False,
+            valid_items=ArgumentBinding.static(width - 1),
+        ).require_supported()
+        assert plan.target is GroupLoweringTarget.CUB_WARP
+        return provider._CubReduceRequest(plan, "sum", Int32)
+
+    logical_8 = logical_request(8)
+    logical_16 = logical_request(16)
+    assert logical_8.symbol_name != logical_16.symbol_name
+    assert logical_8.plan.temp_storage.instances is None
+    logical_source = "\n".join(provider._render_cub_reduce(logical_8))
+    assert "::cub::WarpReduce<int, 8>" in logical_source
+    assert "TempStorage storage[8]" in logical_source
+    assert ".Sum(item0, 7)" in logical_source
+    assert "cuda_coop_cutlass_warp_sync(8u);" in logical_source
+
+    from cuda.coop.cutlass._compiler import _rendering
+
+    preamble = "\n".join(_rendering.bundle_source_preamble_lines())
+    assert "laneid" in preamble
+    assert "(lane / logical_width) * logical_width" in preamble
+    assert "activemask" not in preamble
+
+
+def test_scan_plans_render_aggregate_storage_and_distinct_widths(monkeypatch) -> None:
+    _provider_dependencies()
+    from cutlass.base_dsl.typing import Float32, Float64, Int32, Uint8
+
+    import cuda.coop.cutlass as coop
+    import cuda.coop.cutlass._compiler._storage as provider_storage
+    import cuda.coop.cutlass._compiler._types as provider_types
+    from cuda.coop._core import GroupLoweringTarget, ScanValueKind
+    from cuda.coop.cutlass._lowering import _scan as provider
+
+    launch = _launch_facts()
+
+    def logical_request(width: int):
+        plan = provider._make_group_scan_plan(
+            group=coop.this_warp().group_by(width),
+            launch=launch,
+            dtype=Int32,
+            value_kind=ScanValueKind.SCALAR,
+            items_per_thread=1,
+            mode="inclusive",
+            op="sum",
+            aggregate=True,
+            valid_items=width - 1,
+        ).require_supported()
+        assert plan.target is GroupLoweringTarget.CUB_WARP
+        return provider._CubScanRequest(plan, "sum", Int32)
+
+    logical_8 = logical_request(8)
+    logical_16 = logical_request(16)
+    assert logical_8.symbol_name != logical_16.symbol_name
+    logical_source = "\n".join(provider._render_cub_scan(logical_8))
+    assert "::cub::WarpScan<int, 8>" in logical_source
+    assert "TempStorage storage[8]" in logical_source
+    assert (
+        ".InclusiveScanPartial(value, result, ::cuda::std::plus<>{}, 7, aggregate)"
+        in logical_source
+    )
+    assert "int result = value;" in logical_source
+
+    for value_type in (Uint8, Float32, Float64):
+        partial_exclusive_plan = provider._make_group_scan_plan(
+            group=coop.this_warp().group_by(8),
+            launch=launch,
+            dtype=value_type,
+            value_kind=ScanValueKind.SCALAR,
+            items_per_thread=1,
+            mode="exclusive",
+            op="sum",
+            initial_value=0,
+            valid_items=5,
+        ).require_supported()
+        partial_exclusive_request = provider._CubScanRequest(
+            partial_exclusive_plan,
+            "sum",
+            value_type,
+        )
+        partial_exclusive_source = "\n".join(
+            provider._render_cub_scan(partial_exclusive_request)
+        )
+        assert (
+            ".ExclusiveScanPartial(value, result, "
+            "initial_value, ::cuda::std::plus<>{}, 5)" in partial_exclusive_source
+        )
+        assert "result = value;" in partial_exclusive_source
+
+    for feature in ("reduce", "scan"):
+        for op in ("bit_and", "bit_or", "bit_xor"):
+            provider_types.validate_scan_reduce_op_for_type(
+                op,
+                Uint8,
+                root_scope="cuda.coop.cutlass",
+                feature=feature,
+                namespace="thread_group",
+            )
+            with pytest.raises(TypeError, match="require an integral type"):
+                provider_types.validate_scan_reduce_op_for_type(
+                    op,
+                    Float32,
+                    root_scope="cuda.coop.cutlass",
+                    feature=feature,
+                    namespace="thread_group",
+                )
+
+    block_plan = provider._make_group_scan_plan(
+        group=coop.this_block(),
+        launch=launch,
+        dtype=Int32,
+        value_kind=ScanValueKind.ARRAY,
+        items_per_thread=2,
+        mode="exclusive",
+        op="sum",
+        aggregate=True,
+    ).require_supported()
+    external_plan = provider._with_caller_owned_scan_storage(block_plan)
+    external_request = provider._CubScanRequest(
+        external_plan,
+        "sum",
+        Int32,
+        external_scratch=True,
+    )
+    external_source = "\n".join(provider._render_cub_scan(external_request))
+    assert "reinterpret_cast" in external_source
+    assert "temp_storage_bytes < required_temp_bytes" in external_source
+    assert "temp_storage_auto_sync != 0" in external_source
+    assert "__shared__ typename implementation_type::TempStorage" not in (
+        external_source
+    )
+    probe = provider._cub_scan_scratch_layout_probe(external_request)
+    assert probe is not None
+    assert probe.requirement_key == external_request.scratch_requirement_key
+
+    fixed = coop.TempStorage(4096, alignment=16, auto_sync=False)
+    assert (
+        provider._temp_storage_for_scan(
+            group=coop.this_block(),
+            explicit_temp_storage=fixed,
+        )
+        is fixed
+    )
+    with pytest.raises(ValueError, match="sharing='exclusive'"):
+        provider._temp_storage_for_scan(
+            group=coop.this_block(),
+            explicit_temp_storage=coop.TempStorage(4096, sharing="exclusive"),
+        )
+    with pytest.raises(ValueError, match="only for block groups"):
+        provider._temp_storage_for_scan(
+            group=coop.this_warp(),
+            explicit_temp_storage=fixed,
+        )
+
+    monkeypatch.setattr(
+        provider_storage,
+        "materialize_temp_storage_binding",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            smem_addr_u32="shared-address",
+            size_in_bytes=4096,
+            auto_sync=False,
+        ),
+    )
+    assert provider._external_scratch_args(
+        fixed,
+        requirement_key=external_request.scratch_requirement_key,
+    ) == ("shared-address", Int32(4096), Int32(0))
+
+
+def test_signless_i8_thread_data_reconciles_with_uint8_dtype() -> None:
+    _provider_dependencies()
+    from cutlass.base_dsl.typing import Uint8
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop.cutlass._compiler import _types as provider_types
+
+    signless_i8 = SimpleNamespace(signed=None, type="i8")
+    value = coop.ThreadData.from_values(signless_i8, dtype=Uint8)
+
+    def resolve_type(candidate, **_kwargs):
+        if candidate is Uint8:
+            return Uint8
+        raise TypeError("unknown value type")
+
+    value_type, values = provider_types.resolve_thread_data_value_type(
+        value,
+        allowed=provider_types.ALL_PROVIDER_TYPES,
+        feature="scan",
+        scope="cuda.coop.cutlass",
+        resolve_type=resolve_type,
+    )
+
+    assert value_type is Uint8
+    assert values == (signless_i8,)
+
+
+def test_zero_byte_temp_storage_use_does_not_grow_exclusive_capacity():
+    _provider_dependencies()
+
+    import cuda.coop.cutlass as coop
+
+    deferred = coop.TempStorage(sharing="exclusive")
+    first = deferred.record_use(
+        "first",
+        required_size_in_bytes=3,
+        required_alignment=1,
+    )
+    zero = deferred.record_use(
+        "zero",
+        required_size_in_bytes=0,
+        required_alignment=8,
+    )
+
+    assert first.byte_offset_in_bytes == 0
+    assert zero.byte_offset_in_bytes == 8
+
+    with pytest.raises(ValueError, match="power of two"):
+        deferred.record_use(
+            "invalid_alignment",
+            required_size_in_bytes=1,
+            required_alignment=3,
+        )
+    assert deferred.required_size_in_bytes == 3
+    assert deferred.capacity_size_in_bytes is None
+
+    fixed = coop.TempStorage(4, sharing="exclusive")
+    fixed.record_use("first", required_size_in_bytes=3)
+    fixed.record_use("zero", required_size_in_bytes=0, required_alignment=8)
+    assert fixed.required_size_in_bytes == 3
+    assert fixed.capacity_size_in_bytes == 4
+
+
+class _FakeTensor:
+    class _Iterator:
+        llvm_ptr = object()
+
+    iterator = _Iterator()
+
+    def __getitem__(self, index):
+        return index
+
+
+def test_fixed_scan_failure_rolls_back_provider_session(monkeypatch) -> None:
+    _provider_dependencies()
+    from cutlass.base_dsl.typing import Int32
+
+    import cuda.coop.cutlass as coop
+    from cuda.coop._core import ScanValueKind
+    from cuda.coop.cutlass._compiler import _state as provider_state
+    from cuda.coop.cutlass._lowering import _scan as provider
+
+    plan = provider._make_group_scan_plan(
+        group=coop.this_block(),
+        launch=_launch_facts(),
+        dtype=Int32,
+        value_kind=ScanValueKind.ARRAY,
+        items_per_thread=2,
+        mode="inclusive",
+        op="sum",
+    ).require_supported()
+    plan = provider._with_caller_owned_scan_storage(plan)
+    value = coop.ThreadData.from_values(Int32(1), Int32(2), dtype=Int32)
+    storage = coop.TempStorage(4096, alignment=16)
+    snapshot = object()
+    restored = []
+    monkeypatch.setattr(
+        provider_state,
+        "snapshot_active_session_state",
+        lambda: snapshot,
+    )
+    monkeypatch.setattr(
+        provider_state,
+        "restore_active_session_state",
+        restored.append,
+    )
+    monkeypatch.setattr(provider_state, "register_request", lambda _request: None)
+    monkeypatch.setattr(
+        provider,
+        "_external_scratch_args",
+        lambda *_args, **_kwargs: (object(), object(), object()),
+    )
+    monkeypatch.setattr(
+        provider._cute, "make_rmem_tensor", lambda *_args: _FakeTensor()
+    )
+    monkeypatch.setattr(provider.llvm.PointerType, "get", lambda *_args: object())
+
+    def failing_ffi(**_kwargs):
+        def invoke(*_args):
+            raise RuntimeError("forced FFI failure")
+
+        return invoke
+
+    monkeypatch.setattr(provider, "ffi", failing_ffi)
+    with pytest.raises(RuntimeError, match="forced FFI failure"):
+        provider._materialize_scan(
+            plan=plan,
+            value=value,
+            values=(Int32(1), Int32(2)),
+            value_type=Int32,
+            op="sum",
+            initial_value=None,
+            aggregate_output=None,
+            valid_items=None,
+            external_temp_storage=storage,
+        )
+
+    assert restored == [snapshot]

--- a/python/cuda_coop/tests/backends/cutlass/unit/test_thread_data.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/test_thread_data.py
@@ -1,0 +1,1108 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import textwrap
+
+import pytest
+
+from ..support._subprocess import run_python_with_source
+
+
+def test_portable_thread_data_rejects_a_qualified_only_dtype():
+    pytest.importorskip("cutlass.cute.ffi")
+
+    import cuda.coop.cutlass as cutlass_coop
+    from cuda import coop
+    from cuda.coop._core.api._dispatch import _compiler_scope
+
+    class StructuralUint64:
+        width = 64
+
+    with _compiler_scope("cuda.coop.cutlass"):
+        with pytest.raises(TypeError, match="through the portable API"):
+            coop.ThreadData(1, dtype=StructuralUint64)
+
+    qualified = cutlass_coop.ThreadData(1, dtype=StructuralUint64)
+    assert qualified.dtype is StructuralUint64
+
+
+def test_thread_data_from_vector_like_payload():
+    script = textwrap.dedent(
+        """
+        import cuda.coop.cutlass as coop
+
+        class FakeVector:
+            shape = (3,)
+            dtype = "i32"
+
+            def numel(self):
+                return 3
+
+            def __getitem__(self, idx):
+                return f"item{idx}"
+
+        items = coop.ThreadData.from_vector(FakeVector())
+
+        assert len(items) == 3
+        assert items.items_per_thread == 3
+        assert items.dtype == "i32"
+        assert items.values("test") == ("item0", "item1", "item2")
+        """
+    )
+
+    result = run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_thread_data_from_fn_builds_generated_payloads():
+    script = textwrap.dedent(
+        """
+        import cuda.coop.cutlass as coop
+
+        class StaticInt:
+            def __init__(self, value):
+                self.value = value
+
+            def __index__(self):
+                return self.value
+
+        class FakeDslUint32:
+            __module__ = "cutlass.base_dsl.typing"
+
+            def __init__(self, value):
+                self.value = value
+
+        generated = coop.ThreadData.from_fn(
+            StaticInt(3),
+            lambda item: item + 10,
+            dtype=FakeDslUint32,
+        )
+        assert generated.items_per_thread == 3
+        assert generated.dtype is FakeDslUint32
+        assert [value.value for value in generated.values("generated")] == [
+            10,
+            11,
+            12,
+        ]
+
+        try:
+            coop.ThreadData.from_fn(2, None)
+        except TypeError as exc:
+            assert "requires a callable" in str(exc)
+        else:
+            raise AssertionError("non-callable from_fn argument should fail")
+
+        def fail(_):
+            raise RuntimeError("boom")
+
+        try:
+            coop.ThreadData.from_fn(2, fail)
+        except TypeError as exc:
+            assert "callable failed for item 0" in str(exc)
+        else:
+            raise AssertionError("raising from_fn callable should fail")
+        """
+    )
+
+    result = run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_thread_data_from_vector_infers_metadata_fallbacks():
+    script = textwrap.dedent(
+        """
+        import cuda.coop.cutlass as coop
+
+        class StaticInt:
+            def __init__(self, value):
+                self.value = value
+
+            def __index__(self):
+                return self.value
+
+        class ShapeOnlyVector:
+            _shape = (StaticInt(2),)
+            _dtype = "fallback-i32"
+
+            def numel(self):
+                raise RuntimeError("probe fallback")
+
+            def __getitem__(self, idx):
+                return idx + 20
+
+        class ElementTypeVector:
+            shape = StaticInt(2)
+            element_type = "element-i64"
+
+            def __getitem__(self, idx):
+                return idx + 30
+
+        class RaisingNumelVector:
+            shape = (2,)
+            dtype = "raising-numel-i32"
+
+            @property
+            def numel(self):
+                raise RuntimeError("numel probe failed")
+
+            def __getitem__(self, idx):
+                return idx + 35
+
+        class ExplicitVector:
+            def __getitem__(self, idx):
+                return idx + 40
+
+        class FakeDslUint32:
+            __module__ = "cutlass.base_dsl.typing"
+
+            def __init__(self, value):
+                self.value = value
+
+        class RaisingDtypeVector:
+            shape = (2,)
+
+            @property
+            def dtype(self):
+                raise RuntimeError("dtype probe failed")
+
+            @property
+            def _dtype(self):
+                raise RuntimeError("_dtype probe failed")
+
+            @property
+            def element_type(self):
+                raise RuntimeError("element_type probe failed")
+
+            def __getitem__(self, idx):
+                return idx + 50
+
+        shape_items = coop.ThreadData.from_vector(ShapeOnlyVector())
+        assert shape_items.items_per_thread == 2
+        assert shape_items.dtype == "fallback-i32"
+        assert shape_items.values("shape") == (20, 21)
+
+        element_items = coop.ThreadData.from_vector(ElementTypeVector())
+        assert element_items.items_per_thread == 2
+        assert element_items.dtype == "element-i64"
+        assert element_items.values("element") == (30, 31)
+
+        raising_numel_items = coop.ThreadData.from_vector(RaisingNumelVector())
+        assert raising_numel_items.items_per_thread == 2
+        assert raising_numel_items.dtype == "raising-numel-i32"
+        assert raising_numel_items.values("raising-numel") == (35, 36)
+
+        explicit_items = coop.ThreadData.from_vector(
+            ExplicitVector(),
+            items_per_thread=StaticInt(1),
+            dtype="override-f32",
+        )
+        assert explicit_items.items_per_thread == 1
+        assert explicit_items.dtype == "override-f32"
+        assert explicit_items.values("explicit") == (40,)
+
+        cast_items = coop.ThreadData.from_vector(
+            ElementTypeVector(),
+            dtype=FakeDslUint32,
+        )
+        assert cast_items.items_per_thread == 2
+        assert cast_items.dtype is FakeDslUint32
+        assert [value.value for value in cast_items.values("cast")] == [30, 31]
+        assert all(
+            isinstance(value, FakeDslUint32)
+            for value in cast_items.values("cast")
+        )
+
+        raising_dtype_items = coop.ThreadData.from_vector(RaisingDtypeVector())
+        assert raising_dtype_items.items_per_thread == 2
+        assert raising_dtype_items.dtype is None
+        assert raising_dtype_items.values("raising-dtype") == (50, 51)
+
+        empty_items = coop.ThreadData(StaticInt(2), dtype="i8")
+        assert empty_items.items_per_thread == 2
+        assert empty_items.dtype == "i8"
+        """
+    )
+
+    result = run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_thread_data_from_vector_reports_bad_memory_payloads():
+    script = textwrap.dedent(
+        """
+        import sys
+        import types
+
+        import cuda.coop.cutlass as coop
+
+        class MissingShapeVector:
+            def __getitem__(self, idx):
+                return idx
+
+        class NonIndexableVector:
+            shape = (2,)
+
+        class ShapedVector:
+            shape = (2,)
+
+            def __getitem__(self, idx):
+                return idx
+
+        class RaisingShapeVector:
+            @property
+            def shape(self):
+                raise RuntimeError("shape should not be probed")
+
+            def __getitem__(self, idx):
+                return idx
+
+        class RaisingMetadataVector:
+            @property
+            def shape(self):
+                raise RuntimeError("shape probe failed")
+
+            @property
+            def _shape(self):
+                raise RuntimeError("_shape probe failed")
+
+            def __getitem__(self, idx):
+                return idx
+
+        class MemoryTensor:
+            memspace = object()
+            shape = (2,)
+
+            def __getitem__(self, idx):
+                return idx
+
+        class MemoryArray:
+            space = object()
+            shape = (2,)
+
+            def __getitem__(self, idx):
+                return idx
+
+        class CutlassArray:
+            shape = (2,)
+            dtype = "i32"
+
+            def __getitem__(self, idx):
+                return idx
+
+            def load(self, *args, **kwargs):
+                return None
+
+            def store(self, *args, **kwargs):
+                return None
+
+        CutlassArray.__module__ = "cutlass.base_dsl.array"
+        CutlassArray.__qualname__ = "Array"
+        cutlass_module = types.ModuleType("cutlass")
+        cutlass_module.Array = CutlassArray
+        sys.modules["cutlass"] = cutlass_module
+
+        class RaisingMemorySpaceVector:
+            shape = (2,)
+
+            @property
+            def memspace(self):
+                raise RuntimeError("memspace probe failed")
+
+            def __getitem__(self, idx):
+                return idx
+
+        class RaisingSpaceVector:
+            shape = (2,)
+
+            @property
+            def space(self):
+                raise RuntimeError("space probe failed")
+
+            def __getitem__(self, idx):
+                return idx
+
+        class HostArrayProtocol:
+            __array_interface__ = {
+                "shape": (2,),
+                "typestr": "<i4",
+                "data": (0, False),
+                "version": 3,
+            }
+            shape = (2,)
+
+            def __getitem__(self, idx):
+                return idx
+
+        class CudaArrayProtocol:
+            __cuda_array_interface__ = {
+                "shape": (2,),
+                "typestr": "<i4",
+                "data": (0, False),
+                "version": 3,
+            }
+            shape = (2,)
+
+            def __getitem__(self, idx):
+                return idx
+
+        class DlpackTensorProtocol:
+            shape = (2,)
+
+            def __dlpack__(self):
+                raise RuntimeError("not called")
+
+            def __getitem__(self, idx):
+                return idx
+
+        class RaisingCudaArrayProtocol:
+            shape = (2,)
+
+            @property
+            def __cuda_array_interface__(self):
+                raise RuntimeError("not called")
+
+            def __getitem__(self, idx):
+                return idx
+
+        class RaisingDlpackDeviceProtocol:
+            shape = (2,)
+
+            @property
+            def __dlpack_device__(self):
+                raise RuntimeError("not called")
+
+            def __getitem__(self, idx):
+                return idx
+
+        def assert_raises(exc_type, message, fn):
+            try:
+                fn()
+            except exc_type as exc:
+                assert message in str(exc), str(exc)
+            else:
+                raise AssertionError(f"{exc_type.__name__} was not raised")
+
+        assert_raises(
+            ValueError,
+            "could not infer items_per_thread",
+            lambda: coop.ThreadData.from_vector(MissingShapeVector()),
+        )
+        assert_raises(
+            ValueError,
+            "could not infer items_per_thread",
+            lambda: coop.ThreadData.from_vector(RaisingMetadataVector()),
+        )
+        assert_raises(
+            TypeError,
+            "requires integer-indexable vector items",
+            lambda: coop.ThreadData.from_vector(NonIndexableVector()),
+        )
+        assert_raises(
+            TypeError,
+            "requires a CUTLASS vector-like per-thread payload",
+            lambda: coop.ThreadData.from_vector(MemoryTensor()),
+        )
+        assert_raises(
+            TypeError,
+            "requires a CUTLASS vector-like per-thread payload",
+            lambda: coop.ThreadData.from_vector(MemoryArray()),
+        )
+        for memory_payload in (
+            HostArrayProtocol(),
+            CudaArrayProtocol(),
+            DlpackTensorProtocol(),
+            CutlassArray(),
+            RaisingMemorySpaceVector(),
+            RaisingSpaceVector(),
+            RaisingCudaArrayProtocol(),
+            RaisingDlpackDeviceProtocol(),
+        ):
+            assert_raises(
+                TypeError,
+                "requires a CUTLASS vector-like per-thread payload",
+                lambda memory_payload=memory_payload: coop.ThreadData.from_vector(
+                    memory_payload
+                ),
+            )
+        assert_raises(
+            TypeError,
+            "items_per_thread must be an integer",
+            lambda: coop.ThreadData.from_vector(
+                MissingShapeVector(),
+                items_per_thread=True,
+            ),
+        )
+        assert_raises(
+            TypeError,
+            "items_per_thread must be an integer",
+            lambda: coop.ThreadData.from_vector(
+                RaisingShapeVector(),
+                items_per_thread=True,
+            ),
+        )
+        assert_raises(
+            ValueError,
+            "items_per_thread must be a positive integer",
+            lambda: coop.ThreadData.from_vector(
+                MissingShapeVector(),
+                items_per_thread=0,
+            ),
+        )
+        assert_raises(
+            ValueError,
+            "items_per_thread does not match payload item count",
+            lambda: coop.ThreadData.from_vector(
+                ShapedVector(),
+                items_per_thread=1,
+            ),
+        )
+        """
+    )
+
+    result = run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_thread_data_from_register_tensor_builds_cute_payload():
+    script = textwrap.dedent(
+        """
+        import sys
+        import types
+
+        class AddressSpace:
+            rmem = object()
+            gmem = object()
+
+        for module_name in (
+            "cutlass",
+            "cutlass._mlir",
+            "cutlass._mlir.dialects",
+        ):
+            module = types.ModuleType(module_name)
+            module.__path__ = []
+            sys.modules[module_name] = module
+        cute_module = types.ModuleType("cutlass._mlir.dialects.cute")
+        cute_module.AddressSpace = AddressSpace
+        sys.modules["cutlass._mlir.dialects.cute"] = cute_module
+
+        import cuda.coop.cutlass as coop
+
+        class StaticInt:
+            def __init__(self, value):
+                self.value = value
+
+            def __index__(self):
+                return self.value
+
+        class FakeDslUint32:
+            __module__ = "cutlass.base_dsl.typing"
+
+            def __init__(self, value):
+                self.value = value
+
+        class RegisterTensor:
+            memspace = AddressSpace.rmem
+            shape = (StaticInt(3),)
+            element_type = "i32"
+
+            def __getitem__(self, idx):
+                return f"r{idx}"
+
+        class Layout:
+            shape = (2,)
+
+        class LayoutTensor:
+            memspace = AddressSpace.rmem
+            layout = Layout()
+            element_type = "layout-i32"
+
+            def __getitem__(self, idx):
+                return f"layout{idx}"
+
+        class ExplicitRegisterTensor:
+            memspace = AddressSpace.rmem
+
+            def __getitem__(self, idx):
+                return f"explicit{idx}"
+
+        class CastRegisterTensor:
+            memspace = AddressSpace.rmem
+            shape = (2,)
+
+            def __getitem__(self, idx):
+                return idx + 70
+
+        class RaisingElementTypeTensor:
+            memspace = AddressSpace.rmem
+            shape = (2,)
+
+            @property
+            def element_type(self):
+                raise RuntimeError("element_type probe failed")
+
+            def __getitem__(self, idx):
+                return f"raising{idx}"
+
+        shape_items = coop.ThreadData.from_register_tensor(RegisterTensor())
+        assert shape_items.items_per_thread == 3
+        assert shape_items.dtype == "i32"
+        assert shape_items.values("register") == ("r0", "r1", "r2")
+
+        layout_items = coop.ThreadData.from_register_tensor(LayoutTensor())
+        assert layout_items.items_per_thread == 2
+        assert layout_items.dtype == "layout-i32"
+        assert layout_items.values("layout") == ("layout0", "layout1")
+
+        explicit_items = coop.ThreadData.from_register_tensor(
+            ExplicitRegisterTensor(),
+            items_per_thread=StaticInt(1),
+            dtype="override-f32",
+        )
+        assert explicit_items.items_per_thread == 1
+        assert explicit_items.dtype == "override-f32"
+        assert explicit_items.values("explicit") == ("explicit0",)
+
+        cast_items = coop.ThreadData.from_register_tensor(
+            CastRegisterTensor(),
+            dtype=FakeDslUint32,
+        )
+        assert cast_items.items_per_thread == 2
+        assert cast_items.dtype is FakeDslUint32
+        assert [
+            value.value for value in cast_items.values("cast-register")
+        ] == [70, 71]
+
+        raising_element_items = coop.ThreadData.from_register_tensor(
+            RaisingElementTypeTensor()
+        )
+        assert raising_element_items.items_per_thread == 2
+        assert raising_element_items.dtype is None
+        assert raising_element_items.values("raising-element") == (
+            "raising0",
+            "raising1",
+        )
+        """
+    )
+
+    result = run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_thread_data_from_payload_adapts_backend_payloads():
+    script = textwrap.dedent(
+        """
+        import sys
+        import types
+
+        class AddressSpace:
+            rmem = object()
+            gmem = object()
+
+        for module_name in (
+            "cutlass",
+            "cutlass._mlir",
+            "cutlass._mlir.dialects",
+        ):
+            module = types.ModuleType(module_name)
+            module.__path__ = []
+            sys.modules[module_name] = module
+        cute_module = types.ModuleType("cutlass._mlir.dialects.cute")
+        cute_module.AddressSpace = AddressSpace
+        sys.modules["cutlass._mlir.dialects.cute"] = cute_module
+
+        import cuda.coop.cutlass as coop
+
+        class StaticInt:
+            def __init__(self, value):
+                self.value = value
+
+            def __index__(self):
+                return self.value
+
+        class RegisterTensor:
+            memspace = AddressSpace.rmem
+            shape = (2,)
+            element_type = "i32"
+
+            def __getitem__(self, idx):
+                return f"r{idx}"
+
+        class Vector:
+            shape = (3,)
+            dtype = "i64"
+
+            def __getitem__(self, idx):
+                return f"item{idx}"
+
+        class CutlassArray:
+            shape = (2,)
+            dtype = "i32"
+
+            def __getitem__(self, idx):
+                return f"a{idx}"
+
+            def load(self, *args, **kwargs):
+                return None
+
+            def store(self, *args, **kwargs):
+                return None
+
+        CutlassArray.__module__ = "cutlass.base_dsl.array"
+        CutlassArray.__qualname__ = "Array"
+        sys.modules["cutlass"].Array = CutlassArray
+
+        class RaisingDtypeVector:
+            shape = (2,)
+
+            @property
+            def dtype(self):
+                raise RuntimeError("dtype probe failed")
+
+            @property
+            def _dtype(self):
+                raise RuntimeError("_dtype probe failed")
+
+            @property
+            def element_type(self):
+                raise RuntimeError("element_type probe failed")
+
+            def __getitem__(self, idx):
+                return f"vd{idx}"
+
+        class FakeDslUint32:
+            __module__ = "cutlass.base_dsl.typing"
+
+            def __init__(self, value):
+                self.value = value
+
+        from_register = coop.ThreadData.from_payload(RegisterTensor())
+        assert from_register.items_per_thread == 2
+        assert from_register.dtype == "i32"
+        assert from_register.values("register") == ("r0", "r1")
+
+        from_vector = coop.ThreadData.from_payload(Vector())
+        assert from_vector.items_per_thread == 3
+        assert from_vector.dtype == "i64"
+        assert from_vector.values("vector") == ("item0", "item1", "item2")
+
+        from_raising_dtype_vector = coop.ThreadData.from_payload(RaisingDtypeVector())
+        assert from_raising_dtype_vector.items_per_thread == 2
+        assert from_raising_dtype_vector.dtype is None
+        assert from_raising_dtype_vector.values("raising-dtype-vector") == (
+            "vd0",
+            "vd1",
+        )
+
+        existing = coop.ThreadData.from_values(1, 2)
+        assert coop.ThreadData.from_payload(existing) is existing
+        typed_existing = coop.ThreadData.from_payload(existing, dtype="i32")
+        assert typed_existing is not existing
+        assert typed_existing.dtype == "i32"
+        assert typed_existing.values("existing") == (1, 2)
+        dsl_typed_existing = coop.ThreadData.from_payload(
+            existing,
+            dtype=FakeDslUint32,
+        )
+        assert dsl_typed_existing.dtype is FakeDslUint32
+        assert [
+            value.value for value in dsl_typed_existing.values("dsl-existing")
+        ] == [1, 2]
+        assert coop.ThreadData.from_payload(
+            existing,
+            items_per_thread=StaticInt(2),
+        ) is existing
+
+        typed_payload = coop.ThreadData.from_values(3, 4, dtype="i16")
+
+        def assert_raises(exc_type, message, fn):
+            try:
+                fn()
+            except exc_type as exc:
+                assert message in str(exc), str(exc)
+            else:
+                raise AssertionError(f"{exc_type.__name__} was not raised")
+
+        assert_raises(
+            TypeError,
+            "items_per_thread must be an integer",
+            lambda: coop.ThreadData.from_payload(existing, items_per_thread=True),
+        )
+        assert_raises(
+            ValueError,
+            "items_per_thread must be a positive integer",
+            lambda: coop.ThreadData.from_payload(existing, items_per_thread=0),
+        )
+        assert_raises(
+            ValueError,
+            "items_per_thread does not match payload.items_per_thread",
+            lambda: coop.ThreadData.from_payload(existing, items_per_thread=1),
+        )
+        assert_raises(
+            TypeError,
+            "dtype does not match payload",
+            lambda: coop.ThreadData.from_payload(typed_payload, dtype="i32"),
+        )
+        assert_raises(
+            TypeError,
+            "a group-first load for cutlass.Array values",
+            lambda: coop.ThreadData.from_payload(CutlassArray()),
+        )
+        """
+    )
+
+    result = run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_thread_data_load_uses_explicit_producer_capability():
+    script = textwrap.dedent(
+        """
+        import cuda.coop.cutlass as coop
+
+        class RegisterVector:
+            shape = (3,)
+            dtype = "f32"
+
+            def __getitem__(self, idx):
+                return f"r{idx}"
+
+        class ProducerSelectedLoad:
+            # A producer wrapper may describe a memory-resident accumulator.
+            # The explicit hook, rather than its address space, authorizes and
+            # implements the tracing-time load.
+            memspace = object()
+
+            def __init__(self):
+                self.calls = 0
+
+            def __cuda_coop_thread_data_load__(self):
+                self.calls += 1
+                return RegisterVector()
+
+        class ExistingPayload:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __cuda_coop_thread_data_load__(self):
+                return self.payload
+
+        source = ProducerSelectedLoad()
+        loaded = coop.ThreadData.load(
+            source,
+            items_per_thread=3,
+            dtype="f32",
+        )
+        assert source.calls == 1
+        assert loaded.items_per_thread == 3
+        assert loaded.dtype == "f32"
+        assert loaded.values("producer-load") == ("r0", "r1", "r2")
+
+        existing = coop.ThreadData.from_values(10, 11, dtype="i32")
+        assert coop.ThreadData.load(ExistingPayload(existing)) is existing
+        assert hasattr(coop.ThreadDataLoadSource, "__cuda_coop_thread_data_load__")
+        assert hasattr(coop.ThreadDataSource, "__cuda_coop_thread_data_load__")
+        assert hasattr(coop.ThreadDataTensorMetadata, "shape")
+        assert hasattr(coop.ThreadDataTensorMetadata, "dtype")
+        """
+    )
+
+    result = run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_thread_data_load_rejects_implicit_or_unsafe_sources():
+    script = textwrap.dedent(
+        """
+        import cuda.coop.cutlass as coop
+
+        class BareTmemTensor:
+            memspace = object()
+            shape = (2,)
+
+            def __getitem__(self, idx):
+                return idx
+
+        class DynamicHook:
+            def __getattr__(self, name):
+                if name == "__cuda_coop_thread_data_load__":
+                    return lambda: coop.ThreadData.from_values(1)
+                raise AttributeError(name)
+
+        class NonCallableHook:
+            __cuda_coop_thread_data_load__ = None
+
+        class RaisingHookProperty:
+            @property
+            def __cuda_coop_thread_data_load__(self):
+                raise RuntimeError("hook access failed")
+
+        class FailingHook:
+            def __cuda_coop_thread_data_load__(self):
+                raise RuntimeError("producer load failed")
+
+        class MissingShapeVector:
+            def __getitem__(self, idx):
+                return idx
+
+        class DynamicExtentHook:
+            def __cuda_coop_thread_data_load__(self):
+                return MissingShapeVector()
+
+        class ReturnedMemoryHook:
+            def __cuda_coop_thread_data_load__(self):
+                return BareTmemTensor()
+
+        class StaticVector:
+            shape = (3,)
+            dtype = "f32"
+
+            def __getitem__(self, idx):
+                return idx
+
+        class CountingHook:
+            def __init__(self):
+                self.calls = 0
+
+            def __cuda_coop_thread_data_load__(self):
+                self.calls += 1
+                return StaticVector()
+
+        class TypedThreadDataHook:
+            def __cuda_coop_thread_data_load__(self):
+                return coop.ThreadData.from_values(1, 2, dtype="i32")
+
+        def assert_raises(exc_type, message, fn):
+            try:
+                fn()
+            except exc_type as exc:
+                assert message in str(exc), str(exc)
+            else:
+                raise AssertionError(f"{exc_type.__name__} was not raised")
+
+        bare_tmem = BareTmemTensor()
+        assert_raises(
+            TypeError,
+            "bare memory-backed tensors including TMEM",
+            lambda: coop.ThreadData.load(bare_tmem),
+        )
+        # The existing generic adapter must remain strict as well.
+        assert_raises(
+            TypeError,
+            "requires a per-thread register payload",
+            lambda: coop.ThreadData.from_payload(bare_tmem),
+        )
+        assert_raises(
+            TypeError,
+            "requires source to define",
+            lambda: coop.ThreadData.load(DynamicHook()),
+        )
+        assert_raises(
+            TypeError,
+            "hook to be callable",
+            lambda: coop.ThreadData.load(NonCallableHook()),
+        )
+        assert_raises(
+            TypeError,
+            "could not access",
+            lambda: coop.ThreadData.load(RaisingHookProperty()),
+        )
+        assert_raises(
+            RuntimeError,
+            "producer load failed",
+            lambda: coop.ThreadData.load(FailingHook()),
+        )
+        assert_raises(
+            ValueError,
+            "statically sized per-thread register payload",
+            lambda: coop.ThreadData.load(DynamicExtentHook()),
+        )
+        assert_raises(
+            TypeError,
+            "statically sized per-thread register payload",
+            lambda: coop.ThreadData.load(ReturnedMemoryHook()),
+        )
+        unconsumed = CountingHook()
+        assert_raises(
+            ValueError,
+            "items_per_thread must be a positive integer",
+            lambda: coop.ThreadData.load(unconsumed, items_per_thread=0),
+        )
+        assert unconsumed.calls == 0
+        assert_raises(
+            ValueError,
+            "CountingHook returned StaticVector",
+            lambda: coop.ThreadData.load(
+                CountingHook(),
+                items_per_thread=2,
+            ),
+        )
+        assert_raises(
+            TypeError,
+            "TypedThreadDataHook returned ThreadData",
+            lambda: coop.ThreadData.load(
+                TypedThreadDataHook(),
+                dtype="f32",
+            ),
+        )
+        """
+    )
+
+    result = run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_thread_data_from_register_tensor_reports_bad_cute_payloads():
+    script = textwrap.dedent(
+        """
+        import sys
+        import types
+
+        class AddressSpace:
+            rmem = object()
+            gmem = object()
+
+        for module_name in (
+            "cutlass",
+            "cutlass._mlir",
+            "cutlass._mlir.dialects",
+        ):
+            module = types.ModuleType(module_name)
+            module.__path__ = []
+            sys.modules[module_name] = module
+        cute_module = types.ModuleType("cutlass._mlir.dialects.cute")
+        cute_module.AddressSpace = AddressSpace
+        sys.modules["cutlass._mlir.dialects.cute"] = cute_module
+
+        import cuda.coop.cutlass as coop
+
+        class GlobalTensor:
+            memspace = AddressSpace.gmem
+            shape = (1,)
+
+            def __getitem__(self, idx):
+                return idx
+
+        class MissingShapeTensor:
+            memspace = AddressSpace.rmem
+
+            def __getitem__(self, idx):
+                return idx
+
+        class ShapedTensor:
+            memspace = AddressSpace.rmem
+            shape = (2,)
+
+            def __getitem__(self, idx):
+                return idx
+
+        class RaisingShapeTensor:
+            memspace = AddressSpace.rmem
+
+            @property
+            def shape(self):
+                raise RuntimeError("shape should not be probed")
+
+            def __getitem__(self, idx):
+                return idx
+
+        class RaisingMetadataTensor:
+            memspace = AddressSpace.rmem
+
+            @property
+            def shape(self):
+                raise RuntimeError("shape probe failed")
+
+            @property
+            def layout(self):
+                raise RuntimeError("layout probe failed")
+
+            @property
+            def type(self):
+                raise RuntimeError("type probe failed")
+
+            def __getitem__(self, idx):
+                return idx
+
+        class RaisingMemorySpaceTensor:
+            @property
+            def memspace(self):
+                raise RuntimeError("memspace probe failed")
+
+            def __getitem__(self, idx):
+                return idx
+
+        def assert_raises(exc_type, message, fn):
+            try:
+                fn()
+            except exc_type as exc:
+                assert message in str(exc), str(exc)
+            else:
+                raise AssertionError(f"{exc_type.__name__} was not raised")
+
+        assert_raises(
+            TypeError,
+            "requires a register-memory",
+            lambda: coop.ThreadData.from_register_tensor(GlobalTensor()),
+        )
+        assert_raises(
+            TypeError,
+            "requires a register-memory",
+            lambda: coop.ThreadData.from_register_tensor(RaisingMemorySpaceTensor()),
+        )
+        assert_raises(
+            ValueError,
+            "could not infer items_per_thread",
+            lambda: coop.ThreadData.from_register_tensor(MissingShapeTensor()),
+        )
+        assert_raises(
+            ValueError,
+            "could not infer items_per_thread",
+            lambda: coop.ThreadData.from_register_tensor(RaisingMetadataTensor()),
+        )
+        assert_raises(
+            TypeError,
+            "items_per_thread must be an integer",
+            lambda: coop.ThreadData.from_register_tensor(
+                MissingShapeTensor(),
+                items_per_thread=True,
+            ),
+        )
+        assert_raises(
+            TypeError,
+            "items_per_thread must be an integer",
+            lambda: coop.ThreadData.from_register_tensor(
+                RaisingShapeTensor(),
+                items_per_thread=True,
+            ),
+        )
+        assert_raises(
+            ValueError,
+            "items_per_thread must be a positive integer",
+            lambda: coop.ThreadData.from_register_tensor(
+                MissingShapeTensor(),
+                items_per_thread=0,
+            ),
+        )
+        assert_raises(
+            ValueError,
+            "items_per_thread does not match payload item count",
+            lambda: coop.ThreadData.from_register_tensor(
+                ShapedTensor(),
+                items_per_thread=1,
+            ),
+        )
+        """
+    )
+
+    result = run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr

--- a/python/cuda_coop/tests/backends/cutlass/unit/test_thread_data_container.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/test_thread_data_container.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import textwrap
+
+from ..support._subprocess import run_python_with_source as _run_python_with_source
+
+
+def test_thread_data_value_container():
+    script = textwrap.dedent(
+        """
+        import cuda.coop.cutlass as coop
+
+        class U64:
+            width = 64
+
+        data = coop.ThreadData.from_values(10, 20, dtype=U64)
+
+        assert len(data) == 2
+        assert data.items_per_thread == 2
+        assert data.dtype is U64
+        assert data[0] == 10
+        assert data[1] == 20
+        assert data.values("test") == (10, 20)
+
+        data[1] = 30
+        assert tuple(data) == (10, 30)
+
+        try:
+            tuple(coop.ThreadData(1))
+        except ValueError as exc:
+            assert "ThreadData iteration requires" in str(exc)
+            assert "thread_data_iter" not in str(exc)
+        else:
+            raise AssertionError("uninitialized ThreadData iteration should fail")
+
+        try:
+            coop.ThreadData(0)
+        except ValueError as exc:
+            assert "positive integer" in str(exc)
+        else:
+            raise AssertionError("zero-item ThreadData should be rejected")
+        """
+    )
+
+    result = _run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr

--- a/python/cuda_coop/tests/backends/cutlass/unit/test_thread_groups.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/test_thread_groups.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import textwrap
+
+from ..support._subprocess import run_python_with_source as _run_python_with_source
+
+
+def test_thread_group_descriptor_validation():
+    script = textwrap.dedent(
+        """
+        import cuda.coop.cutlass as coop
+
+        hierarchy = coop.ThreadHierarchy()
+        assert hierarchy.block_dim is None
+        assert hierarchy.grid_dim is None
+        assert hierarchy.cluster_dim is None
+        assert hierarchy.thread_count is None
+        assert hierarchy.symbol_suffix == "current"
+        assert hierarchy.implicit
+        assert coop.Hierarchy is coop.ThreadHierarchy
+
+        block = coop.this_block()
+        assert isinstance(block, coop.ThreadGroup)
+        assert block.kind == "block"
+        assert block.is_current
+        assert block.block_dim is None
+        assert block.static_thread_count is None
+        try:
+            block.thread_count
+        except ValueError as exc:
+            assert "runtime hierarchy" in str(exc)
+        else:
+            raise AssertionError("current group should not have static thread_count")
+
+        warp = coop.this_warp()
+        assert isinstance(warp, coop.ThreadGroup)
+        assert warp.kind == "warp"
+        assert warp.is_current
+        assert warp.block_dim is None
+        assert warp.static_size == 32
+        assert warp.thread_count == 32
+
+        from cuda.coop._core import ThreadGroup as CoreThreadGroup
+        from cuda.coop._core import ThreadHierarchy as CoreThreadHierarchy
+
+        assert issubclass(coop.ThreadGroup, CoreThreadGroup)
+        assert coop.ThreadHierarchy is CoreThreadHierarchy
+
+        thread = coop.this_thread()
+        assert thread.kind == "thread"
+        assert thread.is_current
+        cluster = coop.this_cluster()
+        assert cluster.kind == "cluster"
+        grid = coop.this_grid()
+        assert grid.kind == "grid"
+
+        mapped_warps = block.group_by(1)
+        assert mapped_warps.kind == "warps_within_block"
+        assert mapped_warps.static_size == 32
+        mapped_lanes = warp.group_by(8)
+        assert mapped_lanes.kind == "threads_within_warp"
+        assert mapped_lanes.static_size == 8
+
+        assert not hasattr(coop.ThreadGroup, "block")
+        assert not hasattr(coop.ThreadGroup, "warp")
+
+        rejected = (
+            lambda: coop.ThreadHierarchy(block_dim=32),
+            lambda: coop.this_thread(hierarchy),
+            lambda: coop.this_warp(16),
+            lambda: coop.this_warp(block_dim=64),
+            lambda: coop.this_block(64),
+            lambda: coop.this_cluster(block_dim=64),
+            lambda: coop.this_grid(hierarchy=hierarchy),
+            lambda: coop.ThreadGroup(kind="block", block_dim=64),
+        )
+        for call in rejected:
+            try:
+                call()
+            except TypeError:
+                pass
+            else:
+                raise AssertionError("explicit launch metadata was accepted")
+        """
+    )
+
+    result = _run_python_with_source(script)
+
+    assert result.returncode == 0, result.stderr

--- a/python/cuda_coop/tests/backends/cutlass/unit/test_value_metadata.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/test_value_metadata.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import copy
+
+import pytest
+
+from cuda.coop._core import ResultVisibility, ThreadHierarchy, this_block, this_warp
+from cuda.coop.cutlass import _thread_data
+from cuda.coop.cutlass._thread_data import ThreadData
+from cuda.coop.cutlass._value_metadata import (
+    DefinedThreadDomain,
+    ResolvedGroupIdentity,
+    attach_thread_data_metadata,
+    merge_value_metadata,
+    metadata_for_group,
+    thread_data_metadata,
+    validate_operand_domains,
+)
+
+
+def _resolved_block(width=64, source="test"):
+    return this_block().with_hierarchy(
+        ThreadHierarchy._resolved(block_dim=width),
+        source=source,
+    )
+
+
+def test_resolved_group_identity_ignores_source_but_preserves_shape():
+    first = ResolvedGroupIdentity(_resolved_block(source="reqntid"))
+    second = ResolvedGroupIdentity(_resolved_block(source="launch_config"))
+    dimensional = ResolvedGroupIdentity(
+        this_block().with_hierarchy(ThreadHierarchy._resolved(block_dim=(8, 4, 2)))
+    )
+
+    assert first == second
+    assert hash(first) == hash(second)
+    assert first != dimensional
+
+
+def test_explicit_narrower_group_is_covered_by_full_domain_metadata():
+    block = _resolved_block()
+    warp = this_warp().with_hierarchy(block.hierarchy)
+    loaded = metadata_for_group(block, visibility=ResultVisibility.PER_MEMBER)
+
+    assert loaded.defined_domain == DefinedThreadDomain.all_callers()
+    assert loaded.defined_domain.covers(ResolvedGroupIdentity(warp))
+
+
+def test_implicit_current_per_member_metadata_needs_no_static_identity():
+    current = this_block()
+    metadata = metadata_for_group(
+        current,
+        visibility=ResultVisibility.PER_MEMBER,
+    )
+
+    assert metadata.defined_domain == DefinedThreadDomain.all_callers()
+    with pytest.raises(ValueError, match="static resolved group"):
+        metadata_for_group(current, visibility=ResultVisibility.GROUP_ROOT)
+
+
+def test_non_exhaustive_mapping_domain_rejects_wider_group():
+    block = _resolved_block(320)
+    mapped = block.group_by(3, exhaustive=False)
+    metadata = metadata_for_group(
+        mapped,
+        visibility=ResultVisibility.ALL_MEMBERS,
+    )
+
+    assert metadata.defined_domain.covers(ResolvedGroupIdentity(mapped))
+    assert not metadata.defined_domain.covers(ResolvedGroupIdentity(block))
+
+
+def test_root_only_domain_rejects_every_cooperative_target():
+    block = _resolved_block()
+    metadata = metadata_for_group(block, visibility=ResultVisibility.GROUP_ROOT)
+
+    assert metadata.defined_domain.contains_roots_only
+    assert not metadata.defined_domain.covers(ResolvedGroupIdentity(block))
+
+
+def test_thread_data_copy_and_composition_preserve_or_merge_metadata():
+    block = _resolved_block()
+    warp = this_warp().with_hierarchy(block.hierarchy)
+    block_metadata = metadata_for_group(
+        block,
+        visibility=ResultVisibility.PER_MEMBER,
+    )
+    warp_metadata = metadata_for_group(
+        warp,
+        visibility=ResultVisibility.ALL_MEMBERS,
+    )
+    first = attach_thread_data_metadata(
+        ThreadData.from_values(1, 2),
+        block_metadata,
+    )
+    second = attach_thread_data_metadata(
+        ThreadData.from_values(3),
+        warp_metadata,
+    )
+
+    assert thread_data_metadata(copy.copy(first)) == block_metadata
+    assert thread_data_metadata(copy.deepcopy(first)) == block_metadata
+    merged = merge_value_metadata(
+        (thread_data_metadata(first), thread_data_metadata(second))
+    )
+    assert merged is not None
+    assert merged.defined_domain == DefinedThreadDomain.all_callers()
+    assert merged.visibility is ResultVisibility.PER_MEMBER
+
+
+def test_new_uninitialized_thread_data_drops_group_metadata():
+    value = attach_thread_data_metadata(
+        ThreadData.from_values(1, 2),
+        metadata_for_group(
+            _resolved_block(),
+            visibility=ResultVisibility.PER_MEMBER,
+        ),
+    )
+
+    assert thread_data_metadata(value._new_uninitialized()) is None
+
+
+def test_thread_data_replacement_recomputes_metadata_from_remaining_items():
+    root_metadata = metadata_for_group(
+        _resolved_block(),
+        visibility=ResultVisibility.GROUP_ROOT,
+    )
+    value = attach_thread_data_metadata(
+        ThreadData.from_values(1, 2),
+        root_metadata,
+    )
+
+    value[0] = 3
+    assert thread_data_metadata(value) == root_metadata
+
+    value[1] = 4
+    assert thread_data_metadata(value) is None
+
+
+def test_thread_data_replacement_adds_and_removes_item_metadata():
+    root_metadata = metadata_for_group(
+        _resolved_block(),
+        visibility=ResultVisibility.GROUP_ROOT,
+    )
+
+    class TaggedValue:
+        pass
+
+    tagged = attach_thread_data_metadata(TaggedValue(), root_metadata)
+    value = ThreadData.from_values(1, 2)
+
+    value[0] = tagged
+    assert thread_data_metadata(value) == root_metadata
+
+    copied = copy.copy(value)
+    copied[0] = 3
+    assert thread_data_metadata(copied) is None
+    assert thread_data_metadata(value) == root_metadata
+
+    value[0] = 3
+    assert thread_data_metadata(value) is None
+
+
+def test_thread_data_replacement_is_atomic_when_metadata_lookup_fails(monkeypatch):
+    value = ThreadData.from_values(1)
+
+    def fail_metadata_lookup(_value):
+        raise RuntimeError("metadata lookup failed")
+
+    monkeypatch.setattr(_thread_data, "_value_group_metadata", fail_metadata_lookup)
+
+    with pytest.raises(RuntimeError, match="metadata lookup failed"):
+        value[0] = 2
+
+    assert value[0] == 1
+    assert thread_data_metadata(value) is None
+
+
+def test_domain_validation_rejects_root_only_and_wider_targets():
+    block = _resolved_block(320)
+    mapped = block.group_by(3, exhaustive=False)
+    mapped_value = attach_thread_data_metadata(
+        ThreadData.from_values(1),
+        metadata_for_group(mapped, visibility=ResultVisibility.ALL_MEMBERS),
+    )
+    root_value = attach_thread_data_metadata(
+        ThreadData.from_values(2),
+        metadata_for_group(block, visibility=ResultVisibility.GROUP_ROOT),
+    )
+
+    validate_operand_domains(
+        mapped,
+        {"value": mapped_value},
+        scope="cuda.coop.cutlass",
+        primitive_name="reduce",
+    )
+    with pytest.raises(ValueError, match="not defined for every member"):
+        validate_operand_domains(
+            block,
+            {"value": mapped_value},
+            scope="cuda.coop.cutlass",
+            primitive_name="reduce",
+        )
+    with pytest.raises(ValueError, match="defined only at group roots"):
+        validate_operand_domains(
+            block,
+            {"value": root_value},
+            scope="cuda.coop.cutlass",
+            primitive_name="store",
+        )

--- a/python/cuda_coop/tests/contracts/core/test_core_types.py
+++ b/python/cuda_coop/tests/contracts/core/test_core_types.py
@@ -3,13 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # ruff: noqa: E402
 
+import enum
 import os
 import subprocess
 import sys
 import textwrap
 from collections import defaultdict
 from dataclasses import dataclass
-from functools import partial
+from enum import Enum
+from functools import partial, wraps
+from types import ModuleType
 
 import pytest
 
@@ -45,6 +48,74 @@ from cuda.coop._core import (
     Value,
     semantic_token,
 )
+from cuda.coop._core._symbols import _TokenState, _type_reference_token
+
+_TOKEN_GLOBAL_OFFSET = 1
+offset = 100
+
+
+class _TokenGlobalHolder:
+    offset = 7
+
+
+_TOKEN_GLOBAL_HOLDER = _TokenGlobalHolder()
+_TOKEN_GLOBAL_MODULE = ModuleType("_cuda_coop_token_settings")
+_TOKEN_GLOBAL_MODULE.offset = 11
+
+
+class _TokenGlobalPolicy:
+    def __init__(self, value):
+        self.value = value
+
+    def result(self):
+        return self.value + 1
+
+
+class _TokenGlobalStaticPolicy:
+    @staticmethod
+    def apply(value):
+        return value + 1
+
+
+def _token_global_value_op(value):
+    return value + _TOKEN_GLOBAL_OFFSET
+
+
+def _token_attribute_op(value):
+    return value + _TOKEN_GLOBAL_HOLDER.offset
+
+
+def _token_module_attribute_op(value):
+    return value + _TOKEN_GLOBAL_MODULE.offset
+
+
+def _token_global_policy_op(value):
+    return _TokenGlobalPolicy(value).result()
+
+
+def _token_global_static_policy_op(value):
+    return _TokenGlobalStaticPolicy.apply(value)
+
+
+def _token_helper_add(value):
+    return value + 1
+
+
+def _token_helper_subtract(value):
+    return value - 1
+
+
+_TOKEN_GLOBAL_HELPER = _token_helper_add
+
+
+def _token_global_helper_op(value):
+    return _TOKEN_GLOBAL_HELPER(value)
+
+
+def _token_recursive_op(value):
+    if value == 0:
+        return 0
+    return _token_recursive_op(value - 1)
 
 
 @pytest.mark.parametrize("pointer_arg_index", [-1, True, "zero"])
@@ -338,6 +409,39 @@ def test_semantic_token_tracks_private_slotted_callable_state():
     assert semantic_token(Offset(1)) != semantic_token(Offset(2))
 
 
+def test_semantic_token_tracks_class_dependencies_in_callable_state(monkeypatch):
+    class Helper:
+        @staticmethod
+        def apply(value):
+            return value + 1
+
+    class StatefulPolicy:
+        def __init__(self):
+            self.helper = Helper
+
+        def __call__(self, value):
+            return self.helper.apply(value)
+
+    class SlottedStatefulPolicy:
+        __slots__ = ("helper",)
+
+        def __init__(self):
+            self.helper = Helper
+
+        def __call__(self, value):
+            return self.helper.apply(value)
+
+    operations = (StatefulPolicy(), SlottedStatefulPolicy())
+    originals = tuple(semantic_token(operation) for operation in operations)
+    monkeypatch.setattr(
+        Helper,
+        "apply",
+        staticmethod(lambda value: value - 1),
+    )
+
+    assert originals != tuple(semantic_token(operation) for operation in operations)
+
+
 def test_semantic_token_tracks_only_referenced_globals(monkeypatch):
     original = semantic_token(_global_dependent_operator)
 
@@ -368,6 +472,467 @@ def test_semantic_token_handles_recursive_callables():
 
     assert semantic_token(recurse) == semantic_token(recurse)
     assert semantic_token(even) == semantic_token(even)
+
+
+def test_semantic_token_keeps_memoized_values_alive_during_traversal():
+    @dataclass
+    class DynamicFields:
+        first: object = None
+        second: object = None
+
+        def __getattribute__(self, name):
+            if name == "first":
+                return [1]
+            if name == "second":
+                return [2]
+            return object.__getattribute__(self, name)
+
+    token = semantic_token(DynamicFields())
+    field_tokens = dict(token[2])
+
+    assert field_tokens["first"] != field_tokens["second"]
+
+
+def test_semantic_token_tracks_class_dependencies_in_nested_defaults(monkeypatch):
+    class DefaultPolicy:
+        @staticmethod
+        def apply(value):
+            return value + 1
+
+    default_settings = {"policies": (DefaultPolicy,)}
+
+    def default_op(value, settings=default_settings):
+        return settings["policies"][0].apply(value)
+
+    original = semantic_token(default_op)
+
+    monkeypatch.setattr(
+        DefaultPolicy,
+        "apply",
+        staticmethod(lambda value: value - 1),
+    )
+
+    assert original != semantic_token(default_op)
+
+
+def test_semantic_token_tracks_class_dependencies_in_closures(monkeypatch):
+    class ClosurePolicy:
+        @staticmethod
+        def apply(value):
+            return value + 1
+
+    policy = ClosurePolicy
+
+    def closure_op(value):
+        return policy.apply(value)
+
+    original = semantic_token(closure_op)
+
+    monkeypatch.setattr(
+        ClosurePolicy,
+        "apply",
+        staticmethod(lambda value: value - 1),
+    )
+
+    assert original != semantic_token(closure_op)
+
+
+def test_semantic_token_tracks_class_valued_class_members(monkeypatch):
+    class Helper:
+        @staticmethod
+        def apply(value):
+            return value + 1
+
+    class Policy:
+        helper = Helper
+
+    def member_op(value, policy=Policy):
+        return policy.helper.apply(value)
+
+    original = semantic_token(member_op)
+
+    monkeypatch.setattr(
+        Helper,
+        "apply",
+        staticmethod(lambda value: value - 1),
+    )
+
+    assert original != semantic_token(member_op)
+
+
+def test_semantic_token_shallows_standard_library_type_dependencies():
+    assert _type_reference_token(Enum, _TokenState()) == (
+        "type",
+        "enum",
+        "Enum",
+    )
+    assert _type_reference_token(type(lambda: None), _TokenState()) == (
+        "type",
+        "builtins",
+        "function",
+    )
+
+
+def test_semantic_token_expands_heap_types_with_stdlib_metadata():
+    class SpoofedType:
+        offset = 1
+
+    SpoofedType.__module__ = "builtins"
+    original = _type_reference_token(SpoofedType, _TokenState())
+    SpoofedType.offset = 2
+
+    assert original != _type_reference_token(SpoofedType, _TokenState())
+
+
+def test_semantic_token_shallows_verified_standard_library_functions():
+    assert semantic_token(enum.unique) == (
+        "callable-reference",
+        "enum",
+        "unique",
+    )
+
+
+def test_semantic_token_expands_user_wrappers_with_stdlib_metadata():
+    @wraps(enum.unique)
+    def increment(value):
+        return value + 1
+
+    @wraps(enum.unique)
+    def decrement(value):
+        return value - 1
+
+    increment_token = semantic_token(increment)
+    decrement_token = semantic_token(decrement)
+
+    assert increment_token[0] == "callable"
+    assert decrement_token[0] == "callable"
+    assert increment_token != decrement_token
+
+
+def test_semantic_token_expands_user_modules_with_stdlib_names(
+    monkeypatch,
+    tmp_path,
+):
+    module_name = "types.cuda_coop_token_test"
+    module = ModuleType(module_name)
+    source_path = tmp_path / "types" / "cuda_coop_token_test.py"
+    module.__file__ = str(source_path)
+    exec(
+        compile(
+            textwrap.dedent(
+                """
+                class Policy:
+                    offset = 1
+
+                def apply(value):
+                    return value + Policy.offset
+                """
+            ),
+            str(source_path),
+            "exec",
+        ),
+        module.__dict__,
+    )
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    original = semantic_token(module.apply)
+    module.Policy.offset = 2
+
+    assert original != semantic_token(module.apply)
+
+
+def test_semantic_token_tracks_function_metadata():
+    def add(value):
+        return value + 1
+
+    def subtract(value):
+        return value - 1
+
+    def wrapper(value):
+        return value
+
+    wrapper.__wrapped__ = add
+    original = semantic_token(wrapper)
+    wrapper.__wrapped__ = subtract
+    changed_wrapped = semantic_token(wrapper)
+    assert original != changed_wrapped
+
+    wrapper.policy = {"offset": 1}
+    with_policy = semantic_token(wrapper)
+    wrapper.policy["offset"] = 2
+
+    assert changed_wrapped != with_policy
+    assert with_policy != semantic_token(wrapper)
+
+
+def test_semantic_token_preserves_malformed_callable_metadata(monkeypatch):
+    class CallableWithMalformedMetadata:
+        __code__ = "code-a"
+        __globals__ = "globals-a"
+        __closure__ = "closure-a"
+
+        def __call__(self, value):
+            return value
+
+    op = CallableWithMalformedMetadata()
+    original = semantic_token(op)
+
+    monkeypatch.setattr(CallableWithMalformedMetadata, "__code__", "code-b")
+    changed_code = semantic_token(op)
+    assert original != changed_code
+
+    monkeypatch.setattr(
+        CallableWithMalformedMetadata,
+        "__globals__",
+        "globals-b",
+    )
+    changed_globals = semantic_token(op)
+    assert changed_code != changed_globals
+
+    monkeypatch.setattr(
+        CallableWithMalformedMetadata,
+        "__closure__",
+        "closure-b",
+    )
+
+    assert changed_globals != semantic_token(op)
+
+
+def test_semantic_token_validates_metadata_with_exposed_code(monkeypatch):
+    class CallableWithExposedCode:
+        __code__ = (lambda: None).__code__
+        __globals__ = "globals-a"
+        __closure__ = "closure-a"
+
+        def __call__(self, value):
+            return value
+
+    op = CallableWithExposedCode()
+    original = semantic_token(op)
+
+    monkeypatch.setattr(CallableWithExposedCode, "__globals__", "globals-b")
+    changed_globals = semantic_token(op)
+    assert original != changed_globals
+
+    monkeypatch.setattr(CallableWithExposedCode, "__closure__", "closure-b")
+
+    assert changed_globals != semantic_token(op)
+
+
+def test_semantic_token_handles_non_string_callable_module():
+    class CallableWithoutStringModule:
+        __module__ = []
+
+        def __call__(self, value):
+            return value
+
+    op = CallableWithoutStringModule()
+    token = semantic_token(op)
+
+    assert token == semantic_token(op)
+    hash(token)
+
+
+def test_semantic_token_expands_types_without_string_modules(monkeypatch):
+    class Policy:
+        @staticmethod
+        def apply(value):
+            return value + 1
+
+    Policy.__module__ = None
+
+    def apply(value, policy=Policy):
+        return policy.apply(value)
+
+    original = semantic_token(apply)
+    monkeypatch.setattr(Policy, "apply", staticmethod(lambda value: value - 1))
+
+    assert original != semantic_token(apply)
+
+
+def test_semantic_token_tracks_referenced_closure_attributes(monkeypatch):
+    class ClosureSettings:
+        offset = 1
+
+    settings = ClosureSettings()
+
+    def closure_op(value):
+        return value + settings.offset
+
+    original = semantic_token(closure_op)
+
+    monkeypatch.setattr(ClosureSettings, "offset", 2)
+
+    assert original != semantic_token(closure_op)
+
+
+def test_semantic_token_tolerates_mismatched_closure_metadata(monkeypatch):
+    class ClosurePolicy:
+        @staticmethod
+        def apply(value):
+            return value + 1
+
+    def capture(value):
+        return lambda: value
+
+    class CallableWithMismatchedClosure:
+        __code__ = (lambda: None).__code__
+        __closure__ = capture(ClosurePolicy).__closure__
+        __globals__ = {}
+
+        def __call__(self, value):
+            return ClosurePolicy.apply(value)
+
+    op = CallableWithMismatchedClosure()
+    original = semantic_token(op)
+
+    monkeypatch.setattr(
+        ClosurePolicy,
+        "apply",
+        staticmethod(lambda value: value - 1),
+    )
+
+    changed_dependency = semantic_token(op)
+    assert original != changed_dependency
+
+    monkeypatch.setattr(
+        CallableWithMismatchedClosure,
+        "__call__",
+        lambda self, value: value - 2,
+    )
+
+    assert changed_dependency != semantic_token(op)
+
+
+def test_semantic_token_tolerates_non_cell_closure_metadata():
+    class CallableWithInvalidClosure:
+        __code__ = (lambda: None).__code__
+        __closure__ = ("not-a-cell",)
+        __globals__ = {}
+
+        def __call__(self, value):
+            return value
+
+    op = CallableWithInvalidClosure()
+    assert semantic_token(op) == semantic_token(op)
+
+
+def test_semantic_token_tracks_closure_attributes_in_nested_code(monkeypatch):
+    class GeneratorSettings:
+        offset = 1
+
+    settings = GeneratorSettings()
+
+    def generator_op(values):
+        return sum(value + settings.offset for value in values)
+
+    original = semantic_token(generator_op)
+
+    monkeypatch.setattr(GeneratorSettings, "offset", 2)
+
+    assert original != semantic_token(generator_op)
+
+
+def test_semantic_token_tracks_custom_descriptor_implementations(monkeypatch):
+    class OffsetDescriptor:
+        def __get__(self, instance, owner):
+            del instance, owner
+            return 1
+
+    class DescriptorPolicy:
+        offset = OffsetDescriptor()
+
+    def descriptor_op(value, policy=DescriptorPolicy):
+        return value + policy.offset
+
+    original = semantic_token(descriptor_op)
+
+    monkeypatch.setattr(
+        OffsetDescriptor,
+        "__get__",
+        lambda self, instance, owner: 2,
+    )
+
+    assert original != semantic_token(descriptor_op)
+
+
+def test_semantic_token_tracks_custom_metaclass_implementations(monkeypatch):
+    class PolicyMeta(type):
+        def __call__(cls, value):
+            del cls
+            return value + 1
+
+    class MetaclassPolicy(metaclass=PolicyMeta):
+        pass
+
+    def metaclass_op(value, policy=MetaclassPolicy):
+        return policy(value)
+
+    original = semantic_token(metaclass_op)
+
+    monkeypatch.setattr(
+        PolicyMeta,
+        "__call__",
+        lambda cls, value: value - 1,
+    )
+
+    assert original != semantic_token(metaclass_op)
+
+
+def test_semantic_token_tracks_referenced_global_values(monkeypatch):
+    original = semantic_token(_token_global_value_op)
+
+    monkeypatch.setitem(globals(), "_TOKEN_GLOBAL_OFFSET", 2)
+
+    assert original != semantic_token(_token_global_value_op)
+
+
+def test_semantic_token_ignores_attribute_names_that_match_unread_globals(
+    monkeypatch,
+):
+    original = semantic_token(_token_attribute_op)
+
+    monkeypatch.setitem(globals(), "offset", 200)
+
+    assert original == semantic_token(_token_attribute_op)
+
+
+def test_semantic_token_tracks_referenced_global_attributes(monkeypatch):
+    holder_original = semantic_token(_token_attribute_op)
+    module_original = semantic_token(_token_module_attribute_op)
+
+    monkeypatch.setattr(_TokenGlobalHolder, "offset", 8)
+    monkeypatch.setattr(_TOKEN_GLOBAL_MODULE, "offset", 12)
+
+    assert holder_original != semantic_token(_token_attribute_op)
+    assert module_original != semantic_token(_token_module_attribute_op)
+
+
+def test_semantic_token_tracks_referenced_global_class_bodies(monkeypatch):
+    policy_original = semantic_token(_token_global_policy_op)
+    static_original = semantic_token(_token_global_static_policy_op)
+
+    monkeypatch.setattr(_TokenGlobalPolicy, "result", lambda self: self.value - 1)
+    monkeypatch.setattr(
+        _TokenGlobalStaticPolicy,
+        "apply",
+        staticmethod(lambda value: value - 1),
+    )
+
+    assert policy_original != semantic_token(_token_global_policy_op)
+    assert static_original != semantic_token(_token_global_static_policy_op)
+
+
+def test_semantic_token_tracks_rebound_global_helpers(monkeypatch):
+    original = semantic_token(_token_global_helper_op)
+
+    monkeypatch.setitem(globals(), "_TOKEN_GLOBAL_HELPER", _token_helper_subtract)
+
+    assert original != semantic_token(_token_global_helper_op)
+
+
+def test_semantic_token_handles_recursive_global_callables():
+    assert semantic_token(_token_recursive_op) == semantic_token(_token_recursive_op)
 
 
 def test_semantic_token_handles_recursive_values():
@@ -466,9 +1031,69 @@ def test_semantic_token_tracks_container_state_in_callable_defaults():
     assert original != semantic_token(with_default)
 
 
+def test_semantic_token_distinguishes_cycle_topology():
+    outer_cycle = []
+    inner_cycle = []
+    outer_cycle.append(inner_cycle)
+    inner_cycle.append(outer_cycle)
+
+    outer_self = []
+    inner_self = []
+    outer_self.append(inner_self)
+    inner_self.append(inner_self)
+
+    assert semantic_token(outer_cycle) != semantic_token(outer_self)
+
+
+def test_semantic_token_memoizes_acyclic_diamonds():
+    class CountingMapping(dict):
+        visits = 0
+
+        def items(self):
+            self.visits += 1
+            return super().items()
+
+    nodes = [CountingMapping(value=1)]
+    for _ in range(12):
+        nodes.append(CountingMapping(left=nodes[-1], right=nodes[-1]))
+
+    semantic_token(nodes[-1])
+
+    assert [node.visits for node in nodes] == [1] * len(nodes)
+
+
+def test_semantic_token_memoization_is_mapping_order_independent():
+    def make_shared_cycle(order):
+        first = []
+        second = []
+        shared = [first]
+        first.append(shared)
+        second.append(shared)
+        nodes = {"first": first, "second": second}
+        return {name: nodes[name] for name in order}
+
+    forward = make_shared_cycle(("first", "second"))
+    reverse = make_shared_cycle(("second", "first"))
+
+    assert semantic_token(forward) == semantic_token(reverse)
+
+
 def test_semantic_token_namespaces_string_enums():
     assert semantic_token(ArgumentKind.STATIC) != semantic_token("static")
     assert semantic_token(ParameterRole.STATE) != semantic_token("state")
+
+
+def test_semantic_token_preserves_container_kinds():
+    assert semantic_token((1, 2)) != semantic_token([1, 2])
+    assert semantic_token({1, 2}) != semantic_token(frozenset({1, 2}))
+    assert semantic_token({"key": 1}) != semantic_token([("key", 1)])
+
+    def with_default(value=(1, 2)):
+        return value
+
+    tuple_default = semantic_token(with_default)
+    with_default.__defaults__ = ([1, 2],)
+    assert tuple_default != semantic_token(with_default)
 
 
 def test_semantic_token_normalizes_nan_values():

--- a/python/cuda_coop/tests/contracts/headers/test_identity.py
+++ b/python/cuda_coop/tests/contracts/headers/test_identity.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from pathlib import Path
+
+import pytest
+
+from cuda.coop._headers import _identity
+from cuda.coop._headers._identity import include_dirs_identity
+
+
+def _record_hash(content: bytes) -> str:
+    encoded = base64.urlsafe_b64encode(hashlib.sha256(content).digest())
+    return f"sha256={encoded.rstrip(b'=').decode('ascii')}"
+
+
+@pytest.mark.parametrize("mutation", ["content", "addition", "deletion"])
+def test_installed_record_never_replaces_live_header_identity(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    include = site_packages / "cuda" / "cccl" / "include"
+    include.mkdir(parents=True)
+    header = include / "header.cuh"
+    original_content = b"first"
+    header.write_bytes(original_content)
+
+    dist_info = site_packages / "cuda_cccl-1.0.dist-info"
+    dist_info.mkdir()
+    record = dist_info / "RECORD"
+    relative_header = header.relative_to(site_packages).as_posix()
+    record.write_text(
+        f"{relative_header},{_record_hash(original_content)},"
+        f"{len(original_content)}\n{dist_info.name}/RECORD,,\n",
+        encoding="utf-8",
+    )
+
+    original_stat = header.stat()
+    original = include_dirs_identity((str(include),))
+    if mutation == "content":
+        header.write_bytes(b"other")
+        os.utime(
+            header,
+            ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+        )
+    elif mutation == "addition":
+        (include / "added.cuh").write_bytes(b"added")
+    else:
+        header.unlink()
+    mutated = include_dirs_identity((str(include),))
+
+    assert original.roots[0].method == "recursive-content"
+    assert mutated.roots[0].method == "recursive-content"
+    assert original.digest != mutated.digest
+
+
+def test_missing_git_executable_falls_back_to_recursive_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    (repository / ".git").mkdir(parents=True)
+    include = repository / "include"
+    include.mkdir()
+    (include / "header.cuh").write_bytes(b"header")
+
+    def missing_git(*args: object, **kwargs: object) -> None:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(_identity.subprocess, "run", missing_git)
+
+    identity = include_dirs_identity((str(include),))
+
+    assert identity.roots[0].method == "recursive-content"
+    assert identity.recursive_walks == 1

--- a/python/cuda_coop/tests/contracts/headers/test_toolkit.py
+++ b/python/cuda_coop/tests/contracts/headers/test_toolkit.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import cuda.pathfinder
+import pytest
+
+from cuda.coop._headers import _toolkit
+
+
+class _FakeNvJitLinkVersion:
+    def __init__(self, version):
+        self.version = version
+        self.argtypes = None
+        self.restype = None
+
+    def __call__(self, major, minor):
+        pointer_type = _toolkit.ctypes.POINTER(_toolkit.ctypes.c_uint)
+        assert self.argtypes == (pointer_type, pointer_type)
+        assert self.restype is _toolkit.ctypes.c_int
+        _toolkit.ctypes.cast(major, pointer_type)[0] = self.version[0]
+        _toolkit.ctypes.cast(minor, pointer_type)[0] = self.version[1]
+        return 0
+
+
+class _FakeNvJitLinkLibrary:
+    def __init__(self, version):
+        self.nvJitLinkVersion = _FakeNvJitLinkVersion(version)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_exact_library_handles():
+    with _toolkit._PRELOAD_LOCK:
+        _toolkit._EXACT_LIBRARY_HANDLES.clear()
+    yield
+    with _toolkit._PRELOAD_LOCK:
+        _toolkit._EXACT_LIBRARY_HANDLES.clear()
+
+
+def _write_cuda_header(include_dir: Path, encoded_version: int) -> None:
+    include_dir.mkdir(parents=True)
+    (include_dir / "cuda_runtime_api.h").write_text(
+        f"#define CUDART_VERSION {encoded_version}\n",
+        encoding="utf-8",
+    )
+
+
+def _library_path(directory: Path, kind: str, major: int) -> Path:
+    """Return the platform spelling used by the preload implementation."""
+
+    return directory / _toolkit._library_names(kind, major)[0]
+
+
+@pytest.mark.parametrize(
+    ("os_name", "kind", "expected"),
+    (
+        ("posix", "nvrtc", ("libnvrtc.so.13",)),
+        ("posix", "nvJitLink", ("libnvJitLink.so.13",)),
+        ("nt", "nvrtc", ("nvrtc64_130_0.dll",)),
+        ("nt", "nvJitLink", ("nvJitLink_130_0.dll",)),
+    ),
+)
+def test_library_names_match_platform_spelling(
+    monkeypatch,
+    os_name,
+    kind,
+    expected,
+):
+    monkeypatch.setattr(_toolkit, "os", SimpleNamespace(name=os_name))
+
+    assert _toolkit._library_names(kind, 13) == expected
+
+
+def test_preload_reuses_exact_nvjitlink_handle(monkeypatch, tmp_path):
+    first_include = tmp_path / "first" / "include"
+    second_include = tmp_path / "second" / "include"
+    first_lib = tmp_path / "first" / "lib"
+    second_lib = tmp_path / "second" / "lib64"
+    _write_cuda_header(first_include, 13000)
+    _write_cuda_header(second_include, 13000)
+    first_lib.mkdir()
+    second_lib.mkdir()
+
+    nvrtc = _library_path(first_lib, "nvrtc", 13)
+    nvjitlink = _library_path(second_lib, "nvJitLink", 13)
+    ignored = _library_path(first_lib, "nvrtc", 12)
+    for library in (nvrtc, nvjitlink, ignored):
+        library.touch()
+
+    loaded = []
+    fake_nvjitlink = _FakeNvJitLinkLibrary((13, 0))
+
+    def load_library(path, *, mode):
+        path = Path(path)
+        loaded.append((path, mode))
+        return fake_nvjitlink if path == nvjitlink else object()
+
+    monkeypatch.setattr(_toolkit.ctypes, "CDLL", load_library)
+    monkeypatch.setattr(
+        cuda.pathfinder,
+        "load_nvidia_dynamic_lib",
+        lambda name: SimpleNamespace(
+            abs_path=str(nvrtc if name == "nvrtc" else nvjitlink)
+        ),
+    )
+    libraries = _toolkit.preload_toolkit_compiler_libraries(
+        (first_include, second_include)
+    )
+
+    assert [path for path, _ in loaded] == [nvrtc, nvjitlink]
+    assert sum(path == nvjitlink for path, _ in loaded) == 1
+    assert libraries.nvrtc_path == str(nvrtc)
+    assert libraries.nvjitlink_path == str(nvjitlink)
+    assert libraries.toolkit_version == (13, 0)
+
+
+def test_preload_accepts_compatible_newer_nvjitlink_fallback(
+    monkeypatch,
+    tmp_path,
+):
+    include_dir = tmp_path / "toolkit" / "include"
+    lib_dir = tmp_path / "toolkit" / "lib"
+    _write_cuda_header(include_dir, 13000)
+    lib_dir.mkdir()
+    _library_path(lib_dir, "nvrtc", 13).touch()
+
+    fallback_nvjitlink = _library_path(tmp_path / "fallback", "nvJitLink", 13)
+    monkeypatch.setattr(
+        _toolkit.ctypes,
+        "CDLL",
+        lambda path, *, mode: _FakeNvJitLinkLibrary((13, 3)),
+    )
+    monkeypatch.setattr(
+        cuda.pathfinder,
+        "load_nvidia_dynamic_lib",
+        lambda name: SimpleNamespace(
+            abs_path=str(
+                _library_path(lib_dir, "nvrtc", 13)
+                if name == "nvrtc"
+                else fallback_nvjitlink
+            )
+        ),
+    )
+    libraries = _toolkit.preload_toolkit_compiler_libraries((include_dir,))
+
+    assert libraries.nvjitlink_path == str(fallback_nvjitlink)
+
+
+@pytest.mark.parametrize("actual_version", [(12, 8), (13, 0)])
+def test_preload_rejects_version_mismatched_nvjitlink_fallback(
+    monkeypatch,
+    tmp_path,
+    actual_version,
+):
+    include_dir = tmp_path / "toolkit" / "include"
+    _write_cuda_header(include_dir, 13020)
+    fallback_nvrtc = _library_path(tmp_path / "fallback", "nvrtc", 13)
+    fallback_nvjitlink = _library_path(
+        tmp_path / "fallback", "nvJitLink", actual_version[0]
+    )
+
+    monkeypatch.setattr(
+        cuda.pathfinder,
+        "load_nvidia_dynamic_lib",
+        lambda name: SimpleNamespace(
+            abs_path=str(fallback_nvrtc if name == "nvrtc" else fallback_nvjitlink)
+        ),
+    )
+    monkeypatch.setattr(
+        _toolkit.ctypes,
+        "CDLL",
+        lambda path, *, mode: _FakeNvJitLinkLibrary(actual_version),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"headers report Toolkit 13\.2, but loaded nvJitLink .* reports "
+            rf"{actual_version[0]}\.{actual_version[1]}"
+        ),
+    ):
+        _toolkit.preload_toolkit_compiler_libraries((include_dir,))
+
+
+def test_preload_tries_all_exact_toolkit_candidates(monkeypatch, tmp_path):
+    include_dir = tmp_path / "toolkit" / "include"
+    lib_dir = tmp_path / "toolkit" / "lib"
+    lib64_dir = tmp_path / "toolkit" / "lib64"
+    _write_cuda_header(include_dir, 13000)
+    lib_dir.mkdir()
+    lib64_dir.mkdir()
+    nvrtc = _library_path(lib_dir, "nvrtc", 13)
+    first_nvjitlink = _library_path(lib_dir, "nvJitLink", 13)
+    second_nvjitlink = _library_path(lib64_dir, "nvJitLink", 13)
+    for library in (nvrtc, first_nvjitlink, second_nvjitlink):
+        library.touch()
+
+    attempts = []
+    fake_nvjitlink = _FakeNvJitLinkLibrary((13, 0))
+
+    def load_library(path, *, mode):
+        del mode
+        path = Path(path)
+        attempts.append(path)
+        if path == first_nvjitlink:
+            raise OSError("first candidate is unavailable")
+        return fake_nvjitlink if path == second_nvjitlink else object()
+
+    monkeypatch.setattr(_toolkit.ctypes, "CDLL", load_library)
+    monkeypatch.setattr(
+        cuda.pathfinder,
+        "load_nvidia_dynamic_lib",
+        lambda name: SimpleNamespace(
+            abs_path=str(nvrtc if name == "nvrtc" else second_nvjitlink)
+        ),
+    )
+
+    libraries = _toolkit.preload_toolkit_compiler_libraries((include_dir,))
+
+    assert [path for path in attempts if "nvJitLink" in path.name] == [
+        first_nvjitlink,
+        second_nvjitlink,
+    ]
+    assert libraries.nvjitlink_path == str(second_nvjitlink)
+
+
+def test_preload_reports_all_exact_toolkit_library_load_failures(
+    monkeypatch,
+    tmp_path,
+):
+    include_dir = tmp_path / "toolkit" / "include"
+    lib_dir = tmp_path / "toolkit" / "lib"
+    lib64_dir = tmp_path / "toolkit" / "lib64"
+    _write_cuda_header(include_dir, 13000)
+    lib_dir.mkdir()
+    lib64_dir.mkdir()
+    _library_path(lib_dir, "nvrtc", 13).touch()
+    candidates = (
+        _library_path(lib_dir, "nvJitLink", 13),
+        _library_path(lib64_dir, "nvJitLink", 13),
+    )
+    for candidate in candidates:
+        candidate.touch()
+
+    def fail_load(path, *, mode):
+        del mode
+        if Path(path) in candidates:
+            raise OSError(f"test load failure for {Path(path).parent.name}")
+        return object()
+
+    fallback_calls = []
+    monkeypatch.setattr(_toolkit.ctypes, "CDLL", fail_load)
+    monkeypatch.setattr(
+        cuda.pathfinder,
+        "load_nvidia_dynamic_lib",
+        lambda name: fallback_calls.append(name),
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="failed loading all resolved CUDA Toolkit nvJitLink candidates",
+    ) as exc_info:
+        _toolkit.preload_toolkit_compiler_libraries((include_dir,))
+
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert str(exc_info.value.__cause__) == "test load failure for lib64"
+    assert all(str(candidate) in str(exc_info.value) for candidate in candidates)
+    assert fallback_calls == []
+
+
+def test_validate_nvrtc_version_rejects_header_mismatch():
+    libraries = _toolkit.ToolkitCompilerLibraries(
+        nvrtc_path="/toolkit/lib/libnvrtc.so.12",
+        nvjitlink_path="/toolkit/lib/libnvJitLink.so.12",
+        toolkit_version=(13, 2),
+    )
+
+    with pytest.raises(RuntimeError, match="headers report Toolkit 13.2"):
+        _toolkit.validate_nvrtc_version(libraries, (12, 8))


### PR DESCRIPTION
## Why this is needed

The portable `cuda.coop` layer defines cooperative operations, but it does not
yet make them usable from CUTLASS DSL kernels. This stack layer adds the
CUTLASS compiler substrate and implements the initial load/store, reduce, and
scan cohort behind the same API introduced in #11035.

```python
import cuda.coop.cutlass as coop

items = coop.load(coop.this_block(), source, coop.ThreadData(2))
total = coop.sum(coop.this_block(), items)
coop.store(coop.this_block(), destination, items)
```

## What this PR includes

- CUTLASS DSL 4.8 activation and automatic backend registration
- lowering and provider generation for load/store, reduce/sum, and scan
- provider compilation, final linking, scratch storage, and CUB/CUDAX routing
- semantic, header, toolkit, and compiler cache identity with integrity and
  fork-safe locking

PCH and AOT land in stack layers 6 and 7.

## Stack

2 of 7, based on #11035. The next layer is the Numba-CUDA-MLIR backend.

## Local validation

- 552 focused CUTLASS source tests passed across unit, provider compilation,
  linking, and GPU runtime coverage
- 101 affected import/boundary tests passed after the final stack cleanup
- source-root and root-free final-link GPU lanes passed in the local CUTLASS
  DSL 4.8 environment
- source imports, `compileall`, changed-file pre-commit, and
  `git diff --check` passed

Wheel and installed-package qualification, GitHub CI, and automated AI review
are deferred for now.
