### PR TITLE
Apply mypy fixes to our benchmarks infra scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,7 +103,8 @@ repos:
         # pre-commit.ci runs. numpy is instead ignored in the mypy config.
         additional_dependencies: [types-cachetools]
         args: ["--config-file=python/cuda_cccl/pyproject.toml",
-               "python/cuda_cccl/cuda/compute/"]
+               "python/cuda_cccl/cuda/compute/",
+               "benchmarks/scripts/"]
         pass_filenames: false
 
   - repo: https://github.com/sirosen/texthooks

--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -330,7 +330,6 @@ def coverage(args):
 
 def parallel_coordinates_plot(df, title):
     # Parallel coordinates plot adaptation of https://stackoverflow.com/a/69411450
-    import matplotlib.cm as cm
     import matplotlib.patches as patches
     from matplotlib.path import Path
 
@@ -395,7 +394,7 @@ def parallel_coordinates_plot(df, title):
     host_ax.tick_params(axis="x", which="major", pad=7)
 
     # Color map:
-    colormap = cm.get_cmap("turbo")
+    colormap = plt.get_cmap("turbo")
 
     # Normalize speedups:
     df["speedup_normalized"] = (df["speedup"] - df["speedup"].min()) / (
@@ -535,7 +534,7 @@ def extract_modes(samples):
     """
     mode_ids = []
 
-    widths, heights = hd_displot(samples)
+    widths, heights = qrde_hd(samples)
     peak_ids = extract_peaks(heights)
     bin_area = 1.0 / len(heights)
 

--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -7,6 +7,7 @@ import json
 import math
 import os
 import re
+from typing import Any
 
 import cccl
 import matplotlib.pyplot as plt
@@ -74,7 +75,7 @@ def get_rt_axes(df):
 def ct_space(df):
     ct_axes = get_ct_axes(df)
 
-    unique_ct_combinations: list[dict] = []
+    unique_ct_combinations: list[dict[str, Any]] = []
     for _, row in df[ct_axes].drop_duplicates().iterrows():
         unique_ct_combinations.append({})
         for col in ct_axes:
@@ -240,7 +241,7 @@ def iterate_case_dfs(args, callable):
         if not pattern.match(algname):
             continue
 
-        case_dfs: dict[str, pd.DataFrame] = {}
+        case_dfs: dict[str, dict[str, pd.DataFrame]] = {}
         for file in storages:
             storage = storages[file]
             for subbench in storage.subbenches(algname):

--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -19,7 +19,7 @@ pd.options.display.max_colwidth = 100
 
 default_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
 color_cycle = itertools.cycle(default_colors)
-color_map = {}
+color_map: dict[str, str] = {}
 
 precision = 0.01
 sensitivity = 0.5
@@ -74,7 +74,7 @@ def get_rt_axes(df):
 def ct_space(df):
     ct_axes = get_ct_axes(df)
 
-    unique_ct_combinations = []
+    unique_ct_combinations: list[dict] = []
     for _, row in df[ct_axes].drop_duplicates().iterrows():
         unique_ct_combinations.append({})
         for col in ct_axes:
@@ -240,7 +240,7 @@ def iterate_case_dfs(args, callable):
         if not pattern.match(algname):
             continue
 
-        case_dfs = {}
+        case_dfs: dict[str, pd.DataFrame] = {}
         for file in storages:
             storage = storages[file]
             for subbench in storage.subbenches(algname):

--- a/benchmarks/scripts/cccl/bench/bench.py
+++ b/benchmarks/scripts/cccl/bench/bench.py
@@ -31,6 +31,8 @@ def first_val(my_dict):
 
 class JsonCache:
     _instance = None
+    bench_cache: dict
+    device_cache: dict
 
     def __new__(cls):
         if cls._instance is None:
@@ -225,7 +227,7 @@ class SubBenchState:
 class SubBenchResult:
     def __init__(self, bench):
         axes_names = {}
-        axes_values = {}
+        axes_values: dict[str, dict] = {}
         for axis in bench["axes"]:
             short_name = axis["name"]
             full_name = get_axis_name(axis)
@@ -373,6 +375,7 @@ class RunsCache:
 
 class BenchCache:
     _instance = None
+    existing_tables: set[str]
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
@@ -402,7 +405,7 @@ class BenchCache:
 
         self.create_table_if_not_exists(conn, bench)
 
-        centers = {}
+        centers: dict[str, dict] = {}
         with conn:
             for subbench in result.subbenches:
                 centers[subbench] = {}
@@ -418,7 +421,6 @@ class BenchCache:
                         placeholders = placeholders + ", ?"
                         values.append(value)
 
-                    values = tuple(values)
                     samples = fpzip.compress(state.samples)
                     center = estimator(state.samples)
                     to_insert = (
@@ -430,7 +432,7 @@ class BenchCache:
                         center,
                         state.bw,
                         samples,
-                    ) + values
+                    ) + tuple(values)
 
                     query = """
                     INSERT INTO "{0}" (ctk, cccl, gpu, variant, elapsed, center, bw, samples {1})
@@ -452,7 +454,7 @@ class BenchCache:
 
         self.create_table_if_not_exists(conn, bench)
 
-        centers = {}
+        centers: dict[str, dict] = {}
 
         with conn:
             for subbench in rt_values:
@@ -502,7 +504,7 @@ def speedup(base, variant):
     if benchmarks != set(variant.keys()):
         raise Exception("Benchmarks do not match.")
 
-    result = {}
+    result: dict[str, dict] = {}
     for bench in benchmarks:
         base_states = base[bench]
         variant_states = variant[bench]
@@ -628,7 +630,7 @@ class Bench:
     def ct_axes_value_descriptions(self):
         subbench_descriptions = {}
         for bench in json_benches(self.algname)["benchmarks"]:
-            descriptions = {}
+            descriptions: dict[str, dict] = {}
             for axis in bench["axes"]:
                 name = axis["name"]
                 if "{ct}" not in name:

--- a/benchmarks/scripts/cccl/bench/bench.py
+++ b/benchmarks/scripts/cccl/bench/bench.py
@@ -31,8 +31,8 @@ def first_val(my_dict):
 
 class JsonCache:
     _instance = None
-    bench_cache: dict
-    device_cache: dict
+    bench_cache: dict[str, dict]
+    device_cache: dict[str, dict]
 
     def __new__(cls):
         if cls._instance is None:
@@ -227,7 +227,7 @@ class SubBenchState:
 class SubBenchResult:
     def __init__(self, bench):
         axes_names = {}
-        axes_values: dict[str, dict] = {}
+        axes_values: dict[str, dict[str | float, str]] = {}
         for axis in bench["axes"]:
             short_name = axis["name"]
             full_name = get_axis_name(axis)
@@ -405,7 +405,7 @@ class BenchCache:
 
         self.create_table_if_not_exists(conn, bench)
 
-        centers: dict[str, dict] = {}
+        centers: dict[str, dict[str, float]] = {}
         with conn:
             for subbench in result.subbenches:
                 centers[subbench] = {}
@@ -454,7 +454,7 @@ class BenchCache:
 
         self.create_table_if_not_exists(conn, bench)
 
-        centers: dict[str, dict] = {}
+        centers: dict[str, dict[str, float]] = {}
 
         with conn:
             for subbench in rt_values:
@@ -504,7 +504,7 @@ def speedup(base, variant):
     if benchmarks != set(variant.keys()):
         raise Exception("Benchmarks do not match.")
 
-    result: dict[str, dict] = {}
+    result: dict[str, dict[str, float]] = {}
     for bench in benchmarks:
         base_states = base[bench]
         variant_states = variant[bench]
@@ -630,7 +630,7 @@ class Bench:
     def ct_axes_value_descriptions(self):
         subbench_descriptions = {}
         for bench in json_benches(self.algname)["benchmarks"]:
-            descriptions: dict[str, dict] = {}
+            descriptions: dict[str, dict[str, str]] = {}
             for axis in bench["axes"]:
                 name = axis["name"]
                 if "{ct}" not in name:

--- a/benchmarks/scripts/cccl/bench/cmake.py
+++ b/benchmarks/scripts/cccl/bench/cmake.py
@@ -129,7 +129,7 @@ class CMake:
         cache.push_build(bench, build)
         return build
 
-    def clean():
+    def clean(self):
         cmd = ["cmake", "--build", ".", "--target", "clean"]
         p = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         p.wait()

--- a/benchmarks/scripts/cccl/bench/config.py
+++ b/benchmarks/scripts/cccl/bench/config.py
@@ -8,7 +8,7 @@ def randomized_cartesian_product(list_of_lists):
     for lst in list_of_lists:
         length *= len(lst)
 
-    visited = set()
+    visited: set[tuple] = set()
     while len(visited) < length:
         variant = tuple(map(random.choice, list_of_lists))
         if variant not in visited:
@@ -107,6 +107,9 @@ def parse_meta():
 
 class Config:
     _instance = None
+    ctk: str
+    cccl: str
+    benchmarks: dict[str, list[Range]]
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
@@ -132,7 +135,7 @@ class Config:
         return VariantPoint(points)
 
     def variant_space(self, algname):
-        variants = []
+        variants: list[list[RangePoint]] = []
         for param_space in self.benchmarks[algname]:
             variants.append([])
             for value in range(param_space.low, param_space.high, param_space.step):

--- a/benchmarks/scripts/cccl/bench/logger.py
+++ b/benchmarks/scripts/cccl/bench/logger.py
@@ -3,6 +3,7 @@ import logging
 
 class Logger:
     _instance = None
+    logger: logging.Logger
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:

--- a/benchmarks/scripts/cccl/bench/search.py
+++ b/benchmarks/scripts/cccl/bench/search.py
@@ -173,6 +173,10 @@ def filter_benchmarks(benchmarks, args):
 def search(seeker):
     args = parse_arguments()
 
+    # This guard has never fired: Storage() calls sqlite3.connect(), which
+    # creates the DB file before exists() is checked. Making it fire would
+    # wipe all built benchmark binaries on every fresh campaign; current
+    # workflows rely on fresh runs reusing existing binaries (see #11096).
     if not Storage().exists():
         CMake().clean()
 

--- a/benchmarks/scripts/cccl/bench/storage.py
+++ b/benchmarks/scripts/cccl/bench/storage.py
@@ -230,8 +230,8 @@ if POSTGRES_AVAILABLE:
                 "DataFrame storage for PostgreSQL not yet implemented"
             )
 else:
-    # Define a dummy class when psycopg2 is not available
-    PostgreSQLStorage = None
+    # Placeholder when psycopg2 is not available; callers check for None.
+    PostgreSQLStorage = None  # type: ignore[assignment, misc]
 
 
 class DualStorageWrapper:
@@ -358,6 +358,7 @@ class DualConnectionWrapper:
 
 class Storage:
     _instance = None
+    base: DualStorageWrapper
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -83,14 +83,12 @@ def alg_dfs(files, alg_regex):
 
 
 def alg_bws(dfs, verbose):
-    medians = None
+    frames = []
     for algname in dfs:
         df = dfs[algname]
         df["alg"] = algname
-        if df is None:
-            medians = df
-        else:
-            medians = pd.concat([medians, df])
+        frames.append(df)
+    medians = pd.concat(frames)
     # print more information if it's not unique across all runs or when requested (verbose)
     medians["hue"] = ""
     if verbose or medians["cccl"].unique().size > 1:

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -47,7 +47,7 @@ def filter_by_type(df):
 
 def alg_dfs(files, alg_regex):
     pattern = re.compile(alg_regex)
-    result = {}
+    result: dict[str, pd.DataFrame] = {}
     for file in files:
         storage = cccl.bench.SQLiteStorage(file)
         for algname in storage.algnames():
@@ -83,6 +83,8 @@ def alg_dfs(files, alg_regex):
 
 
 def alg_bws(dfs, verbose):
+    # Concat once at the end: the old per-iteration concat relied on
+    # pd.concat silently dropping a None accumulator (see #11096).
     frames = []
     for algname in dfs:
         df = dfs[algname]

--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -179,9 +179,47 @@ module = [
   "cuda.bindings.*",
   "cuda.core.*",
   "cuda.pathfinder.*",
+  # Third-party dependencies of benchmarks/scripts that are not installed in
+  # the pre-commit environment.
+  "colorama",
+  "compileiq.*",
+  "fpzip",
+  "matplotlib",
+  "matplotlib.*",
+  "pandas",
+  "pandas.*",
+  "psycopg2",
+  "psycopg2.*",
+  "pytest",
+  "scipy",
+  "scipy.*",
+  "seaborn",
 ]
 ignore_missing_imports = true
 follow_imports = "skip"
+
+[[tool.mypy.overrides]]
+# The benchmark scripts are untyped; without this, mypy skips their function
+# bodies entirely and misses errors like calls with missing arguments.
+module = [
+  "analyze",
+  "compare",
+  "conftest",
+  "run",
+  "search",
+  "search_iq",
+  "sol",
+  "test_score",
+  "verify",
+  "cccl.*",
+]
+check_untyped_defs = true
+
+[[tool.mypy.overrides]]
+# TODO: verify.py predates the current Bench.do_run/BenchResult API and needs
+# a rewrite before it can be type-checked.
+module = ["verify"]
+ignore_errors = true
 
 [tool.ruff]
 extend = "../../pyproject.toml"


### PR DESCRIPTION
tiny stain https://github.com/NVIDIA/cccl/pull/10995 turned out to be a big hidden cavity.

I applied mypy to our benchamrks scripts (analyze, sol, search) and linted them. Also extend `mypy` to run on the benchmark scripts from now on.

These bugs were mostly silent, unreached or in code that we rarely used (e.g. `--variants-pdf`) so not super harmful. But as I am building the automated tuning skill I did encounter as I am using a much bigger set of our tools.

The rest of integration changes are merely imposing some type-safety changes.

fixes 2/3 work items in https://github.com/NVIDIA/cccl/issues/11096