### PR TITLE
Fix more `_CCCL_DEVICE static` -> `_CCCL_DEVICE_API`

### DIFF
--- a/cub/cub/detail/env_dispatch.cuh
+++ b/cub/cub/detail/env_dispatch.cuh
@@ -37,7 +37,7 @@ namespace detail
 //! @param env The execution environment
 //! @param algorithm_callable Callable that invokes the algorithm implementation with determinism specified
 template <typename EnvT, typename AlgorithmCallable>
-CUB_RUNTIME_FUNCTION static cudaError_t dispatch_with_env(const EnvT& env, AlgorithmCallable&& algorithm_callable)
+CUB_RUNTIME_FUNCTION cudaError_t dispatch_with_env(const EnvT& env, AlgorithmCallable&& algorithm_callable)
 {
   // Query stream from environment
   auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
@@ -76,8 +76,7 @@ CUB_RUNTIME_FUNCTION static cudaError_t dispatch_with_env(const EnvT& env, Algor
 //! @endcond
 
 template <typename DefaultPolicySelector, typename EnvT, typename AlgorithmCallable>
-CUB_RUNTIME_FUNCTION static cudaError_t
-dispatch_with_env_and_tuning(const EnvT& env, AlgorithmCallable&& algorithm_callable)
+CUB_RUNTIME_FUNCTION cudaError_t dispatch_with_env_and_tuning(const EnvT& env, AlgorithmCallable&& algorithm_callable)
 {
   return detail::dispatch_with_env(
     env,
@@ -102,7 +101,7 @@ dispatch_with_env_and_tuning(const EnvT& env, AlgorithmCallable&& algorithm_call
 //! @param[in,out] temp_storage_bytes Reference to size in bytes of `d_temp_storage` allocation
 //! @param algorithm_callable Callable that invokes the algorithm implementation with determinism specified
 template <typename EnvT, typename AlgorithmCallable>
-CUB_RUNTIME_FUNCTION static cudaError_t dispatch_with_env(
+CUB_RUNTIME_FUNCTION cudaError_t dispatch_with_env(
   void* d_temp_storage, size_t& temp_storage_bytes, const EnvT& env, AlgorithmCallable&& algorithm_callable)
 {
   // Query stream from environment
@@ -116,7 +115,7 @@ CUB_RUNTIME_FUNCTION static cudaError_t dispatch_with_env(
 //! @endcond
 
 template <typename DefaultPolicySelector, typename EnvT, typename AlgorithmCallable>
-CUB_RUNTIME_FUNCTION static cudaError_t dispatch_with_env_and_tuning(
+CUB_RUNTIME_FUNCTION cudaError_t dispatch_with_env_and_tuning(
   void* d_temp_storage, size_t& temp_storage_bytes, const EnvT& env, AlgorithmCallable&& algorithm_callable)
 {
   return detail::dispatch_with_env(

--- a/cub/cub/device/device_batched_topk.cuh
+++ b/cub/cub/device/device_batched_topk.cuh
@@ -79,7 +79,7 @@ template <topk::select SelectDirection,
           typename NumSegmentsParameterT,
           typename TuningT,
           typename EnvT>
-_CCCL_HOST_API static cudaError_t dispatch_batched_topk(
+_CCCL_HOST_API cudaError_t dispatch_batched_topk(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
   KeyInputIteratorItT d_keys_in,

--- a/cub/cub/device/device_topk.cuh
+++ b/cub/cub/device/device_topk.cuh
@@ -51,7 +51,7 @@ template <topk::select SelectDirection,
           typename NumOutItemsT,
           typename DecomposerT,
           typename EnvT>
-CUB_RUNTIME_FUNCTION static cudaError_t dispatch_topk(
+CUB_RUNTIME_FUNCTION cudaError_t dispatch_topk(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
   KeyInputIteratorT d_keys_in,
@@ -128,7 +128,7 @@ template <topk::select SelectDirection,
           typename NumItemsT,
           typename NumOutItemsT,
           typename EnvT>
-CUB_RUNTIME_FUNCTION static cudaError_t dispatch_topk_hub(
+CUB_RUNTIME_FUNCTION cudaError_t dispatch_topk_hub(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
   KeyInputIteratorT d_keys_in,

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -471,7 +471,7 @@ template <
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY,
   typename LowerLevelArrayT      = ::cuda::std::array<LevelT, NUM_ACTIVE_CHANNELS>,
   typename UpperLevelArrayT      = ::cuda::std::array<LevelT, NUM_ACTIVE_CHANNELS>>
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t __dispatch_even_device_init(
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t __dispatch_even_device_init(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
   SampleIteratorT d_samples,
@@ -643,7 +643,7 @@ template <
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY,
   typename LowerLevelArrayT      = ::cuda::std::array<LevelT, NUM_ACTIVE_CHANNELS>,
   typename UpperLevelArrayT      = ::cuda::std::array<LevelT, NUM_ACTIVE_CHANNELS>>
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t __dispatch_even_device_init(
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t __dispatch_even_device_init(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
   SampleIteratorT d_samples,
@@ -795,7 +795,7 @@ template <
   typename KernelSource =
     DeviceHistogramKernelSource<NUM_CHANNELS, NUM_ACTIVE_CHANNELS, SampleIteratorT, CounterT, LevelT, OffsetT, SampleT>,
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-CUB_RUNTIME_FUNCTION static cudaError_t dispatch_range(
+CUB_RUNTIME_FUNCTION cudaError_t dispatch_range(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
   SampleIteratorT d_samples,
@@ -974,7 +974,7 @@ template <
   typename KernelSource =
     DeviceHistogramKernelSource<NUM_CHANNELS, NUM_ACTIVE_CHANNELS, SampleIteratorT, CounterT, LevelT, OffsetT, SampleT>,
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch_even(
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_even(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
   SampleIteratorT d_samples,

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -684,7 +684,7 @@ template <typename KeysInputIteratorT,
 #if _CCCL_HAS_CONCEPTS()
   requires reduce_by_key::reduce_by_key_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch(
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
   KeysInputIteratorT d_keys_in,

--- a/cub/cub/device/dispatch/dispatch_rle.cuh
+++ b/cub/cub/device/dispatch/dispatch_rle.cuh
@@ -655,7 +655,7 @@ template <typename InputIteratorT,
 #if _CCCL_HAS_CONCEPTS()
   requires non_trivial_runs::rle_non_trivial_runs_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch(
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
   InputIteratorT d_in,

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -563,7 +563,7 @@ template <requires_stable_address StableAddress,
 #if _CCCL_HAS_CONCEPTS()
   requires transform_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch(
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   ::cuda::std::tuple<RandomAccessIteratorsIn...> in,
   RandomAccessIteratorOut out,
   Offset num_items,

--- a/libcudacxx/codegen/generators/compare_and_swap.h
+++ b/libcudacxx/codegen/generators/compare_and_swap.h
@@ -20,7 +20,7 @@ inline void FormatCompareAndSwap(std::ostream& out)
 {
   out << R"XXX(
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_order_dispatch(_Fn& __cuda_cas, int __success_memorder, int __failure_memorder, _Sco) {
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange_order_dispatch(_Fn& __cuda_cas, int __success_memorder, int __failure_memorder, _Sco) {
   bool __res = false;
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
@@ -60,7 +60,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_order_dispatch(_F
   // 6 - Scope function tag
   constexpr auto asm_intrinsic_format_128 = R"XXX(
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, {4}, __cuda_atomic_operand_{0}{1}, {6})
 {{
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -81,7 +81,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
 
   constexpr auto asm_intrinsic_format = R"XXX(
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, {4}, __cuda_atomic_operand_{0}{1}, {6})
 {{ asm volatile("atom.cas{3}{5}.{0}{1} %0,[%1],%2,%3;" : "={2}"(__dst) : "l"(__ptr), "{2}"(__cmp), "{2}"(__op) : "memory"); return __dst == __cmp; }})XXX";
 
@@ -165,12 +165,12 @@ struct __cuda_atomic_bind_compare_exchange {
   _Type* __des;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE bool operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API bool operator()(_Atomic_Memorder) {
     return __cuda_atomic_compare_exchange(__ptr, *__exp, *__exp, *__des, _Atomic_Memorder{}, _Tag{}, _Sco{});
   }
 };
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_dispatch(_Type* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange_dispatch(_Type* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -183,7 +183,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_dispatch(_Type* _
   return __cuda_atomic_compare_exchange_order_dispatch(__bound_compare_swap, __success_memorder, __failure_memorder, _Sco{});
 }
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_dispatch(_Type volatile* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange_dispatch(_Type volatile* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;

--- a/libcudacxx/codegen/generators/exchange.h
+++ b/libcudacxx/codegen/generators/exchange.h
@@ -20,7 +20,7 @@ inline void FormatExchange(std::ostream& out)
 {
   out << R"XXX(
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange_order_dispatch(_Fn& __cuda_exch, int __memorder, _Sco) {
+_CCCL_DEVICE_API void __cuda_atomic_exchange_order_dispatch(_Fn& __cuda_exch, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
@@ -58,7 +58,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange_order_dispatch(_Fn& __cud
   // 6 - Scope function tag
   constexpr auto asm_intrinsic_format_128 = R"XXX(
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, {4}, __cuda_atomic_operand_{0}{1}, {6})
 {{
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -79,7 +79,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
 
   constexpr auto asm_intrinsic_format = R"XXX(
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, {4}, __cuda_atomic_operand_{0}{1}, {6})
 {{ asm volatile("atom.exch{3}{5}.{0}{1} %0,[%1],%2;" : "={2}"(__old) : "l"(__ptr), "{2}"(__new) : "memory"); }})XXX";
 
@@ -163,12 +163,12 @@ struct __cuda_atomic_bind_exchange {
   _Type* __new;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {
     __cuda_atomic_exchange(__ptr, *__old, *__new, _Atomic_Memorder{}, _Tag{}, _Sco{});
   }
 };
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE void __atomic_exchange_cuda(_Type* __ptr, _Type& __old, _Type __new, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_exchange_cuda(_Type* __ptr, _Type& __old, _Type __new, int __memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -180,7 +180,7 @@ static inline _CCCL_DEVICE void __atomic_exchange_cuda(_Type* __ptr, _Type& __ol
   __cuda_atomic_exchange_order_dispatch(__bound_swap, __memorder, _Sco{});
 }
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE void __atomic_exchange_cuda(_Type volatile* __ptr, _Type& __old, _Type __new, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_exchange_cuda(_Type volatile* __ptr, _Type& __old, _Type __new, int __memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;

--- a/libcudacxx/codegen/generators/fence.h
+++ b/libcudacxx/codegen/generators/fence.h
@@ -33,7 +33,7 @@ inline void FormatFence(std::ostream& out)
   // 0 - Membar scope tag
   // 1 - Membar scope
   constexpr auto intrinsic_membar = R"XXX(
-static inline _CCCL_DEVICE void __cuda_atomic_membar({0})
+_CCCL_DEVICE_API inline void __cuda_atomic_membar({0})
 {{ asm volatile("membar{1};" ::: "memory"); }})XXX";
 
   const std::map membar_scopes{
@@ -53,7 +53,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_membar({0})
   // 2 - Fence order tag
   // 3 - Fence order
   constexpr auto intrinsic_fence = R"XXX(
-static inline _CCCL_DEVICE void __cuda_atomic_fence({0}, {2})
+_CCCL_DEVICE_API inline void __cuda_atomic_fence({0}, {2})
 {{ asm volatile("fence{1}{3};" ::: "memory"); }})XXX";
 
   const Scope fence_scopes[] = {
@@ -78,7 +78,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_fence({0}, {2})
   out << "\n"
       << R"XXX(
 template <typename _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_thread_fence(int __memorder, _Sco) {
+_CCCL_DEVICE_API void __cuda_atomic_thread_fence(int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {

--- a/libcudacxx/codegen/generators/fetch_ops.h
+++ b/libcudacxx/codegen/generators/fetch_ops.h
@@ -53,7 +53,7 @@ inline void FormatFetchOps(std::ostream& out)
   // Memory order dispatcher
   out << R"XXX(
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_order_dispatch(_Fn& __cuda_fetch, int __memorder, _Sco) {
+_CCCL_DEVICE_API void __cuda_atomic_fetch_order_dispatch(_Fn& __cuda_fetch, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
@@ -92,7 +92,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_fetch_order_dispatch(_Fn& __cuda_f
   // 7 - Scope function tag
   constexpr auto asm_intrinsic_format = R"XXX(
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_{0}(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_{0}(
   _Type* __ptr, _Type& __dst, _Type __op, {5}, __cuda_atomic_operand_{1}{2}, {7})
 {{ asm volatile("atom.{0}{4}{6}.{1}{2} %0,[%1],%2;" : "={3}"(__dst) : "l"(__ptr), "{3}"(__op) : "memory"); }})XXX";
 
@@ -107,12 +107,12 @@ struct __cuda_atomic_bind_fetch_{0} {{
   _Type* __op;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {{
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {{
     __cuda_atomic_fetch_{0}(__ptr, *__dst, *__op, _Atomic_Memorder{{}}, _Tag{{}}, _Sco{{}});
   }}
 }};
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_{1}<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_{0}_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_{0}_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {{
   {2}
   __op = __op * __skip_v;
@@ -128,7 +128,7 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_{1}<_Typ
   return __dst;
 }}
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_{1}<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_{0}_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_{0}_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {{
   {2}
   __op = __op * __skip_v;
@@ -204,12 +204,12 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_{1}<_Typ
 
   out << R"XXX(
 template <class _Type, class _Up, class _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_sub_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_sub_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_add_dispatch(__ptr, -__op, __memorder, _Sco{});
 }
 template <class _Type, class _Up, class _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_sub_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_sub_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_add_dispatch(__ptr, -__op, __memorder, _Sco{});
 }

--- a/libcudacxx/codegen/generators/ld_st.h
+++ b/libcudacxx/codegen/generators/ld_st.h
@@ -40,7 +40,7 @@ inline void FormatLoad(std::ostream& out)
 {
   out << R"XXX(
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_load_order_dispatch(_Fn &__cuda_load, int __memorder, _Sco) {
+_CCCL_DEVICE_API void __cuda_atomic_load_order_dispatch(_Fn &__cuda_load, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
@@ -76,7 +76,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load_order_dispatch(_Fn &__cuda_lo
   // 8 - Mmio semantic
   constexpr auto asm_intrinsic_format_128 = R"XXX(
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, {3}, __cuda_atomic_operand_{0}{1}, {5}, {7})
 {{
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -94,12 +94,12 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
 }})XXX";
   constexpr auto asm_intrinsic_format     = R"XXX(
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, {3}, __cuda_atomic_operand_{0}{1}, {5}, {7})
 {{ asm volatile("ld{8}{4}{6}.{0}{1} %0,[%1];" : "={2}"(__dst) : "l"(__ptr) : "memory"); }})XXX";
   constexpr auto asm_intrinsic_format_8   = R"XXX(
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, {3}, __cuda_atomic_operand_{0}{1}, {5}, {7})
 {{
   uint16_t __tmp;
@@ -218,12 +218,12 @@ struct __cuda_atomic_bind_load {
   _Type* __dst;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {
     __cuda_atomic_load(__ptr, *__dst, _Atomic_Memorder{}, _Tag{}, _Sco{}, _Mmio{});
   }
 };
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE void __atomic_load_cuda(const _Type* __ptr, _Type& __dst, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_load_cuda(const _Type* __ptr, _Type& __dst, int __memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -234,7 +234,7 @@ static inline _CCCL_DEVICE void __atomic_load_cuda(const _Type* __ptr, _Type& __
   __cuda_atomic_load_order_dispatch(__bound_load, __memorder, _Sco{});
 }
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE void __atomic_load_cuda(const _Type volatile* __ptr, _Type& __dst, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_load_cuda(const _Type volatile* __ptr, _Type& __dst, int __memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -251,7 +251,7 @@ inline void FormatStore(std::ostream& out)
 {
   out << R"XXX(
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_store_order_dispatch(_Fn &__cuda_store, int __memorder, _Sco) {
+_CCCL_DEVICE_API void __cuda_atomic_store_order_dispatch(_Fn &__cuda_store, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
@@ -284,7 +284,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store_order_dispatch(_Fn &__cuda_s
   // 8 - Mmio semantic
   constexpr auto asm_intrinsic_format_128 = R"XXX(
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, {3}, __cuda_atomic_operand_{0}{1}, {5}, {7})
 {{
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -302,12 +302,12 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
 }})XXX";
   constexpr auto asm_intrinsic_format     = R"XXX(
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, {3}, __cuda_atomic_operand_{0}{1}, {5}, {7})
 {{ asm volatile("st{8}{4}{6}.{0}{1} [%0],%1;" :: "l"(__ptr), "{2}"(__val) : "memory"); }})XXX";
   constexpr auto asm_intrinsic_format_8   = R"XXX(
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, {3}, __cuda_atomic_operand_{0}{1}, {5}, {7})
 {{
   const uint16_t __tmp = static_cast<uint16_t>(__val);
@@ -422,12 +422,12 @@ struct __cuda_atomic_bind_store {
   _Type* __val;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {
     __cuda_atomic_store(__ptr, *__val, _Atomic_Memorder{}, _Tag{}, _Sco{}, _Mmio{});
   }
 };
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE void __atomic_store_cuda(_Type* __ptr, _Type& __val, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_store_cuda(_Type* __ptr, _Type& __val, int __memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -438,7 +438,7 @@ static inline _CCCL_DEVICE void __atomic_store_cuda(_Type* __ptr, _Type& __val, 
   __cuda_atomic_store_order_dispatch(__bound_store, __memorder, _Sco{});
 }
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE void __atomic_store_cuda(volatile _Type* __ptr, _Type& __val, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_store_cuda(volatile _Type* __ptr, _Type& __val, int __memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_derived.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_derived.h
@@ -45,7 +45,7 @@ template <class _Operand>
 using __cuda_atomic_enable_native_bitwise = enable_if_t<_Operand::__size >= 32, bool>;
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_bitwise<_Operand> = 0>
-_CCCL_DEVICE static bool
+_CCCL_DEVICE_API bool
 __cuda_atomic_compare_exchange(_Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, _Order, _Operand, _Sco)
 {
   constexpr uint64_t __alignmask = (sizeof(uint32_t) - 1);
@@ -223,7 +223,7 @@ _CCCL_DEVICE_API _Type __cuda_atomic_fetch_update(_Type* __ptr, const _Fn& __op,
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_arithmetic<_Operand> = 0>
-_CCCL_DEVICE static void __cuda_atomic_fetch_add(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -234,7 +234,7 @@ _CCCL_DEVICE static void __cuda_atomic_fetch_add(_Type* __ptr, _Type& __dst, _Ty
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_bitwise<_Operand> = 0>
-_CCCL_DEVICE static void __cuda_atomic_fetch_and(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -245,7 +245,7 @@ _CCCL_DEVICE static void __cuda_atomic_fetch_and(_Type* __ptr, _Type& __dst, _Ty
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_bitwise<_Operand> = 0>
-_CCCL_DEVICE static void __cuda_atomic_fetch_xor(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -256,7 +256,7 @@ _CCCL_DEVICE static void __cuda_atomic_fetch_xor(_Type* __ptr, _Type& __dst, _Ty
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_bitwise<_Operand> = 0>
-_CCCL_DEVICE static void __cuda_atomic_fetch_or(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -267,7 +267,7 @@ _CCCL_DEVICE static void __cuda_atomic_fetch_or(_Type* __ptr, _Type& __dst, _Typ
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_arithmetic<_Operand> = 0>
-_CCCL_DEVICE static void __cuda_atomic_fetch_min(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -278,7 +278,7 @@ _CCCL_DEVICE static void __cuda_atomic_fetch_min(_Type* __ptr, _Type& __dst, _Ty
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_arithmetic<_Operand> = 0>
-_CCCL_DEVICE static void __cuda_atomic_fetch_max(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -289,7 +289,7 @@ _CCCL_DEVICE static void __cuda_atomic_fetch_max(_Type* __ptr, _Type& __dst, _Ty
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_bitwise<_Operand> = 0>
-_CCCL_DEVICE static void __cuda_atomic_exchange(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_exchange(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -300,7 +300,7 @@ _CCCL_DEVICE static void __cuda_atomic_exchange(_Type* __ptr, _Type& __dst, _Typ
 }
 
 template <typename _Tp, typename _Fn, typename _Sco>
-[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_update(_Tp* __ptr, const _Fn& __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_update(_Tp* __ptr, const _Fn& __op, int __memorder, _Sco)
 {
   _Tp __expected = __atomic_load_n_cuda(__ptr, __ATOMIC_RELAXED, _Sco{});
   _Tp __desired  = __op(__expected);
@@ -311,8 +311,7 @@ template <typename _Tp, typename _Fn, typename _Sco>
   return __expected;
 }
 template <typename _Tp, typename _Fn, typename _Sco>
-[[nodiscard]] _CCCL_DEVICE static _Tp
-__cuda_atomic_fetch_update(_Tp volatile* __ptr, const _Fn& __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_update(_Tp volatile* __ptr, const _Fn& __op, int __memorder, _Sco)
 {
   _Tp __expected = __atomic_load_n_cuda(__ptr, __ATOMIC_RELAXED, _Sco{});
   _Tp __desired  = __op(__expected);
@@ -324,14 +323,14 @@ __cuda_atomic_fetch_update(_Tp volatile* __ptr, const _Fn& __op, int __memorder,
 }
 
 template <typename _Tp, typename _Sco>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_load_n_cuda(const _Tp* __ptr, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_load_n_cuda(const _Tp* __ptr, int __memorder, _Sco)
 {
   _Tp __ret;
   __atomic_load_cuda(__ptr, __ret, __memorder, _Sco{});
   return __ret;
 }
 template <typename _Tp, typename _Sco>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_load_n_cuda(const _Tp volatile* __ptr, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_load_n_cuda(const _Tp volatile* __ptr, int __memorder, _Sco)
 {
   _Tp __ret;
   __atomic_load_cuda(__ptr, __ret, __memorder, _Sco{});
@@ -350,14 +349,14 @@ _CCCL_DEVICE_API void __atomic_store_n_cuda(_Tp volatile* __ptr, _Tp __val, int 
 }
 
 template <typename _Tp, typename _Sco>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_exchange_n_cuda(_Tp* __ptr, _Tp __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_exchange_n_cuda(_Tp* __ptr, _Tp __val, int __memorder, _Sco)
 {
   _Tp __ret;
   __atomic_exchange_cuda(__ptr, __ret, __val, __memorder, _Sco{});
   return __ret;
 }
 template <typename _Tp, typename _Sco>
-[[nodiscard]] _CCCL_DEVICE static _Tp __atomic_exchange_n_cuda(_Tp volatile* __ptr, _Tp __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_exchange_n_cuda(_Tp volatile* __ptr, _Tp __val, int __memorder, _Sco)
 {
   _Tp __ret;
   __atomic_exchange_cuda(__ptr, __ret, __val, __memorder, _Sco{});
@@ -365,82 +364,76 @@ template <typename _Tp, typename _Sco>
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_arithmetic<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_add_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_add_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::plus>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_arithmetic<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp
-__cuda_atomic_fetch_add_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_add_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::plus>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_and_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_and_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_and>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp
-__cuda_atomic_fetch_and_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_and_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_and>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_or_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_or_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_or>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp
-__cuda_atomic_fetch_or_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_or_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_or>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_xor_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_xor_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_xor>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp
-__cuda_atomic_fetch_xor_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_xor_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_update(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_xor>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_minmax<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_min_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_min_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_update(
     __ptr, __cuda_atomic_op_bind<_Tp, __cuda_atomic_op_fetch_min>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_minmax<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp
-__cuda_atomic_fetch_min_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_min_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_update(
     __ptr, __cuda_atomic_op_bind<_Tp, __cuda_atomic_op_fetch_min>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_minmax<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp __cuda_atomic_fetch_max_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_max_dispatch(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_update(
     __ptr, __cuda_atomic_op_bind<_Tp, __cuda_atomic_op_fetch_max>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_minmax<_Tp> = 0>
-[[nodiscard]] _CCCL_DEVICE static _Tp
-__cuda_atomic_fetch_max_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __cuda_atomic_fetch_max_dispatch(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_update(
     __ptr, __cuda_atomic_op_bind<_Tp, __cuda_atomic_op_fetch_max>{__val}, __memorder, _Sco{});
 }
 
-_CCCL_DEVICE static inline void __cuda_atomic_signal_fence(int)
+_CCCL_DEVICE_API inline void __cuda_atomic_signal_fence(int)
 {
   asm volatile("" ::: "memory");
 }

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
@@ -47,31 +47,31 @@ extern "C" _CCCL_DEVICE void __atomic_cas_128b_unsupported_before_SM_90();
 extern "C" _CCCL_DEVICE void __atomic_exchange_128b_unsupported_before_SM_90();
 extern "C" _CCCL_DEVICE void __atomic_ldst_128b_unsupported_before_SM_70();
 
-static inline _CCCL_DEVICE void __cuda_atomic_membar(__thread_scope_block_tag)
+_CCCL_DEVICE_API void __cuda_atomic_membar(__thread_scope_block_tag)
 { asm volatile("membar.cta;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_membar(__thread_scope_device_tag)
+_CCCL_DEVICE_API void __cuda_atomic_membar(__thread_scope_device_tag)
 { asm volatile("membar.gl;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_membar(__thread_scope_system_tag)
+_CCCL_DEVICE_API void __cuda_atomic_membar(__thread_scope_system_tag)
 { asm volatile("membar.sys;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_block_tag, __cuda_atomic_order_acq_rel)
+_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_block_tag, __cuda_atomic_order_acq_rel)
 { asm volatile("fence.acq_rel.cta;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_block_tag, __cuda_atomic_order_seq_cst)
+_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_block_tag, __cuda_atomic_order_seq_cst)
 { asm volatile("fence.sc.cta;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_cluster_tag, __cuda_atomic_order_acq_rel)
+_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_cluster_tag, __cuda_atomic_order_acq_rel)
 { asm volatile("fence.acq_rel.cluster;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_cluster_tag, __cuda_atomic_order_seq_cst)
+_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_cluster_tag, __cuda_atomic_order_seq_cst)
 { asm volatile("fence.sc.cluster;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_device_tag, __cuda_atomic_order_acq_rel)
+_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_device_tag, __cuda_atomic_order_acq_rel)
 { asm volatile("fence.acq_rel.gpu;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_device_tag, __cuda_atomic_order_seq_cst)
+_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_device_tag, __cuda_atomic_order_seq_cst)
 { asm volatile("fence.sc.gpu;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_system_tag, __cuda_atomic_order_acq_rel)
+_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_system_tag, __cuda_atomic_order_acq_rel)
 { asm volatile("fence.acq_rel.sys;" ::: "memory"); }
-static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_system_tag, __cuda_atomic_order_seq_cst)
+_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_system_tag, __cuda_atomic_order_seq_cst)
 { asm volatile("fence.sc.sys;" ::: "memory"); }
 
 template <typename _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_thread_fence(int __memorder, _Sco) {
+_CCCL_DEVICE_API void __cuda_atomic_thread_fence(int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
@@ -99,7 +99,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_thread_fence(int __memorder, _Sco)
 }
 
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_load_order_dispatch(_Fn &__cuda_load, int __memorder, _Sco) {
+_CCCL_DEVICE_API void __cuda_atomic_load_order_dispatch(_Fn &__cuda_load, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
@@ -123,7 +123,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load_order_dispatch(_Fn &__cuda_lo
 }
 
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -131,7 +131,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -139,7 +139,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -147,7 +147,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -155,7 +155,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -163,7 +163,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -171,7 +171,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -179,7 +179,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -187,7 +187,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 {
   uint16_t __tmp;
@@ -195,7 +195,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -203,7 +203,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -211,7 +211,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -219,7 +219,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -227,7 +227,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -235,7 +235,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -243,7 +243,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -251,7 +251,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -259,7 +259,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -267,7 +267,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -275,7 +275,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -283,7 +283,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -291,7 +291,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u8, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 {
   uint16_t __tmp;
@@ -299,7 +299,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -307,7 +307,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -315,7 +315,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -323,7 +323,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -331,7 +331,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -339,7 +339,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -347,7 +347,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -355,7 +355,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -363,7 +363,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -371,7 +371,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -379,7 +379,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -387,7 +387,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -395,7 +395,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s8, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 {
   uint16_t __tmp;
@@ -403,7 +403,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -411,7 +411,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -419,7 +419,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -427,7 +427,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   uint16_t __tmp;
@@ -435,579 +435,579 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   __dst = static_cast<_Type>(__tmp);
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u16, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s16, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s16 %0,[%1];" : "=h"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f32 %0,[%1];" : "=f"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s32 %0,[%1];" : "=r"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.b64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.f64 %0,[%1];" : "=d"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.u64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cta.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.cluster.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.gpu.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.acquire.sys.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cta.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.cluster.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.gpu.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.relaxed.sys.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("ld.mmio.relaxed.sys.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("ld.volatile.s64 %0,[%1];" : "=l"(__dst) : "l"(__ptr) : "memory"); }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1024,7 +1024,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr) : "memory");
 }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1041,7 +1041,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr) : "memory");
 }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1058,7 +1058,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr) : "memory");
 }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1075,7 +1075,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr) : "memory");
 }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1092,7 +1092,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr) : "memory");
 }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1109,7 +1109,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr) : "memory");
 }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1126,7 +1126,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr) : "memory");
 }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1143,7 +1143,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr) : "memory");
 }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1160,7 +1160,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr) : "memory");
 }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1177,7 +1177,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr) : "memory");
 }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1194,7 +1194,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr) : "memory");
 }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1211,7 +1211,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_load(
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr) : "memory");
 }
   template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_load(
+_CCCL_DEVICE_API void __cuda_atomic_load(
   const _Type* __ptr, _Type& __dst, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1239,7 +1239,7 @@ struct __cuda_atomic_bind_load {
   }
 };
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE void __atomic_load_cuda(const _Type* __ptr, _Type& __dst, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_load_cuda(const _Type* __ptr, _Type& __dst, int __memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -1250,7 +1250,7 @@ static inline _CCCL_DEVICE void __atomic_load_cuda(const _Type* __ptr, _Type& __
   __cuda_atomic_load_order_dispatch(__bound_load, __memorder, _Sco{});
 }
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE void __atomic_load_cuda(const _Type volatile* __ptr, _Type& __dst, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_load_cuda(const _Type volatile* __ptr, _Type& __dst, int __memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -1262,7 +1262,7 @@ static inline _CCCL_DEVICE void __atomic_load_cuda(const _Type volatile* __ptr, 
 }
 
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_store_order_dispatch(_Fn &__cuda_store, int __memorder, _Sco) {
+_CCCL_DEVICE_API void __cuda_atomic_store_order_dispatch(_Fn &__cuda_store, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
@@ -1284,254 +1284,254 @@ static inline _CCCL_DEVICE void __cuda_atomic_store_order_dispatch(_Fn &__cuda_s
 }
 
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.release.cta.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.release.cluster.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.release.gpu.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.release.sys.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.relaxed.cta.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.relaxed.cluster.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.relaxed.gpu.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.relaxed.sys.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.mmio.relaxed.sys.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.volatile.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.volatile.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.volatile.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b8, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   const uint16_t __tmp = static_cast<uint16_t>(__val);
   asm volatile("st.volatile.b8 [%0],%1;" :: "l"(__ptr), "h"(__tmp) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.cta.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.cluster.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.gpu.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.sys.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.cta.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.cluster.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.gpu.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.sys.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("st.mmio.relaxed.sys.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b16, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b16 [%0],%1;" :: "l"(__ptr), "h"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.cta.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.cluster.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.gpu.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.sys.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.cta.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.cluster.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.gpu.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.sys.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("st.mmio.relaxed.sys.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b32 [%0],%1;" :: "l"(__ptr), "r"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.cta.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.cluster.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.gpu.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.release.sys.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.cta.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.cluster.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.gpu.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.relaxed.sys.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 { asm volatile("st.mmio.relaxed.sys.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 { asm volatile("st.volatile.b64 [%0],%1;" :: "l"(__ptr), "l"(__val) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1548,7 +1548,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   )YYY" :: "l"(__ptr), "l"(__val.__x),"l"(__val.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1565,7 +1565,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   )YYY" :: "l"(__ptr), "l"(__val.__x),"l"(__val.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1582,7 +1582,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   )YYY" :: "l"(__ptr), "l"(__val.__x),"l"(__val.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1599,7 +1599,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   )YYY" :: "l"(__ptr), "l"(__val.__x),"l"(__val.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1616,7 +1616,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   )YYY" :: "l"(__ptr), "l"(__val.__x),"l"(__val.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1633,7 +1633,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   )YYY" :: "l"(__ptr), "l"(__val.__x),"l"(__val.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1650,7 +1650,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   )YYY" :: "l"(__ptr), "l"(__val.__x),"l"(__val.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1667,7 +1667,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   )YYY" :: "l"(__ptr), "l"(__val.__x),"l"(__val.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_enable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1684,7 +1684,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   )YYY" :: "l"(__ptr), "l"(__val.__x),"l"(__val.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_block_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1701,7 +1701,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   )YYY" :: "l"(__ptr), "l"(__val.__x),"l"(__val.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_cluster_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1718,7 +1718,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   )YYY" :: "l"(__ptr), "l"(__val.__x),"l"(__val.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_device_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1735,7 +1735,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_store(
   )YYY" :: "l"(__ptr), "l"(__val.__x),"l"(__val.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_store(
+_CCCL_DEVICE_API void __cuda_atomic_store(
   _Type* __ptr, _Type& __val, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_system_tag, __cuda_atomic_mmio_disable)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b ld/st is not supported until PTX ISA version 840");
@@ -1763,7 +1763,7 @@ struct __cuda_atomic_bind_store {
   }
 };
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE void __atomic_store_cuda(_Type* __ptr, _Type& __val, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_store_cuda(_Type* __ptr, _Type& __val, int __memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -1774,7 +1774,7 @@ static inline _CCCL_DEVICE void __atomic_store_cuda(_Type* __ptr, _Type& __val, 
   __cuda_atomic_store_order_dispatch(__bound_store, __memorder, _Sco{});
 }
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE void __atomic_store_cuda(volatile _Type* __ptr, _Type& __val, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_store_cuda(volatile _Type* __ptr, _Type& __val, int __memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -1786,7 +1786,7 @@ static inline _CCCL_DEVICE void __atomic_store_cuda(volatile _Type* __ptr, _Type
 }
 
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_order_dispatch(_Fn& __cuda_cas, int __success_memorder, int __failure_memorder, _Sco) {
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange_order_dispatch(_Fn& __cuda_cas, int __success_memorder, int __failure_memorder, _Sco) {
   bool __res = false;
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
@@ -1816,167 +1816,167 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_order_dispatch(_F
 }
 
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.cas.acquire.cta.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.acquire.cluster.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.cas.acquire.gpu.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.cas.acquire.sys.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.cas.relaxed.cta.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.relaxed.cluster.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.cas.relaxed.gpu.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.cas.relaxed.sys.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.cas.release.cta.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.release.cluster.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.cas.release.gpu.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.cas.release.sys.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.cas.acq_rel.cta.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.acq_rel.cluster.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.cas.acq_rel.gpu.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.cas.acq_rel.sys.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.cas.cta.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.cluster.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.cas.gpu.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.cas.sys.b32 %0,[%1],%2,%3;" : "=r"(__dst) : "l"(__ptr), "r"(__cmp), "r"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.cas.acquire.cta.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.acquire.cluster.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.cas.acquire.gpu.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.cas.acquire.sys.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.cas.relaxed.cta.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.relaxed.cluster.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.cas.relaxed.gpu.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.cas.relaxed.sys.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.cas.release.cta.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.release.cluster.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.cas.release.gpu.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.cas.release.sys.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.cas.acq_rel.cta.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.acq_rel.cluster.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.cas.acq_rel.gpu.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.cas.acq_rel.sys.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.cas.cta.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.cas.cluster.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.cas.gpu.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.cas.sys.b64 %0,[%1],%2,%3;" : "=l"(__dst) : "l"(__ptr), "l"(__cmp), "l"(__op) : "memory"); return __dst == __cmp; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -1995,7 +1995,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2014,7 +2014,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2033,7 +2033,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2052,7 +2052,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2071,7 +2071,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2090,7 +2090,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2109,7 +2109,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2128,7 +2128,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2147,7 +2147,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2166,7 +2166,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2185,7 +2185,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2204,7 +2204,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2223,7 +2223,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2242,7 +2242,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2261,7 +2261,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2280,7 +2280,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2299,7 +2299,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2318,7 +2318,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2337,7 +2337,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
     }
   )YYY" : "=l"(__dst.__x),"=l"(__dst.__y) : "l"(__ptr), "l"(__cmp.__x),"l"(__cmp.__y), "l"(__op.__x),"l"(__op.__y) : "memory"); return __dst.__x == __cmp.__x && __dst.__y == __cmp.__y; }
 template <class _Type>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange(
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
   _Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b CAS is not supported until PTX ISA version 840");
@@ -2368,7 +2368,7 @@ struct __cuda_atomic_bind_compare_exchange {
   }
 };
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_dispatch(_Type* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange_dispatch(_Type* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -2381,7 +2381,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_dispatch(_Type* _
   return __cuda_atomic_compare_exchange_order_dispatch(__bound_compare_swap, __success_memorder, __failure_memorder, _Sco{});
 }
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_dispatch(_Type volatile* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
+_CCCL_DEVICE_API bool __cuda_atomic_compare_exchange_dispatch(_Type volatile* __ptr, _Type* __exp, _Type __des, bool, int __success_memorder, int __failure_memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -2395,7 +2395,7 @@ static inline _CCCL_DEVICE bool __cuda_atomic_compare_exchange_dispatch(_Type vo
 }
 
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange_order_dispatch(_Fn& __cuda_exch, int __memorder, _Sco) {
+_CCCL_DEVICE_API void __cuda_atomic_exchange_order_dispatch(_Fn& __cuda_exch, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
@@ -2423,167 +2423,167 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange_order_dispatch(_Fn& __cud
 }
 
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.exch.acquire.cta.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.acquire.cluster.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.exch.acquire.gpu.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.exch.acquire.sys.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.exch.relaxed.cta.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.relaxed.cluster.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.exch.relaxed.gpu.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.exch.relaxed.sys.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.exch.release.cta.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.release.cluster.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.exch.release.gpu.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.exch.release.sys.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.exch.acq_rel.cta.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.acq_rel.cluster.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.exch.acq_rel.gpu.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.exch.acq_rel.sys.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.exch.cta.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.cluster.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.exch.gpu.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.exch.sys.b32 %0,[%1],%2;" : "=r"(__old) : "l"(__ptr), "r"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.exch.acquire.cta.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.acquire.cluster.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.exch.acquire.gpu.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.exch.acquire.sys.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.exch.relaxed.cta.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.relaxed.cluster.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.exch.relaxed.gpu.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.exch.relaxed.sys.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.exch.release.cta.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.release.cluster.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.exch.release.gpu.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.exch.release.sys.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.exch.acq_rel.cta.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.acq_rel.cluster.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.exch.acq_rel.gpu.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.exch.acq_rel.sys.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.exch.cta.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.exch.cluster.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.exch.gpu.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.exch.sys.b64 %0,[%1],%2;" : "=l"(__old) : "l"(__ptr), "l"(__new) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2602,7 +2602,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2621,7 +2621,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2640,7 +2640,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acquire, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2659,7 +2659,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2678,7 +2678,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2697,7 +2697,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2716,7 +2716,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2735,7 +2735,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2754,7 +2754,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2773,7 +2773,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2792,7 +2792,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_release, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2811,7 +2811,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2830,7 +2830,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2849,7 +2849,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2868,7 +2868,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2887,7 +2887,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_block_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2906,7 +2906,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_cluster_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2925,7 +2925,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_device_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2944,7 +2944,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(
   )YYY" : "=l"(__old.__x),"=l"(__old.__y) : "l"(__ptr), "l"(__new.__x),"l"(__new.__y) : "memory");
 }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
   _Type* __ptr, _Type& __old, _Type __new, __cuda_atomic_order_volatile, __cuda_atomic_operand_b128, __thread_scope_system_tag)
 {
   static_assert(__cccl_ptx_isa >= 840 && (sizeof(_Type) == 16), "128b exchange is not supported until PTX ISA version 840");
@@ -2975,7 +2975,7 @@ struct __cuda_atomic_bind_exchange {
   }
 };
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE void __atomic_exchange_cuda(_Type* __ptr, _Type& __old, _Type __new, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_exchange_cuda(_Type* __ptr, _Type& __old, _Type __new, int __memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -2987,7 +2987,7 @@ static inline _CCCL_DEVICE void __atomic_exchange_cuda(_Type* __ptr, _Type& __ol
   __cuda_atomic_exchange_order_dispatch(__bound_swap, __memorder, _Sco{});
 }
 template <class _Type, class _Sco>
-static inline _CCCL_DEVICE void __atomic_exchange_cuda(_Type volatile* __ptr, _Type& __old, _Type __new, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_exchange_cuda(_Type volatile* __ptr, _Type& __old, _Type __new, int __memorder, _Sco)
 {
   using __proxy_t        = typename __cuda_atomic_deduce_bitwise<_Type>::__type;
   using __proxy_tag      = typename __cuda_atomic_deduce_bitwise<_Type>::__tag;
@@ -3000,7 +3000,7 @@ static inline _CCCL_DEVICE void __atomic_exchange_cuda(_Type volatile* __ptr, _T
 }
 
 template <class _Fn, class _Sco>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_order_dispatch(_Fn& __cuda_fetch, int __memorder, _Sco) {
+_CCCL_DEVICE_API void __cuda_atomic_fetch_order_dispatch(_Fn& __cuda_fetch, int __memorder, _Sco) {
   NV_DISPATCH_TARGET(
     NV_PROVIDES_SM_70, (
       switch (__memorder) {
@@ -3028,403 +3028,403 @@ static inline _CCCL_DEVICE void __cuda_atomic_fetch_order_dispatch(_Fn& __cuda_f
 }
 
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_block_tag)
 { asm volatile("atom.add.acquire.cta.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_block_tag)
 { asm volatile("atom.add.relaxed.cta.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f32, __thread_scope_block_tag)
 { asm volatile("atom.add.release.cta.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f32, __thread_scope_block_tag)
 { asm volatile("atom.add.acq_rel.cta.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_block_tag)
 { asm volatile("atom.add.cta.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acquire.cluster.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.relaxed.cluster.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.release.cluster.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acq_rel.cluster.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.cluster.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_device_tag)
 { asm volatile("atom.add.acquire.gpu.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_device_tag)
 { asm volatile("atom.add.relaxed.gpu.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f32, __thread_scope_device_tag)
 { asm volatile("atom.add.release.gpu.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f32, __thread_scope_device_tag)
 { asm volatile("atom.add.acq_rel.gpu.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_device_tag)
 { asm volatile("atom.add.gpu.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f32, __thread_scope_system_tag)
 { asm volatile("atom.add.acquire.sys.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f32, __thread_scope_system_tag)
 { asm volatile("atom.add.relaxed.sys.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f32, __thread_scope_system_tag)
 { asm volatile("atom.add.release.sys.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f32, __thread_scope_system_tag)
 { asm volatile("atom.add.acq_rel.sys.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f32, __thread_scope_system_tag)
 { asm volatile("atom.add.sys.f32 %0,[%1],%2;" : "=f"(__dst) : "l"(__ptr), "f"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_block_tag)
 { asm volatile("atom.add.acquire.cta.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_block_tag)
 { asm volatile("atom.add.relaxed.cta.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f64, __thread_scope_block_tag)
 { asm volatile("atom.add.release.cta.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f64, __thread_scope_block_tag)
 { asm volatile("atom.add.acq_rel.cta.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_block_tag)
 { asm volatile("atom.add.cta.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acquire.cluster.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.relaxed.cluster.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.release.cluster.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acq_rel.cluster.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.cluster.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_device_tag)
 { asm volatile("atom.add.acquire.gpu.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_device_tag)
 { asm volatile("atom.add.relaxed.gpu.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f64, __thread_scope_device_tag)
 { asm volatile("atom.add.release.gpu.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f64, __thread_scope_device_tag)
 { asm volatile("atom.add.acq_rel.gpu.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_device_tag)
 { asm volatile("atom.add.gpu.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_f64, __thread_scope_system_tag)
 { asm volatile("atom.add.acquire.sys.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_f64, __thread_scope_system_tag)
 { asm volatile("atom.add.relaxed.sys.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_f64, __thread_scope_system_tag)
 { asm volatile("atom.add.release.sys.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_f64, __thread_scope_system_tag)
 { asm volatile("atom.add.acq_rel.sys.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_f64, __thread_scope_system_tag)
 { asm volatile("atom.add.sys.f64 %0,[%1],%2;" : "=d"(__dst) : "l"(__ptr), "d"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.add.acquire.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.add.relaxed.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.add.release.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.add.acq_rel.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.add.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acquire.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.relaxed.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.release.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acq_rel.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.add.acquire.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.add.relaxed.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.add.release.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.add.acq_rel.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.add.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.add.acquire.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.add.relaxed.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.add.release.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.add.acq_rel.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.add.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.add.acquire.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.add.relaxed.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.add.release.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.add.acq_rel.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.add.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acquire.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.relaxed.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.release.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acq_rel.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.add.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.add.acquire.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.add.relaxed.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.add.release.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.add.acq_rel.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.add.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.add.acquire.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.add.relaxed.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.add.release.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.add.acq_rel.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.add.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.add.acquire.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.add.relaxed.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.add.release.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.add.acq_rel.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.add.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acquire.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.relaxed.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.release.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.acq_rel.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.add.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.add.acquire.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.add.relaxed.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.add.release.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.add.acq_rel.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.add.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.add.acquire.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.add.relaxed.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.add.release.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.add.acq_rel.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.add.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 
@@ -3440,7 +3440,7 @@ struct __cuda_atomic_bind_fetch_add {
   }
 };
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_arithmetic<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_add_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_add_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = __atomic_ptr_skip_t<_Type>::__skip;
   __op = __op * __skip_v;
@@ -3456,7 +3456,7 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_arithmet
   return __dst;
 }
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_arithmetic<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_add_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_add_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = __atomic_ptr_skip_t<_Type>::__skip;
   __op = __op * __skip_v;
@@ -3473,163 +3473,163 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_arithmet
 }
 
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.and.acquire.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.and.relaxed.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.and.release.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.and.acq_rel.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.and.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.and.acquire.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.and.relaxed.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.and.release.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.and.acq_rel.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.and.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.and.acquire.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.and.relaxed.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.and.release.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.and.acq_rel.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.and.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.and.acquire.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.and.relaxed.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.and.release.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.and.acq_rel.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.and.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.and.acquire.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.and.relaxed.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.and.release.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.and.acq_rel.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.and.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.and.acquire.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.and.relaxed.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.and.release.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.and.acq_rel.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.and.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.and.acquire.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.and.relaxed.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.and.release.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.and.acq_rel.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.and.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.and.acquire.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.and.relaxed.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.and.release.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.and.acq_rel.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.and.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 
@@ -3645,7 +3645,7 @@ struct __cuda_atomic_bind_fetch_and {
   }
 };
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_and_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_and_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
@@ -3661,7 +3661,7 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<
   return __dst;
 }
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_and_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_and_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
@@ -3678,323 +3678,323 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<
 }
 
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.max.acquire.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.max.relaxed.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.max.release.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.max.acq_rel.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.max.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acquire.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.relaxed.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.release.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acq_rel.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.max.acquire.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.max.relaxed.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.max.release.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.max.acq_rel.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.max.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.max.acquire.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.max.relaxed.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.max.release.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.max.acq_rel.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.max.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.max.acquire.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.max.relaxed.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.max.release.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.max.acq_rel.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.max.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acquire.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.relaxed.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.release.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acq_rel.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.max.acquire.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.max.relaxed.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.max.release.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.max.acq_rel.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.max.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.max.acquire.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.max.relaxed.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.max.release.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.max.acq_rel.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.max.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.max.acquire.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.max.relaxed.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.max.release.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.max.acq_rel.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.max.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acquire.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.relaxed.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.release.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acq_rel.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.max.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.max.acquire.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.max.relaxed.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.max.release.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.max.acq_rel.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.max.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.max.acquire.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.max.relaxed.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.max.release.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.max.acq_rel.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.max.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.max.acquire.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.max.relaxed.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.max.release.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.max.acq_rel.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.max.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acquire.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.relaxed.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.release.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.acq_rel.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.max.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.max.acquire.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.max.relaxed.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.max.release.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.max.acq_rel.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.max.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.max.acquire.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.max.relaxed.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.max.release.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.max.acq_rel.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.max.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 
@@ -4010,7 +4010,7 @@ struct __cuda_atomic_bind_fetch_max {
   }
 };
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_minmax<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_max_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_max_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
@@ -4026,7 +4026,7 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_minmax<_
   return __dst;
 }
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_minmax<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_max_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_max_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
@@ -4043,323 +4043,323 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_minmax<_
 }
 
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.min.acquire.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.min.relaxed.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.min.release.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.min.acq_rel.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_block_tag)
 { asm volatile("atom.min.cta.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acquire.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.relaxed.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.release.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acq_rel.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.cluster.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.min.acquire.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.min.relaxed.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.min.release.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.min.acq_rel.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_device_tag)
 { asm volatile("atom.min.gpu.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.min.acquire.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.min.relaxed.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.min.release.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.min.acq_rel.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u32, __thread_scope_system_tag)
 { asm volatile("atom.min.sys.u32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.min.acquire.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.min.relaxed.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.min.release.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.min.acq_rel.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_block_tag)
 { asm volatile("atom.min.cta.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acquire.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.relaxed.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.release.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acq_rel.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.cluster.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.min.acquire.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.min.relaxed.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.min.release.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.min.acq_rel.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_device_tag)
 { asm volatile("atom.min.gpu.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.min.acquire.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.min.relaxed.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.min.release.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.min.acq_rel.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_u64, __thread_scope_system_tag)
 { asm volatile("atom.min.sys.u64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.min.acquire.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.min.relaxed.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.min.release.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.min.acq_rel.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_block_tag)
 { asm volatile("atom.min.cta.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acquire.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.relaxed.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.release.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acq_rel.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_cluster_tag)
 { asm volatile("atom.min.cluster.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.min.acquire.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.min.relaxed.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.min.release.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.min.acq_rel.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_device_tag)
 { asm volatile("atom.min.gpu.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.min.acquire.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.min.relaxed.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.min.release.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.min.acq_rel.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s32, __thread_scope_system_tag)
 { asm volatile("atom.min.sys.s32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.min.acquire.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.min.relaxed.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.min.release.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.min.acq_rel.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_block_tag)
 { asm volatile("atom.min.cta.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acquire.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.relaxed.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.release.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.acq_rel.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_cluster_tag)
 { asm volatile("atom.min.cluster.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.min.acquire.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.min.relaxed.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.min.release.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.min.acq_rel.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_device_tag)
 { asm volatile("atom.min.gpu.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.min.acquire.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.min.relaxed.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.min.release.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.min.acq_rel.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_s64, __thread_scope_system_tag)
 { asm volatile("atom.min.sys.s64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 
@@ -4375,7 +4375,7 @@ struct __cuda_atomic_bind_fetch_min {
   }
 };
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_minmax<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_min_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_min_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
@@ -4391,7 +4391,7 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_minmax<_
   return __dst;
 }
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_minmax<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_min_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_min_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
@@ -4408,163 +4408,163 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_minmax<_
 }
 
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.or.acquire.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.or.relaxed.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.or.release.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.or.acq_rel.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.or.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.or.acquire.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.or.relaxed.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.or.release.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.or.acq_rel.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.or.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.or.acquire.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.or.relaxed.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.or.release.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.or.acq_rel.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.or.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.or.acquire.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.or.relaxed.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.or.release.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.or.acq_rel.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.or.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.or.acquire.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.or.relaxed.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.or.release.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.or.acq_rel.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.or.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.or.acquire.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.or.relaxed.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.or.release.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.or.acq_rel.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.or.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.or.acquire.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.or.relaxed.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.or.release.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.or.acq_rel.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.or.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.or.acquire.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.or.relaxed.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.or.release.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.or.acq_rel.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.or.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 
@@ -4580,7 +4580,7 @@ struct __cuda_atomic_bind_fetch_or {
   }
 };
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_or_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_or_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
@@ -4596,7 +4596,7 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<
   return __dst;
 }
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_or_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_or_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
@@ -4613,163 +4613,163 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<
 }
 
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.xor.acquire.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.xor.relaxed.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.xor.release.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.xor.acq_rel.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_block_tag)
 { asm volatile("atom.xor.cta.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.acquire.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.relaxed.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.release.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.acq_rel.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.cluster.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.xor.acquire.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.xor.relaxed.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.xor.release.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.xor.acq_rel.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_device_tag)
 { asm volatile("atom.xor.gpu.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.xor.acquire.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.xor.relaxed.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.xor.release.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.xor.acq_rel.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b32, __thread_scope_system_tag)
 { asm volatile("atom.xor.sys.b32 %0,[%1],%2;" : "=r"(__dst) : "l"(__ptr), "r"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.xor.acquire.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.xor.relaxed.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.xor.release.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.xor.acq_rel.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_block_tag)
 { asm volatile("atom.xor.cta.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.acquire.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.relaxed.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.release.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.acq_rel.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_cluster_tag)
 { asm volatile("atom.xor.cluster.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.xor.acquire.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.xor.relaxed.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.xor.release.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.xor.acq_rel.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_device_tag)
 { asm volatile("atom.xor.gpu.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acquire, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.xor.acquire.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_relaxed, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.xor.relaxed.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_release, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.xor.release.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_acq_rel, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.xor.acq_rel.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 template <class _Type>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(
   _Type* __ptr, _Type& __dst, _Type __op, __cuda_atomic_order_volatile, __cuda_atomic_operand_b64, __thread_scope_system_tag)
 { asm volatile("atom.xor.sys.b64 %0,[%1],%2;" : "=l"(__dst) : "l"(__ptr), "l"(__op) : "memory"); }
 
@@ -4785,7 +4785,7 @@ struct __cuda_atomic_bind_fetch_xor {
   }
 };
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_xor_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_xor_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
@@ -4801,7 +4801,7 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<
   return __dst;
 }
 template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<_Type> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_xor_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_xor_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   constexpr auto __skip_v = 1;
   __op = __op * __skip_v;
@@ -4818,12 +4818,12 @@ template <class _Type, class _Up, class _Sco, __atomic_enable_if_native_bitwise<
 }
 
 template <class _Type, class _Up, class _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_sub_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_sub_dispatch(_Type* __ptr, _Up __op, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_add_dispatch(__ptr, -__op, __memorder, _Sco{});
 }
 template <class _Type, class _Up, class _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Type __cuda_atomic_fetch_sub_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Type __cuda_atomic_fetch_sub_dispatch(_Type volatile* __ptr, _Up __op, int __memorder, _Sco)
 {
   return __cuda_atomic_fetch_add_dispatch(__ptr, -__op, __memorder, _Sco{});
 }

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
@@ -1234,7 +1234,7 @@ struct __cuda_atomic_bind_load {
   _Type* __dst;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {
     __cuda_atomic_load(__ptr, *__dst, _Atomic_Memorder{}, _Tag{}, _Sco{}, _Mmio{});
   }
 };
@@ -1758,7 +1758,7 @@ struct __cuda_atomic_bind_store {
   _Type* __val;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {
     __cuda_atomic_store(__ptr, *__val, _Atomic_Memorder{}, _Tag{}, _Sco{}, _Mmio{});
   }
 };
@@ -2363,7 +2363,7 @@ struct __cuda_atomic_bind_compare_exchange {
   _Type* __des;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE bool operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API bool operator()(_Atomic_Memorder) {
     return __cuda_atomic_compare_exchange(__ptr, *__exp, *__exp, *__des, _Atomic_Memorder{}, _Tag{}, _Sco{});
   }
 };
@@ -2970,7 +2970,7 @@ struct __cuda_atomic_bind_exchange {
   _Type* __new;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {
     __cuda_atomic_exchange(__ptr, *__old, *__new, _Atomic_Memorder{}, _Tag{}, _Sco{});
   }
 };
@@ -3435,7 +3435,7 @@ struct __cuda_atomic_bind_fetch_add {
   _Type* __op;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {
     __cuda_atomic_fetch_add(__ptr, *__dst, *__op, _Atomic_Memorder{}, _Tag{}, _Sco{});
   }
 };
@@ -3640,7 +3640,7 @@ struct __cuda_atomic_bind_fetch_and {
   _Type* __op;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {
     __cuda_atomic_fetch_and(__ptr, *__dst, *__op, _Atomic_Memorder{}, _Tag{}, _Sco{});
   }
 };
@@ -4005,7 +4005,7 @@ struct __cuda_atomic_bind_fetch_max {
   _Type* __op;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {
     __cuda_atomic_fetch_max(__ptr, *__dst, *__op, _Atomic_Memorder{}, _Tag{}, _Sco{});
   }
 };
@@ -4370,7 +4370,7 @@ struct __cuda_atomic_bind_fetch_min {
   _Type* __op;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {
     __cuda_atomic_fetch_min(__ptr, *__dst, *__op, _Atomic_Memorder{}, _Tag{}, _Sco{});
   }
 };
@@ -4575,7 +4575,7 @@ struct __cuda_atomic_bind_fetch_or {
   _Type* __op;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {
     __cuda_atomic_fetch_or(__ptr, *__dst, *__op, _Atomic_Memorder{}, _Tag{}, _Sco{});
   }
 };
@@ -4780,7 +4780,7 @@ struct __cuda_atomic_bind_fetch_xor {
   _Type* __op;
 
   template <typename _Atomic_Memorder>
-  inline _CCCL_DEVICE void operator()(_Atomic_Memorder) {
+  _CCCL_DEVICE_API void operator()(_Atomic_Memorder) {
     __cuda_atomic_fetch_xor(__ptr, *__dst, *__op, _Atomic_Memorder{}, _Tag{}, _Sco{});
   }
 };

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
@@ -47,27 +47,27 @@ extern "C" _CCCL_DEVICE void __atomic_cas_128b_unsupported_before_SM_90();
 extern "C" _CCCL_DEVICE void __atomic_exchange_128b_unsupported_before_SM_90();
 extern "C" _CCCL_DEVICE void __atomic_ldst_128b_unsupported_before_SM_70();
 
-_CCCL_DEVICE_API void __cuda_atomic_membar(__thread_scope_block_tag)
+_CCCL_DEVICE_API inline void __cuda_atomic_membar(__thread_scope_block_tag)
 { asm volatile("membar.cta;" ::: "memory"); }
-_CCCL_DEVICE_API void __cuda_atomic_membar(__thread_scope_device_tag)
+_CCCL_DEVICE_API inline void __cuda_atomic_membar(__thread_scope_device_tag)
 { asm volatile("membar.gl;" ::: "memory"); }
-_CCCL_DEVICE_API void __cuda_atomic_membar(__thread_scope_system_tag)
+_CCCL_DEVICE_API inline void __cuda_atomic_membar(__thread_scope_system_tag)
 { asm volatile("membar.sys;" ::: "memory"); }
-_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_block_tag, __cuda_atomic_order_acq_rel)
+_CCCL_DEVICE_API inline void __cuda_atomic_fence(__thread_scope_block_tag, __cuda_atomic_order_acq_rel)
 { asm volatile("fence.acq_rel.cta;" ::: "memory"); }
-_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_block_tag, __cuda_atomic_order_seq_cst)
+_CCCL_DEVICE_API inline void __cuda_atomic_fence(__thread_scope_block_tag, __cuda_atomic_order_seq_cst)
 { asm volatile("fence.sc.cta;" ::: "memory"); }
-_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_cluster_tag, __cuda_atomic_order_acq_rel)
+_CCCL_DEVICE_API inline void __cuda_atomic_fence(__thread_scope_cluster_tag, __cuda_atomic_order_acq_rel)
 { asm volatile("fence.acq_rel.cluster;" ::: "memory"); }
-_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_cluster_tag, __cuda_atomic_order_seq_cst)
+_CCCL_DEVICE_API inline void __cuda_atomic_fence(__thread_scope_cluster_tag, __cuda_atomic_order_seq_cst)
 { asm volatile("fence.sc.cluster;" ::: "memory"); }
-_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_device_tag, __cuda_atomic_order_acq_rel)
+_CCCL_DEVICE_API inline void __cuda_atomic_fence(__thread_scope_device_tag, __cuda_atomic_order_acq_rel)
 { asm volatile("fence.acq_rel.gpu;" ::: "memory"); }
-_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_device_tag, __cuda_atomic_order_seq_cst)
+_CCCL_DEVICE_API inline void __cuda_atomic_fence(__thread_scope_device_tag, __cuda_atomic_order_seq_cst)
 { asm volatile("fence.sc.gpu;" ::: "memory"); }
-_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_system_tag, __cuda_atomic_order_acq_rel)
+_CCCL_DEVICE_API inline void __cuda_atomic_fence(__thread_scope_system_tag, __cuda_atomic_order_acq_rel)
 { asm volatile("fence.acq_rel.sys;" ::: "memory"); }
-_CCCL_DEVICE_API void __cuda_atomic_fence(__thread_scope_system_tag, __cuda_atomic_order_seq_cst)
+_CCCL_DEVICE_API inline void __cuda_atomic_fence(__thread_scope_system_tag, __cuda_atomic_order_seq_cst)
 { asm volatile("fence.sc.sys;" ::: "memory"); }
 
 template <typename _Sco>

--- a/libcudacxx/include/cuda/std/__atomic/platform/msvc_to_builtins.h
+++ b/libcudacxx/include/cuda/std/__atomic/platform/msvc_to_builtins.h
@@ -63,7 +63,7 @@ inline int __stronger_order_msvc(int __a, int __b)
   return __xform[__a < __b ? __a : __b];
 }
 
-static inline void __atomic_signal_fence(int __memorder)
+inline void __atomic_signal_fence(int __memorder)
 {
   if (__memorder != __ATOMIC_RELAXED)
   {
@@ -71,7 +71,7 @@ static inline void __atomic_signal_fence(int __memorder)
   }
 }
 
-static inline void __atomic_thread_fence(int __memorder)
+inline void __atomic_thread_fence(int __memorder)
 {
   if (__memorder != __ATOMIC_RELAXED)
   {


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

More LLVM23 `-Wunused-template` warnings. After this round of fixes, however, we should just disable the warning entirely.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
