### PR TITLE
Get the current context from the stream not comm

### DIFF
--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/common.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/common.h
@@ -47,10 +47,10 @@
 
 namespace cuda::experimental::__detail
 {
-#define __CUDAX_MULTI_GPU_DISPATCH(__logical_device, __call, ...)                        \
+#define __CUDAX_MULTI_GPU_DISPATCH(__stream, __call, ...)                                \
   do                                                                                     \
   {                                                                                      \
-    const auto __cur_context = ::cuda::__ensure_current_context{__logical_device};       \
+    const auto __cur_context = ::cuda::__ensure_current_context{__stream};               \
     _CCCL_TRY_CUDA_API(__call, "performing " #__call "(" #__VA_ARGS__ ")", __VA_ARGS__); \
   } while (0)
 

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h
@@ -67,18 +67,8 @@ template <class _Buffer, class _Comm, class _Env, class _InputIt, class _SizeT, 
   const _BinaryOp& __op,
   const _Tp& __ident)
 {
-  const auto& __logical_device = __comm.logical_device();
-  // Workaround for the case where:
-  //
-  // 1. The stream is the NULL stream.
-  // 2. The resource is the default per-device memory resource.
-  // 3. There is no current context set.
-  //
-  // In this case cuMemAllocFromPool fails with INVALID_CONTEXT because the driver cannot pick
-  // an appropriate context to tie the allocation to.
-  const auto _                = ::cuda::__ensure_current_context{__logical_device};
   ::cuda::stream_ref __stream = ::cuda::get_stream(__env);
-  auto __resource             = ::cuda::experimental::__detail::__resource_from_env(__env, __logical_device);
+  auto __resource             = ::cuda::experimental::__detail::__resource_from_env(__env, __stream.__logical_device());
 
   // Allocate enough storage so that we can use the buffer directly in an in-place comm all
   // gather/all reduce call. Those calls require that the receive buffer is of size nranks *

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h
@@ -90,7 +90,7 @@ template <class _Buffer, class _Comm, class _Env, class _InputIt, class _SizeT, 
   const auto __rank = __comm.rank();
 
   __CUDAX_MULTI_GPU_DISPATCH(
-    __logical_device,
+    __stream,
     CUB_NS_QUALIFIER::DeviceReduce::Reduce,
     __input_it,
     // Similarly to above, prepare for the comm calls later. In order for those to be
@@ -146,7 +146,7 @@ _CCCL_HOST_API void __two_stage_gather_reduction(
        ::cuda::std::ranges::views::zip(__comms, __envs, *__partials, __outputs))
   {
     __CUDAX_MULTI_GPU_DISPATCH(
-      __comm.logical_device(),
+      __buffer.stream(),
       CUB_NS_QUALIFIER::DeviceReduce::Reduce,
       __buffer.begin(),
       __out,

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/segmented_reduce.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/segmented_reduce.h
@@ -103,7 +103,7 @@ template <bool __has_direct_reduction,
   const auto __rank = __comm.rank();
 
   __CUDAX_MULTI_GPU_DISPATCH(
-    __logical_device,
+    __stream,
     CUB_NS_QUALIFIER::DeviceSegmentedReduce::Reduce,
     __input_it,
     __buff.begin(),
@@ -169,7 +169,7 @@ _CCCL_HOST_API void __exchange_and_fold(
       auto __recv = __buf.subspan(__num_segments, __num_segments);
 
       __CUDAX_MULTI_GPU_DISPATCH(
-        __comm.logical_device(),
+        __buf.stream(),
         CUB_NS_QUALIFIER::DeviceTransform::Transform,
         ::cuda::std::make_tuple(__send.data(), __recv.data()),
         __send.data(),
@@ -295,11 +295,10 @@ _CCCL_HOST_API void __butterfly_reduction(
   // written to directly.
   //
   // All in all *probably* not worth the pain of implementing.
-  for (auto&& [__comm, __env, __local, __out_it] :
-       ::cuda::std::ranges::views::zip(__comms, __envs, *__partials, __outputs))
+  for (auto&& [__env, __local, __out_it] : ::cuda::std::ranges::views::zip(__envs, *__partials, __outputs))
   {
     __CUDAX_MULTI_GPU_DISPATCH(
-      __comm.logical_device(),
+      __local.stream(),
       CUB_NS_QUALIFIER::DeviceTransform::Transform,
       __local.data(),
       __out_it,

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/segmented_reduce.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/segmented_reduce.h
@@ -81,18 +81,8 @@ template <bool __has_direct_reduction,
   const _BinaryOp& __op,
   const _Tp& __ident)
 {
-  const auto& __logical_device = __comm.logical_device();
-  // Workaround for the case where:
-  //
-  // 1. The stream is the NULL stream.
-  // 2. The resource is the default per-device memory resource.
-  // 3. There is no current context set.
-  //
-  // In this case cuMemAllocFromPool fails with INVALID_CONTEXT because the driver cannot pick
-  // an appropriate context to tie the allocation to.
-  const auto _                = ::cuda::__ensure_current_context{__logical_device};
   ::cuda::stream_ref __stream = ::cuda::get_stream(__env);
-  auto __resource             = ::cuda::experimental::__detail::__resource_from_env(__env, __logical_device);
+  auto __resource             = ::cuda::experimental::__detail::__resource_from_env(__env, __stream.__logical_device());
 
   // One partial per segment. The butterfly fallback folds in place, but needs extra room for
   // the other ranks' data so we allocate it here

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/scan/scan.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/scan/scan.h
@@ -180,7 +180,7 @@ _CCCL_HOST_API void __scan(
       // that only happens once, we can probably reasonably fuse these kernels. If it happens
       // multiple times, we need to cache the result.
       __CUDAX_MULTI_GPU_DISPATCH(
-        __comm.logical_device(),
+        __prefix.stream(),
         CUB_NS_QUALIFIER::DeviceReduce::Reduce,
         __part.begin(),
         __prefix.begin(),
@@ -198,7 +198,7 @@ _CCCL_HOST_API void __scan(
                                                           typename __properties::__buffer_type::iterator>;
 
       __CUDAX_MULTI_GPU_DISPATCH(
-        __comm.logical_device(),
+        __prefix.stream(),
         CUB_NS_QUALIFIER::DeviceScan::ExclusiveScan,
         __input_it,
         __out,
@@ -210,7 +210,7 @@ _CCCL_HOST_API void __scan(
     else
     {
       __CUDAX_MULTI_GPU_DISPATCH(
-        __comm.logical_device(),
+        __prefix.stream(),
         CUB_NS_QUALIFIER::DeviceScan::InclusiveScanInit,
         __input_it,
         __out,

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/data_exchange.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/data_exchange.h
@@ -266,7 +266,7 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__compute_send_counts_and_offsets(
       auto __out = ::cuda::std::make_tuple(__send_counts.data(), __offsets.data());
 
       __CUDAX_MULTI_GPU_DISPATCH(
-        __comm_it->logical_device(),
+        __offsets.stream(),
         CUB_NS_QUALIFIER::DeviceTransform::Transform,
         ::cuda::counting_iterator<::cuda::std::uint64_t>{},
         ::cuda::std::move(__out),
@@ -423,10 +423,9 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__data_exchange(
   __local_merged.reserve(__num_local);
 
   {
-    auto __comm_it = ::cuda::std::ranges::begin(__comms);
-    auto __env_it  = ::cuda::std::ranges::begin(__envs);
+    auto __env_it = ::cuda::std::ranges::begin(__envs);
 
-    for (::cuda::std::size_t __idx = 0; __idx < __num_local; (void) ++__idx, (void) ++__comm_it, (void) ++__env_it)
+    for (::cuda::std::size_t __idx = 0; __idx < __num_local; (void) ++__idx, (void) ++__env_it)
     {
       auto& __merged = __local_merged.emplace_back(
         __local_recvd[__idx].stream(),
@@ -434,7 +433,6 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__data_exchange(
         ::cuda::experimental::__detail::__sanitize_buffer_env(*__env_it));
 
       __merge_k_way(
-        *__comm_it,
         *__env_it,
         __local_recvd[__idx],
         __h_column(__local_h_counts, __comm_size, __idx, __h_recv_counts_column),

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/data_exchange.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/data_exchange.h
@@ -317,9 +317,8 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__make_recv_buffers(
         __local_counts[__idx].stream(),
         __local_counts[__idx],
         ::cuda::std::span<::cuda::std::size_t>{__h_send_counts.data(), 2 * __h_send_counts.size()},
-        ::cuda::copy_configuration{__comm_it->logical_device().underlying_device(),
-                                   ::cuda::host_memory_location,
-                                   ::cuda::source_access_order::stream});
+        ::cuda::copy_configuration{
+          __local_counts[__idx].stream().device(), ::cuda::host_memory_location, ::cuda::source_access_order::stream});
     }
   }
 

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/execute.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/execute.h
@@ -85,16 +85,15 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__execute(
   // First and foremost, kick off the local sorts...
   {
     const auto __num_local_inputs = ::cuda::std::ranges::size(__comms);
-    auto __comm_it                = ::cuda::std::ranges::begin(__comms);
     auto __env_it                 = ::cuda::std::ranges::begin(__envs);
     auto __input_it               = ::cuda::std::ranges::begin(__input_iters);
     auto __num_items_it           = ::cuda::std::ranges::begin(__num_items_range);
 
     for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs;
-         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__input_it, (void) ++__num_items_it)
+         (void) ++__idx, (void) ++__env_it, (void) ++__input_it, (void) ++__num_items_it)
     {
       __CUDAX_MULTI_GPU_DISPATCH(
-        __comm_it->logical_device(),
+        ::cuda::get_stream(*__env_it),
         CUB_NS_QUALIFIER::DeviceMergeSort::SortKeys,
         *__input_it,
         *__num_items_it,

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/histogramming.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/histogramming.h
@@ -557,7 +557,7 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__histogramming_phase(
 {
   const auto __comm_size                       = __setup.__comm_size;
   const auto __N                               = __setup.__N;
-  auto [__local_scratch, __local_hist_results] = __allocate_histogramming_buffers(__setup, __comms, __envs);
+  auto [__local_scratch, __local_hist_results] = __allocate_histogramming_buffers(__setup, __envs);
 
   // Host scratch for the sample gather, hoisted out of the sampling loop so it is sized once
   // per sort instead of once per round. Every rank all-gathers the same counts, so one set of

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/histogramming.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/histogramming.h
@@ -275,34 +275,34 @@ struct __update_intervals_fn
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
 template <class _Tp, class _Env, class _BinaryOp>
-template <class _CommRange, class _EnvRange>
+template <class _EnvRange>
 [[nodiscard]]
 _CCCL_HOST_API ::cuda::std::pair<
   ::std::vector<typename _HSSSorter<_Tp, _Env, _BinaryOp>::__per_comm_sampling_scratch_type>,
   ::std::vector<typename _HSSSorter<_Tp, _Env, _BinaryOp>::__per_comm_histogramming_result_type>>
 _HSSSorter<_Tp, _Env, _BinaryOp>::__allocate_histogramming_buffers(
-  const __local_setup_result_type& __setup, _CommRange&& __comms, _EnvRange&& __envs)
+  const __local_setup_result_type& __setup, _EnvRange&& __envs)
 {
-  const auto __comm_size        = __setup.__comm_size;
-  const auto __N                = __setup.__N;
-  const auto __num_local_inputs = ::cuda::std::ranges::size(__comms);
+  const auto __comm_size = __setup.__comm_size;
+  const auto __N         = __setup.__N;
 
   ::std::vector<__per_comm_sampling_scratch_type> __local_scratch;
   ::std::vector<__per_comm_histogramming_result_type> __local_hist_results;
 
-  __local_scratch.reserve(__num_local_inputs);
-  __local_hist_results.reserve(__num_local_inputs);
-
-  auto __comm_it = ::cuda::std::ranges::begin(__comms);
-  auto __env_it  = ::cuda::std::ranges::begin(__envs);
-
-  for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs; (void) ++__idx, (void) ++__comm_it, (void) ++__env_it)
   {
-    const auto __stream  = ::cuda::get_stream(*__env_it);
+    const auto __num_local_inputs = __setup.__all_local_sizes.size();
+
+    __local_scratch.reserve(__num_local_inputs);
+    __local_hist_results.reserve(__num_local_inputs);
+  }
+
+  for (auto&& __env : __envs)
+  {
+    const auto __stream  = ::cuda::get_stream(__env);
     const auto __n_split = __comm_size - 1;
 
-    auto&& __resource   = ::cuda::experimental::__detail::__resource_from_env(*__env_it, __comm_it->logical_device());
-    auto&& __buffer_env = ::cuda::experimental::__detail::__sanitize_buffer_env(*__env_it);
+    auto&& __resource   = ::cuda::experimental::__detail::__resource_from_env(__env, __stream.__logical_device());
+    auto&& __buffer_env = ::cuda::experimental::__detail::__sanitize_buffer_env(__env);
 
     __local_scratch.emplace_back(__per_comm_sampling_scratch_type{
       /*__all_samples=*/
@@ -375,9 +375,8 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__exchange_sample_counts(
     __samples_size.stream(),
     __samples_size,
     __h_recvcounts,
-    ::cuda::copy_configuration{::cuda::std::ranges::begin(__comms)->logical_device().underlying_device(),
-                               ::cuda::host_memory_location,
-                               ::cuda::source_access_order::stream});
+    ::cuda::copy_configuration{
+      __samples_size.stream().device(), ::cuda::host_memory_location, ::cuda::source_access_order::stream});
 
   // Need to sync here because __gather_merge_probes() needs these on the host for comms. Could
   // potentially move this sync there

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/histogramming.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/histogramming.h
@@ -427,16 +427,13 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__gather_and_merge_probes(
 
   // Every rank merges the p sorted runs into one sorted probe set
   {
-    auto __comm_it = ::cuda::std::ranges::begin(__comms);
-    auto __env_it  = ::cuda::std::ranges::begin(__envs);
+    auto __env_it = ::cuda::std::ranges::begin(__envs);
 
-    for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs;
-         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it)
+    for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs; (void) ++__idx, (void) ++__env_it)
     {
       auto& __probes = (*__local_hist_results)[__idx].__splitters.__probes;
 
       __merge_k_way(
-        *__comm_it,
         *__env_it,
         (*__local_scratch)[__idx].__all_samples,
         __h_recvcounts,
@@ -461,13 +458,12 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__compute_histogram(
   const auto __num_local_inputs = ::cuda::std::ranges::size(__comms);
 
   {
-    auto __comm_it      = ::cuda::std::ranges::begin(__comms);
     auto __env_it       = ::cuda::std::ranges::begin(__envs);
     auto __keys_it      = ::cuda::std::ranges::begin(__key_iters);
     auto __num_items_it = ::cuda::std::ranges::begin(__num_items_range);
 
     for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs;
-         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__keys_it, (void) ++__num_items_it)
+         (void) ++__idx, (void) ++__env_it, (void) ++__keys_it, (void) ++__num_items_it)
     {
       auto& __hist               = (*__local_hist_results)[__idx].__hist;
       auto& __probes             = (*__local_hist_results)[__idx].__splitters.__probes;
@@ -484,7 +480,7 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__compute_histogram(
                           _BinaryOp>{__keys_first, __keys_first + *__num_items_it, __probes_first, __num_probes, __cmp};
 
       __CUDAX_MULTI_GPU_DISPATCH(
-        __comm_it->logical_device(),
+        __hist.stream(),
         CUB_NS_QUALIFIER::DeviceTransform::Transform,
         ::cuda::counting_iterator<::cuda::std::uint64_t>{},
         __hist.data(),
@@ -538,7 +534,7 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__update_intervals(
     auto __op = __update_intervals_fn<_Tp>{__probes.data(), __hist.data(), __probes.size()};
 
     __CUDAX_MULTI_GPU_DISPATCH(
-      __comm_it->logical_device(),
+      __I_j.stream(),
       CUB_NS_QUALIFIER::DeviceTransform::Transform,
       ::cuda::std::make_tuple(::cuda::std::move(__in), __I_j.data()),
       __I_j.data(),

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/local_setup.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/local_setup.h
@@ -61,16 +61,17 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__local_setup(
   __all_local_sizes.reserve(__num_local_inputs);
 
   {
-    auto __comm_it      = ::cuda::std::ranges::begin(__comms);
     auto __env_it       = ::cuda::std::ranges::begin(__envs);
     auto __num_items_it = ::cuda::std::ranges::begin(__num_items_range);
 
     for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs;
-         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__num_items_it)
+         (void) ++__idx, (void) ++__env_it, (void) ++__num_items_it)
     {
+      const ::cuda::stream_ref __stream = ::cuda::get_stream(*__env_it);
+
       __all_local_sizes.emplace_back(::cuda::make_buffer<::cuda::std::uint64_t>(
-        ::cuda::get_stream(*__env_it),
-        ::cuda::experimental::__detail::__resource_from_env(*__env_it, __comm_it->logical_device()),
+        __stream,
+        ::cuda::experimental::__detail::__resource_from_env(*__env_it, __stream.__logical_device()),
         __comm_size,
         // Technically, we only need to write this value at entry rank(), but that would
         // require a whole separate memcpy call which honestly does not seem worth it.
@@ -96,7 +97,7 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__local_setup(
 
   __all_local_offsets.reserve(__num_local_inputs);
 
-  ::std::vector<::cuda::std::uint64_t> __h_sizes(__comm_size);
+  ::std::vector<::cuda::std::uint64_t> __h_sizes(static_cast<::cuda::std::size_t>(__comm_size));
 
   {
     auto __comm_it = ::cuda::std::ranges::begin(__comms);
@@ -126,7 +127,7 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__local_setup(
           __all_local_sizes[__idx].stream(),
           __all_local_sizes[__idx],
           __h_sizes,
-          ::cuda::copy_configuration{__comm_it->logical_device().underlying_device(),
+          ::cuda::copy_configuration{__all_local_sizes[__idx].stream().device(),
                                      ::cuda::host_memory_location,
                                      ::cuda::source_access_order::stream});
       }

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/local_setup.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/local_setup.h
@@ -113,7 +113,7 @@ _HSSSorter<_Tp, _Env, _BinaryOp>::__local_setup(
         ::cuda::experimental::__detail::__sanitize_buffer_env(*__env_it));
 
       __CUDAX_MULTI_GPU_DISPATCH(
-        __comm_it->logical_device(),
+        __offsets.stream(),
         CUB_NS_QUALIFIER::DeviceScan::ExclusiveSum,
         __all_local_sizes[__idx].begin(),
         __offsets.begin(),

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/merge_k_way.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/merge_k_way.h
@@ -44,9 +44,7 @@ namespace cuda::experimental::__detail::__hss_sort
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
 template <class _Tp, class _Env, class _BinaryOp>
-template <class _Comm>
 _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__merge_k_way_tree(
-  const _Comm& __comm,
   const _Env& __env,
   const __resizable_buffer_type<_Tp>& __data,
   ::cuda::std::span<const ::cuda::std::size_t> __counts,
@@ -96,7 +94,7 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__merge_k_way_tree(
       const auto __right_node = __cur_level[__i + 1];
 
       __CUDAX_MULTI_GPU_DISPATCH(
-        __comm.logical_device(),
+        __next_level_buffer->stream(),
         CUB_NS_QUALIFIER::DeviceMerge::MergeKeys,
         __left_node.data(),
         __left_node.size(),
@@ -125,7 +123,7 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__merge_k_way_tree(
       const auto __src = ::cuda::std::mdspan{__left_node.data(), __left_node.size()};
       const auto __dst = ::cuda::std::mdspan{__next_level_node.data(), __next_level_node.size()};
 
-      __CUDAX_MULTI_GPU_DISPATCH(__comm.logical_device(), CUB_NS_QUALIFIER::DeviceCopy::Copy, __src, __dst, __env);
+      __CUDAX_MULTI_GPU_DISPATCH(__next_level_buffer->stream(), CUB_NS_QUALIFIER::DeviceCopy::Copy, __src, __dst, __env);
 
       __next_level.push_back(__next_level_node);
     }
@@ -144,9 +142,7 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__merge_k_way_tree(
 // __data holds a series of sorted sequences. The offsets of the beginning of each such
 // sequence is in __displs, while the count is in __counts.
 template <class _Tp, class _Env, class _BinaryOp>
-template <class _Comm>
 _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__merge_k_way(
-  const _Comm& __comm,
   const _Env& __env,
   const __resizable_buffer_type<_Tp>& __data,
   ::cuda::std::span<const ::cuda::std::size_t> __counts,
@@ -168,7 +164,7 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__merge_k_way(
   if (__counts.size() == 2)
   {
     __CUDAX_MULTI_GPU_DISPATCH(
-      __comm.logical_device(),
+      __ret->stream(),
       CUB_NS_QUALIFIER::DeviceMerge::MergeKeys,
       __data.data() + __displs[0],
       __counts[0],
@@ -180,7 +176,7 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__merge_k_way(
   }
   else
   {
-    __merge_k_way_tree(__comm, __env, __data, __counts, __displs, __cmp, __ret);
+    __merge_k_way_tree(__env, __data, __counts, __displs, __cmp, __ret);
   }
 }
 

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/rebalance.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/rebalance.h
@@ -211,9 +211,8 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__rebalance_to_original_co
           __counts.stream(),
           __counts,
           ::cuda::std::span<::cuda::std::size_t>{__h_counts_dest.data(), __num_columns * __h_counts_dest.size()},
-          ::cuda::copy_configuration{__comm_it->logical_device().underlying_device(),
-                                     ::cuda::host_memory_location,
-                                     ::cuda::source_access_order::stream});
+          ::cuda::copy_configuration{
+            __counts.stream().device(), ::cuda::host_memory_location, ::cuda::source_access_order::stream});
       }
 
       __local_rebalanced.emplace_back(

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/rebalance.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/rebalance.h
@@ -192,7 +192,7 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__rebalance_to_original_co
         __setup.__all_local_offsets[__idx].data()};
 
       __CUDAX_MULTI_GPU_DISPATCH(
-        __comm_it->logical_device(),
+        __counts.stream(),
         CUB_NS_QUALIFIER::DeviceTransform::Transform,
         ::cuda::counting_iterator<::cuda::std::uint64_t>{},
         ::cuda::std::move(__out),
@@ -247,20 +247,19 @@ _CCCL_HOST_API void _HSSSorter<_Tp, _Env, _BinaryOp>::__rebalance_to_original_co
   }
 
   {
-    auto __comm_it      = ::cuda::std::ranges::begin(__comms);
     auto __env_it       = ::cuda::std::ranges::begin(__envs);
     auto __input_it     = ::cuda::std::ranges::begin(__input_iters);
     auto __num_items_it = ::cuda::std::ranges::begin(__num_items_range);
 
     for (::cuda::std::size_t __idx = 0; __idx < __num_local_inputs;
-         (void) ++__idx, (void) ++__comm_it, (void) ++__env_it, (void) ++__input_it, (void) ++__num_items_it)
+         (void) ++__idx, (void) ++__env_it, (void) ++__input_it, (void) ++__num_items_it)
     {
       const auto __n = *__num_items_it;
 
       _CCCL_VERIFY(__n == __local_rebalanced[__idx].size(), "Incorrect sizing for temp storage");
 
       __CUDAX_MULTI_GPU_DISPATCH(
-        __comm_it->logical_device(),
+        __local_rebalanced[__idx].stream(),
         CUB_NS_QUALIFIER::DeviceCopy::Copy,
         ::cuda::std::mdspan{__local_rebalanced[__idx].data(), __local_rebalanced[__idx].size()},
         ::cuda::std::mdspan{::cuda::std::to_address(*__input_it), __n},

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/sorter.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/sorter.h
@@ -224,9 +224,7 @@ private:
 
   // ------------------------------------------------------------------------------------------
 
-  template <class _Comm>
   _CCCL_HOST_API static void __merge_k_way_tree(
-    const _Comm& __comm,
     const _Env& __env,
     const __resizable_buffer_type<_Tp>& __data,
     ::cuda::std::span<const ::cuda::std::size_t> __counts,
@@ -234,9 +232,7 @@ private:
     const _BinaryOp& __cmp,
     __resizable_buffer_type<_Tp>* __ret);
 
-  template <class _Comm>
   _CCCL_HOST_API static void __merge_k_way(
-    const _Comm& __comm,
     const _Env& __env,
     const __resizable_buffer_type<_Tp>& __data,
     ::cuda::std::span<const ::cuda::std::size_t> __counts,

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/sorter.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/sort/hss/sorter.h
@@ -152,11 +152,11 @@ private:
     ::cuda::std::span<const ::cuda::std::size_t> __cap_displs,
     ::std::vector<__per_comm_sampling_scratch_type>* __local_scratch);
 
-  template <class _CommRange, class _EnvRange>
+  template <class _EnvRange>
   [[nodiscard]]
   _CCCL_HOST_API static ::cuda::std::pair<::std::vector<__per_comm_sampling_scratch_type>,
                                           ::std::vector<__per_comm_histogramming_result_type>>
-  __allocate_histogramming_buffers(const __local_setup_result_type& __setup, _CommRange&& __comms, _EnvRange&& __envs);
+  __allocate_histogramming_buffers(const __local_setup_result_type& __setup, _EnvRange&& __envs);
 
   template <class _CommRange>
   _CCCL_HOST_API static void __exchange_sample_counts(

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/transform/transform.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/transform/transform.h
@@ -127,11 +127,11 @@ _CCCL_HOST_API void transform(
 
   _CCCL_NVTX_RANGE_SCOPE("cuda::experimental::transform");
 
-  for (auto&& [__comm, __env, __input_it, __num_items, __output_it] :
+  for ([[maybe_unused]] auto&& [__comm, __env, __input_it, __num_items, __output_it] :
        ::cuda::std::ranges::views::zip(__comms, __envs, __input_iters, __num_items_range, __output_iters))
   {
     __CUDAX_MULTI_GPU_DISPATCH(
-      __comm.logical_device(),
+      ::cuda::get_stream(__env),
       CUB_NS_QUALIFIER::DeviceTransform::Transform,
       __input_it,
       __output_it,

--- a/libcudacxx/include/cuda/__device/logical_device_ref.h
+++ b/libcudacxx/include/cuda/__device/logical_device_ref.h
@@ -51,7 +51,7 @@ public:
   __logical_device_ref(device_ref, ::cuda::std::nullptr_t) = delete;
 
   _CCCL_HOST_API explicit __logical_device_ref(device_ref __dev)
-      : __logical_device_ref{__dev, __dev.__primary_context(), ::CUgreenCtx{}}
+      : __logical_device_ref{__dev, __dev.__primary_context()}
   {}
 
   _CCCL_HOST_API __logical_device_ref(device_ref __dev, ::CUgreenCtx __gctx)
@@ -62,6 +62,10 @@ public:
                              ::CUcontext{},
 #  endif // ^^^ 12.4- ^^^
                              __gctx}
+  {}
+
+  _CCCL_HOST_API __logical_device_ref(device_ref __dev, ::CUcontext __ctx)
+      : __logical_device_ref{__dev, __ctx, ::CUgreenCtx{}}
   {}
 
   [[nodiscard]] _CCCL_HOST_API device_ref underlying_device() const noexcept
@@ -121,8 +125,8 @@ public:
   [[nodiscard]] _CCCL_HOST_API friend constexpr bool
   operator==(const __logical_device_ref& __lhs, const __logical_device_ref& __rhs) noexcept
   {
-    // It suffices to check the cu context, the same green context will return the same outer context
-    return __lhs.__device_ == __rhs.__device_ && __lhs.__cu_ctx_ == __rhs.__cu_ctx_;
+    return __lhs.__device_ == __rhs.__device_ && __lhs.__cu_ctx_ == __rhs.__cu_ctx_
+        && __lhs.__green_ctx_ == __rhs.__green_ctx_;
   }
 
 #  if _CCCL_STD_VER <= 2017
@@ -144,15 +148,6 @@ protected:
   device_ref __device_{0};
   ::CUcontext __cu_ctx_{};
   ::CUgreenCtx __green_ctx_{};
-};
-
-class __logical_device_ref_access final : public __logical_device_ref
-{
-public:
-  _CCCL_HOST_API constexpr explicit __logical_device_ref_access(
-    device_ref __device, ::CUcontext __cu_ctx, ::CUgreenCtx __green_ctx) noexcept
-      : __logical_device_ref{__device, __cu_ctx, __green_ctx}
-  {}
 };
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__device/logical_device_ref.h
+++ b/libcudacxx/include/cuda/__device/logical_device_ref.h
@@ -146,6 +146,15 @@ protected:
   ::CUgreenCtx __green_ctx_{};
 };
 
+class __logical_device_ref_access final : public __logical_device_ref
+{
+public:
+  _CCCL_HOST_API constexpr explicit __logical_device_ref_access(
+    device_ref __device, ::CUcontext __cu_ctx, ::CUgreenCtx __green_ctx) noexcept
+      : __logical_device_ref{__device, __cu_ctx, __green_ctx}
+  {}
+};
+
 _CCCL_END_NAMESPACE_CUDA
 
 #  include <cuda/std/__cccl/epilogue.h>

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -810,30 +810,31 @@ struct __ctx_from_stream
   };
 
   __kind __ctx_kind_;
-  union
-  {
-    ::CUcontext __ctx_device_;
-    ::CUgreenCtx __ctx_green_;
-  };
+  ::CUcontext __ctx_device_;
+  ::CUgreenCtx __ctx_green_;
 };
 
 [[nodiscard]] _CCCL_HOST_API inline __ctx_from_stream __streamGetCtx_v2(::CUstream __stream)
 {
-  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuStreamGetCtx, cuStreamGetCtx_v2, 12, 5);
+  static const auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuStreamGetCtx, cuStreamGetCtx_v2, 12, 5);
 
-  ::CUcontext __ctx   = nullptr;
-  ::CUgreenCtx __gctx = nullptr;
-  __ctx_from_stream __result;
-  _CCCLRT_CALL_STREAM_DRIVER_FN(__driver_fn, __stream, "Failed to get context from a stream", __stream, &__ctx, &__gctx);
-  if (__gctx)
+  __ctx_from_stream __result{};
+
+  _CCCLRT_CALL_STREAM_DRIVER_FN(
+    __driver_fn,
+    __stream,
+    "Failed to get context from a stream",
+    __stream,
+    &__result.__ctx_device_,
+    &__result.__ctx_green_);
+
+  if (__result.__ctx_green_)
   {
-    __result.__ctx_kind_  = __ctx_from_stream::__kind::__green;
-    __result.__ctx_green_ = __gctx;
+    __result.__ctx_kind_ = __ctx_from_stream::__kind::__green;
   }
   else
   {
-    __result.__ctx_kind_   = __ctx_from_stream::__kind::__device;
-    __result.__ctx_device_ = __ctx;
+    __result.__ctx_kind_ = __ctx_from_stream::__kind::__device;
   }
   return __result;
 }

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -295,6 +295,17 @@ public:
     return device_ref{::cuda::__driver::__cudevice_to_ordinal(__device)};
   }
 
+  [[nodiscard]] _CCCL_HOST_API __logical_device_ref __logical_device() const
+  {
+#  if _CCCL_CTK_AT_LEAST(12, 5)
+    const auto __ctx = ::cuda::__driver::__streamGetCtx_v2(__stream);
+
+    return __logical_device_ref_access{this->device(), __ctx.__ctx_device_, __ctx.__ctx_green_};
+#  else // ^^^ _CCCL_CTK_AT_LEAST(12, 5) ^^^ / vvv _CCCL_CTK_BELOW(12, 5) vvv
+    return __logical_device_ref{this->device()};
+#  endif // ^^^ _CCCL_CTK_BELOW(12, 5) ^^^
+  }
+
   //! @brief Queries the \c stream_ref for itself. This makes \c stream_ref usable in places where we expect an
   //! environment with a \c get_stream_t query
   [[nodiscard]] _CCCL_API constexpr stream_ref query(const ::cuda::get_stream_t&) const noexcept

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -308,7 +308,19 @@ public:
 #  if _CCCL_CTK_AT_LEAST(12, 5)
     const auto __ctx = ::cuda::__driver::__streamGetCtx_v2(__stream);
 
-    return __logical_device_ref_access{this->device(), __ctx.__ctx_device_, __ctx.__ctx_green_};
+    // For a green-context stream, cuStreamGetCtx_v2() returns the primary/device context of
+    // the stream, not the one you would get from cuCtxFromGreenCtx(green).
+    //
+    // So the outer context of the green context must be recovered separately to match what
+    // __logical_device_ref{device_ref, CUgreenCtx} would store.
+    switch (__ctx.__ctx_kind_)
+    {
+      case ::cuda::__driver::__ctx_from_stream::__kind::__green:
+        return {this->device(), __ctx.__ctx_green_};
+      case ::cuda::__driver::__ctx_from_stream::__kind::__device:
+        return {this->device(), __ctx.__ctx_device_};
+    }
+    _CCCL_UNREACHABLE();
 #  else // ^^^ _CCCL_CTK_AT_LEAST(12, 5) ^^^ / vvv _CCCL_CTK_BELOW(12, 5) vvv
     return __logical_device_ref{this->device()};
 #  endif // ^^^ _CCCL_CTK_BELOW(12, 5) ^^^

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -303,6 +303,11 @@ public:
     return device_ref{::cuda::__driver::__cudevice_to_ordinal(__device)};
   }
 
+  // The whole _CCCL_UNREACHABLE() thing was added for MSVC, yet now it complains the
+  // _CCCL_UNREACHABLE() is in fact not reachable. Incredible.
+  _CCCL_DIAG_PUSH
+  _CCCL_DIAG_SUPPRESS_MSVC(4702) // warning C4702: unreachable code
+
   [[nodiscard]] _CCCL_HOST_API __logical_device_ref __logical_device() const
   {
 #  if _CCCL_CTK_AT_LEAST(12, 5)
@@ -321,10 +326,11 @@ public:
         return {this->device(), __ctx.__ctx_device_};
     }
     _CCCL_UNREACHABLE();
-#  else // ^^^ _CCCL_CTK_AT_LEAST(12, 5) ^^^ / vvv _CCCL_CTK_BELOW(12, 5) vvv
+#  endif // ^^^ _CCCL_AT_LEAST(12, 5) ^^^
     return __logical_device_ref{this->device()};
-#  endif // ^^^ _CCCL_CTK_BELOW(12, 5) ^^^
   }
+
+  _CCCL_DIAG_POP
 
   //! @brief Queries the \c stream_ref for itself. This makes \c stream_ref usable in places where we expect an
   //! environment with a \c get_stream_t query

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -285,13 +285,21 @@ public:
     ::CUdevice __device{};
 #  if _CCCL_CTK_AT_LEAST(13, 0)
     __device = ::cuda::__driver::__streamGetDevice(__stream);
-#  else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
+#  elif _CCCL_CTK_AT_LEAST(12, 5) // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_AT_LEAST(12, 5) vvv
     {
-      ::CUcontext __stream_ctx = ::cuda::__driver::__streamGetCtx(__stream);
-      __ensure_current_context __setter(__stream_ctx);
+      // cuStreamGetCtx() returns CUDA_ERROR_NOT_SUPPORTED for a stream that cuGreenCtxStreamCreate()
+      // made. cuStreamGetCtx_v2() supports such a stream, and always gives a usable device context.
+      const auto _ = __ensure_current_context{::cuda::__driver::__streamGetCtx_v2(__stream).__ctx_device_};
+
       __device = ::cuda::__driver::__ctxGetDevice();
     }
-#  endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
+#  else // ^^^ _CCCL_CTK_AT_LEAST(12, 5) ^^^ / vvv _CCCL_CTK_BELOW(12, 5) vvv
+    {
+      const auto _ = __ensure_current_context{::cuda::__driver::__streamGetCtx(__stream)};
+
+      __device = ::cuda::__driver::__ctxGetDevice();
+    }
+#  endif // ^^^ _CCCL_CTK_BELOW(12, 5) ^^^
     return device_ref{::cuda::__driver::__cudevice_to_ordinal(__device)};
   }
 

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/logical_device_stream.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/logical_device_stream.c2h.cu
@@ -20,6 +20,73 @@
 
 #include <testing.cuh>
 
+C2H_CCCLRT_TEST("Stream logical device without a green context", "[stream][logical_device]")
+{
+  const auto device = cuda::devices[0];
+
+  SECTION("A stream on a device reports a device-backed logical device")
+  {
+    cuda::stream str{device};
+    const auto ldev = str.__logical_device();
+
+    REQUIRE(ldev.kind() == cuda::__logical_device_ref::kinds::device);
+    REQUIRE(ldev.green_context() == nullptr);
+    REQUIRE(ldev.underlying_device() == device);
+    REQUIRE(ldev.context() == device.__primary_context());
+  }
+
+  SECTION("The reported logical device equals one built from the device")
+  {
+    cuda::stream str{device};
+
+    REQUIRE(str.__logical_device() == cuda::__logical_device_ref{device});
+  }
+
+  SECTION("Two streams on the same device report the same logical device")
+  {
+    cuda::stream str0{device};
+    cuda::stream str1{device};
+
+    REQUIRE(str0.__logical_device() == str1.__logical_device());
+  }
+
+  SECTION("A stream created through the runtime reports its device")
+  {
+    cuda::__ensure_current_context guard(device);
+    ::cudaStream_t handle{};
+    CUDART(cudaStreamCreate(&handle));
+
+    const cuda::stream_ref str{handle};
+    REQUIRE(str.__logical_device() == cuda::__logical_device_ref{device});
+
+    CUDART(cudaStreamDestroy(handle));
+  }
+
+  SECTION("The query leaves the driver context stack unchanged")
+  {
+    // The fixture only checks that the stack is empty at the end of the test, so it does not catch
+    // a query that pushes a context onto a non-empty stack.
+    cuda::stream str{device};
+    cuda::__ensure_current_context guard(device);
+
+    const auto before = ::test::count_driver_stack();
+    (void) str.__logical_device();
+    REQUIRE(::test::count_driver_stack() == before);
+  }
+
+  SECTION("A stream on a second device reports that device")
+  {
+    if (cuda::devices.size() > 1)
+    {
+      const auto second = cuda::devices[1];
+      cuda::stream str{second};
+
+      REQUIRE(str.__logical_device() == cuda::__logical_device_ref{second});
+      REQUIRE(str.__logical_device() != cuda::__logical_device_ref{device});
+    }
+  }
+}
+
 // Green contexts require CTK 12.5, so the `__logical_device_ref` stream constructor is only declared
 // from that version on.
 #if _CCCL_CTK_AT_LEAST(12, 5)
@@ -108,6 +175,43 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
     REQUIRE(str.__logical_device().kind() == cuda::__logical_device_ref::kinds::green_context);
     REQUIRE(str.__logical_device().green_context() == ldev.green_context());
     REQUIRE(str.__logical_device().underlying_device() == device);
+  }
+
+  SECTION("The reported logical device carries the context of the green context")
+  {
+    auto ldev = ::make_logical_device(device);
+    cuda::stream str{ldev};
+
+    REQUIRE(str.__logical_device().context() == cuda::__driver::__ctxFromGreenCtx(ldev.green_context()));
+    REQUIRE(str.__logical_device().context() != device.__primary_context());
+  }
+
+  SECTION("The reported logical device compares equal to the one the stream was built from")
+  {
+    auto ldev = ::make_logical_device(device);
+    cuda::stream str{ldev};
+
+    REQUIRE(str.__logical_device() == static_cast<const cuda::__logical_device_ref&>(ldev));
+  }
+
+  SECTION("Streams from different green contexts report different logical devices")
+  {
+    auto ldev0 = ::make_logical_device(device);
+    auto ldev1 = ::make_logical_device(device);
+
+    cuda::stream str0{ldev0};
+    cuda::stream str1{ldev1};
+
+    REQUIRE(str0.__logical_device() != str1.__logical_device());
+  }
+
+  SECTION("A stream_ref reports the same logical device as the owning stream")
+  {
+    auto ldev = ::make_logical_device(device);
+    cuda::stream str{ldev};
+    const cuda::stream_ref ref{str.get()};
+
+    REQUIRE(ref.__logical_device() == str.__logical_device());
   }
 
   SECTION("The stream belongs to the context of the green context")

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/logical_device_stream.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/logical_device_stream.c2h.cu
@@ -98,6 +98,18 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
     REQUIRE(str.device() == ldev.underlying_device());
   }
 
+  SECTION("The stream reports the green context it was created on")
+  {
+    // A green context stream rejects cuStreamGetCtx(), so a query that reaches for the legacy
+    // context of the stream throws instead of reporting the green context.
+    auto ldev = ::make_logical_device(device);
+    cuda::stream str{ldev};
+
+    REQUIRE(str.__logical_device().kind() == cuda::__logical_device_ref::kinds::green_context);
+    REQUIRE(str.__logical_device().green_context() == ldev.green_context());
+    REQUIRE(str.__logical_device().underlying_device() == device);
+  }
+
   SECTION("The stream belongs to the context of the green context")
   {
     auto ldev = ::make_logical_device(device);


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

We should get the current context for the purposes of multi-GPU dispatch from the stream, not the communicator. The communicator's job is to move bytes, and while a lot of communication libraries do expose some kind of location information for a comm, it is not a fundamental property of one.

Streams on the other hand are a much more natural place for this information (other than the data itself). The incoming data must be stream-ordered, ergo the stream must also belong to the same device as the data.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
