### PR TITLE
libcu++: __nv_atomic based atomics backend.

### DIFF
--- a/libcudacxx/include/cuda/__atomic/atomic.h
+++ b/libcudacxx/include/cuda/__atomic/atomic.h
@@ -145,15 +145,15 @@ atomic_thread_fence(memory_order __m, [[maybe_unused]] thread_scope _Scope = thr
     (switch (_Scope) {
       case thread_scope::thread_scope_system:
         ::cuda::std::__cuda_atomic_thread_fence(
-          ::cuda::std::__cuda_atomic_ptx_backend{}, __m, __thread_scope_system_tag{});
+          ::cuda::std::__cuda_atomic_device_backend{}, __m, __thread_scope_system_tag{});
         break;
       case thread_scope::thread_scope_device:
         ::cuda::std::__cuda_atomic_thread_fence(
-          ::cuda::std::__cuda_atomic_ptx_backend{}, __m, __thread_scope_device_tag{});
+          ::cuda::std::__cuda_atomic_device_backend{}, __m, __thread_scope_device_tag{});
         break;
       case thread_scope::thread_scope_block:
         ::cuda::std::__cuda_atomic_thread_fence(
-          ::cuda::std::__cuda_atomic_ptx_backend{}, __m, __thread_scope_block_tag{});
+          ::cuda::std::__cuda_atomic_device_backend{}, __m, __thread_scope_block_tag{});
         break;
       // Atomics scoped to themselves do not require fencing
       case thread_scope::thread_scope_thread:

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_nvvm.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_nvvm.h
@@ -323,6 +323,24 @@ _CCCL_DEVICE_API void __cuda_atomic_exchange(
 
 _CCCL_DEFINE_NVVM_FETCH_ARITHMETIC(add)
 _CCCL_DEFINE_NVVM_FETCH_ARITHMETIC(sub)
+
+template <class _Type, class _Order, size_t _Size, class _Scope, enable_if_t<(_Size == 32) || (_Size == 64), bool> = false>
+_CCCL_DEVICE_API void __cuda_atomic_fetch_sub(
+  __cuda_atomic_nvvm_backend,
+  _Type* __ptr,
+  __unv<_Type>& __dst,
+  __unv<_Type> __op,
+  _Order,
+  __cuda_atomic_operand_tag<__cuda_atomic_operand::_f, _Size>,
+  _Scope)
+{
+  __dst = ::__nv_atomic_fetch_add(
+    __cuda_atomic_nvvm_ptr(__ptr),
+    -__op,
+    +__cuda_atomic_nvvm_order<_Order>::__value,
+    +__cuda_atomic_nvvm_scope<_Scope>::__value);
+}
+
 _CCCL_DEFINE_NVVM_FETCH_OP(and, true)
 _CCCL_DEFINE_NVVM_FETCH_OP(or, true)
 _CCCL_DEFINE_NVVM_FETCH_OP(xor, true)

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_nvvm.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_nvvm.h
@@ -1,0 +1,382 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___ATOMIC_FUNCTIONS_CUDA_NVVM_H
+#define _CUDA_STD___ATOMIC_FUNCTIONS_CUDA_NVVM_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__atomic/functions/cuda_nvvm_backend.h>
+#include <cuda/std/__atomic/functions/generic.h>
+#include <cuda/std/__bit/bit_cast.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+#if _CCCL_CTK_AT_LEAST(13, 5) && _CCCL_HAS_NV_ATOMIC_BUILTINS()
+
+extern "C" _CCCL_DEVICE void __cuda_atomic_nvvm_cas_128b_unsupported_before_SM_90();
+extern "C" _CCCL_DEVICE void __cuda_atomic_nvvm_exchange_128b_unsupported_before_SM_90();
+
+template <class _Order>
+struct __cuda_atomic_nvvm_order;
+
+template <>
+struct __cuda_atomic_nvvm_order<__cuda_atomic_order_relaxed>
+{
+  static constexpr int __value = __NV_ATOMIC_RELAXED;
+};
+
+template <>
+struct __cuda_atomic_nvvm_order<__cuda_atomic_order_release>
+{
+  static constexpr int __value = __NV_ATOMIC_RELEASE;
+};
+
+template <>
+struct __cuda_atomic_nvvm_order<__cuda_atomic_order_acquire>
+{
+  static constexpr int __value = __NV_ATOMIC_ACQUIRE;
+};
+
+template <>
+struct __cuda_atomic_nvvm_order<__cuda_atomic_order_acq_rel>
+{
+  static constexpr int __value = __NV_ATOMIC_ACQ_REL;
+};
+
+template <>
+struct __cuda_atomic_nvvm_order<__cuda_atomic_order_seq_cst>
+{
+  static constexpr int __value = __NV_ATOMIC_SEQ_CST;
+};
+
+template <class _Scope>
+struct __cuda_atomic_nvvm_scope;
+
+template <>
+struct __cuda_atomic_nvvm_scope<__thread_scope_block_tag>
+{
+  static constexpr int __value = __NV_THREAD_SCOPE_BLOCK;
+};
+
+template <>
+struct __cuda_atomic_nvvm_scope<__thread_scope_cluster_tag>
+{
+  static constexpr int __value = __NV_THREAD_SCOPE_CLUSTER;
+};
+
+template <>
+struct __cuda_atomic_nvvm_scope<__thread_scope_device_tag>
+{
+  static constexpr int __value = __NV_THREAD_SCOPE_DEVICE;
+};
+
+template <>
+struct __cuda_atomic_nvvm_scope<__thread_scope_system_tag>
+{
+  static constexpr int __value = __NV_THREAD_SCOPE_SYSTEM;
+};
+
+template <class _Type>
+[[nodiscard]] _CCCL_DEVICE_API __unv<_Type>* __cuda_atomic_nvvm_ptr(_Type* __ptr)
+{
+  return const_cast<__unv<_Type>*>(__ptr);
+}
+
+template <class _Order>
+struct __cuda_atomic_nvvm_failure_order
+{
+  using type = _Order;
+};
+
+template <>
+struct __cuda_atomic_nvvm_failure_order<__cuda_atomic_order_release>
+{
+  using type = __cuda_atomic_order_relaxed;
+};
+
+template <>
+struct __cuda_atomic_nvvm_failure_order<__cuda_atomic_order_acq_rel>
+{
+  using type = __cuda_atomic_order_acquire;
+};
+
+template <class _Order>
+struct __cuda_atomic_nvvm_cas_orders
+{
+  using __success = _Order;
+  using __failure = typename __cuda_atomic_nvvm_failure_order<_Order>::type;
+};
+
+template <class _Success, class _Failure>
+struct __cuda_atomic_nvvm_cas_orders<__cuda_atomic_cas_order<_Success, _Failure>>
+{
+  using __success = _Success;
+  using __failure = _Failure;
+};
+
+template <class _Type, class _Order, class _Operand, class _Scope>
+_CCCL_DEVICE_API void __cuda_atomic_load(
+  __cuda_atomic_nvvm_backend,
+  const _Type* __ptr,
+  __unv<_Type>& __dst,
+  _Order,
+  _Operand,
+  _Scope __scope,
+  __cuda_atomic_mmio_disable)
+{
+  ::__nv_atomic_load(__cuda_atomic_nvvm_ptr(__ptr),
+                     &__dst,
+                     +__cuda_atomic_nvvm_order<_Order>::__value,
+                     +__cuda_atomic_nvvm_scope<_Scope>::__value);
+}
+
+template <class _Type, class _Order, class _Operand, class _Scope>
+_CCCL_DEVICE_API void __cuda_atomic_store(
+  __cuda_atomic_nvvm_backend,
+  _Type* __ptr,
+  __unv<_Type> __val,
+  _Order,
+  _Operand,
+  _Scope __scope,
+  __cuda_atomic_mmio_disable)
+{
+  ::__nv_atomic_store(__cuda_atomic_nvvm_ptr(__ptr),
+                      &__val,
+                      +__cuda_atomic_nvvm_order<_Order>::__value,
+                      +__cuda_atomic_nvvm_scope<_Scope>::__value);
+}
+
+template <class _Type,
+          class _Cas,
+          class _Order,
+          class _Operand,
+          class _Scope,
+          enable_if_t<(_Operand::__size != 8) || (_CCCL_PTX_ARCH() >= 1000), bool> = false>
+[[nodiscard]] _CCCL_DEVICE_API bool __cuda_atomic_compare_exchange(
+  __cuda_atomic_nvvm_backend,
+  _Type* __ptr,
+  __unv<_Type>& __dst,
+  __unv<_Type> __cmp,
+  __unv<_Type> __op,
+  _Cas,
+  _Order,
+  _Operand,
+  _Scope __scope)
+{
+  using __orders  = __cuda_atomic_nvvm_cas_orders<_Order>;
+  using __success = typename __orders::__success;
+  using __failure = typename __orders::__failure;
+  __dst           = __cmp;
+
+  if constexpr (_Operand::__size == 128)
+  {
+    NV_IF_ELSE_TARGET(
+      NV_PROVIDES_SM_90,
+      (return ::__nv_atomic_compare_exchange(
+                __cuda_atomic_nvvm_ptr(__ptr),
+                &__dst,
+                &__op,
+                __cuda_atomic_cas_is_weak(_Cas{}),
+                +__cuda_atomic_nvvm_order<__success>::__value,
+                +__cuda_atomic_nvvm_order<__failure>::__value,
+                +__cuda_atomic_nvvm_scope<_Scope>::__value);),
+      (__cuda_atomic_nvvm_cas_128b_unsupported_before_SM_90(); return false;))
+  }
+  else
+  {
+    return ::__nv_atomic_compare_exchange(
+      __cuda_atomic_nvvm_ptr(__ptr),
+      &__dst,
+      &__op,
+      __cuda_atomic_cas_is_weak(_Cas{}),
+      +__cuda_atomic_nvvm_order<__success>::__value,
+      +__cuda_atomic_nvvm_order<__failure>::__value,
+      +__cuda_atomic_nvvm_scope<_Scope>::__value);
+  }
+}
+
+template <class _Type, class _Order, class _Operand, class _Scope>
+_CCCL_DEVICE_API void __cuda_atomic_exchange(
+  __cuda_atomic_nvvm_backend,
+  _Type* __ptr,
+  __unv<_Type>& __dst,
+  __unv<_Type> __op,
+  _Order __order,
+  _Operand,
+  _Scope __scope)
+{
+  if constexpr (_Operand::__size < 32)
+  {
+    NV_IF_ELSE_TARGET(
+      NV_PROVIDES_SM_100,
+      (::__nv_atomic_exchange(
+         __cuda_atomic_nvvm_ptr(__ptr),
+         &__op,
+         &__dst,
+         +__cuda_atomic_nvvm_order<_Order>::__value,
+         +__cuda_atomic_nvvm_scope<_Scope>::__value);),
+      (__dst = __cuda_atomic_fetch_update(
+         __cuda_atomic_nvvm_backend{},
+         __ptr,
+         __cuda_atomic_op_bind<__unv<_Type>, __cuda_atomic_op_store>{__op},
+         __order,
+         _Operand{},
+         __scope);))
+  }
+  else if constexpr (_Operand::__size == 128)
+  {
+    NV_IF_ELSE_TARGET(
+      NV_PROVIDES_SM_90,
+      (::__nv_atomic_exchange(
+         __cuda_atomic_nvvm_ptr(__ptr),
+         &__op,
+         &__dst,
+         +__cuda_atomic_nvvm_order<_Order>::__value,
+         +__cuda_atomic_nvvm_scope<_Scope>::__value);),
+      (__cuda_atomic_nvvm_exchange_128b_unsupported_before_SM_90();))
+  }
+  else
+  {
+    ::__nv_atomic_exchange(
+      __cuda_atomic_nvvm_ptr(__ptr),
+      &__op,
+      &__dst,
+      +__cuda_atomic_nvvm_order<_Order>::__value,
+      +__cuda_atomic_nvvm_scope<_Scope>::__value);
+  }
+}
+
+#  define _CCCL_DEFINE_NVVM_FETCH_ARITHMETIC(_Name)                                                                   \
+    template <class _Type,                                                                                            \
+              class _Order,                                                                                           \
+              class _Operand,                                                                                         \
+              class _Scope,                                                                                           \
+              enable_if_t<(_Operand::__size < 128) && ((_Operand::__size >= 32) || (_CCCL_PTX_ARCH() >= 1000))        \
+                            && !(is_integral_v<_Type> && is_signed_v<_Type> && sizeof(_Type) == 8),                   \
+                          bool> = false>                                                                              \
+    _CCCL_DEVICE_API void __cuda_atomic_fetch_##_Name(                                                                \
+      __cuda_atomic_nvvm_backend, _Type* __ptr, __unv<_Type>& __dst, __unv<_Type> __op, _Order, _Operand, _Scope)     \
+    {                                                                                                                 \
+      __dst = ::__nv_atomic_fetch_##_Name(                                                                            \
+        __cuda_atomic_nvvm_ptr(__ptr),                                                                                \
+        __op,                                                                                                         \
+        +__cuda_atomic_nvvm_order<_Order>::__value,                                                                   \
+        +__cuda_atomic_nvvm_scope<_Scope>::__value);                                                                  \
+    }                                                                                                                 \
+                                                                                                                      \
+    template <class _Type,                                                                                            \
+              class _Order,                                                                                           \
+              class _Operand,                                                                                         \
+              class _Scope,                                                                                           \
+              enable_if_t<is_integral_v<_Type> && is_signed_v<_Type> && sizeof(_Type) == 8 && _Operand::__size == 64, \
+                          bool> = false>                                                                              \
+    _CCCL_DEVICE_API void __cuda_atomic_fetch_##_Name(                                                                \
+      __cuda_atomic_nvvm_backend, _Type* __ptr, __unv<_Type>& __dst, __unv<_Type> __op, _Order, _Operand, _Scope)     \
+    {                                                                                                                 \
+      const auto __result = ::__nv_atomic_fetch_##_Name(                                                              \
+        reinterpret_cast<uint64_t*>(__cuda_atomic_nvvm_ptr(__ptr)),                                                   \
+        ::cuda::std::bit_cast<uint64_t>(__op),                                                                        \
+        +__cuda_atomic_nvvm_order<_Order>::__value,                                                                   \
+        +__cuda_atomic_nvvm_scope<_Scope>::__value);                                                                  \
+      __dst = ::cuda::std::bit_cast<__unv<_Type>>(__result);                                                          \
+    }
+
+#  define _CCCL_DEFINE_NVVM_FETCH_OP(_Name, _TypeConstraint)                                                      \
+    template <class _Type,                                                                                        \
+              class _Order,                                                                                       \
+              class _Operand,                                                                                     \
+              class _Scope,                                                                                       \
+              enable_if_t<(_Operand::__size < 128) && ((_Operand::__size >= 32) || (_CCCL_PTX_ARCH() >= 1000))    \
+                            && (_TypeConstraint),                                                                 \
+                          bool> = false>                                                                          \
+    _CCCL_DEVICE_API void __cuda_atomic_fetch_##_Name(                                                            \
+      __cuda_atomic_nvvm_backend, _Type* __ptr, __unv<_Type>& __dst, __unv<_Type> __op, _Order, _Operand, _Scope) \
+    {                                                                                                             \
+      __dst = ::__nv_atomic_fetch_##_Name(                                                                        \
+        __cuda_atomic_nvvm_ptr(__ptr),                                                                            \
+        __op,                                                                                                     \
+        +__cuda_atomic_nvvm_order<_Order>::__value,                                                               \
+        +__cuda_atomic_nvvm_scope<_Scope>::__value);                                                              \
+    }
+
+_CCCL_DEFINE_NVVM_FETCH_ARITHMETIC(add)
+_CCCL_DEFINE_NVVM_FETCH_ARITHMETIC(sub)
+_CCCL_DEFINE_NVVM_FETCH_OP(and, true)
+_CCCL_DEFINE_NVVM_FETCH_OP(or, true)
+_CCCL_DEFINE_NVVM_FETCH_OP(xor, true)
+_CCCL_DEFINE_NVVM_FETCH_OP(min, is_integral_v<_Type>)
+_CCCL_DEFINE_NVVM_FETCH_OP(max, is_integral_v<_Type>)
+
+#  undef _CCCL_DEFINE_NVVM_FETCH_ARITHMETIC
+#  undef _CCCL_DEFINE_NVVM_FETCH_OP
+
+template <class _Scope>
+struct __cuda_atomic_nvvm_fence
+{
+  template <class _Order>
+  _CCCL_DEVICE_API void operator()(_Order) const
+  {
+    ::__nv_atomic_thread_fence(+__cuda_atomic_nvvm_order<_Order>::__value, +__cuda_atomic_nvvm_scope<_Scope>::__value);
+  }
+};
+
+template <class _Scope>
+_CCCL_DEVICE_API void
+__cuda_atomic_thread_fence(__cuda_atomic_nvvm_backend __backend, memory_order __order, _Scope __scope)
+{
+  (void) __backend;
+  (void) __scope;
+  __cuda_atomic_nvvm_fence<_Scope> __fence;
+  switch (__atomic_order_to_int(__order))
+  {
+    case __ATOMIC_RELAXED:
+      return;
+    case __ATOMIC_CONSUME:
+      [[fallthrough]];
+    case __ATOMIC_ACQUIRE:
+      return __fence(__cuda_atomic_order_acquire{});
+    case __ATOMIC_RELEASE:
+      return __fence(__cuda_atomic_order_release{});
+    case __ATOMIC_ACQ_REL:
+      return __fence(__cuda_atomic_order_acq_rel{});
+    case __ATOMIC_SEQ_CST:
+      return __fence(__cuda_atomic_order_seq_cst{});
+    default:
+      _CCCL_ASSERT(false, "invalid fence memory order");
+  }
+}
+
+_CCCL_DEVICE_API void __cuda_atomic_signal_fence(__cuda_atomic_nvvm_backend, memory_order)
+{
+  asm volatile("" ::: "memory");
+}
+
+#endif // _CCCL_CTK_AT_LEAST(13, 5) && _CCCL_HAS_NV_ATOMIC_BUILTINS()
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___ATOMIC_FUNCTIONS_CUDA_NVVM_H

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_nvvm.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_nvvm.h
@@ -353,7 +353,7 @@ __cuda_atomic_thread_fence(__cuda_atomic_nvvm_backend __backend, memory_order __
   }
 }
 
-_CCCL_DEVICE_API void __cuda_atomic_signal_fence(__cuda_atomic_nvvm_backend, memory_order)
+_CCCL_DEVICE_API inline void __cuda_atomic_signal_fence(__cuda_atomic_nvvm_backend, memory_order)
 {
   asm volatile("" ::: "memory");
 }

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_nvvm.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_nvvm.h
@@ -24,6 +24,7 @@
 #include <cuda/std/__atomic/functions/cuda_nvvm_backend.h>
 #include <cuda/std/__atomic/functions/generic.h>
 #include <cuda/std/__bit/bit_cast.h>
+#include <cuda/std/__type_traits/always_false.h>
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/__type_traits/is_signed.h>
 #include <cuda/std/cassert>
@@ -39,64 +40,43 @@ extern "C" _CCCL_DEVICE void __cuda_atomic_nvvm_cas_128b_unsupported_before_SM_9
 extern "C" _CCCL_DEVICE void __cuda_atomic_nvvm_exchange_128b_unsupported_before_SM_90();
 
 template <class _Order>
-struct __cuda_atomic_nvvm_order;
+inline constexpr int __cuda_atomic_nvvm_order = [] {
+  static_assert(__always_false_v<_Order>, "invalid atomic memory order");
+  return 0;
+}();
 
 template <>
-struct __cuda_atomic_nvvm_order<__cuda_atomic_order_relaxed>
-{
-  static constexpr int __value = __NV_ATOMIC_RELAXED;
-};
+inline constexpr int __cuda_atomic_nvvm_order<__cuda_atomic_order_relaxed> = __NV_ATOMIC_RELAXED;
 
 template <>
-struct __cuda_atomic_nvvm_order<__cuda_atomic_order_release>
-{
-  static constexpr int __value = __NV_ATOMIC_RELEASE;
-};
+inline constexpr int __cuda_atomic_nvvm_order<__cuda_atomic_order_release> = __NV_ATOMIC_RELEASE;
 
 template <>
-struct __cuda_atomic_nvvm_order<__cuda_atomic_order_acquire>
-{
-  static constexpr int __value = __NV_ATOMIC_ACQUIRE;
-};
+inline constexpr int __cuda_atomic_nvvm_order<__cuda_atomic_order_acquire> = __NV_ATOMIC_ACQUIRE;
 
 template <>
-struct __cuda_atomic_nvvm_order<__cuda_atomic_order_acq_rel>
-{
-  static constexpr int __value = __NV_ATOMIC_ACQ_REL;
-};
+inline constexpr int __cuda_atomic_nvvm_order<__cuda_atomic_order_acq_rel> = __NV_ATOMIC_ACQ_REL;
 
 template <>
-struct __cuda_atomic_nvvm_order<__cuda_atomic_order_seq_cst>
-{
-  static constexpr int __value = __NV_ATOMIC_SEQ_CST;
-};
+inline constexpr int __cuda_atomic_nvvm_order<__cuda_atomic_order_seq_cst> = __NV_ATOMIC_SEQ_CST;
 
 template <class _Scope>
-struct __cuda_atomic_nvvm_scope;
+inline constexpr int __cuda_atomic_nvvm_scope = [] {
+  static_assert(__always_false_v<_Scope>, "invalid atomic thread scope");
+  return 0;
+}();
 
 template <>
-struct __cuda_atomic_nvvm_scope<__thread_scope_block_tag>
-{
-  static constexpr int __value = __NV_THREAD_SCOPE_BLOCK;
-};
+inline constexpr int __cuda_atomic_nvvm_scope<__thread_scope_block_tag> = __NV_THREAD_SCOPE_BLOCK;
 
 template <>
-struct __cuda_atomic_nvvm_scope<__thread_scope_cluster_tag>
-{
-  static constexpr int __value = __NV_THREAD_SCOPE_CLUSTER;
-};
+inline constexpr int __cuda_atomic_nvvm_scope<__thread_scope_cluster_tag> = __NV_THREAD_SCOPE_CLUSTER;
 
 template <>
-struct __cuda_atomic_nvvm_scope<__thread_scope_device_tag>
-{
-  static constexpr int __value = __NV_THREAD_SCOPE_DEVICE;
-};
+inline constexpr int __cuda_atomic_nvvm_scope<__thread_scope_device_tag> = __NV_THREAD_SCOPE_DEVICE;
 
 template <>
-struct __cuda_atomic_nvvm_scope<__thread_scope_system_tag>
-{
-  static constexpr int __value = __NV_THREAD_SCOPE_SYSTEM;
-};
+inline constexpr int __cuda_atomic_nvvm_scope<__thread_scope_system_tag> = __NV_THREAD_SCOPE_SYSTEM;
 
 template <class _Type>
 [[nodiscard]] _CCCL_DEVICE_API __unv<_Type>* __cuda_atomic_nvvm_ptr(_Type* __ptr)
@@ -146,10 +126,8 @@ _CCCL_DEVICE_API void __cuda_atomic_load(
   _Scope __scope,
   __cuda_atomic_mmio_disable)
 {
-  ::__nv_atomic_load(__cuda_atomic_nvvm_ptr(__ptr),
-                     &__dst,
-                     +__cuda_atomic_nvvm_order<_Order>::__value,
-                     +__cuda_atomic_nvvm_scope<_Scope>::__value);
+  ::__nv_atomic_load(
+    __cuda_atomic_nvvm_ptr(__ptr), &__dst, +__cuda_atomic_nvvm_order<_Order>, +__cuda_atomic_nvvm_scope<_Scope>);
 }
 
 template <class _Type, class _Order, class _Operand, class _Scope>
@@ -162,10 +140,8 @@ _CCCL_DEVICE_API void __cuda_atomic_store(
   _Scope __scope,
   __cuda_atomic_mmio_disable)
 {
-  ::__nv_atomic_store(__cuda_atomic_nvvm_ptr(__ptr),
-                      &__val,
-                      +__cuda_atomic_nvvm_order<_Order>::__value,
-                      +__cuda_atomic_nvvm_scope<_Scope>::__value);
+  ::__nv_atomic_store(
+    __cuda_atomic_nvvm_ptr(__ptr), &__val, +__cuda_atomic_nvvm_order<_Order>, +__cuda_atomic_nvvm_scope<_Scope>);
 }
 
 template <class _Type,
@@ -199,9 +175,9 @@ template <class _Type,
                 &__dst,
                 &__op,
                 __cuda_atomic_cas_is_weak(_Cas{}),
-                +__cuda_atomic_nvvm_order<__success>::__value,
-                +__cuda_atomic_nvvm_order<__failure>::__value,
-                +__cuda_atomic_nvvm_scope<_Scope>::__value);),
+                +__cuda_atomic_nvvm_order<__success>,
+                +__cuda_atomic_nvvm_order<__failure>,
+                +__cuda_atomic_nvvm_scope<_Scope>);),
       (__cuda_atomic_nvvm_cas_128b_unsupported_before_SM_90(); return false;))
   }
   else
@@ -211,9 +187,9 @@ template <class _Type,
       &__dst,
       &__op,
       __cuda_atomic_cas_is_weak(_Cas{}),
-      +__cuda_atomic_nvvm_order<__success>::__value,
-      +__cuda_atomic_nvvm_order<__failure>::__value,
-      +__cuda_atomic_nvvm_scope<_Scope>::__value);
+      +__cuda_atomic_nvvm_order<__success>,
+      +__cuda_atomic_nvvm_order<__failure>,
+      +__cuda_atomic_nvvm_scope<_Scope>);
   }
 }
 
@@ -235,8 +211,8 @@ _CCCL_DEVICE_API void __cuda_atomic_exchange(
          __cuda_atomic_nvvm_ptr(__ptr),
          &__op,
          &__dst,
-         +__cuda_atomic_nvvm_order<_Order>::__value,
-         +__cuda_atomic_nvvm_scope<_Scope>::__value);),
+         +__cuda_atomic_nvvm_order<_Order>,
+         +__cuda_atomic_nvvm_scope<_Scope>);),
       (__dst = __cuda_atomic_fetch_update(
          __cuda_atomic_nvvm_backend{},
          __ptr,
@@ -253,8 +229,8 @@ _CCCL_DEVICE_API void __cuda_atomic_exchange(
          __cuda_atomic_nvvm_ptr(__ptr),
          &__op,
          &__dst,
-         +__cuda_atomic_nvvm_order<_Order>::__value,
-         +__cuda_atomic_nvvm_scope<_Scope>::__value);),
+         +__cuda_atomic_nvvm_order<_Order>,
+         +__cuda_atomic_nvvm_scope<_Scope>);),
       (__cuda_atomic_nvvm_exchange_128b_unsupported_before_SM_90();))
   }
   else
@@ -263,8 +239,8 @@ _CCCL_DEVICE_API void __cuda_atomic_exchange(
       __cuda_atomic_nvvm_ptr(__ptr),
       &__op,
       &__dst,
-      +__cuda_atomic_nvvm_order<_Order>::__value,
-      +__cuda_atomic_nvvm_scope<_Scope>::__value);
+      +__cuda_atomic_nvvm_order<_Order>,
+      +__cuda_atomic_nvvm_scope<_Scope>);
   }
 }
 
@@ -280,10 +256,7 @@ _CCCL_DEVICE_API void __cuda_atomic_exchange(
       __cuda_atomic_nvvm_backend, _Type* __ptr, __unv<_Type>& __dst, __unv<_Type> __op, _Order, _Operand, _Scope)     \
     {                                                                                                                 \
       __dst = ::__nv_atomic_fetch_##_Name(                                                                            \
-        __cuda_atomic_nvvm_ptr(__ptr),                                                                                \
-        __op,                                                                                                         \
-        +__cuda_atomic_nvvm_order<_Order>::__value,                                                                   \
-        +__cuda_atomic_nvvm_scope<_Scope>::__value);                                                                  \
+        __cuda_atomic_nvvm_ptr(__ptr), __op, +__cuda_atomic_nvvm_order<_Order>, +__cuda_atomic_nvvm_scope<_Scope>);   \
     }                                                                                                                 \
                                                                                                                       \
     template <class _Type,                                                                                            \
@@ -298,27 +271,24 @@ _CCCL_DEVICE_API void __cuda_atomic_exchange(
       const auto __result = ::__nv_atomic_fetch_##_Name(                                                              \
         reinterpret_cast<uint64_t*>(__cuda_atomic_nvvm_ptr(__ptr)),                                                   \
         ::cuda::std::bit_cast<uint64_t>(__op),                                                                        \
-        +__cuda_atomic_nvvm_order<_Order>::__value,                                                                   \
-        +__cuda_atomic_nvvm_scope<_Scope>::__value);                                                                  \
+        +__cuda_atomic_nvvm_order<_Order>,                                                                            \
+        +__cuda_atomic_nvvm_scope<_Scope>);                                                                           \
       __dst = ::cuda::std::bit_cast<__unv<_Type>>(__result);                                                          \
     }
 
-#  define _CCCL_DEFINE_NVVM_FETCH_OP(_Name, _TypeConstraint)                                                      \
-    template <class _Type,                                                                                        \
-              class _Order,                                                                                       \
-              class _Operand,                                                                                     \
-              class _Scope,                                                                                       \
-              enable_if_t<(_Operand::__size < 128) && ((_Operand::__size >= 32) || (_CCCL_PTX_ARCH() >= 1000))    \
-                            && (_TypeConstraint),                                                                 \
-                          bool> = false>                                                                          \
-    _CCCL_DEVICE_API void __cuda_atomic_fetch_##_Name(                                                            \
-      __cuda_atomic_nvvm_backend, _Type* __ptr, __unv<_Type>& __dst, __unv<_Type> __op, _Order, _Operand, _Scope) \
-    {                                                                                                             \
-      __dst = ::__nv_atomic_fetch_##_Name(                                                                        \
-        __cuda_atomic_nvvm_ptr(__ptr),                                                                            \
-        __op,                                                                                                     \
-        +__cuda_atomic_nvvm_order<_Order>::__value,                                                               \
-        +__cuda_atomic_nvvm_scope<_Scope>::__value);                                                              \
+#  define _CCCL_DEFINE_NVVM_FETCH_OP(_Name, _TypeConstraint)                                                        \
+    template <class _Type,                                                                                          \
+              class _Order,                                                                                         \
+              class _Operand,                                                                                       \
+              class _Scope,                                                                                         \
+              enable_if_t<(_Operand::__size < 128) && ((_Operand::__size >= 32) || (_CCCL_PTX_ARCH() >= 1000))      \
+                            && (_TypeConstraint),                                                                   \
+                          bool> = false>                                                                            \
+    _CCCL_DEVICE_API void __cuda_atomic_fetch_##_Name(                                                              \
+      __cuda_atomic_nvvm_backend, _Type* __ptr, __unv<_Type>& __dst, __unv<_Type> __op, _Order, _Operand, _Scope)   \
+    {                                                                                                               \
+      __dst = ::__nv_atomic_fetch_##_Name(                                                                          \
+        __cuda_atomic_nvvm_ptr(__ptr), __op, +__cuda_atomic_nvvm_order<_Order>, +__cuda_atomic_nvvm_scope<_Scope>); \
     }
 
 _CCCL_DEFINE_NVVM_FETCH_ARITHMETIC(add)
@@ -335,10 +305,7 @@ _CCCL_DEVICE_API void __cuda_atomic_fetch_sub(
   _Scope)
 {
   __dst = ::__nv_atomic_fetch_add(
-    __cuda_atomic_nvvm_ptr(__ptr),
-    -__op,
-    +__cuda_atomic_nvvm_order<_Order>::__value,
-    +__cuda_atomic_nvvm_scope<_Scope>::__value);
+    __cuda_atomic_nvvm_ptr(__ptr), -__op, +__cuda_atomic_nvvm_order<_Order>, +__cuda_atomic_nvvm_scope<_Scope>);
 }
 
 _CCCL_DEFINE_NVVM_FETCH_OP(and, true)
@@ -356,7 +323,7 @@ struct __cuda_atomic_nvvm_fence
   template <class _Order>
   _CCCL_DEVICE_API void operator()(_Order) const
   {
-    ::__nv_atomic_thread_fence(+__cuda_atomic_nvvm_order<_Order>::__value, +__cuda_atomic_nvvm_scope<_Scope>::__value);
+    ::__nv_atomic_thread_fence(+__cuda_atomic_nvvm_order<_Order>, +__cuda_atomic_nvvm_scope<_Scope>);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_nvvm_backend.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_nvvm_backend.h
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___ATOMIC_FUNCTIONS_CUDA_NVVM_BACKEND_H
+#define _CUDA_STD___ATOMIC_FUNCTIONS_CUDA_NVVM_BACKEND_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__atomic/functions/backend.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_scalar.h>
+#include <cuda/std/cstddef>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+struct __cuda_atomic_nvvm_backend
+{
+private:
+  template <class _Type>
+  static constexpr bool __has_builtin_subword_rmw = sizeof(_Type) >= 4 || _CCCL_PTX_ARCH() >= 1000;
+
+public:
+  template <class _Order>
+  _CCCL_HOST_DEVICE_API static constexpr _Order __collapse_cas_order(_Order __order)
+  {
+    return __order;
+  }
+
+  template <class _Operation, class _Fn, class _Order, class _Sco, class... _Args>
+  _CCCL_DEVICE_API static auto
+  __with_transformed_order(_Operation, _Fn& __fn, _Order __order, _Sco __scope, _Args... __args)
+    -> decltype(__fn(__order, __args..., __scope))
+  {
+    return __fn(__order, __args..., __scope);
+  }
+
+  template <class _Type>
+  static constexpr bool __use_direct_bitwise = sizeof(_Type) < 16 && __has_builtin_subword_rmw<_Type>;
+
+  template <class _Type>
+  static constexpr bool __use_direct_arithmetic =
+    is_scalar_v<_Type> && sizeof(_Type) < 16 && __has_builtin_subword_rmw<_Type>;
+
+  template <class _Type>
+  static constexpr bool __use_direct_minmax =
+    is_integral_v<_Type> && sizeof(_Type) < 16 && __has_builtin_subword_rmw<_Type>;
+
+  template <class _Type>
+  static constexpr bool __use_fallback_bitwise = sizeof(_Type) == 16 || !__has_builtin_subword_rmw<_Type>;
+
+  template <class _Type>
+  static constexpr bool __use_fallback_arithmetic =
+    is_scalar_v<_Type> && (sizeof(_Type) == 16 || !__has_builtin_subword_rmw<_Type>);
+
+  template <class _Type>
+  static constexpr bool __use_fallback_minmax =
+    !is_integral_v<_Type> || (is_scalar_v<_Type> && (sizeof(_Type) == 16 || !__has_builtin_subword_rmw<_Type>) );
+
+  static constexpr bool __needs_constant_order             = true;
+  static constexpr bool __requires_local_memory_workaround = true;
+  static constexpr size_t __smallest_cas                   = 32;
+  static constexpr size_t __widest_cas                     = 128;
+};
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___ATOMIC_FUNCTIONS_CUDA_NVVM_BACKEND_H

--- a/libcudacxx/include/cuda/std/__atomic/functions/device_backend.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/device_backend.h
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___ATOMIC_FUNCTIONS_DEVICE_BACKEND_H
+#define _CUDA_STD___ATOMIC_FUNCTIONS_DEVICE_BACKEND_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_CTK_AT_LEAST(13, 5) && _CCCL_HAS_NV_ATOMIC_BUILTINS()
+#  include <cuda/std/__atomic/functions/cuda_nvvm.h>
+#else
+#  include <cuda/std/__atomic/functions/cuda_ptx.h>
+#endif
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+#if _CCCL_CTK_AT_LEAST(13, 5) && _CCCL_HAS_NV_ATOMIC_BUILTINS()
+using __cuda_atomic_device_backend = __cuda_atomic_nvvm_backend;
+#else
+using __cuda_atomic_device_backend = __cuda_atomic_ptx_backend;
+#endif
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___ATOMIC_FUNCTIONS_DEVICE_BACKEND_H

--- a/libcudacxx/include/cuda/std/__atomic/functions/device_backend.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/device_backend.h
@@ -23,8 +23,10 @@
 
 #if _CCCL_CTK_AT_LEAST(13, 5) && _CCCL_HAS_NV_ATOMIC_BUILTINS()
 #  include <cuda/std/__atomic/functions/cuda_nvvm.h>
+#  include <cuda/std/__atomic/functions/cuda_nvvm_backend.h>
 #else
 #  include <cuda/std/__atomic/functions/cuda_ptx.h>
+#  include <cuda/std/__atomic/functions/cuda_ptx_backend.h>
 #endif
 
 #include <cuda/std/__cccl/prologue.h>

--- a/libcudacxx/include/cuda/std/__atomic/functions/dispatch.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/dispatch.h
@@ -23,7 +23,7 @@
 
 #include <cuda/std/__atomic/functions/common.h>
 #include <cuda/std/__atomic/functions/cuda_local.h>
-#include <cuda/std/__atomic/functions/cuda_ptx.h>
+#include <cuda/std/__atomic/functions/device_backend.h>
 #include <cuda/std/__atomic/functions/generic.h>
 #include <cuda/std/__atomic/functions/host.h>
 #include <cuda/std/__type_traits/copy_cv.h>

--- a/libcudacxx/include/cuda/std/__atomic/types/base.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/base.h
@@ -69,16 +69,16 @@ struct __atomic_storage
   }
 };
 
-#define _CCCL_DISPATCH_ATOMIC_BACKEND(_Fn, ...)                               \
-  NV_DISPATCH_TARGET(NV_IS_DEVICE,                                            \
-                     (return _Fn(__cuda_atomic_ptx_backend{}, __VA_ARGS__);), \
-                     NV_IS_HOST,                                              \
+#define _CCCL_DISPATCH_ATOMIC_BACKEND(_Fn, ...)                                  \
+  NV_DISPATCH_TARGET(NV_IS_DEVICE,                                               \
+                     (return _Fn(__cuda_atomic_device_backend{}, __VA_ARGS__);), \
+                     NV_IS_HOST,                                                 \
                      (return _Fn(__cuda_atomic_host_backend{}, __VA_ARGS__);))
 
-#define _CCCL_DISPATCH_SCOPED_ATOMIC_BACKEND(_Fn, _Scope, ...)                        \
-  NV_DISPATCH_TARGET(NV_IS_DEVICE,                                                    \
-                     (return _Fn(__cuda_atomic_ptx_backend{}, __VA_ARGS__, _Scope);), \
-                     NV_IS_HOST,                                                      \
+#define _CCCL_DISPATCH_SCOPED_ATOMIC_BACKEND(_Fn, _Scope, ...)                           \
+  NV_DISPATCH_TARGET(NV_IS_DEVICE,                                                       \
+                     (return _Fn(__cuda_atomic_device_backend{}, __VA_ARGS__, _Scope);), \
+                     NV_IS_HOST,                                                         \
                      (return _Fn(__cuda_atomic_host_backend{}, __VA_ARGS__, __thread_scope_tag{});))
 
 _CCCL_HOST_DEVICE_API inline void __atomic_thread_fence_dispatch(memory_order __order)

--- a/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
+++ b/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
@@ -61,7 +61,28 @@ check_source_compiles(
   ]]
   libcudacxx_atomic_codegen_has_int128
 )
+check_source_compiles(
+  CUDA
+  [[
+    #include <cuda/std/detail/__config>
+
+    #if defined(__CUDA_ARCH__) \
+      && (!_CCCL_CTK_AT_LEAST(13, 5) || !_CCCL_HAS_NV_ATOMIC_BUILTINS())
+    #  error "the NVVM atomic backend is unavailable"
+    #endif
+
+    __global__ void test() {}
+    int main() { test<<<1, 1>>>(); }
+  ]]
+  libcudacxx_atomic_codegen_uses_nvvm_backend
+)
 cmake_pop_check_state()
+
+if (libcudacxx_atomic_codegen_uses_nvvm_backend)
+  set(atomic_codegen_sass_backend_prefix NVVM)
+else()
+  set(atomic_codegen_sass_backend_prefix PTX)
+endif()
 
 if (NOT libcudacxx_atomic_codegen_has_int128)
   message(
@@ -88,7 +109,9 @@ libcudacxx_codegen_add_sass_tests(
   TARGET_PREFIX atomic_codegen
   ARCHITECTURES ${atomic_codegen_sass_cuda_archs}
   DUMP_FUNCTIONS atomic_codegen_test
-  CHECK_PREFIXES ${atomic_codegen_sass_cuda_version_prefix}
+  CHECK_PREFIXES
+    ${atomic_codegen_sass_cuda_version_prefix}
+    ${atomic_codegen_sass_backend_prefix}
   TESTS ${libcudacxx_atomic_codegen_tests}
   COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1
 )

--- a/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
+++ b/libcudacxx/test/atomic_codegen/sass/CMakeLists.txt
@@ -78,10 +78,29 @@ check_source_compiles(
 )
 cmake_pop_check_state()
 
+set(atomic_codegen_sass_cas_subword_bitwise_archs)
+set(atomic_codegen_sass_native_subword_bitwise_archs)
 if (libcudacxx_atomic_codegen_uses_nvvm_backend)
   set(atomic_codegen_sass_backend_prefix NVVM)
+  set(atomic_codegen_sass_cas_compare_prefix CAS_COMPARE_EXPECTED_OLD)
+  set(atomic_codegen_sass_cas_subword_fence_prefix SUBWORD_RMW_FENCE_LATE)
+  set(atomic_codegen_sass_native_compare_prefix CAS_COMPARE_OLD_EXPECTED)
+  set(atomic_codegen_sass_native_subword_fence_prefix SUBWORD_RMW_FENCE_EARLY)
+  foreach (arch IN LISTS atomic_codegen_sass_cuda_archs)
+    if (arch GREATER_EQUAL 100)
+      list(APPEND atomic_codegen_sass_native_subword_bitwise_archs ${arch})
+    else()
+      list(APPEND atomic_codegen_sass_cas_subword_bitwise_archs ${arch})
+    endif()
+  endforeach()
 else()
   set(atomic_codegen_sass_backend_prefix PTX)
+  set(atomic_codegen_sass_cas_compare_prefix CAS_COMPARE_OLD_EXPECTED)
+  set(atomic_codegen_sass_cas_subword_fence_prefix SUBWORD_RMW_FENCE_LATE)
+  set(
+    atomic_codegen_sass_cas_subword_bitwise_archs
+    ${atomic_codegen_sass_cuda_archs}
+  )
 endif()
 
 if (NOT libcudacxx_atomic_codegen_has_int128)
@@ -104,14 +123,36 @@ endif()
 
 # Restrict FileCheck to the wrapper so instructions in outlined helpers cannot
 # mask an inlining regression.
-libcudacxx_codegen_add_sass_tests(
-  AGGREGATE_TARGET libcudacxx.test.atomics.sass
-  TARGET_PREFIX atomic_codegen
-  ARCHITECTURES ${atomic_codegen_sass_cuda_archs}
-  DUMP_FUNCTIONS atomic_codegen_test
-  CHECK_PREFIXES
-    ${atomic_codegen_sass_cuda_version_prefix}
-    ${atomic_codegen_sass_backend_prefix}
-  TESTS ${libcudacxx_atomic_codegen_tests}
-  COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1
-)
+if (atomic_codegen_sass_cas_subword_bitwise_archs)
+  libcudacxx_codegen_add_sass_tests(
+    AGGREGATE_TARGET libcudacxx.test.atomics.sass
+    TARGET_PREFIX atomic_codegen
+    ARCHITECTURES ${atomic_codegen_sass_cas_subword_bitwise_archs}
+    DUMP_FUNCTIONS atomic_codegen_test
+    CHECK_PREFIXES
+      ${atomic_codegen_sass_cuda_version_prefix}
+      ${atomic_codegen_sass_backend_prefix}
+      ${atomic_codegen_sass_cas_compare_prefix}
+      ${atomic_codegen_sass_cas_subword_fence_prefix}
+      CAS_SUBWORD_BITWISE
+    TESTS ${libcudacxx_atomic_codegen_tests}
+    COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1
+  )
+endif()
+
+if (atomic_codegen_sass_native_subword_bitwise_archs)
+  libcudacxx_codegen_add_sass_tests(
+    AGGREGATE_TARGET libcudacxx.test.atomics.sass
+    TARGET_PREFIX atomic_codegen
+    ARCHITECTURES ${atomic_codegen_sass_native_subword_bitwise_archs}
+    DUMP_FUNCTIONS atomic_codegen_test
+    CHECK_PREFIXES
+      ${atomic_codegen_sass_cuda_version_prefix}
+      ${atomic_codegen_sass_backend_prefix}
+      ${atomic_codegen_sass_native_compare_prefix}
+      ${atomic_codegen_sass_native_subword_fence_prefix}
+      NATIVE_SUBWORD_BITWISE
+    TESTS ${libcudacxx_atomic_codegen_tests}
+    COMPILE_DEFINITIONS _CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE=1
+  )
+endif()

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_apis.cu
@@ -27,6 +27,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
   return atom.OP(value, ORDER);
 }
 
+// clang-format off
 /*
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
@@ -41,10 +42,10 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; ADD_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; ADD_NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; SUB_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
-; SUB_NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
+; ADD_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; ADD_NON_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SUB_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
+; SUB_NON_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -52,3 +53,4 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic.cu
@@ -13,10 +13,8 @@
 // %PARAM% TYPE,FILECHECK_PREFIX_TYPE type f16=f16,f16:bf16=bf16,bf16
 // %PARAM% OP op fetch_min:fetch_max
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm75,f16
-// %FILECHECK% PREFIX_COMBINE sm75,bf16
-// %FILECHECK% PREFIX_COMBINE sm80,f16
-// %FILECHECK% PREFIX_COMBINE sm80,bf16
+// %FILECHECK% PREFIX_COMBINE not-sm90-plus,bf16
+// %FILECHECK% PREFIX_COMBINE sm90-plus,bf16
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
@@ -42,11 +40,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
-; SM75_F16-DAG: {{.*}}HSETP2{{.*}}
-; SM75_BF16-DAG: {{.*}}FSETP{{.*}}
-; SM80_F16-DAG: {{.*}}HSETP2{{.*}}
-; SM80_BF16-DAG: {{.*}}FSETP{{.*}}
-; SM90-PLUS-DAG: {{.*}}HSETP2{{.*}}
+; F16-DAG: {{.*}}HSETP2{{.*}}
+; NOT-SM90-PLUS_BF16-DAG: {{.*}}FSETP{{.*}}
+; SM90-PLUS_BF16-DAG: {{.*}}HSETP2{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -60,7 +56,8 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]]{{(\.reuse)?}}, [[EXPECTED]]{{(\.reuse)?}}, {{.*}}
+; CAS_COMPARE_EXPECTED_OLD-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_types_8_16_atomic_ref.cu
@@ -13,10 +13,8 @@
 // %PARAM% TYPE,FILECHECK_PREFIX_TYPE type f16=f16,f16:bf16=bf16,bf16
 // %PARAM% OP op fetch_min:fetch_max
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm75,f16
-// %FILECHECK% PREFIX_COMBINE sm75,bf16
-// %FILECHECK% PREFIX_COMBINE sm80,f16
-// %FILECHECK% PREFIX_COMBINE sm80,bf16
+// %FILECHECK% PREFIX_COMBINE not-sm90-plus,bf16
+// %FILECHECK% PREFIX_COMBINE sm90-plus,bf16
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
@@ -40,11 +38,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
-; SM75_F16-DAG: {{.*}}HSETP2{{.*}}
-; SM75_BF16-DAG: {{.*}}FSETP{{.*}}
-; SM80_F16-DAG: {{.*}}HSETP2{{.*}}
-; SM80_BF16-DAG: {{.*}}FSETP{{.*}}
-; SM90-PLUS-DAG: {{.*}}HSETP2{{.*}}
+; F16-DAG: {{.*}}HSETP2{{.*}}
+; NOT-SM90-PLUS_BF16-DAG: {{.*}}FSETP{{.*}}
+; SM90-PLUS_BF16-DAG: {{.*}}HSETP2{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -58,7 +54,8 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]]{{(\.reuse)?}}, [[EXPECTED]]{{(\.reuse)?}}, {{.*}}
+; CAS_COMPARE_EXPECTED_OLD-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic.cu
@@ -13,10 +13,8 @@
 // %PARAM% TYPE,FILECHECK_PREFIX_TYPE type f16=f16,f16:bf16=bf16,bf16
 // %PARAM% OP op fetch_min:fetch_max
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm75,f16
-// %FILECHECK% PREFIX_COMBINE sm75,bf16
-// %FILECHECK% PREFIX_COMBINE sm80,f16
-// %FILECHECK% PREFIX_COMBINE sm80,bf16
+// %FILECHECK% PREFIX_COMBINE not-sm90-plus,bf16
+// %FILECHECK% PREFIX_COMBINE sm90-plus,bf16
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
@@ -42,11 +40,9 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR:R[0-9]+]]{{(\.64)?\].*}}
-; SM75_F16-DAG: {{.*}}HSETP2{{.*}}
-; SM75_BF16-DAG: {{.*}}FSETP{{.*}}
-; SM80_F16-DAG: {{.*}}HSETP2{{.*}}
-; SM80_BF16-DAG: {{.*}}FSETP{{.*}}
-; SM90-PLUS-DAG: {{.*}}HSETP2{{.*}}
+; F16-DAG: {{.*}}HSETP2{{.*}}
+; NOT-SM90-PLUS_BF16-DAG: {{.*}}FSETP{{.*}}
+; SM90-PLUS_BF16-DAG: {{.*}}HSETP2{{.*}}
 ; SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -60,7 +56,8 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, [[EXPECTED:R[0-9]+]], {{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]]{{(\.reuse)?}}, [[EXPECTED]]{{(\.reuse)?}}, {{.*}}
+; CAS_COMPARE_EXPECTED_OLD-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_minmax_volatile_types_8_16_atomic_ref.cu
@@ -13,10 +13,8 @@
 // %PARAM% TYPE,FILECHECK_PREFIX_TYPE type f16=f16,f16:bf16=bf16,bf16
 // %PARAM% OP op fetch_min:fetch_max
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm75,f16
-// %FILECHECK% PREFIX_COMBINE sm75,bf16
-// %FILECHECK% PREFIX_COMBINE sm80,f16
-// %FILECHECK% PREFIX_COMBINE sm80,bf16
+// %FILECHECK% PREFIX_COMBINE not-sm90-plus,bf16
+// %FILECHECK% PREFIX_COMBINE sm90-plus,bf16
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
 // clang-format on
@@ -40,11 +38,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
-; SM75_F16-DAG: {{.*}}HSETP2{{.*}}
-; SM75_BF16-DAG: {{.*}}FSETP{{.*}}
-; SM80_F16-DAG: {{.*}}HSETP2{{.*}}
-; SM80_BF16-DAG: {{.*}}FSETP{{.*}}
-; SM90-PLUS-DAG: {{.*}}HSETP2{{.*}}
+; F16-DAG: {{.*}}HSETP2{{.*}}
+; NOT-SM90-PLUS_BF16-DAG: {{.*}}FSETP{{.*}}
+; SM90-PLUS_BF16-DAG: {{.*}}HSETP2{{.*}}
 ; BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -59,7 +55,8 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]]{{(\.reuse)?}}, [[EXPECTED]]{{(\.reuse)?}}, {{.*}}
+; CAS_COMPARE_EXPECTED_OLD-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_apis.cu
@@ -56,8 +56,8 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; DEC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}0xffffffff{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
+; BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
 ; NON_BLOCK-NEXT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; POST_INC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_operators_volatile_apis.cu
@@ -49,7 +49,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD{{(\.S32)?}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK-DAG: {{.*}}CCTL.IVALL{{.*}}
@@ -57,9 +57,9 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; DEC-DAG: {{.*}}{{(IMAD\.)?MOV(\.U32)?}} [[OPERAND:R[0-9]+]], {{.*}}0xffffffff{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
-; BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD{{(\.S32)?}}{{.*}}
+; BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, [[OLD:R[0-9]+]], {{.*}}, [[OPERAND]]{{.*}}
 ; NON_BLOCK-NEXT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; POST_INC-NOT: {{.*}}{{(VIADD|IADD3|IADD)}}{{.*}}[[OLD]]{{.*}}
@@ -67,7 +67,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom)
 ; PRE_INC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], 0x1{{([,;[:space:]]|$)}}{{.*}}
 ; PRE_DEC: {{.*}}{{(VIADD|IADD3|IADD)}} {{R[0-9]+}}, {{(PT, PT, )?}}[[OLD]], {{(-0x1|0xffffffff)([,;[:space:]]|$)}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD{{(\.S32)?}}{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types.cu
@@ -10,11 +10,15 @@
 
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api cab=ca,tsb,CTA,block:card=car,tsd,GPU,non_block:csa=csa,tss,SYS,non_block
-// %PARAM% TYPE,SASS_TYPE type i32=int32_t,.S32:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64
+// %PARAM% TYPE,FILECHECK_PREFIX_WIDTH type i32=int32_t,word:u32=uint32_t,word:i64=int64_t,dword:u64=uint64_t,dword
 // %PARAM% OP op fetch_add:fetch_sub
 // %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
+// %FILECHECK% PREFIX_COMBINE word,block
+// %FILECHECK% PREFIX_COMBINE word,non_block
+// %FILECHECK% PREFIX_COMBINE dword,block
+// %FILECHECK% PREFIX_COMBINE dword,non_block
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -24,6 +28,7 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
   return atom.OP(value, ORDER);
 }
 
+// clang-format off
 /*
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
@@ -36,8 +41,10 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; WORD_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; WORD_NON_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; DWORD_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; DWORD_NON_BLOCK: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -45,3 +52,4 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
@@ -56,13 +56,13 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{.*}}
+; SMXX-DAG: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX: {{.*}}@{{!?P[0-9]+}} BRA{{.*}}
+; SMXX: {{.*}}@[[RETRY_PRED]] BRA{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
@@ -56,7 +56,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
+; SMXX-DAG: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|ISETP\.NE\.U64\.OR|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_128_atomic_ref.cu
@@ -56,7 +56,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|ISETP\.NE\.U64\.OR|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
+; SMXX-DAG: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|ISETP\.NE\.[SU]64\.OR|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic.cu
@@ -11,10 +11,14 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE,SASS_TYPE type i8=int8_t,.S32:u8=uint8_t,:i16=int16_t,.S32:u16=uint16_t,
-// %PARAM% OP,SASS_OP op add=fetch_add,ADD:sub=fetch_sub,ADD:min=fetch_min,MIN:max=fetch_max,MAX
+// %PARAM% OP,SASS_OP,FILECHECK_PREFIX_OP op add=fetch_add,ADD,add_sub:sub=fetch_sub,ADD,add_sub:min=fetch_min,MIN,minmax:max=fetch_max,MAX,minmax
 // %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
+// %FILECHECK% PREFIX_COMBINE add_sub,block
+// %FILECHECK% PREFIX_COMBINE add_sub,non_block
+// %FILECHECK% PREFIX_COMBINE minmax,block
+// %FILECHECK% PREFIX_COMBINE minmax,non_block
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -36,8 +40,10 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic<TYPE, SCOPE>& atom, 
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}}{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]]{{.*}}
+; ADD_SUB_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.{{CTA|SM}}{{.*}}
+; ADD_SUB_NON_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.[[SASS_SCOPE]]{{.*}}
+; MINMAX_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}}{{.*}}
+; MINMAX_NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
@@ -13,8 +13,28 @@
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t
 // %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub:min=fetch_min,min:max=fetch_max,max
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
-// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
+// %FILECHECK% PREFIX_COMBINE ptx,seq_cst
+// %FILECHECK% PREFIX_COMBINE ptx,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE ptx,release
+// %FILECHECK% PREFIX_COMBINE sm75,nvvm
+// %FILECHECK% PREFIX_COMBINE sm75,nvvm,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm75,nvvm,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm75,nvvm,release
+// %FILECHECK% PREFIX_COMBINE sm80,nvvm
+// %FILECHECK% PREFIX_COMBINE sm80,nvvm,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm80,nvvm,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm80,nvvm,release
+// %FILECHECK% PREFIX_COMBINE sm90,nvvm
+// %FILECHECK% PREFIX_COMBINE sm90,nvvm,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm90,nvvm,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm90,nvvm,release
+// %FILECHECK% PREFIX_COMBINE sm100,nvvm,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm100,nvvm,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm100,nvvm,release
+// %FILECHECK% PREFIX_COMBINE sm120,nvvm,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm120,nvvm,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm120,nvvm,release
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -30,6 +50,12 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SM100_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM120_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM100_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM120_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM100_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SM120_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
@@ -43,16 +69,28 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD|PRMT|LOP3\.LUT}} {{R[0-9]+}}, {{.*}}[[SUB_VALUE]]{{.*}}
 ; MIN: {{.*}}IMNMX{{.*}}
 ; MAX: {{.*}}IMNMX{{.*}}
-; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; PTX_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM75_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM80_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM90_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; PTX_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM75_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM80_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM90_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; PTX_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SM75_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SM80_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SM90_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; PTX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]]{{(\.reuse)?}}, [[EXPECTED]]{{(\.reuse)?}}, {{.*}}
+; SM75_NVVM-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
+; SM80_NVVM-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
+; SM90_NVVM-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_types_8_16_atomic_ref.cu
@@ -14,27 +14,12 @@
 // %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub:min=fetch_min,min:max=fetch_max,max
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
-// %FILECHECK% PREFIX_COMBINE ptx,seq_cst
-// %FILECHECK% PREFIX_COMBINE ptx,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE ptx,release
-// %FILECHECK% PREFIX_COMBINE sm75,nvvm
-// %FILECHECK% PREFIX_COMBINE sm75,nvvm,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm75,nvvm,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm75,nvvm,release
-// %FILECHECK% PREFIX_COMBINE sm80,nvvm
-// %FILECHECK% PREFIX_COMBINE sm80,nvvm,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm80,nvvm,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm80,nvvm,release
-// %FILECHECK% PREFIX_COMBINE sm90,nvvm
-// %FILECHECK% PREFIX_COMBINE sm90,nvvm,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm90,nvvm,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm90,nvvm,release
-// %FILECHECK% PREFIX_COMBINE sm100,nvvm,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm100,nvvm,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm100,nvvm,release
-// %FILECHECK% PREFIX_COMBINE sm120,nvvm,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm120,nvvm,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm120,nvvm,release
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_late,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_late,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_late,release
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_early,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_early,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_early,release
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -50,12 +35,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
-; SM100_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SM120_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SM100_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM120_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM100_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; SM120_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SUBWORD_RMW_FENCE_EARLY_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_EARLY_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_EARLY_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
@@ -69,28 +51,17 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD|PRMT|LOP3\.LUT}} {{R[0-9]+}}, {{.*}}[[SUB_VALUE]]{{.*}}
 ; MIN: {{.*}}IMNMX{{.*}}
 ; MAX: {{.*}}IMNMX{{.*}}
-; PTX_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SM75_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SM80_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SM90_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; PTX_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM75_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM80_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM90_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; PTX_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; SM75_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; SM80_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; SM90_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SUBWORD_RMW_FENCE_LATE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_LATE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_LATE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; PTX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]]{{(\.reuse)?}}, [[EXPECTED]]{{(\.reuse)?}}, {{.*}}
-; SM75_NVVM-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
-; SM80_NVVM-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
-; SM90_NVVM-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
+; CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]]{{(\.reuse)?}}, [[EXPECTED]]{{(\.reuse)?}}, {{.*}}
+; CAS_COMPARE_EXPECTED_OLD-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_apis.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_apis.cu
@@ -27,11 +27,12 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
   return atom.OP(value, ORDER);
 }
 
+// clang-format off
 /*
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD{{(\.S32)?}}{{.*}}
 ; ADD-NOT: {{.*}}{{(IADD3|IADD|IMAD\.MOV)}} {{R[0-9]+}}, {{.*}}-{{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -42,16 +43,17 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<int32_t, SCOPE>& atom, i
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
-; ADD_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; ADD_NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
-; SUB_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
-; SUB_NON_BLOCK: {{.*}}ATOM.E.ADD.S32.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD{{(\.S32)?}}{{.*}}
+; ADD_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; ADD_NON_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SUB_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
+; SUB_NON_BLOCK: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, [[OPERAND]]{{.*}}
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.ADD.S32{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD{{(\.S32)?}}{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types.cu
@@ -10,7 +10,7 @@
 
 // clang-format off
 // %PARAM% TEMPLATE,SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE api vcad=vca,tsd,GPU,non_block:vcard=vcar,tsd,GPU,non_block
-// %PARAM% TYPE,SASS_TYPE type i32=int32_t,.S32:u32=uint32_t,:i64=int64_t,.64:u64=uint64_t,.64
+// %PARAM% TYPE,FILECHECK_PREFIX_WIDTH type i32=int32_t,word:u32=uint32_t,word:i64=int64_t,dword:u64=uint64_t,dword
 // %PARAM% OP op fetch_add:fetch_sub
 // %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
@@ -28,19 +28,20 @@ extern "C" __device__ auto atomic_codegen_test(TEMPLATE<TYPE, SCOPE>& atom, TYPE
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.ADD[[SASS_TYPE]].STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD{{.*}}
+; WORD: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
+; DWORD: {{.*}}ATOM.E.ADD.64.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.ADD[[SASS_TYPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.ADD{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_128_atomic_ref.cu
@@ -58,13 +58,13 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{.*}}
+; SMXX-DAG: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|ISETP\.NE\.[SU]64\.OR|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
-; SMXX: {{.*}}@{{!?P[0-9]+}} BRA{{.*}}
+; SMXX: {{.*}}@[[RETRY_PRED]] BRA{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic.cu
@@ -11,7 +11,7 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE,SASS_TYPE type i8=int8_t,.S32:u8=uint8_t,:i16=int16_t,.S32:u16=uint16_t,
-// %PARAM% OP,SASS_OP op add=fetch_add,ADD:sub=fetch_sub,ADD:min=fetch_min,MIN:max=fetch_max,MAX
+// %PARAM% OP,SASS_OP,FILECHECK_PREFIX_OP op add=fetch_add,ADD,add_sub:sub=fetch_sub,ADD,add_sub:min=fetch_min,MIN,minmax:max=fetch_max,MAX,minmax
 // %PARAM% ORDER,SASS_MEMBAR,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,,non_seq_cst,no_acquire,no_membar:acquire=moa,,non_seq_cst,acquire,no_membar:release=more,ALL,non_seq_cst,no_acquire,membar:acq_rel=moar,ALL,non_seq_cst,acquire,membar:seq_cst=mosc,SC,seq_cst,acquire,membar
 // %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
@@ -28,7 +28,7 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; MEMBAR: {{.*}}MEMBAR.[[SASS_MEMBAR]].[[SASS_SCOPE]]{{.*}}
@@ -37,14 +37,14 @@ extern "C" __device__ auto atomic_codegen_test(volatile cuda::atomic<TYPE, SCOPE
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
-; BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.{{CTA|SM}}{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
+; ADD_SUB: {{.*}}ATOM.E.ADD{{(\.S32)?}}.STRONG.[[SASS_SCOPE]]{{.*}}
+; MINMAX: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]].STRONG.[[SASS_SCOPE]]{{.*}}
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]][[SASS_TYPE]]{{.*}}
+; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/arithmetic_volatile_types_8_16_atomic_ref.cu
@@ -13,8 +13,13 @@
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t
 // %PARAM% OP,FILECHECK_PREFIX_OP op add=fetch_add,add:sub=fetch_sub,sub:min=fetch_min,min:max=fetch_max,max
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
-// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_late,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_late,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_late,release
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_early,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_early,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_early,release
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -30,6 +35,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SUBWORD_RMW_FENCE_EARLY_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_EARLY_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_EARLY_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
@@ -43,9 +51,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SUB: {{.*}}{{IADD3|IADD|IMAD\.IADD|PRMT|LOP3\.LUT}} {{R[0-9]+}}, {{.*}}[[SUB_VALUE]]{{.*}}
 ; MIN: {{.*}}IMNMX{{.*}}
 ; MAX: {{.*}}IMNMX{{.*}}
-; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SUBWORD_RMW_FENCE_LATE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_LATE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_LATE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{ADD|MIN|MAX}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
@@ -53,7 +61,8 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]]{{(\.reuse)?}}, [[EXPECTED]]{{(\.reuse)?}}, {{.*}}
+; CAS_COMPARE_EXPECTED_OLD-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/bitwise_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/bitwise_types_128_atomic_ref.cu
@@ -48,7 +48,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
+; SMXX: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|ISETP\.NE\.U64\.OR|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{AND|OR|XOR}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}@[[RETRY_PRED]] BRA{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/bitwise_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/bitwise_types_128_atomic_ref.cu
@@ -48,9 +48,10 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}}
+; SMXX: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{AND|OR|XOR}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX: {{.*}}@[[RETRY_PRED]] BRA{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/bitwise_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/bitwise_types_128_atomic_ref.cu
@@ -48,7 +48,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|ISETP\.NE\.U64\.OR|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
+; SMXX: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|ISETP\.NE\.[SU]64\.OR|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{AND|OR|XOR}}{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
 ; SMXX: {{.*}}@[[RETRY_PRED]] BRA{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/bitwise_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/bitwise_types_128_atomic_ref.cu
@@ -42,7 +42,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{AND|OR|XOR}}{{.*}}
-; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.{{CTA|SM}} {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK: {{.*}}ATOM.E.CAS.128.STRONG.[[SASS_SCOPE]] {{P(T|[0-9]+)}}, {{R[0-9]+}}, {{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}, {{R[0-9]+}}, {{R[0-9]+}}{{.*}}
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
@@ -50,7 +50,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|ISETP\.NE\.[SU]64\.OR|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{AND|OR|XOR}}{{.*}}
-; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*}}
+; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX: {{.*}}@[[RETRY_PRED]] BRA{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/bitwise_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/bitwise_types_8_16_atomic_ref.cu
@@ -11,10 +11,30 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t
-// %PARAM% OP,SASS_OP op and=fetch_and,AND:or=fetch_or,OR:xor=fetch_xor,XOR
+// %PARAM% OP,SASS_OP,FILECHECK_PREFIX_BITWISE_OP op and=fetch_and,AND,and:or=fetch_or,OR,or_xor:xor=fetch_xor,XOR,or_xor
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
-// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE non_block,acquire
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,block
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,non_block
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,non_seq_cst
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,seq_cst
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,release
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,no_membar
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,non_block,acquire
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,no_acquire
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,cas_compare_old_expected
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,cas_compare_expected_old
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,block
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,non_block
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,non_seq_cst
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,seq_cst
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,release
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,no_membar
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,non_block,acquire
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,no_acquire
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,and
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,or_xor
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -24,38 +44,64 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
   return atom.OP(value, ORDER);
 }
 
-// The compiler may fuse the bitwise operation with subword packing, so check
-// the CAS protocol without fixing a particular LOP3 truth table.
+// The compiler may fuse the bitwise operation with subword packing, so avoid
+// fixing a particular LOP3 truth table.
+// TODO: Improve PTX codegen for SM100+ to use the native widened and masked
+// subword bitwise operations too.
 // clang-format off
 /*
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
-; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
-; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; SMXX: {{.*}}LOP3.LUT {{.*}}
-; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
-; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
-; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
-; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+; CAS_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
+; CAS_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE: {{.*}}LOP3.LUT [[CAS_ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; CAS_SUBWORD_BITWISE_BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[CAS_ALIGNED_ADDR]]{{(\.64)?\].*}}
+; CAS_SUBWORD_BITWISE_NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[CAS_ALIGNED_ADDR]]{{(\.64)?\].*}}
+; CAS_SUBWORD_BITWISE: {{.*}}LOP3.LUT {{.*}}
+; CAS_SUBWORD_BITWISE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; CAS_SUBWORD_BITWISE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; CAS_SUBWORD_BITWISE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; CAS_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
+; CAS_SUBWORD_BITWISE_BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[CAS_ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; CAS_SUBWORD_BITWISE_NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[CAS_ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; CAS_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; CAS_SUBWORD_BITWISE_CAS_COMPARE_EXPECTED_OLD-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
+; CAS_SUBWORD_BITWISE_NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
+; CAS_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; CAS_SUBWORD_BITWISE: {{.*}}RET.ABS.NODEC{{.*}}
+
+; NATIVE_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; NATIVE_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NATIVE_SUBWORD_BITWISE_NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NATIVE_SUBWORD_BITWISE_RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NATIVE_SUBWORD_BITWISE_SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NATIVE_SUBWORD_BITWISE_NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; NATIVE_SUBWORD_BITWISE_NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; NATIVE_SUBWORD_BITWISE-DAG: {{.*}}LOP3.LUT [[NATIVE_ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; NATIVE_SUBWORD_BITWISE-DAG: {{.*}}LOP3.LUT [[SHIFT:R[0-9]+]], {{.*}}, 0x18, {{.*}}
+; NATIVE_SUBWORD_BITWISE_AND-DAG: {{.*}}SHF.L.U32 [[SHIFTED_OPERAND:R[0-9]+]], {{.*}}, [[SHIFT]]{{(\.reuse)?}}, RZ{{.*}}
+; NATIVE_SUBWORD_BITWISE_AND-DAG: {{.*}}LOP3.LUT [[NATIVE_OPERAND:R[0-9]+]], [[SHIFTED_OPERAND]], {{.*}}
+; NATIVE_SUBWORD_BITWISE_OR_XOR-DAG: {{.*}}SHF.L.U32 [[NATIVE_OPERAND:R[0-9]+]], {{.*}}, [[SHIFT]]{{(\.reuse)?}}, RZ{{.*}}
+; NATIVE_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; NATIVE_SUBWORD_BITWISE_BLOCK: {{.*}}ATOM.E.[[SASS_OP]].STRONG.{{CTA|SM}} PT, [[NATIVE_OLD:R[0-9]+]], {{.*\[}}[[NATIVE_ALIGNED_ADDR]]{{(\.64)?\].*}}, [[NATIVE_OPERAND]]{{.*}}
+; NATIVE_SUBWORD_BITWISE_NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]].STRONG.[[SASS_SCOPE]] PT, [[NATIVE_OLD:R[0-9]+]], {{.*\[}}[[NATIVE_ALIGNED_ADDR]]{{(\.64)?\].*}}, [[NATIVE_OPERAND]]{{.*}}
+; NATIVE_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NATIVE_SUBWORD_BITWISE_NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NATIVE_SUBWORD_BITWISE_NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; NATIVE_SUBWORD_BITWISE-DAG: {{.*}}SHF.R.U32.HI {{R[0-9]+}}, RZ, [[SHIFT]]{{(\.reuse)?}}, [[NATIVE_OLD]]{{.*}}
+; NATIVE_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
+; NATIVE_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; NATIVE_SUBWORD_BITWISE: {{.*}}RET.ABS.NODEC{{.*}}
 
 */
 // clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/bitwise_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/bitwise_types_8_16_atomic_ref.cu
@@ -71,7 +71,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; CAS_SUBWORD_BITWISE_NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[CAS_ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; CAS_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; CAS_SUBWORD_BITWISE_NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; CAS_SUBWORD_BITWISE_CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; CAS_SUBWORD_BITWISE_CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]]{{(\.reuse)?}}, [[EXPECTED]]{{(\.reuse)?}}, {{.*}}
 ; CAS_SUBWORD_BITWISE_CAS_COMPARE_EXPECTED_OLD-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
 ; CAS_SUBWORD_BITWISE_NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; CAS_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/bitwise_volatile_types_128_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/bitwise_volatile_types_128_atomic_ref.cu
@@ -50,9 +50,10 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}ISETP.NE{{.*}}
+; SMXX: {{.*}}{{ISETP\.NE(\.U32)?\.OR\.EX|ISETP\.NE\.[SU]64\.OR|LOP3\.LUT}} [[RETRY_PRED:P[0-9]+]], {{.*}}[[RETRY_PRED]]{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.{{.*}}CAS{{.*\[}}[[ATOM_ADDR]]{{(\.64)?\].*}}
 ; SMXX-NOT: {{.*}}ATOM.E.{{AND|OR|XOR}}{{.*}}
+; SMXX: {{.*}}@[[RETRY_PRED]] BRA{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */

--- a/libcudacxx/test/atomic_codegen/sass/bitwise_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/bitwise_volatile_types_8_16_atomic_ref.cu
@@ -71,7 +71,7 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; CAS_SUBWORD_BITWISE_NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[CAS_ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
 ; CAS_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; CAS_SUBWORD_BITWISE_NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; CAS_SUBWORD_BITWISE_CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; CAS_SUBWORD_BITWISE_CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]]{{(\.reuse)?}}, [[EXPECTED]]{{(\.reuse)?}}, {{.*}}
 ; CAS_SUBWORD_BITWISE_CAS_COMPARE_EXPECTED_OLD-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
 ; CAS_SUBWORD_BITWISE_NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; CAS_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/bitwise_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/bitwise_volatile_types_8_16_atomic_ref.cu
@@ -11,10 +11,30 @@
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t
-// %PARAM% OP,SASS_OP op and=fetch_and,AND:or=fetch_or,OR:xor=fetch_xor,XOR
+// %PARAM% OP,SASS_OP,FILECHECK_PREFIX_BITWISE_OP op and=fetch_and,AND,and:or=fetch_or,OR,or_xor:xor=fetch_xor,XOR,or_xor
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
-// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE non_block,acquire
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,block
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,non_block
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,non_seq_cst
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,seq_cst
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,release
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,no_membar
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,non_block,acquire
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,no_acquire
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,cas_compare_old_expected
+// %FILECHECK% PREFIX_COMBINE cas_subword_bitwise,cas_compare_expected_old
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,block
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,non_block
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,non_seq_cst
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,seq_cst
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,release
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,no_membar
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,non_block,acquire
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,no_acquire
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,and
+// %FILECHECK% PREFIX_COMBINE native_subword_bitwise,or_xor
 // clang-format on
 
 #include "atomic_codegen_helpers.h"
@@ -24,41 +44,64 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
   return atom.OP(value, ORDER);
 }
 
-// The compiler may fuse the bitwise operation with subword packing, so check
-// the CAS protocol without fixing a particular LOP3 truth table.
+// The compiler may fuse the bitwise operation with subword packing, so avoid
+// fixing a particular LOP3 truth table.
+// TODO: Improve PTX codegen for SM100+ to use the native widened and masked
+// subword bitwise operations too.
 // clang-format off
 /*
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
-; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; SMXX: {{.*}}LOP3.LUT {{.*}}
-; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
-; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
-; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
-; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
-; SMXX-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
-; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
+; CAS_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
+; CAS_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE: {{.*}}LOP3.LUT [[CAS_ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; CAS_SUBWORD_BITWISE_BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[EXPECTED:R[0-9]+]], {{.*\[}}[[CAS_ALIGNED_ADDR]]{{(\.64)?\].*}}
+; CAS_SUBWORD_BITWISE_NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[EXPECTED:R[0-9]+]], {{.*\[}}[[CAS_ALIGNED_ADDR]]{{(\.64)?\].*}}
+; CAS_SUBWORD_BITWISE: {{.*}}LOP3.LUT {{.*}}
+; CAS_SUBWORD_BITWISE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; CAS_SUBWORD_BITWISE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; CAS_SUBWORD_BITWISE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; CAS_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
+; CAS_SUBWORD_BITWISE_BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[OLD:R[0-9]+]], {{\[}}[[CAS_ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; CAS_SUBWORD_BITWISE_NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[OLD:R[0-9]+]], {{\[}}[[CAS_ALIGNED_ADDR]]{{\]}}, [[EXPECTED]], {{R[0-9]+}}{{.*}}
+; CAS_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[OLD]], [[EXPECTED]], {{.*}}
+; CAS_SUBWORD_BITWISE_CAS_COMPARE_EXPECTED_OLD-DAG: {{.*}}ISETP.NE{{.*}} [[EXPECTED]]{{(\.reuse)?}}, [[OLD]]{{(\.reuse)?}}, {{.*}}
+; CAS_SUBWORD_BITWISE_NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE_NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
+; CAS_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
+; CAS_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; CAS_SUBWORD_BITWISE: {{.*}}RET.ABS.NODEC{{.*}}
+
+; NATIVE_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; NATIVE_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NATIVE_SUBWORD_BITWISE_NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NATIVE_SUBWORD_BITWISE_RELEASE-DAG: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NATIVE_SUBWORD_BITWISE_SEQ_CST-DAG: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NATIVE_SUBWORD_BITWISE_NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
+; NATIVE_SUBWORD_BITWISE_NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; NATIVE_SUBWORD_BITWISE-DAG: {{.*}}LOP3.LUT [[NATIVE_ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; NATIVE_SUBWORD_BITWISE-DAG: {{.*}}LOP3.LUT [[SHIFT:R[0-9]+]], {{.*}}, 0x18, {{.*}}
+; NATIVE_SUBWORD_BITWISE_AND-DAG: {{.*}}SHF.L.U32 [[SHIFTED_OPERAND:R[0-9]+]], {{.*}}, [[SHIFT]]{{(\.reuse)?}}, RZ{{.*}}
+; NATIVE_SUBWORD_BITWISE_AND-DAG: {{.*}}LOP3.LUT [[NATIVE_OPERAND:R[0-9]+]], [[SHIFTED_OPERAND]], {{.*}}
+; NATIVE_SUBWORD_BITWISE_OR_XOR-DAG: {{.*}}SHF.L.U32 [[NATIVE_OPERAND:R[0-9]+]], {{.*}}, [[SHIFT]]{{(\.reuse)?}}, RZ{{.*}}
+; NATIVE_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; NATIVE_SUBWORD_BITWISE_BLOCK: {{.*}}ATOM.E.[[SASS_OP]].STRONG.{{CTA|SM}} PT, [[NATIVE_OLD:R[0-9]+]], {{.*\[}}[[NATIVE_ALIGNED_ADDR]]{{(\.64)?\].*}}, [[NATIVE_OPERAND]]{{.*}}
+; NATIVE_SUBWORD_BITWISE_NON_BLOCK: {{.*}}ATOM.E.[[SASS_OP]].STRONG.[[SASS_SCOPE]] PT, [[NATIVE_OLD:R[0-9]+]], {{.*\[}}[[NATIVE_ALIGNED_ADDR]]{{(\.64)?\].*}}, [[NATIVE_OPERAND]]{{.*}}
+; NATIVE_SUBWORD_BITWISE_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NATIVE_SUBWORD_BITWISE_NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NATIVE_SUBWORD_BITWISE_NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
+; NATIVE_SUBWORD_BITWISE-DAG: {{.*}}SHF.R.U32.HI {{R[0-9]+}}, RZ, [[SHIFT]]{{(\.reuse)?}}, [[NATIVE_OLD]]{{.*}}
+; NATIVE_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.[[SASS_OP]]{{.*}}
+; NATIVE_SUBWORD_BITWISE-NOT: {{.*}}ATOM.E.CAS{{.*}}
+; NATIVE_SUBWORD_BITWISE: {{.*}}RET.ABS.NODEC{{.*}}
 
 */
 // clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
@@ -10,11 +10,51 @@
 
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
-// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% TYPE,FILECHECK_PREFIX_WIDTH type int8_t=int8_t,byte:uint8_t=uint8_t,byte:int16_t=int16_t,halfword:uint16_t=uint16_t,halfword:f16=f16,halfword:bf16=bf16,halfword
 // %PARAM% CAS cas compare_exchange_weak:compare_exchange_strong
 // %PARAM% SUCCESS_ORDER,FAILURE_ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order rr=mor,mor,non_seq_cst,no_acquire,no_membar:ar=moa,mor,non_seq_cst,acquire,no_membar:aa=moa,moa,non_seq_cst,acquire,no_membar:er=more,mor,non_seq_cst,no_acquire,release:br=moar,mor,non_seq_cst,acquire,release:ba=moar,moa,non_seq_cst,acquire,release:sr=mosc,mor,seq_cst,acquire,seq_cst:sa=mosc,moa,seq_cst,acquire,seq_cst:ss=mosc,mosc,seq_cst,acquire,seq_cst
-// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
+// %FILECHECK% PREFIX_COMBINE nvvm,byte
+// %FILECHECK% PREFIX_COMBINE nvvm,byte,block
+// %FILECHECK% PREFIX_COMBINE nvvm,byte,non_block
+// %FILECHECK% PREFIX_COMBINE ptx,block
+// %FILECHECK% PREFIX_COMBINE ptx,non_block
+// %FILECHECK% PREFIX_COMBINE ptx,seq_cst
+// %FILECHECK% PREFIX_COMBINE ptx,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE ptx,release
+// %FILECHECK% PREFIX_COMBINE sm75,nvvm,halfword
+// %FILECHECK% PREFIX_COMBINE sm75,nvvm,halfword,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm75,nvvm,halfword,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm75,nvvm,halfword,release
+// %FILECHECK% PREFIX_COMBINE sm75,nvvm,byte,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm75,nvvm,byte,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm75,nvvm,byte,release
+// %FILECHECK% PREFIX_COMBINE sm80,nvvm,halfword
+// %FILECHECK% PREFIX_COMBINE sm80,nvvm,halfword,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm80,nvvm,halfword,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm80,nvvm,halfword,release
+// %FILECHECK% PREFIX_COMBINE sm80,nvvm,byte,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm80,nvvm,byte,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm80,nvvm,byte,release
+// %FILECHECK% PREFIX_COMBINE sm90,nvvm,halfword
+// %FILECHECK% PREFIX_COMBINE sm90,nvvm,halfword,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm90,nvvm,halfword,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm90,nvvm,halfword,release
+// %FILECHECK% PREFIX_COMBINE sm90,nvvm,byte,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm90,nvvm,byte,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm90,nvvm,byte,release
+// %FILECHECK% PREFIX_COMBINE sm100,nvvm,halfword
+// %FILECHECK% PREFIX_COMBINE sm100,nvvm,halfword,block
+// %FILECHECK% PREFIX_COMBINE sm100,nvvm,halfword,non_block
+// %FILECHECK% PREFIX_COMBINE sm100,nvvm,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm100,nvvm,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm100,nvvm,release
+// %FILECHECK% PREFIX_COMBINE sm120,nvvm,halfword
+// %FILECHECK% PREFIX_COMBINE sm120,nvvm,halfword,block
+// %FILECHECK% PREFIX_COMBINE sm120,nvvm,halfword,non_block
+// %FILECHECK% PREFIX_COMBINE sm120,nvvm,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm120,nvvm,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm120,nvvm,release
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -32,16 +72,55 @@ extern "C" __device__ bool atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SM100_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM120_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM100_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM120_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM100_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SM120_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SM75_NVVM_HALFWORD_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM80_NVVM_HALFWORD_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM90_NVVM_HALFWORD_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM90_NVVM_HALFWORD_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; PTX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; NVVM_BYTE-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; SM75_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffd, {{.*}}
+; SM80_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffd, {{.*}}
+; SM90_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffd, {{.*}}
+; SM100_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; SM120_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; SM75_NVVM_HALFWORD_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SM80_NVVM_HALFWORD_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SM75_NVVM_HALFWORD_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM80_NVVM_HALFWORD_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
-; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; PTX_BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; PTX_NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; NVVM_BYTE_BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; NVVM_BYTE_NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; SM75_NVVM_HALFWORD: {{.*}}LD.E.SYS {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; SM80_NVVM_HALFWORD: {{.*}}LD.E {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; SM90_NVVM_HALFWORD: {{.*}}LD.E {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; SM100_NVVM_HALFWORD_BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; SM100_NVVM_HALFWORD_NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; SM120_NVVM_HALFWORD_BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; SM120_NVVM_HALFWORD_NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; PTX_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM75_NVVM_BYTE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM80_NVVM_BYTE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM90_NVVM_BYTE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM90_NVVM_HALFWORD_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; PTX_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM75_NVVM_BYTE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM80_NVVM_BYTE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM90_NVVM_BYTE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; PTX_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SM75_NVVM_BYTE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SM80_NVVM_BYTE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SM90_NVVM_BYTE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_types_8_16_atomic_ref.cu
@@ -22,39 +22,20 @@
 // %FILECHECK% PREFIX_COMBINE ptx,seq_cst
 // %FILECHECK% PREFIX_COMBINE ptx,non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE ptx,release
-// %FILECHECK% PREFIX_COMBINE sm75,nvvm,halfword
-// %FILECHECK% PREFIX_COMBINE sm75,nvvm,halfword,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm75,nvvm,halfword,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm75,nvvm,halfword,release
-// %FILECHECK% PREFIX_COMBINE sm75,nvvm,byte,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm75,nvvm,byte,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm75,nvvm,byte,release
-// %FILECHECK% PREFIX_COMBINE sm80,nvvm,halfword
-// %FILECHECK% PREFIX_COMBINE sm80,nvvm,halfword,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm80,nvvm,halfword,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm80,nvvm,halfword,release
-// %FILECHECK% PREFIX_COMBINE sm80,nvvm,byte,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm80,nvvm,byte,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm80,nvvm,byte,release
-// %FILECHECK% PREFIX_COMBINE sm90,nvvm,halfword
-// %FILECHECK% PREFIX_COMBINE sm90,nvvm,halfword,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm90,nvvm,halfword,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE not-sm100-plus,nvvm,halfword
+// %FILECHECK% PREFIX_COMBINE not-sm100-plus,nvvm,halfword,seq_cst
+// %FILECHECK% PREFIX_COMBINE not-sm100-plus,nvvm,halfword,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE not-sm90-plus,nvvm,halfword,release
+// %FILECHECK% PREFIX_COMBINE not-sm100-plus,nvvm,byte,seq_cst
+// %FILECHECK% PREFIX_COMBINE not-sm100-plus,nvvm,byte,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE not-sm100-plus,nvvm,byte,release
+// %FILECHECK% PREFIX_COMBINE sm100-plus,nvvm,halfword
+// %FILECHECK% PREFIX_COMBINE sm100-plus,nvvm,halfword,block
+// %FILECHECK% PREFIX_COMBINE sm100-plus,nvvm,halfword,non_block
+// %FILECHECK% PREFIX_COMBINE sm100-plus,nvvm,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm100-plus,nvvm,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm100-plus,nvvm,release
 // %FILECHECK% PREFIX_COMBINE sm90,nvvm,halfword,release
-// %FILECHECK% PREFIX_COMBINE sm90,nvvm,byte,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm90,nvvm,byte,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm90,nvvm,byte,release
-// %FILECHECK% PREFIX_COMBINE sm100,nvvm,halfword
-// %FILECHECK% PREFIX_COMBINE sm100,nvvm,halfword,block
-// %FILECHECK% PREFIX_COMBINE sm100,nvvm,halfword,non_block
-// %FILECHECK% PREFIX_COMBINE sm100,nvvm,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm100,nvvm,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm100,nvvm,release
-// %FILECHECK% PREFIX_COMBINE sm120,nvvm,halfword
-// %FILECHECK% PREFIX_COMBINE sm120,nvvm,halfword,block
-// %FILECHECK% PREFIX_COMBINE sm120,nvvm,halfword,non_block
-// %FILECHECK% PREFIX_COMBINE sm120,nvvm,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm120,nvvm,non_block,seq_cst
-// %FILECHECK% PREFIX_COMBINE sm120,nvvm,release
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -67,60 +48,40 @@ extern "C" __device__ bool atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
 
+// clang-format off
 /*
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
-; SM100_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SM120_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SM100_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM120_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM100_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; SM120_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; SM75_NVVM_HALFWORD_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM80_NVVM_HALFWORD_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM90_NVVM_HALFWORD_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM90_NVVM_HALFWORD_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SM100-PLUS_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM100-PLUS_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM100-PLUS_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; NOT-SM100-PLUS_NVVM_HALFWORD_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; PTX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
 ; NVVM_BYTE-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
-; SM75_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffd, {{.*}}
-; SM80_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffd, {{.*}}
-; SM90_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffd, {{.*}}
-; SM100_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
-; SM120_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
-; SM75_NVVM_HALFWORD_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; SM80_NVVM_HALFWORD_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; SM75_NVVM_HALFWORD_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SM80_NVVM_HALFWORD_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NOT-SM100-PLUS_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffd, {{.*}}
+; SM100-PLUS_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; NOT-SM90-PLUS_NVVM_HALFWORD_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NOT-SM100-PLUS_NVVM_HALFWORD_NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; PTX_BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; PTX_NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NVVM_BYTE_BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; NVVM_BYTE_NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; SM75_NVVM_HALFWORD: {{.*}}LD.E.SYS {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
-; SM80_NVVM_HALFWORD: {{.*}}LD.E {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
-; SM90_NVVM_HALFWORD: {{.*}}LD.E {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
-; SM100_NVVM_HALFWORD_BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; SM100_NVVM_HALFWORD_NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; SM120_NVVM_HALFWORD_BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; SM120_NVVM_HALFWORD_NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; PTX_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SM75_NVVM_BYTE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SM80_NVVM_BYTE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SM90_NVVM_BYTE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NOT-SM100-PLUS_NVVM_HALFWORD-DAG: {{.*}}LD.E{{(\.SYS)?}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; SM100-PLUS_NVVM_HALFWORD_BLOCK-DAG: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; SM100-PLUS_NVVM_HALFWORD_NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
 ; SM90_NVVM_HALFWORD_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; PTX_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NOT-SM100-PLUS_NVVM_BYTE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
 ; PTX_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM75_NVVM_BYTE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM80_NVVM_BYTE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; SM90_NVVM_BYTE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NOT-SM100-PLUS_NVVM_BYTE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; PTX_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; SM75_NVVM_BYTE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; SM80_NVVM_BYTE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
-; SM90_NVVM_BYTE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; NOT-SM100-PLUS_NVVM_BYTE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}}{{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
@@ -132,3 +93,4 @@ extern "C" __device__ bool atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/compare_exchange_volatile_types_8_16_atomic_ref.cu
@@ -10,12 +10,30 @@
 
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
-// %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
+// %PARAM% TYPE,FILECHECK_PREFIX_WIDTH type int8_t=int8_t,byte:uint8_t=uint8_t,byte:int16_t=int16_t,halfword:uint16_t=uint16_t,halfword:f16=f16,halfword:bf16=bf16,halfword
 // Strong compare-exchange may retry internally using weak compare-exchange; only the weak overload must contain one CAS.
 // %PARAM% CAS,FILECHECK_PREFIX_SINGLE_CAS cas compare_exchange_weak=compare_exchange_weak,single_cas:compare_exchange_strong=compare_exchange_strong,smxx
 // %PARAM% SUCCESS_ORDER,FAILURE_ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order rr=mor,mor,non_seq_cst,no_acquire,no_membar:ar=moa,mor,non_seq_cst,acquire,no_membar:aa=moa,moa,non_seq_cst,acquire,no_membar:er=more,mor,non_seq_cst,no_acquire,release:br=moar,mor,non_seq_cst,acquire,release:ba=moar,moa,non_seq_cst,acquire,release:sr=mosc,mor,seq_cst,acquire,seq_cst:sa=mosc,moa,seq_cst,acquire,seq_cst:ss=mosc,mosc,seq_cst,acquire,seq_cst
-// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
+// %FILECHECK% PREFIX_COMBINE nvvm,byte
+// %FILECHECK% PREFIX_COMBINE nvvm,byte,non_block
+// %FILECHECK% PREFIX_COMBINE ptx,non_block
+// %FILECHECK% PREFIX_COMBINE ptx,seq_cst
+// %FILECHECK% PREFIX_COMBINE ptx,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE ptx,release
+// %FILECHECK% PREFIX_COMBINE not-sm100-plus,nvvm,halfword
+// %FILECHECK% PREFIX_COMBINE not-sm100-plus,nvvm,halfword,seq_cst
+// %FILECHECK% PREFIX_COMBINE not-sm100-plus,nvvm,halfword,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE not-sm90-plus,nvvm,halfword,release
+// %FILECHECK% PREFIX_COMBINE not-sm100-plus,nvvm,byte,seq_cst
+// %FILECHECK% PREFIX_COMBINE not-sm100-plus,nvvm,byte,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE not-sm100-plus,nvvm,byte,release
+// %FILECHECK% PREFIX_COMBINE sm100-plus,nvvm,halfword
+// %FILECHECK% PREFIX_COMBINE sm100-plus,nvvm,halfword,non_block
+// %FILECHECK% PREFIX_COMBINE sm100-plus,nvvm,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm100-plus,nvvm,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE sm100-plus,nvvm,release
+// %FILECHECK% PREFIX_COMBINE sm90,nvvm,halfword,release
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -29,24 +47,40 @@ atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected
   return atom.CAS(expected, desired, SUCCESS_ORDER, FAILURE_ORDER);
 }
 
+// clang-format off
 /*
 
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SM100-PLUS_NVVM_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SM100-PLUS_NVVM_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SM100-PLUS_NVVM_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; NOT-SM100-PLUS_NVVM_HALFWORD_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; PTX-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; NVVM_BYTE-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; NOT-SM100-PLUS_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffd, {{.*}}
+; SM100-PLUS_NVVM_HALFWORD-DAG: {{.*}}LOP3.LUT [[ALIGNED_ADDR:R[0-9]+]], [[ATOM_ADDR]]{{(\.reuse)?}}, 0xfffffffc, {{.*}}
+; NOT-SM90-PLUS_NVVM_HALFWORD_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NOT-SM100-PLUS_NVVM_HALFWORD_NON_BLOCK_SEQ_CST-DAG: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
-; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
-; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; PTX_NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; NVVM_BYTE_NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; NOT-SM100-PLUS_NVVM_HALFWORD-DAG: {{.*}}LD.E{{(\.SYS)?}} {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{\].*}}
+; SM100-PLUS_NVVM_HALFWORD_NON_BLOCK-DAG: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] {{R[0-9]+}}, {{.*\[}}[[ALIGNED_ADDR]]{{(\.64)?\].*}}
+; SM90_NVVM_HALFWORD_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
-; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; PTX_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; NOT-SM100-PLUS_NVVM_BYTE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; PTX_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; NOT-SM100-PLUS_NVVM_BYTE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; PTX_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; NOT-SM100-PLUS_NVVM_BYTE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
@@ -61,3 +95,4 @@ atomic_codegen_test(cuda::atomic_ref<volatile TYPE, SCOPE>& atom, TYPE& expected
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 
 */
+// clang-format on

--- a/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_types_8_16_atomic_ref.cu
@@ -12,8 +12,13 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
-// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_late,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_late,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_late,release
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_early,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_early,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_early,release
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -31,6 +36,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SUBWORD_RMW_FENCE_EARLY_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_EARLY_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_EARLY_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-DAG: {{.*}}LOP3.LUT [[A:R[0-9]+]], [[ATOM_ADDR]], 0xfffffffc, {{.*}}
@@ -38,17 +46,18 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<TYPE, SCOPE>& at
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[E:R[0-9]+]], {{.*\[}}[[A]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[E:R[0-9]+]], {{.*\[}}[[A]]{{(\.64)?\].*}}
-; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SUBWORD_RMW_FENCE_LATE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_LATE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_LATE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
-; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], {{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[C]], [[E]], {{.*}}
+; CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[C]]{{(\.reuse)?}}, [[E]]{{(\.reuse)?}}, {{.*}}
+; CAS_COMPARE_EXPECTED_OLD-DAG: {{.*}}ISETP.NE{{.*}} [[E]]{{(\.reuse)?}}, [[C]]{{(\.reuse)?}}, {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}
 

--- a/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic_ref.cu
+++ b/libcudacxx/test/atomic_codegen/sass/exchange_volatile_types_8_16_atomic_ref.cu
@@ -12,8 +12,13 @@
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope device=tsd,GPU,non_block
 // %PARAM% TYPE type int8_t:uint8_t:int16_t:uint16_t:f16:bf16
 // %PARAM% ORDER,FILECHECK_PREFIX_SEQ_CST,FILECHECK_PREFIX_ACQUIRE,FILECHECK_PREFIX_ORDER order relaxed=mor,non_seq_cst,no_acquire,no_membar:acquire=moa,non_seq_cst,acquire,no_membar:release=more,non_seq_cst,no_acquire,release:acq_rel=moar,non_seq_cst,acquire,release:seq_cst=mosc,seq_cst,acquire,seq_cst
-// %FILECHECK% PREFIX_COMBINE non_block,seq_cst
 // %FILECHECK% PREFIX_COMBINE non_block,acquire
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_late,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_late,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_late,release
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_early,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_early,non_block,seq_cst
+// %FILECHECK% PREFIX_COMBINE subword_rmw_fence_early,release
 // clang-format on
 
 #include <cuda_bf16.h>
@@ -31,6 +36,9 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX: {{.*}}LD.E.64{{(\.SYS)?}} [[ATOM_ADDR:R[0-9]+]], {{.*}}
+; SUBWORD_RMW_FENCE_EARLY_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_EARLY_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_EARLY_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_SEQ_CST-NOT: {{.*}}CCTL.IVALL{{.*}}
@@ -41,18 +49,19 @@ extern "C" __device__ auto atomic_codegen_test(cuda::atomic_ref<volatile TYPE, S
 ; BLOCK: {{.*}}LD.E.STRONG.{{CTA|SM}} [[E:R[0-9]+]], {{.*\[}}[[A]]{{(\.64)?\].*}}
 ; NON_BLOCK: {{.*}}LD.E.STRONG.[[SASS_SCOPE]] [[E:R[0-9]+]], {{.*\[}}[[A]]{{(\.64)?\].*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
-; RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
-; SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
-; NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
+; SUBWORD_RMW_FENCE_LATE_RELEASE: {{.*}}MEMBAR.ALL.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_LATE_SEQ_CST: {{.*}}MEMBAR.SC.[[SASS_SCOPE]]{{.*}}
+; SUBWORD_RMW_FENCE_LATE_NON_BLOCK_SEQ_CST: {{.*}}CCTL.IVALL{{.*}}
 ; NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
 ; SMXX-NOT: {{.*}}LD.E{{.*}}.STRONG{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
-; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
-; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], [[C]]{{.*}}
+; BLOCK: {{.*}}ATOM.E.CAS.STRONG.{{CTA|SM}} PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], {{R[0-9]+}}{{.*}}
+; NON_BLOCK: {{.*}}ATOM.E.CAS.STRONG.[[SASS_SCOPE]] PT, [[C:R[0-9]+]], {{\[}}[[A]]{{\]}}, [[E]], {{R[0-9]+}}{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; NON_BLOCK_ACQUIRE-DAG: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-DAG: {{.*}}ISETP.NE{{.*}} [[C]], [[E]], {{.*}}
+; CAS_COMPARE_OLD_EXPECTED-DAG: {{.*}}ISETP.NE{{.*}} [[C]]{{(\.reuse)?}}, [[E]]{{(\.reuse)?}}, {{.*}}
+; CAS_COMPARE_EXPECTED_OLD-DAG: {{.*}}ISETP.NE{{.*}} [[E]]{{(\.reuse)?}}, [[C]]{{(\.reuse)?}}, {{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.EXCH{{.*}}
 ; SMXX-NOT: {{.*}}ATOM.E.CAS{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/fence_cuda.cu
+++ b/libcudacxx/test/atomic_codegen/sass/fence_cuda.cu
@@ -10,7 +10,14 @@
 
 // clang-format off
 // %PARAM% SCOPE,SASS_SCOPE,FILECHECK_PREFIX_SCOPE scope block=tsb,CTA,block:device=tsd,GPU,non_block:system=tss,SYS,non_block
-// %PARAM% ORDER,SASS_SEMANTIC order acquire=moa,ALL:release=more,ALL:acq_rel=moar,ALL:seq_cst=mosc,SC
+// %PARAM% ORDER,SASS_SEMANTIC,FILECHECK_PREFIX_MEMBAR,FILECHECK_PREFIX_ACQUIRE order acquire=moa,ALL,no_membar,acquire:release=more,ALL,membar,no_acquire:acq_rel=moar,ALL,membar,acquire:seq_cst=mosc,SC,membar,acquire
+// %FILECHECK% PREFIX_COMBINE non_block,acquire
+// %FILECHECK% PREFIX_COMBINE ptx,no_membar
+// %FILECHECK% PREFIX_COMBINE ptx,non_block,no_acquire
+// %FILECHECK% PREFIX_COMBINE not-sm90-plus,nvvm,no_membar
+// %FILECHECK% PREFIX_COMBINE not-sm90-plus,nvvm,non_block,no_acquire
+// %FILECHECK% PREFIX_COMBINE sm90-plus,nvvm,no_membar
+// %FILECHECK% PREFIX_COMBINE sm90-plus,nvvm,no_acquire
 // clang-format on
 
 #include <cuda/std/cstdint>
@@ -29,16 +36,16 @@ extern "C" __device__ int32_t atomic_codegen_test(int32_t* before, const int32_t
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX: {{.*}}ST{{G?}}.E{{.*}}
 ; SMXX-NOT: {{.*}}ST{{G?}}.E{{.*}}
-; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
-; BLOCK-NOT: {{.*}}MEMBAR.{{.*}}
-; NON_BLOCK-NOT: {{.*}}MEMBAR.{{.*}}.[[SASS_SCOPE]]{{.*}}
-; SMXX: {{.*}}MEMBAR.[[SASS_SEMANTIC]].[[SASS_SCOPE]]{{.*}}
-; BLOCK-NOT: {{.*}}MEMBAR.{{.*}}
 ; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
-; NON_BLOCK-NOT: {{.*}}MEMBAR.{{.*}}
-; NON_BLOCK: {{.*}}CCTL.IVALL{{.*}}
-; NON_BLOCK-NOT: {{.*}}MEMBAR.{{.*}}
-; NON_BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_SEMANTIC]].[[SASS_SCOPE]]{{.*}}
+; PTX_NO_MEMBAR: {{.*}}MEMBAR.[[SASS_SEMANTIC]].[[SASS_SCOPE]]{{.*}}
+; NOT-SM90-PLUS_NVVM_NO_MEMBAR: {{.*}}MEMBAR.[[SASS_SEMANTIC]].[[SASS_SCOPE]]{{.*}}
+; SM90-PLUS_NVVM_NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; BLOCK-NOT: {{.*}}CCTL.IVALL{{.*}}
+; NON_BLOCK_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
+; PTX_NON_BLOCK_NO_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
+; NOT-SM90-PLUS_NVVM_NON_BLOCK_NO_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
+; SM90-PLUS_NVVM_NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}LD{{G?}}.E{{.*}}
 ; SMXX-NOT: {{.*}}LD{{G?}}.E{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/atomic_codegen/sass/fence_std.cu
+++ b/libcudacxx/test/atomic_codegen/sass/fence_std.cu
@@ -8,7 +8,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-// %PARAM% ORDER,SASS_SEMANTIC order acquire=moa,ALL:release=more,ALL:acq_rel=moar,ALL:seq_cst=mosc,SC
+// clang-format off
+// %PARAM% ORDER,SASS_SEMANTIC,FILECHECK_PREFIX_MEMBAR,FILECHECK_PREFIX_ACQUIRE order acquire=moa,ALL,no_membar,acquire:release=more,ALL,membar,no_acquire:acq_rel=moar,ALL,membar,acquire:seq_cst=mosc,SC,membar,acquire
+// %FILECHECK% PREFIX_COMBINE ptx,no_membar
+// %FILECHECK% PREFIX_COMBINE ptx,no_acquire
+// %FILECHECK% PREFIX_COMBINE not-sm90-plus,nvvm,no_membar
+// %FILECHECK% PREFIX_COMBINE not-sm90-plus,nvvm,no_acquire
+// %FILECHECK% PREFIX_COMBINE sm90-plus,nvvm,no_membar
+// %FILECHECK% PREFIX_COMBINE sm90-plus,nvvm,no_acquire
+// clang-format on
 
 #include <cuda/std/cstdint>
 
@@ -26,14 +34,14 @@ extern "C" __device__ int32_t atomic_codegen_test(int32_t* before, const int32_t
 ; SMXX-LABEL: {{[[:space:]]*}}Function : atomic_codegen_test
 ; SMXX: {{.*}}ST{{G?}}.E{{.*}}
 ; SMXX-NOT: {{.*}}ST{{G?}}.E{{.*}}
-; SMXX-NOT: {{.*}}MEMBAR.{{.*}}.SYS{{.*}}
-; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}MEMBAR.[[SASS_SEMANTIC]].SYS{{.*}}
-; SMXX-NOT: {{.*}}MEMBAR.{{.*}}
-; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
-; SMXX: {{.*}}CCTL.IVALL{{.*}}
-; SMXX-NOT: {{.*}}MEMBAR.{{.*}}
-; SMXX-NOT: {{.*}}CCTL.IVALL{{.*}}
+; MEMBAR: {{.*}}MEMBAR.[[SASS_SEMANTIC]].SYS{{.*}}
+; PTX_NO_MEMBAR: {{.*}}MEMBAR.[[SASS_SEMANTIC]].SYS{{.*}}
+; NOT-SM90-PLUS_NVVM_NO_MEMBAR: {{.*}}MEMBAR.[[SASS_SEMANTIC]].SYS{{.*}}
+; SM90-PLUS_NVVM_NO_MEMBAR-NOT: {{.*}}MEMBAR.{{.*}}
+; ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
+; PTX_NO_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
+; NOT-SM90-PLUS_NVVM_NO_ACQUIRE: {{.*}}CCTL.IVALL{{.*}}
+; SM90-PLUS_NVVM_NO_ACQUIRE-NOT: {{.*}}CCTL.IVALL{{.*}}
 ; SMXX: {{.*}}LD{{G?}}.E{{.*}}
 ; SMXX-NOT: {{.*}}LD{{G?}}.E{{.*}}
 ; SMXX: {{.*}}RET.ABS.NODEC{{.*}}

--- a/libcudacxx/test/cmake/CodegenTest.cmake
+++ b/libcudacxx/test/cmake/CodegenTest.cmake
@@ -596,14 +596,22 @@ function(libcudacxx_codegen_add_sass_tests)
         "${arch}"
       )
       string(REPLACE "," ";" common_check_prefixes "${check_prefixes}")
+      string(TOUPPER "${test_contents}" uppercase_test_contents)
       foreach (check_prefix IN LISTS arg_CHECK_PREFIXES)
+        string(TOUPPER "${check_prefix}" uppercase_check_prefix)
         string(
           REGEX MATCH
           "; ${check_prefix}(:|-[A-Z]+:)"
           has_check_prefix
           "${test_contents}"
         )
-        if (has_check_prefix)
+        string(
+          REGEX MATCH
+          "%FILECHECK%[ ]+PREFIX_COMBINE[ ]+([A-Z][A-Z0-9_-]*[ ]*,[ ]*)*${uppercase_check_prefix}[ ]*(,|$)"
+          has_combined_check_prefix
+          "${uppercase_test_contents}"
+        )
+        if (has_check_prefix OR has_combined_check_prefix)
           list(APPEND common_check_prefixes "${check_prefix}")
         endif()
       endforeach()

--- a/libcudacxx/test/cmake/CodegenTest.cmake
+++ b/libcudacxx/test/cmake/CodegenTest.cmake
@@ -657,7 +657,9 @@ function(libcudacxx_codegen_add_sass_tests)
         )
         string(
           REGEX MATCH
-          "%FILECHECK%[ ]+PREFIX_COMBINE[ ]+([A-Z][A-Z0-9_-]*[ ]*,[ ]*)*${uppercase_check_prefix}[ ]*(,|$)"
+          # The prefix may be the final component before the directive's line
+          # ending, not just a component followed by a comma.
+          "%FILECHECK%[ ]+PREFIX_COMBINE[ ]+([A-Z][A-Z0-9_-]*[ ]*,[ ]*)*${uppercase_check_prefix}[ ]*(,|[\r\n])"
           has_combined_check_prefix
           "${uppercase_test_contents}"
         )

--- a/libcudacxx/test/cmake/CodegenTest.cmake
+++ b/libcudacxx/test/cmake/CodegenTest.cmake
@@ -152,6 +152,9 @@ endfunction()
 # SMXX:       any arch
 # SM1XX:      any SM100-series arch
 # SM100-PLUS: SM100 and newer
+# NOT-SM100-PLUS: older than SM100
+# Architecture-family prefixes used only in PREFIX_COMBINE directives are
+# activated without being passed to FileCheck as standalone prefixes.
 function(
   libcudacxx_codegen_get_sass_check_prefixes
   out_prefixes
@@ -161,6 +164,31 @@ function(
 )
   set(check_prefixes SMXX)
   set(arch_prefix "SM${arch}")
+  string(TOUPPER "${test_contents}" uppercase_test_contents)
+
+  # Architecture-family markers may be used solely as PREFIX_COMBINE inputs.
+  # The resolver below keeps such markers out of the standalone FileCheck
+  # prefixes while still enabling the corresponding combined prefix.
+  string(
+    REGEX MATCHALL
+    "%FILECHECK%[ ]+PREFIX_COMBINE[ ]+[A-Z][A-Z0-9_-]*([ ]*,[ ]*[A-Z][A-Z0-9_-]*)+"
+    prefix_combine_directives
+    "${uppercase_test_contents}"
+  )
+  set(prefix_combine_components)
+  foreach (directive IN LISTS prefix_combine_directives)
+    string(
+      REGEX REPLACE
+      ".*%FILECHECK%[ ]+PREFIX_COMBINE[ ]+"
+      ""
+      components
+      "${directive}"
+    )
+    string(REPLACE " " "" components "${components}")
+    string(REPLACE "," ";" components "${components}")
+    list(APPEND prefix_combine_components ${components})
+  endforeach()
+  list(REMOVE_DUPLICATES prefix_combine_components)
 
   string(
     REGEX MATCH
@@ -168,13 +196,11 @@ function(
     has_arch_prefix
     "${test_contents}"
   )
-  string(TOUPPER "${test_contents}" uppercase_test_contents)
-  string(
-    REGEX MATCH
-    "%FILECHECK%[ ]+PREFIX_COMBINE[ ]+${arch_prefix}[ ]*,"
-    has_arch_combined_prefix
-    "${uppercase_test_contents}"
-  )
+  if (arch_prefix IN_LIST prefix_combine_components)
+    set(has_arch_combined_prefix TRUE)
+  else()
+    set(has_arch_combined_prefix FALSE)
+  endif()
   if (has_arch_prefix OR has_arch_combined_prefix)
     list(APPEND check_prefixes "${arch_prefix}")
   endif()
@@ -186,7 +212,7 @@ function(
       has_sm1xx_prefix
       "${test_contents}"
     )
-    if (has_sm1xx_prefix)
+    if (has_sm1xx_prefix OR "SM1XX" IN_LIST prefix_combine_components)
       list(APPEND check_prefixes SM1XX)
     endif()
   endif()
@@ -206,15 +232,39 @@ function(
       list(APPEND check_prefixes "SM${plus_arch}-PLUS")
     endif()
   endforeach()
+
+  if (NOT "${arch}" MATCHES "[af]$")
+    foreach (component IN LISTS prefix_combine_components)
+      if (component MATCHES "^SM([0-9]+)-PLUS$")
+        set(plus_arch "${CMAKE_MATCH_1}")
+        if (arch GREATER_EQUAL plus_arch)
+          list(APPEND check_prefixes "${component}")
+        endif()
+      elseif (component MATCHES "^NOT-SM([0-9]+)-PLUS$")
+        set(plus_arch "${CMAKE_MATCH_1}")
+        if (arch LESS plus_arch)
+          list(APPEND check_prefixes "${component}")
+        endif()
+      endif()
+    endforeach()
+  endif()
   list(REMOVE_DUPLICATES check_prefixes)
   list(JOIN check_prefixes "," check_prefixes)
 
   string(
     REGEX MATCH
-    "; SM([0-9]+[a-f]?|1XX|[0-9]+-PLUS)(:|-[A-Z]+:)"
+    "; (NOT-)?SM([0-9]+[a-f]?|1XX|[0-9]+-PLUS)(:|-[A-Z]+:)"
     has_specific_checks
     "${test_contents}"
   )
+  if (NOT has_specific_checks)
+    foreach (component IN LISTS prefix_combine_components)
+      if (component MATCHES "^(NOT-)?SM([0-9]+[AF]?|1XX|[0-9]+-PLUS)$")
+        set(has_specific_checks TRUE)
+        break()
+      endif()
+    endforeach()
+  endif()
   set(${out_prefixes} "${check_prefixes}" PARENT_SCOPE)
   set(${out_has_specific_checks} "${has_specific_checks}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
## Description

Resolves #7480.

This PR introduces an alternative to the PTX atomics backend, based on the `__nv_atomic` family of intrinsics. It will be enabled starting with CTK 13.5.

These changes have been verified with the top of tree build of the compiler.

Full check with the dev branch compiler is pending, but spot checks around the areas that were problematic is green.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
