### PR TITLE
Fix PTX instructions using static inline on templates

### DIFF
--- a/libcudacxx/include/cuda/__ptx/instructions/generated/applypriority_async_bulk.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/applypriority_async_bulk.h
@@ -15,7 +15,7 @@ __device__ static inline void applypriority_async_bulk_L2_evict_normal(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void applypriority_async_bulk_L2_evict_normal(void* __srcMem, ::cuda::std::uint32_t __size)
+_CCCL_DEVICE_API void applypriority_async_bulk_L2_evict_normal(void* __srcMem, ::cuda::std::uint32_t __size)
 {
   asm volatile("applypriority.async.bulk.global.bulk_group.L2::evict_normal [%0], %1;"
                :

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/barrier_cluster.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/barrier_cluster.h
@@ -14,7 +14,7 @@ __device__ static inline void barrier_cluster_arrive();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline void barrier_cluster_arrive()
+_CCCL_DEVICE_API void barrier_cluster_arrive()
 {
   asm volatile("barrier.cluster.arrive;" : : : "memory");
 }
@@ -28,7 +28,7 @@ __device__ static inline void barrier_cluster_wait();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline void barrier_cluster_wait()
+_CCCL_DEVICE_API void barrier_cluster_wait()
 {
   asm volatile("barrier.cluster.wait;" : : : "memory");
 }
@@ -44,7 +44,7 @@ __device__ static inline void barrier_cluster_arrive(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void barrier_cluster_arrive(::cuda::ptx::sem_release_t)
+_CCCL_DEVICE_API void barrier_cluster_arrive(::cuda::ptx::sem_release_t)
 {
   // __sem == sem_release (due to parameter type constraint)
   asm volatile("barrier.cluster.arrive.release;" : : : "memory");
@@ -61,7 +61,7 @@ __device__ static inline void barrier_cluster_arrive(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void barrier_cluster_arrive(::cuda::ptx::sem_relaxed_t)
+_CCCL_DEVICE_API void barrier_cluster_arrive(::cuda::ptx::sem_relaxed_t)
 {
   // __sem == sem_relaxed (due to parameter type constraint)
   asm volatile("barrier.cluster.arrive.relaxed;" : : :);
@@ -78,7 +78,7 @@ __device__ static inline void barrier_cluster_wait(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void barrier_cluster_wait(::cuda::ptx::sem_acquire_t)
+_CCCL_DEVICE_API void barrier_cluster_wait(::cuda::ptx::sem_acquire_t)
 {
   // __sem == sem_acquire (due to parameter type constraint)
   asm volatile("barrier.cluster.wait.acquire;" : : : "memory");

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/bfind.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/bfind.h
@@ -17,7 +17,7 @@ template <
   typename _U32,
   ::cuda::std::enable_if_t<sizeof(_U32) == 4 && ::cuda::std::is_integral_v<_U32>&& ::cuda::std::is_unsigned_v<_U32>,
                            bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind(_U32 __a_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t bfind(_U32 __a_reg)
 {
   ::cuda::std::uint32_t __dest;
   asm("bfind.u32 %0, %1;" : "=r"(__dest) : "r"(*reinterpret_cast<const ::cuda::std::uint32_t*>(&__a_reg)) :);
@@ -36,7 +36,7 @@ template <
   typename _U32,
   ::cuda::std::enable_if_t<sizeof(_U32) == 4 && ::cuda::std::is_integral_v<_U32>&& ::cuda::std::is_unsigned_v<_U32>,
                            bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind_shiftamt(_U32 __a_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t bfind_shiftamt(_U32 __a_reg)
 {
   ::cuda::std::uint32_t __dest;
   asm("bfind.shiftamt.u32 %0, %1;" : "=r"(__dest) : "r"(*reinterpret_cast<const ::cuda::std::uint32_t*>(&__a_reg)) :);
@@ -55,7 +55,7 @@ template <
   typename _U64,
   ::cuda::std::enable_if_t<sizeof(_U64) == 8 && ::cuda::std::is_integral_v<_U64>&& ::cuda::std::is_unsigned_v<_U64>,
                            bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind(_U64 __a_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t bfind(_U64 __a_reg)
 {
   ::cuda::std::uint32_t __dest;
   asm("bfind.u64 %0, %1;" : "=r"(__dest) : "l"(*reinterpret_cast<const ::cuda::std::uint64_t*>(&__a_reg)) :);
@@ -74,7 +74,7 @@ template <
   typename _U64,
   ::cuda::std::enable_if_t<sizeof(_U64) == 8 && ::cuda::std::is_integral_v<_U64>&& ::cuda::std::is_unsigned_v<_U64>,
                            bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind_shiftamt(_U64 __a_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t bfind_shiftamt(_U64 __a_reg)
 {
   ::cuda::std::uint32_t __dest;
   asm("bfind.shiftamt.u64 %0, %1;" : "=r"(__dest) : "l"(*reinterpret_cast<const ::cuda::std::uint64_t*>(&__a_reg)) :);
@@ -92,7 +92,7 @@ __device__ static inline uint32_t bfind(
 template <typename _S32,
           ::cuda::std::enable_if_t<sizeof(_S32) == 4 && ::cuda::std::is_integral_v<_S32>&& ::cuda::std::is_signed_v<_S32>,
                                    bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind(_S32 __a_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t bfind(_S32 __a_reg)
 {
   ::cuda::std::uint32_t __dest;
   asm("bfind.s32 %0, %1;" : "=r"(__dest) : "r"(*reinterpret_cast<const ::cuda::std::int32_t*>(&__a_reg)) :);
@@ -110,7 +110,7 @@ __device__ static inline uint32_t bfind_shiftamt(
 template <typename _S32,
           ::cuda::std::enable_if_t<sizeof(_S32) == 4 && ::cuda::std::is_integral_v<_S32>&& ::cuda::std::is_signed_v<_S32>,
                                    bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind_shiftamt(_S32 __a_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t bfind_shiftamt(_S32 __a_reg)
 {
   ::cuda::std::uint32_t __dest;
   asm("bfind.shiftamt.s32 %0, %1;" : "=r"(__dest) : "r"(*reinterpret_cast<const ::cuda::std::int32_t*>(&__a_reg)) :);
@@ -128,7 +128,7 @@ __device__ static inline uint32_t bfind(
 template <typename _S64,
           ::cuda::std::enable_if_t<sizeof(_S64) == 8 && ::cuda::std::is_integral_v<_S64>&& ::cuda::std::is_signed_v<_S64>,
                                    bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind(_S64 __a_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t bfind(_S64 __a_reg)
 {
   ::cuda::std::uint32_t __dest;
   asm("bfind.s64 %0, %1;" : "=r"(__dest) : "l"(*reinterpret_cast<const ::cuda::std::int64_t*>(&__a_reg)) :);
@@ -146,7 +146,7 @@ __device__ static inline uint32_t bfind_shiftamt(
 template <typename _S64,
           ::cuda::std::enable_if_t<sizeof(_S64) == 8 && ::cuda::std::is_integral_v<_S64>&& ::cuda::std::is_signed_v<_S64>,
                                    bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind_shiftamt(_S64 __a_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t bfind_shiftamt(_S64 __a_reg)
 {
   ::cuda::std::uint32_t __dest;
   asm("bfind.shiftamt.s64 %0, %1;" : "=r"(__dest) : "l"(*reinterpret_cast<const ::cuda::std::int64_t*>(&__a_reg)) :);

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/bmsk.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/bmsk.h
@@ -15,7 +15,7 @@ __device__ static inline uint32_t bmsk_clamp(
 */
 #if __cccl_ptx_isa >= 760
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bmsk_clamp(::cuda::std::uint32_t __a_reg, ::cuda::std::uint32_t __b_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t bmsk_clamp(::cuda::std::uint32_t __a_reg, ::cuda::std::uint32_t __b_reg)
 {
   ::cuda::std::uint32_t __dest;
   asm("bmsk.clamp.b32 %0, %1, %2;" : "=r"(__dest) : "r"(__a_reg), "r"(__b_reg) :);
@@ -32,7 +32,7 @@ __device__ static inline uint32_t bmsk_wrap(
 */
 #if __cccl_ptx_isa >= 760
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bmsk_wrap(::cuda::std::uint32_t __a_reg, ::cuda::std::uint32_t __b_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t bmsk_wrap(::cuda::std::uint32_t __a_reg, ::cuda::std::uint32_t __b_reg)
 {
   ::cuda::std::uint32_t __dest;
   asm("bmsk.wrap.b32 %0, %1, %2;" : "=r"(__dest) : "r"(__a_reg), "r"(__b_reg) :);

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/clusterlaunchcontrol.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/clusterlaunchcontrol.h
@@ -15,7 +15,7 @@ __device__ static inline void clusterlaunchcontrol_try_cancel(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void clusterlaunchcontrol_try_cancel(void* __addr, ::cuda::std::uint64_t* __smem_bar)
+_CCCL_DEVICE_API void clusterlaunchcontrol_try_cancel(void* __addr, ::cuda::std::uint64_t* __smem_bar)
 {
   asm("clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.b128 [%0], [%1];"
       :
@@ -34,8 +34,7 @@ __device__ static inline void clusterlaunchcontrol_try_cancel_multicast(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void
-clusterlaunchcontrol_try_cancel_multicast(void* __addr, ::cuda::std::uint64_t* __smem_bar)
+_CCCL_DEVICE_API void clusterlaunchcontrol_try_cancel_multicast(void* __addr, ::cuda::std::uint64_t* __smem_bar)
 {
   asm("clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128 "
       "[%0], [%1];"
@@ -53,7 +52,7 @@ __device__ static inline bool clusterlaunchcontrol_query_cancel_is_canceled(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline bool clusterlaunchcontrol_query_cancel_is_canceled(_B128 __try_cancel_response)
+_CCCL_DEVICE_API bool clusterlaunchcontrol_query_cancel_is_canceled(_B128 __try_cancel_response)
 {
   static_assert(sizeof(_B128) == 16, "");
   ::cuda::std::uint32_t __pred_is_canceled;
@@ -84,7 +83,7 @@ template <typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           typename _B128,
           ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B32 clusterlaunchcontrol_query_cancel_get_first_ctaid_x(_B128 __try_cancel_response)
+_CCCL_DEVICE_API _B32 clusterlaunchcontrol_query_cancel_get_first_ctaid_x(_B128 __try_cancel_response)
 {
   static_assert(sizeof(_B32) == 4, "");
   static_assert(sizeof(_B128) == 16, "");
@@ -114,7 +113,7 @@ template <typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           typename _B128,
           ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B32 clusterlaunchcontrol_query_cancel_get_first_ctaid_y(_B128 __try_cancel_response)
+_CCCL_DEVICE_API _B32 clusterlaunchcontrol_query_cancel_get_first_ctaid_y(_B128 __try_cancel_response)
 {
   static_assert(sizeof(_B32) == 4, "");
   static_assert(sizeof(_B128) == 16, "");
@@ -144,7 +143,7 @@ template <typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           typename _B128,
           ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B32 clusterlaunchcontrol_query_cancel_get_first_ctaid_z(_B128 __try_cancel_response)
+_CCCL_DEVICE_API _B32 clusterlaunchcontrol_query_cancel_get_first_ctaid_z(_B128 __try_cancel_response)
 {
   static_assert(sizeof(_B32) == 4, "");
   static_assert(sizeof(_B128) == 16, "");
@@ -175,7 +174,7 @@ template <typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           typename _B128,
           ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 clusterlaunchcontrol_query_cancel_get_first_ctaid(_B32 (&__block_dim)[4], _B128 __try_cancel_response)
 {
   static_assert(sizeof(_B32) == 4, "");

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk.h
@@ -21,7 +21,7 @@ __device__ static inline void cp_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk(
+_CCCL_DEVICE_API void cp_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -53,7 +53,7 @@ __device__ static inline void cp_async_bulk(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk(
+_CCCL_DEVICE_API void cp_async_bulk(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -85,7 +85,7 @@ __device__ static inline void cp_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk(
+_CCCL_DEVICE_API void cp_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   void* __dstMem,
@@ -123,7 +123,7 @@ __device__ static inline void cp_async_bulk_ignore_oob(
 */
 #if __cccl_ptx_isa >= 920
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_ignore_oob(
+_CCCL_DEVICE_API void cp_async_bulk_ignore_oob(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -161,7 +161,7 @@ __device__ static inline void cp_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk(
+_CCCL_DEVICE_API void cp_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   void* __dstMem,
@@ -192,7 +192,7 @@ __device__ static inline void cp_async_bulk_cp_mask(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_cp_mask(
+_CCCL_DEVICE_API void cp_async_bulk_cp_mask(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   void* __dstMem,
@@ -229,7 +229,7 @@ __device__ static inline void cp_async_bulk(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_space _Space, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk(
+_CCCL_DEVICE_API void cp_async_bulk(
   ::cuda::ptx::space_t<_Space> __space,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::report_mechanism_t<_Report_Mechanism> __report_mechanism,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_commit_group.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_commit_group.h
@@ -13,7 +13,7 @@ __device__ static inline void cp_async_bulk_commit_group();
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_commit_group()
+_CCCL_DEVICE_API void cp_async_bulk_commit_group()
 {
   asm volatile("cp.async.bulk.commit_group;" : : :);
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_multicast.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_multicast.h
@@ -23,7 +23,7 @@ __device__ static inline void cp_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk(
+_CCCL_DEVICE_API void cp_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -62,7 +62,7 @@ __device__ static inline void cp_async_bulk_multicast_32b(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_multicast_32b(
+_CCCL_DEVICE_API void cp_async_bulk_multicast_32b(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -106,7 +106,7 @@ __device__ static inline void cp_async_bulk_multicast_32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_multicast_32b(
+_CCCL_DEVICE_API void cp_async_bulk_multicast_32b(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::report_mechanism_t<_Report_Mechanism> __report_mechanism,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_prefetch.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_prefetch.h
@@ -16,7 +16,7 @@ __device__ static inline void cp_async_bulk_prefetch(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch(
   const void* __srcMem, ::cuda::std::uint32_t __size, ::cuda::std::uint64_t __cache_policy = 0x10F0000000000000)
 {
   asm volatile("cp.async.bulk.prefetch.L2.global.L2::cache_hint [%0], %1, %2;"
@@ -35,7 +35,7 @@ __device__ static inline void cp_async_bulk_prefetch_L2_evict_last(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_L2_evict_last(const void* __srcMem, ::cuda::std::uint32_t __size)
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_L2_evict_last(const void* __srcMem, ::cuda::std::uint32_t __size)
 {
   asm volatile("cp.async.bulk.prefetch.L2.global.L2::evict_last [%0], %1;"
                :

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_prefetch_tensor.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_prefetch_tensor.h
@@ -19,7 +19,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const ::cuda::std::int32_t (&__tensorCoords)[1],
@@ -46,7 +46,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const ::cuda::std::int32_t (&__tensorCoords)[2],
@@ -73,7 +73,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const ::cuda::std::int32_t (&__tensorCoords)[3],
@@ -100,7 +100,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const ::cuda::std::int32_t (&__tensorCoords)[4],
@@ -132,7 +132,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const ::cuda::std::int32_t (&__tensorCoords)[5],
@@ -165,7 +165,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_tile_gather4(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_tile_gather4(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_tile_gather4(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const ::cuda::std::int32_t (&__tensorCoords)[5],
@@ -197,7 +197,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_L2_evict_last(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last(
   ::cuda::ptx::space_global_t, const void* __tensorMap, const ::cuda::std::int32_t (&__tensorCoords)[1])
 {
   // __space == space_global (due to parameter type constraint)
@@ -222,7 +222,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -250,7 +250,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_overri
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -279,7 +279,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -315,7 +315,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_overri
 */
 #if __cccl_ptx_isa >= 940
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -347,7 +347,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_L2_evict_last(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last(
   ::cuda::ptx::space_global_t, const void* __tensorMap, const ::cuda::std::int32_t (&__tensorCoords)[2])
 {
   // __space == space_global (due to parameter type constraint)
@@ -372,7 +372,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -400,7 +400,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_overri
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -436,7 +436,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -487,7 +487,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -527,7 +527,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_L2_evict_last(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last(
   ::cuda::ptx::space_global_t, const void* __tensorMap, const ::cuda::std::int32_t (&__tensorCoords)[3])
 {
   // __space == space_global (due to parameter type constraint)
@@ -552,7 +552,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -586,7 +586,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_overri
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -622,7 +622,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -676,7 +676,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -719,7 +719,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_L2_evict_last(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last(
   ::cuda::ptx::space_global_t, const void* __tensorMap, const ::cuda::std::int32_t (&__tensorCoords)[4])
 {
   // __space == space_global (due to parameter type constraint)
@@ -744,7 +744,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -779,7 +779,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_overri
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -821,7 +821,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -878,7 +878,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -924,7 +924,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_L2_evict_last(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last(
   ::cuda::ptx::space_global_t, const void* __tensorMap, const ::cuda::std::int32_t (&__tensorCoords)[5])
 {
   // __space == space_global (due to parameter type constraint)
@@ -954,7 +954,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -990,7 +990,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_overri
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -1033,7 +1033,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -1093,7 +1093,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_L2_evict_last_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -1142,7 +1142,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_tile_gather4_L2_evic
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_tile_gather4_L2_evict_last(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_tile_gather4_L2_evict_last(
   ::cuda::ptx::space_global_t, const void* __tensorMap, const ::cuda::std::int32_t (&__tensorCoords)[5])
 {
   // __space == space_global (due to parameter type constraint)
@@ -1172,7 +1172,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_tile_gather4_overrid
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_tile_gather4_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_tile_gather4_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,
@@ -1208,7 +1208,7 @@ __device__ static inline void cp_async_bulk_prefetch_tensor_tile_gather4_L2_evic
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_prefetch_tensor_tile_gather4_L2_evict_last_override(
+_CCCL_DEVICE_API void cp_async_bulk_prefetch_tensor_tile_gather4_L2_evict_last_override(
   ::cuda::ptx::space_global_t,
   const void* __tensorMap,
   const void* __gAddrToOverride,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_tensor.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_tensor.h
@@ -22,7 +22,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -53,7 +53,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -85,7 +85,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -120,7 +120,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -152,7 +152,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -188,7 +188,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -224,7 +224,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -262,7 +262,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -299,7 +299,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -338,7 +338,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -376,7 +376,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -411,7 +411,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -458,7 +458,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -497,7 +497,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -552,7 +552,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -592,7 +592,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -649,7 +649,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -690,7 +690,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -749,7 +749,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -792,7 +792,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -859,7 +859,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -1001,7 +1001,7 @@ __device__ static inline void cp_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -1185,7 +1185,7 @@ __device__ static inline void cp_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -1231,7 +1231,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           ::cuda::ptx::dot_cta_group _Cta_Group,
           ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -1432,7 +1432,7 @@ __device__ static inline void cp_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -1478,7 +1478,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -1668,7 +1668,7 @@ __device__ static inline void cp_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -1864,7 +1864,7 @@ __device__ static inline void cp_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -1919,7 +1919,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_cta_group _Cta_Group,
           ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -2189,7 +2189,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -2243,7 +2243,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -2445,7 +2445,7 @@ __device__ static inline void cp_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -2653,7 +2653,7 @@ __device__ static inline void cp_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -2710,7 +2710,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_cta_group _Cta_Group,
           ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -3016,7 +3016,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -3073,7 +3073,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -3287,7 +3287,7 @@ __device__ static inline void cp_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -3507,7 +3507,7 @@ __device__ static inline void cp_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -3565,7 +3565,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_cta_group _Cta_Group,
           ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -3907,7 +3907,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -3967,7 +3967,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -4193,7 +4193,7 @@ __device__ static inline void cp_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -4425,7 +4425,7 @@ __device__ static inline void cp_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -4484,7 +4484,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_cta_group _Cta_Group,
           ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -4862,7 +4862,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_tensor_gather_scatter.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_tensor_gather_scatter.h
@@ -22,7 +22,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_gather4(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_tile_gather4(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -65,7 +65,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_gather4(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_tile_gather4(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -128,7 +128,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_gather4(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_tile_gather4(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -175,7 +175,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_gather4(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_tile_gather4(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -238,7 +238,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_scatter4(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_scatter4(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_tile_scatter4(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,
@@ -282,7 +282,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_gather4(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_tile_gather4(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -509,7 +509,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_gather4_multicast_32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4_multicast_32b(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_tile_gather4_multicast_32b(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -749,7 +749,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_gather4_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_tile_gather4_override(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -990,7 +990,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_gather4_multicast_32b_ov
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4_multicast_32b_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_tile_gather4_multicast_32b_override(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -1247,7 +1247,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_scatter4_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_scatter4_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_tile_scatter4_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   const void* __tensorMap,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_tensor_multicast.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_tensor_multicast.h
@@ -24,7 +24,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -65,7 +65,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -107,7 +107,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -150,7 +150,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -194,7 +194,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   void* __dstMem,
@@ -241,7 +241,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -301,7 +301,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -363,7 +363,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -427,7 +427,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -493,7 +493,7 @@ __device__ static inline void cp_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_async_bulk_tensor(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -564,7 +564,7 @@ __device__ static inline void cp_async_bulk_tensor_multicast_32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -757,7 +757,7 @@ __device__ static inline void cp_async_bulk_tensor_multicast_32b_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b_override(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -979,7 +979,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true,
           ::cuda::ptx::dot_cta_group _Cta_Group,
           ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b_override(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -1209,7 +1209,7 @@ __device__ static inline void cp_async_bulk_tensor_multicast_32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -1414,7 +1414,7 @@ __device__ static inline void cp_async_bulk_tensor_multicast_32b_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b_override(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -1652,7 +1652,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_cta_group _Cta_Group,
           ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b_override(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -1934,7 +1934,7 @@ __device__ static inline void cp_async_bulk_tensor_multicast_32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -2151,7 +2151,7 @@ __device__ static inline void cp_async_bulk_tensor_multicast_32b_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b_override(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -2401,7 +2401,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_cta_group _Cta_Group,
           ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b_override(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -2719,7 +2719,7 @@ __device__ static inline void cp_async_bulk_tensor_multicast_32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -2948,7 +2948,7 @@ __device__ static inline void cp_async_bulk_tensor_multicast_32b_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b_override(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -3210,7 +3210,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_cta_group _Cta_Group,
           ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b_override(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -3564,7 +3564,7 @@ __device__ static inline void cp_async_bulk_tensor_multicast_32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -3805,7 +3805,7 @@ __device__ static inline void cp_async_bulk_tensor_multicast_32b_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group, ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b_override(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
@@ -4081,7 +4081,7 @@ template <typename _B16,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_cta_group _Cta_Group,
           ::cuda::ptx::dot_report_mechanism _Report_Mechanism>
-_CCCL_DEVICE static inline void cp_async_bulk_tensor_multicast_32b_override(
+_CCCL_DEVICE_API void cp_async_bulk_tensor_multicast_32b_override(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_wait_group.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_wait_group.h
@@ -14,7 +14,7 @@ __device__ static inline void cp_async_bulk_wait_group(
 */
 #if __cccl_ptx_isa >= 800
 template <int _N32>
-_CCCL_DEVICE static inline void cp_async_bulk_wait_group(::cuda::ptx::n32_t<_N32> __N)
+_CCCL_DEVICE_API void cp_async_bulk_wait_group(::cuda::ptx::n32_t<_N32> __N)
 {
   asm volatile("cp.async.bulk.wait_group %0;" : : "n"(__N.value) : "memory");
 }
@@ -28,7 +28,7 @@ __device__ static inline void cp_async_bulk_wait_group_read(
 */
 #if __cccl_ptx_isa >= 800
 template <int _N32>
-_CCCL_DEVICE static inline void cp_async_bulk_wait_group_read(::cuda::ptx::n32_t<_N32> __N)
+_CCCL_DEVICE_API void cp_async_bulk_wait_group_read(::cuda::ptx::n32_t<_N32> __N)
 {
   asm volatile("cp.async.bulk.wait_group.read %0;" : : "n"(__N.value) : "memory");
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_mbarrier_arrive.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_mbarrier_arrive.h
@@ -14,7 +14,7 @@ __device__ static inline void cp_async_mbarrier_arrive(
 */
 #if __cccl_ptx_isa >= 700
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_mbarrier_arrive(::cuda::std::uint64_t* __addr)
+_CCCL_DEVICE_API void cp_async_mbarrier_arrive(::cuda::std::uint64_t* __addr)
 {
   asm("cp.async.mbarrier.arrive.b64 [%0];" : : "r"(__as_ptr_smem(__addr)) : "memory");
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_mbarrier_arrive_noinc.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_mbarrier_arrive_noinc.h
@@ -14,7 +14,7 @@ __device__ static inline void cp_async_mbarrier_arrive_noinc(
 */
 #if __cccl_ptx_isa >= 700
 template <typename = void>
-_CCCL_DEVICE static inline void cp_async_mbarrier_arrive_noinc(::cuda::std::uint64_t* __addr)
+_CCCL_DEVICE_API void cp_async_mbarrier_arrive_noinc(::cuda::std::uint64_t* __addr)
 {
   asm("cp.async.mbarrier.arrive.noinc.b64 [%0];" : : "r"(__as_ptr_smem(__addr)) : "memory");
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_reduce_async_bulk.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_reduce_async_bulk.h
@@ -25,7 +25,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_and_op_t,
@@ -68,7 +68,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_or_op_t,
@@ -110,7 +110,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_xor_op_t,
@@ -153,7 +153,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_min_t,
@@ -196,7 +196,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_max_t,
@@ -239,7 +239,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_add_t,
@@ -282,7 +282,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_inc_t,
@@ -325,7 +325,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_dec_t,
@@ -368,7 +368,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_min_t,
@@ -411,7 +411,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_max_t,
@@ -454,7 +454,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_add_t,
@@ -497,7 +497,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_add_t,
@@ -540,7 +540,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_cluster_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_add_t,
@@ -581,7 +581,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename _Type>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_and_op_t,
@@ -627,7 +627,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename _Type>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_or_op_t,
@@ -673,7 +673,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename _Type>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_xor_op_t,
@@ -719,7 +719,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_min_t,
@@ -755,7 +755,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_max_t,
@@ -791,7 +791,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_add_t,
@@ -827,7 +827,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_inc_t,
@@ -863,7 +863,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_dec_t,
@@ -899,7 +899,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_min_t,
@@ -935,7 +935,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_max_t,
@@ -971,7 +971,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_add_t,
@@ -1007,7 +1007,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_min_t,
@@ -1043,7 +1043,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_max_t,
@@ -1079,7 +1079,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_add_t,
@@ -1115,7 +1115,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_min_t,
@@ -1151,7 +1151,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_max_t,
@@ -1187,7 +1187,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_add_t,
@@ -1223,7 +1223,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_add_t,
@@ -1259,7 +1259,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_add_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_reduce_async_bulk_bf16.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_reduce_async_bulk_bf16.h
@@ -23,7 +23,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_min_t,
@@ -59,7 +59,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_max_t,
@@ -95,7 +95,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_add_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_reduce_async_bulk_f16.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_reduce_async_bulk_f16.h
@@ -23,7 +23,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_min_t,
@@ -59,7 +59,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_max_t,
@@ -95,7 +95,7 @@ __device__ static inline void cp_reduce_async_bulk(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk(
+_CCCL_DEVICE_API void cp_reduce_async_bulk(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_add_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_reduce_async_bulk_tensor.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_reduce_async_bulk_tensor.h
@@ -22,7 +22,7 @@ __device__ static inline void cp_reduce_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -110,7 +110,7 @@ __device__ static inline void cp_reduce_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -198,7 +198,7 @@ __device__ static inline void cp_reduce_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -318,7 +318,7 @@ __device__ static inline void cp_reduce_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -446,7 +446,7 @@ __device__ static inline void cp_reduce_async_bulk_tensor(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -584,7 +584,7 @@ __device__ static inline void cp_reduce_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -684,7 +684,7 @@ __device__ static inline void cp_reduce_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -817,7 +817,7 @@ __device__ static inline void cp_reduce_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -957,7 +957,7 @@ template <typename _B16,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -1126,7 +1126,7 @@ __device__ static inline void cp_reduce_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -1274,7 +1274,7 @@ template <typename _B16,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -1467,7 +1467,7 @@ __device__ static inline void cp_reduce_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -1623,7 +1623,7 @@ template <typename _B16,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -1840,7 +1840,7 @@ __device__ static inline void cp_reduce_async_bulk_tensor_override(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,
@@ -2004,7 +2004,7 @@ template <typename _B16,
           typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline void cp_reduce_async_bulk_tensor_override(
+_CCCL_DEVICE_API void cp_reduce_async_bulk_tensor_override(
   ::cuda::ptx::space_global_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::op_t<_Op> __op,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/elect_sync.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/elect_sync.h
@@ -14,7 +14,7 @@ __device__ static inline bool elect_sync(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline bool elect_sync(const ::cuda::std::uint32_t& __membermask)
+_CCCL_DEVICE_API bool elect_sync(const ::cuda::std::uint32_t& __membermask)
 {
   ::cuda::std::uint32_t __is_elected;
   asm volatile(

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/exit.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/exit.h
@@ -13,7 +13,7 @@ __device__ static inline void exit();
 */
 #if __cccl_ptx_isa >= 100
 template <typename = void>
-_CCCL_DEVICE static inline void exit()
+_CCCL_DEVICE_API void exit()
 {
   asm volatile("exit;" : : :);
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fabric_submit.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fabric_submit.h
@@ -13,7 +13,7 @@ __device__ static inline void fabric_submit();
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_submit()
+_CCCL_DEVICE_API void fabric_submit()
 {
   asm volatile("fabric.submit;" : : : "memory");
 }
@@ -26,7 +26,7 @@ __device__ static inline void fabric_submit_op_restrict_fetching();
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_submit_op_restrict_fetching()
+_CCCL_DEVICE_API void fabric_submit_op_restrict_fetching()
 {
   asm volatile("fabric.submit.op_restrict::fetching;" : : : "memory");
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fabric_try_get.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fabric_try_get.h
@@ -25,7 +25,7 @@ __device__ static inline void fabric_try_get(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_get(
+_CCCL_DEVICE_API void fabric_try_get(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fabric_try_pullred.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fabric_try_pullred.h
@@ -27,7 +27,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_and_op_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -71,7 +71,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_xor_op_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -115,7 +115,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_or_op_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -159,7 +159,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_and_op_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -203,7 +203,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_xor_op_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -247,7 +247,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_or_op_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -291,7 +291,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -335,7 +335,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -379,7 +379,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -423,7 +423,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -467,7 +467,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -511,7 +511,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -555,7 +555,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -599,7 +599,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -644,7 +644,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #  if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -690,7 +690,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #  if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -736,7 +736,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #  if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -782,7 +782,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #  if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -827,7 +827,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -871,7 +871,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -916,7 +916,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #  if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -962,7 +962,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #  if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -1007,7 +1007,7 @@ __device__ static inline void fabric_try_pullred(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred(
+_CCCL_DEVICE_API void fabric_try_pullred(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -1054,7 +1054,7 @@ __device__ static inline void fabric_try_pullred_acc_f32(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred_acc_f32(
+_CCCL_DEVICE_API void fabric_try_pullred_acc_f32(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -1102,7 +1102,7 @@ __device__ static inline void fabric_try_pullred_acc_f32(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_pullred_acc_f32(
+_CCCL_DEVICE_API void fabric_try_pullred_acc_f32(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fabric_try_put.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fabric_try_put.h
@@ -25,7 +25,7 @@ __device__ static inline void fabric_try_put(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_put(
+_CCCL_DEVICE_API void fabric_try_put(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -66,7 +66,7 @@ __device__ static inline void fabric_try_put_cp_mask(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_put_cp_mask(
+_CCCL_DEVICE_API void fabric_try_put_cp_mask(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -113,7 +113,7 @@ __device__ static inline void fabric_try_put_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_put_counted(
+_CCCL_DEVICE_API void fabric_try_put_counted(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -159,7 +159,7 @@ __device__ static inline void fabric_try_put_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_put_multimem(
+_CCCL_DEVICE_API void fabric_try_put_multimem(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -200,7 +200,7 @@ __device__ static inline void fabric_try_put_multimem_cp_mask(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_put_multimem_cp_mask(
+_CCCL_DEVICE_API void fabric_try_put_multimem_cp_mask(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,
@@ -247,7 +247,7 @@ __device__ static inline void fabric_try_put_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_put_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_put_multimem_counted(
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_sys_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fabric_try_red.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fabric_try_red.h
@@ -27,7 +27,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_and_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -72,7 +72,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_and_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -122,7 +122,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_and_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -167,7 +167,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_and_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -217,7 +217,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_xor_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -262,7 +262,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_xor_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -312,7 +312,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_xor_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -357,7 +357,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_xor_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -407,7 +407,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_or_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -452,7 +452,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_or_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -502,7 +502,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_or_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -547,7 +547,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_or_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -597,7 +597,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_and_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -642,7 +642,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_and_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -692,7 +692,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_and_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -737,7 +737,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_and_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -787,7 +787,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_xor_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -832,7 +832,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_xor_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -882,7 +882,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_xor_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -927,7 +927,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_xor_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -977,7 +977,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_or_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1022,7 +1022,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_or_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1072,7 +1072,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_or_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1117,7 +1117,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_or_op_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1167,7 +1167,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1212,7 +1212,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1262,7 +1262,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1307,7 +1307,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1357,7 +1357,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1402,7 +1402,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1452,7 +1452,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1497,7 +1497,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1547,7 +1547,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1592,7 +1592,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1642,7 +1642,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1687,7 +1687,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1737,7 +1737,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1782,7 +1782,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1832,7 +1832,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1877,7 +1877,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1927,7 +1927,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -1972,7 +1972,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2022,7 +2022,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2067,7 +2067,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2117,7 +2117,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2162,7 +2162,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2212,7 +2212,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2257,7 +2257,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2307,7 +2307,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2352,7 +2352,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2402,7 +2402,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2447,7 +2447,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2497,7 +2497,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2542,7 +2542,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2592,7 +2592,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2637,7 +2637,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2688,7 +2688,7 @@ __device__ static inline void fabric_try_red(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2735,7 +2735,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2787,7 +2787,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2834,7 +2834,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2886,7 +2886,7 @@ __device__ static inline void fabric_try_red(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2933,7 +2933,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -2985,7 +2985,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3032,7 +3032,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3084,7 +3084,7 @@ __device__ static inline void fabric_try_red(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3131,7 +3131,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3183,7 +3183,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3231,7 +3231,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_min_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3283,7 +3283,7 @@ __device__ static inline void fabric_try_red(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3330,7 +3330,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3382,7 +3382,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3430,7 +3430,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_max_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3481,7 +3481,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3526,7 +3526,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3576,7 +3576,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3621,7 +3621,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3671,7 +3671,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3716,7 +3716,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3766,7 +3766,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3811,7 +3811,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3862,7 +3862,7 @@ __device__ static inline void fabric_try_red(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3909,7 +3909,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -3961,7 +3961,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4008,7 +4008,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4060,7 +4060,7 @@ __device__ static inline void fabric_try_red(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4107,7 +4107,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4159,7 +4159,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4207,7 +4207,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #  if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4258,7 +4258,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4303,7 +4303,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4353,7 +4353,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4398,7 +4398,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4448,7 +4448,7 @@ __device__ static inline void fabric_try_red(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red(
+_CCCL_DEVICE_API void fabric_try_red(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4493,7 +4493,7 @@ __device__ static inline void fabric_try_red_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_counted(
+_CCCL_DEVICE_API void fabric_try_red_counted(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4543,7 +4543,7 @@ __device__ static inline void fabric_try_red_multimem(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem(
+_CCCL_DEVICE_API void fabric_try_red_multimem(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,
@@ -4588,7 +4588,7 @@ __device__ static inline void fabric_try_red_multimem_counted(
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_try_red_multimem_counted(
+_CCCL_DEVICE_API void fabric_try_red_multimem_counted(
   ::cuda::ptx::op_add_t,
   ::cuda::ptx::space_shared_t,
   ::cuda::ptx::sem_relaxed_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fabric_wait.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fabric_wait.h
@@ -13,7 +13,7 @@ __device__ static inline void fabric_wait();
 */
 #if __cccl_ptx_isa >= 930
 template <typename = void>
-_CCCL_DEVICE static inline void fabric_wait()
+_CCCL_DEVICE_API void fabric_wait()
 {
   asm volatile("fabric.wait.sync_restrict::reads;" : : :);
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fence.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fence.h
@@ -17,7 +17,7 @@ __device__ static inline void fence(
 */
 #if __cccl_ptx_isa >= 600
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void fence(::cuda::ptx::sem_sc_t, ::cuda::ptx::scope_t<_Scope> __scope)
+_CCCL_DEVICE_API void fence(::cuda::ptx::sem_sc_t, ::cuda::ptx::scope_t<_Scope> __scope)
 {
   // __sem == sem_sc (due to parameter type constraint)
   static_assert(__scope == scope_cta || __scope == scope_gpu || __scope == scope_sys, "");
@@ -47,7 +47,7 @@ __device__ static inline void fence(
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline void fence(::cuda::ptx::sem_sc_t, ::cuda::ptx::scope_cluster_t)
+_CCCL_DEVICE_API void fence(::cuda::ptx::sem_sc_t, ::cuda::ptx::scope_cluster_t)
 {
   // __sem == sem_sc (due to parameter type constraint)
   // __scope == scope_cluster (due to parameter type constraint)
@@ -66,7 +66,7 @@ __device__ static inline void fence(
 */
 #if __cccl_ptx_isa >= 600
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void fence(::cuda::ptx::sem_acq_rel_t, ::cuda::ptx::scope_t<_Scope> __scope)
+_CCCL_DEVICE_API void fence(::cuda::ptx::sem_acq_rel_t, ::cuda::ptx::scope_t<_Scope> __scope)
 {
   // __sem == sem_acq_rel (due to parameter type constraint)
   static_assert(__scope == scope_cta || __scope == scope_gpu || __scope == scope_sys, "");
@@ -96,7 +96,7 @@ __device__ static inline void fence(
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline void fence(::cuda::ptx::sem_acq_rel_t, ::cuda::ptx::scope_cluster_t)
+_CCCL_DEVICE_API void fence(::cuda::ptx::sem_acq_rel_t, ::cuda::ptx::scope_cluster_t)
 {
   // __sem == sem_acq_rel (due to parameter type constraint)
   // __scope == scope_cluster (due to parameter type constraint)
@@ -115,7 +115,7 @@ __device__ static inline void fence(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void fence(::cuda::ptx::sem_acquire_t, ::cuda::ptx::scope_t<_Scope> __scope)
+_CCCL_DEVICE_API void fence(::cuda::ptx::sem_acquire_t, ::cuda::ptx::scope_t<_Scope> __scope)
 {
   // __sem == sem_acquire (due to parameter type constraint)
   static_assert(__scope == scope_cta || __scope == scope_cluster || __scope == scope_gpu || __scope == scope_sys, "");
@@ -149,7 +149,7 @@ __device__ static inline void fence(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void fence(::cuda::ptx::sem_release_t, ::cuda::ptx::scope_t<_Scope> __scope)
+_CCCL_DEVICE_API void fence(::cuda::ptx::sem_release_t, ::cuda::ptx::scope_t<_Scope> __scope)
 {
   // __sem == sem_release (due to parameter type constraint)
   static_assert(__scope == scope_cta || __scope == scope_cluster || __scope == scope_gpu || __scope == scope_sys, "");

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fence_mbarrier_init.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fence_mbarrier_init.h
@@ -17,7 +17,7 @@ __device__ static inline void fence_mbarrier_init(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void fence_mbarrier_init(::cuda::ptx::sem_release_t, ::cuda::ptx::scope_cluster_t)
+_CCCL_DEVICE_API void fence_mbarrier_init(::cuda::ptx::sem_release_t, ::cuda::ptx::scope_cluster_t)
 {
   // __sem == sem_release (due to parameter type constraint)
   // __scope == scope_cluster (due to parameter type constraint)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_alias.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_alias.h
@@ -13,7 +13,7 @@ __device__ static inline void fence_proxy_alias();
 */
 #if __cccl_ptx_isa >= 750
 template <typename = void>
-_CCCL_DEVICE static inline void fence_proxy_alias()
+_CCCL_DEVICE_API void fence_proxy_alias()
 {
   asm volatile("fence.proxy.alias; // 4." : : : "memory");
 }
@@ -28,7 +28,7 @@ __device__ static inline void fence_proxy_alias(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem>
-_CCCL_DEVICE static inline void fence_proxy_alias(::cuda::ptx::sem_t<_Sem> __sem)
+_CCCL_DEVICE_API void fence_proxy_alias(::cuda::ptx::sem_t<_Sem> __sem)
 {
   static_assert(__sem == sem_acquire || __sem == sem_release, "");
   if constexpr (__sem == sem_acquire)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_async.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_async.h
@@ -13,7 +13,7 @@ __device__ static inline void fence_proxy_async();
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void fence_proxy_async()
+_CCCL_DEVICE_API void fence_proxy_async()
 {
   asm volatile("fence.proxy.async; // 5." : : : "memory");
 }
@@ -28,7 +28,7 @@ __device__ static inline void fence_proxy_async(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_space _Space>
-_CCCL_DEVICE static inline void fence_proxy_async(::cuda::ptx::space_t<_Space> __space)
+_CCCL_DEVICE_API void fence_proxy_async(::cuda::ptx::space_t<_Space> __space)
 {
   static_assert(__space == space_global || __space == space_cluster || __space == space_shared, "");
   if constexpr (__space == space_global)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_async_generic_sync_restrict.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_async_generic_sync_restrict.h
@@ -19,7 +19,7 @@ __device__ static inline void fence_proxy_async_generic_sync_restrict(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void fence_proxy_async_generic_sync_restrict(
+_CCCL_DEVICE_API void fence_proxy_async_generic_sync_restrict(
   ::cuda::ptx::sem_acquire_t, ::cuda::ptx::space_cluster_t, ::cuda::ptx::scope_cluster_t)
 {
   // __sem == sem_acquire (due to parameter type constraint)
@@ -42,7 +42,7 @@ __device__ static inline void fence_proxy_async_generic_sync_restrict(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void fence_proxy_async_generic_sync_restrict(
+_CCCL_DEVICE_API void fence_proxy_async_generic_sync_restrict(
   ::cuda::ptx::sem_release_t, ::cuda::ptx::space_shared_t, ::cuda::ptx::scope_cluster_t)
 {
   // __sem == sem_release (due to parameter type constraint)
@@ -65,7 +65,7 @@ __device__ static inline void fence_proxy_async_generic_sync_restrict(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void fence_proxy_async_generic_sync_restrict(
+_CCCL_DEVICE_API void fence_proxy_async_generic_sync_restrict(
   ::cuda::ptx::sem_release_t, ::cuda::ptx::space_cluster_t, ::cuda::ptx::scope_t<_Scope> __scope)
 {
   // __sem == sem_release (due to parameter type constraint)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_fabric_fabric_alias.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_fabric_fabric_alias.h
@@ -15,7 +15,7 @@ __device__ static inline void fence_proxy_fabric_fabric_alias(
 */
 #if __cccl_ptx_isa >= 930
 template <::cuda::ptx::dot_sem _Sem>
-_CCCL_DEVICE static inline void fence_proxy_fabric_fabric_alias(::cuda::ptx::sem_t<_Sem> __sem)
+_CCCL_DEVICE_API void fence_proxy_fabric_fabric_alias(::cuda::ptx::sem_t<_Sem> __sem)
 {
   static_assert(__sem == sem_acquire || __sem == sem_release, "");
   if constexpr (__sem == sem_acquire)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_fabric_generic_alias.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_fabric_generic_alias.h
@@ -15,7 +15,7 @@ __device__ static inline void fence_proxy_fabric_generic_alias(
 */
 #if __cccl_ptx_isa >= 930
 template <::cuda::ptx::dot_sem _Sem>
-_CCCL_DEVICE static inline void fence_proxy_fabric_generic_alias(::cuda::ptx::sem_t<_Sem> __sem)
+_CCCL_DEVICE_API void fence_proxy_fabric_generic_alias(::cuda::ptx::sem_t<_Sem> __sem)
 {
   static_assert(__sem == sem_acquire || __sem == sem_release, "");
   if constexpr (__sem == sem_acquire)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_generic_fabric_alias.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_generic_fabric_alias.h
@@ -15,7 +15,7 @@ __device__ static inline void fence_proxy_generic_fabric_alias(
 */
 #if __cccl_ptx_isa >= 930
 template <::cuda::ptx::dot_sem _Sem>
-_CCCL_DEVICE static inline void fence_proxy_generic_fabric_alias(::cuda::ptx::sem_t<_Sem> __sem)
+_CCCL_DEVICE_API void fence_proxy_generic_fabric_alias(::cuda::ptx::sem_t<_Sem> __sem)
 {
   static_assert(__sem == sem_acquire || __sem == sem_release, "");
   if constexpr (__sem == sem_acquire)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_tensormap_generic.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fence_proxy_tensormap_generic.h
@@ -17,8 +17,7 @@ __device__ static inline void fence_proxy_tensormap_generic(
 */
 #if __cccl_ptx_isa >= 830
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void
-fence_proxy_tensormap_generic(::cuda::ptx::sem_release_t, ::cuda::ptx::scope_t<_Scope> __scope)
+_CCCL_DEVICE_API void fence_proxy_tensormap_generic(::cuda::ptx::sem_release_t, ::cuda::ptx::scope_t<_Scope> __scope)
 {
   // __sem == sem_release (due to parameter type constraint)
   static_assert(__scope == scope_cta || __scope == scope_cluster || __scope == scope_gpu || __scope == scope_sys, "");
@@ -54,7 +53,7 @@ __device__ static inline void fence_proxy_tensormap_generic(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void fence_proxy_tensormap_generic(
+_CCCL_DEVICE_API void fence_proxy_tensormap_generic(
   ::cuda::ptx::sem_acquire_t, ::cuda::ptx::scope_t<_Scope> __scope, const void* __addr, ::cuda::ptx::n32_t<_N32> __size)
 {
   // __sem == sem_acquire (due to parameter type constraint)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/fence_sync_restrict.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/fence_sync_restrict.h
@@ -19,7 +19,7 @@ __device__ static inline void fence_sync_restrict(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
   fence_sync_restrict(::cuda::ptx::sem_acquire_t, ::cuda::ptx::space_cluster_t, ::cuda::ptx::scope_cluster_t)
 {
   // __sem == sem_acquire (due to parameter type constraint)
@@ -42,7 +42,7 @@ __device__ static inline void fence_sync_restrict(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
   fence_sync_restrict(::cuda::ptx::sem_release_t, ::cuda::ptx::space_shared_t, ::cuda::ptx::scope_cluster_t)
 {
   // __sem == sem_release (due to parameter type constraint)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/get_sreg.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/get_sreg.h
@@ -13,7 +13,7 @@ __device__ static inline uint32_t get_sreg_tid_x();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_tid_x()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_tid_x()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%tid.x;" : "=r"(__sreg_value) : :);
@@ -28,7 +28,7 @@ __device__ static inline uint32_t get_sreg_tid_y();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_tid_y()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_tid_y()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%tid.y;" : "=r"(__sreg_value) : :);
@@ -43,7 +43,7 @@ __device__ static inline uint32_t get_sreg_tid_z();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_tid_z()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_tid_z()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%tid.z;" : "=r"(__sreg_value) : :);
@@ -58,7 +58,7 @@ __device__ static inline uint32_t get_sreg_ntid_x();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_ntid_x()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_ntid_x()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm volatile("mov.u32 %0, %%ntid.x;" : "=r"(__sreg_value) : :);
@@ -73,7 +73,7 @@ __device__ static inline uint32_t get_sreg_ntid_y();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_ntid_y()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_ntid_y()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm volatile("mov.u32 %0, %%ntid.y;" : "=r"(__sreg_value) : :);
@@ -88,7 +88,7 @@ __device__ static inline uint32_t get_sreg_ntid_z();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_ntid_z()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_ntid_z()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm volatile("mov.u32 %0, %%ntid.z;" : "=r"(__sreg_value) : :);
@@ -103,7 +103,7 @@ __device__ static inline uint32_t get_sreg_laneid();
 */
 #if __cccl_ptx_isa >= 130
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_laneid()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_laneid()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%laneid;" : "=r"(__sreg_value) : :);
@@ -118,7 +118,7 @@ __device__ static inline uint32_t get_sreg_warpid();
 */
 #if __cccl_ptx_isa >= 130
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_warpid()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_warpid()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm volatile("mov.u32 %0, %%warpid;" : "=r"(__sreg_value) : :);
@@ -133,7 +133,7 @@ __device__ static inline uint32_t get_sreg_nwarpid();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_nwarpid()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_nwarpid()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm volatile("mov.u32 %0, %%nwarpid;" : "=r"(__sreg_value) : :);
@@ -148,7 +148,7 @@ __device__ static inline uint32_t get_sreg_ctaid_x();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_ctaid_x()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_ctaid_x()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%ctaid.x;" : "=r"(__sreg_value) : :);
@@ -163,7 +163,7 @@ __device__ static inline uint32_t get_sreg_ctaid_y();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_ctaid_y()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_ctaid_y()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%ctaid.y;" : "=r"(__sreg_value) : :);
@@ -178,7 +178,7 @@ __device__ static inline uint32_t get_sreg_ctaid_z();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_ctaid_z()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_ctaid_z()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%ctaid.z;" : "=r"(__sreg_value) : :);
@@ -193,7 +193,7 @@ __device__ static inline uint32_t get_sreg_nctaid_x();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_nctaid_x()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_nctaid_x()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%nctaid.x;" : "=r"(__sreg_value) : :);
@@ -208,7 +208,7 @@ __device__ static inline uint32_t get_sreg_nctaid_y();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_nctaid_y()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_nctaid_y()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%nctaid.y;" : "=r"(__sreg_value) : :);
@@ -223,7 +223,7 @@ __device__ static inline uint32_t get_sreg_nctaid_z();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_nctaid_z()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_nctaid_z()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%nctaid.z;" : "=r"(__sreg_value) : :);
@@ -238,7 +238,7 @@ __device__ static inline uint32_t get_sreg_smid();
 */
 #if __cccl_ptx_isa >= 130
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_smid()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_smid()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%smid;" : "=r"(__sreg_value) : :);
@@ -253,7 +253,7 @@ __device__ static inline uint32_t get_sreg_nsmid();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_nsmid()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_nsmid()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm volatile("mov.u32 %0, %%nsmid;" : "=r"(__sreg_value) : :);
@@ -268,7 +268,7 @@ __device__ static inline uint64_t get_sreg_gridid();
 */
 #if __cccl_ptx_isa >= 300
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t get_sreg_gridid()
+_CCCL_DEVICE_API ::cuda::std::uint64_t get_sreg_gridid()
 {
   ::cuda::std::uint64_t __sreg_value;
   asm("mov.u64 %0, %%gridid;" : "=l"(__sreg_value) : :);
@@ -283,7 +283,7 @@ __device__ static inline bool get_sreg_is_explicit_cluster();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline bool get_sreg_is_explicit_cluster()
+_CCCL_DEVICE_API bool get_sreg_is_explicit_cluster()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("{\n\t"
@@ -305,7 +305,7 @@ __device__ static inline uint32_t get_sreg_clusterid_x();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_clusterid_x()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_clusterid_x()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%clusterid.x;" : "=r"(__sreg_value) : :);
@@ -320,7 +320,7 @@ __device__ static inline uint32_t get_sreg_clusterid_y();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_clusterid_y()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_clusterid_y()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%clusterid.y;" : "=r"(__sreg_value) : :);
@@ -335,7 +335,7 @@ __device__ static inline uint32_t get_sreg_clusterid_z();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_clusterid_z()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_clusterid_z()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%clusterid.z;" : "=r"(__sreg_value) : :);
@@ -350,7 +350,7 @@ __device__ static inline uint32_t get_sreg_nclusterid_x();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_nclusterid_x()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_nclusterid_x()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%nclusterid.x;" : "=r"(__sreg_value) : :);
@@ -365,7 +365,7 @@ __device__ static inline uint32_t get_sreg_nclusterid_y();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_nclusterid_y()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_nclusterid_y()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%nclusterid.y;" : "=r"(__sreg_value) : :);
@@ -380,7 +380,7 @@ __device__ static inline uint32_t get_sreg_nclusterid_z();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_nclusterid_z()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_nclusterid_z()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%nclusterid.z;" : "=r"(__sreg_value) : :);
@@ -395,7 +395,7 @@ __device__ static inline uint32_t get_sreg_cluster_ctaid_x();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_cluster_ctaid_x()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_cluster_ctaid_x()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%cluster_ctaid.x;" : "=r"(__sreg_value) : :);
@@ -410,7 +410,7 @@ __device__ static inline uint32_t get_sreg_cluster_ctaid_y();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_cluster_ctaid_y()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_cluster_ctaid_y()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%cluster_ctaid.y;" : "=r"(__sreg_value) : :);
@@ -425,7 +425,7 @@ __device__ static inline uint32_t get_sreg_cluster_ctaid_z();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_cluster_ctaid_z()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_cluster_ctaid_z()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%cluster_ctaid.z;" : "=r"(__sreg_value) : :);
@@ -440,7 +440,7 @@ __device__ static inline uint32_t get_sreg_cluster_nctaid_x();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_cluster_nctaid_x()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_cluster_nctaid_x()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%cluster_nctaid.x;" : "=r"(__sreg_value) : :);
@@ -455,7 +455,7 @@ __device__ static inline uint32_t get_sreg_cluster_nctaid_y();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_cluster_nctaid_y()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_cluster_nctaid_y()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%cluster_nctaid.y;" : "=r"(__sreg_value) : :);
@@ -470,7 +470,7 @@ __device__ static inline uint32_t get_sreg_cluster_nctaid_z();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_cluster_nctaid_z()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_cluster_nctaid_z()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%cluster_nctaid.z;" : "=r"(__sreg_value) : :);
@@ -485,7 +485,7 @@ __device__ static inline uint32_t get_sreg_cluster_ctarank();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_cluster_ctarank()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_cluster_ctarank()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%cluster_ctarank;" : "=r"(__sreg_value) : :);
@@ -500,7 +500,7 @@ __device__ static inline uint32_t get_sreg_cluster_nctarank();
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_cluster_nctarank()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_cluster_nctarank()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%cluster_nctarank;" : "=r"(__sreg_value) : :);
@@ -515,7 +515,7 @@ __device__ static inline uint32_t get_sreg_lanemask_eq();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_lanemask_eq()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_lanemask_eq()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%lanemask_eq;" : "=r"(__sreg_value) : :);
@@ -530,7 +530,7 @@ __device__ static inline uint32_t get_sreg_lanemask_le();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_lanemask_le()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_lanemask_le()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%lanemask_le;" : "=r"(__sreg_value) : :);
@@ -545,7 +545,7 @@ __device__ static inline uint32_t get_sreg_lanemask_lt();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_lanemask_lt()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_lanemask_lt()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%lanemask_lt;" : "=r"(__sreg_value) : :);
@@ -560,7 +560,7 @@ __device__ static inline uint32_t get_sreg_lanemask_ge();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_lanemask_ge()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_lanemask_ge()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%lanemask_ge;" : "=r"(__sreg_value) : :);
@@ -575,7 +575,7 @@ __device__ static inline uint32_t get_sreg_lanemask_gt();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_lanemask_gt()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_lanemask_gt()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%lanemask_gt;" : "=r"(__sreg_value) : :);
@@ -590,7 +590,7 @@ __device__ static inline uint32_t get_sreg_clock();
 */
 #if __cccl_ptx_isa >= 100
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_clock()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_clock()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm volatile("mov.u32 %0, %%clock;" : "=r"(__sreg_value) : :);
@@ -605,7 +605,7 @@ __device__ static inline uint32_t get_sreg_clock_hi();
 */
 #if __cccl_ptx_isa >= 500
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_clock_hi()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_clock_hi()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm volatile("mov.u32 %0, %%clock_hi;" : "=r"(__sreg_value) : :);
@@ -620,7 +620,7 @@ __device__ static inline uint64_t get_sreg_clock64();
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t get_sreg_clock64()
+_CCCL_DEVICE_API ::cuda::std::uint64_t get_sreg_clock64()
 {
   ::cuda::std::uint64_t __sreg_value;
   asm volatile("mov.u64 %0, %%clock64;" : "=l"(__sreg_value) : :);
@@ -635,7 +635,7 @@ __device__ static inline uint64_t get_sreg_globaltimer();
 */
 #if __cccl_ptx_isa >= 310
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t get_sreg_globaltimer()
+_CCCL_DEVICE_API ::cuda::std::uint64_t get_sreg_globaltimer()
 {
   ::cuda::std::uint64_t __sreg_value;
   asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(__sreg_value) : :);
@@ -650,7 +650,7 @@ __device__ static inline uint32_t get_sreg_globaltimer_lo();
 */
 #if __cccl_ptx_isa >= 310
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_globaltimer_lo()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_globaltimer_lo()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm volatile("mov.u32 %0, %%globaltimer_lo;" : "=r"(__sreg_value) : :);
@@ -665,7 +665,7 @@ __device__ static inline uint32_t get_sreg_globaltimer_hi();
 */
 #if __cccl_ptx_isa >= 310
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_globaltimer_hi()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_globaltimer_hi()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm volatile("mov.u32 %0, %%globaltimer_hi;" : "=r"(__sreg_value) : :);
@@ -680,7 +680,7 @@ __device__ static inline uint32_t get_sreg_total_smem_size();
 */
 #if __cccl_ptx_isa >= 410
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_total_smem_size()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_total_smem_size()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%total_smem_size;" : "=r"(__sreg_value) : :);
@@ -695,7 +695,7 @@ __device__ static inline uint32_t get_sreg_aggr_smem_size();
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_aggr_smem_size()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_aggr_smem_size()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%aggr_smem_size;" : "=r"(__sreg_value) : :);
@@ -710,7 +710,7 @@ __device__ static inline uint32_t get_sreg_dynamic_smem_size();
 */
 #if __cccl_ptx_isa >= 410
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t get_sreg_dynamic_smem_size()
+_CCCL_DEVICE_API ::cuda::std::uint32_t get_sreg_dynamic_smem_size()
 {
   ::cuda::std::uint32_t __sreg_value;
   asm("mov.u32 %0, %%dynamic_smem_size;" : "=r"(__sreg_value) : :);
@@ -725,7 +725,7 @@ __device__ static inline uint64_t get_sreg_current_graph_exec();
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t get_sreg_current_graph_exec()
+_CCCL_DEVICE_API ::cuda::std::uint64_t get_sreg_current_graph_exec()
 {
   ::cuda::std::uint64_t __sreg_value;
   asm("mov.u64 %0, %%current_graph_exec;" : "=l"(__sreg_value) : :);

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/getctarank.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/getctarank.h
@@ -16,7 +16,7 @@ __device__ static inline uint32_t getctarank(
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t getctarank(::cuda::ptx::space_cluster_t, const void* __addr)
+_CCCL_DEVICE_API ::cuda::std::uint32_t getctarank(::cuda::ptx::space_cluster_t, const void* __addr)
 {
   // __space == space_cluster (due to parameter type constraint)
   ::cuda::std::uint32_t __dest;

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/ld.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/ld.h
@@ -16,7 +16,7 @@ __device__ static inline B8 ld(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -36,7 +36,7 @@ __device__ static inline B8 ld_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -56,7 +56,7 @@ __device__ static inline B16 ld(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -76,7 +76,7 @@ __device__ static inline B16 ld_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -96,7 +96,7 @@ __device__ static inline B32 ld(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -116,7 +116,7 @@ __device__ static inline B32 ld_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -136,7 +136,7 @@ __device__ static inline B64 ld(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -156,7 +156,7 @@ __device__ static inline B64 ld_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -176,7 +176,7 @@ __device__ static inline B128 ld(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -203,7 +203,7 @@ __device__ static inline B128 ld_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -230,7 +230,7 @@ __device__ static inline B256 ld(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256 ld(::cuda::ptx::space_global_t, const _B256* __addr)
+_CCCL_DEVICE_API _B256 ld(::cuda::ptx::space_global_t, const _B256* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -254,8 +254,8 @@ __device__ static inline B8 ld_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L2_cache_hint(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B8 ld_L2_cache_hint(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -279,8 +279,8 @@ __device__ static inline B8 ld_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B8 ld_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -304,8 +304,8 @@ __device__ static inline B16 ld_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L2_cache_hint(::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B16 ld_L2_cache_hint(::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -329,8 +329,8 @@ __device__ static inline B16 ld_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B16 ld_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -354,8 +354,8 @@ __device__ static inline B32 ld_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L2_cache_hint(::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B32 ld_L2_cache_hint(::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -379,8 +379,8 @@ __device__ static inline B32 ld_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B32 ld_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -404,8 +404,8 @@ __device__ static inline B64 ld_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L2_cache_hint(::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B64 ld_L2_cache_hint(::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -429,8 +429,8 @@ __device__ static inline B64 ld_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B64 ld_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -454,8 +454,8 @@ __device__ static inline B128 ld_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L2_cache_hint(::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B128 ld_L2_cache_hint(::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -483,8 +483,8 @@ __device__ static inline B128 ld_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B128 ld_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -512,8 +512,8 @@ __device__ static inline B256 ld_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256
-ld_L2_cache_hint(::cuda::ptx::space_global_t, const _B256* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B256 ld_L2_cache_hint(::cuda::ptx::space_global_t, const _B256* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -536,7 +536,7 @@ __device__ static inline B8 ld_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_first(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_L1_evict_first(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -556,7 +556,7 @@ __device__ static inline B8 ld_L1_evict_first_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -576,7 +576,7 @@ __device__ static inline B16 ld_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_first(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_L1_evict_first(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -596,7 +596,7 @@ __device__ static inline B16 ld_L1_evict_first_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -616,7 +616,7 @@ __device__ static inline B32 ld_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_first(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_L1_evict_first(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -636,7 +636,7 @@ __device__ static inline B32 ld_L1_evict_first_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -656,7 +656,7 @@ __device__ static inline B64 ld_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_first(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_L1_evict_first(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -676,7 +676,7 @@ __device__ static inline B64 ld_L1_evict_first_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -696,7 +696,7 @@ __device__ static inline B128 ld_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_first(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_L1_evict_first(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -723,7 +723,7 @@ __device__ static inline B128 ld_L1_evict_first_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -750,7 +750,7 @@ __device__ static inline B256 ld_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256 ld_L1_evict_first(::cuda::ptx::space_global_t, const _B256* __addr)
+_CCCL_DEVICE_API _B256 ld_L1_evict_first(::cuda::ptx::space_global_t, const _B256* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -774,7 +774,7 @@ __device__ static inline B8 ld_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
+_CCCL_DEVICE_API _B8
 ld_L1_evict_first_L2_cache_hint(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -799,7 +799,7 @@ __device__ static inline B8 ld_L1_evict_first_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_first_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B8 ld_L1_evict_first_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -824,7 +824,7 @@ __device__ static inline B16 ld_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
+_CCCL_DEVICE_API _B16
 ld_L1_evict_first_L2_cache_hint(::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -849,7 +849,7 @@ __device__ static inline B16 ld_L1_evict_first_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_first_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B16 ld_L1_evict_first_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -874,7 +874,7 @@ __device__ static inline B32 ld_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
+_CCCL_DEVICE_API _B32
 ld_L1_evict_first_L2_cache_hint(::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -899,7 +899,7 @@ __device__ static inline B32 ld_L1_evict_first_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_first_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B32 ld_L1_evict_first_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -924,7 +924,7 @@ __device__ static inline B64 ld_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
+_CCCL_DEVICE_API _B64
 ld_L1_evict_first_L2_cache_hint(::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -949,7 +949,7 @@ __device__ static inline B64 ld_L1_evict_first_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_first_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B64 ld_L1_evict_first_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -974,7 +974,7 @@ __device__ static inline B128 ld_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
+_CCCL_DEVICE_API _B128
 ld_L1_evict_first_L2_cache_hint(::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1003,7 +1003,7 @@ __device__ static inline B128 ld_L1_evict_first_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_first_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B128 ld_L1_evict_first_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1032,7 +1032,7 @@ __device__ static inline B256 ld_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256
+_CCCL_DEVICE_API _B256
 ld_L1_evict_first_L2_cache_hint(::cuda::ptx::space_global_t, const _B256* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1056,7 +1056,7 @@ __device__ static inline B8 ld_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_last(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_L1_evict_last(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -1076,7 +1076,7 @@ __device__ static inline B8 ld_L1_evict_last_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -1096,7 +1096,7 @@ __device__ static inline B16 ld_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_last(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_L1_evict_last(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -1116,7 +1116,7 @@ __device__ static inline B16 ld_L1_evict_last_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -1136,7 +1136,7 @@ __device__ static inline B32 ld_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_last(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_L1_evict_last(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -1156,7 +1156,7 @@ __device__ static inline B32 ld_L1_evict_last_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -1176,7 +1176,7 @@ __device__ static inline B64 ld_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_last(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_L1_evict_last(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -1196,7 +1196,7 @@ __device__ static inline B64 ld_L1_evict_last_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -1216,7 +1216,7 @@ __device__ static inline B128 ld_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_last(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_L1_evict_last(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -1243,7 +1243,7 @@ __device__ static inline B128 ld_L1_evict_last_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -1270,7 +1270,7 @@ __device__ static inline B256 ld_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256 ld_L1_evict_last(::cuda::ptx::space_global_t, const _B256* __addr)
+_CCCL_DEVICE_API _B256 ld_L1_evict_last(::cuda::ptx::space_global_t, const _B256* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -1294,8 +1294,8 @@ __device__ static inline B8 ld_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_last_L2_cache_hint(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B8 ld_L1_evict_last_L2_cache_hint(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -1319,7 +1319,7 @@ __device__ static inline B8 ld_L1_evict_last_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_last_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B8 ld_L1_evict_last_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1344,7 +1344,7 @@ __device__ static inline B16 ld_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
+_CCCL_DEVICE_API _B16
 ld_L1_evict_last_L2_cache_hint(::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1369,7 +1369,7 @@ __device__ static inline B16 ld_L1_evict_last_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_last_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B16 ld_L1_evict_last_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1394,7 +1394,7 @@ __device__ static inline B32 ld_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
+_CCCL_DEVICE_API _B32
 ld_L1_evict_last_L2_cache_hint(::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1419,7 +1419,7 @@ __device__ static inline B32 ld_L1_evict_last_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_last_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B32 ld_L1_evict_last_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1444,7 +1444,7 @@ __device__ static inline B64 ld_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
+_CCCL_DEVICE_API _B64
 ld_L1_evict_last_L2_cache_hint(::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1469,7 +1469,7 @@ __device__ static inline B64 ld_L1_evict_last_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_last_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B64 ld_L1_evict_last_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1494,7 +1494,7 @@ __device__ static inline B128 ld_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
+_CCCL_DEVICE_API _B128
 ld_L1_evict_last_L2_cache_hint(::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1523,7 +1523,7 @@ __device__ static inline B128 ld_L1_evict_last_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_last_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B128 ld_L1_evict_last_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1552,7 +1552,7 @@ __device__ static inline B256 ld_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256
+_CCCL_DEVICE_API _B256
 ld_L1_evict_last_L2_cache_hint(::cuda::ptx::space_global_t, const _B256* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1576,7 +1576,7 @@ __device__ static inline B8 ld_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_no_allocate(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_L1_no_allocate(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -1596,7 +1596,7 @@ __device__ static inline B8 ld_L1_no_allocate_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -1616,7 +1616,7 @@ __device__ static inline B16 ld_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_no_allocate(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_L1_no_allocate(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -1636,7 +1636,7 @@ __device__ static inline B16 ld_L1_no_allocate_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -1656,7 +1656,7 @@ __device__ static inline B32 ld_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_no_allocate(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_L1_no_allocate(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -1676,7 +1676,7 @@ __device__ static inline B32 ld_L1_no_allocate_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -1696,7 +1696,7 @@ __device__ static inline B64 ld_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_no_allocate(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_L1_no_allocate(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -1716,7 +1716,7 @@ __device__ static inline B64 ld_L1_no_allocate_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -1736,7 +1736,7 @@ __device__ static inline B128 ld_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_no_allocate(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_L1_no_allocate(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -1763,7 +1763,7 @@ __device__ static inline B128 ld_L1_no_allocate_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -1790,7 +1790,7 @@ __device__ static inline B256 ld_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256 ld_L1_no_allocate(::cuda::ptx::space_global_t, const _B256* __addr)
+_CCCL_DEVICE_API _B256 ld_L1_no_allocate(::cuda::ptx::space_global_t, const _B256* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -1814,7 +1814,7 @@ __device__ static inline B8 ld_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
+_CCCL_DEVICE_API _B8
 ld_L1_no_allocate_L2_cache_hint(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1839,7 +1839,7 @@ __device__ static inline B8 ld_L1_no_allocate_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_no_allocate_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B8 ld_L1_no_allocate_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1864,7 +1864,7 @@ __device__ static inline B16 ld_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
+_CCCL_DEVICE_API _B16
 ld_L1_no_allocate_L2_cache_hint(::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1889,7 +1889,7 @@ __device__ static inline B16 ld_L1_no_allocate_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_no_allocate_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B16 ld_L1_no_allocate_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1914,7 +1914,7 @@ __device__ static inline B32 ld_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
+_CCCL_DEVICE_API _B32
 ld_L1_no_allocate_L2_cache_hint(::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1939,7 +1939,7 @@ __device__ static inline B32 ld_L1_no_allocate_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_no_allocate_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B32 ld_L1_no_allocate_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1964,7 +1964,7 @@ __device__ static inline B64 ld_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
+_CCCL_DEVICE_API _B64
 ld_L1_no_allocate_L2_cache_hint(::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1989,7 +1989,7 @@ __device__ static inline B64 ld_L1_no_allocate_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_no_allocate_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B64 ld_L1_no_allocate_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -2014,7 +2014,7 @@ __device__ static inline B128 ld_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
+_CCCL_DEVICE_API _B128
 ld_L1_no_allocate_L2_cache_hint(::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -2043,7 +2043,7 @@ __device__ static inline B128 ld_L1_no_allocate_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_no_allocate_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B128 ld_L1_no_allocate_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -2072,7 +2072,7 @@ __device__ static inline B256 ld_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256
+_CCCL_DEVICE_API _B256
 ld_L1_no_allocate_L2_cache_hint(::cuda::ptx::space_global_t, const _B256* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -2096,7 +2096,7 @@ __device__ static inline B8 ld_nc(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_nc(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -2116,7 +2116,7 @@ __device__ static inline B8 ld_nc_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_nc_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -2136,7 +2136,7 @@ __device__ static inline B16 ld_nc(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_nc(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -2156,7 +2156,7 @@ __device__ static inline B16 ld_nc_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_nc_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -2176,7 +2176,7 @@ __device__ static inline B32 ld_nc(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_nc(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -2196,7 +2196,7 @@ __device__ static inline B32 ld_nc_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_nc_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -2216,7 +2216,7 @@ __device__ static inline B64 ld_nc(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_nc(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -2236,7 +2236,7 @@ __device__ static inline B64 ld_nc_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_nc_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -2256,7 +2256,7 @@ __device__ static inline B128 ld_nc(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_nc(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -2283,7 +2283,7 @@ __device__ static inline B128 ld_nc_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_nc_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -2310,7 +2310,7 @@ __device__ static inline B256 ld_nc(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256 ld_nc(::cuda::ptx::space_global_t, const _B256* __addr)
+_CCCL_DEVICE_API _B256 ld_nc(::cuda::ptx::space_global_t, const _B256* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -2334,8 +2334,8 @@ __device__ static inline B8 ld_nc_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L2_cache_hint(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B8 ld_nc_L2_cache_hint(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -2359,8 +2359,8 @@ __device__ static inline B8 ld_nc_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B8 ld_nc_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -2384,8 +2384,8 @@ __device__ static inline B16 ld_nc_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L2_cache_hint(::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B16 ld_nc_L2_cache_hint(::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -2409,8 +2409,8 @@ __device__ static inline B16 ld_nc_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B16 ld_nc_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -2434,8 +2434,8 @@ __device__ static inline B32 ld_nc_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L2_cache_hint(::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B32 ld_nc_L2_cache_hint(::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -2459,8 +2459,8 @@ __device__ static inline B32 ld_nc_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B32 ld_nc_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -2484,8 +2484,8 @@ __device__ static inline B64 ld_nc_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L2_cache_hint(::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B64 ld_nc_L2_cache_hint(::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -2509,8 +2509,8 @@ __device__ static inline B64 ld_nc_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B64 ld_nc_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -2534,8 +2534,8 @@ __device__ static inline B128 ld_nc_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L2_cache_hint(::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B128 ld_nc_L2_cache_hint(::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -2563,7 +2563,7 @@ __device__ static inline B128 ld_nc_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
+_CCCL_DEVICE_API _B128
 ld_nc_L2_cache_hint_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -2592,8 +2592,8 @@ __device__ static inline B256 ld_nc_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256
-ld_nc_L2_cache_hint(::cuda::ptx::space_global_t, const _B256* __addr, ::cuda::std::uint64_t __cache_policy)
+_CCCL_DEVICE_API
+_B256 ld_nc_L2_cache_hint(::cuda::ptx::space_global_t, const _B256* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -2616,7 +2616,7 @@ __device__ static inline B8 ld_nc_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_first(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_nc_L1_evict_first(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -2636,7 +2636,7 @@ __device__ static inline B8 ld_nc_L1_evict_first_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_nc_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -2656,7 +2656,7 @@ __device__ static inline B16 ld_nc_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_first(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_nc_L1_evict_first(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -2676,7 +2676,7 @@ __device__ static inline B16 ld_nc_L1_evict_first_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_nc_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -2696,7 +2696,7 @@ __device__ static inline B32 ld_nc_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_first(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_nc_L1_evict_first(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -2716,7 +2716,7 @@ __device__ static inline B32 ld_nc_L1_evict_first_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_nc_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -2736,7 +2736,7 @@ __device__ static inline B64 ld_nc_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_first(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_nc_L1_evict_first(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -2756,7 +2756,7 @@ __device__ static inline B64 ld_nc_L1_evict_first_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_nc_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -2776,7 +2776,7 @@ __device__ static inline B128 ld_nc_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_first(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_nc_L1_evict_first(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -2803,7 +2803,7 @@ __device__ static inline B128 ld_nc_L1_evict_first_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_nc_L1_evict_first_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -2830,7 +2830,7 @@ __device__ static inline B256 ld_nc_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256 ld_nc_L1_evict_first(::cuda::ptx::space_global_t, const _B256* __addr)
+_CCCL_DEVICE_API _B256 ld_nc_L1_evict_first(::cuda::ptx::space_global_t, const _B256* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -2854,7 +2854,7 @@ __device__ static inline B8 ld_nc_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
+_CCCL_DEVICE_API _B8
 ld_nc_L1_evict_first_L2_cache_hint(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -2879,7 +2879,7 @@ __device__ static inline B8 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B8 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -2904,7 +2904,7 @@ __device__ static inline B16 ld_nc_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_first_L2_cache_hint(
+_CCCL_DEVICE_API _B16 ld_nc_L1_evict_first_L2_cache_hint(
   ::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -2929,7 +2929,7 @@ __device__ static inline B16 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B16 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -2954,7 +2954,7 @@ __device__ static inline B32 ld_nc_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_first_L2_cache_hint(
+_CCCL_DEVICE_API _B32 ld_nc_L1_evict_first_L2_cache_hint(
   ::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -2979,7 +2979,7 @@ __device__ static inline B32 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B32 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3004,7 +3004,7 @@ __device__ static inline B64 ld_nc_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_first_L2_cache_hint(
+_CCCL_DEVICE_API _B64 ld_nc_L1_evict_first_L2_cache_hint(
   ::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3029,7 +3029,7 @@ __device__ static inline B64 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B64 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3054,7 +3054,7 @@ __device__ static inline B128 ld_nc_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_first_L2_cache_hint(
+_CCCL_DEVICE_API _B128 ld_nc_L1_evict_first_L2_cache_hint(
   ::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3083,7 +3083,7 @@ __device__ static inline B128 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B128 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3112,7 +3112,7 @@ __device__ static inline B256 ld_nc_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256 ld_nc_L1_evict_first_L2_cache_hint(
+_CCCL_DEVICE_API _B256 ld_nc_L1_evict_first_L2_cache_hint(
   ::cuda::ptx::space_global_t, const _B256* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3136,7 +3136,7 @@ __device__ static inline B8 ld_nc_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_last(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_nc_L1_evict_last(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -3156,7 +3156,7 @@ __device__ static inline B8 ld_nc_L1_evict_last_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_nc_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -3176,7 +3176,7 @@ __device__ static inline B16 ld_nc_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_last(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_nc_L1_evict_last(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -3196,7 +3196,7 @@ __device__ static inline B16 ld_nc_L1_evict_last_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_nc_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -3216,7 +3216,7 @@ __device__ static inline B32 ld_nc_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_last(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_nc_L1_evict_last(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -3236,7 +3236,7 @@ __device__ static inline B32 ld_nc_L1_evict_last_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_nc_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -3256,7 +3256,7 @@ __device__ static inline B64 ld_nc_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_last(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_nc_L1_evict_last(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -3276,7 +3276,7 @@ __device__ static inline B64 ld_nc_L1_evict_last_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_nc_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -3296,7 +3296,7 @@ __device__ static inline B128 ld_nc_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_last(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_nc_L1_evict_last(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -3323,7 +3323,7 @@ __device__ static inline B128 ld_nc_L1_evict_last_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_nc_L1_evict_last_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -3350,7 +3350,7 @@ __device__ static inline B256 ld_nc_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256 ld_nc_L1_evict_last(::cuda::ptx::space_global_t, const _B256* __addr)
+_CCCL_DEVICE_API _B256 ld_nc_L1_evict_last(::cuda::ptx::space_global_t, const _B256* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -3374,7 +3374,7 @@ __device__ static inline B8 ld_nc_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
+_CCCL_DEVICE_API _B8
 ld_nc_L1_evict_last_L2_cache_hint(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3399,7 +3399,7 @@ __device__ static inline B8 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B8 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3424,7 +3424,7 @@ __device__ static inline B16 ld_nc_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
+_CCCL_DEVICE_API _B16
 ld_nc_L1_evict_last_L2_cache_hint(::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3449,7 +3449,7 @@ __device__ static inline B16 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B16 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3474,7 +3474,7 @@ __device__ static inline B32 ld_nc_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
+_CCCL_DEVICE_API _B32
 ld_nc_L1_evict_last_L2_cache_hint(::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3499,7 +3499,7 @@ __device__ static inline B32 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B32 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3524,7 +3524,7 @@ __device__ static inline B64 ld_nc_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
+_CCCL_DEVICE_API _B64
 ld_nc_L1_evict_last_L2_cache_hint(::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3549,7 +3549,7 @@ __device__ static inline B64 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B64 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3574,7 +3574,7 @@ __device__ static inline B128 ld_nc_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_last_L2_cache_hint(
+_CCCL_DEVICE_API _B128 ld_nc_L1_evict_last_L2_cache_hint(
   ::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3603,7 +3603,7 @@ __device__ static inline B128 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B128 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3632,7 +3632,7 @@ __device__ static inline B256 ld_nc_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256 ld_nc_L1_evict_last_L2_cache_hint(
+_CCCL_DEVICE_API _B256 ld_nc_L1_evict_last_L2_cache_hint(
   ::cuda::ptx::space_global_t, const _B256* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3656,7 +3656,7 @@ __device__ static inline B8 ld_nc_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_no_allocate(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_nc_L1_no_allocate(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -3676,7 +3676,7 @@ __device__ static inline B8 ld_nc_L1_no_allocate_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
+_CCCL_DEVICE_API _B8 ld_nc_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B8* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -3696,7 +3696,7 @@ __device__ static inline B16 ld_nc_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_no_allocate(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_nc_L1_no_allocate(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -3716,7 +3716,7 @@ __device__ static inline B16 ld_nc_L1_no_allocate_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
+_CCCL_DEVICE_API _B16 ld_nc_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B16* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -3736,7 +3736,7 @@ __device__ static inline B32 ld_nc_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_no_allocate(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_nc_L1_no_allocate(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -3756,7 +3756,7 @@ __device__ static inline B32 ld_nc_L1_no_allocate_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 ld_nc_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B32* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -3776,7 +3776,7 @@ __device__ static inline B64 ld_nc_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_no_allocate(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_nc_L1_no_allocate(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -3796,7 +3796,7 @@ __device__ static inline B64 ld_nc_L1_no_allocate_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 ld_nc_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B64* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -3816,7 +3816,7 @@ __device__ static inline B128 ld_nc_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_no_allocate(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_nc_L1_no_allocate(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -3843,7 +3843,7 @@ __device__ static inline B128 ld_nc_L1_no_allocate_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
+_CCCL_DEVICE_API _B128 ld_nc_L1_no_allocate_L2_256B(::cuda::ptx::space_global_t, const _B128* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -3870,7 +3870,7 @@ __device__ static inline B256 ld_nc_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256 ld_nc_L1_no_allocate(::cuda::ptx::space_global_t, const _B256* __addr)
+_CCCL_DEVICE_API _B256 ld_nc_L1_no_allocate(::cuda::ptx::space_global_t, const _B256* __addr)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -3894,7 +3894,7 @@ __device__ static inline B8 ld_nc_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
+_CCCL_DEVICE_API _B8
 ld_nc_L1_no_allocate_L2_cache_hint(::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3919,7 +3919,7 @@ __device__ static inline B8 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B8 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B8* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3944,7 +3944,7 @@ __device__ static inline B16 ld_nc_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_no_allocate_L2_cache_hint(
+_CCCL_DEVICE_API _B16 ld_nc_L1_no_allocate_L2_cache_hint(
   ::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3969,7 +3969,7 @@ __device__ static inline B16 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B16 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B16* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -3994,7 +3994,7 @@ __device__ static inline B32 ld_nc_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_no_allocate_L2_cache_hint(
+_CCCL_DEVICE_API _B32 ld_nc_L1_no_allocate_L2_cache_hint(
   ::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -4019,7 +4019,7 @@ __device__ static inline B32 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B32 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B32* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -4044,7 +4044,7 @@ __device__ static inline B64 ld_nc_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_no_allocate_L2_cache_hint(
+_CCCL_DEVICE_API _B64 ld_nc_L1_no_allocate_L2_cache_hint(
   ::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -4069,7 +4069,7 @@ __device__ static inline B64 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B64 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B64* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -4094,7 +4094,7 @@ __device__ static inline B128 ld_nc_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_no_allocate_L2_cache_hint(
+_CCCL_DEVICE_API _B128 ld_nc_L1_no_allocate_L2_cache_hint(
   ::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -4123,7 +4123,7 @@ __device__ static inline B128 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
+_CCCL_DEVICE_API _B128 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
   ::cuda::ptx::space_global_t, const _B128* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -4152,7 +4152,7 @@ __device__ static inline B256 ld_nc_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline _B256 ld_nc_L1_no_allocate_L2_cache_hint(
+_CCCL_DEVICE_API _B256 ld_nc_L1_no_allocate_L2_cache_hint(
   ::cuda::ptx::space_global_t, const _B256* __addr, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/ldmatrix.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/ldmatrix.h
@@ -17,7 +17,7 @@ __device__ static inline void ldmatrix_m8n8(
 */
 #if __cccl_ptx_isa >= 650
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 ldmatrix_m8n8(::cuda::ptx::space_shared_t, ::cuda::std::uint32_t (&__out_var)[1], const _B16* __smem_ptr)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -39,7 +39,7 @@ __device__ static inline void ldmatrix_m8n8(
 */
 #if __cccl_ptx_isa >= 650
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 ldmatrix_m8n8(::cuda::ptx::space_shared_t, ::cuda::std::uint32_t (&__out_var)[2], const _B16* __smem_ptr)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -61,7 +61,7 @@ __device__ static inline void ldmatrix_m8n8(
 */
 #if __cccl_ptx_isa >= 650
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 ldmatrix_m8n8(::cuda::ptx::space_shared_t, ::cuda::std::uint32_t (&__out_var)[4], const _B16* __smem_ptr)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -83,7 +83,7 @@ __device__ static inline void ldmatrix_m8n8_trans(
 */
 #if __cccl_ptx_isa >= 650
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 ldmatrix_m8n8_trans(::cuda::ptx::space_shared_t, ::cuda::std::uint32_t (&__out_var)[1], const _B16* __smem_ptr)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -105,7 +105,7 @@ __device__ static inline void ldmatrix_m8n8_trans(
 */
 #if __cccl_ptx_isa >= 650
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 ldmatrix_m8n8_trans(::cuda::ptx::space_shared_t, ::cuda::std::uint32_t (&__out_var)[2], const _B16* __smem_ptr)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -127,7 +127,7 @@ __device__ static inline void ldmatrix_m8n8_trans(
 */
 #if __cccl_ptx_isa >= 650
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 ldmatrix_m8n8_trans(::cuda::ptx::space_shared_t, ::cuda::std::uint32_t (&__out_var)[4], const _B16* __smem_ptr)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -149,7 +149,7 @@ __device__ static inline void ldmatrix_m8n16_b8x16_b6x16_p32(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void ldmatrix_m8n16_b8x16_b6x16_p32(
+_CCCL_DEVICE_API void ldmatrix_m8n16_b8x16_b6x16_p32(
   ::cuda::ptx::space_shared_t, ::cuda::std::uint32_t (&__out_var)[1], const void* __smem_ptr)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -171,7 +171,7 @@ __device__ static inline void ldmatrix_m8n16_b8x16_b4x16_p64(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void ldmatrix_m8n16_b8x16_b4x16_p64(
+_CCCL_DEVICE_API void ldmatrix_m8n16_b8x16_b4x16_p64(
   ::cuda::ptx::space_shared_t, ::cuda::std::uint32_t (&__out_var)[1], const void* __smem_ptr)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -193,7 +193,7 @@ __device__ static inline void ldmatrix_m8n16_b8x16_b6x16_p32(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void ldmatrix_m8n16_b8x16_b6x16_p32(
+_CCCL_DEVICE_API void ldmatrix_m8n16_b8x16_b6x16_p32(
   ::cuda::ptx::space_shared_t, ::cuda::std::uint32_t (&__out_var)[2], const void* __smem_ptr)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -215,7 +215,7 @@ __device__ static inline void ldmatrix_m8n16_b8x16_b4x16_p64(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void ldmatrix_m8n16_b8x16_b4x16_p64(
+_CCCL_DEVICE_API void ldmatrix_m8n16_b8x16_b4x16_p64(
   ::cuda::ptx::space_shared_t, ::cuda::std::uint32_t (&__out_var)[2], const void* __smem_ptr)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -237,7 +237,7 @@ __device__ static inline void ldmatrix_m8n16_b8x16_b6x16_p32(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void ldmatrix_m8n16_b8x16_b6x16_p32(
+_CCCL_DEVICE_API void ldmatrix_m8n16_b8x16_b6x16_p32(
   ::cuda::ptx::space_shared_t, ::cuda::std::uint32_t (&__out_var)[4], const void* __smem_ptr)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -259,7 +259,7 @@ __device__ static inline void ldmatrix_m8n16_b8x16_b4x16_p64(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void ldmatrix_m8n16_b8x16_b4x16_p64(
+_CCCL_DEVICE_API void ldmatrix_m8n16_b8x16_b4x16_p64(
   ::cuda::ptx::space_shared_t, ::cuda::std::uint32_t (&__out_var)[4], const void* __smem_ptr)
 {
   // __space == space_shared (due to parameter type constraint)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_arrive.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_arrive.h
@@ -14,7 +14,7 @@ __device__ static inline uint64_t mbarrier_arrive(
 */
 #if __cccl_ptx_isa >= 700
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t mbarrier_arrive(::cuda::std::uint64_t* __addr)
+_CCCL_DEVICE_API ::cuda::std::uint64_t mbarrier_arrive(::cuda::std::uint64_t* __addr)
 {
   ::cuda::std::uint64_t __state;
   asm("mbarrier.arrive.shared.b64                                  %0,  [%1];           // 1. "
@@ -34,7 +34,7 @@ __device__ static inline uint64_t mbarrier_arrive(
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t
+_CCCL_DEVICE_API ::cuda::std::uint64_t
 mbarrier_arrive(::cuda::std::uint64_t* __addr, const ::cuda::std::uint32_t& __count)
 {
   ::cuda::std::uint64_t __state;
@@ -60,7 +60,7 @@ __device__ static inline uint64_t mbarrier_arrive(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t mbarrier_arrive(
+_CCCL_DEVICE_API ::cuda::std::uint64_t mbarrier_arrive(
   ::cuda::ptx::sem_release_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_shared_t,
@@ -103,7 +103,7 @@ __device__ static inline uint64_t mbarrier_arrive(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t mbarrier_arrive(
+_CCCL_DEVICE_API ::cuda::std::uint64_t mbarrier_arrive(
   ::cuda::ptx::sem_release_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_shared_t,
@@ -146,7 +146,7 @@ __device__ static inline void mbarrier_arrive(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void mbarrier_arrive(
+_CCCL_DEVICE_API void mbarrier_arrive(
   ::cuda::ptx::sem_release_t, ::cuda::ptx::scope_cluster_t, ::cuda::ptx::space_cluster_t, ::cuda::std::uint64_t* __addr)
 {
   // __sem == sem_release (due to parameter type constraint)
@@ -174,7 +174,7 @@ __device__ static inline void mbarrier_arrive(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void mbarrier_arrive(
+_CCCL_DEVICE_API void mbarrier_arrive(
   ::cuda::ptx::sem_release_t,
   ::cuda::ptx::scope_cluster_t,
   ::cuda::ptx::space_cluster_t,
@@ -206,7 +206,7 @@ __device__ static inline uint64_t mbarrier_arrive(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t mbarrier_arrive(
+_CCCL_DEVICE_API ::cuda::std::uint64_t mbarrier_arrive(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_shared_t,
@@ -249,7 +249,7 @@ __device__ static inline uint64_t mbarrier_arrive(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t mbarrier_arrive(
+_CCCL_DEVICE_API ::cuda::std::uint64_t mbarrier_arrive(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_shared_t,
@@ -292,7 +292,7 @@ __device__ static inline void mbarrier_arrive(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void mbarrier_arrive(
+_CCCL_DEVICE_API void mbarrier_arrive(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_cluster_t,
   ::cuda::ptx::space_cluster_t,
@@ -323,7 +323,7 @@ __device__ static inline void mbarrier_arrive(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void mbarrier_arrive(
+_CCCL_DEVICE_API void mbarrier_arrive(
   ::cuda::ptx::sem_relaxed_t, ::cuda::ptx::scope_cluster_t, ::cuda::ptx::space_cluster_t, ::cuda::std::uint64_t* __addr)
 {
   // __sem == sem_relaxed (due to parameter type constraint)
@@ -350,7 +350,7 @@ __device__ static inline void mbarrier_arrive_multicast_32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem>
-_CCCL_DEVICE static inline void mbarrier_arrive_multicast_32b(
+_CCCL_DEVICE_API void mbarrier_arrive_multicast_32b(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_cluster_t,
   ::cuda::ptx::space_cluster_t,
@@ -395,7 +395,7 @@ __device__ static inline void mbarrier_arrive_expect_tx_multicast_32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem>
-_CCCL_DEVICE static inline void mbarrier_arrive_expect_tx_multicast_32b(
+_CCCL_DEVICE_API void mbarrier_arrive_expect_tx_multicast_32b(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_cluster_t,
   ::cuda::ptx::space_cluster_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_arrive_drop.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_arrive_drop.h
@@ -21,7 +21,7 @@ __device__ static inline uint64_t mbarrier_arrive_drop(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t mbarrier_arrive_drop(
+_CCCL_DEVICE_API ::cuda::std::uint64_t mbarrier_arrive_drop(
   ::cuda::ptx::sem_release_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_shared_t,
@@ -65,7 +65,7 @@ __device__ static inline void mbarrier_arrive_drop(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void mbarrier_arrive_drop(
+_CCCL_DEVICE_API void mbarrier_arrive_drop(
   ::cuda::ptx::sem_release_t,
   ::cuda::ptx::scope_cluster_t,
   ::cuda::ptx::space_cluster_t,
@@ -97,7 +97,7 @@ __device__ static inline uint64_t mbarrier_arrive_drop(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t mbarrier_arrive_drop(
+_CCCL_DEVICE_API ::cuda::std::uint64_t mbarrier_arrive_drop(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_shared_t,
@@ -141,7 +141,7 @@ __device__ static inline void mbarrier_arrive_drop(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void mbarrier_arrive_drop(
+_CCCL_DEVICE_API void mbarrier_arrive_drop(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_cluster_t,
   ::cuda::ptx::space_cluster_t,
@@ -175,7 +175,7 @@ __device__ static inline void mbarrier_arrive_drop_multicast(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem>
-_CCCL_DEVICE static inline void mbarrier_arrive_drop_multicast(
+_CCCL_DEVICE_API void mbarrier_arrive_drop_multicast(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_cluster_t,
   ::cuda::ptx::space_cluster_t,
@@ -220,7 +220,7 @@ __device__ static inline void mbarrier_arrive_drop_expect_tx_multicast(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem>
-_CCCL_DEVICE static inline void mbarrier_arrive_drop_expect_tx_multicast(
+_CCCL_DEVICE_API void mbarrier_arrive_drop_expect_tx_multicast(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_cluster_t,
   ::cuda::ptx::space_cluster_t,
@@ -257,7 +257,7 @@ __device__ static inline uint64_t mbarrier_arrive_drop_no_complete(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t
+_CCCL_DEVICE_API ::cuda::std::uint64_t
 mbarrier_arrive_drop_no_complete(::cuda::std::uint64_t* __addr, ::cuda::std::uint32_t __count)
 {
   ::cuda::std::uint64_t __state;
@@ -284,7 +284,7 @@ __device__ static inline uint64_t mbarrier_arrive_drop_expect_tx(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t mbarrier_arrive_drop_expect_tx(
+_CCCL_DEVICE_API ::cuda::std::uint64_t mbarrier_arrive_drop_expect_tx(
   ::cuda::ptx::sem_release_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_shared_t,
@@ -328,7 +328,7 @@ __device__ static inline void mbarrier_arrive_drop_expect_tx(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void mbarrier_arrive_drop_expect_tx(
+_CCCL_DEVICE_API void mbarrier_arrive_drop_expect_tx(
   ::cuda::ptx::sem_release_t,
   ::cuda::ptx::scope_cluster_t,
   ::cuda::ptx::space_cluster_t,
@@ -360,7 +360,7 @@ __device__ static inline uint64_t mbarrier_arrive_drop_expect_tx(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t mbarrier_arrive_drop_expect_tx(
+_CCCL_DEVICE_API ::cuda::std::uint64_t mbarrier_arrive_drop_expect_tx(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_shared_t,
@@ -404,7 +404,7 @@ __device__ static inline void mbarrier_arrive_drop_expect_tx(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void mbarrier_arrive_drop_expect_tx(
+_CCCL_DEVICE_API void mbarrier_arrive_drop_expect_tx(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_cluster_t,
   ::cuda::ptx::space_cluster_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_arrive_expect_tx.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_arrive_expect_tx.h
@@ -21,7 +21,7 @@ __device__ static inline uint64_t mbarrier_arrive_expect_tx(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t mbarrier_arrive_expect_tx(
+_CCCL_DEVICE_API ::cuda::std::uint64_t mbarrier_arrive_expect_tx(
   ::cuda::ptx::sem_release_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_shared_t,
@@ -65,7 +65,7 @@ __device__ static inline void mbarrier_arrive_expect_tx(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void mbarrier_arrive_expect_tx(
+_CCCL_DEVICE_API void mbarrier_arrive_expect_tx(
   ::cuda::ptx::sem_release_t,
   ::cuda::ptx::scope_cluster_t,
   ::cuda::ptx::space_cluster_t,
@@ -97,7 +97,7 @@ __device__ static inline uint64_t mbarrier_arrive_expect_tx(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t mbarrier_arrive_expect_tx(
+_CCCL_DEVICE_API ::cuda::std::uint64_t mbarrier_arrive_expect_tx(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_shared_t,
@@ -141,7 +141,7 @@ __device__ static inline void mbarrier_arrive_expect_tx(
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void mbarrier_arrive_expect_tx(
+_CCCL_DEVICE_API void mbarrier_arrive_expect_tx(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_cluster_t,
   ::cuda::ptx::space_cluster_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_arrive_no_complete.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_arrive_no_complete.h
@@ -15,7 +15,7 @@ __device__ static inline uint64_t mbarrier_arrive_no_complete(
 */
 #if __cccl_ptx_isa >= 700
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t
+_CCCL_DEVICE_API ::cuda::std::uint64_t
 mbarrier_arrive_no_complete(::cuda::std::uint64_t* __addr, const ::cuda::std::uint32_t& __count)
 {
   ::cuda::std::uint64_t __state;

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_check_layout.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_check_layout.h
@@ -16,8 +16,7 @@ __device__ static inline bool mbarrier_check_layout(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_layout _Layout>
-_CCCL_DEVICE static inline bool
-mbarrier_check_layout(::cuda::ptx::layout_t<_Layout> __layout, const ::cuda::std::uint64_t* __addr)
+_CCCL_DEVICE_API bool mbarrier_check_layout(::cuda::ptx::layout_t<_Layout> __layout, const ::cuda::std::uint64_t* __addr)
 {
   static_assert(__layout == layout_v0 || __layout == layout_v1, "");
   ::cuda::std::uint32_t __p;

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_complete_tx.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_complete_tx.h
@@ -21,7 +21,7 @@ __device__ static inline void mbarrier_complete_tx(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void mbarrier_complete_tx(
+_CCCL_DEVICE_API void mbarrier_complete_tx(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_shared_t,
@@ -63,7 +63,7 @@ __device__ static inline void mbarrier_complete_tx(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void mbarrier_complete_tx(
+_CCCL_DEVICE_API void mbarrier_complete_tx(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_cluster_t,
@@ -107,7 +107,7 @@ __device__ static inline void mbarrier_complete_tx_multicast_32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void mbarrier_complete_tx_multicast_32b(
+_CCCL_DEVICE_API void mbarrier_complete_tx_multicast_32b(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_cluster_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_expect_tx.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_expect_tx.h
@@ -21,7 +21,7 @@ __device__ static inline void mbarrier_expect_tx(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void mbarrier_expect_tx(
+_CCCL_DEVICE_API void mbarrier_expect_tx(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_shared_t,
@@ -63,7 +63,7 @@ __device__ static inline void mbarrier_expect_tx(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void mbarrier_expect_tx(
+_CCCL_DEVICE_API void mbarrier_expect_tx(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::space_cluster_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_init.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_init.h
@@ -15,7 +15,7 @@ __device__ static inline void mbarrier_init(
 */
 #if __cccl_ptx_isa >= 700
 template <typename = void>
-_CCCL_DEVICE static inline void mbarrier_init(::cuda::std::uint64_t* __addr, const ::cuda::std::uint32_t& __count)
+_CCCL_DEVICE_API void mbarrier_init(::cuda::std::uint64_t* __addr, const ::cuda::std::uint32_t& __count)
 {
   asm("mbarrier.init.shared.b64 [%0], %1;" : : "r"(__as_ptr_smem(__addr)), "r"(__count) : "memory");
 }
@@ -32,7 +32,7 @@ __device__ static inline void mbarrier_init(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_layout _Layout>
-_CCCL_DEVICE static inline void mbarrier_init(
+_CCCL_DEVICE_API void mbarrier_init(
   ::cuda::ptx::layout_t<_Layout> __layout, ::cuda::std::uint64_t* __addr, const ::cuda::std::uint32_t& __count)
 {
   static_assert(__layout == layout_v0 || __layout == layout_v1, "");

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_inval.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_inval.h
@@ -14,7 +14,7 @@ __device__ static inline void mbarrier_inval(
 */
 #if __cccl_ptx_isa >= 700
 template <typename = void>
-_CCCL_DEVICE static inline void mbarrier_inval(::cuda::std::uint64_t* __addr)
+_CCCL_DEVICE_API void mbarrier_inval(::cuda::std::uint64_t* __addr)
 {
   asm("mbarrier.inval.shared.b64 [%0];" : : "r"(__as_ptr_smem(__addr)) : "memory");
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_pending_count.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_pending_count.h
@@ -14,7 +14,7 @@ __device__ static inline uint32_t mbarrier_pending_count(
 */
 #if __cccl_ptx_isa >= 700
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t mbarrier_pending_count(::cuda::std::uint64_t __state)
+_CCCL_DEVICE_API ::cuda::std::uint32_t mbarrier_pending_count(::cuda::std::uint64_t __state)
 {
   ::cuda::std::uint32_t __count;
   asm volatile("mbarrier.pending_count.b64 %0, %1;" : "=r"(__count) : "l"(__state) :);

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_test_wait.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_test_wait.h
@@ -15,7 +15,7 @@ __device__ static inline bool mbarrier_test_wait(
 */
 #if __cccl_ptx_isa >= 700
 template <typename = void>
-_CCCL_DEVICE static inline bool mbarrier_test_wait(::cuda::std::uint64_t* __addr, const ::cuda::std::uint64_t& __state)
+_CCCL_DEVICE_API bool mbarrier_test_wait(::cuda::std::uint64_t* __addr, const ::cuda::std::uint64_t& __state)
 {
   ::cuda::std::uint32_t __waitComplete;
   asm("{\n\t"
@@ -43,7 +43,7 @@ __device__ static inline bool mbarrier_test_wait(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_test_wait(
+_CCCL_DEVICE_API bool mbarrier_test_wait(
   ::cuda::ptx::sem_acquire_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::std::uint64_t* __addr,
@@ -91,7 +91,7 @@ __device__ static inline bool mbarrier_test_wait(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_test_wait(
+_CCCL_DEVICE_API bool mbarrier_test_wait(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::std::uint64_t* __addr,
@@ -143,7 +143,7 @@ __device__ static inline bool mbarrier_test_wait(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_test_wait(
+_CCCL_DEVICE_API bool mbarrier_test_wait(
   ::cuda::ptx::mbarrier_phase_primary_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
@@ -235,7 +235,7 @@ __device__ static inline bool mbarrier_test_wait(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_test_wait(
+_CCCL_DEVICE_API bool mbarrier_test_wait(
   ::cuda::ptx::mbarrier_phase_primary_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_test_wait_parity.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_test_wait_parity.h
@@ -15,7 +15,7 @@ __device__ static inline bool mbarrier_test_wait_parity(
 */
 #if __cccl_ptx_isa >= 710
 template <typename = void>
-_CCCL_DEVICE static inline bool
+_CCCL_DEVICE_API bool
 mbarrier_test_wait_parity(::cuda::std::uint64_t* __addr, const ::cuda::std::uint32_t& __phaseParity)
 {
   ::cuda::std::uint32_t __waitComplete;
@@ -44,7 +44,7 @@ __device__ static inline bool mbarrier_test_wait_parity(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_test_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_test_wait_parity(
   ::cuda::ptx::sem_acquire_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::std::uint64_t* __addr,
@@ -92,7 +92,7 @@ __device__ static inline bool mbarrier_test_wait_parity(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_test_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_test_wait_parity(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::std::uint64_t* __addr,
@@ -144,7 +144,7 @@ __device__ static inline bool mbarrier_test_wait_parity(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_test_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_test_wait_parity(
   ::cuda::ptx::mbarrier_phase_primary_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
@@ -236,7 +236,7 @@ __device__ static inline bool mbarrier_test_wait_parity(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_test_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_test_wait_parity(
   ::cuda::ptx::mbarrier_phase_primary_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
@@ -337,7 +337,7 @@ __device__ static inline bool mbarrier_test_wait_parity(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_test_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_test_wait_parity(
   ::cuda::ptx::mbarrier_phase_conditional_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_try_wait.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_try_wait.h
@@ -15,7 +15,7 @@ __device__ static inline bool mbarrier_try_wait(
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline bool mbarrier_try_wait(::cuda::std::uint64_t* __addr, const ::cuda::std::uint64_t& __state)
+_CCCL_DEVICE_API bool mbarrier_try_wait(::cuda::std::uint64_t* __addr, const ::cuda::std::uint64_t& __state)
 {
   ::cuda::std::uint32_t __waitComplete;
   asm("{\n\t"
@@ -40,7 +40,7 @@ __device__ static inline bool mbarrier_try_wait(
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline bool mbarrier_try_wait(
+_CCCL_DEVICE_API bool mbarrier_try_wait(
   ::cuda::std::uint64_t* __addr, const ::cuda::std::uint64_t& __state, const ::cuda::std::uint32_t& __suspendTimeHint)
 {
   ::cuda::std::uint32_t __waitComplete;
@@ -69,7 +69,7 @@ __device__ static inline bool mbarrier_try_wait(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait(
+_CCCL_DEVICE_API bool mbarrier_try_wait(
   ::cuda::ptx::sem_acquire_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::std::uint64_t* __addr,
@@ -118,7 +118,7 @@ __device__ static inline bool mbarrier_try_wait(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait(
+_CCCL_DEVICE_API bool mbarrier_try_wait(
   ::cuda::ptx::sem_acquire_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::std::uint64_t* __addr,
@@ -167,7 +167,7 @@ __device__ static inline bool mbarrier_try_wait(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait(
+_CCCL_DEVICE_API bool mbarrier_try_wait(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::std::uint64_t* __addr,
@@ -216,7 +216,7 @@ __device__ static inline bool mbarrier_try_wait(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait(
+_CCCL_DEVICE_API bool mbarrier_try_wait(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::std::uint64_t* __addr,
@@ -268,7 +268,7 @@ __device__ static inline bool mbarrier_try_wait(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait(
+_CCCL_DEVICE_API bool mbarrier_try_wait(
   ::cuda::ptx::mbarrier_phase_primary_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
@@ -360,7 +360,7 @@ __device__ static inline bool mbarrier_try_wait(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait(
+_CCCL_DEVICE_API bool mbarrier_try_wait(
   ::cuda::ptx::mbarrier_phase_primary_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
@@ -467,7 +467,7 @@ __device__ static inline bool mbarrier_try_wait(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait(
+_CCCL_DEVICE_API bool mbarrier_try_wait(
   ::cuda::ptx::mbarrier_phase_primary_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
@@ -561,7 +561,7 @@ __device__ static inline bool mbarrier_try_wait(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait(
+_CCCL_DEVICE_API bool mbarrier_try_wait(
   ::cuda::ptx::mbarrier_phase_primary_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_try_wait_parity.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/mbarrier_try_wait_parity.h
@@ -15,8 +15,7 @@ __device__ static inline bool mbarrier_try_wait_parity(
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline bool
-mbarrier_try_wait_parity(::cuda::std::uint64_t* __addr, const ::cuda::std::uint32_t& __phaseParity)
+_CCCL_DEVICE_API bool mbarrier_try_wait_parity(::cuda::std::uint64_t* __addr, const ::cuda::std::uint32_t& __phaseParity)
 {
   ::cuda::std::uint32_t __waitComplete;
   asm("{\n\t"
@@ -41,7 +40,7 @@ __device__ static inline bool mbarrier_try_wait_parity(
 */
 #if __cccl_ptx_isa >= 780
 template <typename = void>
-_CCCL_DEVICE static inline bool mbarrier_try_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_try_wait_parity(
   ::cuda::std::uint64_t* __addr,
   const ::cuda::std::uint32_t& __phaseParity,
   const ::cuda::std::uint32_t& __suspendTimeHint)
@@ -72,7 +71,7 @@ __device__ static inline bool mbarrier_try_wait_parity(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_try_wait_parity(
   ::cuda::ptx::sem_acquire_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::std::uint64_t* __addr,
@@ -122,7 +121,7 @@ __device__ static inline bool mbarrier_try_wait_parity(
 */
 #if __cccl_ptx_isa >= 800
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_try_wait_parity(
   ::cuda::ptx::sem_acquire_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::std::uint64_t* __addr,
@@ -171,7 +170,7 @@ __device__ static inline bool mbarrier_try_wait_parity(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_try_wait_parity(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::std::uint64_t* __addr,
@@ -221,7 +220,7 @@ __device__ static inline bool mbarrier_try_wait_parity(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_try_wait_parity(
   ::cuda::ptx::sem_relaxed_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::std::uint64_t* __addr,
@@ -274,7 +273,7 @@ __device__ static inline bool mbarrier_try_wait_parity(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_try_wait_parity(
   ::cuda::ptx::mbarrier_phase_primary_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
@@ -366,7 +365,7 @@ __device__ static inline bool mbarrier_try_wait_parity(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_try_wait_parity(
   ::cuda::ptx::mbarrier_phase_primary_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
@@ -466,7 +465,7 @@ __device__ static inline bool mbarrier_try_wait_parity(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_try_wait_parity(
   ::cuda::ptx::mbarrier_phase_conditional_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
@@ -543,7 +542,7 @@ __device__ static inline bool mbarrier_try_wait_parity(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_try_wait_parity(
   ::cuda::ptx::mbarrier_phase_primary_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
@@ -637,7 +636,7 @@ __device__ static inline bool mbarrier_try_wait_parity(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_try_wait_parity(
   ::cuda::ptx::mbarrier_phase_primary_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
@@ -740,7 +739,7 @@ __device__ static inline bool mbarrier_try_wait_parity(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline bool mbarrier_try_wait_parity(
+_CCCL_DEVICE_API bool mbarrier_try_wait_parity(
   ::cuda::ptx::mbarrier_phase_conditional_t,
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/multimem_ld_reduce.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/multimem_ld_reduce.h
@@ -18,7 +18,7 @@ __device__ static inline uint32_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t
+_CCCL_DEVICE_API ::cuda::std::uint32_t
 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_min_t, const ::cuda::std::uint32_t* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
@@ -43,7 +43,7 @@ __device__ static inline uint32_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t multimem_ld_reduce(
+_CCCL_DEVICE_API ::cuda::std::uint32_t multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_min_t,
@@ -125,7 +125,7 @@ __device__ static inline uint64_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t
+_CCCL_DEVICE_API ::cuda::std::uint64_t
 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_min_t, const ::cuda::std::uint64_t* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
@@ -150,7 +150,7 @@ __device__ static inline uint64_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t multimem_ld_reduce(
+_CCCL_DEVICE_API ::cuda::std::uint64_t multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_min_t,
@@ -232,7 +232,7 @@ __device__ static inline int32_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::int32_t
+_CCCL_DEVICE_API ::cuda::std::int32_t
 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_min_t, const ::cuda::std::int32_t* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
@@ -257,7 +257,7 @@ __device__ static inline int32_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::int32_t multimem_ld_reduce(
+_CCCL_DEVICE_API ::cuda::std::int32_t multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_min_t,
@@ -339,7 +339,7 @@ __device__ static inline int64_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::int64_t
+_CCCL_DEVICE_API ::cuda::std::int64_t
 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_min_t, const ::cuda::std::int64_t* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
@@ -364,7 +364,7 @@ __device__ static inline int64_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::int64_t multimem_ld_reduce(
+_CCCL_DEVICE_API ::cuda::std::int64_t multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_min_t,
@@ -446,7 +446,7 @@ __device__ static inline uint32_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t
+_CCCL_DEVICE_API ::cuda::std::uint32_t
 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_max_t, const ::cuda::std::uint32_t* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
@@ -471,7 +471,7 @@ __device__ static inline uint32_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t multimem_ld_reduce(
+_CCCL_DEVICE_API ::cuda::std::uint32_t multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_max_t,
@@ -553,7 +553,7 @@ __device__ static inline uint64_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t
+_CCCL_DEVICE_API ::cuda::std::uint64_t
 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_max_t, const ::cuda::std::uint64_t* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
@@ -578,7 +578,7 @@ __device__ static inline uint64_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t multimem_ld_reduce(
+_CCCL_DEVICE_API ::cuda::std::uint64_t multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_max_t,
@@ -660,7 +660,7 @@ __device__ static inline int32_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::int32_t
+_CCCL_DEVICE_API ::cuda::std::int32_t
 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_max_t, const ::cuda::std::int32_t* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
@@ -685,7 +685,7 @@ __device__ static inline int32_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::int32_t multimem_ld_reduce(
+_CCCL_DEVICE_API ::cuda::std::int32_t multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_max_t,
@@ -767,7 +767,7 @@ __device__ static inline int64_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::int64_t
+_CCCL_DEVICE_API ::cuda::std::int64_t
 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_max_t, const ::cuda::std::int64_t* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
@@ -792,7 +792,7 @@ __device__ static inline int64_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::int64_t multimem_ld_reduce(
+_CCCL_DEVICE_API ::cuda::std::int64_t multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_max_t,
@@ -874,7 +874,7 @@ __device__ static inline uint32_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t
+_CCCL_DEVICE_API ::cuda::std::uint32_t
 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_add_t, const ::cuda::std::uint32_t* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
@@ -899,7 +899,7 @@ __device__ static inline uint32_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t multimem_ld_reduce(
+_CCCL_DEVICE_API ::cuda::std::uint32_t multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_add_t,
@@ -981,7 +981,7 @@ __device__ static inline uint64_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t
+_CCCL_DEVICE_API ::cuda::std::uint64_t
 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_add_t, const ::cuda::std::uint64_t* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
@@ -1006,7 +1006,7 @@ __device__ static inline uint64_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::uint64_t multimem_ld_reduce(
+_CCCL_DEVICE_API ::cuda::std::uint64_t multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_add_t,
@@ -1088,7 +1088,7 @@ __device__ static inline int32_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::int32_t
+_CCCL_DEVICE_API ::cuda::std::int32_t
 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_add_t, const ::cuda::std::int32_t* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
@@ -1113,7 +1113,7 @@ __device__ static inline int32_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::int32_t multimem_ld_reduce(
+_CCCL_DEVICE_API ::cuda::std::int32_t multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_add_t,
@@ -1195,7 +1195,7 @@ __device__ static inline int64_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::int64_t
+_CCCL_DEVICE_API ::cuda::std::int64_t
 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_add_t, const ::cuda::std::int64_t* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
@@ -1220,7 +1220,7 @@ __device__ static inline int64_t multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline ::cuda::std::int64_t multimem_ld_reduce(
+_CCCL_DEVICE_API ::cuda::std::int64_t multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_add_t,
@@ -1302,7 +1302,7 @@ __device__ static inline B32 multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_and_op_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_and_op_t, const _B32* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
   // __op == op_and_op (due to parameter type constraint)
@@ -1330,7 +1330,7 @@ template <typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline _B32 multimem_ld_reduce(
+_CCCL_DEVICE_API _B32 multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem, ::cuda::ptx::scope_t<_Scope> __scope, ::cuda::ptx::op_and_op_t, const _B32* __addr)
 {
   static_assert(__sem == sem_relaxed || __sem == sem_acquire, "");
@@ -1410,7 +1410,7 @@ __device__ static inline B32 multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_or_op_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_or_op_t, const _B32* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
   // __op == op_or_op (due to parameter type constraint)
@@ -1438,7 +1438,7 @@ template <typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline _B32 multimem_ld_reduce(
+_CCCL_DEVICE_API _B32 multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem, ::cuda::ptx::scope_t<_Scope> __scope, ::cuda::ptx::op_or_op_t, const _B32* __addr)
 {
   static_assert(__sem == sem_relaxed || __sem == sem_acquire, "");
@@ -1518,7 +1518,7 @@ __device__ static inline B32 multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_xor_op_t, const _B32* __addr)
+_CCCL_DEVICE_API _B32 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_xor_op_t, const _B32* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
   // __op == op_xor_op (due to parameter type constraint)
@@ -1546,7 +1546,7 @@ template <typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline _B32 multimem_ld_reduce(
+_CCCL_DEVICE_API _B32 multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem, ::cuda::ptx::scope_t<_Scope> __scope, ::cuda::ptx::op_xor_op_t, const _B32* __addr)
 {
   static_assert(__sem == sem_relaxed || __sem == sem_acquire, "");
@@ -1626,7 +1626,7 @@ __device__ static inline B64 multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_and_op_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_and_op_t, const _B64* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
   // __op == op_and_op (due to parameter type constraint)
@@ -1654,7 +1654,7 @@ template <typename _B64,
           ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline _B64 multimem_ld_reduce(
+_CCCL_DEVICE_API _B64 multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem, ::cuda::ptx::scope_t<_Scope> __scope, ::cuda::ptx::op_and_op_t, const _B64* __addr)
 {
   static_assert(__sem == sem_relaxed || __sem == sem_acquire, "");
@@ -1734,7 +1734,7 @@ __device__ static inline B64 multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_or_op_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_or_op_t, const _B64* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
   // __op == op_or_op (due to parameter type constraint)
@@ -1762,7 +1762,7 @@ template <typename _B64,
           ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline _B64 multimem_ld_reduce(
+_CCCL_DEVICE_API _B64 multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem, ::cuda::ptx::scope_t<_Scope> __scope, ::cuda::ptx::op_or_op_t, const _B64* __addr)
 {
   static_assert(__sem == sem_relaxed || __sem == sem_acquire, "");
@@ -1842,7 +1842,7 @@ __device__ static inline B64 multimem_ld_reduce(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_xor_op_t, const _B64* __addr)
+_CCCL_DEVICE_API _B64 multimem_ld_reduce(::cuda::ptx::sem_weak_t, ::cuda::ptx::op_xor_op_t, const _B64* __addr)
 {
   // __sem == sem_weak (due to parameter type constraint)
   // __op == op_xor_op (due to parameter type constraint)
@@ -1870,7 +1870,7 @@ template <typename _B64,
           ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline _B64 multimem_ld_reduce(
+_CCCL_DEVICE_API _B64 multimem_ld_reduce(
   ::cuda::ptx::sem_t<_Sem> __sem, ::cuda::ptx::scope_t<_Scope> __scope, ::cuda::ptx::op_xor_op_t, const _B64* __addr)
 {
   static_assert(__sem == sem_relaxed || __sem == sem_acquire, "");

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/multimem_red.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/multimem_red.h
@@ -21,7 +21,7 @@ __device__ static inline void multimem_red(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_min_t,
@@ -81,7 +81,7 @@ __device__ static inline void multimem_red(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_min_t,
@@ -141,7 +141,7 @@ __device__ static inline void multimem_red(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_min_t,
@@ -201,7 +201,7 @@ __device__ static inline void multimem_red(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_min_t,
@@ -261,7 +261,7 @@ __device__ static inline void multimem_red(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_max_t,
@@ -321,7 +321,7 @@ __device__ static inline void multimem_red(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_max_t,
@@ -381,7 +381,7 @@ __device__ static inline void multimem_red(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_max_t,
@@ -441,7 +441,7 @@ __device__ static inline void multimem_red(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_max_t,
@@ -501,7 +501,7 @@ __device__ static inline void multimem_red(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_add_t,
@@ -561,7 +561,7 @@ __device__ static inline void multimem_red(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_add_t,
@@ -621,7 +621,7 @@ __device__ static inline void multimem_red(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_add_t,
@@ -681,7 +681,7 @@ __device__ static inline void multimem_red(
 */
 #if __cccl_ptx_isa >= 810
 template <::cuda::ptx::dot_sem _Sem, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_add_t,
@@ -744,7 +744,7 @@ template <typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_and_op_t,
@@ -832,7 +832,7 @@ template <typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_or_op_t,
@@ -920,7 +920,7 @@ template <typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_xor_op_t,
@@ -1008,7 +1008,7 @@ template <typename _B64,
           ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_and_op_t,
@@ -1096,7 +1096,7 @@ template <typename _B64,
           ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_or_op_t,
@@ -1184,7 +1184,7 @@ template <typename _B64,
           ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void multimem_red(
+_CCCL_DEVICE_API void multimem_red(
   ::cuda::ptx::sem_t<_Sem> __sem,
   ::cuda::ptx::scope_t<_Scope> __scope,
   ::cuda::ptx::op_xor_op_t,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/multimem_st.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/multimem_st.h
@@ -17,7 +17,7 @@ __device__ static inline void multimem_st(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void multimem_st(::cuda::ptx::sem_weak_t, _B32* __addr, _B32 __val)
+_CCCL_DEVICE_API void multimem_st(::cuda::ptx::sem_weak_t, _B32* __addr, _B32 __val)
 {
   // __sem == sem_weak (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -44,7 +44,7 @@ template <typename _B32,
           ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 multimem_st(::cuda::ptx::sem_t<_Sem> __sem, ::cuda::ptx::scope_t<_Scope> __scope, _B32* __addr, _B32 __val)
 {
   static_assert(__sem == sem_relaxed || __sem == sem_release, "");
@@ -120,7 +120,7 @@ __device__ static inline void multimem_st(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void multimem_st(::cuda::ptx::sem_weak_t, _B64* __addr, _B64 __val)
+_CCCL_DEVICE_API void multimem_st(::cuda::ptx::sem_weak_t, _B64* __addr, _B64 __val)
 {
   // __sem == sem_weak (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -147,7 +147,7 @@ template <typename _B64,
           ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true,
           ::cuda::ptx::dot_sem _Sem,
           ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 multimem_st(::cuda::ptx::sem_t<_Sem> __sem, ::cuda::ptx::scope_t<_Scope> __scope, _B64* __addr, _B64 __val)
 {
   static_assert(__sem == sem_relaxed || __sem == sem_release, "");

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/prefetch.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/prefetch.h
@@ -14,7 +14,7 @@ __device__ static inline void prefetch_L1(
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline void prefetch_L1(const void* __addr)
+_CCCL_DEVICE_API void prefetch_L1(const void* __addr)
 {
   asm volatile("prefetch.global.L1 [%0];" : : "l"(__as_ptr_gmem(__addr)) : "memory");
 }
@@ -28,7 +28,7 @@ __device__ static inline void prefetch_L2(
 */
 #if __cccl_ptx_isa >= 200
 template <typename = void>
-_CCCL_DEVICE static inline void prefetch_L2(const void* __addr)
+_CCCL_DEVICE_API void prefetch_L2(const void* __addr)
 {
   asm volatile("prefetch.global.L2 [%0];" : : "l"(__as_ptr_gmem(__addr)) : "memory");
 }
@@ -42,7 +42,7 @@ __device__ static inline void prefetch_L1_32B(
 */
 #if __cccl_ptx_isa >= 940
 template <typename = void>
-_CCCL_DEVICE static inline void prefetch_L1_32B(const void* __addr)
+_CCCL_DEVICE_API void prefetch_L1_32B(const void* __addr)
 {
   asm volatile("prefetch.global.L1::32B.valid_addr [%0];" : : "l"(__as_ptr_gmem(__addr)) : "memory");
 }
@@ -56,7 +56,7 @@ __device__ static inline void prefetch_L2_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename = void>
-_CCCL_DEVICE static inline void prefetch_L2_evict_last(const void* __addr)
+_CCCL_DEVICE_API void prefetch_L2_evict_last(const void* __addr)
 {
   asm volatile("prefetch.global.L2::evict_last [%0];" : : "l"(__as_ptr_gmem(__addr)) : "memory");
 }
@@ -70,7 +70,7 @@ __device__ static inline void prefetch_L2_evict_normal(
 */
 #if __cccl_ptx_isa >= 740
 template <typename = void>
-_CCCL_DEVICE static inline void prefetch_L2_evict_normal(const void* __addr)
+_CCCL_DEVICE_API void prefetch_L2_evict_normal(const void* __addr)
 {
   asm volatile("prefetch.global.L2::evict_normal [%0];" : : "l"(__as_ptr_gmem(__addr)) : "memory");
 }
@@ -84,7 +84,7 @@ __device__ static inline void prefetch_tensormap(
 */
 #if __cccl_ptx_isa >= 800
 template <typename = void>
-_CCCL_DEVICE static inline void prefetch_tensormap(const void* __addr)
+_CCCL_DEVICE_API void prefetch_tensormap(const void* __addr)
 {
   asm volatile("prefetch.tensormap [%0];" : : "l"(__addr) : "memory");
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/prmt.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/prmt.h
@@ -16,7 +16,7 @@ __device__ static inline uint32_t prmt(
 */
 #if __cccl_ptx_isa >= 200
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t prmt(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t prmt(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
 {
   static_assert(sizeof(_B32) == 4, "");
   static_assert(sizeof(_B32) == 4, "");
@@ -41,7 +41,7 @@ __device__ static inline uint32_t prmt_f4e(
 */
 #if __cccl_ptx_isa >= 200
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t prmt_f4e(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t prmt_f4e(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
 {
   static_assert(sizeof(_B32) == 4, "");
   static_assert(sizeof(_B32) == 4, "");
@@ -66,7 +66,7 @@ __device__ static inline uint32_t prmt_b4e(
 */
 #if __cccl_ptx_isa >= 200
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t prmt_b4e(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t prmt_b4e(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
 {
   static_assert(sizeof(_B32) == 4, "");
   static_assert(sizeof(_B32) == 4, "");
@@ -91,7 +91,7 @@ __device__ static inline uint32_t prmt_rc8(
 */
 #if __cccl_ptx_isa >= 200
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t prmt_rc8(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t prmt_rc8(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
 {
   static_assert(sizeof(_B32) == 4, "");
   static_assert(sizeof(_B32) == 4, "");
@@ -116,7 +116,7 @@ __device__ static inline uint32_t prmt_ecl(
 */
 #if __cccl_ptx_isa >= 200
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t prmt_ecl(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t prmt_ecl(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
 {
   static_assert(sizeof(_B32) == 4, "");
   static_assert(sizeof(_B32) == 4, "");
@@ -141,7 +141,7 @@ __device__ static inline uint32_t prmt_ecr(
 */
 #if __cccl_ptx_isa >= 200
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t prmt_ecr(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t prmt_ecr(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
 {
   static_assert(sizeof(_B32) == 4, "");
   static_assert(sizeof(_B32) == 4, "");
@@ -166,7 +166,7 @@ __device__ static inline uint32_t prmt_rc16(
 */
 #if __cccl_ptx_isa >= 200
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t prmt_rc16(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
+_CCCL_DEVICE_API ::cuda::std::uint32_t prmt_rc16(_B32 __a_reg, _B32 __b_reg, ::cuda::std::uint32_t __c_reg)
 {
   static_assert(sizeof(_B32) == 4, "");
   static_assert(sizeof(_B32) == 4, "");

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/red_async.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/red_async.h
@@ -20,7 +20,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_inc_t,
           ::cuda::std::uint32_t* __dest,
           const ::cuda::std::uint32_t& __value,
@@ -49,7 +49,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_dec_t,
           ::cuda::std::uint32_t* __dest,
           const ::cuda::std::uint32_t& __value,
@@ -78,7 +78,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_min_t,
           ::cuda::std::uint32_t* __dest,
           const ::cuda::std::uint32_t& __value,
@@ -107,7 +107,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_max_t,
           ::cuda::std::uint32_t* __dest,
           const ::cuda::std::uint32_t& __value,
@@ -136,7 +136,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_add_t,
           ::cuda::std::uint32_t* __dest,
           const ::cuda::std::uint32_t& __value,
@@ -165,7 +165,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_min_t,
           ::cuda::std::int32_t* __dest,
           const ::cuda::std::int32_t& __value,
@@ -194,7 +194,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_max_t,
           ::cuda::std::int32_t* __dest,
           const ::cuda::std::int32_t& __value,
@@ -223,7 +223,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_add_t,
           ::cuda::std::int32_t* __dest,
           const ::cuda::std::int32_t& __value,
@@ -252,7 +252,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_and_op_t, _B32* __dest, const _B32& __value, ::cuda::std::uint64_t* __remote_bar)
 {
   // __type == type_b32 (due to parameter type constraint)
@@ -281,7 +281,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_or_op_t, _B32* __dest, const _B32& __value, ::cuda::std::uint64_t* __remote_bar)
 {
   // __type == type_b32 (due to parameter type constraint)
@@ -310,7 +310,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_xor_op_t, _B32* __dest, const _B32& __value, ::cuda::std::uint64_t* __remote_bar)
 {
   // __type == type_b32 (due to parameter type constraint)
@@ -339,7 +339,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_add_t,
           ::cuda::std::uint64_t* __dest,
           const ::cuda::std::uint64_t& __value,
@@ -367,7 +367,7 @@ __device__ static inline void red_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename = void>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 red_async(::cuda::ptx::op_add_t,
           ::cuda::std::int64_t* __dest,
           const ::cuda::std::int64_t& __value,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/setmaxnreg.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/setmaxnreg.h
@@ -14,7 +14,7 @@ __device__ static inline void setmaxnreg_inc(
 */
 #if __cccl_ptx_isa >= 800
 template <int _N32>
-_CCCL_DEVICE static inline void setmaxnreg_inc(::cuda::ptx::n32_t<_N32> __imm_reg_count)
+_CCCL_DEVICE_API void setmaxnreg_inc(::cuda::ptx::n32_t<_N32> __imm_reg_count)
 {
   asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;" : : "n"(__imm_reg_count.value) :);
 }
@@ -28,7 +28,7 @@ __device__ static inline void setmaxnreg_dec(
 */
 #if __cccl_ptx_isa >= 800
 template <int _N32>
-_CCCL_DEVICE static inline void setmaxnreg_dec(::cuda::ptx::n32_t<_N32> __imm_reg_count)
+_CCCL_DEVICE_API void setmaxnreg_dec(::cuda::ptx::n32_t<_N32> __imm_reg_count)
 {
   asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;" : : "n"(__imm_reg_count.value) :);
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/shl.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/shl.h
@@ -15,7 +15,7 @@ __device__ static inline B16 shl(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 shl(_B16 __a_reg, ::cuda::std::uint32_t __b_reg)
+_CCCL_DEVICE_API _B16 shl(_B16 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
   static_assert(sizeof(_B16) == 2, "");
   static_assert(sizeof(_B16) == 2, "");
@@ -37,7 +37,7 @@ __device__ static inline B32 shl(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 shl(_B32 __a_reg, ::cuda::std::uint32_t __b_reg)
+_CCCL_DEVICE_API _B32 shl(_B32 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
   static_assert(sizeof(_B32) == 4, "");
   static_assert(sizeof(_B32) == 4, "");
@@ -59,7 +59,7 @@ __device__ static inline B64 shl(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 shl(_B64 __a_reg, ::cuda::std::uint32_t __b_reg)
+_CCCL_DEVICE_API _B64 shl(_B64 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
   static_assert(sizeof(_B64) == 8, "");
   static_assert(sizeof(_B64) == 8, "");

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/shr.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/shr.h
@@ -15,7 +15,7 @@ __device__ static inline B16 shr(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 shr(_B16 __a_reg, ::cuda::std::uint32_t __b_reg)
+_CCCL_DEVICE_API _B16 shr(_B16 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
   static_assert(sizeof(_B16) == 2);
   static_assert(sizeof(_B16) == 2);
@@ -40,7 +40,7 @@ template <
   typename _B32,
   ::cuda::std::enable_if_t<sizeof(_B32) == 4 && !(::cuda::std::is_integral_v<_B32> && ::cuda::std::is_signed_v<_B32>),
                            bool> = true>
-_CCCL_DEVICE static inline _B32 shr(_B32 __a_reg, ::cuda::std::uint32_t __b_reg)
+_CCCL_DEVICE_API _B32 shr(_B32 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
   ::cuda::std::uint32_t __dest;
   asm("shr.b32 %0, %1, %2;"
@@ -63,7 +63,7 @@ template <
   typename _B64,
   ::cuda::std::enable_if_t<sizeof(_B64) == 8 && !(::cuda::std::is_integral_v<_B64> && ::cuda::std::is_signed_v<_B64>),
                            bool> = true>
-_CCCL_DEVICE static inline _B64 shr(_B64 __a_reg, ::cuda::std::uint32_t __b_reg)
+_CCCL_DEVICE_API _B64 shr(_B64 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
   ::cuda::std::uint64_t __dest;
   asm("shr.b64 %0, %1, %2;"
@@ -83,7 +83,7 @@ __device__ static inline int16_t shr(
 */
 #if __cccl_ptx_isa >= 100
 template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::int16_t shr(::cuda::std::int16_t __a_reg, ::cuda::std::uint32_t __b_reg)
+_CCCL_DEVICE_API ::cuda::std::int16_t shr(::cuda::std::int16_t __a_reg, ::cuda::std::uint32_t __b_reg)
 {
   ::cuda::std::int16_t __dest;
   asm("shr.s16 %0, %1, %2;" : "=h"(__dest) : "h"(__a_reg), "r"(__b_reg) :);
@@ -102,7 +102,7 @@ __device__ static inline S32 shr(
 template <typename _S32,
           ::cuda::std::enable_if_t<sizeof(_S32) == 4 && ::cuda::std::is_integral_v<_S32>&& ::cuda::std::is_signed_v<_S32>,
                                    bool> = true>
-_CCCL_DEVICE static inline _S32 shr(_S32 __a_reg, ::cuda::std::uint32_t __b_reg)
+_CCCL_DEVICE_API _S32 shr(_S32 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
   ::cuda::std::int32_t __dest;
   asm("shr.s32 %0, %1, %2;"
@@ -124,7 +124,7 @@ __device__ static inline S64 shr(
 template <typename _S64,
           ::cuda::std::enable_if_t<sizeof(_S64) == 8 && ::cuda::std::is_integral_v<_S64>&& ::cuda::std::is_signed_v<_S64>,
                                    bool> = true>
-_CCCL_DEVICE static inline _S64 shr(_S64 __a_reg, ::cuda::std::uint32_t __b_reg)
+_CCCL_DEVICE_API _S64 shr(_S64 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
   ::cuda::std::int64_t __dest;
   asm("shr.s64 %0, %1, %2;"

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/st.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/st.h
@@ -17,7 +17,7 @@ __device__ static inline void st(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void st(::cuda::ptx::space_global_t, _B8* __addr, _B8 __src)
+_CCCL_DEVICE_API void st(::cuda::ptx::space_global_t, _B8* __addr, _B8 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -36,7 +36,7 @@ __device__ static inline void st(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void st(::cuda::ptx::space_global_t, _B16* __addr, _B16 __src)
+_CCCL_DEVICE_API void st(::cuda::ptx::space_global_t, _B16* __addr, _B16 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -58,7 +58,7 @@ __device__ static inline void st(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void st(::cuda::ptx::space_global_t, _B32* __addr, _B32 __src)
+_CCCL_DEVICE_API void st(::cuda::ptx::space_global_t, _B32* __addr, _B32 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -80,7 +80,7 @@ __device__ static inline void st(
 */
 #if __cccl_ptx_isa >= 100
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void st(::cuda::ptx::space_global_t, _B64* __addr, _B64 __src)
+_CCCL_DEVICE_API void st(::cuda::ptx::space_global_t, _B64* __addr, _B64 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -102,7 +102,7 @@ __device__ static inline void st(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void st(::cuda::ptx::space_global_t, _B128* __addr, _B128 __src)
+_CCCL_DEVICE_API void st(::cuda::ptx::space_global_t, _B128* __addr, _B128 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -130,7 +130,7 @@ __device__ static inline void st(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline void st(::cuda::ptx::space_global_t, _B256* __addr, _B256 __src)
+_CCCL_DEVICE_API void st(::cuda::ptx::space_global_t, _B256* __addr, _B256 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -157,7 +157,7 @@ __device__ static inline void st_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 st_L2_cache_hint(::cuda::ptx::space_global_t, _B8* __addr, _B8 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -181,7 +181,7 @@ __device__ static inline void st_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 st_L2_cache_hint(::cuda::ptx::space_global_t, _B16* __addr, _B16 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -207,7 +207,7 @@ __device__ static inline void st_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 st_L2_cache_hint(::cuda::ptx::space_global_t, _B32* __addr, _B32 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -233,7 +233,7 @@ __device__ static inline void st_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 st_L2_cache_hint(::cuda::ptx::space_global_t, _B64* __addr, _B64 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -259,7 +259,7 @@ __device__ static inline void st_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 st_L2_cache_hint(::cuda::ptx::space_global_t, _B128* __addr, _B128 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -290,7 +290,7 @@ __device__ static inline void st_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 st_L2_cache_hint(::cuda::ptx::space_global_t, _B256* __addr, _B256 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -318,7 +318,7 @@ __device__ static inline void st_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_first(::cuda::ptx::space_global_t, _B8* __addr, _B8 __src)
+_CCCL_DEVICE_API void st_L1_evict_first(::cuda::ptx::space_global_t, _B8* __addr, _B8 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -337,7 +337,7 @@ __device__ static inline void st_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_first(::cuda::ptx::space_global_t, _B16* __addr, _B16 __src)
+_CCCL_DEVICE_API void st_L1_evict_first(::cuda::ptx::space_global_t, _B16* __addr, _B16 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -359,7 +359,7 @@ __device__ static inline void st_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_first(::cuda::ptx::space_global_t, _B32* __addr, _B32 __src)
+_CCCL_DEVICE_API void st_L1_evict_first(::cuda::ptx::space_global_t, _B32* __addr, _B32 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -381,7 +381,7 @@ __device__ static inline void st_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_first(::cuda::ptx::space_global_t, _B64* __addr, _B64 __src)
+_CCCL_DEVICE_API void st_L1_evict_first(::cuda::ptx::space_global_t, _B64* __addr, _B64 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -403,7 +403,7 @@ __device__ static inline void st_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_first(::cuda::ptx::space_global_t, _B128* __addr, _B128 __src)
+_CCCL_DEVICE_API void st_L1_evict_first(::cuda::ptx::space_global_t, _B128* __addr, _B128 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -431,7 +431,7 @@ __device__ static inline void st_L1_evict_first(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_first(::cuda::ptx::space_global_t, _B256* __addr, _B256 __src)
+_CCCL_DEVICE_API void st_L1_evict_first(::cuda::ptx::space_global_t, _B256* __addr, _B256 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -458,7 +458,7 @@ __device__ static inline void st_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_first_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_evict_first_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B8* __addr, _B8 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -482,7 +482,7 @@ __device__ static inline void st_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_first_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_evict_first_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B16* __addr, _B16 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -508,7 +508,7 @@ __device__ static inline void st_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_first_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_evict_first_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B32* __addr, _B32 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -534,7 +534,7 @@ __device__ static inline void st_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_first_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_evict_first_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B64* __addr, _B64 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -560,7 +560,7 @@ __device__ static inline void st_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_first_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_evict_first_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B128* __addr, _B128 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -591,7 +591,7 @@ __device__ static inline void st_L1_evict_first_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_first_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_evict_first_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B256* __addr, _B256 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -619,7 +619,7 @@ __device__ static inline void st_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_last(::cuda::ptx::space_global_t, _B8* __addr, _B8 __src)
+_CCCL_DEVICE_API void st_L1_evict_last(::cuda::ptx::space_global_t, _B8* __addr, _B8 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -638,7 +638,7 @@ __device__ static inline void st_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_last(::cuda::ptx::space_global_t, _B16* __addr, _B16 __src)
+_CCCL_DEVICE_API void st_L1_evict_last(::cuda::ptx::space_global_t, _B16* __addr, _B16 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -660,7 +660,7 @@ __device__ static inline void st_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_last(::cuda::ptx::space_global_t, _B32* __addr, _B32 __src)
+_CCCL_DEVICE_API void st_L1_evict_last(::cuda::ptx::space_global_t, _B32* __addr, _B32 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -682,7 +682,7 @@ __device__ static inline void st_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_last(::cuda::ptx::space_global_t, _B64* __addr, _B64 __src)
+_CCCL_DEVICE_API void st_L1_evict_last(::cuda::ptx::space_global_t, _B64* __addr, _B64 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -704,7 +704,7 @@ __device__ static inline void st_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_last(::cuda::ptx::space_global_t, _B128* __addr, _B128 __src)
+_CCCL_DEVICE_API void st_L1_evict_last(::cuda::ptx::space_global_t, _B128* __addr, _B128 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -732,7 +732,7 @@ __device__ static inline void st_L1_evict_last(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_last(::cuda::ptx::space_global_t, _B256* __addr, _B256 __src)
+_CCCL_DEVICE_API void st_L1_evict_last(::cuda::ptx::space_global_t, _B256* __addr, _B256 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -759,7 +759,7 @@ __device__ static inline void st_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_last_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_evict_last_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B8* __addr, _B8 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -783,7 +783,7 @@ __device__ static inline void st_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_last_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_evict_last_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B16* __addr, _B16 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -809,7 +809,7 @@ __device__ static inline void st_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_last_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_evict_last_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B32* __addr, _B32 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -835,7 +835,7 @@ __device__ static inline void st_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_last_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_evict_last_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B64* __addr, _B64 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -861,7 +861,7 @@ __device__ static inline void st_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_last_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_evict_last_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B128* __addr, _B128 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -892,7 +892,7 @@ __device__ static inline void st_L1_evict_last_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_last_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_evict_last_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B256* __addr, _B256 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -920,7 +920,7 @@ __device__ static inline void st_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void st_L1_no_allocate(::cuda::ptx::space_global_t, _B8* __addr, _B8 __src)
+_CCCL_DEVICE_API void st_L1_no_allocate(::cuda::ptx::space_global_t, _B8* __addr, _B8 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B8) == 1, "");
@@ -939,7 +939,7 @@ __device__ static inline void st_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void st_L1_no_allocate(::cuda::ptx::space_global_t, _B16* __addr, _B16 __src)
+_CCCL_DEVICE_API void st_L1_no_allocate(::cuda::ptx::space_global_t, _B16* __addr, _B16 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B16) == 2, "");
@@ -961,7 +961,7 @@ __device__ static inline void st_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void st_L1_no_allocate(::cuda::ptx::space_global_t, _B32* __addr, _B32 __src)
+_CCCL_DEVICE_API void st_L1_no_allocate(::cuda::ptx::space_global_t, _B32* __addr, _B32 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -983,7 +983,7 @@ __device__ static inline void st_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void st_L1_no_allocate(::cuda::ptx::space_global_t, _B64* __addr, _B64 __src)
+_CCCL_DEVICE_API void st_L1_no_allocate(::cuda::ptx::space_global_t, _B64* __addr, _B64 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -1005,7 +1005,7 @@ __device__ static inline void st_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void st_L1_no_allocate(::cuda::ptx::space_global_t, _B128* __addr, _B128 __src)
+_CCCL_DEVICE_API void st_L1_no_allocate(::cuda::ptx::space_global_t, _B128* __addr, _B128 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B128) == 16, "");
@@ -1033,7 +1033,7 @@ __device__ static inline void st_L1_no_allocate(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline void st_L1_no_allocate(::cuda::ptx::space_global_t, _B256* __addr, _B256 __src)
+_CCCL_DEVICE_API void st_L1_no_allocate(::cuda::ptx::space_global_t, _B256* __addr, _B256 __src)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B256) == 32, "");
@@ -1060,7 +1060,7 @@ __device__ static inline void st_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void st_L1_no_allocate_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_no_allocate_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B8* __addr, _B8 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1084,7 +1084,7 @@ __device__ static inline void st_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void st_L1_no_allocate_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_no_allocate_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B16* __addr, _B16 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1110,7 +1110,7 @@ __device__ static inline void st_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void st_L1_no_allocate_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_no_allocate_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B32* __addr, _B32 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1136,7 +1136,7 @@ __device__ static inline void st_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 740
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void st_L1_no_allocate_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_no_allocate_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B64* __addr, _B64 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1162,7 +1162,7 @@ __device__ static inline void st_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B128, ::cuda::std::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void st_L1_no_allocate_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_no_allocate_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B128* __addr, _B128 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
@@ -1193,7 +1193,7 @@ __device__ static inline void st_L1_no_allocate_L2_cache_hint(
 */
 #if __cccl_ptx_isa >= 880
 template <typename _B256, ::cuda::std::enable_if_t<sizeof(_B256) == 32, bool> = true>
-_CCCL_DEVICE static inline void st_L1_no_allocate_L2_cache_hint(
+_CCCL_DEVICE_API void st_L1_no_allocate_L2_cache_hint(
   ::cuda::ptx::space_global_t, _B256* __addr, _B256 __src, ::cuda::std::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/st_async.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/st_async.h
@@ -18,7 +18,7 @@ __device__ static inline void st_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _Type>
-_CCCL_DEVICE static inline void st_async(_Type* __addr, const _Type& __value, ::cuda::std::uint64_t* __remote_bar)
+_CCCL_DEVICE_API void st_async(_Type* __addr, const _Type& __value, ::cuda::std::uint64_t* __remote_bar)
 {
   static_assert(sizeof(_Type) == 4 || sizeof(_Type) == 8, "");
   if constexpr (sizeof(_Type) == 4)
@@ -54,7 +54,7 @@ __device__ static inline void st_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _Type>
-_CCCL_DEVICE static inline void st_async(_Type* __addr, const _Type (&__value)[2], ::cuda::std::uint64_t* __remote_bar)
+_CCCL_DEVICE_API void st_async(_Type* __addr, const _Type (&__value)[2], ::cuda::std::uint64_t* __remote_bar)
 {
   static_assert(sizeof(_Type) == 4 || sizeof(_Type) == 8, "");
   if constexpr (sizeof(_Type) == 4)
@@ -90,7 +90,7 @@ __device__ static inline void st_async(
 */
 #if __cccl_ptx_isa >= 810
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void st_async(_B32* __addr, const _B32 (&__value)[4], ::cuda::std::uint64_t* __remote_bar)
+_CCCL_DEVICE_API void st_async(_B32* __addr, const _B32 (&__value)[4], ::cuda::std::uint64_t* __remote_bar)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("st.async.weak.shared::cluster.mbarrier::complete_tx::bytes.v4.b32 [%0], {%1, %2, %3, %4}, [%5];    // 3. "

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/st_bulk.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/st_bulk.h
@@ -16,7 +16,7 @@ __device__ static inline void st_bulk(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32>
-_CCCL_DEVICE static inline void st_bulk(void* __addr, ::cuda::std::uint64_t __size, ::cuda::ptx::n32_t<_N32> __initval)
+_CCCL_DEVICE_API void st_bulk(void* __addr, ::cuda::std::uint64_t __size, ::cuda::ptx::n32_t<_N32> __initval)
 {
   asm("st.bulk.weak.shared::cta [%0], %1, %2;"
       :

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/stmatrix.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/stmatrix.h
@@ -15,7 +15,7 @@ __device__ static inline void stmatrix_m8n8(
 */
 #if __cccl_ptx_isa >= 780
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void stmatrix_m8n8(_B16* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[1])
+_CCCL_DEVICE_API void stmatrix_m8n8(_B16* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[1])
 {
   asm volatile("stmatrix.sync.aligned.m8n8.x1.shared.b16 [%0], {%1};"
                :
@@ -33,7 +33,7 @@ __device__ static inline void stmatrix_m8n8(
 */
 #if __cccl_ptx_isa >= 780
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void stmatrix_m8n8(_B16* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[2])
+_CCCL_DEVICE_API void stmatrix_m8n8(_B16* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[2])
 {
   asm volatile("stmatrix.sync.aligned.m8n8.x2.shared.b16 [%0], {%1, %2};"
                :
@@ -51,7 +51,7 @@ __device__ static inline void stmatrix_m8n8(
 */
 #if __cccl_ptx_isa >= 780
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void stmatrix_m8n8(_B16* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[4])
+_CCCL_DEVICE_API void stmatrix_m8n8(_B16* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[4])
 {
   asm volatile(
     "stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};"
@@ -70,7 +70,7 @@ __device__ static inline void stmatrix_m8n8_trans(
 */
 #if __cccl_ptx_isa >= 780
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void stmatrix_m8n8_trans(_B16* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[1])
+_CCCL_DEVICE_API void stmatrix_m8n8_trans(_B16* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[1])
 {
   asm volatile("stmatrix.sync.aligned.m8n8.x1.trans.shared.b16 [%0], {%1};"
                :
@@ -88,7 +88,7 @@ __device__ static inline void stmatrix_m8n8_trans(
 */
 #if __cccl_ptx_isa >= 780
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void stmatrix_m8n8_trans(_B16* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[2])
+_CCCL_DEVICE_API void stmatrix_m8n8_trans(_B16* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[2])
 {
   asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};"
                :
@@ -106,7 +106,7 @@ __device__ static inline void stmatrix_m8n8_trans(
 */
 #if __cccl_ptx_isa >= 780
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void stmatrix_m8n8_trans(_B16* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[4])
+_CCCL_DEVICE_API void stmatrix_m8n8_trans(_B16* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[4])
 {
   asm volatile(
     "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};"
@@ -126,7 +126,7 @@ __device__ static inline void stmatrix_m16n8_trans(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void stmatrix_m16n8_trans(_B8* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[1])
+_CCCL_DEVICE_API void stmatrix_m16n8_trans(_B8* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[1])
 {
   asm volatile("stmatrix.sync.aligned.m16n8.x1.trans.shared.b8 [%0], {%1};"
                :
@@ -145,7 +145,7 @@ __device__ static inline void stmatrix_m16n8_trans(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void stmatrix_m16n8_trans(_B8* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[2])
+_CCCL_DEVICE_API void stmatrix_m16n8_trans(_B8* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[2])
 {
   asm volatile("stmatrix.sync.aligned.m16n8.x2.trans.shared.b8 [%0], {%1, %2};"
                :
@@ -164,7 +164,7 @@ __device__ static inline void stmatrix_m16n8_trans(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B8, ::cuda::std::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void stmatrix_m16n8_trans(_B8* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[4])
+_CCCL_DEVICE_API void stmatrix_m16n8_trans(_B8* __gmem_ptr, const ::cuda::std::uint32_t (&__input_var)[4])
 {
   asm volatile(
     "stmatrix.sync.aligned.m16n8.x4.trans.shared.b8 [%0], {%1, %2, %3, %4};"

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_alloc.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_alloc.h
@@ -18,7 +18,7 @@ __device__ static inline void tcgen05_alloc(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_alloc(
+_CCCL_DEVICE_API void tcgen05_alloc(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t* __dst, const ::cuda::std::uint32_t& __nCols)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -51,7 +51,7 @@ __device__ static inline void tcgen05_dealloc(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_dealloc(
+_CCCL_DEVICE_API void tcgen05_dealloc(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, const ::cuda::std::uint32_t& __nCols)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -78,7 +78,7 @@ __device__ static inline void tcgen05_alloc_exclusive(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_alloc_exclusive(
+_CCCL_DEVICE_API void tcgen05_alloc_exclusive(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t* __dst, const ::cuda::std::uint32_t& __nCols)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -111,7 +111,7 @@ __device__ static inline void tcgen05_dealloc_exclusive(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_dealloc_exclusive(
+_CCCL_DEVICE_API void tcgen05_dealloc_exclusive(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, const ::cuda::std::uint32_t& __nCols)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -142,7 +142,7 @@ __device__ static inline void tcgen05_relinquish_alloc_permit(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_relinquish_alloc_permit(::cuda::ptx::cta_group_t<_Cta_Group> __cta_group)
+_CCCL_DEVICE_API void tcgen05_relinquish_alloc_permit(::cuda::ptx::cta_group_t<_Cta_Group> __cta_group)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
   if constexpr (__cta_group == cta_group_1)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_commit.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_commit.h
@@ -17,8 +17,7 @@ __device__ static inline void tcgen05_commit(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void
-tcgen05_commit(::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint64_t* __smem_bar)
+_CCCL_DEVICE_API void tcgen05_commit(::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint64_t* __smem_bar)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
   if constexpr (__cta_group == cta_group_1)
@@ -50,7 +49,7 @@ __device__ static inline void tcgen05_commit_multicast(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_commit_multicast(
+_CCCL_DEVICE_API void tcgen05_commit_multicast(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint64_t* __smem_bar, ::cuda::std::uint16_t __ctaMask)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -83,7 +82,7 @@ __device__ static inline void tcgen05_commit_multicast_32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_commit_multicast_32b(
+_CCCL_DEVICE_API void tcgen05_commit_multicast_32b(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint64_t* __smem_bar, ::cuda::std::uint32_t __ctaMask)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -117,7 +116,7 @@ __device__ static inline void tcgen05_commit_sync_restrict_shared_read_mma_a(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_commit_sync_restrict_shared_read_mma_a(
+_CCCL_DEVICE_API void tcgen05_commit_sync_restrict_shared_read_mma_a(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint64_t* __smem_bar)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -153,7 +152,7 @@ __device__ static inline void tcgen05_commit_sync_restrict_shared_read_mma_a_mul
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_commit_sync_restrict_shared_read_mma_a_multicast_32b(
+_CCCL_DEVICE_API void tcgen05_commit_sync_restrict_shared_read_mma_a_multicast_32b(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint64_t* __smem_bar, ::cuda::std::uint32_t __ctaMask)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_cp.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_cp.h
@@ -18,7 +18,7 @@ __device__ static inline void tcgen05_cp_128x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_128x256b(
+_CCCL_DEVICE_API void tcgen05_cp_128x256b(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -45,7 +45,7 @@ __device__ static inline void tcgen05_cp_4x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_4x256b(
+_CCCL_DEVICE_API void tcgen05_cp_4x256b(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -72,7 +72,7 @@ __device__ static inline void tcgen05_cp_128x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_128x128b(
+_CCCL_DEVICE_API void tcgen05_cp_128x128b(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -99,7 +99,7 @@ __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_02_13(
+_CCCL_DEVICE_API void tcgen05_cp_64x128b_warpx2_02_13(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -126,7 +126,7 @@ __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_01_23(
+_CCCL_DEVICE_API void tcgen05_cp_64x128b_warpx2_01_23(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -153,7 +153,7 @@ __device__ static inline void tcgen05_cp_32x128b_warpx4(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_32x128b_warpx4(
+_CCCL_DEVICE_API void tcgen05_cp_32x128b_warpx4(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -180,7 +180,7 @@ __device__ static inline void tcgen05_cp_128x256b_b8x16_b6x16_p32(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_128x256b_b8x16_b6x16_p32(
+_CCCL_DEVICE_API void tcgen05_cp_128x256b_b8x16_b6x16_p32(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -207,7 +207,7 @@ __device__ static inline void tcgen05_cp_4x256b_b8x16_b6x16_p32(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_4x256b_b8x16_b6x16_p32(
+_CCCL_DEVICE_API void tcgen05_cp_4x256b_b8x16_b6x16_p32(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -234,7 +234,7 @@ __device__ static inline void tcgen05_cp_128x128b_b8x16_b6x16_p32(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_128x128b_b8x16_b6x16_p32(
+_CCCL_DEVICE_API void tcgen05_cp_128x128b_b8x16_b6x16_p32(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -261,7 +261,7 @@ __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32(
+_CCCL_DEVICE_API void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -294,7 +294,7 @@ __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32(
+_CCCL_DEVICE_API void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -327,7 +327,7 @@ __device__ static inline void tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32(
+_CCCL_DEVICE_API void tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -354,7 +354,7 @@ __device__ static inline void tcgen05_cp_128x256b_b8x16_b4x16_p64(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_128x256b_b8x16_b4x16_p64(
+_CCCL_DEVICE_API void tcgen05_cp_128x256b_b8x16_b4x16_p64(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -381,7 +381,7 @@ __device__ static inline void tcgen05_cp_4x256b_b8x16_b4x16_p64(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_4x256b_b8x16_b4x16_p64(
+_CCCL_DEVICE_API void tcgen05_cp_4x256b_b8x16_b4x16_p64(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -408,7 +408,7 @@ __device__ static inline void tcgen05_cp_128x128b_b8x16_b4x16_p64(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_128x128b_b8x16_b4x16_p64(
+_CCCL_DEVICE_API void tcgen05_cp_128x128b_b8x16_b4x16_p64(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -435,7 +435,7 @@ __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64(
+_CCCL_DEVICE_API void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -468,7 +468,7 @@ __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64(
+_CCCL_DEVICE_API void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
@@ -501,7 +501,7 @@ __device__ static inline void tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64(
+_CCCL_DEVICE_API void tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64(
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr, ::cuda::std::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_fence.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_fence.h
@@ -13,7 +13,7 @@ __device__ static inline void tcgen05_fence_before_thread_sync();
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void tcgen05_fence_before_thread_sync()
+_CCCL_DEVICE_API void tcgen05_fence_before_thread_sync()
 {
   asm volatile("tcgen05.fence::before_thread_sync;" : : : "memory");
 }
@@ -26,7 +26,7 @@ __device__ static inline void tcgen05_fence_after_thread_sync();
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void tcgen05_fence_after_thread_sync()
+_CCCL_DEVICE_API void tcgen05_fence_after_thread_sync()
 {
   asm volatile("tcgen05.fence::after_thread_sync;" : : : "memory");
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_ld.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_ld.h
@@ -15,7 +15,7 @@ __device__ static inline void tcgen05_ld_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out_var)[1], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b(_B32 (&__out_var)[1], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x64b.x1.b32 {%0}, [%1];" : "=r"(__out_var[0]) : "r"(__taddr) : "memory");
@@ -31,7 +31,7 @@ __device__ static inline void tcgen05_ld_16x64b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[1], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[1], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x64b.x1.pack::16b.b32 {%0}, [%1];" : "=r"(__out_var[0]) : "r"(__taddr) : "memory");
@@ -47,7 +47,7 @@ __device__ static inline void tcgen05_ld_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x64b.x2.b32 {%0, %1}, [%2];"
@@ -66,7 +66,7 @@ __device__ static inline void tcgen05_ld_16x64b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x64b.x2.pack::16b.b32 {%0, %1}, [%2];"
@@ -85,7 +85,7 @@ __device__ static inline void tcgen05_ld_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x64b.x4.b32 {%0, %1, %2, %3}, [%4];"
@@ -104,7 +104,7 @@ __device__ static inline void tcgen05_ld_16x64b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x64b.x4.pack::16b.b32 {%0, %1, %2, %3}, [%4];"
@@ -123,7 +123,7 @@ __device__ static inline void tcgen05_ld_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x64b.x8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
@@ -149,7 +149,7 @@ __device__ static inline void tcgen05_ld_16x64b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x64b.x8.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
@@ -175,7 +175,7 @@ __device__ static inline void tcgen05_ld_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x64b.x16.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, "
@@ -210,7 +210,7 @@ __device__ static inline void tcgen05_ld_16x64b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x64b.x16.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
@@ -245,7 +245,7 @@ __device__ static inline void tcgen05_ld_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -297,7 +297,7 @@ __device__ static inline void tcgen05_ld_16x64b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -349,7 +349,7 @@ __device__ static inline void tcgen05_ld_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -435,7 +435,7 @@ __device__ static inline void tcgen05_ld_16x64b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -521,7 +521,7 @@ __device__ static inline void tcgen05_ld_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -674,7 +674,7 @@ __device__ static inline void tcgen05_ld_16x64b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x64b_pack_16b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -827,7 +827,7 @@ __device__ static inline void tcgen05_ld_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x128b.x1.b32 {%0, %1}, [%2];"
@@ -846,7 +846,7 @@ __device__ static inline void tcgen05_ld_16x128b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x128b.x1.pack::16b.b32 {%0, %1}, [%2];"
@@ -865,7 +865,7 @@ __device__ static inline void tcgen05_ld_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x128b.x2.b32 {%0, %1, %2, %3}, [%4];"
@@ -884,7 +884,7 @@ __device__ static inline void tcgen05_ld_16x128b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x128b.x2.pack::16b.b32 {%0, %1, %2, %3}, [%4];"
@@ -903,7 +903,7 @@ __device__ static inline void tcgen05_ld_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x128b.x4.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
@@ -929,7 +929,7 @@ __device__ static inline void tcgen05_ld_16x128b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x128b.x4.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
@@ -955,7 +955,7 @@ __device__ static inline void tcgen05_ld_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x128b.x8.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, "
@@ -990,7 +990,7 @@ __device__ static inline void tcgen05_ld_16x128b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x128b.x8.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
@@ -1025,7 +1025,7 @@ __device__ static inline void tcgen05_ld_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1077,7 +1077,7 @@ __device__ static inline void tcgen05_ld_16x128b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1129,7 +1129,7 @@ __device__ static inline void tcgen05_ld_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1215,7 +1215,7 @@ __device__ static inline void tcgen05_ld_16x128b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1301,7 +1301,7 @@ __device__ static inline void tcgen05_ld_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1454,7 +1454,7 @@ __device__ static inline void tcgen05_ld_16x128b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x128b_pack_16b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1607,7 +1607,7 @@ __device__ static inline void tcgen05_ld_16x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x256b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x256b.x1.b32 {%0, %1, %2, %3}, [%4];"
@@ -1626,7 +1626,7 @@ __device__ static inline void tcgen05_ld_16x256b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x256b_pack_16b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x256b.x1.pack::16b.b32 {%0, %1, %2, %3}, [%4];"
@@ -1645,7 +1645,7 @@ __device__ static inline void tcgen05_ld_16x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x256b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x256b.x2.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
@@ -1671,7 +1671,7 @@ __device__ static inline void tcgen05_ld_16x256b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x256b_pack_16b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x256b.x2.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
@@ -1697,7 +1697,7 @@ __device__ static inline void tcgen05_ld_16x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x256b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x256b.x4.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, "
@@ -1732,7 +1732,7 @@ __device__ static inline void tcgen05_ld_16x256b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x256b_pack_16b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.16x256b.x4.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
@@ -1767,7 +1767,7 @@ __device__ static inline void tcgen05_ld_16x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x256b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1819,7 +1819,7 @@ __device__ static inline void tcgen05_ld_16x256b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x256b_pack_16b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1871,7 +1871,7 @@ __device__ static inline void tcgen05_ld_16x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x256b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1957,7 +1957,7 @@ __device__ static inline void tcgen05_ld_16x256b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x256b_pack_16b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2043,7 +2043,7 @@ __device__ static inline void tcgen05_ld_16x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x256b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2196,7 +2196,7 @@ __device__ static inline void tcgen05_ld_16x256b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_16x256b_pack_16b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2349,7 +2349,7 @@ __device__ static inline void tcgen05_ld_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out_var)[1], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b(_B32 (&__out_var)[1], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.32x32b.x1.b32 {%0}, [%1];" : "=r"(__out_var[0]) : "r"(__taddr) : "memory");
@@ -2365,7 +2365,7 @@ __device__ static inline void tcgen05_ld_32x32b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[1], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[1], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.32x32b.x1.pack::16b.b32 {%0}, [%1];" : "=r"(__out_var[0]) : "r"(__taddr) : "memory");
@@ -2381,7 +2381,7 @@ __device__ static inline void tcgen05_ld_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.32x32b.x2.b32 {%0, %1}, [%2];"
@@ -2400,7 +2400,7 @@ __device__ static inline void tcgen05_ld_32x32b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.32x32b.x2.pack::16b.b32 {%0, %1}, [%2];"
@@ -2419,7 +2419,7 @@ __device__ static inline void tcgen05_ld_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.32x32b.x4.b32 {%0, %1, %2, %3}, [%4];"
@@ -2438,7 +2438,7 @@ __device__ static inline void tcgen05_ld_32x32b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.32x32b.x4.pack::16b.b32 {%0, %1, %2, %3}, [%4];"
@@ -2457,7 +2457,7 @@ __device__ static inline void tcgen05_ld_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.32x32b.x8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
@@ -2483,7 +2483,7 @@ __device__ static inline void tcgen05_ld_32x32b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.32x32b.x8.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
@@ -2509,7 +2509,7 @@ __device__ static inline void tcgen05_ld_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.32x32b.x16.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, "
@@ -2544,7 +2544,7 @@ __device__ static inline void tcgen05_ld_32x32b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.ld.sync.aligned.32x32b.x16.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
@@ -2579,7 +2579,7 @@ __device__ static inline void tcgen05_ld_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2631,7 +2631,7 @@ __device__ static inline void tcgen05_ld_32x32b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2683,7 +2683,7 @@ __device__ static inline void tcgen05_ld_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2769,7 +2769,7 @@ __device__ static inline void tcgen05_ld_32x32b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2855,7 +2855,7 @@ __device__ static inline void tcgen05_ld_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -3008,7 +3008,7 @@ __device__ static inline void tcgen05_ld_32x32b_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_ld_32x32b_pack_16b(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -3162,7 +3162,7 @@ __device__ static inline void tcgen05_ld_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tcgen05_ld_16x32bx2(_B32 (&__out_var)[1], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3184,7 +3184,7 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void tcgen05_ld_16x32bx2_pack_16b(
+_CCCL_DEVICE_API void tcgen05_ld_16x32bx2_pack_16b(
   _B32 (&__out_var)[1], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3205,7 +3205,7 @@ __device__ static inline void tcgen05_ld_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tcgen05_ld_16x32bx2(_B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3227,7 +3227,7 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void tcgen05_ld_16x32bx2_pack_16b(
+_CCCL_DEVICE_API void tcgen05_ld_16x32bx2_pack_16b(
   _B32 (&__out_var)[2], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3248,7 +3248,7 @@ __device__ static inline void tcgen05_ld_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tcgen05_ld_16x32bx2(_B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3270,7 +3270,7 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void tcgen05_ld_16x32bx2_pack_16b(
+_CCCL_DEVICE_API void tcgen05_ld_16x32bx2_pack_16b(
   _B32 (&__out_var)[4], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3291,7 +3291,7 @@ __device__ static inline void tcgen05_ld_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tcgen05_ld_16x32bx2(_B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3320,7 +3320,7 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void tcgen05_ld_16x32bx2_pack_16b(
+_CCCL_DEVICE_API void tcgen05_ld_16x32bx2_pack_16b(
   _B32 (&__out_var)[8], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3348,7 +3348,7 @@ __device__ static inline void tcgen05_ld_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tcgen05_ld_16x32bx2(_B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3386,7 +3386,7 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void tcgen05_ld_16x32bx2_pack_16b(
+_CCCL_DEVICE_API void tcgen05_ld_16x32bx2_pack_16b(
   _B32 (&__out_var)[16], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3423,7 +3423,7 @@ __device__ static inline void tcgen05_ld_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tcgen05_ld_16x32bx2(_B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3478,7 +3478,7 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void tcgen05_ld_16x32bx2_pack_16b(
+_CCCL_DEVICE_API void tcgen05_ld_16x32bx2_pack_16b(
   _B32 (&__out_var)[32], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3532,7 +3532,7 @@ __device__ static inline void tcgen05_ld_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tcgen05_ld_16x32bx2(_B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3621,7 +3621,7 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void tcgen05_ld_16x32bx2_pack_16b(
+_CCCL_DEVICE_API void tcgen05_ld_16x32bx2_pack_16b(
   _B32 (&__out_var)[64], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3710,7 +3710,7 @@ __device__ static inline void tcgen05_ld_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tcgen05_ld_16x32bx2(_B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3866,7 +3866,7 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
-_CCCL_DEVICE static inline void tcgen05_ld_16x32bx2_pack_16b(
+_CCCL_DEVICE_API void tcgen05_ld_16x32bx2_pack_16b(
   _B32 (&__out_var)[128], ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -4023,7 +4023,7 @@ __device__ static inline uint32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t
+_CCCL_DEVICE_API ::cuda::std::uint32_t
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__out_var)[2], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4058,7 +4058,7 @@ __device__ static inline int32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t
+_CCCL_DEVICE_API ::cuda::std::int32_t
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, ::cuda::std::int32_t (&__out_var)[2], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4093,7 +4093,7 @@ __device__ static inline float tcgen05_ld_red_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b_abs(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[2], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4128,7 +4128,7 @@ __device__ static inline float tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[2], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4163,7 +4163,7 @@ __device__ static inline uint32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t
+_CCCL_DEVICE_API ::cuda::std::uint32_t
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__out_var)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4198,7 +4198,7 @@ __device__ static inline int32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t
+_CCCL_DEVICE_API ::cuda::std::int32_t
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, ::cuda::std::int32_t (&__out_var)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4233,7 +4233,7 @@ __device__ static inline float tcgen05_ld_red_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b_abs(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4268,7 +4268,7 @@ __device__ static inline float tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4303,7 +4303,7 @@ __device__ static inline uint32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t
+_CCCL_DEVICE_API ::cuda::std::uint32_t
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__out_var)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4354,7 +4354,7 @@ __device__ static inline int32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t
+_CCCL_DEVICE_API ::cuda::std::int32_t
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, ::cuda::std::int32_t (&__out_var)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4405,7 +4405,7 @@ __device__ static inline float tcgen05_ld_red_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b_abs(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4456,7 +4456,7 @@ __device__ static inline float tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4507,7 +4507,7 @@ __device__ static inline uint32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t tcgen05_ld_red_32x32b(
+_CCCL_DEVICE_API ::cuda::std::uint32_t tcgen05_ld_red_32x32b(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__out_var)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4576,7 +4576,7 @@ __device__ static inline int32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t
+_CCCL_DEVICE_API ::cuda::std::int32_t
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, ::cuda::std::int32_t (&__out_var)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4645,7 +4645,7 @@ __device__ static inline float tcgen05_ld_red_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b_abs(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4714,7 +4714,7 @@ __device__ static inline float tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4783,7 +4783,7 @@ __device__ static inline uint32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t tcgen05_ld_red_32x32b(
+_CCCL_DEVICE_API ::cuda::std::uint32_t tcgen05_ld_red_32x32b(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__out_var)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4886,7 +4886,7 @@ __device__ static inline int32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t
+_CCCL_DEVICE_API ::cuda::std::int32_t
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, ::cuda::std::int32_t (&__out_var)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -4989,7 +4989,7 @@ __device__ static inline float tcgen05_ld_red_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b_abs(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -5092,7 +5092,7 @@ __device__ static inline float tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -5195,7 +5195,7 @@ __device__ static inline uint32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t tcgen05_ld_red_32x32b(
+_CCCL_DEVICE_API ::cuda::std::uint32_t tcgen05_ld_red_32x32b(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__out_var)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -5366,7 +5366,7 @@ __device__ static inline int32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t
+_CCCL_DEVICE_API ::cuda::std::int32_t
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, ::cuda::std::int32_t (&__out_var)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -5537,7 +5537,7 @@ __device__ static inline float tcgen05_ld_red_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b_abs(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -5708,7 +5708,7 @@ __device__ static inline float tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -5879,7 +5879,7 @@ __device__ static inline uint32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t tcgen05_ld_red_32x32b(
+_CCCL_DEVICE_API ::cuda::std::uint32_t tcgen05_ld_red_32x32b(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__out_var)[128], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -6184,7 +6184,7 @@ __device__ static inline int32_t tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t tcgen05_ld_red_32x32b(
+_CCCL_DEVICE_API ::cuda::std::int32_t tcgen05_ld_red_32x32b(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::int32_t (&__out_var)[128], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -6489,7 +6489,7 @@ __device__ static inline float tcgen05_ld_red_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b_abs(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[128], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -6794,7 +6794,7 @@ __device__ static inline float tcgen05_ld_red_32x32b(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float
+_CCCL_DEVICE_API float
 tcgen05_ld_red_32x32b(::cuda::ptx::op_t<_Op> __op, float (&__out_var)[128], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -7100,7 +7100,7 @@ __device__ static inline uint32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::uint32_t (&__out_var)[2],
   ::cuda::std::uint32_t __taddr,
@@ -7139,7 +7139,7 @@ __device__ static inline int32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::int32_t (&__out_var)[2],
   ::cuda::std::uint32_t __taddr,
@@ -7178,7 +7178,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2_abs(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[2],
   ::cuda::std::uint32_t __taddr,
@@ -7217,7 +7217,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[2],
   ::cuda::std::uint32_t __taddr,
@@ -7256,7 +7256,7 @@ __device__ static inline uint32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::uint32_t (&__out_var)[4],
   ::cuda::std::uint32_t __taddr,
@@ -7295,7 +7295,7 @@ __device__ static inline int32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::int32_t (&__out_var)[4],
   ::cuda::std::uint32_t __taddr,
@@ -7334,7 +7334,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2_abs(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[4],
   ::cuda::std::uint32_t __taddr,
@@ -7373,7 +7373,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[4],
   ::cuda::std::uint32_t __taddr,
@@ -7412,7 +7412,7 @@ __device__ static inline uint32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::uint32_t (&__out_var)[8],
   ::cuda::std::uint32_t __taddr,
@@ -7467,7 +7467,7 @@ __device__ static inline int32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::int32_t (&__out_var)[8],
   ::cuda::std::uint32_t __taddr,
@@ -7522,7 +7522,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2_abs(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[8],
   ::cuda::std::uint32_t __taddr,
@@ -7577,7 +7577,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[8],
   ::cuda::std::uint32_t __taddr,
@@ -7632,7 +7632,7 @@ __device__ static inline uint32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::uint32_t (&__out_var)[16],
   ::cuda::std::uint32_t __taddr,
@@ -7705,7 +7705,7 @@ __device__ static inline int32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::int32_t (&__out_var)[16],
   ::cuda::std::uint32_t __taddr,
@@ -7778,7 +7778,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2_abs(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[16],
   ::cuda::std::uint32_t __taddr,
@@ -7851,7 +7851,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[16],
   ::cuda::std::uint32_t __taddr,
@@ -7924,7 +7924,7 @@ __device__ static inline uint32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::uint32_t (&__out_var)[32],
   ::cuda::std::uint32_t __taddr,
@@ -8031,7 +8031,7 @@ __device__ static inline int32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::int32_t (&__out_var)[32],
   ::cuda::std::uint32_t __taddr,
@@ -8138,7 +8138,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2_abs(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[32],
   ::cuda::std::uint32_t __taddr,
@@ -8245,7 +8245,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[32],
   ::cuda::std::uint32_t __taddr,
@@ -8352,7 +8352,7 @@ __device__ static inline uint32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::uint32_t (&__out_var)[64],
   ::cuda::std::uint32_t __taddr,
@@ -8527,7 +8527,7 @@ __device__ static inline int32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::int32_t (&__out_var)[64],
   ::cuda::std::uint32_t __taddr,
@@ -8702,7 +8702,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2_abs(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[64],
   ::cuda::std::uint32_t __taddr,
@@ -8877,7 +8877,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[64],
   ::cuda::std::uint32_t __taddr,
@@ -9052,7 +9052,7 @@ __device__ static inline uint32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::uint32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::uint32_t (&__out_var)[128],
   ::cuda::std::uint32_t __taddr,
@@ -9361,7 +9361,7 @@ __device__ static inline int32_t tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API ::cuda::std::int32_t tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   ::cuda::std::int32_t (&__out_var)[128],
   ::cuda::std::uint32_t __taddr,
@@ -9670,7 +9670,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2_abs(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2_abs(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[128],
   ::cuda::std::uint32_t __taddr,
@@ -9979,7 +9979,7 @@ __device__ static inline float tcgen05_ld_red_16x32bx2(
 */
 #if __cccl_ptx_isa >= 880
 template <int _N32, ::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_16x32bx2(
+_CCCL_DEVICE_API float tcgen05_ld_red_16x32bx2(
   ::cuda::ptx::op_t<_Op> __op,
   float (&__out_var)[128],
   ::cuda::std::uint32_t __taddr,
@@ -10288,7 +10288,7 @@ __device__ static inline float tcgen05_ld_red_spcompress_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_spcompress_32x32b_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_spcompress_32x32b_abs(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__mdata)[1], float (&__cdata)[2], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -10324,7 +10324,7 @@ __device__ static inline float tcgen05_ld_red_spcompress_32x32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_spcompress_32x32b(
+_CCCL_DEVICE_API float tcgen05_ld_red_spcompress_32x32b(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__mdata)[1], float (&__cdata)[2], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -10360,7 +10360,7 @@ __device__ static inline float tcgen05_ld_red_spcompress_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_spcompress_32x32b_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_spcompress_32x32b_abs(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__mdata)[1], float (&__cdata)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -10396,7 +10396,7 @@ __device__ static inline float tcgen05_ld_red_spcompress_32x32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_spcompress_32x32b(
+_CCCL_DEVICE_API float tcgen05_ld_red_spcompress_32x32b(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__mdata)[1], float (&__cdata)[4], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -10432,7 +10432,7 @@ __device__ static inline float tcgen05_ld_red_spcompress_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_spcompress_32x32b_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_spcompress_32x32b_abs(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__mdata)[1], float (&__cdata)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -10488,7 +10488,7 @@ __device__ static inline float tcgen05_ld_red_spcompress_32x32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_spcompress_32x32b(
+_CCCL_DEVICE_API float tcgen05_ld_red_spcompress_32x32b(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__mdata)[1], float (&__cdata)[8], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -10544,7 +10544,7 @@ __device__ static inline float tcgen05_ld_red_spcompress_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_spcompress_32x32b_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_spcompress_32x32b_abs(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__mdata)[1], float (&__cdata)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -10616,7 +10616,7 @@ __device__ static inline float tcgen05_ld_red_spcompress_32x32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_spcompress_32x32b(
+_CCCL_DEVICE_API float tcgen05_ld_red_spcompress_32x32b(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__mdata)[1], float (&__cdata)[16], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -10688,7 +10688,7 @@ __device__ static inline float tcgen05_ld_red_spcompress_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_spcompress_32x32b_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_spcompress_32x32b_abs(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__mdata)[2], float (&__cdata)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -10798,7 +10798,7 @@ __device__ static inline float tcgen05_ld_red_spcompress_32x32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_spcompress_32x32b(
+_CCCL_DEVICE_API float tcgen05_ld_red_spcompress_32x32b(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__mdata)[2], float (&__cdata)[32], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -10908,7 +10908,7 @@ __device__ static inline float tcgen05_ld_red_spcompress_32x32b_abs(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_spcompress_32x32b_abs(
+_CCCL_DEVICE_API float tcgen05_ld_red_spcompress_32x32b_abs(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__mdata)[4], float (&__cdata)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");
@@ -11088,7 +11088,7 @@ __device__ static inline float tcgen05_ld_red_spcompress_32x32b(
 */
 #if __cccl_ptx_isa >= 940
 template <::cuda::ptx::dot_op _Op>
-_CCCL_DEVICE static inline float tcgen05_ld_red_spcompress_32x32b(
+_CCCL_DEVICE_API float tcgen05_ld_red_spcompress_32x32b(
   ::cuda::ptx::op_t<_Op> __op, ::cuda::std::uint32_t (&__mdata)[4], float (&__cdata)[64], ::cuda::std::uint32_t __taddr)
 {
   static_assert(__op == op_min || __op == op_max, "");

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_mma.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_mma.h
@@ -25,7 +25,7 @@ __device__ static inline void tcgen05_mma(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, ::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma(
+_CCCL_DEVICE_API void tcgen05_mma(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_1_t,
   ::cuda::std::uint32_t __d_tmem,
@@ -102,7 +102,7 @@ __device__ static inline void tcgen05_mma(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, ::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma(
+_CCCL_DEVICE_API void tcgen05_mma(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_2_t,
   ::cuda::std::uint32_t __d_tmem,
@@ -188,7 +188,7 @@ __device__ static inline void tcgen05_mma(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma(
+_CCCL_DEVICE_API void tcgen05_mma(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_1_t,
   ::cuda::std::uint32_t __d_tmem,
@@ -301,7 +301,7 @@ __device__ static inline void tcgen05_mma(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma(
+_CCCL_DEVICE_API void tcgen05_mma(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_2_t,
   ::cuda::std::uint32_t __d_tmem,
@@ -432,7 +432,7 @@ __device__ static inline void tcgen05_mma(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, ::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma(
+_CCCL_DEVICE_API void tcgen05_mma(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -532,7 +532,7 @@ __device__ static inline void tcgen05_mma(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma(
+_CCCL_DEVICE_API void tcgen05_mma(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -693,7 +693,7 @@ __device__ static inline void tcgen05_mma_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, ::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_tmem_a(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_1_t,
   ::cuda::std::uint32_t __d_tmem,
@@ -770,7 +770,7 @@ __device__ static inline void tcgen05_mma_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, ::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_tmem_a(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_2_t,
   ::cuda::std::uint32_t __d_tmem,
@@ -856,7 +856,7 @@ __device__ static inline void tcgen05_mma_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_tmem_a(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_1_t,
   ::cuda::std::uint32_t __d_tmem,
@@ -969,7 +969,7 @@ __device__ static inline void tcgen05_mma_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_tmem_a(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_2_t,
   ::cuda::std::uint32_t __d_tmem,
@@ -1102,7 +1102,7 @@ __device__ static inline void tcgen05_mma_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, ::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_tmem_a(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1202,7 +1202,7 @@ __device__ static inline void tcgen05_mma_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_tmem_a(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1363,7 +1363,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_1x(
   ::cuda::ptx::kind_mxf8f6f4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1436,7 +1436,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_2x(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1547,7 +1547,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_4x(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1620,7 +1620,7 @@ __device__ static inline void tcgen05_mma_block_scale_block16(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block16(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block16(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1693,7 +1693,7 @@ __device__ static inline void tcgen05_mma_block_scale_block32(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block32(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block32(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1840,7 +1840,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_1x_tmem_a(
   ::cuda::ptx::kind_mxf8f6f4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1913,7 +1913,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_2_tmem_a(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2024,7 +2024,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_4x_tmem_a(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2097,7 +2097,7 @@ __device__ static inline void tcgen05_mma_block_scale_block16_tmem_a(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block16_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block16_tmem_a(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2170,7 +2170,7 @@ __device__ static inline void tcgen05_mma_block_scale_block32_tmem_a(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block32_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block32_tmem_a(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2317,7 +2317,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_collector_a_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_1x_collector_a_fill(
   ::cuda::ptx::kind_mxf8f6f4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2390,7 +2390,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x_collector_a_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_2x_collector_a_fill(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2501,7 +2501,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_collector_a_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_4x_collector_a_fill(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2574,7 +2574,7 @@ __device__ static inline void tcgen05_mma_block_scale_block16_collector_a_fill(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block16_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block16_collector_a_fill(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2647,7 +2647,7 @@ __device__ static inline void tcgen05_mma_block_scale_block32_collector_a_fill(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block32_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block32_collector_a_fill(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2796,7 +2796,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill(
   ::cuda::ptx::kind_mxf8f6f4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2869,7 +2869,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_f
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2980,7 +2980,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -3053,7 +3053,7 @@ __device__ static inline void tcgen05_mma_block_scale_block16_tmem_a_collector_a
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -3126,7 +3126,7 @@ __device__ static inline void tcgen05_mma_block_scale_block32_tmem_a_collector_a
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -3275,7 +3275,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_collector_a_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_1x_collector_a_use(
   ::cuda::ptx::kind_mxf8f6f4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -3348,7 +3348,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x_collector_a_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_2x_collector_a_use(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -3459,7 +3459,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_collector_a_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_4x_collector_a_use(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -3532,7 +3532,7 @@ __device__ static inline void tcgen05_mma_block_scale_block16_collector_a_use(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block16_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block16_collector_a_use(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -3605,7 +3605,7 @@ __device__ static inline void tcgen05_mma_block_scale_block32_collector_a_use(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block32_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block32_collector_a_use(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -3754,7 +3754,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use(
   ::cuda::ptx::kind_mxf8f6f4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -3827,7 +3827,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_u
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -3938,7 +3938,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -4011,7 +4011,7 @@ __device__ static inline void tcgen05_mma_block_scale_block16_tmem_a_collector_a
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block16_tmem_a_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block16_tmem_a_collector_a_use(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -4084,7 +4084,7 @@ __device__ static inline void tcgen05_mma_block_scale_block32_tmem_a_collector_a
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block32_tmem_a_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block32_tmem_a_collector_a_use(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -4233,7 +4233,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_collector_a_lastuse
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_1x_collector_a_lastuse(
   ::cuda::ptx::kind_mxf8f6f4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -4306,7 +4306,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x_collector_a_lastuse
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_2x_collector_a_lastuse(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -4417,7 +4417,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_collector_a_lastuse
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_4x_collector_a_lastuse(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -4490,7 +4490,7 @@ __device__ static inline void tcgen05_mma_block_scale_block16_collector_a_lastus
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block16_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block16_collector_a_lastuse(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -4563,7 +4563,7 @@ __device__ static inline void tcgen05_mma_block_scale_block32_collector_a_lastus
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block32_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block32_collector_a_lastuse(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -4712,7 +4712,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse(
   ::cuda::ptx::kind_mxf8f6f4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -4785,7 +4785,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_l
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -4896,7 +4896,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -4970,7 +4970,7 @@ __device__ static inline void tcgen05_mma_block_scale_block16_tmem_a_collector_a
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -5044,7 +5044,7 @@ __device__ static inline void tcgen05_mma_block_scale_block32_tmem_a_collector_a
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -5193,7 +5193,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_collector_a_discard
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_1x_collector_a_discard(
   ::cuda::ptx::kind_mxf8f6f4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -5266,7 +5266,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x_collector_a_discard
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_2x_collector_a_discard(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -5377,7 +5377,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_collector_a_discard
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_4x_collector_a_discard(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -5450,7 +5450,7 @@ __device__ static inline void tcgen05_mma_block_scale_block16_collector_a_discar
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block16_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block16_collector_a_discard(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -5523,7 +5523,7 @@ __device__ static inline void tcgen05_mma_block_scale_block32_collector_a_discar
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block32_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block32_collector_a_discard(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -5672,7 +5672,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard(
   ::cuda::ptx::kind_mxf8f6f4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -5745,7 +5745,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_d
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -5856,7 +5856,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -5930,7 +5930,7 @@ __device__ static inline void tcgen05_mma_block_scale_block16_tmem_a_collector_a
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -6004,7 +6004,7 @@ __device__ static inline void tcgen05_mma_block_scale_block32_tmem_a_collector_a
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_mma_sp.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_mma_sp.h
@@ -24,7 +24,7 @@ __device__ static inline void tcgen05_mma_sp(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp(
+_CCCL_DEVICE_API void tcgen05_mma_sp(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -125,7 +125,7 @@ __device__ static inline void tcgen05_mma_sp_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_sp_tmem_a(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -228,7 +228,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block16(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block16(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block16(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -305,7 +305,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block32(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block32(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block32(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -462,7 +462,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block16_tmem_a(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block16_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block16_tmem_a(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -539,7 +539,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block32_tmem_a(
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block32_tmem_a(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block32_tmem_a(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -696,7 +696,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block16_collector_a_fil
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block16_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block16_collector_a_fill(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -774,7 +774,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block32_collector_a_fil
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block32_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block32_collector_a_fill(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -931,7 +931,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block16_tmem_a_collecto
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block16_tmem_a_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block16_tmem_a_collector_a_fill(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1009,7 +1009,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block32_tmem_a_collecto
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block32_tmem_a_collector_a_fill(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block32_tmem_a_collector_a_fill(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1166,7 +1166,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block16_collector_a_use
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block16_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block16_collector_a_use(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1244,7 +1244,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block32_collector_a_use
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block32_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block32_collector_a_use(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1401,7 +1401,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block16_tmem_a_collecto
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block16_tmem_a_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block16_tmem_a_collector_a_use(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1479,7 +1479,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block32_tmem_a_collecto
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block32_tmem_a_collector_a_use(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block32_tmem_a_collector_a_use(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1636,7 +1636,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block16_collector_a_las
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block16_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block16_collector_a_lastuse(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1714,7 +1714,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block32_collector_a_las
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block32_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block32_collector_a_lastuse(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1871,7 +1871,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block16_tmem_a_collecto
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block16_tmem_a_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block16_tmem_a_collector_a_lastuse(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -1949,7 +1949,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block32_tmem_a_collecto
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block32_tmem_a_collector_a_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block32_tmem_a_collector_a_lastuse(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2106,7 +2106,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block16_collector_a_dis
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block16_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block16_collector_a_discard(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2184,7 +2184,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block32_collector_a_dis
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block32_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block32_collector_a_discard(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2341,7 +2341,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block16_tmem_a_collecto
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block16_tmem_a_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block16_tmem_a_collector_a_discard(
   ::cuda::ptx::kind_mxf4nvf4_t,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,
@@ -2419,7 +2419,7 @@ __device__ static inline void tcgen05_mma_sp_block_scale_block32_tmem_a_collecto
 */
 #if __cccl_ptx_isa >= 880
 template <::cuda::ptx::dot_kind _Kind, ::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void tcgen05_mma_sp_block_scale_block32_tmem_a_collector_a_discard(
+_CCCL_DEVICE_API void tcgen05_mma_sp_block_scale_block32_tmem_a_collector_a_discard(
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::ptx::cta_group_t<_Cta_Group> __cta_group,
   ::cuda::std::uint32_t __d_tmem,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_mma_ws.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_mma_ws.h
@@ -24,7 +24,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b0_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -124,7 +124,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b0_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -220,7 +220,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b0_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -320,7 +320,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b0_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -416,7 +416,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b0_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -516,7 +516,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b0_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -612,7 +612,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b0_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -712,7 +712,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b0_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -808,7 +808,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b0_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -908,7 +908,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b0_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -1004,7 +1004,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -1104,7 +1104,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -1200,7 +1200,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b0_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -1300,7 +1300,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b0_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -1396,7 +1396,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b0_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -1496,7 +1496,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b0_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -1592,7 +1592,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b1_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -1692,7 +1692,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b1_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -1788,7 +1788,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b1_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -1888,7 +1888,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b1_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -1984,7 +1984,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b1_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -2084,7 +2084,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b1_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -2180,7 +2180,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b1_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -2280,7 +2280,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b1_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -2376,7 +2376,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b1_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -2476,7 +2476,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b1_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -2572,7 +2572,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -2672,7 +2672,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -2768,7 +2768,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b1_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -2868,7 +2868,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b1_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -2964,7 +2964,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b1_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -3064,7 +3064,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b1_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -3160,7 +3160,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b2_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -3260,7 +3260,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b2_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -3356,7 +3356,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b2_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -3456,7 +3456,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b2_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -3552,7 +3552,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b2_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -3652,7 +3652,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b2_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -3748,7 +3748,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b2_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -3848,7 +3848,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b2_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -3944,7 +3944,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b2_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -4044,7 +4044,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b2_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -4140,7 +4140,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -4240,7 +4240,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -4336,7 +4336,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b2_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -4436,7 +4436,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b2_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -4532,7 +4532,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b2_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -4632,7 +4632,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b2_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -4728,7 +4728,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b3_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -4828,7 +4828,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b3_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -4924,7 +4924,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b3_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -5024,7 +5024,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_fill(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_fill(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b3_fill(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -5120,7 +5120,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b3_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -5220,7 +5220,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b3_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -5316,7 +5316,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b3_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -5416,7 +5416,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_use(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_use(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b3_use(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -5512,7 +5512,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b3_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -5612,7 +5612,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b3_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -5708,7 +5708,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -5808,7 +5808,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -5904,7 +5904,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b3_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -6004,7 +6004,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_collector_b3_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -6100,7 +6100,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b3_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,
@@ -6200,7 +6200,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_discard(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_kind _Kind>
-_CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_discard(
+_CCCL_DEVICE_API void tcgen05_mma_ws_tmem_a_collector_b3_discard(
   ::cuda::ptx::cta_group_1_t,
   ::cuda::ptx::kind_t<_Kind> __kind,
   ::cuda::std::uint32_t __d_tmem,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_shift.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_shift.h
@@ -16,8 +16,7 @@ __device__ static inline void tcgen05_shift_down(
 */
 #if __cccl_ptx_isa >= 860
 template <::cuda::ptx::dot_cta_group _Cta_Group>
-_CCCL_DEVICE static inline void
-tcgen05_shift_down(::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr)
+_CCCL_DEVICE_API void tcgen05_shift_down(::cuda::ptx::cta_group_t<_Cta_Group> __cta_group, ::cuda::std::uint32_t __taddr)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
   if constexpr (__cta_group == cta_group_1)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_st.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_st.h
@@ -15,7 +15,7 @@ __device__ static inline void tcgen05_st_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[1])
+_CCCL_DEVICE_API void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[1])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x64b.x1.b32 [%0], {%1};"
@@ -34,7 +34,7 @@ __device__ static inline void tcgen05_st_16x64b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[1])
+_CCCL_DEVICE_API void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[1])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x64b.x1.unpack::16b.b32 [%0], {%1};"
@@ -53,7 +53,7 @@ __device__ static inline void tcgen05_st_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[2])
+_CCCL_DEVICE_API void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x64b.x2.b32 [%0], {%1, %2};"
@@ -74,7 +74,7 @@ __device__ static inline void tcgen05_st_16x64b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[2])
+_CCCL_DEVICE_API void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x64b.x2.unpack::16b.b32 [%0], {%1, %2};"
@@ -95,7 +95,7 @@ __device__ static inline void tcgen05_st_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
+_CCCL_DEVICE_API void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x64b.x4.b32 [%0], {%1, %2, %3, %4};"
@@ -118,7 +118,7 @@ __device__ static inline void tcgen05_st_16x64b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
+_CCCL_DEVICE_API void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x64b.x4.unpack::16b.b32 [%0], {%1, %2, %3, %4};"
@@ -141,7 +141,7 @@ __device__ static inline void tcgen05_st_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
+_CCCL_DEVICE_API void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x64b.x8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
@@ -168,7 +168,7 @@ __device__ static inline void tcgen05_st_16x64b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
+_CCCL_DEVICE_API void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x64b.x8.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
@@ -195,7 +195,7 @@ __device__ static inline void tcgen05_st_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
+_CCCL_DEVICE_API void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x64b.x16.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
@@ -231,7 +231,7 @@ __device__ static inline void tcgen05_st_16x64b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
+_CCCL_DEVICE_API void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x64b.x16.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
@@ -267,7 +267,7 @@ __device__ static inline void tcgen05_st_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
+_CCCL_DEVICE_API void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -320,7 +320,7 @@ __device__ static inline void tcgen05_st_16x64b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
+_CCCL_DEVICE_API void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -373,7 +373,7 @@ __device__ static inline void tcgen05_st_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
+_CCCL_DEVICE_API void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -460,7 +460,7 @@ __device__ static inline void tcgen05_st_16x64b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
+_CCCL_DEVICE_API void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -547,7 +547,7 @@ __device__ static inline void tcgen05_st_16x64b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
+_CCCL_DEVICE_API void tcgen05_st_16x64b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -701,7 +701,7 @@ __device__ static inline void tcgen05_st_16x64b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
+_CCCL_DEVICE_API void tcgen05_st_16x64b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -855,7 +855,7 @@ __device__ static inline void tcgen05_st_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[2])
+_CCCL_DEVICE_API void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x128b.x1.b32 [%0], {%1, %2};"
@@ -876,7 +876,7 @@ __device__ static inline void tcgen05_st_16x128b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[2])
+_CCCL_DEVICE_API void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x128b.x1.unpack::16b.b32 [%0], {%1, %2};"
@@ -897,7 +897,7 @@ __device__ static inline void tcgen05_st_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
+_CCCL_DEVICE_API void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x128b.x2.b32 [%0], {%1, %2, %3, %4};"
@@ -920,7 +920,7 @@ __device__ static inline void tcgen05_st_16x128b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
+_CCCL_DEVICE_API void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x128b.x2.unpack::16b.b32 [%0], {%1, %2, %3, %4};"
@@ -943,7 +943,7 @@ __device__ static inline void tcgen05_st_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
+_CCCL_DEVICE_API void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x128b.x4.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
@@ -970,7 +970,7 @@ __device__ static inline void tcgen05_st_16x128b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
+_CCCL_DEVICE_API void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x128b.x4.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
@@ -997,7 +997,7 @@ __device__ static inline void tcgen05_st_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
+_CCCL_DEVICE_API void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x128b.x8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
@@ -1033,7 +1033,7 @@ __device__ static inline void tcgen05_st_16x128b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
+_CCCL_DEVICE_API void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x128b.x8.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
@@ -1069,7 +1069,7 @@ __device__ static inline void tcgen05_st_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
+_CCCL_DEVICE_API void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1122,7 +1122,7 @@ __device__ static inline void tcgen05_st_16x128b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
+_CCCL_DEVICE_API void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1175,7 +1175,7 @@ __device__ static inline void tcgen05_st_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
+_CCCL_DEVICE_API void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1262,7 +1262,7 @@ __device__ static inline void tcgen05_st_16x128b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
+_CCCL_DEVICE_API void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1349,7 +1349,7 @@ __device__ static inline void tcgen05_st_16x128b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
+_CCCL_DEVICE_API void tcgen05_st_16x128b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1503,7 +1503,7 @@ __device__ static inline void tcgen05_st_16x128b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
+_CCCL_DEVICE_API void tcgen05_st_16x128b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1657,7 +1657,7 @@ __device__ static inline void tcgen05_st_16x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x256b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
+_CCCL_DEVICE_API void tcgen05_st_16x256b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x256b.x1.b32 [%0], {%1, %2, %3, %4};"
@@ -1680,7 +1680,7 @@ __device__ static inline void tcgen05_st_16x256b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
+_CCCL_DEVICE_API void tcgen05_st_16x256b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x256b.x1.unpack::16b.b32 [%0], {%1, %2, %3, %4};"
@@ -1703,7 +1703,7 @@ __device__ static inline void tcgen05_st_16x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x256b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
+_CCCL_DEVICE_API void tcgen05_st_16x256b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x256b.x2.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
@@ -1730,7 +1730,7 @@ __device__ static inline void tcgen05_st_16x256b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
+_CCCL_DEVICE_API void tcgen05_st_16x256b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x256b.x2.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
@@ -1757,7 +1757,7 @@ __device__ static inline void tcgen05_st_16x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x256b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
+_CCCL_DEVICE_API void tcgen05_st_16x256b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x256b.x4.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
@@ -1793,7 +1793,7 @@ __device__ static inline void tcgen05_st_16x256b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
+_CCCL_DEVICE_API void tcgen05_st_16x256b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.16x256b.x4.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
@@ -1829,7 +1829,7 @@ __device__ static inline void tcgen05_st_16x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x256b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
+_CCCL_DEVICE_API void tcgen05_st_16x256b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1882,7 +1882,7 @@ __device__ static inline void tcgen05_st_16x256b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
+_CCCL_DEVICE_API void tcgen05_st_16x256b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -1935,7 +1935,7 @@ __device__ static inline void tcgen05_st_16x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x256b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
+_CCCL_DEVICE_API void tcgen05_st_16x256b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2022,7 +2022,7 @@ __device__ static inline void tcgen05_st_16x256b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
+_CCCL_DEVICE_API void tcgen05_st_16x256b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2109,7 +2109,7 @@ __device__ static inline void tcgen05_st_16x256b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x256b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
+_CCCL_DEVICE_API void tcgen05_st_16x256b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2263,7 +2263,7 @@ __device__ static inline void tcgen05_st_16x256b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
+_CCCL_DEVICE_API void tcgen05_st_16x256b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2417,7 +2417,7 @@ __device__ static inline void tcgen05_st_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[1])
+_CCCL_DEVICE_API void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[1])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.32x32b.x1.b32 [%0], {%1};"
@@ -2436,7 +2436,7 @@ __device__ static inline void tcgen05_st_32x32b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[1])
+_CCCL_DEVICE_API void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[1])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.32x32b.x1.unpack::16b.b32 [%0], {%1};"
@@ -2455,7 +2455,7 @@ __device__ static inline void tcgen05_st_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[2])
+_CCCL_DEVICE_API void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.32x32b.x2.b32 [%0], {%1, %2};"
@@ -2476,7 +2476,7 @@ __device__ static inline void tcgen05_st_32x32b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[2])
+_CCCL_DEVICE_API void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.32x32b.x2.unpack::16b.b32 [%0], {%1, %2};"
@@ -2497,7 +2497,7 @@ __device__ static inline void tcgen05_st_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
+_CCCL_DEVICE_API void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.32x32b.x4.b32 [%0], {%1, %2, %3, %4};"
@@ -2520,7 +2520,7 @@ __device__ static inline void tcgen05_st_32x32b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
+_CCCL_DEVICE_API void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.32x32b.x4.unpack::16b.b32 [%0], {%1, %2, %3, %4};"
@@ -2543,7 +2543,7 @@ __device__ static inline void tcgen05_st_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
+_CCCL_DEVICE_API void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.32x32b.x8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
@@ -2570,7 +2570,7 @@ __device__ static inline void tcgen05_st_32x32b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
+_CCCL_DEVICE_API void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.32x32b.x8.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
@@ -2597,7 +2597,7 @@ __device__ static inline void tcgen05_st_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
+_CCCL_DEVICE_API void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.32x32b.x16.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
@@ -2633,7 +2633,7 @@ __device__ static inline void tcgen05_st_32x32b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
+_CCCL_DEVICE_API void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm("tcgen05.st.sync.aligned.32x32b.x16.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
@@ -2669,7 +2669,7 @@ __device__ static inline void tcgen05_st_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
+_CCCL_DEVICE_API void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2722,7 +2722,7 @@ __device__ static inline void tcgen05_st_32x32b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
+_CCCL_DEVICE_API void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2775,7 +2775,7 @@ __device__ static inline void tcgen05_st_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
+_CCCL_DEVICE_API void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2862,7 +2862,7 @@ __device__ static inline void tcgen05_st_32x32b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
+_CCCL_DEVICE_API void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -2949,7 +2949,7 @@ __device__ static inline void tcgen05_st_32x32b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
+_CCCL_DEVICE_API void tcgen05_st_32x32b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -3103,7 +3103,7 @@ __device__ static inline void tcgen05_st_32x32b_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
+_CCCL_DEVICE_API void tcgen05_st_32x32b_unpack_16b(::cuda::std::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
   asm(
@@ -3258,7 +3258,7 @@ __device__ static inline void tcgen05_st_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[1])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3282,7 +3282,7 @@ __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2_unpack_16b(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2_unpack_16b(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[1])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3305,7 +3305,7 @@ __device__ static inline void tcgen05_st_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3330,7 +3330,7 @@ __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2_unpack_16b(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2_unpack_16b(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3354,7 +3354,7 @@ __device__ static inline void tcgen05_st_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3381,7 +3381,7 @@ __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2_unpack_16b(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2_unpack_16b(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3407,7 +3407,7 @@ __device__ static inline void tcgen05_st_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3438,7 +3438,7 @@ __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2_unpack_16b(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2_unpack_16b(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3468,7 +3468,7 @@ __device__ static inline void tcgen05_st_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3508,7 +3508,7 @@ __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2_unpack_16b(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2_unpack_16b(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3547,7 +3547,7 @@ __device__ static inline void tcgen05_st_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3604,7 +3604,7 @@ __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2_unpack_16b(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2_unpack_16b(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3660,7 +3660,7 @@ __device__ static inline void tcgen05_st_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3751,7 +3751,7 @@ __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2_unpack_16b(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2_unpack_16b(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3841,7 +3841,7 @@ __device__ static inline void tcgen05_st_16x32bx2(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
@@ -3999,7 +3999,7 @@ __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tcgen05_st_16x32bx2_unpack_16b(
+_CCCL_DEVICE_API void tcgen05_st_16x32bx2_unpack_16b(
   ::cuda::std::uint32_t __taddr, ::cuda::ptx::n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_wait.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_wait.h
@@ -13,7 +13,7 @@ __device__ static inline void tcgen05_wait_ld();
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void tcgen05_wait_ld()
+_CCCL_DEVICE_API void tcgen05_wait_ld()
 {
   asm volatile("tcgen05.wait::ld.sync.aligned;" : : : "memory");
 }
@@ -26,7 +26,7 @@ __device__ static inline void tcgen05_wait_st();
 */
 #if __cccl_ptx_isa >= 860
 template <typename = void>
-_CCCL_DEVICE static inline void tcgen05_wait_st()
+_CCCL_DEVICE_API void tcgen05_wait_st()
 {
   asm volatile("tcgen05.wait::st.sync.aligned;" : : : "memory");
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tensormap_cp_fenceproxy.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tensormap_cp_fenceproxy.h
@@ -21,7 +21,7 @@ __device__ static inline void tensormap_cp_fenceproxy(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32, ::cuda::ptx::dot_scope _Scope>
-_CCCL_DEVICE static inline void tensormap_cp_fenceproxy(
+_CCCL_DEVICE_API void tensormap_cp_fenceproxy(
   ::cuda::ptx::sem_release_t,
   ::cuda::ptx::scope_t<_Scope> __scope,
   void* __dst,

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tensormap_replace.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tensormap_replace.h
@@ -18,8 +18,7 @@ __device__ static inline void tensormap_replace_global_address(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void
-tensormap_replace_global_address(::cuda::ptx::space_global_t, void* __tm_addr, _B64 __new_val)
+_CCCL_DEVICE_API void tensormap_replace_global_address(::cuda::ptx::space_global_t, void* __tm_addr, _B64 __new_val)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -42,8 +41,7 @@ __device__ static inline void tensormap_replace_global_address(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void
-tensormap_replace_global_address(::cuda::ptx::space_shared_t, void* __tm_addr, _B64 __new_val)
+_CCCL_DEVICE_API void tensormap_replace_global_address(::cuda::ptx::space_shared_t, void* __tm_addr, _B64 __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
@@ -66,7 +64,7 @@ __device__ static inline void tensormap_replace_rank(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tensormap_replace_rank(::cuda::ptx::space_global_t, void* __tm_addr, _B32 __new_val)
+_CCCL_DEVICE_API void tensormap_replace_rank(::cuda::ptx::space_global_t, void* __tm_addr, _B32 __new_val)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -89,7 +87,7 @@ __device__ static inline void tensormap_replace_rank(
 */
 #if __cccl_ptx_isa >= 830
 template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tensormap_replace_rank(::cuda::ptx::space_shared_t, void* __tm_addr, _B32 __new_val)
+_CCCL_DEVICE_API void tensormap_replace_rank(::cuda::ptx::space_shared_t, void* __tm_addr, _B32 __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
@@ -113,7 +111,7 @@ __device__ static inline void tensormap_replace_box_dim(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tensormap_replace_box_dim(::cuda::ptx::space_global_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __ord, _B32 __new_val)
 {
   // __space == space_global (due to parameter type constraint)
@@ -140,7 +138,7 @@ __device__ static inline void tensormap_replace_box_dim(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tensormap_replace_box_dim(::cuda::ptx::space_shared_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __ord, _B32 __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -167,7 +165,7 @@ __device__ static inline void tensormap_replace_global_dim(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tensormap_replace_global_dim(
+_CCCL_DEVICE_API void tensormap_replace_global_dim(
   ::cuda::ptx::space_global_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __ord, _B32 __new_val)
 {
   // __space == space_global (due to parameter type constraint)
@@ -194,7 +192,7 @@ __device__ static inline void tensormap_replace_global_dim(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tensormap_replace_global_dim(
+_CCCL_DEVICE_API void tensormap_replace_global_dim(
   ::cuda::ptx::space_shared_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __ord, _B32 __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -221,7 +219,7 @@ __device__ static inline void tensormap_replace_global_stride(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32, typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void tensormap_replace_global_stride(
+_CCCL_DEVICE_API void tensormap_replace_global_stride(
   ::cuda::ptx::space_global_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __ord, _B64 __new_val)
 {
   // __space == space_global (due to parameter type constraint)
@@ -248,7 +246,7 @@ __device__ static inline void tensormap_replace_global_stride(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32, typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void tensormap_replace_global_stride(
+_CCCL_DEVICE_API void tensormap_replace_global_stride(
   ::cuda::ptx::space_shared_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __ord, _B64 __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -275,7 +273,7 @@ __device__ static inline void tensormap_replace_element_stride(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tensormap_replace_element_stride(
+_CCCL_DEVICE_API void tensormap_replace_element_stride(
   ::cuda::ptx::space_global_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __ord, _B32 __new_val)
 {
   // __space == space_global (due to parameter type constraint)
@@ -302,7 +300,7 @@ __device__ static inline void tensormap_replace_element_stride(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tensormap_replace_element_stride(
+_CCCL_DEVICE_API void tensormap_replace_element_stride(
   ::cuda::ptx::space_shared_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __ord, _B32 __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -329,7 +327,7 @@ __device__ static inline void tensormap_replace_element_size(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tensormap_replace_element_size(
+_CCCL_DEVICE_API void tensormap_replace_element_size(
   ::cuda::ptx::space_global_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __ord, _B32 __new_val)
 {
   // __space == space_global (due to parameter type constraint)
@@ -356,7 +354,7 @@ __device__ static inline void tensormap_replace_element_size(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32, typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void tensormap_replace_element_size(
+_CCCL_DEVICE_API void tensormap_replace_element_size(
   ::cuda::ptx::space_shared_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __ord, _B32 __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -382,7 +380,7 @@ __device__ static inline void tensormap_replace_elemtype(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tensormap_replace_elemtype(::cuda::ptx::space_global_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __new_val)
 {
   // __space == space_global (due to parameter type constraint)
@@ -405,7 +403,7 @@ __device__ static inline void tensormap_replace_elemtype(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tensormap_replace_elemtype(::cuda::ptx::space_shared_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -428,7 +426,7 @@ __device__ static inline void tensormap_replace_interleave_layout(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tensormap_replace_interleave_layout(::cuda::ptx::space_global_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __new_val)
 {
   // __space == space_global (due to parameter type constraint)
@@ -451,7 +449,7 @@ __device__ static inline void tensormap_replace_interleave_layout(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tensormap_replace_interleave_layout(::cuda::ptx::space_shared_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -474,7 +472,7 @@ __device__ static inline void tensormap_replace_swizzle_mode(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tensormap_replace_swizzle_mode(::cuda::ptx::space_global_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __new_val)
 {
   // __space == space_global (due to parameter type constraint)
@@ -497,7 +495,7 @@ __device__ static inline void tensormap_replace_swizzle_mode(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tensormap_replace_swizzle_mode(::cuda::ptx::space_shared_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -520,7 +518,7 @@ __device__ static inline void tensormap_replace_fill_mode(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tensormap_replace_fill_mode(::cuda::ptx::space_global_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __new_val)
 {
   // __space == space_global (due to parameter type constraint)
@@ -543,7 +541,7 @@ __device__ static inline void tensormap_replace_fill_mode(
 */
 #if __cccl_ptx_isa >= 830
 template <int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tensormap_replace_fill_mode(::cuda::ptx::space_shared_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
@@ -566,7 +564,7 @@ __device__ static inline void tensormap_replace_swizzle_atomicity(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tensormap_replace_swizzle_atomicity(::cuda::ptx::space_global_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __new_val)
 {
   // __space == space_global (due to parameter type constraint)
@@ -589,7 +587,7 @@ __device__ static inline void tensormap_replace_swizzle_atomicity(
 */
 #if __cccl_ptx_isa >= 860
 template <int _N32>
-_CCCL_DEVICE static inline void
+_CCCL_DEVICE_API void
 tensormap_replace_swizzle_atomicity(::cuda::ptx::space_shared_t, void* __tm_addr, ::cuda::ptx::n32_t<_N32> __new_val)
 {
   // __space == space_shared (due to parameter type constraint)

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/trap.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/trap.h
@@ -13,7 +13,7 @@ __device__ static inline void trap();
 */
 #if __cccl_ptx_isa >= 100
 template <typename = void>
-_CCCL_DEVICE static inline void trap()
+_CCCL_DEVICE_API void trap()
 {
   asm volatile("trap;" : : :);
 }

--- a/libcudacxx/include/cuda/__ptx/instructions/shfl_sync.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/shfl_sync.h
@@ -43,8 +43,8 @@ enum class __dot_shfl_mode
 };
 
 [[maybe_unused]]
-_CCCL_DEVICE_API
-uint32_t __shfl_sync_dst_lane(__dot_shfl_mode __shfl_mode, uint32_t __lane_idx_offset, uint32_t __clamp_segmask)
+_CCCL_DEVICE_API inline uint32_t
+__shfl_sync_dst_lane(__dot_shfl_mode __shfl_mode, uint32_t __lane_idx_offset, uint32_t __clamp_segmask)
 {
   auto __lane     = ::cuda::ptx::get_sreg_laneid();
   auto __clamp    = __clamp_segmask & 0b11111;

--- a/libcudacxx/include/cuda/__ptx/instructions/shfl_sync.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/shfl_sync.h
@@ -43,8 +43,8 @@ enum class __dot_shfl_mode
 };
 
 [[maybe_unused]]
-_CCCL_DEVICE static inline uint32_t
-__shfl_sync_dst_lane(__dot_shfl_mode __shfl_mode, uint32_t __lane_idx_offset, uint32_t __clamp_segmask)
+_CCCL_DEVICE_API
+uint32_t __shfl_sync_dst_lane(__dot_shfl_mode __shfl_mode, uint32_t __lane_idx_offset, uint32_t __clamp_segmask)
 {
   auto __lane     = ::cuda::ptx::get_sreg_laneid();
   auto __clamp    = __clamp_segmask & 0b11111;
@@ -75,7 +75,7 @@ __shfl_sync_dst_lane(__dot_shfl_mode __shfl_mode, uint32_t __lane_idx_offset, ui
 }
 
 template <typename _Tp>
-_CCCL_DEVICE static inline void __shfl_sync_checks(
+_CCCL_DEVICE_API void __shfl_sync_checks(
   __dot_shfl_mode __shfl_mode,
   _Tp,
   [[maybe_unused]] uint32_t __lane_idx_offset,
@@ -95,7 +95,7 @@ _CCCL_DEVICE static inline void __shfl_sync_checks(
 }
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_DEVICE static inline _Tp shfl_sync_idx(
+[[nodiscard]] _CCCL_DEVICE_API _Tp shfl_sync_idx(
   _Tp __data, bool& __pred, uint32_t __lane_idx_offset, uint32_t __clamp_segmask, uint32_t __lane_mask) noexcept
 {
   ::cuda::ptx::__shfl_sync_checks(__dot_shfl_mode::__idx, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
@@ -115,7 +115,7 @@ template <typename _Tp>
 }
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_DEVICE static inline _Tp
+[[nodiscard]] _CCCL_DEVICE_API _Tp
 shfl_sync_idx(_Tp __data, uint32_t __lane_idx_offset, uint32_t __clamp_segmask, uint32_t __lane_mask) noexcept
 {
   ::cuda::ptx::__shfl_sync_checks(__dot_shfl_mode::__idx, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
@@ -130,7 +130,7 @@ shfl_sync_idx(_Tp __data, uint32_t __lane_idx_offset, uint32_t __clamp_segmask, 
 }
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_DEVICE static inline _Tp shfl_sync_up(
+[[nodiscard]] _CCCL_DEVICE_API _Tp shfl_sync_up(
   _Tp __data, bool& __pred, uint32_t __lane_idx_offset, uint32_t __clamp_segmask, uint32_t __lane_mask) noexcept
 {
   ::cuda::ptx::__shfl_sync_checks(__dot_shfl_mode::__up, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
@@ -150,7 +150,7 @@ template <typename _Tp>
 }
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_DEVICE static inline _Tp
+[[nodiscard]] _CCCL_DEVICE_API _Tp
 shfl_sync_up(_Tp __data, uint32_t __lane_idx_offset, uint32_t __clamp_segmask, uint32_t __lane_mask) noexcept
 {
   ::cuda::ptx::__shfl_sync_checks(__dot_shfl_mode::__up, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
@@ -165,7 +165,7 @@ shfl_sync_up(_Tp __data, uint32_t __lane_idx_offset, uint32_t __clamp_segmask, u
 }
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_DEVICE static inline _Tp shfl_sync_down(
+[[nodiscard]] _CCCL_DEVICE_API _Tp shfl_sync_down(
   _Tp __data, bool& __pred, uint32_t __lane_idx_offset, uint32_t __clamp_segmask, uint32_t __lane_mask) noexcept
 {
   ::cuda::ptx::__shfl_sync_checks(__dot_shfl_mode::__down, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
@@ -185,7 +185,7 @@ template <typename _Tp>
 }
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_DEVICE static inline _Tp
+[[nodiscard]] _CCCL_DEVICE_API _Tp
 shfl_sync_down(_Tp __data, uint32_t __lane_idx_offset, uint32_t __clamp_segmask, uint32_t __lane_mask) noexcept
 {
   ::cuda::ptx::__shfl_sync_checks(__dot_shfl_mode::__down, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
@@ -200,7 +200,7 @@ shfl_sync_down(_Tp __data, uint32_t __lane_idx_offset, uint32_t __clamp_segmask,
 }
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_DEVICE static inline _Tp shfl_sync_bfly(
+[[nodiscard]] _CCCL_DEVICE_API _Tp shfl_sync_bfly(
   _Tp __data, bool& __pred, uint32_t __lane_idx_offset, uint32_t __clamp_segmask, uint32_t __lane_mask) noexcept
 {
   ::cuda::ptx::__shfl_sync_checks(__dot_shfl_mode::__bfly, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
@@ -220,7 +220,7 @@ template <typename _Tp>
 }
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_DEVICE static inline _Tp
+[[nodiscard]] _CCCL_DEVICE_API _Tp
 shfl_sync_bfly(_Tp __data, uint32_t __lane_idx_offset, uint32_t __clamp_segmask, uint32_t __lane_mask) noexcept
 {
   ::cuda::ptx::__shfl_sync_checks(__dot_shfl_mode::__bfly, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Equivalent to the MR in the ptx repo but done here first to find any issues with _quirky_ compilers first.

This PR is quite literally
```sh
$ sed 's/_CCCL_DEVICE\s+static\s+inline\s+/_CCCL_DEVICE_API /g'
```

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
