### PR TITLE
[libcu++] Disable internal test due to ptxas issue

### DIFF
--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset_self.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset_self.pass.cpp
@@ -11,8 +11,8 @@
 // UNSUPPORTED: force-tile
 // error: dynamic allocation is not supported in tile mode
 
-// UNSUPPORTED: enable-tile && !c++17
-// ptxas error   : Stack size for entry function '_Z16fake_main_kernelPi' cannot be statically determined
+// UNSUPPORTED: !c++17
+// ptxas error: Stack size for entry function '_Z16fake_main_kernelPi' cannot be statically determined
 
 // <memory>
 


### PR DESCRIPTION
We are getting a warning about ptxas because it cannot determine the stack space.

This is a purely internal feature with a constexpr test, so disable the test for that standard mode

Fixes nvbug6661912