### PR TITLE
[libcu++] Add `TREAT_WARNINGS_AS_ERRORS.` `lit` parser

### DIFF
--- a/libcudacxx/test/libcudacxx/libcxx/macros/lifetime_bound.compile.fail.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/macros/lifetime_bound.compile.fail.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // FORCE_ALL_WARNINGS.
+// TREAT_WARNINGS_AS_ERRORS.
 
 #include <cuda/std/__cccl/attributes.h>
 

--- a/libcudacxx/test/utils/libcudacxx/compiler.py
+++ b/libcudacxx/test/utils/libcudacxx/compiler.py
@@ -30,6 +30,7 @@ class CXXCompiler(object):
         verify_supported=None,
         verify_flags=None,
         use_verify=False,
+        treat_warnings_as_errors=False,
         modules_flags=None,
         use_modules=False,
         use_ccache=False,
@@ -48,6 +49,7 @@ class CXXCompiler(object):
         self.warning_flags = list(warning_flags or [])
         self.verify_supported = verify_supported
         self.use_verify = use_verify
+        self.treat_warnings_as_errors = treat_warnings_as_errors
         self.verify_flags = list(verify_flags or [])
         assert not use_verify or verify_supported
         assert not use_verify or verify_flags is not None
@@ -94,6 +96,9 @@ class CXXCompiler(object):
 
     def useWarnings(self, value=True):
         self.use_warnings = value
+
+    def treatWarningsAsErrors(self, value=True):
+        self.treat_warnings_as_errors = value
 
     def _initTypeAndVersion(self):
         # Get compiler type and version
@@ -206,6 +211,10 @@ class CXXCompiler(object):
         if self.use_verify:
             cmd += self.verify_flags
             assert mode in [self.CM_Default, self.CM_Compile]
+        if self.treat_warnings_as_errors:
+            if self.type == "nvcc":
+                cmd += ["-Werror=all-warnings", "-Xcompiler"]
+            cmd += ["/WX"]
         if self.use_modules:
             cmd += self.modules_flags
         if mode != self.CM_Link:
@@ -263,6 +272,13 @@ class CXXCompiler(object):
         if self.use_verify:
             cmd += self.verify_flags
             assert mode in [self.CM_Default, self.CM_Compile]
+        if self.treat_warnings_as_errors:
+            if self.type == "nvcc":
+                host_cxx_type = self.host_cxx.type
+                cmd += ["-Werror=all-warnings", "-Xcompiler"]
+            else:
+                host_cxx_type = self.type
+            cmd += ["/WX"] if host_cxx_type == "msvc" else ["-Werror"]
         if self.use_modules:
             cmd += self.modules_flags
         if mode != self.CM_Link:

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -1231,14 +1231,11 @@ class Configuration(object):
         enable_warnings = self.get_lit_bool("enable_warnings", default_enable_warnings)
         enable_pedantic = self.get_lit_bool("enable_pedantic_warnings", default=True)
         self.cxx.useWarnings(enable_warnings)
+        self.cxx.treatWarningsAsErrors(enable_pedantic)
         if "nvcc" in self.config.available_features:
             self.cxx.warning_flags += ["-Xcudafe", "--display_error_number"]
-            if enable_pedantic:
-                self.cxx.warning_flags += ["-Werror=all-warnings"]
             if "msvc" in self.config.available_features:
                 self.cxx.warning_flags += ["-Xcompiler", "/W4"]
-                if enable_pedantic:
-                    self.cxx.warning_flags += ["-Xcompiler", "/WX"]
                 # warning C4100: 'quack': unreferenced formal parameter
                 self.cxx.warning_flags += ["-Xcompiler", "-wd4100"]
                 # warning C4127: conditional expression is constant
@@ -1262,8 +1259,6 @@ class Configuration(object):
 
                 addIfHostSupports("-Wall")
                 addIfHostSupports("-Wextra")
-                if enable_pedantic:
-                    addIfHostSupports("-Werror")
                 if "gcc" in self.config.available_features:
                     addIfHostSupports(
                         "-Wno-literal-suffix"
@@ -1298,7 +1293,6 @@ class Configuration(object):
             if enable_pedantic:
                 self.cxx.warning_flags += [
                     "-D_LIBCUDACXX_DISABLE_PRAGMA_GCC_SYSTEM_HEADER",
-                    "-Werror",
                 ]
             if self.cxx.hasWarningFlag("-Wuser-defined-warnings"):
                 self.cxx.warning_flags += ["-Wuser-defined-warnings"]

--- a/libcudacxx/test/utils/libcudacxx/test/format.py
+++ b/libcudacxx/test/utils/libcudacxx/test/format.py
@@ -63,6 +63,9 @@ class LibcxxTestFormat(object):
                 "FORCE_ALL_WARNINGS.", ParserKind.TAG, initial_value=False
             ),
             IntegratedTestKeywordParser(
+                "TREAT_WARNINGS_AS_ERRORS.", ParserKind.TAG, initial_value=False
+            ),
+            IntegratedTestKeywordParser(
                 "MODULES_DEFINES:", ParserKind.LIST, initial_value=[]
             ),
             IntegratedTestKeywordParser(
@@ -168,11 +171,17 @@ class LibcxxTestFormat(object):
         if is_fail_test:
             test_cxx.useCCache(False)
             test_cxx.useWarnings(False)
+            test_cxx.treatWarningsAsErrors(False)
 
         force_all_warnings = self._get_parser("FORCE_ALL_WARNINGS.", parsers).getValue()
-
         if force_all_warnings:
             test_cxx.useWarnings(True)
+
+        treat_warnings_as_errors = self._get_parser(
+            "TREAT_WARNINGS_AS_ERRORS.", parsers
+        ).getValue()
+        if treat_warnings_as_errors:
+            test_cxx.treatWarningsAsErrors()
 
         extra_compile_definitions = self._get_parser(
             "ADDITIONAL_COMPILE_DEFINITIONS:", parsers


### PR DESCRIPTION
This PR introduces the `TREAT_WARNINGS_AS_ERRORS.` `lit` parser, so we can force the `-Werror` flags from within the test file independently on whether we are compiling in pedantic mode or not.

Fixes nvbug 6208829.