### PR TITLE
[libcu++] Enable `sub.sat.s32` in CUDA 13

### DIFF
--- a/libcudacxx/include/cuda/std/__numeric/saturating_sub.h
+++ b/libcudacxx/include/cuda/std/__numeric/saturating_sub.h
@@ -139,13 +139,15 @@ template <class _Tp>
       // sub.sat.s16x2 doesn't exist for now
       return ::cuda::std::saturating_cast<_Tp>(int32_t{__x} - int32_t{__y});
     }
-    // Disabled due to nvbug 5033045
-    // else if constexpr (sizeof(_Tp) == sizeof(int32_t))
-    // {
-    //   int32_t __result;
-    //   asm volatile("sub.sat.s32 %0, %1, %2;" : "=r"(__result) : "r"(__x), "r"(__y));
-    //   return __result;
-    // }
+    // Disabled in CUDA < 13.0 due to nvbug 5033045. Use CUDACC for the check, because we care about the ptxas version.
+#  if _CCCL_CUDACC_AT_LEAST(13, 0)
+    else if constexpr (sizeof(_Tp) == sizeof(int32_t))
+    {
+      int32_t __result;
+      asm volatile("sub.sat.s32 %0, %1, %2;" : "=r"(__result) : "r"(__x), "r"(__y));
+      return __result;
+    }
+#  endif // _CCCL_CUDACC_AT_LEAST(13, 0)
     else
     {
       return ::cuda::saturating_sub_overflow(__x, __y).value;


### PR DESCRIPTION
The nvbug has been resolved, the fix is available since CUDA 13.0.