### PR TITLE
Fix __ensure_current_context for green context streams

### DIFF
--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -303,21 +303,23 @@ public:
   [[nodiscard]] _CCCL_HOST_API __logical_device_ref __logical_device() const
   {
 #  if _CCCL_CTK_AT_LEAST(12, 5)
-    const auto __ctx = ::cuda::__driver::__streamGetCtx_v2(__stream);
-
-    // For a green-context stream, cuStreamGetCtx_v2() returns the primary/device context of
-    // the stream, not the one you would get from cuCtxFromGreenCtx(green).
-    //
-    // So the outer context of the green context must be recovered separately to match what
-    // __logical_device_ref{device_ref, CUgreenCtx} would store.
-    switch (__ctx.__ctx_kind_)
+    // NOLINTNEXTLINE(readability-magic-numbers, bugprone-argument-comment)
+    if (::cuda::__driver::__version_at_least(12, 5))
     {
-      case ::cuda::__driver::__ctx_from_stream::__kind::__green:
-        return {this->device(), __ctx.__ctx_green_};
-      case ::cuda::__driver::__ctx_from_stream::__kind::__device:
-        return {this->device(), __ctx.__ctx_device_};
+      // For a green-context stream, cuStreamGetCtx_v2() returns the primary/device context of
+      // the stream, not the one you would get from cuCtxFromGreenCtx(green).
+      //
+      // So the outer context of the green context must be recovered separately to match what
+      // __logical_device_ref{device_ref, CUgreenCtx} would store.
+      switch (const auto __ctx = ::cuda::__driver::__streamGetCtx_v2(__stream); __ctx.__ctx_kind_)
+      {
+        case ::cuda::__driver::__ctx_from_stream::__kind::__green:
+          return {this->device(), __ctx.__ctx_green_};
+        case ::cuda::__driver::__ctx_from_stream::__kind::__device:
+          return {this->device(), __ctx.__ctx_device_};
+      }
+      _CCCL_UNREACHABLE();
     }
-    _CCCL_UNREACHABLE();
 #  endif // ^^^ _CCCL_AT_LEAST(12, 5) ^^^
     return {this->device(), this->__cu_context()};
   }
@@ -344,20 +346,22 @@ protected:
     // cuGreenCtxStreamCreate() made. cuStreamGetCtx_v2() supports such a stream, and always
     // gives a usable device context.
 #    if _CCCL_CTK_AT_LEAST(12, 5)
-    // For a green-context stream, cuStreamGetCtx_v2() returns the primary/device context of
-    // the stream, not the one you would get from cuCtxFromGreenCtx(green).
-    switch (const auto __ctx = ::cuda::__driver::__streamGetCtx_v2(__stream); __ctx.__ctx_kind_)
+    // NOLINTNEXTLINE(readability-magic-numbers, bugprone-argument-comment)
+    if (::cuda::__driver::__version_at_least(12, 5))
     {
-      case ::cuda::__driver::__ctx_from_stream::__kind::__green:
-        return ::cuda::__driver::__ctxFromGreenCtx(__ctx.__ctx_green_);
-      case ::cuda::__driver::__ctx_from_stream::__kind::__device:
-        return __ctx.__ctx_device_;
+      // For a green-context stream, cuStreamGetCtx_v2() returns the primary/device context of
+      // the stream, not the one you would get from cuCtxFromGreenCtx(green).
+      switch (const auto __ctx = ::cuda::__driver::__streamGetCtx_v2(__stream); __ctx.__ctx_kind_)
+      {
+        case ::cuda::__driver::__ctx_from_stream::__kind::__green:
+          return ::cuda::__driver::__ctxFromGreenCtx(__ctx.__ctx_green_);
+        case ::cuda::__driver::__ctx_from_stream::__kind::__device:
+          return __ctx.__ctx_device_;
+      }
+      _CCCL_UNREACHABLE();
     }
-    _CCCL_UNREACHABLE();
-    return ::CUcontext{};
-#    else // ^^^ _CCCL_CTK_AT_LEAST(12, 5) ^^^ / vvv _CCCL_CTK_BELOW(12, 5) vvv
+#    endif // ^^^ _CCCL_CTK_AT_LEAST(12, 5) ^^^
     return ::cuda::__driver::__streamGetCtx(__stream);
-#    endif // ^^^ _CCCL_CTK_BELOW(12, 5) ^^^
   }
 #  endif // !_CCCL_DOXYGEN_INVOKED
 
@@ -400,7 +404,7 @@ _CCCL_HOST_API inline __ensure_current_context::__ensure_current_context(stream_
     using stream_ref::__cu_context;
   };
 
-  ::cuda::__driver::__ctxPush(static_cast<__access&>(__stream).__cu_context());
+  ::cuda::__driver::__ctxPush(__access{__stream}.__cu_context());
 }
 #  endif // !_CCCL_DOXYGEN_INVOKED
 

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -285,21 +285,13 @@ public:
     ::CUdevice __device{};
 #  if _CCCL_CTK_AT_LEAST(13, 0)
     __device = ::cuda::__driver::__streamGetDevice(__stream);
-#  elif _CCCL_CTK_AT_LEAST(12, 5) // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_AT_LEAST(12, 5) vvv
+#  else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
     {
-      // cuStreamGetCtx() returns CUDA_ERROR_NOT_SUPPORTED for a stream that cuGreenCtxStreamCreate()
-      // made. cuStreamGetCtx_v2() supports such a stream, and always gives a usable device context.
-      const auto _ = __ensure_current_context{::cuda::__driver::__streamGetCtx_v2(__stream).__ctx_device_};
+      const auto _ = __ensure_current_context{*this};
 
       __device = ::cuda::__driver::__ctxGetDevice();
     }
-#  else // ^^^ _CCCL_CTK_AT_LEAST(12, 5) ^^^ / vvv _CCCL_CTK_BELOW(12, 5) vvv
-    {
-      const auto _ = __ensure_current_context{::cuda::__driver::__streamGetCtx(__stream)};
-
-      __device = ::cuda::__driver::__ctxGetDevice();
-    }
-#  endif // ^^^ _CCCL_CTK_BELOW(12, 5) ^^^
+#  endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
     return device_ref{::cuda::__driver::__cudevice_to_ordinal(__device)};
   }
 
@@ -327,7 +319,7 @@ public:
     }
     _CCCL_UNREACHABLE();
 #  endif // ^^^ _CCCL_AT_LEAST(12, 5) ^^^
-    return __logical_device_ref{this->device()};
+    return {this->device(), this->__cu_context()};
   }
 
   _CCCL_DIAG_POP
@@ -338,6 +330,29 @@ public:
   {
     return *this;
   }
+
+#  ifndef _CCCL_DOXYGEN_INVOKED
+  [[nodiscard]] _CCCL_HOST_API ::CUcontext __cu_context() const
+  {
+    // cuStreamGetCtx() returns CUDA_ERROR_NOT_SUPPORTED for a stream that
+    // cuGreenCtxStreamCreate() made. cuStreamGetCtx_v2() supports such a stream, and always
+    // gives a usable device context.
+#    if _CCCL_CTK_AT_LEAST(12, 5)
+    // For a green-context stream, cuStreamGetCtx_v2() returns the primary/device context of
+    // the stream, not the one you would get from cuCtxFromGreenCtx(green).
+    switch (const auto __ctx = ::cuda::__driver::__streamGetCtx_v2(__stream); __ctx.__ctx_kind_)
+    {
+      case ::cuda::__driver::__ctx_from_stream::__kind::__green:
+        return ::cuda::__driver::__ctxFromGreenCtx(__ctx.__ctx_green_);
+      case ::cuda::__driver::__ctx_from_stream::__kind::__device:
+        return __ctx.__ctx_device_;
+    }
+    _CCCL_UNREACHABLE();
+#    else // ^^^ _CCCL_CTK_AT_LEAST(12, 5) ^^^ / vvv _CCCL_CTK_BELOW(12, 5) vvv
+    return ::cuda::__driver::__streamGetCtx(__stream);
+#    endif // ^^^ _CCCL_CTK_BELOW(12, 5) ^^^
+  }
+#  endif // !_CCCL_DOXYGEN_INVOKED
 };
 
 _CCCL_HOST_API inline void event_ref::record(stream_ref __stream) const
@@ -371,8 +386,7 @@ _CCCL_HOST_API inline timed_event::timed_event(stream_ref __stream, event_flags 
 #  ifndef _CCCL_DOXYGEN_INVOKED
 _CCCL_HOST_API inline __ensure_current_context::__ensure_current_context(stream_ref __stream)
 {
-  auto __ctx = __driver::__streamGetCtx(__stream.get());
-  ::cuda::__driver::__ctxPush(__ctx);
+  ::cuda::__driver::__ctxPush(__stream.__cu_context());
 }
 #  endif // !_CCCL_DOXYGEN_INVOKED
 

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -331,6 +331,7 @@ public:
     return *this;
   }
 
+protected:
 #  ifndef _CCCL_DOXYGEN_INVOKED
   [[nodiscard]] _CCCL_HOST_API ::CUcontext __cu_context() const
   {
@@ -386,7 +387,12 @@ _CCCL_HOST_API inline timed_event::timed_event(stream_ref __stream, event_flags 
 #  ifndef _CCCL_DOXYGEN_INVOKED
 _CCCL_HOST_API inline __ensure_current_context::__ensure_current_context(stream_ref __stream)
 {
-  ::cuda::__driver::__ctxPush(__stream.__cu_context());
+  struct __access final : stream_ref
+  {
+    using stream_ref::__cu_context;
+  };
+
+  ::cuda::__driver::__ctxPush(static_cast<__access&>(__stream).__cu_context());
 }
 #  endif // !_CCCL_DOXYGEN_INVOKED
 

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -332,6 +332,11 @@ public:
   }
 
 protected:
+  // The whole _CCCL_UNREACHABLE() thing was added for MSVC, yet now it complains the
+  // _CCCL_UNREACHABLE() is in fact not reachable. Incredible.
+  _CCCL_DIAG_PUSH
+  _CCCL_DIAG_SUPPRESS_MSVC(4702) // warning C4702: unreachable code
+
 #  ifndef _CCCL_DOXYGEN_INVOKED
   [[nodiscard]] _CCCL_HOST_API ::CUcontext __cu_context() const
   {
@@ -349,11 +354,14 @@ protected:
         return __ctx.__ctx_device_;
     }
     _CCCL_UNREACHABLE();
+    return ::CUcontext{};
 #    else // ^^^ _CCCL_CTK_AT_LEAST(12, 5) ^^^ / vvv _CCCL_CTK_BELOW(12, 5) vvv
     return ::cuda::__driver::__streamGetCtx(__stream);
 #    endif // ^^^ _CCCL_CTK_BELOW(12, 5) ^^^
   }
 #  endif // !_CCCL_DOXYGEN_INVOKED
+
+  _CCCL_DIAG_POP
 };
 
 _CCCL_HOST_API inline void event_ref::record(stream_ref __stream) const

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/ensure_current_context.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/ensure_current_context.c2h.cu
@@ -8,8 +8,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+// `__logical_device` is not reachable from `<cuda/devices>`, so the internal headers are included
+// directly here.
+#include <cuda/__device/logical_device.h>
+#include <cuda/__device/logical_device_ref.h>
 #include <cuda/__runtime/ensure_current_context.h>
 #include <cuda/devices>
+#include <cuda/stream>
 
 #include <testing.cuh>
 
@@ -48,3 +53,116 @@ C2H_TEST("ensure current context", "[device]")
     CCCLRT_REQUIRE(test::count_driver_stack() == 0);
   }
 }
+
+C2H_CCCLRT_TEST("ensure current context from a stream", "[device][stream]")
+{
+  const auto device = cuda::devices[0];
+
+  SECTION("The pushed context is the one the stream was created on")
+  {
+    cuda::stream str{device};
+
+    cuda::__ensure_current_context setter(cuda::stream_ref{str.get()});
+
+    CCCLRT_REQUIRE(driver::__ctxGetCurrent() == device.__primary_context());
+    CCCLRT_REQUIRE(test::count_driver_stack() == 1);
+  }
+
+  SECTION("The context is popped again on destruction")
+  {
+    cuda::stream str{device};
+
+    {
+      cuda::__ensure_current_context setter(cuda::stream_ref{str.get()});
+    }
+
+    CCCLRT_REQUIRE(test::count_driver_stack() == 0);
+  }
+
+  SECTION("A stream on a second device pushes the context of that device")
+  {
+    if (cuda::devices.size() > 1)
+    {
+      const auto second = cuda::devices[1];
+      cuda::stream str{second};
+
+      cuda::__ensure_current_context setter(cuda::stream_ref{str.get()});
+
+      CCCLRT_REQUIRE(driver::__ctxGetCurrent() == second.__primary_context());
+      CCCLRT_REQUIRE(driver::__ctxGetCurrent() != device.__primary_context());
+    }
+    else
+    {
+      SUCCEED("The system has a single device");
+    }
+  }
+}
+
+// Green contexts require CTK 12.5.
+#if _CCCL_CTK_AT_LEAST(12, 5)
+
+C2H_CCCLRT_TEST("ensure current context from a green context stream", "[device][stream]")
+{
+  if (test::cuda_driver_version() < 12050)
+  {
+    SUCCEED("Driver is too old for green context tests");
+    return;
+  }
+
+  const auto device = cuda::devices[0];
+  const auto gctx   = driver::__greenCtxCreate(driver::__deviceGet(device.get()));
+  auto ldev         = cuda::__logical_device::from_native_handle(device, gctx);
+  cuda::stream str{ldev};
+
+  const cuda::stream_ref ref{str.get()};
+
+  SECTION("The constructor accepts a green context stream")
+  {
+    cuda::__ensure_current_context setter(ref);
+
+    CCCLRT_REQUIRE(test::count_driver_stack() == 1);
+  }
+
+  SECTION("The pushed context is the green context, not the primary context")
+  {
+    // cuStreamGetCtx_v2() reports the green context of the stream. The pushed context is the
+    // context of that green context, which is what __logical_device_ref also stores.
+    cuda::__ensure_current_context setter(ref);
+
+    CCCLRT_REQUIRE(driver::__ctxGetCurrent() == driver::__ctxFromGreenCtx(gctx));
+    CCCLRT_REQUIRE(driver::__ctxGetCurrent() != device.__primary_context());
+  }
+
+  SECTION("The pushed context matches the logical device of the stream")
+  {
+    cuda::__ensure_current_context setter(ref);
+
+    CCCLRT_REQUIRE(driver::__ctxGetCurrent() == ref.__logical_device().context());
+  }
+
+  SECTION("The pushed context resolves to the device of the green context")
+  {
+    // A green context resolves to the device that owns it.
+    cuda::__ensure_current_context setter(ref);
+
+    CCCLRT_REQUIRE(driver::__cudevice_to_ordinal(driver::__ctxGetDevice()) == device.get());
+  }
+
+  SECTION("The context is popped again on destruction")
+  {
+    {
+      cuda::__ensure_current_context setter(ref);
+    }
+
+    CCCLRT_REQUIRE(test::count_driver_stack() == 0);
+  }
+
+  SECTION("A green context stream reports the device that owns the green context")
+  {
+    // Below CTK 13.0, device() pushes __cu_context() and asks cuCtxGetDevice(). The green
+    // context must therefore resolve to its owner device.
+    CCCLRT_REQUIRE(ref.device() == device);
+  }
+}
+
+#endif // _CCCL_CTK_AT_LEAST(12, 5)


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

#11067 fixed support for green context streams for `device()`, but forgot to also update the same handling for `__ensure_current_context`. Add some tests as well to cover this

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
