### PR TITLE
Enable NVRTC PCH reuse for CUTLASS providers

### DIFF
--- a/python/cuda_coop/ARCHITECTURE.md
+++ b/python/cuda_coop/ARCHITECTURE.md
@@ -73,9 +73,11 @@ CUTLASS traces qualified calls and registers immutable provider requests in a
 per-trace session. Finalization renders all requested providers in canonical
 order, resolves an exact cache hit when possible, otherwise compiles one bundle,
 materializes deferred scratch storage, and attaches the resulting linkable
-artifact to the kernel. Renderer kinds, source bytes, generated symbols, bundle
-identities, and cache schemas must not change merely because Python modules
-move.
+artifact to the kernel.
+
+A JIT path must preload NVRTC before querying its version or constructing PCH
+state. Renderer kinds, source bytes, generated symbols, bundle identities, and
+cache schemas must not change merely because Python modules move.
 
 ### Numba-CUDA-MLIR
 

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_bundle.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_bundle.py
@@ -23,7 +23,12 @@ from cutlass.base_dsl.common import DSLRuntimeError
 
 from cuda.coop._headers import HeaderResolutionError, resolve_include_paths
 
-from . import _cache, _clang, _nvrtc
+# NVRTC imports PCH before cache so their fork-reset hooks retain the original
+# registration order.
+# isort: off
+from . import _nvrtc, _cache, _clang
+
+# isort: on
 from ._bundle_contract import (
     RESOLUTION_ROUTE_CLANG,
     RESOLUTION_ROUTE_DISK,
@@ -251,6 +256,7 @@ def _compile_bundle_source(
             else _unknown_compiler_process_token()
         )
     else:
+        nvrtc_version_tuple = None
         nvrtc_version = None
         clangxx, clang_version, cache_compiler_version = (
             _clang_support.resolve_clang_compiler(which)
@@ -349,6 +355,11 @@ def _compile_bundle_source(
                 include_dirs=include_dirs,
                 prepared_probes=prepared_probes,
                 nvrtc_version=nvrtc_version,
+                nvrtc_version_tuple=nvrtc_version_tuple,
+                bundle_arch=bundle_arch,
+                bundle_sm_arch=bundle_sm_arch,
+                header_identity=include_identity.digest,
+                phase_timings_ns=phase_timings_ns,
                 scope=scope,
             )
             route = RESOLUTION_ROUTE_NVRTC

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_nvrtc.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_nvrtc.py
@@ -2,12 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""Compile CUTLASS provider bundles with NVRTC."""
+"""Preload and compile CUTLASS provider bundles with NVRTC.
+
+The module owns the NVRTC program lifecycle, PCH retry path, and LTO-IR
+artifact production. Bundle orchestration decides when this backend runs.
+"""
 
 from __future__ import annotations
 
 import hashlib
 import os
+import time
 from collections.abc import Iterable
 from typing import Any
 
@@ -19,28 +24,36 @@ from cuda.coop._headers._toolkit import (
     validate_nvrtc_version,
 )
 
-from . import _cache as _cache_support
+# PCH must register its child reset before cache registers its fork handlers.
+# isort: off
+from . import (
+    _pch as _provider_pch,
+    _cache as _cache_support,
+)
+
+# isort: on
 from ._bundle_contract import (
     BundleCacheIdentity,
     _decode_layout_probe_name,
     _PreparedLayoutProbes,
 )
-from ._cache import (
-    _CachedBundle,
-    _write_bundle_metadata,
-    write_binary_atomic,
-)
 
 _COMPILE_PROGRAM_COUNTER = 0
 
 
-def get_program_log(program: Any) -> str:
-    err, log_size = cuda_nvrtc.nvrtcGetProgramLogSize(program)
-    if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS or log_size <= 0:
+def program_log(nvrtc: Any, program: Any) -> str:
+    """Return a decoded NVRTC program log when the runtime exposes it."""
+
+    get_log_size = getattr(nvrtc, "nvrtcGetProgramLogSize", None)
+    get_log = getattr(nvrtc, "nvrtcGetProgramLog", None)
+    if not callable(get_log_size) or not callable(get_log):
+        return ""
+    err, log_size = get_log_size(program)
+    if err != nvrtc.nvrtcResult.NVRTC_SUCCESS or log_size <= 0:
         return ""
     log = bytearray(log_size)
-    err = cuda_nvrtc.nvrtcGetProgramLog(program, log)[0]
-    if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+    err = get_log(program, log)[0]
+    if err != nvrtc.nvrtcResult.NVRTC_SUCCESS:
         return ""
     return bytes(log).decode("utf-8", errors="replace").strip("\x00").strip()
 
@@ -59,6 +72,10 @@ def version_tuple(nvrtc: Any) -> tuple[int, int] | None:
     if err != nvrtc.nvrtcResult.NVRTC_SUCCESS:
         return None
     return parsed_version
+
+
+def get_program_log(program: Any) -> str:
+    return program_log(cuda_nvrtc, program)
 
 
 def get_version_tuple() -> tuple[int, int] | None:
@@ -94,26 +111,12 @@ def include_options(include_dirs: list[str]) -> list[bytes]:
     return [os.fsencode(f"-I{path}") for path in include_dirs]
 
 
-def compile_bundle(
-    source: str,
+def _create_program(
+    source_bytes: bytes,
+    encoded_expressions: tuple[bytes, ...],
     *,
-    output_path: str,
-    cache_identity: BundleCacheIdentity,
-    compiler_options: tuple[str, ...],
-    include_dirs: list[str],
-    prepared_probes: _PreparedLayoutProbes,
-    nvrtc_version: str | None,
     scope: str,
-) -> _CachedBundle:
-    """Compile one provider source to cached NVRTC LTO-IR."""
-
-    global _COMPILE_PROGRAM_COUNTER
-
-    source_bytes = source.encode("utf-8")
-    options = [
-        *(option.encode("ascii") for option in compiler_options),
-        *include_options(include_dirs),
-    ]
+) -> Any:
     err, program = cuda_nvrtc.nvrtcCreateProgram(
         source_bytes,
         b"cuda_coop_cutlass_bundle.cu",
@@ -125,11 +128,7 @@ def compile_bundle(
         raise DSLRuntimeError(
             f"Failed creating NVRTC program for {scope} provider bundle."
         )
-
     try:
-        encoded_expressions = tuple(
-            expression.encode("utf-8") for expression in prepared_probes.expressions
-        )
         for expression in encoded_expressions:
             result = cuda_nvrtc.nvrtcAddNameExpression(program, expression)
             err = result[0] if isinstance(result, tuple) else result
@@ -138,55 +137,156 @@ def compile_bundle(
                     f"Failed registering an NVRTC layout probe for {scope} "
                     "provider bundle."
                 )
+    except BaseException:
+        cuda_nvrtc.nvrtcDestroyProgram(program)
+        raise
+    return program
 
-        err = cuda_nvrtc.nvrtcCompileProgram(program, len(options), options)[0]
-        if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
-            raise DSLRuntimeError(
-                f"Failed compiling {scope} provider shim to LTO-IR.",
-                cause=RuntimeError(get_program_log(program)),
-            )
-        with _cache_support._STATE_LOCK:
-            _COMPILE_PROGRAM_COUNTER += 1
 
-        layouts_by_expression = {}
-        for expression, encoded_expression in zip(
-            prepared_probes.expressions,
-            encoded_expressions,
-        ):
-            err, lowered_name = cuda_nvrtc.nvrtcGetLoweredName(
-                program,
-                encoded_expression,
+def _compile_program(
+    program: Any,
+    options: list[bytes],
+) -> tuple[Any, int]:
+    global _COMPILE_PROGRAM_COUNTER
+
+    started_ns = time.perf_counter_ns()
+    with _cache_support._STATE_LOCK:
+        _COMPILE_PROGRAM_COUNTER += 1
+    result = cuda_nvrtc.nvrtcCompileProgram(program, len(options), options)
+    duration_ns = max(0, time.perf_counter_ns() - started_ns)
+    err = result[0] if isinstance(result, tuple) else result
+    return err, duration_ns
+
+
+def compile_bundle(
+    source: str,
+    *,
+    output_path: str,
+    cache_identity: BundleCacheIdentity,
+    compiler_options: tuple[str, ...],
+    include_dirs: list[str],
+    prepared_probes: _PreparedLayoutProbes,
+    nvrtc_version: str | None,
+    nvrtc_version_tuple: tuple[int, int] | None,
+    bundle_arch: str,
+    bundle_sm_arch: str,
+    header_identity: str,
+    phase_timings_ns: dict[str, int],
+    scope: str,
+) -> _cache_support._CachedBundle:
+    """Compile one provider source to cached NVRTC LTO-IR."""
+
+    source_bytes = source.encode("utf-8")
+    base_options = [
+        *(option.encode("ascii") for option in compiler_options),
+        *include_options(include_dirs),
+    ]
+    encoded_expressions = tuple(
+        expression.encode("utf-8") for expression in prepared_probes.expressions
+    )
+    pch_session: _provider_pch.PCHSession | None = None
+    program = None
+    try:
+        with _provider_pch.pch_session(
+            nvrtc_version=nvrtc_version_tuple,
+            bundle_arch=bundle_arch,
+            bundle_sm_arch=bundle_sm_arch,
+            compiler_options=compiler_options,
+            include_dirs=tuple(include_dirs),
+            header_identity=header_identity,
+            preamble_identity=_provider_pch.provider_preamble_identity(source),
+        ) as pch_session:
+            program = _create_program(
+                source_bytes,
+                encoded_expressions,
+                scope=scope,
             )
+            options = [*base_options, *pch_session.options]
+            err, compile_duration_ns = _compile_program(program, options)
+            pch_fallback_log = ""
+            used_pch = pch_session.enabled
+            if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS and pch_session.enabled:
+                pch_fallback_log = get_program_log(program)
+                pch_session.disable_after_failure(compile_duration_ns)
+                cuda_nvrtc.nvrtcDestroyProgram(program)
+                program = None
+                program = _create_program(
+                    source_bytes,
+                    encoded_expressions,
+                    scope=scope,
+                )
+                err, retry_duration_ns = _compile_program(program, base_options)
+                pch_session.phase_timings_ns["pch_fallback"] += retry_duration_ns
+                used_pch = False
+            if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+                compiler_log = get_program_log(program)
+                if pch_fallback_log:
+                    compiler_log = (
+                        "PCH-enabled compilation failed:\n"
+                        f"{pch_fallback_log}\n"
+                        "Retry without PCH failed:\n"
+                        f"{compiler_log}"
+                    )
+                raise DSLRuntimeError(
+                    f"Failed compiling {scope} provider shim to LTO-IR.",
+                    cause=RuntimeError(compiler_log),
+                )
+            if used_pch:
+                pch_session.record_success(
+                    cuda_nvrtc,
+                    program,
+                    compile_duration_ns=compile_duration_ns,
+                    program_log=get_program_log(program),
+                )
+            layouts_by_expression = {}
+            for expression, encoded_expression in zip(
+                prepared_probes.expressions,
+                encoded_expressions,
+            ):
+                err, lowered_name = cuda_nvrtc.nvrtcGetLoweredName(
+                    program,
+                    encoded_expression,
+                )
+                if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+                    raise DSLRuntimeError(
+                        f"Failed retrieving an NVRTC layout probe for {scope} "
+                        "provider bundle."
+                    )
+                layouts_by_expression[expression] = _decode_layout_probe_name(
+                    lowered_name,
+                    symbol=prepared_probes.symbol,
+                    expression=expression,
+                )
+
+            err, blob_size = cuda_nvrtc.nvrtcGetLTOIRSize(program)
             if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
                 raise DSLRuntimeError(
-                    f"Failed retrieving an NVRTC layout probe for {scope} "
-                    "provider bundle."
+                    f"Failed querying NVRTC LTO-IR size for {scope} provider shim."
                 )
-            layouts_by_expression[expression] = _decode_layout_probe_name(
-                lowered_name,
-                symbol=prepared_probes.symbol,
-                expression=expression,
-            )
-
-        err, blob_size = cuda_nvrtc.nvrtcGetLTOIRSize(program)
-        if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
-            raise DSLRuntimeError(
-                f"Failed querying NVRTC LTO-IR size for {scope} provider shim."
-            )
-        if blob_size <= 0:
-            raise DSLRuntimeError(
-                f"NVRTC produced an empty LTO-IR artifact for {scope} provider shim."
-            )
-        artifact_blob = bytearray(blob_size)
-        err = cuda_nvrtc.nvrtcGetLTOIR(program, artifact_blob)[0]
-        if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
-            raise DSLRuntimeError(
-                f"Failed retrieving NVRTC LTO-IR for {scope} provider shim."
-            )
+            if blob_size <= 0:
+                raise DSLRuntimeError(
+                    f"NVRTC produced an empty LTO-IR artifact for {scope} "
+                    "provider shim."
+                )
+            artifact_blob = bytearray(blob_size)
+            err = cuda_nvrtc.nvrtcGetLTOIR(program, artifact_blob)[0]
+            if err != cuda_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+                raise DSLRuntimeError(
+                    f"Failed retrieving NVRTC LTO-IR for {scope} provider shim."
+                )
+    except _provider_pch.PCHConfigurationError as exc:
+        raise DSLRuntimeError(
+            f"Invalid {scope} provider PCH configuration.",
+            cause=exc,
+        ) from exc
     finally:
-        cuda_nvrtc.nvrtcDestroyProgram(program)
+        if pch_session is not None:
+            for phase, duration_ns in pch_session.phase_timings_ns.items():
+                phase_timings_ns[phase] = phase_timings_ns.get(phase, 0) + duration_ns
+        if program is not None:
+            cuda_nvrtc.nvrtcDestroyProgram(program)
 
-    cached = _CachedBundle(
+    cached = _cache_support._CachedBundle(
         path=output_path,
         layouts_by_expression=layouts_by_expression,
         producer_compiler="nvrtc",
@@ -194,8 +294,8 @@ def compile_bundle(
         artifact_size=len(artifact_blob),
         artifact_sha256=hashlib.sha256(artifact_blob).hexdigest(),
     )
-    write_binary_atomic(output_path, artifact_blob, scope=scope)
-    _write_bundle_metadata(
+    _cache_support.write_binary_atomic(output_path, artifact_blob, scope=scope)
+    _cache_support._write_bundle_metadata(
         output_path,
         artifact_blob,
         cached,

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_pch.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_pch.py
@@ -1,0 +1,477 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Process-private NVRTC automatic-PCH lifecycle management."""
+
+from __future__ import annotations
+
+import atexit
+import hashlib
+import json
+import os
+import secrets
+import shutil
+import stat
+import tempfile
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+PCH_ENV = "CUDA_COOP_CUTLASS_PROVIDER_PCH"
+PCH_MODE_AUTO = "auto"
+PCH_MODE_OFF = "off"
+PCH_MINIMUM_VERSION = (12, 8)
+
+
+class PCHConfigurationError(ValueError):
+    """Raised for an unsupported process-private PCH configuration."""
+
+
+class PCHUnavailableError(RuntimeError):
+    """Raised when the process-private PCH storage cannot be used safely."""
+
+
+@dataclass
+class PCHSession:
+    """One serialized automatic-PCH decision and its telemetry."""
+
+    domain_key: str | None
+    directory: str | None
+    options: tuple[bytes, ...]
+    state: str
+    phase_timings_ns: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.options)
+
+    def disable_after_failure(self, duration_ns: int) -> None:
+        self._disable_domain()
+        self.phase_timings_ns["pch_fallback"] = max(0, duration_ns)
+
+    def _disable_domain(self) -> None:
+        if self.domain_key is not None:
+            with _PCH_STATE_LOCK:
+                _PCH_DISABLED_DOMAINS.add(self.domain_key)
+
+    def record_success(
+        self,
+        nvrtc: Any,
+        program: Any,
+        *,
+        compile_duration_ns: int,
+        program_log: str,
+    ) -> None:
+        if not self.enabled:
+            return
+        status_function = getattr(nvrtc, "nvrtcGetPCHCreateStatus", None)
+        if not callable(status_function):
+            return
+        result = getattr(nvrtc, "nvrtcResult", None)
+        success = getattr(result, "NVRTC_SUCCESS", object())
+        try:
+            status_result = status_function(program)
+        except Exception:  # noqa: BLE001
+            # PCH telemetry must never invalidate an otherwise valid artifact.
+            return
+        if isinstance(status_result, tuple):
+            if not status_result:
+                return
+            # The current Python binding returns ``(pch_create_status,)``.
+            # Accommodate wrappers that expose an API result followed by the
+            # creation status without mistaking the former for the latter.
+            if len(status_result) > 1:
+                if status_result[0] != success:
+                    return
+                status = status_result[-1]
+            else:
+                status = status_result[0]
+        else:
+            status = status_result
+        no_attempt = getattr(
+            result,
+            "NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED",
+            object(),
+        )
+        heap_exhausted = getattr(
+            result,
+            "NVRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED",
+            object(),
+        )
+        create_error = getattr(result, "NVRTC_ERROR_PCH_CREATE", object())
+        if status == success:
+            self.phase_timings_ns["pch_create"] = max(0, compile_duration_ns)
+            return
+        if status in (heap_exhausted, create_error):
+            # PCH creation status does not invalidate a successful compilation.
+            # In particular, do not resize the global heap: that would invalidate
+            # every PCH file created with its previous base address.
+            self._disable_domain()
+            self.phase_timings_ns["pch_create"] = max(0, compile_duration_ns)
+            self.phase_timings_ns["pch_create_warning"] = 0
+            return
+        if status == no_attempt and "using precompiled header" in program_log.lower():
+            self.phase_timings_ns["pch_hit"] = max(0, compile_duration_ns)
+
+
+_PCH_STATE_LOCK = threading.RLock()
+_PCH_PID = os.getpid()
+_PCH_POOL_PATH: str | None = None
+_PCH_DISABLED_DOMAINS: set[str] = set()
+_PCH_DOMAIN_LOCKS: dict[str, threading.RLock] = {}
+
+
+def configured_pch_mode() -> str:
+    mode = os.environ.get(PCH_ENV, PCH_MODE_AUTO).strip().lower()
+    if mode not in (PCH_MODE_AUTO, PCH_MODE_OFF):
+        raise PCHConfigurationError(
+            f"Unsupported {PCH_ENV} value: {mode!r}. Use auto/off."
+        )
+    return mode
+
+
+def _cleanup_pool() -> None:
+    with _PCH_STATE_LOCK:
+        if _PCH_POOL_PATH is None or _PCH_PID != os.getpid():
+            return
+        shutil.rmtree(_PCH_POOL_PATH, ignore_errors=True)
+
+
+def _reset_after_fork() -> None:
+    global _PCH_DISABLED_DOMAINS, _PCH_DOMAIN_LOCKS
+    global _PCH_PID, _PCH_POOL_PATH, _PCH_STATE_LOCK
+    _PCH_STATE_LOCK = threading.RLock()
+    _PCH_PID = os.getpid()
+    _PCH_POOL_PATH = None
+    _PCH_DISABLED_DOMAINS = set()
+    _PCH_DOMAIN_LOCKS = {}
+
+
+def _ensure_process_state() -> None:
+    if _PCH_PID != os.getpid():
+        _reset_after_fork()
+
+
+def _ensure_pool() -> str:
+    global _PCH_POOL_PATH
+    _ensure_process_state()
+    try:
+        if _PCH_POOL_PATH is None:
+            nonce = secrets.token_hex(8)
+            _PCH_POOL_PATH = tempfile.mkdtemp(
+                prefix=f"cuda-coop-cutlass-pch-{os.getpid()}-{nonce}-"
+            )
+            os.chmod(_PCH_POOL_PATH, 0o700)
+        pool_stat = os.lstat(_PCH_POOL_PATH)
+    except OSError as exc:
+        raise PCHUnavailableError(
+            "Failed preparing the process-private NVRTC PCH pool."
+        ) from exc
+    if (
+        not stat.S_ISDIR(pool_stat.st_mode)
+        or stat.S_ISLNK(pool_stat.st_mode)
+        or stat.S_IMODE(pool_stat.st_mode) != 0o700
+    ):
+        raise PCHUnavailableError(
+            "The process-private NVRTC PCH pool is not a secure directory."
+        )
+    return _PCH_POOL_PATH
+
+
+def make_pch_domain_key(
+    *,
+    nvrtc_version: tuple[int, int],
+    bundle_arch: str,
+    bundle_sm_arch: str,
+    compiler_options: tuple[str, ...],
+    include_dirs: tuple[str, ...],
+    header_identity: str,
+    preamble_identity: str,
+) -> str:
+    payload = {
+        "nvrtc_version": list(nvrtc_version),
+        "bundle_arch": bundle_arch,
+        "bundle_sm_arch": bundle_sm_arch,
+        "compiler_options": list(compiler_options),
+        "include_dirs": list(include_dirs),
+        "header_identity": header_identity,
+        "preamble_identity": preamble_identity,
+    }
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _starts_character_literal(line: str, index: int) -> bool:
+    if index > 0 and index + 1 < len(line):
+        previous = line[index - 1]
+        following = line[index + 1]
+        if (previous.isalnum() or previous == "_") and (
+            following.isalnum() or following == "_"
+        ):
+            prefix_start = index - 1
+            while prefix_start > 0 and (
+                line[prefix_start - 1].isalnum() or line[prefix_start - 1] == "_"
+            ):
+                prefix_start -= 1
+            if line[prefix_start:index] not in {"L", "U", "u", "u8"}:
+                return False
+
+    escaped = False
+    for character in line[index + 1 :]:
+        if escaped:
+            escaped = False
+        elif character == "\\":
+            escaped = True
+        elif character == "'":
+            return True
+    return False
+
+
+def _block_comment_state(line: str, in_block_comment: bool) -> bool:
+    """Return whether a C block comment remains open after one physical line."""
+
+    quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(line):
+        if in_block_comment:
+            comment_end = line.find("*/", index)
+            if comment_end < 0:
+                return True
+            index = comment_end + 2
+            in_block_comment = False
+            continue
+
+        character = line[index]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+            index += 1
+            continue
+        if character == "'" and not _starts_character_literal(line, index):
+            index += 1
+            continue
+        if character in {'"', "'"}:
+            quote = character
+            index += 1
+            continue
+        if line.startswith("//", index):
+            return False
+        if line.startswith("/*", index):
+            in_block_comment = True
+            index += 2
+            continue
+        index += 1
+    return in_block_comment
+
+
+def provider_preamble_identity(source: str) -> str:
+    """Hash the reusable leading preprocessor sequence, excluding request bodies."""
+
+    directives: list[str] = []
+    in_block_comment = False
+    in_continuation = False
+    for line in source.splitlines():
+        if in_continuation:
+            directives.append(line)
+            in_block_comment = _block_comment_state(line, in_block_comment)
+            in_continuation = line.rstrip().endswith("\\")
+            continue
+
+        remaining = line.lstrip()
+        while True:
+            if in_block_comment:
+                comment_end = remaining.find("*/")
+                if comment_end < 0:
+                    remaining = ""
+                    break
+                remaining = remaining[comment_end + 2 :].lstrip()
+                in_block_comment = False
+                continue
+            if remaining.startswith("//") or not remaining:
+                remaining = ""
+                break
+            if remaining.startswith("/*"):
+                in_block_comment = True
+                remaining = remaining[2:]
+                continue
+            break
+
+        if not remaining:
+            continue
+        if not remaining.startswith("#"):
+            break
+        directives.append(remaining)
+        in_block_comment = _block_comment_state(remaining, in_block_comment)
+        in_continuation = remaining.rstrip().endswith("\\")
+
+    payload = {
+        "directives": directives,
+    }
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _domain_directory(domain_key: str) -> str:
+    directory = os.path.join(_ensure_pool(), f"domain-{domain_key}")
+    try:
+        try:
+            os.mkdir(directory, mode=0o700)
+        except FileExistsError:
+            pass
+        directory_stat = os.lstat(directory)
+    except OSError as exc:
+        raise PCHUnavailableError(
+            "Failed preparing an NVRTC PCH compatibility domain."
+        ) from exc
+    if (
+        not stat.S_ISDIR(directory_stat.st_mode)
+        or stat.S_ISLNK(directory_stat.st_mode)
+        or stat.S_IMODE(directory_stat.st_mode) != 0o700
+    ):
+        raise PCHUnavailableError(
+            "The NVRTC PCH compatibility domain is not a secure directory."
+        )
+    return directory
+
+
+@contextmanager
+def pch_session(
+    *,
+    nvrtc_version: tuple[int, int] | None,
+    bundle_arch: str,
+    bundle_sm_arch: str,
+    compiler_options: tuple[str, ...],
+    include_dirs: tuple[str, ...],
+    header_identity: str,
+    preamble_identity: str,
+):
+    """Serialize and configure one process-private automatic-PCH attempt."""
+
+    _ensure_process_state()
+    lookup_started_ns = time.perf_counter_ns()
+    mode = configured_pch_mode()
+    if mode == PCH_MODE_OFF:
+        session = PCHSession(
+            domain_key=None,
+            directory=None,
+            options=(),
+            state="off",
+        )
+        session.phase_timings_ns["pch_off"] = 0
+        session.phase_timings_ns["pch_lookup"] = max(
+            0,
+            time.perf_counter_ns() - lookup_started_ns,
+        )
+        yield session
+        return
+    if nvrtc_version is None or nvrtc_version < PCH_MINIMUM_VERSION:
+        session = PCHSession(
+            domain_key=None,
+            directory=None,
+            options=(),
+            state="unsupported",
+        )
+        session.phase_timings_ns["pch_unsupported"] = 0
+        session.phase_timings_ns["pch_lookup"] = max(
+            0,
+            time.perf_counter_ns() - lookup_started_ns,
+        )
+        yield session
+        return
+
+    domain_key = make_pch_domain_key(
+        nvrtc_version=nvrtc_version,
+        bundle_arch=bundle_arch,
+        bundle_sm_arch=bundle_sm_arch,
+        compiler_options=compiler_options,
+        include_dirs=include_dirs,
+        header_identity=header_identity,
+        preamble_identity=preamble_identity,
+    )
+    with _PCH_STATE_LOCK:
+        domain_lock = _PCH_DOMAIN_LOCKS.setdefault(
+            domain_key,
+            threading.RLock(),
+        )
+
+    domain_lock.acquire()
+    hold_domain_lock = True
+    try:
+        with _PCH_STATE_LOCK:
+            if domain_key in _PCH_DISABLED_DOMAINS:
+                session = PCHSession(
+                    domain_key=domain_key,
+                    directory=None,
+                    options=(),
+                    state="disabled",
+                )
+                session.phase_timings_ns["pch_disabled"] = 0
+                domain_lock.release()
+                hold_domain_lock = False
+            else:
+                try:
+                    directory = _domain_directory(domain_key)
+                except PCHUnavailableError:
+                    _PCH_DISABLED_DOMAINS.add(domain_key)
+                    session = PCHSession(
+                        domain_key=domain_key,
+                        directory=None,
+                        options=(),
+                        state="unavailable",
+                    )
+                    session.phase_timings_ns["pch_unavailable"] = 0
+                    domain_lock.release()
+                    hold_domain_lock = False
+                else:
+                    session = PCHSession(
+                        domain_key=domain_key,
+                        directory=directory,
+                        options=(
+                            b"--pch",
+                            f"--pch-dir={directory}".encode(),
+                            b"--pch-messages=true",
+                        ),
+                        state="enabled",
+                    )
+        session.phase_timings_ns["pch_lookup"] = max(
+            0,
+            time.perf_counter_ns() - lookup_started_ns,
+        )
+        yield session
+    finally:
+        if hold_domain_lock:
+            domain_lock.release()
+
+
+atexit.register(_cleanup_pool)
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_after_fork)
+
+
+__all__ = [
+    "PCH_ENV",
+    "PCHConfigurationError",
+    "PCHSession",
+    "configured_pch_mode",
+    "make_pch_domain_key",
+    "pch_session",
+    "provider_preamble_identity",
+]

--- a/python/cuda_coop/tests/backends/cutlass/compile/test_provider_pch.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/test_provider_pch.py
@@ -1,0 +1,652 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import stat
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("cutlass")
+
+from cutlass.base_dsl.common import DSLRuntimeError
+
+from cuda.coop._headers._identity import IncludeDirsIdentity
+
+# isort: off
+from cuda.coop.cutlass._compiler import (
+    _bundle as provider_bundle,
+    _cache as provider_cache,
+    _nvrtc as provider_nvrtc,
+    _pch as provider_pch,
+)
+
+# isort: on
+
+
+class _NvrtcResult:
+    NVRTC_SUCCESS = 0
+    NVRTC_ERROR_COMPILATION = 6
+    NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED = 13
+    NVRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED = 14
+    NVRTC_ERROR_PCH_CREATE = 15
+
+
+class _Program:
+    def __init__(self, identifier, source):
+        self.identifier = identifier
+        self.source = source
+        self.log = ""
+        self.pch_status = _NvrtcResult.NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED
+        self.destroyed = False
+
+
+class _FakeNvrtc:
+    nvrtcResult = _NvrtcResult
+
+    def __init__(
+        self,
+        *,
+        version=(13, 0),
+        status_shape="binding",
+        create_status=_NvrtcResult.NVRTC_SUCCESS,
+        fail_first_pch_compile=False,
+        compile_delay=0.0,
+        compile_barrier=None,
+    ):
+        self.version = version
+        self.status_shape = status_shape
+        self.create_status = create_status
+        self.fail_first_pch_compile = fail_first_pch_compile
+        self.compile_delay = compile_delay
+        self.compile_barrier = compile_barrier
+        self.calls = []
+        self.blob = b"fake-ltoir"
+        self._next_program = 0
+        self._failed_pch = False
+        self._pch_directories = set()
+        self._lock = threading.Lock()
+        self._active_compiles = 0
+        self.max_active_compiles = 0
+
+    def nvrtcVersion(self):
+        return self.nvrtcResult.NVRTC_SUCCESS, *self.version
+
+    def nvrtcCreateProgram(self, source, name, num_headers, headers, include_names):
+        with self._lock:
+            self._next_program += 1
+            program = _Program(self._next_program, source)
+            self.calls.append(("create", program.identifier, source))
+        return self.nvrtcResult.NVRTC_SUCCESS, program
+
+    def nvrtcAddNameExpression(self, program, expression):
+        self.calls.append(("add", program.identifier, expression))
+        return (self.nvrtcResult.NVRTC_SUCCESS,)
+
+    def nvrtcCompileProgram(self, program, num_options, options):
+        options = tuple(options)
+        with self._lock:
+            self.calls.append(("compile", program.identifier, options))
+            self._active_compiles += 1
+            self.max_active_compiles = max(
+                self.max_active_compiles,
+                self._active_compiles,
+            )
+        try:
+            if self.compile_barrier is not None:
+                self.compile_barrier.wait(timeout=2)
+            if self.compile_delay:
+                time.sleep(self.compile_delay)
+            pch_directory = next(
+                (
+                    option.decode("utf-8").removeprefix("--pch-dir=")
+                    for option in options
+                    if option.startswith(b"--pch-dir=")
+                ),
+                None,
+            )
+            if (
+                pch_directory is not None
+                and self.fail_first_pch_compile
+                and not self._failed_pch
+            ):
+                self._failed_pch = True
+                program.log = "simulated PCH compile failure"
+                return (self.nvrtcResult.NVRTC_ERROR_COMPILATION,)
+            if pch_directory is None:
+                program.log = ""
+                program.pch_status = (
+                    self.nvrtcResult.NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED
+                )
+            elif pch_directory in self._pch_directories:
+                program.log = (
+                    f'using precompiled header file "{pch_directory}/provider.pch"'
+                )
+                program.pch_status = (
+                    self.nvrtcResult.NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED
+                )
+            else:
+                program.pch_status = self.create_status
+                if self.create_status == self.nvrtcResult.NVRTC_SUCCESS:
+                    self._pch_directories.add(pch_directory)
+                    program.log = (
+                        "creating precompiled header file "
+                        f'"{pch_directory}/provider.pch"'
+                    )
+                else:
+                    program.log = "PCH creation warning"
+            return (self.nvrtcResult.NVRTC_SUCCESS,)
+        finally:
+            with self._lock:
+                self._active_compiles -= 1
+
+    def nvrtcGetPCHCreateStatus(self, program):
+        if self.status_shape == "api_and_status":
+            return self.nvrtcResult.NVRTC_SUCCESS, program.pch_status
+        return (program.pch_status,)
+
+    def nvrtcGetProgramLogSize(self, program):
+        return self.nvrtcResult.NVRTC_SUCCESS, len(program.log.encode()) + 1
+
+    def nvrtcGetProgramLog(self, program, log):
+        log[:] = program.log.encode() + b"\0"
+        return (self.nvrtcResult.NVRTC_SUCCESS,)
+
+    def nvrtcGetLTOIRSize(self, program):
+        return self.nvrtcResult.NVRTC_SUCCESS, len(self.blob)
+
+    def nvrtcGetLTOIR(self, program, blob):
+        blob[:] = self.blob
+        return (self.nvrtcResult.NVRTC_SUCCESS,)
+
+    def nvrtcDestroyProgram(self, program):
+        program.destroyed = True
+        self.calls.append(("destroy", program.identifier))
+        return (self.nvrtcResult.NVRTC_SUCCESS,)
+
+    def nvrtcSetPCHHeapSize(self, size):
+        self.calls.append(("set_pch_heap_size", size))
+        raise AssertionError("provider PCH support must not resize the NVRTC heap")
+
+
+def _compile_kwargs(arch="80"):
+    return {
+        "scope": "cuda.coop.cutlass",
+        "provider_dir": provider_bundle.__file__,
+        "registered_headers": dict,
+        "select_bundle_format": lambda: "ltoir",
+        "resolve_nvrtc_sm_arch": lambda: f"sm_{arch}",
+        "resolve_nvrtc_arch": lambda: f"compute_{arch}",
+    }
+
+
+def _pch_directories(fake_nvrtc):
+    return [
+        next(
+            (
+                option.decode("utf-8").removeprefix("--pch-dir=")
+                for option in call[2]
+                if option.startswith(b"--pch-dir=")
+            ),
+            None,
+        )
+        for call in fake_nvrtc.calls
+        if call[0] == "compile"
+    ]
+
+
+def _reset_pch_state():
+    provider_pch._cleanup_pool()
+    provider_pch._PCH_STATE_LOCK = threading.RLock()
+    provider_pch._PCH_PID = os.getpid()
+    provider_pch._PCH_POOL_PATH = None
+    provider_pch._PCH_DISABLED_DOMAINS = set()
+    provider_pch._PCH_DOMAIN_LOCKS = {}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_provider_state(monkeypatch, tmp_path):
+    header_digest = {"value": "headers-a"}
+    monkeypatch.setenv(
+        provider_cache.CACHE_DIR_ENV,
+        str(tmp_path / "provider-cache"),
+    )
+    monkeypatch.setenv(provider_pch.PCH_ENV, provider_pch.PCH_MODE_AUTO)
+    monkeypatch.setattr(
+        provider_bundle,
+        "cccl_include_dirs",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        provider_bundle,
+        "include_dirs_identity",
+        lambda _include_dirs: IncludeDirsIdentity(
+            roots=(),
+            digest=header_digest["value"],
+            recursive_walks=0,
+            duration_ns=0,
+        ),
+    )
+    provider_bundle.reset_compile_state()
+    _reset_pch_state()
+    yield header_digest
+    provider_bundle.reset_compile_state()
+    _reset_pch_state()
+
+
+@pytest.mark.parametrize("status_shape", ["binding", "api_and_status"])
+def test_distinct_uncached_bundles_share_one_pch_domain(
+    monkeypatch,
+    status_shape,
+):
+    fake_nvrtc = _FakeNvrtc(status_shape=status_shape)
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    preamble = "#define CUDA_COOP_FEATURE 1\n#include <stdint.h>\n"
+
+    first = provider_bundle.compile_bundle_source(
+        preamble + 'extern "C" __device__ void provider_a() {}\n',
+        **_compile_kwargs(),
+    )
+    assert provider_bundle.get_nvrtc_compile_program_counter() == 1
+    second = provider_bundle.compile_bundle_source(
+        preamble + 'extern "C" __device__ void provider_b() {}\n',
+        **_compile_kwargs(),
+    )
+
+    assert first != second
+    assert _pch_directories(fake_nvrtc)[0] == _pch_directories(fake_nvrtc)[1]
+    assert all(_pch_directories(fake_nvrtc))
+    assert len([call for call in fake_nvrtc.calls if call[0] == "compile"]) == 2
+    telemetry = provider_bundle.get_bundle_telemetry()
+    assert telemetry.phase_counts["pch_lookup"] == 2
+    assert telemetry.phase_counts["pch_create"] == 1
+    assert telemetry.phase_counts["pch_hit"] == 1
+
+
+def test_preamble_arch_and_header_identity_partition_domains(
+    monkeypatch,
+    _isolated_provider_state,
+):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    preamble = "#define CUDA_COOP_FEATURE 1\n#include <stdint.h>\n"
+
+    provider_bundle.compile_bundle_source(
+        preamble + 'extern "C" __device__ void provider_a() {}\n',
+        **_compile_kwargs(),
+    )
+    provider_bundle.compile_bundle_source(
+        "#define CUDA_COOP_FEATURE 2\n#include <stdint.h>\n"
+        'extern "C" __device__ void provider_b() {}\n',
+        **_compile_kwargs(),
+    )
+    provider_bundle.compile_bundle_source(
+        preamble + 'extern "C" __device__ void provider_c() {}\n',
+        **_compile_kwargs("90"),
+    )
+    _isolated_provider_state["value"] = "headers-b"
+    provider_bundle.compile_bundle_source(
+        preamble + 'extern "C" __device__ void provider_d() {}\n',
+        **_compile_kwargs(),
+    )
+
+    directories = _pch_directories(fake_nvrtc)
+    assert len(directories) == 4
+    assert len(set(directories)) == 4
+
+
+def test_preamble_identity_excludes_request_body():
+    preamble = (
+        "// generated provider\n#define CUDA_COOP_FEATURE 1\n#include <stdint.h>\n"
+    )
+    first = provider_pch.provider_preamble_identity(
+        preamble + 'extern "C" void provider_a();\n'
+    )
+    second = provider_pch.provider_preamble_identity(
+        preamble + 'extern "C" void provider_b();\n'
+    )
+    different = provider_pch.provider_preamble_identity(
+        "#define CUDA_COOP_FEATURE 2\n"
+        "#include <stdint.h>\n"
+        'extern "C" void provider_a();\n'
+    )
+
+    assert first == second
+    assert different != first
+
+
+def test_preamble_identity_tracks_directives_after_multiline_comment():
+    first = provider_pch.provider_preamble_identity(
+        "#include <stdint.h> /* explanatory comment\n"
+        "continued */\n"
+        "#define CUDA_COOP_FEATURE 1\n"
+        'extern "C" void provider();\n'
+    )
+    second = provider_pch.provider_preamble_identity(
+        "#include <stdint.h> /* explanatory comment\n"
+        "continued */\n"
+        "#define CUDA_COOP_FEATURE 2\n"
+        'extern "C" void provider();\n'
+    )
+
+    assert first != second
+
+
+@pytest.mark.parametrize(
+    "preamble",
+    [
+        '#include "cuda/*literal*/header.cuh"\n',
+        "#define CUDA_COOP_MARKER L'a' /* explanatory comment\ncontinued */\n",
+        "#define CUDA_COOP_LIMIT 1'000'000'000 /* explanatory comment\ncontinued */\n",
+        "#define CUDA_COOP_FEATURE \\\n1 /* explanatory comment\ncontinued */\n",
+    ],
+)
+def test_preamble_identity_tracks_directives_after_lexical_edge_cases(preamble):
+    first = provider_pch.provider_preamble_identity(
+        preamble
+        + "#define CUDA_COOP_TRAILING_FEATURE 1\n"
+        + 'extern "C" void provider();\n'
+    )
+    second = provider_pch.provider_preamble_identity(
+        preamble
+        + "#define CUDA_COOP_TRAILING_FEATURE 2\n"
+        + 'extern "C" void provider();\n'
+    )
+
+    assert first != second
+
+
+def test_unsupported_nvrtc_and_explicit_off_skip_pch(monkeypatch):
+    fake_nvrtc = _FakeNvrtc(version=(12, 7))
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+
+    provider_bundle.compile_bundle_source(
+        'extern "C" __device__ void provider_a() {}\n',
+        **_compile_kwargs(),
+    )
+    assert _pch_directories(fake_nvrtc) == [None]
+    assert provider_pch._PCH_POOL_PATH is None
+    assert provider_bundle.get_bundle_telemetry().phase_counts["pch_unsupported"] == 1
+
+    provider_bundle.reset_compile_state()
+    monkeypatch.setenv(provider_pch.PCH_ENV, provider_pch.PCH_MODE_OFF)
+    provider_bundle.compile_bundle_source(
+        'extern "C" __device__ void provider_b() {}\n',
+        **_compile_kwargs(),
+    )
+    assert _pch_directories(fake_nvrtc) == [None, None]
+    assert provider_bundle.get_bundle_telemetry().phase_counts["pch_off"] == 1
+
+
+def test_invalid_mode_fails_before_creating_an_nvrtc_program(monkeypatch):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    monkeypatch.setenv(provider_pch.PCH_ENV, "sometimes")
+
+    with pytest.raises(DSLRuntimeError, match="Invalid .* PCH configuration"):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+
+    assert not any(call[0] == "create" for call in fake_nvrtc.calls)
+
+
+@pytest.mark.parametrize(
+    "failure_site",
+    [
+        "pool_mkdtemp",
+        "pool_chmod",
+        "pool_lstat",
+        "pool_security",
+        "domain_mkdir",
+        "domain_lstat",
+        "domain_security",
+    ],
+)
+def test_operational_setup_failure_compiles_once_and_disables_domain(
+    monkeypatch,
+    failure_site,
+):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    original_chmod = provider_pch.os.chmod
+    original_lstat = provider_pch.os.lstat
+    original_mkdir = provider_pch.os.mkdir
+
+    def is_pool(path):
+        return Path(os.fspath(path)).name.startswith("cuda-coop-cutlass-pch-")
+
+    def is_domain(path):
+        return Path(os.fspath(path)).name.startswith("domain-")
+
+    def unavailable(*_args, **_kwargs):
+        raise OSError("simulated PCH setup failure")
+
+    if failure_site == "pool_mkdtemp":
+        monkeypatch.setattr(provider_pch.tempfile, "mkdtemp", unavailable)
+    elif failure_site == "pool_chmod":
+
+        def chmod(path, mode):
+            if is_pool(path):
+                unavailable()
+            return original_chmod(path, mode)
+
+        monkeypatch.setattr(provider_pch.os, "chmod", chmod)
+    elif failure_site == "domain_mkdir":
+
+        def mkdir(path, mode=0o777):
+            if is_domain(path):
+                unavailable()
+            return original_mkdir(path, mode)
+
+        monkeypatch.setattr(provider_pch.os, "mkdir", mkdir)
+    else:
+        expected_path = is_pool if failure_site.startswith("pool_") else is_domain
+
+        def lstat(path):
+            result = original_lstat(path)
+            if not expected_path(path):
+                return result
+            if failure_site.endswith("_lstat"):
+                unavailable()
+            return SimpleNamespace(
+                st_mode=(result.st_mode & ~0o777) | 0o755,
+            )
+
+        monkeypatch.setattr(provider_pch.os, "lstat", lstat)
+
+    preamble = "#include <stdint.h>\n"
+    first = provider_bundle.compile_bundle_source(
+        preamble + 'extern "C" __device__ void provider_a() {}\n',
+        **_compile_kwargs(),
+    )
+    second = provider_bundle.compile_bundle_source(
+        preamble + 'extern "C" __device__ void provider_b() {}\n',
+        **_compile_kwargs(),
+    )
+    if "lstat" in failure_site or "security" in failure_site:
+        monkeypatch.setattr(provider_pch.os, "lstat", original_lstat)
+
+    assert Path(first).is_file()
+    assert Path(second).is_file()
+    assert _pch_directories(fake_nvrtc) == [None, None]
+    assert provider_bundle.get_nvrtc_compile_program_counter() == 2
+    assert len([call for call in fake_nvrtc.calls if call[0] == "create"]) == 2
+    assert len([call for call in fake_nvrtc.calls if call[0] == "destroy"]) == 2
+    telemetry = provider_bundle.get_bundle_telemetry()
+    assert telemetry.phase_counts["pch_unavailable"] == 1
+    assert telemetry.phase_counts["pch_disabled"] == 1
+    assert "pch_fallback" not in telemetry.phase_counts
+
+
+def test_failed_pch_compile_retries_once_and_disables_domain(monkeypatch):
+    fake_nvrtc = _FakeNvrtc(fail_first_pch_compile=True)
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    preamble = "#include <stdint.h>\n"
+
+    first = provider_bundle.compile_bundle_source(
+        preamble + 'extern "C" __device__ void provider_a() {}\n',
+        **_compile_kwargs(),
+    )
+    assert provider_bundle.get_nvrtc_compile_program_counter() == 2
+    second = provider_bundle.compile_bundle_source(
+        preamble + 'extern "C" __device__ void provider_b() {}\n',
+        **_compile_kwargs(),
+    )
+
+    assert Path(first).is_file()
+    assert Path(second).is_file()
+    assert _pch_directories(fake_nvrtc) == [
+        _pch_directories(fake_nvrtc)[0],
+        None,
+        None,
+    ]
+    assert _pch_directories(fake_nvrtc)[0] is not None
+    assert len([call for call in fake_nvrtc.calls if call[0] == "create"]) == 3
+    assert len([call for call in fake_nvrtc.calls if call[0] == "destroy"]) == 3
+    assert provider_bundle.get_nvrtc_compile_program_counter() == 3
+    telemetry = provider_bundle.get_bundle_telemetry()
+    assert telemetry.phase_counts["pch_fallback"] == 1
+    assert telemetry.phase_counts["pch_disabled"] == 1
+
+
+@pytest.mark.parametrize(
+    "create_status",
+    [
+        _NvrtcResult.NVRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED,
+        _NvrtcResult.NVRTC_ERROR_PCH_CREATE,
+    ],
+)
+def test_pch_create_warning_preserves_artifact_without_heap_resize(
+    monkeypatch,
+    create_status,
+):
+    fake_nvrtc = _FakeNvrtc(create_status=create_status)
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+
+    artifact = provider_bundle.compile_bundle_source(
+        '#include <stdint.h>\nextern "C" __device__ void provider_a() {}\n',
+        **_compile_kwargs(),
+    )
+    provider_bundle.compile_bundle_source(
+        '#include <stdint.h>\nextern "C" __device__ void provider_b() {}\n',
+        **_compile_kwargs(),
+    )
+
+    assert Path(artifact).read_bytes() == fake_nvrtc.blob
+    assert not any(call[0] == "set_pch_heap_size" for call in fake_nvrtc.calls)
+    assert _pch_directories(fake_nvrtc)[0] is not None
+    assert _pch_directories(fake_nvrtc)[1] is None
+    telemetry = provider_bundle.get_bundle_telemetry()
+    assert telemetry.phase_counts["pch_create"] == 1
+    assert telemetry.phase_counts["pch_create_warning"] == 1
+    assert telemetry.phase_counts["pch_disabled"] == 1
+
+
+def test_pch_lifecycle_is_serialized_across_distinct_artifacts(monkeypatch):
+    fake_nvrtc = _FakeNvrtc(compile_delay=0.08)
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    barrier = threading.Barrier(2)
+    preamble = "#include <stdint.h>\n"
+
+    def compile_one(name):
+        barrier.wait(timeout=2)
+        return provider_bundle.compile_bundle_source(
+            preamble + f'extern "C" __device__ void {name}() {{}}\n',
+            **_compile_kwargs(),
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        artifacts = tuple(executor.map(compile_one, ("provider_a", "provider_b")))
+
+    assert len(set(artifacts)) == 2
+    assert fake_nvrtc.max_active_compiles == 1
+    telemetry = provider_bundle.get_bundle_telemetry()
+    assert telemetry.phase_counts["pch_create"] == 1
+    assert telemetry.phase_counts["pch_hit"] == 1
+
+
+def test_unrelated_pch_domains_compile_concurrently(monkeypatch):
+    compile_barrier = threading.Barrier(2)
+    fake_nvrtc = _FakeNvrtc(compile_barrier=compile_barrier)
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    start_barrier = threading.Barrier(2)
+
+    def compile_one(feature):
+        start_barrier.wait(timeout=2)
+        return provider_bundle.compile_bundle_source(
+            f"#define CUDA_COOP_FEATURE {feature}\n"
+            f'extern "C" __device__ void provider_{feature}() {{}}\n',
+            **_compile_kwargs(),
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        artifacts = tuple(executor.map(compile_one, (1, 2)))
+
+    assert len(set(artifacts)) == 2
+    assert fake_nvrtc.max_active_compiles == 2
+
+
+def _forked_pool_worker(connection):
+    with provider_pch.pch_session(
+        nvrtc_version=(13, 0),
+        bundle_arch="compute_80",
+        bundle_sm_arch="sm_80",
+        compiler_options=("--std=c++17",),
+        include_dirs=("/include",),
+        header_identity="headers",
+        preamble_identity="preamble",
+    ) as session:
+        connection.send((os.getpid(), session.directory))
+    _reset_pch_state()
+    connection.close()
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork"),
+    reason="test requires POSIX fork state reset",
+)
+@pytest.mark.filterwarnings(
+    "ignore:This process .* is multi-threaded, use of fork.*:DeprecationWarning"
+)
+def test_fork_uses_a_new_process_private_pool():
+    with provider_pch.pch_session(
+        nvrtc_version=(13, 0),
+        bundle_arch="compute_80",
+        bundle_sm_arch="sm_80",
+        compiler_options=("--std=c++17",),
+        include_dirs=("/include",),
+        header_identity="headers",
+        preamble_identity="preamble",
+    ) as parent_session:
+        parent_directory = Path(parent_session.directory)
+    parent_pool = parent_directory.parent
+
+    context = multiprocessing.get_context("fork")
+    parent_connection, child_connection = context.Pipe(duplex=False)
+    process = context.Process(
+        target=_forked_pool_worker,
+        args=(child_connection,),
+    )
+    process.start()
+    assert parent_connection.poll(5)
+    child_pid, child_directory_text = parent_connection.recv()
+    process.join(timeout=5)
+
+    assert not process.is_alive()
+    assert process.exitcode == 0
+    child_pool = Path(child_directory_text).parent
+    assert child_pool != parent_pool
+    assert str(child_pid) in child_pool.name
+    assert str(os.getpid()) in parent_pool.name
+    assert parent_pool.is_dir()
+    assert stat.S_IMODE(parent_pool.stat().st_mode) == 0o700

--- a/python/cuda_coop/tests/backends/cutlass/unit/test_public_foundation.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/test_public_foundation.py
@@ -69,6 +69,8 @@ def test_cutlass_foundation_exports_current_public_surface():
         )
         assert "cuda.coop.cutlass._compiler._bundle" not in sys.modules
         assert "cuda.coop.cutlass._compiler._finalize" not in sys.modules
+        assert "cuda.coop.cutlass._compiler._pch" not in sys.modules
+
         dsl = _cuda_coop_test_dsl.CuTeDSL._get_dsl()
         assert len(dsl.trace_context_factories) == 1
 


### PR DESCRIPTION
## Why this is needed

CUTLASS provider compilation repeatedly parses the same heavy CUDA/CUB header
preamble. This layer lets compatible NVRTC compilations in one process share
a process-managed precompiled header while preserving the existing provider
API and a safe non-PCH fallback.

## What this PR includes

- process-private automatic NVRTC PCH creation and reuse
- exact domain partitioning by compiler, target, options, headers, and preamble
- off, unsupported, unavailable, warning, and compile-fallback paths
- serialized same-domain creation, independent-domain concurrency, fork
  isolation, cleanup, and phase telemetry

The final stack layer owns AOT capture and publication.

## Stack

6 of 7, based on [PR #11047](https://github.com/NVIDIA/cccl/pull/11047).
The final layer adds relocatable CUTLASS provider AOT packs.

## Local validation

- 72 exact focused PCH/provider tests passed; the complete related compiler
  selection passed 87 tests
- real automatic mode compiled float32 and float64 Merge Sort providers with
  one PCH creation, one hit, and matching GPU output
- real off mode compiled both providers without PCH and matched GPU output
- fallback, domain partitioning, concurrency, fork reset, telemetry, source
  imports, `compileall`, changed-file pre-commit, and `git diff --check` passed

Wheel and installed-package qualification, GitHub CI, and automated AI review
are deferred for now.
