### PR TITLE
Deduplicate and extend nightly/weekly workflows.

### DIFF
--- a/.github/workflows/ci-matrix-build.yml
+++ b/.github/workflows/ci-matrix-build.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/workflows/ci-matrix-build.yml
+++ b/.github/workflows/ci-matrix-build.yml
@@ -73,7 +73,7 @@ jobs:
         uses: ./.github/actions/workflow-build
         with:
           workflows: ${{ inputs.workflows }}
-          matrix_file: ${{ inputs.matrix_file }}
+          matrix_file: ".private/${{ inputs.matrix_file }}"
           slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
           slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
           slack_alert: ${{ inputs.enable_slack_alert == true && secrets.SLACK_CHANNEL_CI_ALERT || '' }}

--- a/.github/workflows/ci-matrix-build.yml
+++ b/.github/workflows/ci-matrix-build.yml
@@ -33,6 +33,14 @@ on:
         description: "When true, also post failure notifications to the alert Slack channel (secrets.SLACK_CHANNEL_CI_ALERT) in addition to the log channel."
         type: boolean
         default: false
+      matrix_file:
+        description: "Path to the CI matrix file to parse. Defaults to 'ci/matrix.yaml' from the current checkout. For sideloaded matrices, point this at a '.private/' checkout of another branch (e.g. '.private/ci/matrix.yaml')."
+        type: string
+        default: ci/matrix.yaml
+      matrix_branch:
+        description: "Branch (in this repo) to checkout into '.private' so its matrix file can be sideloaded. When empty, no extra checkout is performed and 'matrix_file' is read from the current checkout."
+        type: string
+        default: ''
     outputs:
       failure_message:
         description: "Prepared workflow failure notification text, populated when verify-workflow detects failures."
@@ -53,11 +61,19 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Checkout matrix branch into .private
+        if: ${{ inputs.matrix_branch != '' }}
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.matrix_branch }}
+          path: .private
       - name: Build workflow
         id: build-workflow
         uses: ./.github/actions/workflow-build
         with:
           workflows: ${{ inputs.workflows }}
+          matrix_file: ${{ inputs.matrix_file }}
           slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
           slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
           slack_alert: ${{ inputs.enable_slack_alert == true && secrets.SLACK_CHANNEL_CI_ALERT || '' }}

--- a/.github/workflows/ci-matrix-build.yml
+++ b/.github/workflows/ci-matrix-build.yml
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reusable workflow that builds the CI matrix from ci/matrix.yaml and dispatches
+# all build/test job groups. Shared by the nightly and weekly scheduled workflows,
+# which only differ in the matrix `workflows` value and Slack alert preference.
+name: "CI/Matrix Build"
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+on:
+  workflow_call:
+    inputs:
+      workflows:
+        description: "Space separated list of workflows in the matrix file to run (e.g. 'nightly' or 'weekly')."
+        type: string
+        required: true
+      enable_slack_alert:
+        description: "When true, also post failure notifications to the alert Slack channel (secrets.SLACK_CHANNEL_CI_ALERT) in addition to the log channel."
+        type: boolean
+        default: false
+    outputs:
+      failure_message:
+        description: "Prepared workflow failure notification text, populated when verify-workflow detects failures."
+        value: ${{ jobs.verify-workflow.outputs.failure_message }}
+
+jobs:
+
+  build-workflow:
+    name: Build workflow from matrix
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'NVIDIA/cccl' }}
+    permissions:
+      contents: read
+    outputs:
+      workflow: ${{ steps.build-workflow.outputs.workflow }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Build workflow
+        id: build-workflow
+        uses: ./.github/actions/workflow-build
+        with:
+          workflows: ${{ inputs.workflows }}
+          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
+          slack_alert: ${{ inputs.enable_slack_alert == true && secrets.SLACK_CHANNEL_CI_ALERT || '' }}
+
+  dispatch-groups-linux-two-stage:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+    with:
+      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
+
+  dispatch-groups-windows-two-stage:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
+    with:
+      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
+
+  dispatch-groups-linux-standalone:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
+    with:
+      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
+
+  dispatch-groups-windows-standalone:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
+    with:
+      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
+
+  verify-workflow:
+    name: Verify and summarize workflow results
+    if: ${{ always() && !cancelled() }}
+    needs:
+      - build-workflow
+      - dispatch-groups-linux-two-stage
+      - dispatch-groups-windows-two-stage
+      - dispatch-groups-linux-standalone
+      - dispatch-groups-windows-standalone
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      failure_message: ${{ steps.check-workflow.outputs.failure_message }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Check workflow success
+        id: check-workflow
+        uses: ./.github/actions/workflow-results
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
+          slack_alert: ${{ inputs.enable_slack_alert == true && secrets.SLACK_CHANNEL_CI_ALERT || '' }}

--- a/.github/workflows/ci-matrix-build.yml
+++ b/.github/workflows/ci-matrix-build.yml
@@ -33,10 +33,6 @@ on:
         description: "When true, also post failure notifications to the alert Slack channel (secrets.SLACK_CHANNEL_CI_ALERT) in addition to the log channel."
         type: boolean
         default: false
-      matrix_file:
-        description: "Path to the CI matrix file to parse. Defaults to 'ci/matrix.yaml' from the current checkout. For sideloaded matrices, point this at a '.private/' checkout of another branch (e.g. '.private/ci/matrix.yaml')."
-        type: string
-        default: ci/matrix.yaml
       matrix_branch:
         description: "Branch (in this repo) to checkout into '.private' so its matrix file can be sideloaded. When empty, no extra checkout is performed and 'matrix_file' is read from the current checkout."
         type: string
@@ -73,7 +69,10 @@ jobs:
         uses: ./.github/actions/workflow-build
         with:
           workflows: ${{ inputs.workflows }}
-          matrix_file: ".private/${{ inputs.matrix_file }}"
+          # When sideloading from another branch, the matrix checkout is prefixed with
+          # '.private'. Otherwise use the path as-is from the current checkout
+          # (e.g. 'ci/matrix.yaml' for the default callers).
+          matrix_file: ${{ inputs.matrix_branch != '' && ".private/ci/matrix.yaml" || "ci/matrix.yaml" }}
           slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
           slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
           slack_alert: ${{ inputs.enable_slack_alert == true && secrets.SLACK_CHANNEL_CI_ALERT || '' }}

--- a/.github/workflows/ci-matrix-build.yml
+++ b/.github/workflows/ci-matrix-build.yml
@@ -72,7 +72,7 @@ jobs:
           # When sideloading from another branch, the matrix checkout is prefixed with
           # '.private'. Otherwise use the path as-is from the current checkout
           # (e.g. 'ci/matrix.yaml' for the default callers).
-          matrix_file: ${{ inputs.matrix_branch != '' && ".private/ci/matrix.yaml" || "ci/matrix.yaml" }}
+          matrix_file: ${{ inputs.matrix_branch != '' && '.private/ci/matrix.yaml' || 'ci/matrix.yaml' }}
           slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
           slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
           slack_alert: ${{ inputs.enable_slack_alert == true && secrets.SLACK_CHANNEL_CI_ALERT || '' }}

--- a/.github/workflows/ci-workflow-custom.yml
+++ b/.github/workflows/ci-workflow-custom.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/workflows/ci-workflow-custom.yml
+++ b/.github/workflows/ci-workflow-custom.yml
@@ -49,4 +49,4 @@ jobs:
     with:
       workflows: nightly
       matrix_branch: ${{ inputs.branch }}
-      matrix_file: .private/${{ inputs.matrix_path }}
+      matrix_file: ${{ inputs.matrix_path }}

--- a/.github/workflows/ci-workflow-custom.yml
+++ b/.github/workflows/ci-workflow-custom.yml
@@ -27,7 +27,7 @@ defaults:
 on:
   workflow_dispatch:
     inputs:
-      branch:
+      matrix_branch:
         description: "Branch (in this repo) containing the CI matrix file to sideload."
         required: true
         type: string
@@ -48,5 +48,5 @@ jobs:
     secrets: inherit
     with:
       workflows: nightly
-      matrix_branch: ${{ inputs.branch }}
+      matrix_branch: ${{ inputs.matrix_branch }}
       matrix_file: ${{ inputs.matrix_path }}

--- a/.github/workflows/ci-workflow-custom.yml
+++ b/.github/workflows/ci-workflow-custom.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# On-demand workflow that sideloads a CI matrix file from a different branch of
+# this repo and runs the full nightly build matrix defined there. Unlike the
+# scheduled workflows, this always builds a full matrix (no inspect-changes) and
+# fetches the specified branch into '.private' inside ci-matrix-build so the
+# sideloaded matrix file is available to the workflow-build step.
+name: custom
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch (in this repo) containing the CI matrix file to sideload."
+        required: true
+        type: string
+      matrix_path:
+        description: "Path to the CI matrix file within <branch>. It must define a 'nightly' workflow, which is run as a full build."
+        required: true
+        type: string
+        default: ci/matrix.yaml
+
+concurrency:
+  group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
+
+jobs:
+
+  matrix-build:
+    name: Build & dispatch CI matrix
+    uses: ./.github/workflows/ci-matrix-build.yml
+    secrets: inherit
+    with:
+      workflows: nightly
+      matrix_branch: ${{ inputs.branch }}
+      matrix_file: .private/${{ inputs.matrix_path }}

--- a/.github/workflows/ci-workflow-custom.yml
+++ b/.github/workflows/ci-workflow-custom.yml
@@ -31,11 +31,6 @@ on:
         description: "Branch (in this repo) containing the CI matrix file to sideload."
         required: true
         type: string
-      matrix_path:
-        description: "Path to the CI matrix file within <branch>. It must define a 'nightly' workflow, which is run as a full build."
-        required: true
-        type: string
-        default: ci/matrix.yaml
 
 concurrency:
   group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}

--- a/.github/workflows/ci-workflow-nightly.yml
+++ b/.github/workflows/ci-workflow-nightly.yml
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is the main workflow that runs on every PR and push to main
+# Nightly scheduled workflow. Delegates matrix building and job dispatch to
+# .github/workflows/ci-matrix-build.yml, then runs nightly-only third-party
+# builds plus failure analysis and Slack notification.
 name: nightly
 
 defaults:
@@ -30,114 +32,12 @@ concurrency:
 
 jobs:
 
-  build-workflow:
-    name: Build workflow from matrix
-    runs-on: ubuntu-latest
-    if: ${{ github.repository == 'NVIDIA/cccl' }}
-    permissions:
-      contents: read
-    outputs:
-      workflow: ${{ steps.build-workflow.outputs.workflow }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Build workflow
-        id: build-workflow
-        uses: ./.github/actions/workflow-build
-        with:
-          workflows: nightly
-          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
-          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
-
-  dispatch-groups-linux-two-stage:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+  matrix-build:
+    name: Build & dispatch CI matrix
+    uses: ./.github/workflows/ci-matrix-build.yml
+    secrets: inherit
     with:
-      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
-
-  dispatch-groups-windows-two-stage:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
-    with:
-      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
-
-  dispatch-groups-linux-standalone:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
-    with:
-      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
-
-  dispatch-groups-windows-standalone:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
-    with:
-      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
-
-  verify-workflow:
-    name: Verify and summarize workflow results
-    if: ${{ always() && !cancelled() }}
-    needs:
-      - build-workflow
-      - dispatch-groups-linux-two-stage
-      - dispatch-groups-windows-two-stage
-      - dispatch-groups-linux-standalone
-      - dispatch-groups-windows-standalone
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    outputs:
-      failure_message: ${{ steps.check-workflow.outputs.failure_message }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Check workflow success
-        id: check-workflow
-        uses: ./.github/actions/workflow-results
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
-          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
+      workflows: nightly
 
   build-rapids:
     name: Build RAPIDS
@@ -184,16 +84,14 @@ jobs:
         github.repository == 'NVIDIA/cccl' &&
         github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
         (
-          needs.build-workflow.result == 'failure' ||
-          needs.verify-workflow.result == 'failure' ||
+          needs.matrix-build.result == 'failure' ||
           needs.build-rapids.result == 'failure' ||
           needs.build-matx.result == 'failure' ||
           needs.build-pytorch.result == 'failure'
         )
       }}
     needs:
-      - build-workflow
-      - verify-workflow
+      - matrix-build
       - build-rapids
       - build-matx
       - build-pytorch
@@ -250,13 +148,13 @@ jobs:
         github.repository == 'NVIDIA/cccl' &&
         github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
         (
-          needs.verify-workflow.outputs.failure_message != '' ||
+          needs.matrix-build.outputs.failure_message != '' ||
           needs.analyze-failures.outputs.slack_thread != ''
         )
       }}
     needs:
       - analyze-failures
-      - verify-workflow
+      - matrix-build
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -273,7 +171,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_CI_ALERT }}
-          SLACK_PARENT_TEXT: ${{ needs.verify-workflow.outputs.failure_message }}
+          SLACK_PARENT_TEXT: ${{ needs.matrix-build.outputs.failure_message }}
           SLACK_THREAD: ${{ needs.analyze-failures.outputs.slack_thread }}
         shell: bash --noprofile --norc -euo pipefail {0}
         run: |

--- a/.github/workflows/ci-workflow-weekly.yml
+++ b/.github/workflows/ci-workflow-weekly.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Weekly scheduled workflow. Delegates matrix building and job dispatch (with
+# Slack alert notifications) to .github/workflows/ci-matrix-build.yml.
 name: weekly
 
 defaults:
@@ -29,111 +31,10 @@ concurrency:
 
 jobs:
 
-  build-workflow:
-    name: Build workflow from matrix
-    runs-on: ubuntu-latest
-    if: ${{ github.repository == 'NVIDIA/cccl' }}
-    permissions:
-      contents: read
-    outputs:
-      workflow: ${{ steps.build-workflow.outputs.workflow }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Build workflow
-        id: build-workflow
-        uses: ./.github/actions/workflow-build
-        with:
-          workflows: weekly
-          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
-          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
-          slack_alert: ${{ secrets.SLACK_CHANNEL_CI_ALERT }}
-
-  dispatch-groups-linux-two-stage:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+  matrix-build:
+    name: Build & dispatch CI matrix
+    uses: ./.github/workflows/ci-matrix-build.yml
+    secrets: inherit
     with:
-      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
-
-  dispatch-groups-windows-two-stage:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
-    with:
-      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
-
-  dispatch-groups-linux-standalone:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
-    with:
-      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
-
-  dispatch-groups-windows-standalone:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
-    with:
-      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
-
-  verify-workflow:
-    name: Verify and summarize workflow results
-    if: ${{ always() && !cancelled() }}
-    needs:
-      - build-workflow
-      - dispatch-groups-linux-two-stage
-      - dispatch-groups-windows-two-stage
-      - dispatch-groups-linux-standalone
-      - dispatch-groups-windows-standalone
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Check workflow success
-        id: check-workflow
-        uses: ./.github/actions/workflow-results
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
-          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
-          slack_alert: ${{ secrets.SLACK_CHANNEL_CI_ALERT }}
+      workflows: weekly
+      enable_slack_alert: true


### PR DESCRIPTION
## Description

Gets CCCL workflows closer to being executed with different test matrices rather than the one available at the current commit. This PR allows invoking a workflow using a different CI matrix from a different branch.

I thought about just passing the ci matrix in as a single text input, but there's a 65k limit on inputs and figured we might hit that limit in the future.

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
