### PR TITLE
Error early when the CUDA backend is used without a CUDA compiler

### DIFF
--- a/thrust/thrust/system/cuda/config.h
+++ b/thrust/thrust/system/cuda/config.h
@@ -15,9 +15,9 @@
 
 // #806: without a CUDA compiler this backend otherwise fails with a flood of unrelated errors inside CUB.
 #if !_CCCL_CUDA_COMPILATION() && !defined(THRUST_IGNORE_CUDA_COMPILER_CHECK)
-#  error The Thrust CUDA device system requires a CUDA compiler. Either compile as CUDA, or set \
+#  error "The Thrust CUDA device system requires a CUDA compiler. Either compile as CUDA, or set \
 THRUST_DEVICE_SYSTEM to THRUST_DEVICE_SYSTEM_CPP, THRUST_DEVICE_SYSTEM_OMP, or THRUST_DEVICE_SYSTEM_TBB. \
-Define THRUST_IGNORE_CUDA_COMPILER_CHECK to ignore this.
+Define THRUST_IGNORE_CUDA_COMPILER_CHECK to ignore this."
 #endif
 
 #ifdef THRUST_DEBUG_SYNC

--- a/thrust/thrust/system/cuda/config.h
+++ b/thrust/thrust/system/cuda/config.h
@@ -13,10 +13,12 @@
 #  pragma system_header
 #endif // no system header
 
-#if !_CCCL_CUDA_COMPILATION() && !defined(THRUST_IGNORE_CUDA_COMPILER_CHECK)
-#  error "The Thrust CUDA device system requires a CUDA compiler. Either compile as CUDA, or set \
-THRUST_DEVICE_SYSTEM to THRUST_DEVICE_SYSTEM_CPP, THRUST_DEVICE_SYSTEM_OMP, or THRUST_DEVICE_SYSTEM_TBB. \
-Define THRUST_IGNORE_CUDA_COMPILER_CHECK to ignore this."
+// A host translation unit is fine with just the CTK headers: the CUDA backend's algorithms are guarded by
+// _CCCL_CUDA_COMPILATION(), so only the types and execution policies remain, and those need the CTK and nothing more.
+#if !_CCCL_CUDA_COMPILATION() && !_CCCL_HAS_CTK() && !defined(THRUST_IGNORE_CUDA_COMPILER_CHECK)
+#  error "The Thrust CUDA device system requires a CUDA compiler or the CUDA toolkit headers. Either compile as CUDA, \
+make the CUDA toolkit headers available, or set THRUST_DEVICE_SYSTEM to THRUST_DEVICE_SYSTEM_CPP, \
+THRUST_DEVICE_SYSTEM_OMP, or THRUST_DEVICE_SYSTEM_TBB. Define THRUST_IGNORE_CUDA_COMPILER_CHECK to ignore this."
 #endif
 
 #ifdef THRUST_DEBUG_SYNC

--- a/thrust/thrust/system/cuda/config.h
+++ b/thrust/thrust/system/cuda/config.h
@@ -13,6 +13,13 @@
 #  pragma system_header
 #endif // no system header
 
+// #806: without a CUDA compiler this backend otherwise fails with a flood of unrelated errors inside CUB.
+#if !_CCCL_CUDA_COMPILATION() && !defined(THRUST_IGNORE_CUDA_COMPILER_CHECK)
+#  error The Thrust CUDA device system requires a CUDA compiler. Either compile as CUDA, or set \
+THRUST_DEVICE_SYSTEM to THRUST_DEVICE_SYSTEM_CPP, THRUST_DEVICE_SYSTEM_OMP, or THRUST_DEVICE_SYSTEM_TBB. \
+Define THRUST_IGNORE_CUDA_COMPILER_CHECK to ignore this.
+#endif
+
 #ifdef THRUST_DEBUG_SYNC
 
 #  if _CCCL_COMPILER(MSVC)

--- a/thrust/thrust/system/cuda/config.h
+++ b/thrust/thrust/system/cuda/config.h
@@ -13,7 +13,6 @@
 #  pragma system_header
 #endif // no system header
 
-// #806: without a CUDA compiler this backend otherwise fails with a flood of unrelated errors inside CUB.
 #if !_CCCL_CUDA_COMPILATION() && !defined(THRUST_IGNORE_CUDA_COMPILER_CHECK)
 #  error "The Thrust CUDA device system requires a CUDA compiler. Either compile as CUDA, or set \
 THRUST_DEVICE_SYSTEM to THRUST_DEVICE_SYSTEM_CPP, THRUST_DEVICE_SYSTEM_OMP, or THRUST_DEVICE_SYSTEM_TBB. \

--- a/thrust/thrust/system/cuda/config.h
+++ b/thrust/thrust/system/cuda/config.h
@@ -16,7 +16,8 @@
 // A host translation unit is fine with just the CTK headers: the CUDA backend's algorithms are guarded by
 // _CCCL_CUDA_COMPILATION(), so only the types and execution policies remain, and those need the CTK and nothing more.
 #if !_CCCL_CUDA_COMPILATION() && !_CCCL_HAS_CTK() && !defined(THRUST_IGNORE_CUDA_COMPILER_CHECK)
-#  error "The Thrust CUDA device system requires a CUDA compiler or the CUDA toolkit headers. Either compile as CUDA, \
+#  error \
+    "The Thrust CUDA device system requires a CUDA compiler or the CUDA toolkit headers. Either compile as CUDA, \
 make the CUDA toolkit headers available, or set THRUST_DEVICE_SYSTEM to THRUST_DEVICE_SYSTEM_CPP, \
 THRUST_DEVICE_SYSTEM_OMP, or THRUST_DEVICE_SYSTEM_TBB. Define THRUST_IGNORE_CUDA_COMPILER_CHECK to ignore this."
 #endif


### PR DESCRIPTION
Including a Thrust header with the default CUDA device system and a non-CUDA compiler failed with ~1300 unrelated CUB errors, starting with `unknown type name 'cudaError_t'`, none of which named the cause.

This adds a check in `thrust/system/cuda/config.h` that reports it directly:

```
The Thrust CUDA device system requires a CUDA compiler. Either compile as CUDA,
or set THRUST_DEVICE_SYSTEM to THRUST_DEVICE_SYSTEM_CPP, THRUST_DEVICE_SYSTEM_OMP,
or THRUST_DEVICE_SYSTEM_TBB. Define THRUST_IGNORE_CUDA_COMPILER_CHECK to ignore this.
```

It goes in `thrust/system/cuda/config.h` rather than `thrust/detail/config/device_system.h` because `thrust/version.h` includes the latter and compiles fine without CUDA today. Placed here it also fires before CUB is pulled in, so the useful line comes first. It does not reduce the total error count, since `#error` does not stop preprocessing.

Tested with clang++ and g++, C++17 and C++20:

- message is now the first error for `host_vector`, `sort`, `universal_vector` and `device_vector`
- `thrust/version.h` still compiles
- `THRUST_DEVICE_SYSTEM=CPP` unaffected, 0 errors
- silent under `__CUDACC__` and `_NVHPC_CUDA`
- `THRUST_IGNORE_CUDA_COMPILER_CHECK` restores the previous behavior

No test is included: Thrust has no compile-failure test targets and all of its tests are `.cu`, so there is no harness for a non-CUDA translation unit. The existing `THRUST_IGNORE_CUB_VERSION_CHECK` error in the same file is untested for the same reason. Happy to add one if you'd like it wired up.

Fixes #806
