### PR TITLE
Add coderabbit and .agent instructions for perf changes not to leak o…

### DIFF
--- a/.agent/skills/cccl-style/references/common.md
+++ b/.agent/skills/cccl-style/references/common.md
@@ -68,3 +68,16 @@ Apply this guidance across CCCL unless a path-specific style reference says othe
 ## Compiler Compatibility
 
 - Protect host-only code with `#if !_CCCL_COMPILER(NVRTC)`.
+
+## Arch/SM-Scoped Perf Changes
+
+Applies to any change that conditions a tuning constant, dispatch policy, or other perf-affecting
+behavior like tuning encodings on compute capability or an SM arch macro.
+
+- Never leave the comparison open-ended toward higher/future archs (e.g. `cc >= X` with no upper
+  bound). An unbounded lower-only check silently applies to every arch above X, including ones
+  that did not exist when the change was benchmarked.
+- A closed range (`cc >= X && cc < Y`) is not automatically correct either: `Y` must sit exactly at
+  the boundary of what was benchmarked, not at a rounder or more generous value picked out of
+  convenience. A range wider than what was tested still leaks the change onto untested archs inside
+  that range.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -82,6 +82,8 @@ reviews:
         Focus on algorithm correctness, temporary-storage protocol, dispatch/policy selection, stream behavior,
         CUDA error handling, synchronization, memory access safety, performance regressions, and test coverage.
         Prefer comments that catch real correctness, API, compile-time, or performance risks.
+        For arch-scoped tuning/policy changes and other SM-specific optimizations or perf changes, use
+        .agent/skills/cccl-style/references/common.md (Arch/SM-Scoped Perf Changes section) as context.
 
     - path: "thrust/**/*"
       instructions: |


### PR DESCRIPTION
Because of this pitfall https://github.com/NVIDIA/cccl/pull/10943 I added instructions so both `.agent` and `coderabbit` keep a close eye when we do performance improvements so that they are targeted properly and constrained only to the intended archs.