### PR TITLE
[STF] Do not misattribute stale CUDA errors in `pin_memory`/`unpin_memory` and executable-graph updates

### DIFF
--- a/cudax/include/cuda/experimental/__stf/internal/executable_graph_cache.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/executable_graph_cache.cuh
@@ -42,12 +42,17 @@ namespace reserved
 inline bool try_updating_executable_graph(cudaGraphExec_t exec_graph, cudaGraph_t graph)
 {
   cudaGraphExecUpdateResultInfo resultInfo;
-  cudaGraphExecUpdate(exec_graph, graph, &resultInfo);
-
-  // Be sure to "erase" the last error
-  cudaError_t res = cudaGetLastError();
-
-  return (res == cudaSuccess);
+  const cudaError_t res = cudaGraphExecUpdate(exec_graph, graph, &resultInfo);
+  if (res != cudaSuccess)
+  {
+    // A failed update is expected (the caller falls back to instantiation):
+    // consume the sticky error state so it is not misattributed to a later,
+    // unrelated call. Reading cudaGetLastError() INSTEAD of the return value
+    // would have the converse bug: an earlier unrelated failure would make a
+    // successful update look failed.
+    cudaGetLastError();
+  }
+  return res == cudaSuccess;
 }
 
 // Instantiate a CUDA graph

--- a/cudax/include/cuda/experimental/__stf/utility/memory.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/memory.cuh
@@ -345,9 +345,17 @@ cudaError_t pin_memory(T* p, size_t n)
   // We cast to (void *) because T may be a const type : we are not going
   // to modify the content, so this is legit ...
   using NonConstT = typename std::remove_const<T>::type;
-  cudaHostRegister(const_cast<NonConstT*>(p), n * sizeof(T), cudaHostRegisterPortable);
-  // Fetch the result and clear the last error
-  return cudaGetLastError();
+  // Report the result of THIS call only. cudaGetLastError() would return the
+  // sticky error of any earlier failed CUDA call on this thread (e.g. an
+  // expected probe failure or a caught allocation error), misattributing it
+  // to this registration.
+  const cudaError_t res = cudaHostRegister(const_cast<NonConstT*>(p), n * sizeof(T), cudaHostRegisterPortable);
+  if (res != cudaSuccess)
+  {
+    // Consume the sticky error state so it is not re-reported elsewhere.
+    cudaGetLastError();
+  }
+  return res;
 }
 
 /**
@@ -361,15 +369,15 @@ void unpin_memory(T* p)
 {
   assert(p);
 
-  // Make sure no one did a mistake before ignoring the one that may come !
-  cuda_try(cudaGetLastError());
-
   // We cast to non const T * because T may be a const type : we are not going
   // to modify the content, so this is legit ...
   using NonConstT = typename std::remove_const<T>::type;
-  if (cudaHostUnregister(const_cast<NonConstT*>(p)) == cudaErrorHostMemoryNotRegistered)
+  if (cudaHostUnregister(const_cast<NonConstT*>(p)) != cudaSuccess)
   {
-    // Ignore that error, we probably also ignored an error about registering that buffer too !
+    // Tolerate unregister failures (e.g. the matching registration was
+    // skipped or failed) and consume the sticky error state so it is not
+    // misattributed to a later, unrelated call. This runs on cleanup paths
+    // (including destructors), so it must not throw.
     cudaGetLastError();
   }
 }
@@ -431,6 +439,25 @@ UNITTEST("pin_memory const")
   unpin_memory(ca);
 
   EXPECT(!address_is_pinned(ca));
+};
+
+UNITTEST("pin_memory ignores stale sticky errors")
+{
+  // A failed CUDA call earlier on the thread (here an impossible allocation,
+  // as an STF allocator would attempt before reporting an OOM) leaves a
+  // sticky last-error. pin/unpin of an unrelated buffer must not report it
+  // as their own failure.
+  void* p = nullptr;
+  EXPECT(cudaMalloc(&p, size_t(1) << 46) != cudaSuccess);
+
+  ::std::vector<double> a(1024);
+  EXPECT(pin_memory(&a[0], 1024) == cudaSuccess);
+  EXPECT(address_is_pinned(&a[0]));
+  unpin_memory(&a[0]);
+  EXPECT(!address_is_pinned(&a[0]));
+
+  // Consume whatever is left so this test does not poison the next one.
+  cudaGetLastError();
 };
 
 #endif // UNITTESTED_FILE


### PR DESCRIPTION
## Description

`pin_memory()` ignored `cudaHostRegister`'s return value and reported `cudaGetLastError()` instead. `cudaGetLastError()` returns the sticky error left by **any** earlier failed CUDA call on the thread — an expected feature probe, a caught allocation failure, etc. — so one benign, already-handled failure anywhere in the process turned the next pin of an unrelated buffer into a phantom `cuda_exception` (e.g. an `out of memory` reported at `slice.cuh`'s pin even though the registration succeeded).

`unpin_memory()` went further and *threw* on such stale errors via `cuda_try(cudaGetLastError())`, on cleanup paths that can run during destruction.

`try_updating_executable_graph()` had the same pattern with `cudaGraphExecUpdate`: a stale error made a successful executable-graph update look failed, causing a spurious re-instantiation (and conversely its own expected failures relied on the sticky state being consumed).

This cross-contamination is a likely contributor to hard-to-diagnose one-off failures in the STF Python CI job (e.g. the `test_repeat_scope` worker crash in [this run](https://github.com/NVIDIA/cccl/actions/runs/33401623834/job/99528781008)), where many tests sharing one process perform benign failing CUDA calls: locally, a caught allocation failure in one STF context deterministically made a 512-byte pin in a *fresh* context fail with a phantom `cudaErrorMemoryAllocation`.

### Fix

All three sites now use their own call's return status, and consume the sticky error state on failure so it cannot leak into unrelated calls.

### Testing

- New header unittest `pin_memory ignores stale sticky errors` in `memory.cuh` (fails against the old code): a failed oversized `cudaMalloc` must not make a subsequent pin/unpin of an unrelated buffer report an error.
- Compiled and ran the `memory.cuh` header unittests locally (sm_86): pass.
- Full `cuda-stf` Python test suite (`-n 6`, 256 tests) run 5x locally on the fixed build: clean. Before the fix, a caught OOM in one test deterministically poisoned a later test on the same xdist worker.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)