### PR TITLE
Clarify to some compilers that `[[noreturn]]` means `[[noreturn]]`

### DIFF
--- a/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
@@ -566,6 +566,7 @@ private:
                     "translate<From, To>: To must be constructible from const From&, from "
                     "From::what(), or default-constructible");
     }
+    _CCCL_UNREACHABLE();
   }
 };
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Fixes `NVHPC` erroneously thinking we return
```
"/home/coder/cccl/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh", line 569: error: function declared with "noreturn" does return [noreturn_function_does_return]
      } 
      ^

```

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
