### PR TITLE
Avoid use of `__input`/`__output`

### DIFF
--- a/cudax/include/cuda/experimental/__copy_bytes/simplify_paired.cuh
+++ b/cudax/include/cuda/experimental/__copy_bytes/simplify_paired.cuh
@@ -38,21 +38,21 @@ namespace cuda::experimental
 //!
 //! This helps to get a single logic for __tile_iterator_linearized
 //!
-//! @param[in] __input Raw tensor whose modes are reversed
+//! @param[in] __tensor Raw tensor whose modes are reversed
 //! @return New raw tensor with extents and strides in reversed mode order
 template <typename _ExtentT, typename _StrideT, typename _Tp, ::cuda::std::size_t _MaxRank>
 [[nodiscard]] _CCCL_HOST_API __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>
-__reverse_modes(const __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>& __input) noexcept
+__reverse_modes(const __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>& __tensor) noexcept
 {
   using __raw_tensor_t = __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>;
   using __rank_t       = typename __raw_tensor_t::__rank_t;
-  __raw_tensor_t __result{__input.__data, __input.__rank, {}, {}};
-  _CCCL_ASSERT(__input.__rank > 0, "cudax::reverse_modes: input tensor must have rank > 0");
-  for (__rank_t __i = 0; __i < __input.__rank; ++__i)
+  __raw_tensor_t __result{__tensor.__data, __tensor.__rank, {}, {}};
+  _CCCL_ASSERT(__tensor.__rank > 0, "cudax::reverse_modes: input tensor must have rank > 0");
+  for (__rank_t __i = 0; __i < __tensor.__rank; ++__i)
   {
-    const auto __j          = __input.__rank - 1 - __i;
-    __result.__extents[__i] = __input.__extents[__j];
-    __result.__strides[__i] = __input.__strides[__j];
+    const auto __j          = __tensor.__rank - 1 - __i;
+    __result.__extents[__i] = __tensor.__extents[__j];
+    __result.__strides[__i] = __tensor.__strides[__j];
   }
   return __result;
 }

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/segmented_reduce.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/segmented_reduce.h
@@ -504,14 +504,14 @@ _CCCL_HOST_API void segmented_reduce(
 //! @param[in] __policy The result policy object. Currently must be `cudax::broadcasted`.
 //! @param[in] __comm The communicator.
 //! @param[in] __env The execution environment. Must contain a stream.
-//! @param[in] __input The input iterator to reduce.
-//! @param[in] __num_segments The number of segments in `__input`. Must be identical on every
+//! @param[in] __input_it The input iterator to reduce.
+//! @param[in] __num_segments The number of segments in `__input_it`. Must be identical on every
 //!                           rank.
 //! @param[in] __offset_begin The iterator to the segment begin offsets. Must be readable for
 //!                           `__num_segments` values.
 //! @param[in] __offset_end The iterator to the segment end offsets. Must be readable for
 //!                         `__num_segments` values.
-//! @param[out] __output The output iterator receiving the per-segment results. Must be writable
+//! @param[out] __output_it The output iterator receiving the per-segment results. Must be writable
 //!                      for `__num_segments` values.
 //! @param[in] __init The initial value seeding each segment reduction.
 //! @param[in] __op The binary reduction operator.
@@ -535,11 +535,11 @@ _CCCL_HOST_API void segmented_reduce(
   const __result_policy_base<_Policy>& __policy,
   _Comm&& __comm,
   _Env&& __env,
-  _InputIter __input,
+  _InputIter __input_it,
   ::cuda::std::size_t __num_segments,
   _OffsetBeginIter __offset_begin,
   _OffsetEndIter __offset_end,
-  _OutputIter __output,
+  _OutputIter __output_it,
   _Tp __init     = {},
   _BinaryOp __op = {},
   _Tp __ident    = ::cuda::identity_element<_BinaryOp, _Tp>())
@@ -548,11 +548,11 @@ _CCCL_HOST_API void segmented_reduce(
     __policy,
     ::cuda::std::span<::cuda::std::remove_reference_t<_Comm>, 1>{::cuda::std::addressof(__comm), 1},
     ::cuda::std::span<::cuda::std::remove_reference_t<_Env>, 1>{::cuda::std::addressof(__env), 1},
-    ::cuda::std::span<_InputIter, 1>{::cuda::std::addressof(__input), 1},
+    ::cuda::std::span<_InputIter, 1>{::cuda::std::addressof(__input_it), 1},
     __num_segments,
     ::cuda::std::span<_OffsetBeginIter, 1>{::cuda::std::addressof(__offset_begin), 1},
     ::cuda::std::span<_OffsetEndIter, 1>{::cuda::std::addressof(__offset_end), 1},
-    ::cuda::std::span<_OutputIter, 1>{::cuda::std::addressof(__output), 1},
+    ::cuda::std::span<_OutputIter, 1>{::cuda::std::addressof(__output_it), 1},
     ::cuda::std::move(__init),
     ::cuda::std::move(__op),
     ::cuda::std::move(__ident));

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/merge_k_way.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/merge_k_way.h
@@ -122,10 +122,10 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__merge_k_way_tree(
       // the next level
       const auto __next_level_node = __next_level_buffer->subspan(__next_off, __left_node.size());
 
-      const auto __input  = ::cuda::std::mdspan{__left_node.data(), __left_node.size()};
-      const auto __output = ::cuda::std::mdspan{__next_level_node.data(), __next_level_node.size()};
+      const auto __src = ::cuda::std::mdspan{__left_node.data(), __left_node.size()};
+      const auto __dst = ::cuda::std::mdspan{__next_level_node.data(), __next_level_node.size()};
 
-      __CUDAX_MULTI_GPU_DISPATCH(__comm.logical_device(), CUB_NS_QUALIFIER::DeviceCopy::Copy, __input, __output, __env);
+      __CUDAX_MULTI_GPU_DISPATCH(__comm.logical_device(), CUB_NS_QUALIFIER::DeviceCopy::Copy, __src, __dst, __env);
 
       __next_level.push_back(__next_level_node);
     }

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -299,7 +299,7 @@ _CCCL_HOST_API inline void __deviceGetName(char* __name_out, int __len, int __or
 [[nodiscard]] _CCCL_HOST_API inline ::CUdevResource __devSmResourceSplit(
   ::CUdevResource* __groups,
   unsigned int __n_groups,
-  const ::CUdevResource& __input,
+  const ::CUdevResource& __in_resource,
   ::CU_DEV_SM_RESOURCE_GROUP_PARAMS* __params)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDevSmResourceSplit);
@@ -310,7 +310,7 @@ _CCCL_HOST_API inline void __deviceGetName(char* __name_out, int __len, int __or
     "Failed to split the SM resource",
     __groups,
     __n_groups,
-    &__input,
+    &__in_resource,
     &__remainder,
     /*__flags*/ 0U,
     __params);


### PR DESCRIPTION
It's among our nasty macros, it's sometimes defined on Windows.