### PR TITLE
Support no_init for DeviceSegmentedReduce

### DIFF
--- a/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
@@ -475,9 +475,14 @@ namespace detail::segmented_reduce
 {
 // select the accumulator type using an overload set, so __accumulator_t is not instantiated when
 // an overriding accumulator type is present. This is needed by CCCL.C.
-template <typename InputIteratorT, typename InitValueT, typename ReductionOpT>
-_CCCL_HOST_DEVICE_API auto select_segmented_accum_t(use_default*)
-  -> ::cuda::std::__accumulator_t<ReductionOpT, ::cuda::std::iter_value_t<InputIteratorT>, InitValueT>;
+template <typename InputIteratorT,
+          typename InitValueT,
+          typename ReductionOpT,
+          typename InputT = ::cuda::std::iter_value_t<InputIteratorT>>
+_CCCL_HOST_DEVICE_API auto select_segmented_accum_t(use_default*) -> ::cuda::std::__accumulator_t<
+  ReductionOpT,
+  InputT,
+  ::cuda::std::conditional_t<::cuda::std::is_same_v<InitValueT, reduce::no_init_t>, InputT, InitValueT>>;
 
 template <typename InputIteratorT,
           typename InitValueT,

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -408,7 +408,7 @@ struct faulting_reduce
   }
 };
 
-C2H_TEST("Device segmented reduce works without initial value", "[segmented][reduce][device]")
+CUB_TEST("Device segmented reduce works without initial value", "[segmented][reduce][device]", CUB_SMALL)
 {
   SECTION("variable-size segments")
   {

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -386,3 +386,89 @@ CUB_TEST("Device fixed size segmented reduce works with all device interfaces",
     REQUIRE(h_expected_result == h_out_result);
   }
 }
+
+struct checking_reduce
+{
+  static constexpr auto sentinel = 42;
+
+  _CCCL_HOST_DEVICE_API auto operator()(int a, int b) const -> int
+  {
+    CHECK(a == sentinel);
+    CHECK(b == sentinel);
+    return sentinel;
+  }
+};
+
+struct faulting_reduce
+{
+  _CCCL_HOST_DEVICE_API auto operator()(int, int) const -> int
+  {
+    CHECK(false);
+    return 0;
+  }
+};
+
+C2H_TEST("Device segmented reduce works without initial value", "[segmented][reduce][device]")
+{
+  SECTION("variable-size segments")
+  {
+    // segment 0: [0, 5), segment 1: [5, 5) (empty), segment 2: [5, 10)
+    c2h::device_vector<int> offsets{0, 5, 5, 10};
+    c2h::device_vector<int> input(10, checking_reduce::sentinel);
+    c2h::device_vector<int> output(3, -1);
+
+    auto d_offsets_it = thrust::raw_pointer_cast(offsets.data());
+    device_segmented_reduce(
+      thrust::raw_pointer_cast(input.data()),
+      thrust::raw_pointer_cast(output.data()),
+      3,
+      d_offsets_it,
+      d_offsets_it + 1,
+      checking_reduce{},
+      cub::detail::reduce::no_init);
+
+    CHECK(output[0] == checking_reduce::sentinel);
+    CHECK(output[1] == -1); // empty segment: output must be left untouched
+    CHECK(output[2] == checking_reduce::sentinel);
+  }
+
+  SECTION("all segments empty")
+  {
+    // both segments are [0, 0), so the reduction operator must never be invoked
+    c2h::device_vector<int> offsets{0, 0, 0};
+    c2h::device_vector<int> input(0);
+    c2h::device_vector<int> output(2, -1);
+
+    auto d_offsets_it = thrust::raw_pointer_cast(offsets.data());
+    device_segmented_reduce(
+      thrust::raw_pointer_cast(input.data()),
+      thrust::raw_pointer_cast(output.data()),
+      2,
+      d_offsets_it,
+      d_offsets_it + 1,
+      faulting_reduce{},
+      cub::detail::reduce::no_init);
+
+    CHECK(output[0] == -1);
+    CHECK(output[1] == -1);
+  }
+
+  SECTION("fixed-size segments")
+  {
+    c2h::device_vector<int> input(20, checking_reduce::sentinel);
+    c2h::device_vector<int> output(4, -1);
+
+    device_segmented_reduce(
+      thrust::raw_pointer_cast(input.data()),
+      thrust::raw_pointer_cast(output.data()),
+      4,
+      5,
+      checking_reduce{},
+      cub::detail::reduce::no_init);
+
+    for (int i = 0; i < 4; ++i)
+    {
+      CHECK(output[i] == checking_reduce::sentinel);
+    }
+  }
+}


### PR DESCRIPTION
## Description

part of #10942

`cub::DeviceReduce` already supports skipping the initial value via `cub::detail::reduce::no_init` (added in #9289 for the MGMN determinism use case), but `cub::DeviceSegmentedReduce` never got the same treatment - even though the underlying kernel-level plumbing (`handle_empty_problem`) was already added as a side effect of that same PR.

Turns out the only piece missing was `select_segmented_accum_t`: it forwards `InitValueT` straight into `__accumulator_t`, which doesn't know what to do with `no_init_t`. This ports over the exact same fix `select_accum_t` got in #9289 - fall back to the input iterator's value type when there's no init value to look at.

Verified this against both the variable-size (`d_begin_offsets`/`d_end_offsets`) and fixed-size (`segment_size`) `Reduce` overloads, including that empty segments are left untouched and never invoke the reduction operator (mirrors the existing `DeviceReduce` no-init test).

This is my first contribution to cccl, so let me know if I've missed any conventions!

## Checklist
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

(`no_init` isn't part of the documented public API surface for `DeviceReduce` either yet, so there wasn't existing doc to mirror - happy to add some if a maintainer wants it as part of this PR)