### PR TITLE
[libcu++] Restore nvtarget specific macro tests to SM103

### DIFF
--- a/libcudacxx/test/nvtarget/arch_specific/CMakeLists.txt
+++ b/libcudacxx/test/nvtarget/arch_specific/CMakeLists.txt
@@ -2,8 +2,8 @@ if (NOT "${CMAKE_CUDA_COMPILER_ID}" STREQUAL "NVIDIA")
   return()
 endif()
 
-# sm_107 arch-specific features are supported since 13.4
-if ("${CMAKE_CUDA_COMPILER_VERSION}" VERSION_LESS "13.4")
+# arch-specific features are supported since 12.9
+if ("${CMAKE_CUDA_COMPILER_VERSION}" VERSION_LESS "12.9")
   return()
 endif()
 
@@ -15,6 +15,6 @@ set(target_name "libcudacxx.test.nvtarget.arch_specific")
 add_library(${target_name} OBJECT arch_specific.cu)
 set_target_properties(
   ${target_name}
-  PROPERTIES CUDA_ARCHITECTURES "107a-virtual"
+  PROPERTIES CUDA_ARCHITECTURES "103a-virtual"
 )
 add_dependencies(libcudacxx.test.nvtarget ${target_name})

--- a/libcudacxx/test/nvtarget/arch_specific/arch_specific.cu
+++ b/libcudacxx/test/nvtarget/arch_specific/arch_specific.cu
@@ -17,11 +17,11 @@
 #  error "This test works with nvcc only."
 #endif // !__NVCC__
 
-#if defined(__CUDA_ARCH_SPECIFIC__)
-#  if __CUDA_ARCH_SPECIFIC__ != 1070
-#    error "This test must be compiled for sm_107a target."
-#  endif // __CUDA_ARCH_SPECIFIC__ != 1070
-#endif // __CUDA_ARCH_SPECIFIC__
+#if defined(__CUDA_ARCH__)
+#  if __CUDA_ARCH_SPECIFIC__ != 1030
+#    error "This test must be compiled for sm_103a target."
+#  endif // __CUDA_ARCH_SPECIFIC__ != 1030
+#endif // __CUDA_ARCH__
 
 #define CHECK_TRUE(_PRED)                                                 \
   do                                                                      \
@@ -39,27 +39,23 @@ __tile__
 #endif // __CUDACC_TILE__
   __host__ __device__ void fn()
 {
-#if defined(__CUDA_ARCH_SPECIFIC__)
-  CHECK_TRUE(NV_IS_EXACTLY_SM_107);
+#if defined(__CUDA_ARCH__)
+  CHECK_TRUE(NV_IS_EXACTLY_SM_103);
 
-  CHECK_TRUE(NV_HAS_FEATURE_SM_107a);
+  CHECK_TRUE(NV_HAS_FEATURE_SM_103a);
 
   CHECK_TRUE(NV_HAS_FEATURE_SM_100f);
   CHECK_TRUE(NV_HAS_FEATURE_SM_103f);
-  CHECK_TRUE(NV_HAS_FEATURE_SM_107f);
-#elif !defined(__CUDA_ARCH__) // ^^^ __CUDA_ARCH_SPECIFIC__ ^^^ / vvv host vvv
+#else // ^^^ __CUDA_ARCH__ ^^^ / vvv !__CUDA_ARCH__ vvv
   CHECK_TRUE(NV_IS_HOST);
 
   CHECK_FALSE(NV_HAS_FEATURE_SM_103a);
-  CHECK_FALSE(NV_HAS_FEATURE_SM_107a);
 
   CHECK_FALSE(NV_HAS_FEATURE_SM_100f);
   CHECK_FALSE(NV_HAS_FEATURE_SM_103f);
-  CHECK_FALSE(NV_HAS_FEATURE_SM_107f);
-#endif // ^^^ host ^^^
+#endif // ^^^ !__CUDA_ARCH__ ^^^
 
   CHECK_FALSE(NV_HAS_FEATURE_SM_100a);
-  CHECK_FALSE(NV_HAS_FEATURE_SM_103a);
   CHECK_FALSE(NV_HAS_FEATURE_SM_110a);
 
   CHECK_FALSE(NV_HAS_FEATURE_SM_110f);

--- a/libcudacxx/test/nvtarget/family_specific/CMakeLists.txt
+++ b/libcudacxx/test/nvtarget/family_specific/CMakeLists.txt
@@ -2,8 +2,8 @@ if (NOT "${CMAKE_CUDA_COMPILER_ID}" STREQUAL "NVIDIA")
   return()
 endif()
 
-# sm_107 family-specific features are supported since 13.4
-if ("${CMAKE_CUDA_COMPILER_VERSION}" VERSION_LESS "13.4")
+# family-specific features are supported since 12.9
+if ("${CMAKE_CUDA_COMPILER_VERSION}" VERSION_LESS "12.9")
   return()
 endif()
 
@@ -15,6 +15,6 @@ set(target_name "libcudacxx.test.nvtarget.family_specific")
 add_library(${target_name} OBJECT family_specific.cu)
 set_target_properties(
   ${target_name}
-  PROPERTIES CUDA_ARCHITECTURES "107f-virtual"
+  PROPERTIES CUDA_ARCHITECTURES "103f-virtual"
 )
 add_dependencies(libcudacxx.test.nvtarget ${target_name})

--- a/libcudacxx/test/nvtarget/family_specific/family_specific.cu
+++ b/libcudacxx/test/nvtarget/family_specific/family_specific.cu
@@ -17,11 +17,11 @@
 #  error "This test works with nvcc only."
 #endif // !__NVCC__
 
-#if defined(__CUDA_ARCH_FAMILY_SPECIFIC__)
-#  if __CUDA_ARCH_FAMILY_SPECIFIC__ != 1070
-#    error "This test must be compiled for sm_107f target."
-#  endif // __CUDA_ARCH_FAMILY_SPECIFIC__ != 1070
-#endif // __CUDA_ARCH_FAMILY_SPECIFIC__
+#if defined(__CUDA_ARCH__)
+#  if __CUDA_ARCH_FAMILY_SPECIFIC__ != 1030
+#    error "This test must be compiled for sm_103f target."
+#  endif // __CUDA_ARCH_FAMILY_SPECIFIC__ != 1030
+#endif // __CUDA_ARCH__
 
 #define CHECK_TRUE(_PRED)                                                 \
   do                                                                      \
@@ -39,24 +39,21 @@ __tile__
 #endif // __CUDACC_TILE__
   __host__ __device__ void fn()
 {
-#if defined(__CUDA_ARCH_FAMILY_SPECIFIC__)
-  CHECK_TRUE(NV_IS_EXACTLY_SM_107);
+#if defined(__CUDA_ARCH__)
+  CHECK_TRUE(NV_IS_EXACTLY_SM_103);
 
   CHECK_TRUE(NV_HAS_FEATURE_SM_100f);
   CHECK_TRUE(NV_HAS_FEATURE_SM_103f);
-  CHECK_TRUE(NV_HAS_FEATURE_SM_107f);
-#elif !defined(__CUDA_ARCH__) // ^^^ __CUDA_ARCH_FAMILY_SPECIFIC__ ^^^ / vvv host vvv
+#else // ^^^ __CUDA_ARCH__ ^^^ / vvv !__CUDA_ARCH__ vvv
   CHECK_TRUE(NV_IS_HOST);
 
   CHECK_FALSE(NV_HAS_FEATURE_SM_100f);
   CHECK_FALSE(NV_HAS_FEATURE_SM_103f);
-  CHECK_FALSE(NV_HAS_FEATURE_SM_107f);
-#endif // ^^^ host ^^^
+#endif // ^^^ !__CUDA_ARCH__ ^^^
 
   CHECK_FALSE(NV_HAS_FEATURE_SM_110f);
 
   CHECK_FALSE(NV_HAS_FEATURE_SM_100a);
   CHECK_FALSE(NV_HAS_FEATURE_SM_103a);
-  CHECK_FALSE(NV_HAS_FEATURE_SM_107a);
   CHECK_FALSE(NV_HAS_FEATURE_SM_110a);
 }


### PR DESCRIPTION
Follow-up to #10909.

PR 10909 retargeted the existing nvtarget arch-specific/family-specific tests from sm_103a/sm_103f to sm_107a/sm_107f. That dropped the standing 103a/103f coverage. This PR restores those two focused tests to their pre-10909 targets and version gates:

- arch-specific test: 103a-virtual, CUDA >= 12.9
- family-specific test: 103f-virtual, CUDA >= 12.9

The SM107 support added by #10909 remains covered by the general architecture/device tests.
