### PR TITLE
Add relocatable CUTLASS provider AOT packs

### DIFF
--- a/ci/validate_cuda_coop_wheel.py
+++ b/ci/validate_cuda_coop_wheel.py
@@ -45,6 +45,7 @@ _REQUIRED_STUBS = {
     "cuda/coop/cutlass/_thread_data.pyi",
     "cuda/coop/cutlass/_thread_group.pyi",
     "cuda/coop/cutlass/_typing.pyi",
+    "cuda/coop/cutlass/aot.pyi",
     *{f"cuda/coop/cutlass/_group_{family}.pyi" for family in _PRIMITIVE_FAMILIES},
     "cuda/coop/numba_mlir/__init__.pyi",
     "cuda/coop/numba_mlir/_dataclass.pyi",

--- a/docs/python/coop.rst
+++ b/docs/python/coop.rst
@@ -216,6 +216,22 @@ to carry the running prefix forward.
 ``block_prefix_callback_op`` remains an accepted compatibility spelling for
 ``prefix_op``. Warp scans intentionally do not accept either callback form.
 
+CUTLASS AOT packs
+-----------------
+
+The CUTLASS backend can capture exact provider LTO-IR bundles with
+``cuda-coop-aot`` or :func:`cuda.coop.cutlass.aot.capture` and select them with
+:func:`cuda.coop.cutlass.aot.use`. Treat a pack as executable device code:
+digests detect corruption but do not authenticate its producer or establish
+that its LTO-IR is safe. Consume only packs from a build or producer you trust.
+
+Reuse matches the provider ABI, rendered source, bundle format, target
+architecture, compiler options, layout expressions, and nvJitLink
+compatibility. The writer version is informational. Exact hits intentionally
+avoid current-header discovery, so a header or provider change that alters the
+ABI or semantics of otherwise identical rendered source requires a
+provider-ABI bump.
+
 .. _cuda-coop-examples:
 
 Examples

--- a/docs/python/coop_api.rst
+++ b/docs/python/coop_api.rst
@@ -25,7 +25,7 @@ CUTLASS-qualified API
 The qualified module provides the same group constructors and primitive
 families as the portable API. It additionally exports ``ThreadDataSource``,
 ``ThreadDataLoadSource``, and ``ThreadDataTensorMetadata`` for adapting CuTe
-register values.
+register values, plus the :mod:`cuda.coop.cutlass.aot` pack interface.
 
 See the :github:`CUTLASS type declarations
 <python/cuda_coop/cuda/coop/cutlass/__init__.pyi>` for its complete overload

--- a/python/cuda_coop/ARCHITECTURE.md
+++ b/python/cuda_coop/ARCHITECTURE.md
@@ -71,13 +71,22 @@ compilers have the same execution model.
 
 CUTLASS traces qualified calls and registers immutable provider requests in a
 per-trace session. Finalization renders all requested providers in canonical
-order, resolves an exact cache hit when possible, otherwise compiles one bundle,
-materializes deferred scratch storage, and attaches the resulting linkable
-artifact to the kernel.
+order, resolves an exact AOT or cache hit when possible, otherwise compiles one
+bundle, materializes deferred scratch storage, and attaches the resulting
+linkable artifact to the kernel.
 
-A JIT path must preload NVRTC before querying its version or constructing PCH
-state. Renderer kinds, source bytes, generated symbols, bundle identities, and
-cache schemas must not change merely because Python modules move.
+The ordering is a compatibility contract. An exact AOT hit must avoid header
+discovery and mutable cache/toolchain state. A JIT path must preload NVRTC
+before querying its version or constructing PCH state. Renderer kinds, source
+bytes, generated symbols, bundle identities, cache schemas, and AOT manifests
+must not change merely because Python modules move.
+
+AOT portability is governed by the provider ABI plus exact rendered source,
+bundle format, architecture, compiler options, layout expressions, and linker
+compatibility. The writer version is diagnostic rather than an equality gate,
+and current headers are intentionally absent from an exact-hit lookup. A
+header or provider change that can alter the ABI or semantics of identical
+rendered source therefore requires a provider-ABI bump.
 
 ### Numba-CUDA-MLIR
 
@@ -111,7 +120,7 @@ that manage activation can disable portable-root probing before import with
   compiler evidence used to resolve that description, not part of the public
   container itself.
 - Semantic and artifact keys describe behavior and generated-provider
-  identity. Persisted cache formats are versioned only when their actual
+  identity. Persisted cache or AOT formats are versioned only when their actual
   representation changes; directory or module renames do not justify a new
   version.
 

--- a/python/cuda_coop/README.md
+++ b/python/cuda_coop/README.md
@@ -123,6 +123,37 @@ type declarations for the exact dtype, boundary, and result contracts:
 - [CUTLASS API][cutlass-stubs]
 - [Numba-CUDA-MLIR API][numba-stubs]
 
+## CUTLASS provider AOT packs
+
+The CUTLASS backend normally compiles its generated provider bundles as it
+traces a workload. An AOT pack records those exact LTO-IR bundles for reuse on
+machines with compatible CUDA and `cuda.coop` installations. Capture and
+consume packs with the `cuda-coop-aot` command, which requires
+`cuda-coop[cutlass]`. Pack capture, inspection, and use currently require
+Linux:
+
+```console
+cuda-coop-aot capture --output workload.coop-aot -- python workload.py
+cuda-coop-aot inspect workload.coop-aot
+cuda-coop-aot run --pack workload.coop-aot --mode required -- python workload.py
+```
+
+`auto` mode falls back to normal provider compilation after a pack miss,
+`required` reports the miss, and `off` ignores the selected pack. The same
+controls are available through `cuda.coop.cutlass.aot.capture()` and
+`cuda.coop.cutlass.aot.use()`.
+
+Treat an AOT pack as executable device code. Pack digests detect corruption;
+they do not authenticate who produced the pack or prove that its LTO-IR is
+safe. Consume only packs captured by a build or producer you trust.
+
+Pack reuse matches the provider ABI, exact rendered source, bundle format,
+target architecture, compiler options, scratch-layout expressions, and
+nvJitLink compatibility. The recorded writer version is informational, and an
+exact hit intentionally precedes current-header discovery. A change in shipped
+headers that can alter an otherwise identical provider's ABI or semantics must
+bump the provider ABI and invalidate older packs.
+
 ## Examples
 
 The [examples guide][examples-guide] contains complete programs that

--- a/python/cuda_coop/cuda/coop/_aot_cli.py
+++ b/python/cuda_coop/cuda/coop/_aot_cli.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Dependency-light launcher for the optional CUTLASS AOT command."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Sequence
+
+_LINUX_ONLY_ERROR = "CUTLASS provider AOT packs currently require Linux."
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Load the optional CUTLASS command with concise dependency diagnostics."""
+
+    if sys.platform != "linux":
+        print(f"cuda-coop-aot: error: {_LINUX_ONLY_ERROR}", file=sys.stderr)
+        return 2
+    try:
+        cli = importlib.import_module("cuda.coop.cutlass._aot_cli")
+    except ImportError as error:
+        if getattr(error, "backend", None) != "cutlass":
+            raise
+        print(f"cuda-coop-aot: error: {error}", file=sys.stderr)
+        return 2
+    return int(cli.main(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/cuda_coop/cuda/coop/cutlass/__init__.py
+++ b/python/cuda_coop/cuda/coop/cutlass/__init__.py
@@ -65,6 +65,7 @@ __all__ = [
     "ThreadGroup",
     "ThreadHierarchy",
     "adjacent_difference",
+    "aot",
     "discontinuity",
     "exchange",
     "exclusive_scan",
@@ -102,6 +103,10 @@ def __getattr__(name: str):
         value = module.TempStorage
         globals()[name] = value
         return value
+    if name == "aot":
+        module = _importlib.import_module(f"{__name__}.aot")
+        globals()[name] = module
+        return module
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/python/cuda_coop/cuda/coop/cutlass/__init__.pyi
+++ b/python/cuda_coop/cuda/coop/cutlass/__init__.pyi
@@ -4,6 +4,7 @@
 
 """CUTLASS-qualified cooperative primitives and payload helpers."""
 
+from . import aot
 from ._group_adjacent_difference import adjacent_difference
 from ._group_discontinuity import discontinuity
 from ._group_exchange import exchange
@@ -50,6 +51,7 @@ __all__ = [
     "ThreadGroup",
     "ThreadHierarchy",
     "adjacent_difference",
+    "aot",
     "discontinuity",
     "exchange",
     "exclusive_scan",

--- a/python/cuda_coop/cuda/coop/cutlass/_aot_cli.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_aot_cli.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Command-line capture and selection for CUTLASS provider AOT packs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import runpy
+import shutil
+import sys
+from collections.abc import Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import NoReturn
+
+from . import _aot_pack, aot
+
+
+class _WorkloadExit(Exception):
+    def __init__(self, code: int):
+        super().__init__(code)
+        self.code = code
+
+
+class _CommandError(ValueError):
+    pass
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cuda-coop-aot",
+        description="Capture, select, and inspect CUTLASS provider AOT packs.",
+    )
+    subparsers = parser.add_subparsers(dest="action", required=True)
+
+    capture_parser = subparsers.add_parser(
+        "capture",
+        help="run a Python workload and atomically capture its provider bundles",
+    )
+    capture_parser.add_argument("--output", required=True, type=Path)
+    capture_parser.add_argument("--name")
+    capture_parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="Python script or -m module command following --",
+    )
+
+    run_parser = subparsers.add_parser(
+        "run",
+        help="run a Python workload with an explicit provider pack",
+    )
+    run_parser.add_argument("--pack", required=True, type=Path)
+    run_parser.add_argument(
+        "--mode",
+        choices=("auto", "required", "off"),
+        default="auto",
+    )
+    run_parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="Python script or -m module command following --",
+    )
+
+    inspect_parser = subparsers.add_parser(
+        "inspect",
+        help="validate a provider pack and emit structured JSON",
+    )
+    inspect_parser.add_argument("pack", type=Path)
+    return parser
+
+
+def _command_error(message: str) -> NoReturn:
+    raise _CommandError(message)
+
+
+def _strip_separator(command: Sequence[str]) -> list[str]:
+    result = list(command)
+    if result and result[0] == "--":
+        result.pop(0)
+    if not result:
+        _command_error("a Python workload command is required after --")
+    return result
+
+
+def _same_interpreter(command: str) -> bool:
+    resolved = shutil.which(command)
+    if resolved is None:
+        return False
+    try:
+        return os.path.samefile(resolved, sys.executable)
+    except OSError:
+        return os.path.realpath(resolved) == os.path.realpath(sys.executable)
+
+
+def _python_workload(command: Sequence[str]) -> tuple[str, str, list[str]]:
+    arguments = _strip_separator(command)
+    interpreter = arguments.pop(0)
+    if not _same_interpreter(interpreter):
+        _command_error(
+            "the workload must use the same Python interpreter as cuda-coop-aot"
+        )
+    if not arguments:
+        _command_error("the Python workload is missing a script or -m module")
+    if arguments[0] == "-m":
+        if len(arguments) < 2 or not arguments[1] or arguments[1].startswith("-"):
+            _command_error("-m requires a non-empty Python module name")
+        return "module", arguments[1], arguments[2:]
+    if arguments[0].startswith("-"):
+        _command_error(
+            "only 'python SCRIPT ...' and 'python -m MODULE ...' are supported"
+        )
+    return "script", arguments[0], arguments[1:]
+
+
+def _system_exit_code(exception: SystemExit) -> int:
+    code = exception.code
+    if code is None:
+        return 0
+    if isinstance(code, int):
+        return code
+    print(code, file=sys.stderr)
+    return 1
+
+
+def _run_python_workload(command: Sequence[str]) -> int:
+    kind, target, arguments = _python_workload(command)
+    original_argv = sys.argv
+    original_path = sys.path
+    original_path_contents = list(sys.path)
+    try:
+        if kind == "module":
+            sys.argv = [target, *arguments]
+            sys.path[0:1] = [os.getcwd()]
+            try:
+                runpy.run_module(target, run_name="__main__", alter_sys=True)
+            except SystemExit as exception:
+                return _system_exit_code(exception)
+        else:
+            script = Path(target).expanduser().resolve()
+            if not script.is_file():
+                _command_error(f"Python workload script does not exist: {target}")
+            sys.argv = [str(script), *arguments]
+            sys.path[0:1] = [str(script.parent)]
+            try:
+                runpy.run_path(str(script), run_name="__main__")
+            except SystemExit as exception:
+                return _system_exit_code(exception)
+    finally:
+        sys.argv = original_argv
+        sys.path = original_path
+        sys.path[:] = original_path_contents
+    return 0
+
+
+def _run_capture(arguments: argparse.Namespace) -> int:
+    try:
+        with aot.capture(arguments.output, name=arguments.name) as captured:
+            code = _run_python_workload(arguments.command)
+            if code:
+                raise _WorkloadExit(code)
+    except _WorkloadExit as exception:
+        return exception.code
+    result = captured.result
+    print(
+        f"Captured {len(result.entries)} provider bundle(s) to {result.path}.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def _run_with_pack(arguments: argparse.Namespace) -> int:
+    pack_path = os.path.abspath(os.path.expanduser(os.fspath(arguments.pack)))
+    previous_path = os.environ.get(_aot_pack.PACK_PATH_ENV)
+    previous_mode = os.environ.get(_aot_pack.PACK_MODE_ENV)
+    os.environ[_aot_pack.PACK_PATH_ENV] = pack_path
+    os.environ[_aot_pack.PACK_MODE_ENV] = arguments.mode
+    try:
+        with aot.use(arguments.pack, mode=arguments.mode):
+            return _run_python_workload(arguments.command)
+    finally:
+        if previous_path is None:
+            os.environ.pop(_aot_pack.PACK_PATH_ENV, None)
+        else:
+            os.environ[_aot_pack.PACK_PATH_ENV] = previous_path
+        if previous_mode is None:
+            os.environ.pop(_aot_pack.PACK_MODE_ENV, None)
+        else:
+            os.environ[_aot_pack.PACK_MODE_ENV] = previous_mode
+
+
+def _run_inspect(arguments: argparse.Namespace) -> int:
+    info = aot.inspect(arguments.pack)
+    payload = asdict(info)
+    payload["path"] = os.fspath(info.path)
+    payload["artifact_bytes"] = info.artifact_bytes
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    try:
+        arguments = parser.parse_args(argv)
+        if arguments.action == "capture":
+            return _run_capture(arguments)
+        if arguments.action == "run":
+            return _run_with_pack(arguments)
+        if arguments.action == "inspect":
+            return _run_inspect(arguments)
+    except (aot.PackError, _CommandError) as exception:
+        parser.error(str(exception))
+    raise AssertionError(f"unhandled cuda-coop-aot action: {arguments.action}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/cuda_coop/cuda/coop/cutlass/_aot_pack.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_aot_pack.py
@@ -1,0 +1,1717 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Portable exact-bundle AOT packs for the CUTLASS cooperative provider."""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import functools
+import hashlib
+import importlib.metadata
+import json
+import os
+import re
+import shutil
+import stat
+import sys
+import tempfile
+import threading
+import warnings
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Literal
+
+PACK_FORMAT = "cuda.coop.cutlass.aot-pack"
+PACK_SCHEMA_VERSION = 1
+PROVIDER_ABI_VERSION = 1
+PACK_PATH_ENV = "CUDA_COOP_CUTLASS_AOT_PACK_PATH"
+PACK_MODE_ENV = "CUDA_COOP_CUTLASS_AOT_MODE"
+MANIFEST_NAME = "manifest.json"
+_CAPTURE_PROCESS_BOUNDARY_ERROR = (
+    "AOT capture contexts cannot cross a process boundary; "
+    "enter capture after the child process starts."
+)
+MAX_MANIFEST_BYTES = 16 * 1024 * 1024
+MAX_SOURCE_BYTES = 64 * 1024 * 1024
+
+_AT_FDCWD = -100
+_RENAME_NOREPLACE = 1
+_MFD_CLOEXEC = 0x0001
+_MFD_ALLOW_SEALING = 0x0002
+_F_ADD_SEALS = 1033
+_F_SEAL_SEAL = 0x0001
+_F_SEAL_SHRINK = 0x0002
+_F_SEAL_GROW = 0x0004
+_F_SEAL_WRITE = 0x0008
+_HEX_DIGEST = re.compile(r"[0-9a-f]{64}")
+_VERSION = re.compile(r"([0-9]+)\.([0-9]+)(?:\.[0-9]+)?")
+_COMPUTE_ARCH = re.compile(r"compute_([0-9]+[af]?)")
+_SM_ARCH = re.compile(r"sm_([0-9]+[af]?)")
+_VALID_MODES = frozenset({"auto", "required", "off"})
+
+
+def _provider_contract():
+    """Load compiler identity types only when an AOT operation needs them."""
+
+    from ._compiler import _bundle_contract
+
+    return _bundle_contract
+
+
+class PackError(RuntimeError):
+    """Base error for CUTLASS cooperative AOT packs."""
+
+
+class PackIntegrityError(PackError):
+    """A pack is malformed, corrupt, or unsupported."""
+
+
+class PackMissError(PackError):
+    """A required pack has no compatible exact-bundle entry."""
+
+
+class CaptureError(PackError):
+    """A provider resolution cannot be captured or published."""
+
+
+def _require_supported_platform() -> None:
+    if sys.platform != "linux":
+        raise PackError("CUTLASS provider AOT packs currently require Linux.")
+
+
+@dataclass(frozen=True)
+class EntryInfo:
+    """Portable information about one exact provider bundle."""
+
+    entry_id: str
+    source_sha256: str
+    artifact_sha256: str
+    artifact_size: int
+    provider_abi_version: int
+    bundle_format: str
+    compute_arch: str
+    sm_arch: str
+    compiler_options: tuple[str, ...]
+    layout_expressions: tuple[str, ...]
+    symbols: tuple[str, ...]
+    producer_compiler: str
+    producer_version: tuple[int, int]
+    producer_toolkit_version: str | None
+
+
+@dataclass(frozen=True)
+class PackInfo:
+    """Validated information about one relocatable AOT pack."""
+
+    path: Path
+    name: str | None
+    schema_version: int
+    provider_abi_version: int
+    writer_version: str
+    entries: tuple[EntryInfo, ...]
+
+    @property
+    def artifact_bytes(self) -> int:
+        return sum(entry.artifact_size for entry in self.entries)
+
+
+@dataclass(frozen=True)
+class CaptureResult:
+    """Result published by a successful capture context."""
+
+    path: Path
+    name: str | None
+    observations: int
+    entries: tuple[EntryInfo, ...]
+
+    @property
+    def artifact_bytes(self) -> int:
+        return sum(entry.artifact_size for entry in self.entries)
+
+
+@dataclass(frozen=True)
+class _CudaVersion:
+    major: int
+    minor: int
+
+
+@dataclass(frozen=True)
+class _ManifestIdentity:
+    provider_abi_version: int
+    source_sha256: str
+    bundle_format: str
+    compute_arch: str
+    sm_arch: str
+    compiler_options: tuple[str, ...]
+    layout_expressions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _ManifestLayout:
+    expression: str
+    size_in_bytes: int
+    alignment: int
+
+
+@dataclass(frozen=True)
+class _ManifestEntry:
+    entry_id: str
+    identity: _ManifestIdentity
+    artifact_sha256: str
+    artifact_size: int
+    producer_compiler: str
+    producer_version: _CudaVersion
+    producer_toolkit_version: str | None
+    layouts: tuple[_ManifestLayout, ...]
+    symbols: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _Manifest:
+    name: str | None
+    writer_version: str
+    entries: tuple[_ManifestEntry, ...]
+
+
+@dataclass(frozen=True)
+class _LoadedPack:
+    root: Path
+    manifest: _Manifest
+    entries_by_id: Mapping[str, _ManifestEntry]
+    artifact_paths_by_digest: Mapping[str, str]
+
+    @property
+    def info(self) -> PackInfo:
+        return _pack_info(self.root, self.manifest)
+
+
+@dataclass(frozen=True)
+class _Selection:
+    mode: Literal["auto", "required", "off"]
+    pack: _LoadedPack | None
+
+
+@dataclass(frozen=True)
+class _MaterializedArtifact:
+    digest: str
+    descriptor: int
+    path: str
+    size: int
+
+
+class _DuplicateJsonKey(ValueError):
+    pass
+
+
+_ACTIVE_CAPTURE: ContextVar[Capture | None] = ContextVar(
+    "cuda_coop_cutlass_active_aot_capture",
+    default=None,
+)
+_ACTIVE_SELECTION: ContextVar[_Selection | None] = ContextVar(
+    "cuda_coop_cutlass_active_aot_selection",
+    default=None,
+)
+_PACK_CACHE: dict[str, _LoadedPack] = {}
+_PACK_CACHE_LOCK = threading.RLock()
+_MATERIALIZED_ARTIFACTS: dict[str, _MaterializedArtifact] = {}
+_MATERIALIZED_ARTIFACTS_BY_PATH: dict[str, _MaterializedArtifact] = {}
+_MATERIALIZED_ARTIFACTS_LOCK = threading.RLock()
+
+
+def _reset_locks_after_fork() -> None:
+    global _MATERIALIZED_ARTIFACTS_LOCK, _PACK_CACHE_LOCK
+    _PACK_CACHE_LOCK = threading.RLock()
+    _MATERIALIZED_ARTIFACTS_LOCK = threading.RLock()
+    capture = _ACTIVE_CAPTURE.get()
+    if capture is None:
+        return
+
+    _ACTIVE_CAPTURE.set(None)
+    sink = capture._sink
+    observers_context = capture._provider_observers_context
+    if sink is not None and observers_context is not None:
+        observers_context.set(
+            tuple(
+                observer
+                for observer in observers_context.get()
+                if getattr(observer, "__self__", None) is not sink
+            )
+        )
+    capture._capture_token = None
+    capture._observer_context = None
+    capture._provider_observers_context = None
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_locks_after_fork)
+
+
+def _secure_nofollow_flag() -> int:
+    flag = getattr(os, "O_NOFOLLOW", None)
+    if flag is None:
+        raise PackError("Secure AOT pack reads require O_NOFOLLOW support.")
+    return flag
+
+
+def _canonical_json_bytes(payload: Any) -> bytes:
+    return (
+        json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _object_without_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKey(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _require_exact_keys(
+    value: Any,
+    keys: frozenset[str],
+    *,
+    description: str,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise PackIntegrityError(f"{description} must be a JSON object.")
+    actual = frozenset(value)
+    if actual != keys:
+        missing = sorted(keys - actual)
+        unexpected = sorted(actual - keys)
+        raise PackIntegrityError(
+            f"{description} has invalid fields: "
+            f"missing={missing}, unexpected={unexpected}."
+        )
+    return value
+
+
+def _require_string(value: Any, *, description: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise PackIntegrityError(f"{description} must be a non-empty string.")
+    return value
+
+
+def _require_optional_string(value: Any, *, description: str) -> str | None:
+    if value is None:
+        return None
+    return _require_string(value, description=description)
+
+
+def _require_integer(
+    value: Any,
+    *,
+    description: str,
+    minimum: int = 0,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise PackIntegrityError(
+            f"{description} must be an integer greater than or equal to {minimum}."
+        )
+    return value
+
+
+def _require_digest(value: Any, *, description: str) -> str:
+    digest = _require_string(value, description=description)
+    if _HEX_DIGEST.fullmatch(digest) is None:
+        raise PackIntegrityError(
+            f"{description} must be a lowercase SHA-256 hexadecimal digest."
+        )
+    return digest
+
+
+def _require_string_tuple(value: Any, *, description: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise PackIntegrityError(f"{description} must be a JSON array.")
+    return tuple(
+        _require_string(item, description=f"{description} item") for item in value
+    )
+
+
+def _identity_payload(identity: _ManifestIdentity) -> dict[str, Any]:
+    return {
+        "bundle_format": identity.bundle_format,
+        "compiler_options": list(identity.compiler_options),
+        "compute_arch": identity.compute_arch,
+        "layout_expressions": list(identity.layout_expressions),
+        "provider_abi_version": identity.provider_abi_version,
+        "sm_arch": identity.sm_arch,
+        "source_sha256": identity.source_sha256,
+    }
+
+
+def _entry_id(
+    identity: _ManifestIdentity,
+    symbols: tuple[str, ...],
+) -> str:
+    return hashlib.sha256(
+        _canonical_json_bytes(
+            {
+                "identity": _identity_payload(identity),
+                "symbols": list(symbols),
+            }
+        )
+    ).hexdigest()
+
+
+def _layout_payload(layout: _ManifestLayout) -> dict[str, Any]:
+    return {
+        "alignment": layout.alignment,
+        "expression": layout.expression,
+        "size_in_bytes": layout.size_in_bytes,
+    }
+
+
+def _entry_payload(entry: _ManifestEntry) -> dict[str, Any]:
+    return {
+        "artifact_sha256": entry.artifact_sha256,
+        "artifact_size": entry.artifact_size,
+        "entry_id": entry.entry_id,
+        "identity": _identity_payload(entry.identity),
+        "layouts": [_layout_payload(layout) for layout in entry.layouts],
+        "producer": {
+            "compiler": entry.producer_compiler,
+            "toolkit_version": entry.producer_toolkit_version,
+            "version": {
+                "major": entry.producer_version.major,
+                "minor": entry.producer_version.minor,
+            },
+        },
+        "symbols": list(entry.symbols),
+    }
+
+
+def _manifest_payload(manifest: _Manifest) -> dict[str, Any]:
+    return {
+        "entries": [_entry_payload(entry) for entry in manifest.entries],
+        "format": PACK_FORMAT,
+        "name": manifest.name,
+        "provider_abi_version": PROVIDER_ABI_VERSION,
+        "schema_version": PACK_SCHEMA_VERSION,
+        "writer": {
+            "package": "cuda-coop",
+            "version": manifest.writer_version,
+        },
+    }
+
+
+def _parse_identity(value: Any, *, entry_index: int) -> _ManifestIdentity:
+    payload = _require_exact_keys(
+        value,
+        frozenset(
+            {
+                "bundle_format",
+                "compiler_options",
+                "compute_arch",
+                "layout_expressions",
+                "provider_abi_version",
+                "sm_arch",
+                "source_sha256",
+            }
+        ),
+        description=f"entry {entry_index} identity",
+    )
+    identity = _ManifestIdentity(
+        provider_abi_version=_require_integer(
+            payload["provider_abi_version"],
+            description=f"entry {entry_index} provider ABI version",
+            minimum=1,
+        ),
+        source_sha256=_require_digest(
+            payload["source_sha256"],
+            description=f"entry {entry_index} source digest",
+        ),
+        bundle_format=_require_string(
+            payload["bundle_format"],
+            description=f"entry {entry_index} bundle format",
+        ),
+        compute_arch=_require_string(
+            payload["compute_arch"],
+            description=f"entry {entry_index} compute architecture",
+        ),
+        sm_arch=_require_string(
+            payload["sm_arch"],
+            description=f"entry {entry_index} SM architecture",
+        ),
+        compiler_options=_require_string_tuple(
+            payload["compiler_options"],
+            description=f"entry {entry_index} compiler options",
+        ),
+        layout_expressions=_require_string_tuple(
+            payload["layout_expressions"],
+            description=f"entry {entry_index} layout expressions",
+        ),
+    )
+    if identity.provider_abi_version != PROVIDER_ABI_VERSION:
+        raise PackIntegrityError(
+            f"entry {entry_index} uses unsupported provider ABI version "
+            f"{identity.provider_abi_version}."
+        )
+    if identity.bundle_format != "ltoir":
+        raise PackIntegrityError(f"entry {entry_index} must contain an LTO-IR bundle.")
+    compute_match = _COMPUTE_ARCH.fullmatch(identity.compute_arch)
+    sm_match = _SM_ARCH.fullmatch(identity.sm_arch)
+    if (
+        compute_match is None
+        or sm_match is None
+        or compute_match.group(1) != sm_match.group(1)
+    ):
+        raise PackIntegrityError(
+            f"entry {entry_index} compute and SM architectures must be an "
+            "exact matching compute_N/sm_N pair."
+        )
+    if tuple(sorted(set(identity.layout_expressions))) != identity.layout_expressions:
+        raise PackIntegrityError(
+            f"entry {entry_index} layout expressions must be unique and sorted."
+        )
+    return identity
+
+
+def _parse_layout(
+    value: Any, *, entry_index: int, layout_index: int
+) -> _ManifestLayout:
+    payload = _require_exact_keys(
+        value,
+        frozenset({"alignment", "expression", "size_in_bytes"}),
+        description=f"entry {entry_index} layout {layout_index}",
+    )
+    layout = _ManifestLayout(
+        expression=_require_string(
+            payload["expression"],
+            description=f"entry {entry_index} layout {layout_index} expression",
+        ),
+        size_in_bytes=_require_integer(
+            payload["size_in_bytes"],
+            description=f"entry {entry_index} layout {layout_index} size",
+            minimum=1,
+        ),
+        alignment=_require_integer(
+            payload["alignment"],
+            description=f"entry {entry_index} layout {layout_index} alignment",
+            minimum=1,
+        ),
+    )
+    if (
+        layout.alignment & (layout.alignment - 1)
+        or layout.size_in_bytes % layout.alignment
+    ):
+        raise PackIntegrityError(
+            f"entry {entry_index} layout {layout_index} has an invalid "
+            "size or alignment."
+        )
+    return layout
+
+
+def _parse_entry(value: Any, *, entry_index: int) -> _ManifestEntry:
+    payload = _require_exact_keys(
+        value,
+        frozenset(
+            {
+                "artifact_sha256",
+                "artifact_size",
+                "entry_id",
+                "identity",
+                "layouts",
+                "producer",
+                "symbols",
+            }
+        ),
+        description=f"entry {entry_index}",
+    )
+    identity = _parse_identity(payload["identity"], entry_index=entry_index)
+    producer = _require_exact_keys(
+        payload["producer"],
+        frozenset({"compiler", "toolkit_version", "version"}),
+        description=f"entry {entry_index} producer",
+    )
+    producer_version = _require_exact_keys(
+        producer["version"],
+        frozenset({"major", "minor"}),
+        description=f"entry {entry_index} producer version",
+    )
+    layouts_value = payload["layouts"]
+    if not isinstance(layouts_value, list):
+        raise PackIntegrityError(f"entry {entry_index} layouts must be a JSON array.")
+    layouts = tuple(
+        _parse_layout(item, entry_index=entry_index, layout_index=layout_index)
+        for layout_index, item in enumerate(layouts_value)
+    )
+    entry = _ManifestEntry(
+        entry_id=_require_digest(
+            payload["entry_id"],
+            description=f"entry {entry_index} ID",
+        ),
+        identity=identity,
+        artifact_sha256=_require_digest(
+            payload["artifact_sha256"],
+            description=f"entry {entry_index} artifact digest",
+        ),
+        artifact_size=_require_integer(
+            payload["artifact_size"],
+            description=f"entry {entry_index} artifact size",
+            minimum=1,
+        ),
+        producer_compiler=_require_string(
+            producer["compiler"],
+            description=f"entry {entry_index} producer compiler",
+        ),
+        producer_version=_CudaVersion(
+            major=_require_integer(
+                producer_version["major"],
+                description=f"entry {entry_index} producer major version",
+            ),
+            minor=_require_integer(
+                producer_version["minor"],
+                description=f"entry {entry_index} producer minor version",
+            ),
+        ),
+        producer_toolkit_version=_require_optional_string(
+            producer["toolkit_version"],
+            description=f"entry {entry_index} producer toolkit version",
+        ),
+        layouts=layouts,
+        symbols=_require_string_tuple(
+            payload["symbols"],
+            description=f"entry {entry_index} symbols",
+        ),
+    )
+    if entry.entry_id != _entry_id(identity, entry.symbols):
+        raise PackIntegrityError(
+            f"entry {entry_index} ID does not match its exact bundle identity "
+            "and symbol set."
+        )
+    if entry.producer_compiler != "nvrtc":
+        raise PackIntegrityError(
+            f"entry {entry_index} has unsupported producer compiler "
+            f"{entry.producer_compiler!r}."
+        )
+    layout_expressions = tuple(layout.expression for layout in entry.layouts)
+    if layout_expressions != identity.layout_expressions:
+        raise PackIntegrityError(
+            f"entry {entry_index} layout metadata does not match its identity."
+        )
+    if tuple(sorted(set(entry.symbols))) != entry.symbols:
+        raise PackIntegrityError(
+            f"entry {entry_index} symbols must be unique and sorted."
+        )
+    return entry
+
+
+def _parse_manifest(data: bytes) -> _Manifest:
+    try:
+        payload = json.loads(
+            data,
+            object_pairs_hook=_object_without_duplicate_keys,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                ValueError(f"invalid JSON constant {value}")
+            ),
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise PackIntegrityError(
+            "AOT pack manifest is not valid canonical JSON."
+        ) from exc
+    root = _require_exact_keys(
+        payload,
+        frozenset(
+            {
+                "entries",
+                "format",
+                "name",
+                "provider_abi_version",
+                "schema_version",
+                "writer",
+            }
+        ),
+        description="AOT pack manifest",
+    )
+    if root["format"] != PACK_FORMAT:
+        raise PackIntegrityError("AOT pack manifest has an unsupported format.")
+    if root["schema_version"] != PACK_SCHEMA_VERSION:
+        raise PackIntegrityError(
+            f"AOT pack manifest uses unsupported schema version "
+            f"{root['schema_version']!r}."
+        )
+    if root["provider_abi_version"] != PROVIDER_ABI_VERSION:
+        raise PackIntegrityError(
+            f"AOT pack manifest uses unsupported provider ABI version "
+            f"{root['provider_abi_version']!r}."
+        )
+    writer = _require_exact_keys(
+        root["writer"],
+        frozenset({"package", "version"}),
+        description="AOT pack writer",
+    )
+    if writer["package"] != "cuda-coop":
+        raise PackIntegrityError("AOT pack writer package must be 'cuda-coop'.")
+    writer_version = _require_string(
+        writer["version"],
+        description="AOT pack writer version",
+    )
+    name = root["name"]
+    if name is not None:
+        name = _require_string(name, description="AOT pack name")
+    entries_value = root["entries"]
+    if not isinstance(entries_value, list) or not entries_value:
+        raise PackIntegrityError("AOT pack manifest must contain at least one entry.")
+    entries = tuple(
+        _parse_entry(entry, entry_index=index)
+        for index, entry in enumerate(entries_value)
+    )
+    entry_ids = tuple(entry.entry_id for entry in entries)
+    if tuple(sorted(set(entry_ids))) != entry_ids:
+        raise PackIntegrityError("AOT pack entries must have unique sorted IDs.")
+    manifest = _Manifest(
+        name=name,
+        writer_version=writer_version,
+        entries=entries,
+    )
+    if data != _canonical_json_bytes(_manifest_payload(manifest)):
+        raise PackIntegrityError("AOT pack manifest is not canonically encoded.")
+    return manifest
+
+
+def _open_directory(
+    path: str | os.PathLike[str],
+    *,
+    description: str,
+    directory_descriptor: int | None = None,
+) -> int:
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | _secure_nofollow_flag()
+    )
+    try:
+        descriptor = os.open(path, flags, dir_fd=directory_descriptor)
+    except OSError as exc:
+        raise PackIntegrityError(f"{description} must be a real directory.") from exc
+    try:
+        result = os.fstat(descriptor)
+        if not stat.S_ISDIR(result.st_mode):
+            raise PackIntegrityError(f"{description} must be a real directory.")
+    except BaseException:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def _read_open_regular_file(
+    descriptor: int,
+    *,
+    description: str,
+    maximum_size: int | None,
+) -> bytes:
+    try:
+        result = os.fstat(descriptor)
+        if not stat.S_ISREG(result.st_mode):
+            raise PackIntegrityError(f"{description} must be a regular file.")
+        if maximum_size is not None and result.st_size > maximum_size:
+            raise PackIntegrityError(f"{description} is unexpectedly large.")
+        with os.fdopen(descriptor, "rb", closefd=True) as input_file:
+            descriptor = -1
+            if maximum_size is None:
+                return input_file.read()
+            data = input_file.read(result.st_size)
+            if input_file.read(1):
+                raise PackIntegrityError(f"{description} is unexpectedly large.")
+            return data
+    except PackIntegrityError:
+        raise
+    except OSError as exc:
+        raise PackIntegrityError(f"{description} could not be read.") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _read_regular_file_at(
+    directory_descriptor: int,
+    name: str,
+    *,
+    description: str,
+    maximum_size: int | None = None,
+) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | _secure_nofollow_flag()
+    try:
+        descriptor = os.open(name, flags, dir_fd=directory_descriptor)
+    except OSError as exc:
+        raise PackIntegrityError(
+            f"{description} is missing, unreadable, or not a regular file."
+        ) from exc
+    return _read_open_regular_file(
+        descriptor,
+        description=description,
+        maximum_size=maximum_size,
+    )
+
+
+def _read_regular_file(
+    path: Path,
+    *,
+    description: str,
+    maximum_size: int | None = None,
+) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | _secure_nofollow_flag()
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise PackIntegrityError(
+            f"{description} is missing, unreadable, or not a regular file."
+        ) from exc
+    return _read_open_regular_file(
+        descriptor,
+        description=description,
+        maximum_size=maximum_size,
+    )
+
+
+def _directory_inventory(
+    descriptor: int,
+    *,
+    description: str,
+) -> set[str]:
+    try:
+        return set(os.listdir(descriptor))
+    except OSError as exc:
+        raise PackIntegrityError(f"{description} is unreadable.") from exc
+
+
+def _create_sealed_memfd(digest: str, artifact: bytes) -> _MaterializedArtifact:
+    try:
+        function = ctypes.CDLL(None, use_errno=True).memfd_create
+    except AttributeError as exc:
+        raise PackError(
+            "Stable AOT artifact materialization requires Linux memfd_create."
+        ) from exc
+    function.argtypes = (ctypes.c_char_p, ctypes.c_uint)
+    function.restype = ctypes.c_int
+    descriptor = function(
+        f"cuda-coop-{digest}.ltoir".encode("ascii"),
+        _MFD_CLOEXEC | _MFD_ALLOW_SEALING,
+    )
+    if descriptor < 0:
+        error_number = ctypes.get_errno()
+        raise PackError("Failed creating a stable AOT artifact.") from OSError(
+            error_number,
+            os.strerror(error_number),
+        )
+
+    try:
+        view = memoryview(artifact)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError(errno.EIO, "short write to AOT artifact memfd")
+            view = view[written:]
+        os.fsync(descriptor)
+        try:
+            import fcntl
+
+            fcntl.fcntl(
+                descriptor,
+                _F_ADD_SEALS,
+                _F_SEAL_SEAL | _F_SEAL_SHRINK | _F_SEAL_GROW | _F_SEAL_WRITE,
+            )
+        except (ImportError, OSError) as exc:
+            raise PackError("Failed sealing a stable AOT artifact.") from exc
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        path = f"/proc/self/fd/{descriptor}"
+        if not os.path.isfile(path):
+            raise PackError(
+                "Stable AOT artifact materialization requires Linux procfs."
+            )
+        return _MaterializedArtifact(
+            digest=digest,
+            descriptor=descriptor,
+            path=path,
+            size=len(artifact),
+        )
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _materialize_artifact(digest: str, artifact: bytes) -> str:
+    with _MATERIALIZED_ARTIFACTS_LOCK:
+        existing = _MATERIALIZED_ARTIFACTS.get(digest)
+        if existing is not None:
+            if existing.size != len(artifact):
+                raise PackIntegrityError(
+                    f"AOT artifact {digest} conflicts with its materialized bytes."
+                )
+            return existing.path
+        materialized = _create_sealed_memfd(digest, artifact)
+        _MATERIALIZED_ARTIFACTS[digest] = materialized
+        _MATERIALIZED_ARTIFACTS_BY_PATH[materialized.path] = materialized
+        return materialized.path
+
+
+def _validate_pack_tree(
+    root_descriptor: int,
+    manifest: _Manifest,
+    *,
+    materialize_artifacts: bool,
+) -> dict[str, str]:
+    artifacts_descriptor = _open_directory(
+        "artifacts",
+        description="AOT pack artifacts directory",
+        directory_descriptor=root_descriptor,
+    )
+    try:
+        sources_descriptor = _open_directory(
+            "sources",
+            description="AOT pack sources directory",
+            directory_descriptor=root_descriptor,
+        )
+    except BaseException:
+        os.close(artifacts_descriptor)
+        raise
+
+    try:
+        expected_root = {MANIFEST_NAME, "artifacts", "sources"}
+        actual_root = _directory_inventory(
+            root_descriptor,
+            description="AOT pack",
+        )
+        if actual_root != expected_root:
+            raise PackIntegrityError(
+                "AOT pack contains unexpected or missing top-level entries."
+            )
+
+        expected_artifacts = {
+            f"{entry.artifact_sha256}.ltoir" for entry in manifest.entries
+        }
+        expected_sources = {
+            f"{entry.identity.source_sha256}.cu" for entry in manifest.entries
+        }
+        if (
+            _directory_inventory(
+                artifacts_descriptor,
+                description="AOT pack artifacts directory",
+            )
+            != expected_artifacts
+        ):
+            raise PackIntegrityError("AOT pack artifact inventory is inconsistent.")
+        if (
+            _directory_inventory(
+                sources_descriptor,
+                description="AOT pack sources directory",
+            )
+            != expected_sources
+        ):
+            raise PackIntegrityError("AOT pack source inventory is inconsistent.")
+
+        artifacts_to_materialize: dict[str, bytes] = {}
+        verified_artifact_sizes: dict[str, int] = {}
+        verified_sources: set[str] = set()
+        for entry in manifest.entries:
+            verified_size = verified_artifact_sizes.get(entry.artifact_sha256)
+            if verified_size is None:
+                artifact = _read_regular_file_at(
+                    artifacts_descriptor,
+                    f"{entry.artifact_sha256}.ltoir",
+                    description=f"AOT pack artifact {entry.artifact_sha256}",
+                    maximum_size=entry.artifact_size,
+                )
+                if len(artifact) != entry.artifact_size:
+                    raise PackIntegrityError(
+                        f"AOT pack artifact {entry.artifact_sha256} "
+                        "has an invalid size."
+                    )
+                if hashlib.sha256(artifact).hexdigest() != entry.artifact_sha256:
+                    raise PackIntegrityError(
+                        f"AOT pack artifact {entry.artifact_sha256} "
+                        "has an invalid digest."
+                    )
+                if materialize_artifacts:
+                    artifacts_to_materialize[entry.artifact_sha256] = artifact
+                verified_artifact_sizes[entry.artifact_sha256] = len(artifact)
+            elif entry.artifact_size != verified_size:
+                raise PackIntegrityError(
+                    f"AOT pack artifact {entry.artifact_sha256} "
+                    "has conflicting declared sizes."
+                )
+
+            source_sha256 = entry.identity.source_sha256
+            if source_sha256 not in verified_sources:
+                source = _read_regular_file_at(
+                    sources_descriptor,
+                    f"{source_sha256}.cu",
+                    description=f"AOT pack source {source_sha256}",
+                    maximum_size=MAX_SOURCE_BYTES,
+                )
+                if hashlib.sha256(source).hexdigest() != source_sha256:
+                    raise PackIntegrityError(
+                        f"AOT pack source {source_sha256} has an invalid digest."
+                    )
+                try:
+                    source.decode("utf-8", errors="strict")
+                except UnicodeDecodeError as exc:
+                    raise PackIntegrityError(
+                        f"AOT pack source {source_sha256} is not valid UTF-8."
+                    ) from exc
+                verified_sources.add(source_sha256)
+        return {
+            digest: _materialize_artifact(digest, artifact)
+            for digest, artifact in artifacts_to_materialize.items()
+        }
+    finally:
+        os.close(artifacts_descriptor)
+        os.close(sources_descriptor)
+
+
+def _normalize_path(path: str | os.PathLike[str]) -> Path:
+    return Path(os.path.abspath(os.path.expanduser(os.fspath(path))))
+
+
+def _load_pack(
+    path: str | os.PathLike[str],
+    *,
+    materialize_artifacts: bool = False,
+) -> _LoadedPack:
+    _require_supported_platform()
+    root = _normalize_path(path)
+    root_descriptor = _open_directory(root, description="AOT pack")
+    try:
+        data = _read_regular_file_at(
+            root_descriptor,
+            MANIFEST_NAME,
+            description="AOT pack manifest",
+            maximum_size=MAX_MANIFEST_BYTES,
+        )
+        manifest = _parse_manifest(data)
+        artifact_paths = _validate_pack_tree(
+            root_descriptor,
+            manifest,
+            materialize_artifacts=materialize_artifacts,
+        )
+    finally:
+        os.close(root_descriptor)
+    return _LoadedPack(
+        root=root,
+        manifest=manifest,
+        entries_by_id={entry.entry_id: entry for entry in manifest.entries},
+        artifact_paths_by_digest=artifact_paths,
+    )
+
+
+def _load_pack_cached(path: str | os.PathLike[str]) -> _LoadedPack:
+    """Load an environment-selected pack once and treat it as immutable."""
+
+    normalized = _normalize_path(path)
+    key = os.fspath(normalized)
+    with _PACK_CACHE_LOCK:
+        pack = _PACK_CACHE.get(key)
+    if pack is not None:
+        return pack
+    pack = _load_pack(normalized, materialize_artifacts=True)
+    with _PACK_CACHE_LOCK:
+        return _PACK_CACHE.setdefault(key, pack)
+
+
+def _entry_info(entry: _ManifestEntry) -> EntryInfo:
+    identity = entry.identity
+    return EntryInfo(
+        entry_id=entry.entry_id,
+        source_sha256=identity.source_sha256,
+        artifact_sha256=entry.artifact_sha256,
+        artifact_size=entry.artifact_size,
+        provider_abi_version=identity.provider_abi_version,
+        bundle_format=identity.bundle_format,
+        compute_arch=identity.compute_arch,
+        sm_arch=identity.sm_arch,
+        compiler_options=identity.compiler_options,
+        layout_expressions=identity.layout_expressions,
+        symbols=entry.symbols,
+        producer_compiler=entry.producer_compiler,
+        producer_version=(entry.producer_version.major, entry.producer_version.minor),
+        producer_toolkit_version=entry.producer_toolkit_version,
+    )
+
+
+def _pack_info(root: Path, manifest: _Manifest) -> PackInfo:
+    return PackInfo(
+        path=root,
+        name=manifest.name,
+        schema_version=PACK_SCHEMA_VERSION,
+        provider_abi_version=PROVIDER_ABI_VERSION,
+        writer_version=manifest.writer_version,
+        entries=tuple(_entry_info(entry) for entry in manifest.entries),
+    )
+
+
+def inspect(pack: str | os.PathLike[str]) -> PackInfo:
+    """Validate and describe one AOT pack.
+
+    Selected packs are treated as immutable. Explicit ``use`` contexts validate
+    at entry, while environment-selected packs validate once per process.
+    Integrity validation is not authenticity or semantic LTO-IR validation:
+    packs are trusted native-code inputs and must come from trusted provenance.
+    """
+
+    return _load_pack(pack).info
+
+
+def _validate_mode(mode: str) -> Literal["auto", "required", "off"]:
+    if mode not in _VALID_MODES:
+        raise ValueError(f"mode must be one of {sorted(_VALID_MODES)}, got {mode!r}")
+    return mode  # type: ignore[return-value]
+
+
+@contextmanager
+def use(
+    pack: str | os.PathLike[str],
+    *,
+    mode: Literal["auto", "required", "off"] = "auto",
+) -> Iterator[PackInfo | None]:
+    """Select one exact-bundle pack for provider resolution in this context.
+
+    Validation copies artifact bytes into sealed process-lifetime
+    materializations, so later pack mutation cannot alter linker input.
+    """
+
+    validated_mode = _validate_mode(mode)
+    loaded = (
+        None
+        if validated_mode == "off"
+        else _load_pack(pack, materialize_artifacts=True)
+    )
+    selection = _Selection(mode=validated_mode, pack=loaded)
+    token = _ACTIVE_SELECTION.set(selection)
+    try:
+        if loaded is None:
+            yield None
+        else:
+            from ._compiler import _bundle as _provider_bundle
+
+            with _provider_bundle.activate_bundle_precompile_resolver(
+                _precompile_resolver()
+            ):
+                yield loaded.info
+    finally:
+        _ACTIVE_SELECTION.reset(token)
+
+
+def _environment_selection() -> _Selection:
+    raw_mode = os.environ.get(PACK_MODE_ENV)
+    path = os.environ.get(PACK_PATH_ENV)
+    mode = _validate_mode("auto" if raw_mode is None else raw_mode.strip().lower())
+    if mode == "off":
+        return _Selection(mode="off", pack=None)
+    if not path:
+        if mode == "required":
+            raise PackMissError(
+                f"{PACK_MODE_ENV}=required needs a non-empty {PACK_PATH_ENV}."
+            )
+        return _Selection(mode="off", pack=None)
+    if not os.path.isabs(path):
+        raise PackError(f"{PACK_PATH_ENV} must be an absolute path, got {path!r}.")
+    return _Selection(mode=mode, pack=_load_pack_cached(path))
+
+
+def _current_selection() -> _Selection:
+    selection = _ACTIVE_SELECTION.get()
+    if selection is not None:
+        return selection
+    return _environment_selection()
+
+
+def _precompile_resolver() -> Any:
+    from ._compiler import _bundle as _provider_bundle
+
+    return _provider_bundle._bundle_precompile_resolver(
+        resolve_precompiled_bundle,
+        route=_provider_contract().RESOLUTION_ROUTE_AOT_PACK,
+        phase="pack_lookup",
+    )
+
+
+def _environment_precompile_resolver() -> Any | None:
+    """Return the lazy environment resolver unless an explicit selection wins."""
+
+    if _ACTIVE_SELECTION.get() is not None:
+        return None
+    return _precompile_resolver()
+
+
+def _manifest_identity_from_request(request: Any) -> _ManifestIdentity:
+    identity = request.identity
+    return _ManifestIdentity(
+        provider_abi_version=identity.provider_abi_version,
+        source_sha256=identity.source_hash,
+        bundle_format=identity.bundle_format,
+        compute_arch=identity.bundle_arch,
+        sm_arch=identity.bundle_sm_arch,
+        compiler_options=tuple(identity.compiler_options),
+        layout_expressions=tuple(identity.layout_expressions),
+    )
+
+
+def _assert_provider_constants() -> None:
+    if _provider_contract().PROVIDER_BUNDLE_ABI_VERSION != PROVIDER_ABI_VERSION:
+        raise PackIntegrityError(
+            "AOT pack provider ABI version is out of sync with the provider."
+        )
+
+
+@functools.lru_cache(maxsize=1)
+def _consumer_nvjitlink_version() -> _CudaVersion:
+    try:
+        import cuda.bindings.nvjitlink as cuda_nvjitlink
+    except (ImportError, OSError, RuntimeError) as exc:
+        raise PackMissError(
+            "Unable to determine the consumer nvJitLink version."
+        ) from exc
+    try:
+        major, minor = cuda_nvjitlink.version()
+    except (
+        AttributeError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+        cuda_nvjitlink.nvJitLinkError,
+    ) as exc:
+        raise PackMissError(
+            "Unable to determine the consumer nvJitLink version."
+        ) from exc
+    if (
+        isinstance(major, bool)
+        or not isinstance(major, int)
+        or isinstance(minor, bool)
+        or not isinstance(minor, int)
+        or major < 0
+        or minor < 0
+    ):
+        raise PackMissError("Consumer nvJitLink returned an invalid version.")
+    return _CudaVersion(major=major, minor=minor)
+
+
+def _compatible_nvjitlink(entry: _ManifestEntry) -> tuple[bool, str]:
+    try:
+        consumer = _consumer_nvjitlink_version()
+    except PackMissError as exc:
+        return False, str(exc)
+    producer = entry.producer_version
+    if consumer.major != producer.major:
+        return (
+            False,
+            f"producer NVRTC {producer.major}.{producer.minor} and consumer "
+            f"nvJitLink {consumer.major}.{consumer.minor} have different major "
+            "versions",
+        )
+    if consumer.minor < producer.minor:
+        return (
+            False,
+            f"consumer nvJitLink {consumer.major}.{consumer.minor} is older than "
+            f"producer NVRTC {producer.major}.{producer.minor}",
+        )
+    return True, ""
+
+
+def _required_miss(selection: _Selection, identity: _ManifestIdentity, reason: str):
+    assert selection.pack is not None
+    raise PackMissError(
+        f"Required AOT pack {selection.pack.root} has no compatible exact bundle "
+        f"for {identity.compute_arch}/{identity.sm_arch}: {reason}."
+    )
+
+
+def resolve_precompiled_bundle(request: Any) -> Any | None:
+    """Foundation resolver dispatcher for explicit or environment-selected packs."""
+
+    selection = _current_selection()
+    if selection.mode == "off":
+        return None
+    assert selection.pack is not None
+    _assert_provider_constants()
+
+    identity = _manifest_identity_from_request(request)
+    request_symbols = tuple(request.symbols)
+    if tuple(sorted(set(request_symbols))) != request_symbols:
+        raise PackError(
+            "Provider resolution request symbols must be unique and sorted."
+        )
+    entry = selection.pack.entries_by_id.get(_entry_id(identity, request_symbols))
+    if entry is None or entry.identity != identity or entry.symbols != request_symbols:
+        if selection.mode == "required":
+            _required_miss(selection, identity, "entry is absent")
+        return None
+
+    compatible, reason = _compatible_nvjitlink(entry)
+    if not compatible:
+        if selection.mode == "required":
+            _required_miss(selection, identity, reason)
+        return None
+
+    try:
+        artifact_path = selection.pack.artifact_paths_by_digest[entry.artifact_sha256]
+    except KeyError as exc:
+        raise PackIntegrityError(
+            "Selected AOT pack has no stable materialization for its exact artifact."
+        ) from exc
+    return _provider_contract().BundleResolution(
+        request=request,
+        path=artifact_path,
+        layouts_by_expression={
+            layout.expression: _provider_contract().StorageLayout(
+                size_in_bytes=layout.size_in_bytes,
+                alignment=layout.alignment,
+            )
+            for layout in entry.layouts
+        },
+        route=_provider_contract().RESOLUTION_ROUTE_AOT_PACK,
+        producer_compiler=entry.producer_compiler,
+        producer_compiler_version=(
+            f"{entry.producer_version.major}.{entry.producer_version.minor}"
+        ),
+        producer_toolkit_version=entry.producer_toolkit_version,
+        phase_timings_ns={},
+    )
+
+
+def _parse_producer_version(value: str | None) -> _CudaVersion:
+    if value is None:
+        raise CaptureError(
+            "Cannot capture a provider artifact without producer compiler "
+            "version metadata. Clear the legacy provider disk cache and compile "
+            "the bundle again."
+        )
+    match = _VERSION.fullmatch(value)
+    if match is None:
+        raise CaptureError(
+            f"Cannot capture invalid producer compiler version {value!r}."
+        )
+    return _CudaVersion(major=int(match.group(1)), minor=int(match.group(2)))
+
+
+def _write_new_file(path: Path, data: bytes, *, description: str) -> None:
+    try:
+        with path.open("xb") as output:
+            output.write(data)
+            output.flush()
+            os.fsync(output.fileno())
+    except FileExistsError:
+        try:
+            existing = _read_regular_file(path, description=description)
+        except PackIntegrityError as exc:
+            raise CaptureError(
+                f"{description} conflicts with captured content."
+            ) from exc
+        if existing != data:
+            raise CaptureError(f"{description} conflicts with captured content.")
+    except OSError as exc:
+        raise CaptureError(f"Failed writing {description}.") from exc
+
+
+def _read_materialized_artifact(path: str) -> bytes:
+    with _MATERIALIZED_ARTIFACTS_LOCK:
+        materialized = _MATERIALIZED_ARTIFACTS_BY_PATH.get(path)
+    if materialized is None:
+        raise CaptureError(
+            "Resolved AOT artifact is not a process-owned stable materialization."
+        )
+    chunks = []
+    offset = 0
+    try:
+        while offset < materialized.size:
+            chunk = os.pread(
+                materialized.descriptor,
+                materialized.size - offset,
+                offset,
+            )
+            if not chunk:
+                raise OSError(errno.EIO, "short read from AOT artifact memfd")
+            chunks.append(chunk)
+            offset += len(chunk)
+    except OSError as exc:
+        raise CaptureError("Resolved AOT artifact could not be read.") from exc
+    return b"".join(chunks)
+
+
+def _read_resolution_artifact(resolution: Any) -> bytes:
+    if resolution.route == _provider_contract().RESOLUTION_ROUTE_AOT_PACK:
+        artifact = _read_materialized_artifact(resolution.path)
+    else:
+        try:
+            artifact = _read_regular_file(
+                Path(resolution.path),
+                description="Resolved provider artifact",
+            )
+        except PackIntegrityError as exc:
+            raise CaptureError(
+                "Resolved provider artifact must be a readable regular file."
+            ) from exc
+    if not artifact:
+        raise CaptureError("Resolved provider artifact is empty.")
+    return artifact
+
+
+def _capture_resolution_routes() -> frozenset[str]:
+    return frozenset(
+        {
+            _provider_contract().RESOLUTION_ROUTE_AOT_PACK,
+            _provider_contract().RESOLUTION_ROUTE_DISK,
+            _provider_contract().RESOLUTION_ROUTE_MEMORY,
+            _provider_contract().RESOLUTION_ROUTE_NVRTC,
+        }
+    )
+
+
+def _require_trusted_capture_resolution(
+    resolution: Any,
+) -> None:
+    if resolution.route not in _capture_resolution_routes():
+        raise CaptureError(
+            "AOT capture only accepts provider-owned NVRTC, memory-cache, "
+            "disk-cache, or AOT-pack resolutions. Provider artifacts are "
+            "trusted native-code inputs."
+        )
+    try:
+        path = resolution.path
+    except AttributeError as exc:
+        raise CaptureError("Provider resolution is missing its artifact path.") from exc
+    if not isinstance(path, str) or not path:
+        raise CaptureError("Provider resolution has an invalid artifact path.")
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _warn_parent_fsync_failure(output: Path, error: OSError) -> None:
+    try:
+        warnings.warn(
+            f"AOT pack {output} was published atomically, but synchronizing its "
+            f"parent directory failed: {error}",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+    except Exception:
+        # renameat2 is the publication commit point. Warning policy must not
+        # turn an already-visible successful publication into a false failure.
+        pass
+
+
+def _rename_noreplace(source: Path, destination: Path) -> None:
+    try:
+        function = ctypes.CDLL(None, use_errno=True).renameat2
+    except AttributeError as exc:
+        raise CaptureError(
+            "Atomic create-only AOT pack publication requires Linux renameat2."
+        ) from exc
+    function.argtypes = (
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    )
+    function.restype = ctypes.c_int
+    result = function(
+        _AT_FDCWD,
+        os.fsencode(source),
+        _AT_FDCWD,
+        os.fsencode(destination),
+        _RENAME_NOREPLACE,
+    )
+    if result == 0:
+        return
+    error_number = ctypes.get_errno()
+    if error_number in (errno.EEXIST, errno.ENOTEMPTY):
+        raise CaptureError(f"AOT pack output already exists: {destination}")
+    if error_number in (errno.ENOSYS, errno.EINVAL, errno.EOPNOTSUPP):
+        raise CaptureError(
+            "Atomic create-only AOT pack publication is unavailable on this filesystem."
+        )
+    raise CaptureError(
+        f"Failed atomically publishing AOT pack to {destination}."
+    ) from OSError(error_number, os.strerror(error_number))
+
+
+class _CaptureSink:
+    def __init__(self, staging: Path):
+        self.staging = staging
+        self.artifacts = staging / "artifacts"
+        self.sources = staging / "sources"
+        self.entries: dict[str, _ManifestEntry] = {}
+        self.observations = 0
+        self._owner_pid = os.getpid()
+        self._lock = threading.RLock()
+
+    def record(self, resolution: Any) -> None:
+        if os.getpid() != self._owner_pid:
+            raise CaptureError(_CAPTURE_PROCESS_BOUNDARY_ERROR)
+
+        _require_trusted_capture_resolution(resolution)
+        identity = _manifest_identity_from_request(resolution.request)
+        if identity.bundle_format != "ltoir":
+            raise CaptureError("AOT capture only supports LTO-IR provider bundles.")
+        if (
+            resolution.route == _provider_contract().RESOLUTION_ROUTE_DISK
+            and resolution.producer_compiler_version is None
+        ):
+            raise CaptureError(
+                "Cannot capture a legacy provider disk-cache artifact without "
+                "producer compiler version metadata. Clear the legacy provider "
+                "disk cache and compile the bundle again."
+            )
+        if resolution.producer_compiler != "nvrtc":
+            raise CaptureError(
+                "AOT capture requires an NVRTC-produced LTO-IR artifact."
+            )
+        producer_version = _parse_producer_version(resolution.producer_compiler_version)
+
+        source = resolution.request.source.encode("utf-8")
+        if len(source) > MAX_SOURCE_BYTES:
+            raise CaptureError("Provider source is unexpectedly large.")
+        if hashlib.sha256(source).hexdigest() != identity.source_sha256:
+            raise CaptureError("Provider source does not match its bundle identity.")
+        artifact = _read_resolution_artifact(resolution)
+        artifact_sha256 = hashlib.sha256(artifact).hexdigest()
+
+        if set(resolution.layouts_by_expression) != set(identity.layout_expressions):
+            raise CaptureError(
+                "Resolved provider layouts do not match the exact bundle identity."
+            )
+        layouts = tuple(
+            _ManifestLayout(
+                expression=expression,
+                size_in_bytes=resolution.layouts_by_expression[
+                    expression
+                ].size_in_bytes,
+                alignment=resolution.layouts_by_expression[expression].alignment,
+            )
+            for expression in identity.layout_expressions
+        )
+        symbols = tuple(resolution.request.symbols)
+        if tuple(sorted(set(symbols))) != symbols:
+            raise CaptureError("Resolved provider symbols must be unique and sorted.")
+        entry = _ManifestEntry(
+            entry_id=_entry_id(identity, symbols),
+            identity=identity,
+            artifact_sha256=artifact_sha256,
+            artifact_size=len(artifact),
+            producer_compiler="nvrtc",
+            producer_version=producer_version,
+            producer_toolkit_version=resolution.producer_toolkit_version,
+            layouts=layouts,
+            symbols=symbols,
+        )
+
+        with self._lock:
+            existing = self.entries.get(entry.entry_id)
+            if existing is not None and existing != entry:
+                raise CaptureError(
+                    f"Conflicting provider artifacts share AOT entry {entry.entry_id}."
+                )
+            _write_new_file(
+                self.sources / f"{identity.source_sha256}.cu",
+                source,
+                description=f"AOT source {identity.source_sha256}",
+            )
+            _write_new_file(
+                self.artifacts / f"{artifact_sha256}.ltoir",
+                artifact,
+                description=f"AOT artifact {artifact_sha256}",
+            )
+            self.entries[entry.entry_id] = entry
+            self.observations += 1
+
+
+class Capture:
+    """Context manager that captures resolved exact provider bundles."""
+
+    def __init__(
+        self,
+        output: str | os.PathLike[str],
+        *,
+        name: str | None,
+    ):
+        if name is not None:
+            _require_string(name, description="AOT pack name")
+        self.output = _normalize_path(output)
+        self.name = name
+        self._staging: Path | None = None
+        self._sink: _CaptureSink | None = None
+        self._capture_token = None
+        self._observer_context = None
+        self._provider_observers_context = None
+        self._entered = False
+        self._result: CaptureResult | None = None
+        self._owner_pid: int | None = None
+
+    @property
+    def result(self) -> CaptureResult:
+        if self._result is None:
+            raise CaptureError("AOT capture has not published a result.")
+        return self._result
+
+    def __enter__(self) -> Capture:
+        _require_supported_platform()
+        if self._entered:
+            raise CaptureError("AOT capture contexts cannot be reused.")
+        if _ACTIVE_CAPTURE.get() is not None:
+            raise CaptureError("Nested AOT capture contexts are not supported.")
+        self._entered = True
+        self._owner_pid = os.getpid()
+        self.output.parent.mkdir(parents=True, exist_ok=True)
+        if self.output.exists() or self.output.is_symlink():
+            raise CaptureError(f"AOT pack output already exists: {self.output}")
+
+        staging = Path(
+            tempfile.mkdtemp(
+                prefix=f".{self.output.name}.staging-",
+                dir=self.output.parent,
+            )
+        )
+        sink = _CaptureSink(staging)
+        try:
+            sink.artifacts.mkdir()
+            sink.sources.mkdir()
+            self._staging = staging
+            self._sink = sink
+            self._capture_token = _ACTIVE_CAPTURE.set(self)
+            from ._compiler import _bundle as _provider_bundle
+
+            _assert_provider_constants()
+            self._provider_observers_context = (
+                _provider_bundle._ACTIVE_POST_RESOLUTION_OBSERVERS
+            )
+            self._observer_context = (
+                _provider_bundle.activate_bundle_resolution_observer(sink.record)
+            )
+            self._observer_context.__enter__()
+        except BaseException:
+            if self._capture_token is not None:
+                _ACTIVE_CAPTURE.reset(self._capture_token)
+                self._capture_token = None
+            shutil.rmtree(staging, ignore_errors=True)
+            raise
+        return self
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        assert self._staging is not None
+        assert self._sink is not None
+        assert self._owner_pid is not None
+        crossed_process_boundary = os.getpid() != self._owner_pid
+        try:
+            if self._observer_context is not None:
+                self._observer_context.__exit__(
+                    exception_type,
+                    exception,
+                    traceback,
+                )
+        finally:
+            self._observer_context = None
+            self._provider_observers_context = None
+            if self._capture_token is not None:
+                _ACTIVE_CAPTURE.reset(self._capture_token)
+                self._capture_token = None
+
+        if crossed_process_boundary:
+            raise CaptureError(_CAPTURE_PROCESS_BOUNDARY_ERROR)
+
+        if exception_type is not None:
+            shutil.rmtree(self._staging, ignore_errors=True)
+            return False
+
+        try:
+            if not self._sink.entries:
+                raise CaptureError("AOT capture observed no provider bundles.")
+            manifest = _Manifest(
+                name=self.name,
+                writer_version=_writer_version(),
+                entries=tuple(
+                    self._sink.entries[entry_id]
+                    for entry_id in sorted(self._sink.entries)
+                ),
+            )
+            _write_new_file(
+                self._staging / MANIFEST_NAME,
+                _canonical_json_bytes(_manifest_payload(manifest)),
+                description="AOT pack manifest",
+            )
+            _fsync_directory(self._sink.artifacts)
+            _fsync_directory(self._sink.sources)
+            _fsync_directory(self._staging)
+            loaded = _load_pack(self._staging)
+            info = _pack_info(self.output, loaded.manifest)
+            result = CaptureResult(
+                path=info.path,
+                name=info.name,
+                observations=self._sink.observations,
+                entries=info.entries,
+            )
+            _rename_noreplace(self._staging, self.output)
+            try:
+                _fsync_directory(self.output.parent)
+            except OSError as exc:
+                _warn_parent_fsync_failure(self.output, exc)
+            self._result = result
+        except BaseException:
+            shutil.rmtree(self._staging, ignore_errors=True)
+            raise
+        return False
+
+
+def capture(
+    output: str | os.PathLike[str],
+    *,
+    name: str | None = None,
+) -> Capture:
+    """Capture all provider-owned exact bundles resolved in the context.
+
+    Captured LTO-IR is a trusted native-code input. The capture observer accepts
+    only artifacts produced or re-exported through internal provider routes.
+    """
+
+    return Capture(output, name=name)
+
+
+def _writer_version() -> str:
+    try:
+        return importlib.metadata.version("cuda-coop")
+    except importlib.metadata.PackageNotFoundError:
+        return "0+unknown"
+
+
+__all__ = [
+    "Capture",
+    "CaptureError",
+    "CaptureResult",
+    "EntryInfo",
+    "PackError",
+    "PackInfo",
+    "PackIntegrityError",
+    "PackMissError",
+    "capture",
+    "inspect",
+    "use",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_bundle.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_bundle.py
@@ -4,18 +4,22 @@
 
 """Resolve generated CUTLASS providers through the compiler lifecycle.
 
-This module owns phase telemetry and orchestration across target selection,
-cache, Clang, and NVRTC services. Those services own
+This module owns resolver ordering, phase telemetry, and orchestration across
+target selection, cache, Clang, NVRTC, and AOT services. Those services own
 their implementation details and artifact state.
 """
 
 from __future__ import annotations
 
 import hashlib
+import importlib
 import os
 import shutil
 import time
 from collections.abc import Callable, Hashable, Iterable
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from pathlib import Path
 
 from cutlass._mlir import ir
@@ -30,14 +34,20 @@ from . import _nvrtc, _cache, _clang
 
 # isort: on
 from ._bundle_contract import (
+    RESOLUTION_ROUTE_AOT_PACK,
     RESOLUTION_ROUTE_CLANG,
     RESOLUTION_ROUTE_DISK,
     RESOLUTION_ROUTE_MEMORY,
     RESOLUTION_ROUTE_NVRTC,
+    RESOLUTION_ROUTE_PRECOMPILED,
     BundleCompilation,
+    BundleResolution,
+    BundleResolutionRequest,
     BundleTelemetry,
     LayoutProbe,
+    StorageLayout,
     _prepare_layout_probes,
+    _validate_storage_layout,
     bundle_compiler_options,
     include_dirs_identity,
     make_bundle_cache_identity,
@@ -55,6 +65,15 @@ COMMON_CCCL_ROOT_ENV = "CUDA_COOP_CCCL_ROOT"
 LINK_LIBRARIES_ATTR = "link-libraries"
 
 
+@dataclass(frozen=True)
+class _BundlePrecompileResolver:
+    """One typed resolver registration and its exact resolution contract."""
+
+    callback: Callable[[BundleResolutionRequest], BundleResolution | None]
+    route: str
+    phase: str
+
+
 _ROUTE_COUNTS: dict[str, int] = {}
 _PHASE_COUNTS: dict[str, int] = {}
 _PHASE_TIMINGS_NS: dict[str, int] = {}
@@ -63,6 +82,80 @@ _UNKNOWN_COMPILER_PROCESS_NONCE = os.urandom(8).hex()
 
 def _unknown_compiler_process_token() -> str:
     return f"unknown-{os.getpid()}-{_UNKNOWN_COMPILER_PROCESS_NONCE}"
+
+
+_ACTIVE_PRECOMPILE_RESOLVERS: ContextVar[tuple[_BundlePrecompileResolver, ...]] = (
+    ContextVar(
+        "cuda_coop_cutlass_active_precompile_resolvers",
+        default=(),
+    )
+)
+_ACTIVE_POST_RESOLUTION_OBSERVERS: ContextVar[
+    tuple[Callable[[BundleResolution], None], ...]
+] = ContextVar(
+    "cuda_coop_cutlass_active_post_resolution_observers",
+    default=(),
+)
+
+
+def _bundle_precompile_resolver(
+    callback: Callable[[BundleResolutionRequest], BundleResolution | None],
+    *,
+    route: str = RESOLUTION_ROUTE_PRECOMPILED,
+    phase: str = "precompile_resolvers",
+) -> _BundlePrecompileResolver:
+    if not callable(callback):
+        raise TypeError("bundle precompile resolver must be callable")
+    if route not in {RESOLUTION_ROUTE_PRECOMPILED, RESOLUTION_ROUTE_AOT_PACK}:
+        raise ValueError(f"unsupported bundle precompile resolver route {route!r}")
+    if not isinstance(phase, str) or not phase:
+        raise ValueError("bundle precompile resolver phase must be a nonempty string")
+    return _BundlePrecompileResolver(
+        callback=callback,
+        route=route,
+        phase=phase,
+    )
+
+
+@contextmanager
+def activate_bundle_precompile_resolver(
+    resolver: (
+        _BundlePrecompileResolver
+        | Callable[[BundleResolutionRequest], BundleResolution | None]
+    ),
+):
+    """Push one context-local resolver, tried before enclosing resolvers."""
+
+    if isinstance(resolver, _BundlePrecompileResolver):
+        resolver = _bundle_precompile_resolver(
+            resolver.callback,
+            route=resolver.route,
+            phase=resolver.phase,
+        )
+    else:
+        resolver = _bundle_precompile_resolver(resolver)
+    resolvers = _ACTIVE_PRECOMPILE_RESOLVERS.get()
+    token = _ACTIVE_PRECOMPILE_RESOLVERS.set((*resolvers, resolver))
+    try:
+        yield
+    finally:
+        _ACTIVE_PRECOMPILE_RESOLVERS.reset(token)
+
+
+@contextmanager
+def activate_bundle_resolution_observer(
+    observer: Callable[[BundleResolution], None],
+):
+    """Push one context-local observer, invoked after enclosing observers."""
+
+    if not callable(observer):
+        raise TypeError("bundle resolution observer must be callable")
+    observers = _ACTIVE_POST_RESOLUTION_OBSERVERS.get()
+    token = _ACTIVE_POST_RESOLUTION_OBSERVERS.set((*observers, observer))
+    try:
+        yield
+    finally:
+        _ACTIVE_POST_RESOLUTION_OBSERVERS.reset(token)
 
 
 def append_link_library_attr(module: ir.Module, path: str) -> None:
@@ -158,8 +251,53 @@ def _finish_phase(
     phase_timings_ns[phase] = phase_timings_ns.get(phase, 0) + elapsed_ns
 
 
+def _validated_precompiled_bundle(
+    resolution: BundleResolution,
+    request: BundleResolutionRequest,
+    *,
+    route: str,
+) -> _cache_support._CachedBundle:
+    if not isinstance(resolution, BundleResolution):
+        raise TypeError(
+            "bundle precompile resolver must return BundleResolution or None"
+        )
+    if resolution.request != request:
+        raise ValueError("precompiled bundle resolution does not match its request")
+    if resolution.route != route:
+        raise ValueError("precompiled bundle resolution has an invalid route")
+    if not isinstance(resolution.path, str) or not resolution.path:
+        raise ValueError("precompiled bundle resolution requires a non-empty path")
+    if not os.path.isfile(resolution.path):
+        raise ValueError("precompiled bundle resolution path is not a file")
+    layout_expressions = request.identity.layout_expressions
+    if set(resolution.layouts_by_expression) != set(layout_expressions):
+        raise ValueError(
+            "precompiled bundle resolution has incompatible layout metadata"
+        )
+    layouts_by_expression = {}
+    for expression in layout_expressions:
+        layout = resolution.layouts_by_expression[expression]
+        if not isinstance(layout, StorageLayout):
+            raise TypeError(
+                "precompiled bundle layout metadata must contain StorageLayout values"
+            )
+        layouts_by_expression[expression] = _validate_storage_layout(
+            layout.size_in_bytes,
+            layout.alignment,
+            description=expression,
+        )
+    return _cache_support._CachedBundle(
+        path=resolution.path,
+        layouts_by_expression=layouts_by_expression,
+        producer_compiler=resolution.producer_compiler,
+        producer_compiler_version=resolution.producer_compiler_version,
+        producer_toolkit_version=resolution.producer_toolkit_version,
+    )
+
+
 def _finish_bundle_resolution(
     *,
+    request: BundleResolutionRequest,
     cached: _cache_support._CachedBundle,
     route: str,
     key_to_expression: dict[Hashable, str],
@@ -167,11 +305,23 @@ def _finish_bundle_resolution(
     resolution_started_ns: int,
 ) -> BundleCompilation:
     _finish_phase(phase_timings_ns, "total", resolution_started_ns)
+    resolution = BundleResolution(
+        request=request,
+        path=cached.path,
+        layouts_by_expression=dict(cached.layouts_by_expression),
+        route=route,
+        producer_compiler=cached.producer_compiler,
+        producer_compiler_version=cached.producer_compiler_version,
+        producer_toolkit_version=cached.producer_toolkit_version,
+        phase_timings_ns=dict(phase_timings_ns),
+    )
     with _cache_support._STATE_LOCK:
         _ROUTE_COUNTS[route] = _ROUTE_COUNTS.get(route, 0) + 1
         for phase, duration_ns in phase_timings_ns.items():
             _PHASE_COUNTS[phase] = _PHASE_COUNTS.get(phase, 0) + 1
             _PHASE_TIMINGS_NS[phase] = _PHASE_TIMINGS_NS.get(phase, 0) + duration_ns
+    for observer in _ACTIVE_POST_RESOLUTION_OBSERVERS.get():
+        observer(resolution)
     return _bundle_compilation(cached, key_to_expression)
 
 
@@ -185,6 +335,7 @@ def _compile_bundle_source(
     select_bundle_format: Callable[[], str],
     resolve_nvrtc_sm_arch: Callable[[], str],
     resolve_nvrtc_arch: Callable[[], str],
+    symbols: Iterable[str],
     which: Callable[[str], str | None] = shutil.which,
 ) -> BundleCompilation:
     resolution_started_ns = time.perf_counter_ns()
@@ -222,6 +373,48 @@ def _compile_bundle_source(
         compiler_options=compiler_options,
         layout_expressions=prepared_probes.expressions,
     )
+    bundle_symbols = tuple(sorted(set(symbols)))
+    request = BundleResolutionRequest(
+        identity=identity,
+        source=source,
+        symbols=bundle_symbols,
+    )
+
+    resolvers = _ACTIVE_PRECOMPILE_RESOLVERS.get()
+    if (
+        "CUDA_COOP_CUTLASS_AOT_PACK_PATH" in os.environ
+        or "CUDA_COOP_CUTLASS_AOT_MODE" in os.environ
+    ):
+        aot_pack = importlib.import_module("cuda.coop.cutlass._aot_pack")
+        environment_resolver = aot_pack._environment_precompile_resolver()
+        if environment_resolver is not None:
+            resolvers = (environment_resolver, *resolvers)
+    if resolvers:
+        for resolver in reversed(resolvers):
+            phase_started_ns = time.perf_counter_ns()
+            try:
+                resolution = resolver.callback(request)
+            finally:
+                _finish_phase(
+                    phase_timings_ns,
+                    resolver.phase,
+                    phase_started_ns,
+                )
+            if resolution is None:
+                continue
+            return _finish_bundle_resolution(
+                request=request,
+                cached=_validated_precompiled_bundle(
+                    resolution,
+                    request,
+                    route=resolver.route,
+                ),
+                route=resolver.route,
+                key_to_expression=prepared_probes.key_to_expression,
+                phase_timings_ns=phase_timings_ns,
+                resolution_started_ns=resolution_started_ns,
+            )
+
     phase_started_ns = time.perf_counter_ns()
     include_dirs = cccl_include_dirs(
         required_cccl_headers(source, registered_headers=registered_headers),
@@ -280,6 +473,7 @@ def _compile_bundle_source(
     if memory_hit:
         assert cached is not None
         return _finish_bundle_resolution(
+            request=request,
             cached=cached,
             route=RESOLUTION_ROUTE_MEMORY,
             key_to_expression=prepared_probes.key_to_expression,
@@ -306,6 +500,7 @@ def _compile_bundle_source(
         if memory_hit:
             assert cached is not None
             return _finish_bundle_resolution(
+                request=request,
                 cached=cached,
                 route=RESOLUTION_ROUTE_MEMORY,
                 key_to_expression=prepared_probes.key_to_expression,
@@ -325,6 +520,7 @@ def _compile_bundle_source(
         if cached is not None:
             _cache_support.store_memory_bundle(cache_identity.cache_key, cached)
             return _finish_bundle_resolution(
+                request=request,
                 cached=cached,
                 route=RESOLUTION_ROUTE_DISK,
                 key_to_expression=prepared_probes.key_to_expression,
@@ -367,6 +563,7 @@ def _compile_bundle_source(
         _cache_support.record_compilation()
     _finish_phase(phase_timings_ns, "compiler", phase_started_ns)
     return _finish_bundle_resolution(
+        request=request,
         cached=cached,
         route=route,
         key_to_expression=prepared_probes.key_to_expression,
@@ -384,6 +581,7 @@ def compile_bundle_source(
     select_bundle_format: Callable[[], str],
     resolve_nvrtc_sm_arch: Callable[[], str],
     resolve_nvrtc_arch: Callable[[], str],
+    symbols: Iterable[str] = (),
     which: Callable[[str], str | None] = shutil.which,
 ) -> str:
     """Compile a provider bundle and return its linkable artifact path."""
@@ -397,6 +595,7 @@ def compile_bundle_source(
         select_bundle_format=select_bundle_format,
         resolve_nvrtc_sm_arch=resolve_nvrtc_sm_arch,
         resolve_nvrtc_arch=resolve_nvrtc_arch,
+        symbols=symbols,
         which=which,
     ).path
 
@@ -411,6 +610,7 @@ def compile_bundle_source_with_layouts(
     select_bundle_format: Callable[[], str],
     resolve_nvrtc_sm_arch: Callable[[], str],
     resolve_nvrtc_arch: Callable[[], str],
+    symbols: Iterable[str] = (),
     which: Callable[[str], str | None] = shutil.which,
 ) -> BundleCompilation:
     """Compile one LTO-IR bundle and recover exact layouts from that program."""
@@ -424,6 +624,7 @@ def compile_bundle_source_with_layouts(
         select_bundle_format=select_bundle_format,
         resolve_nvrtc_sm_arch=resolve_nvrtc_sm_arch,
         resolve_nvrtc_arch=resolve_nvrtc_arch,
+        symbols=symbols,
         which=which,
     )
 

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_bundle_contract.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_bundle_contract.py
@@ -40,6 +40,10 @@ BUNDLE_METADATA_VERSION = 2
 
 LAYOUT_METADATA_VERSION = BUNDLE_METADATA_VERSION
 
+RESOLUTION_ROUTE_PRECOMPILED = "precompiled"
+
+RESOLUTION_ROUTE_AOT_PACK = "aot_pack"
+
 RESOLUTION_ROUTE_MEMORY = "memory"
 
 RESOLUTION_ROUTE_DISK = "disk"
@@ -115,6 +119,29 @@ class BundleCacheIdentity:
     @property
     def artifact_stem(self) -> str:
         return f"bundle_v{self.schema_version}_{self.contract_digest}"
+
+
+@dataclass(frozen=True)
+class BundleResolutionRequest:
+    """Canonical source and layout metadata presented to bundle resolvers."""
+
+    identity: BundleIdentity
+    source: str
+    symbols: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BundleResolution:
+    """One resolved provider artifact and its exact layout metadata."""
+
+    request: BundleResolutionRequest
+    path: str
+    layouts_by_expression: Mapping[str, StorageLayout]
+    route: str
+    producer_compiler: str | None
+    producer_compiler_version: str | None
+    producer_toolkit_version: str | None
+    phase_timings_ns: Mapping[str, int]
 
 
 @dataclass(frozen=True)

--- a/python/cuda_coop/cuda/coop/cutlass/_compiler/_finalize.py
+++ b/python/cuda_coop/cuda/coop/cutlass/_compiler/_finalize.py
@@ -81,7 +81,7 @@ def _select_bundle_format() -> str:
     return _provider_target_support.select_bundle_format(ROOT_SCOPE)
 
 
-def _compile_bundle_source(source: str) -> str:
+def _compile_bundle_source(source: str, symbols: tuple[str, ...]) -> str:
     return _provider_bundle_support.compile_bundle_source(
         source,
         scope=ROOT_SCOPE,
@@ -90,6 +90,7 @@ def _compile_bundle_source(source: str) -> str:
         select_bundle_format=_select_bundle_format,
         resolve_nvrtc_sm_arch=_resolve_nvrtc_sm_arch,
         resolve_nvrtc_arch=_resolve_nvrtc_arch,
+        symbols=symbols,
         which=shutil.which,
     )
 
@@ -97,6 +98,7 @@ def _compile_bundle_source(source: str) -> str:
 def _compile_bundle_source_with_layouts(
     source: str,
     probes: dict[object, _provider_types.ScratchLayoutProbe],
+    symbols: tuple[str, ...],
 ) -> _provider_bundle_support.BundleCompilation:
     return _provider_bundle_support.compile_bundle_source_with_layouts(
         source,
@@ -114,6 +116,7 @@ def _compile_bundle_source_with_layouts(
         select_bundle_format=_select_bundle_format,
         resolve_nvrtc_sm_arch=_resolve_nvrtc_sm_arch,
         resolve_nvrtc_arch=_resolve_nvrtc_arch,
+        symbols=symbols,
         which=shutil.which,
     )
 
@@ -157,8 +160,9 @@ def _trace_finalize_hook(dsl: Any, module: Any, function_name: str) -> None:
         )
 
     source = _render_bundle_source(requests)
+    symbols = tuple(sorted(request.symbol_name for request in requests))
     if probes:
-        compilation = _compile_bundle_source_with_layouts(source, probes)
+        compilation = _compile_bundle_source_with_layouts(source, probes, symbols)
         bundle_path = compilation.path
         layouts = {
             key: _provider_types.ScratchLayout(
@@ -168,7 +172,7 @@ def _trace_finalize_hook(dsl: Any, module: Any, function_name: str) -> None:
             for key, layout in compilation.layouts.items()
         }
     else:
-        bundle_path = _compile_bundle_source(source)
+        bundle_path = _compile_bundle_source(source, symbols)
         layouts = {}
 
     plans = _provider_storage.plan_deferred_temp_storage_events(events, layouts)

--- a/python/cuda_coop/cuda/coop/cutlass/aot.py
+++ b/python/cuda_coop/cuda/coop/cutlass/aot.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Capture and consume Linux-only CUTLASS cooperative provider AOT packs."""
+
+from ._aot_pack import (
+    Capture,
+    CaptureError,
+    CaptureResult,
+    EntryInfo,
+    PackError,
+    PackInfo,
+    PackIntegrityError,
+    PackMissError,
+    capture,
+    inspect,
+    use,
+)
+
+__all__ = [
+    "Capture",
+    "CaptureError",
+    "CaptureResult",
+    "EntryInfo",
+    "PackError",
+    "PackInfo",
+    "PackIntegrityError",
+    "PackMissError",
+    "capture",
+    "inspect",
+    "use",
+]

--- a/python/cuda_coop/cuda/coop/cutlass/aot.pyi
+++ b/python/cuda_coop/cuda/coop/cutlass/aot.pyi
@@ -1,0 +1,135 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Typed Linux-only CUTLASS cooperative-provider AOT pack API."""
+
+from contextlib import AbstractContextManager
+from os import PathLike
+from pathlib import Path
+from types import TracebackType
+from typing import Literal
+
+class PackError(RuntimeError):
+    """Base error for CUTLASS cooperative AOT packs."""
+
+class PackIntegrityError(PackError):
+    """A pack is malformed, corrupt, or unsupported."""
+
+class PackMissError(PackError):
+    """A required pack has no compatible exact-bundle entry."""
+
+class CaptureError(PackError):
+    """A provider resolution cannot be captured or published."""
+
+class EntryInfo:
+    """Portable information about one exact provider bundle."""
+
+    entry_id: str
+    source_sha256: str
+    artifact_sha256: str
+    artifact_size: int
+    provider_abi_version: int
+    bundle_format: str
+    compute_arch: str
+    sm_arch: str
+    compiler_options: tuple[str, ...]
+    layout_expressions: tuple[str, ...]
+    symbols: tuple[str, ...]
+    producer_compiler: str
+    producer_version: tuple[int, int]
+    producer_toolkit_version: str | None
+
+    def __init__(
+        self,
+        entry_id: str,
+        source_sha256: str,
+        artifact_sha256: str,
+        artifact_size: int,
+        provider_abi_version: int,
+        bundle_format: str,
+        compute_arch: str,
+        sm_arch: str,
+        compiler_options: tuple[str, ...],
+        layout_expressions: tuple[str, ...],
+        symbols: tuple[str, ...],
+        producer_compiler: str,
+        producer_version: tuple[int, int],
+        producer_toolkit_version: str | None,
+    ) -> None: ...
+
+class PackInfo:
+    """Validated information about one relocatable AOT pack."""
+
+    path: Path
+    name: str | None
+    schema_version: int
+    provider_abi_version: int
+    writer_version: str
+    entries: tuple[EntryInfo, ...]
+
+    def __init__(
+        self,
+        path: Path,
+        name: str | None,
+        schema_version: int,
+        provider_abi_version: int,
+        writer_version: str,
+        entries: tuple[EntryInfo, ...],
+    ) -> None: ...
+    @property
+    def artifact_bytes(self) -> int: ...
+
+class CaptureResult:
+    """Result published by a successful capture context."""
+
+    path: Path
+    name: str | None
+    observations: int
+    entries: tuple[EntryInfo, ...]
+
+    def __init__(
+        self,
+        path: Path,
+        name: str | None,
+        observations: int,
+        entries: tuple[EntryInfo, ...],
+    ) -> None: ...
+    @property
+    def artifact_bytes(self) -> int: ...
+
+class Capture:
+    """Context manager that captures resolved exact provider bundles."""
+
+    output: Path
+    name: str | None
+
+    def __init__(
+        self,
+        output: str | PathLike[str],
+        *,
+        name: str | None,
+    ) -> None: ...
+    @property
+    def result(self) -> CaptureResult: ...
+    def __enter__(self) -> Capture: ...
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool: ...
+
+def capture(
+    output: str | PathLike[str],
+    *,
+    name: str | None = None,
+) -> Capture: ...
+def inspect(pack: str | PathLike[str]) -> PackInfo: ...
+def use(
+    pack: str | PathLike[str],
+    *,
+    mode: Literal["auto", "required", "off"] = "auto",
+) -> AbstractContextManager[PackInfo | None]: ...
+
+__all__: list[str]

--- a/python/cuda_coop/pyproject.toml
+++ b/python/cuda_coop/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
 dynamic = ["version"]
 readme = { file = "README.md", content-type = "text/markdown" }
 
+[project.scripts]
+cuda-coop-aot = "cuda.coop._aot_cli:main"
+
 [project.optional-dependencies]
 cutlass = [
   "cuda-bindings>=13.0.0,<14.0.0",

--- a/python/cuda_coop/tests/backends/cutlass/compile/test_aot_pack_resolution.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/test_aot_pack_resolution.py
@@ -1,0 +1,754 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("cutlass")
+
+# isort: off
+from cuda.coop.cutlass._compiler import (
+    _bundle as provider_bundle,
+    _bundle_contract as provider_contract,
+    _cache as provider_cache,
+    _nvrtc as provider_nvrtc,
+)
+
+# isort: on
+
+
+class _NvrtcResult:
+    NVRTC_SUCCESS = 0
+
+
+class _FakeNvrtc:
+    nvrtcResult = _NvrtcResult
+
+    def __init__(self, version=(13, 0)):
+        self.calls = []
+        self.blob = b"jit-ltoir"
+        self.version = version
+
+    def nvrtcVersion(self):
+        return 0, *self.version
+
+    def nvrtcCreateProgram(self, source, name, num_headers, headers, include_names):
+        self.calls.append(("create", source))
+        return 0, object()
+
+    def nvrtcCompileProgram(self, program, num_options, options):
+        self.calls.append(("compile", tuple(options)))
+        return (0,)
+
+    def nvrtcGetLTOIRSize(self, program):
+        self.calls.append(("get_ltoir_size",))
+        return 0, len(self.blob)
+
+    def nvrtcGetLTOIR(self, program, blob):
+        self.calls.append(("get_ltoir",))
+        blob[:] = self.blob
+        return (0,)
+
+    def nvrtcDestroyProgram(self, program):
+        self.calls.append(("destroy",))
+        return (0,)
+
+
+def _compile_kwargs():
+    return {
+        "scope": "cuda.coop.cutlass",
+        "provider_dir": provider_bundle.__file__,
+        "registered_headers": dict,
+        "select_bundle_format": lambda: "ltoir",
+        "resolve_nvrtc_sm_arch": lambda: "sm_80",
+        "resolve_nvrtc_arch": lambda: "compute_80",
+        "symbols": ("provider_a", "provider_z"),
+    }
+
+
+def _precompiled_resolver(artifact: Path, *, producer_version: str | None = "13.0"):
+    def resolver(request):
+        return provider_contract.BundleResolution(
+            request=request,
+            path=str(artifact),
+            layouts_by_expression={},
+            route=provider_contract.RESOLUTION_ROUTE_PRECOMPILED,
+            producer_compiler="nvrtc",
+            producer_compiler_version=producer_version,
+            producer_toolkit_version="13.0",
+            phase_timings_ns={},
+        )
+
+    return resolver
+
+
+def _capture_pack(tmp_path: Path) -> Path:
+    from cuda.coop.cutlass import aot
+
+    output = tmp_path / "provider.coop-aot"
+    with aot.capture(output):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+    return output
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch, tmp_path):
+    monkeypatch.delenv("CUDA_COOP_CUTLASS_AOT_PACK_PATH", raising=False)
+    monkeypatch.delenv("CUDA_COOP_CUTLASS_AOT_MODE", raising=False)
+    monkeypatch.setenv(
+        provider_cache.CACHE_DIR_ENV,
+        str(tmp_path / "provider-cache"),
+    )
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", _FakeNvrtc())
+    provider_bundle.reset_compile_state()
+    yield
+    provider_bundle.reset_compile_state()
+
+
+def test_default_jit_path_does_not_import_or_time_aot_dispatch(monkeypatch):
+    module_name = "cuda.coop.cutlass._aot_pack"
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    real_import_module = importlib.import_module
+
+    def guarded_import(name, package=None):
+        if name == module_name:
+            raise AssertionError("ordinary JIT must not import the AOT pack module")
+        return real_import_module(name, package)
+
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(importlib, "import_module", guarded_import)
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    observed = []
+
+    with provider_bundle.activate_bundle_resolution_observer(observed.append):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void ordinary_jit() {}\n',
+            **_compile_kwargs(),
+        )
+
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 1
+    assert observed[0].route == provider_contract.RESOLUTION_ROUTE_NVRTC
+    assert "pack_lookup" not in observed[0].phase_timings_ns
+    assert module_name not in sys.modules
+
+
+def test_import_and_inspect_do_not_activate_aot_resolution(
+    monkeypatch,
+    tmp_path,
+):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    pack = _capture_pack(tmp_path)
+    assert aot.inspect(pack).entries
+    provider_bundle.reset_compile_state()
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("importing or inspecting a pack must not activate it")
+
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(_aot_pack, "resolve_precompiled_bundle", forbidden)
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    observed = []
+    with provider_bundle.activate_bundle_resolution_observer(observed.append):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void inspect_is_inert() {}\n',
+            **_compile_kwargs(),
+        )
+
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 1
+    assert observed[0].route == provider_contract.RESOLUTION_ROUTE_NVRTC
+    assert "pack_lookup" not in observed[0].phase_timings_ns
+
+
+def test_required_hit_skips_nvrtc_and_mutable_jit_io(
+    monkeypatch,
+    tmp_path,
+):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    pack = _capture_pack(tmp_path)
+    provider_bundle.reset_compile_state()
+    monkeypatch.setattr(
+        _aot_pack,
+        "_consumer_nvjitlink_version",
+        lambda: _aot_pack._CudaVersion(major=13, minor=1),
+    )
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("exact AOT hits must bypass mutable JIT I/O")
+
+    observed = []
+    with monkeypatch.context() as hit_patch:
+        hit_patch.setattr(provider_bundle, "cccl_include_dirs", forbidden)
+        hit_patch.setattr(provider_bundle, "include_dirs_identity", forbidden)
+        hit_patch.setattr(provider_bundle, "maybe_dump_source", forbidden)
+        hit_patch.setattr(provider_cache, "ensure_cache_dir", forbidden)
+        hit_patch.setattr(provider_nvrtc, "cuda_nvrtc", forbidden)
+        with (
+            aot.use(pack, mode="required"),
+            provider_bundle.activate_bundle_resolution_observer(observed.append),
+        ):
+            path = provider_bundle.compile_bundle_source(
+                'extern "C" __device__ void provider_a() {}\n',
+                **_compile_kwargs(),
+            )
+
+    assert Path(path).read_bytes() == b"jit-ltoir"
+    assert observed[0].route == provider_contract.RESOLUTION_ROUTE_AOT_PACK
+    assert "pack_lookup" in observed[0].phase_timings_ns
+    assert "precompile_resolvers" not in observed[0].phase_timings_ns
+    assert "header_resolution" not in observed[0].phase_timings_ns
+
+
+def test_auto_miss_falls_back_and_required_miss_precedes_nvrtc(
+    monkeypatch,
+    tmp_path,
+):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    pack = _capture_pack(tmp_path)
+    provider_bundle.reset_compile_state()
+    monkeypatch.setattr(
+        _aot_pack,
+        "_consumer_nvjitlink_version",
+        lambda: _aot_pack._CudaVersion(major=13, minor=1),
+    )
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+
+    with aot.use(pack, mode="auto"):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void pack_miss() {}\n',
+            **_compile_kwargs(),
+        )
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 1
+
+    provider_bundle.reset_compile_state()
+    fake_nvrtc.calls.clear()
+    mismatched_symbols = _compile_kwargs()
+    mismatched_symbols["symbols"] = ("provider_other",)
+    with (
+        aot.use(pack, mode="required"),
+        pytest.raises(aot.PackMissError, match="entry is absent"),
+    ):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **mismatched_symbols,
+        )
+    assert fake_nvrtc.calls == []
+
+
+def test_selected_artifact_is_stable_after_pack_mutation(
+    monkeypatch,
+    tmp_path,
+):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    pack = _capture_pack(tmp_path)
+    payload = _aot_pack._parse_manifest((pack / "manifest.json").read_bytes())
+    entry = payload.entries[0]
+    pack_artifact = pack / "artifacts" / f"{entry.artifact_sha256}.ltoir"
+    provider_bundle.reset_compile_state()
+    monkeypatch.setattr(
+        _aot_pack,
+        "_consumer_nvjitlink_version",
+        lambda: _aot_pack._CudaVersion(major=13, minor=1),
+    )
+
+    with aot.use(pack, mode="required"):
+        pack_artifact.write_bytes(b"mutated-after-validation")
+        path = provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+
+    assert path != str(pack_artifact)
+    assert path.startswith("/proc/self/fd/")
+    assert Path(path).read_bytes() == b"jit-ltoir"
+    with pytest.raises(PermissionError):
+        Path(path).write_bytes(b"attempted-mutation")
+
+
+def test_auto_version_incompatibility_falls_back_to_nvrtc(
+    monkeypatch,
+    tmp_path,
+):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    pack = _capture_pack(tmp_path)
+    provider_bundle.reset_compile_state()
+    monkeypatch.setenv(
+        provider_cache.CACHE_DIR_ENV,
+        str(tmp_path / "fallback-provider-cache"),
+    )
+    monkeypatch.setattr(
+        _aot_pack,
+        "_consumer_nvjitlink_version",
+        lambda: _aot_pack._CudaVersion(major=12, minor=9),
+    )
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    observed = []
+
+    with (
+        aot.use(pack, mode="auto"),
+        provider_bundle.activate_bundle_resolution_observer(observed.append),
+    ):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 1
+    assert observed[0].route == provider_contract.RESOLUTION_ROUTE_NVRTC
+    assert "pack_lookup" in observed[0].phase_timings_ns
+
+
+def test_environment_selection_and_explicit_off_override(
+    monkeypatch,
+    tmp_path,
+):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    pack = _capture_pack(tmp_path)
+    provider_bundle.reset_compile_state()
+    monkeypatch.setattr(
+        _aot_pack,
+        "_consumer_nvjitlink_version",
+        lambda: _aot_pack._CudaVersion(major=13, minor=1),
+    )
+    monkeypatch.setenv(_aot_pack.PACK_PATH_ENV, str(pack))
+    monkeypatch.setenv(_aot_pack.PACK_MODE_ENV, "required")
+
+    observed = []
+    with provider_bundle.activate_bundle_resolution_observer(observed.append):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+    assert observed[-1].route == provider_contract.RESOLUTION_ROUTE_AOT_PACK
+
+    fallback = tmp_path / "fallback.ltoir"
+    fallback.write_bytes(b"fallback")
+    with (
+        aot.use(tmp_path / "ignored", mode="off"),
+        provider_bundle.activate_bundle_precompile_resolver(
+            _precompiled_resolver(fallback)
+        ),
+        provider_bundle.activate_bundle_resolution_observer(observed.append),
+    ):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+    assert observed[-1].route == provider_contract.RESOLUTION_ROUTE_PRECOMPILED
+
+
+def test_aot_and_generic_resolvers_follow_context_nesting_and_restore(
+    monkeypatch,
+    tmp_path,
+):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    pack = _capture_pack(tmp_path)
+    fallback = tmp_path / "fallback.ltoir"
+    fallback.write_bytes(b"fallback")
+    monkeypatch.setattr(
+        _aot_pack,
+        "_consumer_nvjitlink_version",
+        lambda: _aot_pack._CudaVersion(major=13, minor=1),
+    )
+    observed = []
+
+    with (
+        provider_bundle.activate_bundle_precompile_resolver(
+            _precompiled_resolver(fallback)
+        ),
+        provider_bundle.activate_bundle_resolution_observer(observed.append),
+    ):
+        with aot.use(pack, mode="required"):
+            provider_bundle.compile_bundle_source(
+                'extern "C" __device__ void provider_a() {}\n',
+                **_compile_kwargs(),
+            )
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+
+    with (
+        aot.use(pack, mode="required"),
+        provider_bundle.activate_bundle_precompile_resolver(
+            _precompiled_resolver(fallback)
+        ),
+        provider_bundle.activate_bundle_resolution_observer(observed.append),
+    ):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+
+    assert [resolution.route for resolution in observed] == [
+        provider_contract.RESOLUTION_ROUTE_AOT_PACK,
+        provider_contract.RESOLUTION_ROUTE_PRECOMPILED,
+        provider_contract.RESOLUTION_ROUTE_PRECOMPILED,
+    ]
+    assert "pack_lookup" in observed[0].phase_timings_ns
+    assert "pack_lookup" not in observed[1].phase_timings_ns
+    assert "pack_lookup" not in observed[2].phase_timings_ns
+
+
+def test_copy_context_propagates_required_selection_to_worker_thread(
+    monkeypatch,
+    tmp_path,
+):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    pack = _capture_pack(tmp_path)
+    provider_bundle.reset_compile_state()
+    monkeypatch.setattr(
+        _aot_pack,
+        "_consumer_nvjitlink_version",
+        lambda: _aot_pack._CudaVersion(major=13, minor=1),
+    )
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    observed = []
+
+    with (
+        aot.use(pack, mode="required"),
+        provider_bundle.activate_bundle_resolution_observer(observed.append),
+    ):
+        context = copy_context()
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            executor.submit(
+                context.run,
+                provider_bundle.compile_bundle_source,
+                'extern "C" __device__ void provider_a() {}\n',
+                **_compile_kwargs(),
+            ).result()
+
+    assert observed[0].route == provider_contract.RESOLUTION_ROUTE_AOT_PACK
+    assert fake_nvrtc.calls == []
+
+
+def test_copy_context_propagates_capture_to_worker_thread(tmp_path):
+    from cuda.coop.cutlass import aot
+
+    output = tmp_path / "threaded.coop-aot"
+    with aot.capture(output):
+        context = copy_context()
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            executor.submit(
+                context.run,
+                provider_bundle.compile_bundle_source,
+                'extern "C" __device__ void threaded_capture() {}\n',
+                **_compile_kwargs(),
+            ).result()
+
+    assert len(aot.inspect(output).entries) == 1
+
+
+def test_environment_resolver_is_outermost_to_context_resolvers(
+    monkeypatch,
+    tmp_path,
+):
+    from cuda.coop.cutlass import _aot_pack
+
+    pack = _capture_pack(tmp_path)
+    fallback = tmp_path / "fallback.ltoir"
+    fallback.write_bytes(b"fallback")
+    monkeypatch.setenv(_aot_pack.PACK_PATH_ENV, str(pack))
+    monkeypatch.setenv(_aot_pack.PACK_MODE_ENV, "required")
+    observed = []
+
+    with (
+        provider_bundle.activate_bundle_precompile_resolver(
+            _precompiled_resolver(fallback)
+        ),
+        provider_bundle.activate_bundle_resolution_observer(observed.append),
+    ):
+        path = provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+
+    assert path == str(fallback)
+    assert observed[0].route == provider_contract.RESOLUTION_ROUTE_PRECOMPILED
+    assert "pack_lookup" not in observed[0].phase_timings_ns
+
+
+def test_typed_resolver_rejects_a_resolution_from_another_route(tmp_path):
+    artifact = tmp_path / "wrong-route.ltoir"
+    artifact.write_bytes(b"wrong-route")
+    resolver = provider_bundle._bundle_precompile_resolver(
+        _precompiled_resolver(artifact),
+        route=provider_contract.RESOLUTION_ROUTE_AOT_PACK,
+        phase="pack_lookup",
+    )
+
+    with (
+        provider_bundle.activate_bundle_precompile_resolver(resolver),
+        pytest.raises(ValueError, match="invalid route"),
+    ):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void wrong_route() {}\n',
+            **_compile_kwargs(),
+        )
+
+
+def test_environment_pack_path_must_be_absolute(monkeypatch):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    monkeypatch.setenv(_aot_pack.PACK_PATH_ENV, "relative/pack")
+    monkeypatch.setenv(_aot_pack.PACK_MODE_ENV, "auto")
+
+    with pytest.raises(aot.PackError, match="must be an absolute path"):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+
+
+def test_auto_mode_does_not_fall_back_from_pack_integrity_errors(
+    monkeypatch,
+    tmp_path,
+):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    pack = _capture_pack(tmp_path)
+    (pack / "manifest.json").write_text("not-json", encoding="utf-8")
+    provider_bundle.reset_compile_state()
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    monkeypatch.setenv(_aot_pack.PACK_PATH_ENV, str(pack))
+    monkeypatch.setenv(_aot_pack.PACK_MODE_ENV, "auto")
+
+    with pytest.raises(aot.PackIntegrityError, match="valid canonical JSON"):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+    assert fake_nvrtc.calls == []
+
+
+@pytest.mark.parametrize(
+    ("consumer", "mode", "route_or_error"),
+    [
+        ((13, 0), "required", provider_contract.RESOLUTION_ROUTE_AOT_PACK),
+        ((13, 1), "required", provider_contract.RESOLUTION_ROUTE_AOT_PACK),
+        ((12, 9), "required", "different major versions"),
+    ],
+)
+def test_nvjitlink_compatibility_matrix(
+    monkeypatch,
+    tmp_path,
+    consumer,
+    mode,
+    route_or_error,
+):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    pack = _capture_pack(tmp_path)
+    provider_bundle.reset_compile_state()
+    monkeypatch.setattr(
+        _aot_pack,
+        "_consumer_nvjitlink_version",
+        lambda: _aot_pack._CudaVersion(*consumer),
+    )
+    observed = []
+    context = aot.use(pack, mode=mode)
+    if route_or_error == provider_contract.RESOLUTION_ROUTE_AOT_PACK:
+        with (
+            context,
+            provider_bundle.activate_bundle_resolution_observer(observed.append),
+        ):
+            provider_bundle.compile_bundle_source(
+                'extern "C" __device__ void provider_a() {}\n',
+                **_compile_kwargs(),
+            )
+        assert observed[0].route == route_or_error
+    else:
+        with context, pytest.raises(aot.PackMissError, match=route_or_error):
+            provider_bundle.compile_bundle_source(
+                'extern "C" __device__ void provider_a() {}\n',
+                **_compile_kwargs(),
+            )
+
+
+def test_consumer_nvjitlink_version_is_cached(monkeypatch):
+    import cuda.bindings.nvjitlink as cuda_nvjitlink
+    from cuda.coop.cutlass import _aot_pack
+
+    calls = []
+
+    def version():
+        calls.append(None)
+        return 13, 1
+
+    monkeypatch.setattr(cuda_nvjitlink, "version", version)
+    _aot_pack._consumer_nvjitlink_version.cache_clear()
+    try:
+        assert _aot_pack._consumer_nvjitlink_version() == _aot_pack._CudaVersion(
+            13,
+            1,
+        )
+        assert _aot_pack._consumer_nvjitlink_version() == _aot_pack._CudaVersion(
+            13,
+            1,
+        )
+    finally:
+        _aot_pack._consumer_nvjitlink_version.cache_clear()
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize("failure_kind", ["runtime", "binding"])
+@pytest.mark.parametrize("mode", ["auto", "required"])
+def test_nvjitlink_version_failure_obeys_pack_mode(
+    monkeypatch,
+    tmp_path,
+    failure_kind,
+    mode,
+):
+    import cuda.bindings.nvjitlink as cuda_nvjitlink
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    pack = _capture_pack(tmp_path)
+    monkeypatch.setenv(
+        provider_cache.CACHE_DIR_ENV,
+        str(tmp_path / "fallback-provider-cache"),
+    )
+    provider_bundle.reset_compile_state()
+
+    def unavailable_version():
+        if failure_kind == "runtime":
+            raise RuntimeError("nvJitLink version symbol is unavailable")
+        raise cuda_nvjitlink.nvJitLinkError(cuda_nvjitlink.Result.ERROR_INTERNAL.value)
+
+    monkeypatch.setattr(cuda_nvjitlink, "version", unavailable_version)
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    _aot_pack._consumer_nvjitlink_version.cache_clear()
+    try:
+        if mode == "auto":
+            observed = []
+            with (
+                aot.use(pack, mode=mode),
+                provider_bundle.activate_bundle_resolution_observer(observed.append),
+            ):
+                provider_bundle.compile_bundle_source(
+                    'extern "C" __device__ void provider_a() {}\n',
+                    **_compile_kwargs(),
+                )
+            assert observed[0].route == provider_contract.RESOLUTION_ROUTE_NVRTC
+            assert [call[0] for call in fake_nvrtc.calls].count("compile") == 1
+        else:
+            with (
+                aot.use(pack, mode=mode),
+                pytest.raises(
+                    aot.PackMissError,
+                    match="Unable to determine the consumer nvJitLink version",
+                ),
+            ):
+                provider_bundle.compile_bundle_source(
+                    'extern "C" __device__ void provider_a() {}\n',
+                    **_compile_kwargs(),
+                )
+            assert fake_nvrtc.calls == []
+    finally:
+        _aot_pack._consumer_nvjitlink_version.cache_clear()
+
+
+def test_required_rejects_older_consumer_minor(monkeypatch, tmp_path):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", _FakeNvrtc((13, 1)))
+    pack = tmp_path / "provider.coop-aot"
+    with aot.capture(pack):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+    provider_bundle.reset_compile_state()
+    monkeypatch.setattr(
+        _aot_pack,
+        "_consumer_nvjitlink_version",
+        lambda: _aot_pack._CudaVersion(major=13, minor=0),
+    )
+
+    with (
+        aot.use(pack, mode="required"),
+        pytest.raises(aot.PackMissError, match="older than producer NVRTC"),
+    ):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+
+
+def test_capture_reexports_aot_hit_and_preserves_producer_version(
+    monkeypatch,
+    tmp_path,
+):
+    from cuda.coop.cutlass import _aot_pack, aot
+
+    first_pack = _capture_pack(tmp_path)
+    second_pack = tmp_path / "reexported.coop-aot"
+    provider_bundle.reset_compile_state()
+    monkeypatch.setattr(
+        _aot_pack,
+        "_consumer_nvjitlink_version",
+        lambda: _aot_pack._CudaVersion(major=13, minor=1),
+    )
+
+    with aot.capture(second_pack), aot.use(first_pack, mode="required"):
+        provider_bundle.compile_bundle_source(
+            'extern "C" __device__ void provider_a() {}\n',
+            **_compile_kwargs(),
+        )
+
+    first_entry = aot.inspect(first_pack).entries[0]
+    second_entry = aot.inspect(second_pack).entries[0]
+    assert second_entry == first_entry
+    assert second_entry.producer_version == (13, 0)
+
+
+def test_capture_rejects_missing_legacy_producer_version(tmp_path):
+    from cuda.coop.cutlass import aot
+
+    output = tmp_path / "legacy.coop-aot"
+    source = 'extern "C" __device__ void provider_a() {}\n'
+    provider_bundle.compile_bundle_source(
+        source,
+        **_compile_kwargs(),
+    )
+    metadata_path = next((tmp_path / "provider-cache").glob("*.layouts.json"))
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["producer"]["compiler_version"] = None
+    metadata_path.write_text(
+        json.dumps(metadata, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    provider_bundle.reset_compile_state()
+
+    with (
+        pytest.raises(aot.CaptureError, match="legacy provider disk cache"),
+        aot.capture(output),
+    ):
+        provider_bundle.compile_bundle_source(
+            source,
+            **_compile_kwargs(),
+        )
+    assert not output.exists()

--- a/python/cuda_coop/tests/backends/cutlass/compile/test_provider_bundle_resolution.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/test_provider_bundle_resolution.py
@@ -154,6 +154,22 @@ def test_bitcode_resolution_tracks_the_selected_sm_arch(monkeypatch):
     assert calls[0]["cache_identity"].bundle.bundle_sm_arch == "sm_90"
 
 
+def _precompiled_resolution(request, path):
+    return provider_contract.BundleResolution(
+        request=request,
+        path=str(path),
+        layouts_by_expression={
+            expression: provider_contract.StorageLayout(40, 8)
+            for expression in request.identity.layout_expressions
+        },
+        route=provider_contract.RESOLUTION_ROUTE_PRECOMPILED,
+        producer_compiler="nvcc",
+        producer_compiler_version="13.0",
+        producer_toolkit_version="13.0",
+        phase_timings_ns={},
+    )
+
+
 @pytest.fixture(autouse=True)
 def _isolated_bundle_cache(monkeypatch, tmp_path):
     monkeypatch.setenv(
@@ -283,37 +299,38 @@ def test_preload_toolkit_nvrtc_requires_a_reported_version(monkeypatch):
 def test_resolution_routes_preserve_nvrtc_memory_and_disk_behavior(monkeypatch):
     fake_nvrtc = _FakeNvrtc()
     monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    observed = []
 
-    first = provider_bundle.compile_bundle_source(
-        'extern "C" {}',
-        **_compile_kwargs(),
-    )
-    assert provider_bundle.get_bundle_telemetry().route_counts == {
-        provider_contract.RESOLUTION_ROUTE_NVRTC: 1
-    }
-    second = provider_bundle.compile_bundle_source(
-        'extern "C" {}',
-        **_compile_kwargs(),
-    )
-    assert provider_bundle.get_bundle_telemetry().route_counts == {
-        provider_contract.RESOLUTION_ROUTE_NVRTC: 1,
-        provider_contract.RESOLUTION_ROUTE_MEMORY: 1,
-    }
-    provider_bundle.reset_compile_state()
-    third = provider_bundle.compile_bundle_source(
-        'extern "C" {}',
-        **_compile_kwargs(),
-    )
+    with provider_bundle.activate_bundle_resolution_observer(observed.append):
+        first = provider_bundle.compile_bundle_source(
+            'extern "C" {}',
+            **_compile_kwargs(),
+        )
+        second = provider_bundle.compile_bundle_source(
+            'extern "C" {}',
+            **_compile_kwargs(),
+        )
+        provider_bundle.reset_compile_state()
+        third = provider_bundle.compile_bundle_source(
+            'extern "C" {}',
+            **_compile_kwargs(),
+        )
 
     assert first == second == third
+    assert [result.route for result in observed] == [
+        provider_contract.RESOLUTION_ROUTE_NVRTC,
+        provider_contract.RESOLUTION_ROUTE_MEMORY,
+        provider_contract.RESOLUTION_ROUTE_DISK,
+    ]
     assert [call[0] for call in fake_nvrtc.calls].count("compile") == 1
+    assert observed[0].producer_compiler == "nvrtc"
+    assert observed[0].producer_compiler_version == "13.0"
+    assert observed[1].producer_compiler_version == "13.0"
+    assert observed[2].producer_compiler_version == "13.0"
     compile_options = next(call[1] for call in fake_nvrtc.calls if call[0] == "compile")
     identity_options = tuple(
         option.encode("ascii")
-        for option in provider_contract.bundle_compiler_options(
-            "ltoir",
-            "compute_80",
-        )
+        for option in observed[0].request.identity.compiler_options
     )
     assert compile_options[: len(identity_options)] == identity_options
 
@@ -323,23 +340,182 @@ def test_resolution_routes_preserve_nvrtc_memory_and_disk_behavior(monkeypatch):
     assert "compiler" not in telemetry.phase_counts
 
 
+def test_precompile_hit_skips_mutable_jit_io_and_is_context_local(
+    monkeypatch,
+    tmp_path,
+):
+    fake_nvrtc = _FakeNvrtc()
+    monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    precompiled_path = tmp_path / "captured.ltoir"
+    precompiled_path.write_bytes(b"captured")
+    resolver_requests = []
+    observed = []
+
+    def resolver(request):
+        resolver_requests.append(request)
+        return _precompiled_resolution(request, precompiled_path)
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("exact precompile hits must bypass mutable JIT I/O")
+
+    with monkeypatch.context() as hit_patch:
+        hit_patch.setattr(provider_bundle, "cccl_include_dirs", forbidden)
+        hit_patch.setattr(provider_bundle, "include_dirs_identity", forbidden)
+        hit_patch.setattr(provider_bundle, "maybe_dump_source", forbidden)
+        with (
+            provider_bundle.activate_bundle_precompile_resolver(resolver),
+            provider_bundle.activate_bundle_resolution_observer(observed.append),
+        ):
+            compilation = provider_bundle.compile_bundle_source_with_layouts(
+                "struct Storage {};",
+                layout_probes=(_probe(),),
+                **_compile_kwargs(),
+            )
+
+    assert compilation.path == str(precompiled_path)
+    assert compilation.layouts == {"storage": provider_contract.StorageLayout(40, 8)}
+    assert len(resolver_requests) == 1
+    request = resolver_requests[0]
+    assert request.identity.provider_abi_version == 1
+    assert request.identity.bundle_arch == "compute_80"
+    assert request.identity.bundle_sm_arch == "sm_80"
+    assert request.identity.layout_expressions
+    assert observed[0].route == provider_contract.RESOLUTION_ROUTE_PRECOMPILED
+    assert observed[0].producer_toolkit_version == "13.0"
+    assert "header_resolution" not in observed[0].phase_timings_ns
+    assert "header_fingerprint" not in observed[0].phase_timings_ns
+    assert "source_dump" not in observed[0].phase_timings_ns
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 0
+
+    provider_bundle.compile_bundle_source(
+        'extern "C" {}',
+        **_compile_kwargs(),
+    )
+    assert [call[0] for call in fake_nvrtc.calls].count("compile") == 1
+    assert len(observed) == 1
+
+
+def test_nested_precompile_resolvers_are_tried_newest_first(tmp_path):
+    precompiled_path = tmp_path / "captured.ltoir"
+    precompiled_path.write_bytes(b"captured")
+    calls = []
+
+    def outer(request):
+        calls.append("outer")
+        return _precompiled_resolution(request, precompiled_path)
+
+    def inner(request):
+        calls.append("inner")
+
+    with (
+        provider_bundle.activate_bundle_precompile_resolver(outer),
+        provider_bundle.activate_bundle_precompile_resolver(inner),
+    ):
+        path = provider_bundle.compile_bundle_source(
+            'extern "C" {}',
+            **_compile_kwargs(),
+        )
+
+    assert path == str(precompiled_path)
+    assert calls == ["inner", "outer"]
+
+
+def test_nested_resolution_observers_restore_outer_context(tmp_path):
+    precompiled_path = tmp_path / "captured.ltoir"
+    precompiled_path.write_bytes(b"captured")
+    outer_observed = []
+    inner_observed = []
+
+    def resolver(request):
+        return _precompiled_resolution(request, precompiled_path)
+
+    with provider_bundle.activate_bundle_precompile_resolver(resolver):
+        with provider_bundle.activate_bundle_resolution_observer(outer_observed.append):
+            provider_bundle.compile_bundle_source(
+                'extern "C" {}',
+                **_compile_kwargs(),
+            )
+            with provider_bundle.activate_bundle_resolution_observer(
+                inner_observed.append
+            ):
+                provider_bundle.compile_bundle_source(
+                    'extern "C" {}',
+                    **_compile_kwargs(),
+                )
+            provider_bundle.compile_bundle_source(
+                'extern "C" {}',
+                **_compile_kwargs(),
+            )
+
+        provider_bundle.compile_bundle_source(
+            'extern "C" {}',
+            **_compile_kwargs(),
+        )
+
+    assert [result.route for result in outer_observed] == [
+        provider_contract.RESOLUTION_ROUTE_PRECOMPILED,
+        provider_contract.RESOLUTION_ROUTE_PRECOMPILED,
+        provider_contract.RESOLUTION_ROUTE_PRECOMPILED,
+    ]
+    assert [result.route for result in inner_observed] == [
+        provider_contract.RESOLUTION_ROUTE_PRECOMPILED
+    ]
+
+
+def test_precompile_resolver_rejects_incompatible_layout_metadata(tmp_path):
+    precompiled_path = tmp_path / "captured.ltoir"
+    precompiled_path.write_bytes(b"captured")
+
+    def resolver(request):
+        return provider_contract.BundleResolution(
+            request=request,
+            path=str(precompiled_path),
+            layouts_by_expression={},
+            route=provider_contract.RESOLUTION_ROUTE_PRECOMPILED,
+            producer_compiler=None,
+            producer_compiler_version=None,
+            producer_toolkit_version=None,
+            phase_timings_ns={},
+        )
+
+    with (
+        provider_bundle.activate_bundle_precompile_resolver(resolver),
+        pytest.raises(ValueError, match="incompatible layout metadata"),
+    ):
+        provider_bundle.compile_bundle_source_with_layouts(
+            "struct Storage {};",
+            layout_probes=(_probe(),),
+            **_compile_kwargs(),
+        )
+
+
 def test_resolution_telemetry_counts_routes_and_exact_layouts(monkeypatch):
     fake_nvrtc = _FakeNvrtc()
     monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    observed = []
 
-    first = provider_bundle.compile_bundle_source_with_layouts(
-        "struct Storage {};",
-        layout_probes=(_probe(),),
-        **_compile_kwargs(),
-    )
-    second = provider_bundle.compile_bundle_source_with_layouts(
-        "struct Storage {};",
-        layout_probes=(_probe(),),
-        **_compile_kwargs(),
-    )
+    with provider_bundle.activate_bundle_resolution_observer(observed.append):
+        first = provider_bundle.compile_bundle_source_with_layouts(
+            "struct Storage {};",
+            layout_probes=(_probe(),),
+            **_compile_kwargs(),
+        )
+        second = provider_bundle.compile_bundle_source_with_layouts(
+            "struct Storage {};",
+            layout_probes=(_probe(),),
+            **_compile_kwargs(),
+        )
 
     assert first == second
-    assert first.layouts == {"storage": provider_contract.StorageLayout(40, 8)}
+    assert [result.route for result in observed] == [
+        provider_contract.RESOLUTION_ROUTE_NVRTC,
+        provider_contract.RESOLUTION_ROUTE_MEMORY,
+    ]
+    for result in observed:
+        assert set(result.layouts_by_expression) == set(
+            result.request.identity.layout_expressions
+        )
+        assert all(value >= 0 for value in result.phase_timings_ns.values())
 
     telemetry = provider_bundle.get_bundle_telemetry()
     assert telemetry.route_counts == {
@@ -354,21 +530,28 @@ def test_resolution_telemetry_counts_routes_and_exact_layouts(monkeypatch):
 def test_nvrtc_version_changes_mutable_cache_identity(monkeypatch):
     fake_nvrtc = _FakeNvrtc()
     monkeypatch.setattr(provider_nvrtc, "cuda_nvrtc", fake_nvrtc)
+    observed = []
 
-    first = provider_bundle.compile_bundle_source(
-        'extern "C" {}',
-        **_compile_kwargs(),
-    )
-    fake_nvrtc.version = (13, 1)
-    second = provider_bundle.compile_bundle_source(
-        'extern "C" {}',
-        **_compile_kwargs(),
-    )
+    with provider_bundle.activate_bundle_resolution_observer(observed.append):
+        first = provider_bundle.compile_bundle_source(
+            'extern "C" {}',
+            **_compile_kwargs(),
+        )
+        fake_nvrtc.version = (13, 1)
+        second = provider_bundle.compile_bundle_source(
+            'extern "C" {}',
+            **_compile_kwargs(),
+        )
 
     assert first != second
-    assert provider_bundle.get_bundle_telemetry().route_counts == {
-        provider_contract.RESOLUTION_ROUTE_NVRTC: 2
-    }
+    assert [result.route for result in observed] == [
+        provider_contract.RESOLUTION_ROUTE_NVRTC,
+        provider_contract.RESOLUTION_ROUTE_NVRTC,
+    ]
+    assert [result.producer_compiler_version for result in observed] == [
+        "13.0",
+        "13.1",
+    ]
     assert [call[0] for call in fake_nvrtc.calls].count("compile") == 2
 
 
@@ -439,7 +622,7 @@ def _forked_nvrtc_counter_worker(connection):
         try:
             provider_nvrtc.reset_compile_state()
             outcome["counter"] = provider_nvrtc.get_compile_program_counter()
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             outcome["error"] = repr(exc)
 
     thread = threading.Thread(target=access_counter, daemon=True)

--- a/python/cuda_coop/tests/backends/cutlass/compile/test_provider_finalization.py
+++ b/python/cuda_coop/tests/backends/cutlass/compile/test_provider_finalization.py
@@ -122,12 +122,12 @@ def test_trace_finalizer_compiles_and_links_registered_requests(monkeypatch):
     session.add(_Request())
     _state.set_bundle_session(compile_options, session)
 
-    compiled_sources: list[str] = []
+    compiled_sources: list[tuple[str, tuple[str, ...]]] = []
     materialized: list[tuple[object, ...]] = []
     linked: list[tuple[object, str]] = []
 
-    def compile_source(source: str) -> str:
-        compiled_sources.append(source)
+    def compile_source(source: str, symbols: tuple[str, ...]) -> str:
+        compiled_sources.append((source, symbols))
         return "/tmp/cuda_coop_foundation_test.ltoir"
 
     monkeypatch.setattr(finalizer, "_compile_bundle_source", compile_source)
@@ -145,7 +145,8 @@ def test_trace_finalizer_compiles_and_links_registered_requests(monkeypatch):
     finalizer._trace_finalize_hook(dsl, module, "kernel")
 
     assert len(compiled_sources) == 1
-    assert "cuda_coop_foundation_test" in compiled_sources[0]
+    assert "cuda_coop_foundation_test" in compiled_sources[0][0]
+    assert compiled_sources[0][1] == ("cuda_coop_foundation_test",)
     assert materialized == [()]
     assert linked == [(module, "/tmp/cuda_coop_foundation_test.ltoir")]
     assert _state.lookup_bundle_session(compile_options) is None
@@ -174,7 +175,9 @@ def test_trace_finalizer_preserves_a_session_for_its_owning_module(monkeypatch):
     monkeypatch.setattr(
         finalizer,
         "_compile_bundle_source",
-        lambda source: compiled_sources.append(source) or "/tmp/provider.ltoir",
+        lambda source, _symbols: (
+            compiled_sources.append(source) or "/tmp/provider.ltoir"
+        ),
     )
     monkeypatch.setattr(
         _provider_bundle,

--- a/python/cuda_coop/tests/backends/cutlass/unit/test_aot_cli.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/test_aot_cli.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from cuda.coop.cutlass import _aot_cli, aot
+
+
+def _script(tmp_path: Path, source: str) -> Path:
+    path = tmp_path / "workload.py"
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def test_script_workload_preserves_python_argv_and_import_path(tmp_path):
+    result_path = tmp_path / "result.json"
+    script = _script(
+        tmp_path,
+        "import json, pathlib, sys\n"
+        f"pathlib.Path({str(result_path)!r}).write_text(\n"
+        "    json.dumps({'argv': sys.argv, 'path0': sys.path[0]}),\n"
+        "    encoding='utf-8',\n"
+        ")\n",
+    )
+    original_argv = sys.argv
+    original_path = sys.path
+    original_path_contents = list(sys.path)
+
+    code = _aot_cli._run_python_workload(
+        [sys.executable, str(script), "first", "second"]
+    )
+
+    assert code == 0
+    assert json.loads(result_path.read_text(encoding="utf-8")) == {
+        "argv": [str(script.resolve()), "first", "second"],
+        "path0": str(tmp_path),
+    }
+    assert sys.argv is original_argv
+    assert sys.path is original_path
+    assert sys.path == original_path_contents
+
+
+def test_module_workload_uses_current_directory_and_arguments(
+    tmp_path,
+    monkeypatch,
+):
+    result_path = tmp_path / "module-result.json"
+    module = tmp_path / "captured_module.py"
+    module.write_text(
+        "import json, pathlib, sys\n"
+        f"pathlib.Path({str(result_path)!r}).write_text(\n"
+        "    json.dumps({'argv': sys.argv, 'path0': sys.path[0]}),\n"
+        "    encoding='utf-8',\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    code = _aot_cli._run_python_workload(
+        [sys.executable, "-m", "captured_module", "argument"]
+    )
+
+    assert code == 0
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["argv"][1:] == ["argument"]
+    assert Path(result["argv"][0]) == module
+    assert result["path0"] == str(tmp_path)
+
+
+def test_capture_rolls_back_on_nonzero_system_exit(
+    tmp_path,
+    monkeypatch,
+):
+    script = _script(tmp_path, "raise SystemExit(7)\n")
+    observed = {}
+
+    class FakeCapture:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exception_type, exception, traceback):
+            observed["exception_type"] = exception_type
+            return False
+
+    monkeypatch.setattr(
+        _aot_cli.aot, "capture", lambda *_args, **_kwargs: FakeCapture()
+    )
+    arguments = argparse.Namespace(
+        output=tmp_path / "unused",
+        name=None,
+        command=[sys.executable, str(script)],
+    )
+
+    assert _aot_cli._run_capture(arguments) == 7
+    assert observed["exception_type"] is _aot_cli._WorkloadExit
+
+
+def test_capture_publishes_on_zero_system_exit(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    script = _script(tmp_path, "raise SystemExit(0)\n")
+    output = tmp_path / "captured.coop-aot"
+    observed = {}
+
+    class FakeCapture:
+        result = SimpleNamespace(entries=(object(),), path=output)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exception_type, exception, traceback):
+            observed["exception_type"] = exception_type
+            return False
+
+    monkeypatch.setattr(
+        _aot_cli.aot, "capture", lambda *_args, **_kwargs: FakeCapture()
+    )
+    arguments = argparse.Namespace(
+        output=output,
+        name="workload",
+        command=[sys.executable, str(script)],
+    )
+
+    assert _aot_cli._run_capture(arguments) == 0
+    assert observed["exception_type"] is None
+    assert "Captured 1 provider bundle(s)" in capsys.readouterr().err
+
+
+def test_run_selects_pack_and_preserves_workload_exit_code(
+    tmp_path,
+    monkeypatch,
+):
+    script = _script(tmp_path, "raise SystemExit(5)\n")
+    observed = {}
+
+    @contextmanager
+    def fake_use(pack, *, mode):
+        observed["selection"] = (pack, mode)
+        observed["environment"] = (
+            os.environ[_aot_cli._aot_pack.PACK_PATH_ENV],
+            os.environ[_aot_cli._aot_pack.PACK_MODE_ENV],
+        )
+        yield
+
+    monkeypatch.setattr(_aot_cli.aot, "use", fake_use)
+    monkeypatch.setenv(_aot_cli._aot_pack.PACK_PATH_ENV, "/previous/pack")
+    monkeypatch.setenv(_aot_cli._aot_pack.PACK_MODE_ENV, "auto")
+    pack = tmp_path / "selected.coop-aot"
+    arguments = argparse.Namespace(
+        pack=pack,
+        mode="required",
+        command=[sys.executable, str(script)],
+    )
+
+    assert _aot_cli._run_with_pack(arguments) == 5
+    assert observed["selection"] == (pack, "required")
+    assert observed["environment"] == (str(pack), "required")
+    assert os.environ[_aot_cli._aot_pack.PACK_PATH_ENV] == "/previous/pack"
+    assert os.environ[_aot_cli._aot_pack.PACK_MODE_ENV] == "auto"
+
+
+def test_inspect_emits_structured_json(tmp_path, monkeypatch, capsys):
+    pack = tmp_path / "inspected.coop-aot"
+    info = aot.PackInfo(
+        path=pack,
+        name="inspected",
+        schema_version=1,
+        provider_abi_version=1,
+        writer_version="1.2.3",
+        entries=(),
+    )
+    monkeypatch.setattr(_aot_cli.aot, "inspect", lambda _path: info)
+
+    assert _aot_cli._run_inspect(argparse.Namespace(pack=pack)) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "artifact_bytes": 0,
+        "entries": [],
+        "name": "inspected",
+        "path": str(pack),
+        "provider_abi_version": 1,
+        "schema_version": 1,
+        "writer_version": "1.2.3",
+    }
+
+
+def test_workload_rejects_a_different_python_interpreter(monkeypatch):
+    monkeypatch.setattr(_aot_cli, "_same_interpreter", lambda _command: False)
+
+    with pytest.raises(
+        _aot_cli._CommandError,
+        match="same Python interpreter",
+    ):
+        _aot_cli._python_workload(["python", "workload.py"])

--- a/python/cuda_coop/tests/backends/cutlass/unit/test_aot_pack.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/test_aot_pack.py
@@ -1,0 +1,912 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import hashlib
+import json
+import multiprocessing
+import os
+import shutil
+import sys
+import threading
+import warnings
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from cuda.coop.cutlass import _aot_pack, aot
+
+# isort: off
+from cuda.coop.cutlass._compiler import (
+    _bundle_contract as provider_contract,
+    _nvrtc as provider_nvrtc,
+)
+
+# isort: on
+
+
+class _NvrtcResult:
+    NVRTC_SUCCESS = 0
+
+
+class _FakeNvrtc:
+    nvrtcResult = _NvrtcResult
+
+    def __init__(self):
+        self.blob = b"portable-ltoir"
+
+    def nvrtcVersion(self):
+        return 0, 13, 0
+
+    def nvrtcCreateProgram(self, source, name, num_headers, headers, include_names):
+        return 0, object()
+
+    def nvrtcCompileProgram(self, program, num_options, options):
+        return (0,)
+
+    def nvrtcGetLTOIRSize(self, program):
+        return 0, len(self.blob)
+
+    def nvrtcGetLTOIR(self, program, blob):
+        blob[:] = self.blob
+        return (0,)
+
+    def nvrtcDestroyProgram(self, program):
+        return (0,)
+
+
+@pytest.fixture
+def provider_bundle(monkeypatch, tmp_path):
+    pytest.importorskip("cutlass")
+
+    # isort: off
+    from cuda.coop.cutlass._compiler import (
+        _bundle as _provider_bundle,
+        _cache as _provider_cache,
+        _nvrtc as _provider_nvrtc,
+    )
+
+    # isort: on
+
+    monkeypatch.setenv(
+        _provider_cache.CACHE_DIR_ENV,
+        str(tmp_path / "provider-cache"),
+    )
+    monkeypatch.setattr(_provider_nvrtc, "cuda_nvrtc", _FakeNvrtc())
+    _provider_bundle.reset_compile_state()
+    try:
+        yield _provider_bundle
+    finally:
+        _provider_bundle.reset_compile_state()
+
+
+def _compile_kwargs(provider_bundle, arch: str):
+    suffix = arch.removeprefix("sm_")
+    return {
+        "scope": "cuda.coop.cutlass",
+        "provider_dir": provider_bundle.__file__,
+        "registered_headers": dict,
+        "select_bundle_format": lambda: "ltoir",
+        "resolve_nvrtc_sm_arch": lambda: arch,
+        "resolve_nvrtc_arch": lambda: f"compute_{suffix}",
+    }
+
+
+def _precompiled_resolver(provider_bundle, artifact: Path):
+    def resolver(request):
+        return provider_contract.BundleResolution(
+            request=request,
+            path=str(artifact),
+            layouts_by_expression={
+                expression: provider_contract.StorageLayout(16, 8)
+                for expression in request.identity.layout_expressions
+            },
+            route=provider_contract.RESOLUTION_ROUTE_PRECOMPILED,
+            producer_compiler="nvrtc",
+            producer_compiler_version="13.0",
+            producer_toolkit_version="13.0",
+            phase_timings_ns={},
+        )
+
+    return resolver
+
+
+def _compile_source(
+    provider_bundle,
+    source: str,
+    arch: str = "sm_80",
+    *,
+    symbols: tuple[str, ...] = (
+        "provider_z",
+        "provider_a",
+        "provider_z",
+    ),
+) -> str:
+    return provider_bundle.compile_bundle_source(
+        source,
+        symbols=symbols,
+        **_compile_kwargs(provider_bundle, arch),
+    )
+
+
+def _capture_pack(
+    tmp_path: Path,
+    provider_bundle,
+    *,
+    output_name: str = "captured.coop-aot",
+    sources: tuple[tuple[str, str], ...] = (
+        ('extern "C" __device__ int provider_a() { return 1; }\n', "sm_80"),
+    ),
+) -> tuple[Path, aot.CaptureResult]:
+    output = tmp_path / output_name
+    with aot.capture(output, name="test-pack") as captured:
+        for source, arch in sources:
+            _compile_source(provider_bundle, source, arch)
+    return output, captured.result
+
+
+def _manifest_payload(pack: Path) -> dict:
+    return json.loads((pack / "manifest.json").read_text(encoding="utf-8"))
+
+
+def _write_manifest(pack: Path, payload: dict) -> None:
+    (pack / "manifest.json").write_bytes(_aot_pack._canonical_json_bytes(payload))
+
+
+def test_non_linux_pack_operations_fail_before_filesystem_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_aot_pack.sys, "platform", "win32")
+    pack = tmp_path / "missing.coop-aot"
+    output = tmp_path / "captured.coop-aot"
+
+    with pytest.raises(aot.PackError, match="currently require Linux"):
+        aot.inspect(pack)
+    with (
+        pytest.raises(aot.PackError, match="currently require Linux"),
+        aot.use(pack, mode="required"),
+    ):
+        pass
+    with (
+        pytest.raises(aot.PackError, match="currently require Linux"),
+        aot.capture(output),
+    ):
+        pass
+
+    with aot.use(pack, mode="off") as selected:
+        assert selected is None
+    assert not output.exists()
+
+
+def test_capture_is_canonical_relocatable_and_deduplicates_exact_bundles(
+    tmp_path,
+    provider_bundle,
+):
+    source_a = 'extern "C" __device__ int provider_a() { return 1; }\n'
+    source_b = 'extern "C" __device__ long provider_b() { return 2; }\n'
+    output, result = _capture_pack(
+        tmp_path,
+        provider_bundle,
+        sources=(
+            (source_b, "sm_90a"),
+            (source_a, "sm_80"),
+            (source_b, "sm_90a"),
+        ),
+    )
+
+    assert result.path == output
+    assert result.name == "test-pack"
+    assert result.observations == 3
+    assert len(result.entries) == 2
+    assert [entry.entry_id for entry in result.entries] == sorted(
+        entry.entry_id for entry in result.entries
+    )
+    assert {(entry.compute_arch, entry.sm_arch) for entry in result.entries} == {
+        ("compute_80", "sm_80"),
+        ("compute_90a", "sm_90a"),
+    }
+    assert all(
+        entry.symbols == ("provider_a", "provider_z") for entry in result.entries
+    )
+    manifest_bytes = (output / "manifest.json").read_bytes()
+    assert manifest_bytes == _aot_pack._canonical_json_bytes(json.loads(manifest_bytes))
+
+    relocated = tmp_path / "relocated.coop-aot"
+    output.rename(relocated)
+    info = aot.inspect(relocated)
+
+    assert info.path == relocated
+    assert info.name == "test-pack"
+    assert info.writer_version
+    assert info.entries == result.entries
+    assert info.artifact_bytes == result.artifact_bytes
+    assert all("/" not in entry.entry_id for entry in info.entries)
+
+
+def test_capture_result_and_pack_info_are_frozen(tmp_path, provider_bundle):
+    output, result = _capture_pack(tmp_path, provider_bundle)
+    info = aot.inspect(output)
+
+    with pytest.raises(FrozenInstanceError):
+        result.name = "changed"
+    with pytest.raises(FrozenInstanceError):
+        info.name = "changed"
+    with pytest.raises(FrozenInstanceError):
+        info.entries[0].sm_arch = "sm_90"
+
+
+def _forked_aot_lock_worker(lock_name, pack, connection):
+    if lock_name == "_PACK_CACHE_LOCK":
+        _aot_pack._load_pack_cached(pack)
+    else:
+        artifact = b"forked-materialized-artifact"
+        _aot_pack._materialize_artifact(hashlib.sha256(artifact).hexdigest(), artifact)
+    connection.send("acquired")
+    connection.close()
+
+
+def _forked_capture_worker(inherited_capture, child_output, connection):
+    from cuda.coop.cutlass._compiler import _bundle as _provider_bundle
+
+    result = {
+        "inherited_capture_cleared": _aot_pack._ACTIVE_CAPTURE.get() is None,
+    }
+    try:
+        with aot.capture(child_output) as child_capture:
+            _compile_source(
+                _provider_bundle,
+                'extern "C" __device__ void child_capture() {}\n',
+            )
+    except BaseException as exc:  # noqa: BLE001
+        result["fresh_capture_error"] = (type(exc).__name__, str(exc))
+    else:
+        result["fresh_capture_error"] = None
+        result["fresh_capture_observations"] = child_capture.result.observations
+
+    try:
+        inherited_capture.__exit__(None, None, None)
+    except BaseException as exc:  # noqa: BLE001
+        result["inherited_exit_error"] = (type(exc).__name__, str(exc))
+    else:
+        result["inherited_exit_error"] = None
+
+    connection.send(result)
+    connection.close()
+
+
+@pytest.mark.parametrize(
+    "lock_name",
+    ["_PACK_CACHE_LOCK", "_MATERIALIZED_ARTIFACTS_LOCK"],
+)
+@pytest.mark.skipif(
+    not hasattr(os, "fork"),
+    reason="test requires POSIX fork state reset",
+)
+@pytest.mark.filterwarnings(
+    "ignore:This process .* is multi-threaded, use of fork.*:DeprecationWarning"
+)
+def test_process_locks_reset_after_fork(
+    tmp_path,
+    provider_bundle,
+    lock_name,
+):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    lock = getattr(_aot_pack, lock_name)
+    lock_held = threading.Event()
+    release_lock = threading.Event()
+
+    def hold_lock():
+        with lock:
+            lock_held.set()
+            release_lock.wait()
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    process = None
+    parent_connection = None
+    child_connection = None
+    try:
+        assert lock_held.wait(timeout=5)
+        context = multiprocessing.get_context("fork")
+        parent_connection, child_connection = context.Pipe(duplex=False)
+        process = context.Process(
+            target=_forked_aot_lock_worker,
+            args=(lock_name, output, child_connection),
+        )
+        process.start()
+        assert parent_connection.poll(5)
+        assert parent_connection.recv() == "acquired"
+        process.join(timeout=5)
+    finally:
+        release_lock.set()
+        holder.join(timeout=5)
+        if process is not None and process.is_alive():
+            process.terminate()
+        if process is not None:
+            process.join(timeout=5)
+        if parent_connection is not None:
+            parent_connection.close()
+        if child_connection is not None:
+            child_connection.close()
+
+    assert process is not None
+    assert not holder.is_alive()
+    assert not process.is_alive()
+    assert process.exitcode == 0
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork"),
+    reason="test requires POSIX fork behavior",
+)
+@pytest.mark.filterwarnings(
+    "ignore:This process .* is multi-threaded, use of fork.*:DeprecationWarning"
+)
+def test_active_capture_detaches_before_child_capture(
+    tmp_path,
+    provider_bundle,
+):
+    parent_output = tmp_path / "parent.coop-aot"
+    child_output = tmp_path / "child.coop-aot"
+    process = None
+    parent_connection = None
+    child_connection = None
+    with aot.capture(parent_output) as capture:
+        try:
+            context = multiprocessing.get_context("fork")
+            parent_connection, child_connection = context.Pipe(duplex=False)
+            process = context.Process(
+                target=_forked_capture_worker,
+                args=(capture, child_output, child_connection),
+            )
+            process.start()
+            assert parent_connection.poll(5)
+            result = parent_connection.recv()
+            process.join(timeout=5)
+        finally:
+            if process is not None and process.is_alive():
+                process.terminate()
+            if process is not None:
+                process.join(timeout=5)
+            if parent_connection is not None:
+                parent_connection.close()
+            if child_connection is not None:
+                child_connection.close()
+
+        assert process is not None
+        assert process.exitcode == 0
+        expected = (
+            "CaptureError",
+            _aot_pack._CAPTURE_PROCESS_BOUNDARY_ERROR,
+        )
+        assert result["inherited_capture_cleared"]
+        assert result["fresh_capture_error"] is None
+        assert result["fresh_capture_observations"] == 1
+        assert result["inherited_exit_error"] == expected
+        _compile_source(
+            provider_bundle,
+            'extern "C" __device__ void parent_capture() {}\n',
+        )
+
+    assert capture.result.observations == 1
+    assert len(aot.inspect(parent_output).entries) == 1
+    assert len(aot.inspect(child_output).entries) == 1
+    assert len(tuple((parent_output / "sources").iterdir())) == 1
+    assert len(tuple((child_output / "sources").iterdir())) == 1
+
+
+def test_symbol_sets_are_bound_into_distinct_coexisting_entry_ids(
+    tmp_path,
+    provider_bundle,
+    monkeypatch,
+):
+    source = 'extern "C" __device__ void shared_source() {}\n'
+    output = tmp_path / "symbols.coop-aot"
+
+    with aot.capture(output) as captured:
+        _compile_source(
+            provider_bundle,
+            source,
+            symbols=("provider_a",),
+        )
+        _compile_source(
+            provider_bundle,
+            source,
+            symbols=("provider_b",),
+        )
+
+    entries = captured.result.entries
+    assert len(entries) == 2
+    assert len({entry.entry_id for entry in entries}) == 2
+    assert {entry.symbols for entry in entries} == {
+        ("provider_a",),
+        ("provider_b",),
+    }
+    assert len({entry.source_sha256 for entry in entries}) == 1
+    assert len({entry.artifact_sha256 for entry in entries}) == 1
+    assert len(tuple((output / "sources").iterdir())) == 1
+    assert len(tuple((output / "artifacts").iterdir())) == 1
+
+    observed = []
+    provider_bundle.reset_compile_state()
+    monkeypatch.setattr(
+        _aot_pack,
+        "_consumer_nvjitlink_version",
+        lambda: _aot_pack._CudaVersion(major=13, minor=0),
+    )
+    with (
+        aot.use(output, mode="required"),
+        provider_bundle.activate_bundle_resolution_observer(observed.append),
+    ):
+        _compile_source(
+            provider_bundle,
+            source,
+            symbols=("provider_a",),
+        )
+        _compile_source(
+            provider_bundle,
+            source,
+            symbols=("provider_b",),
+        )
+    assert [resolution.route for resolution in observed] == [
+        provider_contract.RESOLUTION_ROUTE_AOT_PACK,
+        provider_contract.RESOLUTION_ROUTE_AOT_PACK,
+    ]
+
+
+def test_shared_artifact_rejects_conflicting_declared_sizes(
+    tmp_path,
+    provider_bundle,
+):
+    source = 'extern "C" __device__ void shared_source() {}\n'
+    output = tmp_path / "shared-artifact-size.coop-aot"
+
+    with aot.capture(output):
+        _compile_source(provider_bundle, source, symbols=("provider_a",))
+        _compile_source(provider_bundle, source, symbols=("provider_b",))
+
+    manifest = _manifest_payload(output)
+    assert len(manifest["entries"]) == 2
+    assert (
+        manifest["entries"][0]["artifact_sha256"]
+        == manifest["entries"][1]["artifact_sha256"]
+    )
+    manifest["entries"][1]["artifact_size"] += 1
+    _write_manifest(output, manifest)
+
+    with pytest.raises(
+        aot.PackIntegrityError,
+        match="conflicting declared sizes",
+    ):
+        aot.inspect(output)
+
+
+def test_same_identity_and_symbols_reject_conflicting_artifacts(
+    tmp_path,
+    provider_bundle,
+):
+    source = 'extern "C" __device__ void provider_a() {}\n'
+    output = tmp_path / "conflict.coop-aot"
+    fake_nvrtc = provider_nvrtc.cuda_nvrtc
+
+    with (
+        pytest.raises(aot.CaptureError, match="Conflicting provider artifacts"),
+        aot.capture(output),
+    ):
+        first_path = _compile_source(
+            provider_bundle,
+            source,
+            symbols=("provider_a",),
+        )
+        Path(first_path).unlink()
+        provider_bundle.reset_compile_state()
+        fake_nvrtc.blob = b"different-portable-ltoir"
+        _compile_source(
+            provider_bundle,
+            source,
+            symbols=("provider_a",),
+        )
+
+    assert not output.exists()
+
+
+def test_capture_rejects_external_precompile_resolution_origin(
+    tmp_path,
+    provider_bundle,
+):
+    artifact = tmp_path / "external.ltoir"
+    artifact.write_bytes(b"external-ltoir")
+    output = tmp_path / "external.coop-aot"
+
+    with (
+        pytest.raises(aot.CaptureError, match="trusted native-code inputs"),
+        aot.capture(output),
+        provider_bundle.activate_bundle_precompile_resolver(
+            _precompiled_resolver(provider_bundle, artifact)
+        ),
+    ):
+        _compile_source(provider_bundle, 'extern "C" {}')
+
+    assert not output.exists()
+    assert "trusted native-code" in aot.capture.__doc__
+    assert "trusted native-code" in aot.inspect.__doc__
+
+
+def test_nested_capture_is_rejected_without_disrupting_outer_capture(
+    tmp_path,
+    provider_bundle,
+):
+    outer_path = tmp_path / "outer.coop-aot"
+
+    with aot.capture(outer_path) as outer:
+        with (
+            pytest.raises(aot.CaptureError, match="Nested AOT capture"),
+            aot.capture(tmp_path / "inner.coop-aot"),
+        ):
+            pass
+        _compile_source(provider_bundle, 'extern "C" {}')
+
+    assert outer.result.path == outer_path
+    assert len(outer.result.entries) == 1
+
+
+def test_empty_and_exceptional_capture_publish_nothing(tmp_path):
+    empty = tmp_path / "empty.coop-aot"
+    with (
+        pytest.raises(aot.CaptureError, match="observed no provider bundles"),
+        aot.capture(empty),
+    ):
+        pass
+    assert not empty.exists()
+
+    failed = tmp_path / "failed.coop-aot"
+    with pytest.raises(RuntimeError, match="user failure"), aot.capture(failed):
+        raise RuntimeError("user failure")
+    assert not failed.exists()
+    assert not tuple(tmp_path.glob(".*.staging-*"))
+
+
+def test_capture_is_create_only(tmp_path, provider_bundle):
+    output = tmp_path / "existing.coop-aot"
+    output.mkdir()
+
+    with (
+        pytest.raises(aot.CaptureError, match="already exists"),
+        aot.capture(output),
+    ):
+        pass
+
+    assert list(output.iterdir()) == []
+
+
+def test_concurrent_capture_publication_has_exactly_one_winner(
+    tmp_path,
+    provider_bundle,
+):
+    output = tmp_path / "raced.coop-aot"
+    barrier = threading.Barrier(2)
+    results = []
+    errors = []
+
+    def worker() -> None:
+        try:
+            with aot.capture(output) as captured:
+                _compile_source(provider_bundle, 'extern "C" {}')
+                barrier.wait()
+            results.append(captured.result)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(results) == 1
+    assert len(errors) == 1
+    assert isinstance(errors[0], aot.CaptureError)
+    assert "already exists" in str(errors[0])
+    assert aot.inspect(output).entries == results[0].entries
+    assert not tuple(tmp_path.glob(".*.staging-*"))
+
+
+def test_parent_fsync_failure_does_not_report_a_published_pack_as_failed(
+    tmp_path,
+    provider_bundle,
+    monkeypatch,
+):
+    original_fsync_directory = _aot_pack._fsync_directory
+
+    def fail_parent_fsync(path):
+        if path == tmp_path:
+            raise OSError("injected parent fsync failure")
+        original_fsync_directory(path)
+
+    monkeypatch.setattr(_aot_pack, "_fsync_directory", fail_parent_fsync)
+    with pytest.warns(RuntimeWarning, match="was published atomically"):
+        output, result = _capture_pack(
+            tmp_path,
+            provider_bundle,
+            output_name="parent-fsync.coop-aot",
+        )
+
+    assert result.path == output
+    assert aot.inspect(output).entries == result.entries
+    assert not tuple(tmp_path.glob(".*.staging-*"))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        strict_output, strict_result = _capture_pack(
+            tmp_path,
+            provider_bundle,
+            output_name="strict-warning-filter.coop-aot",
+        )
+    assert strict_result.path == strict_output
+    assert aot.inspect(strict_output).entries == strict_result.entries
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("schema_version", 2, "unsupported schema version"),
+        ("provider_abi_version", 2, "unsupported provider ABI version"),
+        ("format", "other", "unsupported format"),
+    ],
+)
+def test_manifest_rejects_unsupported_schema_and_abi(
+    tmp_path,
+    provider_bundle,
+    field,
+    value,
+    match,
+):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    payload = _manifest_payload(output)
+    payload[field] = value
+    _write_manifest(output, payload)
+
+    with pytest.raises(aot.PackIntegrityError, match=match):
+        aot.inspect(output)
+
+
+def test_manifest_rejects_duplicate_entries_and_noncanonical_encoding(
+    tmp_path,
+    provider_bundle,
+):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    payload = _manifest_payload(output)
+    payload["entries"].append(payload["entries"][0])
+    _write_manifest(output, payload)
+
+    with pytest.raises(aot.PackIntegrityError, match="unique sorted IDs"):
+        aot.inspect(output)
+
+    output, _ = _capture_pack(
+        tmp_path,
+        provider_bundle,
+        output_name="noncanonical.coop-aot",
+    )
+    payload = _manifest_payload(output)
+    (output / "manifest.json").write_text(
+        json.dumps(payload, indent=2),
+        encoding="utf-8",
+    )
+    with pytest.raises(aot.PackIntegrityError, match="not canonically encoded"):
+        aot.inspect(output)
+
+
+def test_manifest_rejects_duplicate_json_keys(tmp_path, provider_bundle):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    manifest = (output / "manifest.json").read_text(encoding="utf-8")
+    manifest = manifest.replace(
+        '"format":"cuda.coop.cutlass.aot-pack"',
+        '"format":"cuda.coop.cutlass.aot-pack","format":"duplicate"',
+        1,
+    )
+    (output / "manifest.json").write_text(manifest, encoding="utf-8")
+
+    with pytest.raises(aot.PackIntegrityError, match="valid canonical JSON"):
+        aot.inspect(output)
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "artifact-digest",
+        "artifact-size",
+        "artifact-oversize",
+        "source",
+        "source-oversize",
+    ],
+)
+def test_pack_rejects_corrupt_content(tmp_path, provider_bundle, kind, monkeypatch):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    payload = _manifest_payload(output)
+    entry = payload["entries"][0]
+    if kind == "artifact-digest":
+        artifact = output / "artifacts" / f"{entry['artifact_sha256']}.ltoir"
+        artifact.write_bytes(b"corrupt-ltoir")
+    elif kind == "artifact-size":
+        entry["artifact_size"] += 1
+        _write_manifest(output, payload)
+    elif kind == "artifact-oversize":
+        entry["artifact_size"] -= 1
+        _write_manifest(output, payload)
+    elif kind == "source":
+        source = output / "sources" / f"{entry['identity']['source_sha256']}.cu"
+        source.write_text("corrupt source", encoding="utf-8")
+    else:
+        source = output / "sources" / f"{entry['identity']['source_sha256']}.cu"
+        monkeypatch.setattr(_aot_pack, "MAX_SOURCE_BYTES", source.stat().st_size - 1)
+
+    with pytest.raises(
+        aot.PackIntegrityError,
+        match="invalid (digest|size)|unexpectedly large",
+    ):
+        aot.inspect(output)
+
+
+def test_capture_rejects_oversized_source(tmp_path, provider_bundle, monkeypatch):
+    monkeypatch.setattr(_aot_pack, "MAX_SOURCE_BYTES", 1)
+
+    with pytest.raises(aot.CaptureError, match="unexpectedly large"):
+        _capture_pack(tmp_path, provider_bundle)
+
+    assert not (tmp_path / "captured.coop-aot").exists()
+    assert not tuple(tmp_path.glob(".*.staging-*"))
+
+
+def test_pack_rejects_huge_declared_artifact_size_as_integrity_error(
+    tmp_path,
+    provider_bundle,
+):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    payload = _manifest_payload(output)
+    payload["entries"][0]["artifact_size"] = sys.maxsize
+    _write_manifest(output, payload)
+
+    with pytest.raises(aot.PackIntegrityError, match="invalid size"):
+        aot.inspect(output)
+
+
+@pytest.mark.parametrize("kind", ["root", "artifact", "source"])
+def test_pack_rejects_symlinks(tmp_path, provider_bundle, kind):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    payload = _manifest_payload(output)
+    entry = payload["entries"][0]
+    inspected_path = output
+    if kind == "root":
+        inspected_path = tmp_path / "pack-link"
+        inspected_path.symlink_to(output, target_is_directory=True)
+    else:
+        if kind == "artifact":
+            path = output / "artifacts" / f"{entry['artifact_sha256']}.ltoir"
+        else:
+            path = output / "sources" / f"{entry['identity']['source_sha256']}.cu"
+        replacement = tmp_path / f"{kind}.replacement"
+        path.rename(replacement)
+        path.symlink_to(replacement)
+
+    with pytest.raises(aot.PackIntegrityError, match="(real directory|regular file)"):
+        aot.inspect(inspected_path)
+
+
+def test_pack_rejects_bad_types_and_unexpected_inventory(tmp_path, provider_bundle):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    payload = _manifest_payload(output)
+    artifact = (
+        output / "artifacts" / f"{payload['entries'][0]['artifact_sha256']}.ltoir"
+    )
+    artifact.unlink()
+    artifact.mkdir()
+
+    with pytest.raises(aot.PackIntegrityError, match="regular file"):
+        aot.inspect(output)
+
+    output, _ = _capture_pack(
+        tmp_path,
+        provider_bundle,
+        output_name="inventory.coop-aot",
+    )
+    (output / "unexpected").write_text("unexpected", encoding="utf-8")
+    with pytest.raises(aot.PackIntegrityError, match="unexpected or missing"):
+        aot.inspect(output)
+
+
+def test_pack_rejects_conflicting_identity_and_layout_metadata(
+    tmp_path,
+    provider_bundle,
+):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    payload = _manifest_payload(output)
+    entry = payload["entries"][0]
+    entry["identity"]["layout_expressions"] = ["sizeof(Other)"]
+    _write_manifest(output, payload)
+
+    with pytest.raises(
+        aot.PackIntegrityError,
+        match="ID does not match its exact bundle identity",
+    ):
+        aot.inspect(output)
+
+
+def test_pack_rejects_symbol_changes_not_bound_by_entry_id(
+    tmp_path,
+    provider_bundle,
+):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    payload = _manifest_payload(output)
+    payload["entries"][0]["symbols"] = ["provider_other"]
+    _write_manifest(output, payload)
+
+    with pytest.raises(
+        aot.PackIntegrityError,
+        match="identity and symbol set",
+    ):
+        aot.inspect(output)
+
+
+@pytest.mark.parametrize(
+    ("compute_arch", "sm_arch"),
+    [
+        ("compute_80", "sm_90"),
+        ("compute80", "sm_80"),
+        ("compute_80", "sm80"),
+        ("compute_80x", "sm_80x"),
+    ],
+)
+def test_pack_rejects_invalid_or_mismatched_architecture_pairs(
+    tmp_path,
+    provider_bundle,
+    compute_arch,
+    sm_arch,
+):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    payload = _manifest_payload(output)
+    identity = payload["entries"][0]["identity"]
+    identity["compute_arch"] = compute_arch
+    identity["sm_arch"] = sm_arch
+    _write_manifest(output, payload)
+
+    with pytest.raises(aot.PackIntegrityError, match="exact matching"):
+        aot.inspect(output)
+
+
+def test_pack_rejects_non_utf8_audit_source(tmp_path, provider_bundle):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    payload = _manifest_payload(output)
+    entry = payload["entries"][0]
+    invalid_source = b"\xff"
+    digest = hashlib.sha256(invalid_source).hexdigest()
+    old_source = output / "sources" / f"{entry['identity']['source_sha256']}.cu"
+    old_source.unlink()
+    (output / "sources" / f"{digest}.cu").write_bytes(invalid_source)
+    entry["identity"]["source_sha256"] = digest
+    entry["entry_id"] = _aot_pack._entry_id(
+        _aot_pack._parse_identity(entry["identity"], entry_index=0),
+        tuple(entry["symbols"]),
+    )
+    _write_manifest(output, payload)
+
+    with pytest.raises(aot.PackIntegrityError, match="not valid UTF-8"):
+        aot.inspect(output)
+
+
+def test_relocated_copy_contains_no_caller_paths(tmp_path, provider_bundle):
+    output, _ = _capture_pack(tmp_path, provider_bundle)
+    manifest = (output / "manifest.json").read_text(encoding="utf-8")
+
+    assert str(tmp_path) not in manifest
+    assert "argv" not in manifest
+    assert "environment" not in manifest
+    assert "cubin" not in manifest
+    assert "caller" not in manifest
+
+    copied = tmp_path / "copied.coop-aot"
+    shutil.copytree(output, copied)
+    assert aot.inspect(copied).entries == aot.inspect(output).entries

--- a/python/cuda_coop/tests/backends/cutlass/unit/test_public_foundation.py
+++ b/python/cuda_coop/tests/backends/cutlass/unit/test_public_foundation.py
@@ -26,6 +26,7 @@ def test_cutlass_foundation_exports_current_public_surface():
             "ThreadGroup",
             "ThreadHierarchy",
             "adjacent_difference",
+            "aot",
             "discontinuity",
             "exchange",
             "exclusive_scan",
@@ -58,11 +59,11 @@ def test_cutlass_foundation_exports_current_public_surface():
         assert coop.__all__ == expected
         assert sorted(name for name in dir(coop) if not name.startswith("_")) == expected
         assert not hasattr(coop, "Payload")
-        assert not hasattr(coop, "aot")
         assert not hasattr(coop, "_block")
         assert not hasattr(coop, "_warp")
         assert "numpy" not in sys.modules
 
+        assert coop.aot.__name__ == "cuda.coop.cutlass.aot"
         assert not any(
             name.startswith("cuda.coop.cutlass._lowering.")
             for name in sys.modules

--- a/python/cuda_coop/tests/packaging/test_aot_launcher.py
+++ b/python/cuda_coop/tests/packaging/test_aot_launcher.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from cuda.coop import _aot_cli
+
+_PACKAGE_ROOT = Path(__file__).parents[2]
+
+
+def test_launcher_rejects_windows_before_importing_cutlass(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def unexpected_import(name: str) -> None:
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr(_aot_cli.sys, "platform", "win32")
+    monkeypatch.setattr(_aot_cli.importlib, "import_module", unexpected_import)
+
+    assert _aot_cli.main(()) == 2
+    error = capsys.readouterr().err
+    assert "currently require Linux" in error
+    assert "Traceback" not in error
+
+
+def test_launcher_reports_missing_cutlass_extra_without_traceback() -> None:
+    source = textwrap.dedent(
+        """
+        import importlib.abc
+        import sys
+
+        # Exercise the optional-dependency diagnostic independently of the
+        # earlier, separately tested platform gate.
+        sys.platform = "linux"
+
+        class BlockCutlass(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "cutlass" or fullname.startswith("cutlass."):
+                    raise ModuleNotFoundError(
+                        f"blocked {fullname}",
+                        name=fullname,
+                    )
+                return None
+
+        sys.meta_path.insert(0, BlockCutlass())
+        from cuda.coop import _aot_cli
+        raise SystemExit(_aot_cli.main(("inspect", "missing.coop-aot")))
+        """
+    )
+    environment = os.environ.copy()
+    environment["CUDA_COOP_DISABLE_AUTO_DSL_REGISTRATION"] = "1"
+    environment["PYTHONPATH"] = os.pathsep.join(
+        filter(
+            None,
+            (str(_PACKAGE_ROOT), environment.get("PYTHONPATH")),
+        )
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", source],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert completed.returncode == 2
+    assert "cuda-coop[cutlass]" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_console_script_uses_dependency_light_launcher() -> None:
+    pyproject = (_PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert 'cuda-coop-aot = "cuda.coop._aot_cli:main"' in pyproject


### PR DESCRIPTION
## Why this is needed

Some deployments need to compile CUTLASS providers once and reuse the exact
native inputs in later processes. This final layer adds an explicit,
relocatable AOT pack workflow without changing primitive calls or weakening
exact cache identity.

```bash
python -m cuda.coop._aot_cli capture --output providers.coop-aot -- \
  python my_kernel.py
python -m cuda.coop._aot_cli run --pack providers.coop-aot \
  --mode required -- python my_kernel.py
```

## What this PR includes

- Python capture/use/inspect API and source CLI
- canonical manifests, atomic publication, relocation, and integrity checks
- exact identity and symbol matching before provider resolution
- required, auto, and off behavior with final-link integration

## Stack

7 of 7, based on [PR #11048](https://github.com/NVIDIA/cccl/pull/11048).
This is the top of the `cuda.coop` stack.

## Local validation

- 85 focused AOT API, manifest, resolver, finalizer, and public-surface tests
  passed
- captured, inspected, and relocated a 244,388-byte radix/TopK provider pack
- a fresh required-mode exact hit passed final linking and GPU output without
  creating a JIT cache artifact
- auto exact miss and off mode each compiled one JIT artifact and passed GPU
  output
- source imports, `compileall`, changed-file pre-commit, Ruff, import audit,
  and `git diff --check` passed

Packaging tests, wheel qualification, GitHub CI, and automated AI review are
deferred for now.
