### PR TITLE
Import coding guidelines from CCCL wiki

### DIFF
--- a/.agent/skills/cccl-style/references/common.md
+++ b/.agent/skills/cccl-style/references/common.md
@@ -4,12 +4,6 @@ Read the [CCCL C++ Coding Guidelines](https://nvidia.github.io/cccl/cccl/develop
 which supersede everything below.
 Then apply the guidance in this file across CCCL unless a path-specific style reference says otherwise.
 
-## Naming Style
-
-- Macros: macro style, e.g. `MY_MACRO`.
-- Template parameters: PascalCase, e.g. `MyParameter`.
-- All other symbols: snake style, e.g. `my_variable`. The one exception is the CUB public API, which uses PascalCase.
-
 ## Variables
 
 - All variables that are not modified must use `const`. This includes variables initialized by casts (`static_cast`, `reinterpret_cast`, `bit_cast`), function return values, and loop-invariant computations.
@@ -31,7 +25,6 @@ Then apply the guidance in this file across CCCL unless a path-specific style re
 
 ## Functions
 
-- Functions must be marked `_CCCL_HOST_API`, `_CCCL_DEVICE_API`, `_CCCL_HOST_DEVICE_API`, `_CCCL_TILE_API`, or `_CCCL_API`.
 - Non-template, non-`constexpr` functions must use `inline`.
 - Most functions with a non-void return type should use `[[nodiscard]]`; functions with known side effects may be exceptions.
 - Functions that do not throw exceptions must use `noexcept`.
@@ -59,7 +52,6 @@ Then apply the guidance in this file across CCCL unless a path-specific style re
 
 ## General Guidelines
 
-- The code must reuse `cuda/` or `cuda/std` functionalities as much as possible, including macros.
 - Try to use modern C++ as much as possible. The repository supports C++17 but many more recent functionalities have been backported with functions and macros.
 
 ## Prevent Compiler Errors And Improve Compatibility

--- a/.agent/skills/cccl-style/references/common.md
+++ b/.agent/skills/cccl-style/references/common.md
@@ -1,6 +1,6 @@
 # Common CCCL Style Guidance
 
-Read the [CCCL C++ Coding Guidelines](https://nvidia.github.io/cccl/cccl/development/coding_guidelines.html),
+Read the [CCCL C++ Coding Guidelines](https://nvidia.github.io/cccl/unstable/cccl/development/coding_guidelines.html),
 which supersede everything below.
 Then apply the guidance in this file across CCCL unless a path-specific style reference says otherwise.
 

--- a/.agent/skills/cccl-style/references/common.md
+++ b/.agent/skills/cccl-style/references/common.md
@@ -1,6 +1,8 @@
 # Common CCCL Style Guidance
 
-Apply this guidance across CCCL unless a path-specific style reference says otherwise.
+Read the [CCCL C++ Coding Guidelines](https://nvidia.github.io/cccl/cccl/development/coding_guidelines.html),
+which supersede everything below.
+Then apply the guidance in this file across CCCL unless a path-specific style reference says otherwise.
 
 ## Naming Style
 

--- a/.agent/skills/cccl-style/references/libcudacxx.md
+++ b/.agent/skills/cccl-style/references/libcudacxx.md
@@ -4,10 +4,6 @@ Use this reference for `libcudacxx/include/**/*` and `cudax/include/**/*`.
 
 ## Naming Style
 
-All non-public symbols must be C++ reserved identifiers:
-
-- `_` for macros and template parameters, e.g. `_MY_MACRO`, `_MyParameter`.
-- `__` for all other symbols, e.g. `__my_variable`.
 - Never use reserved keywords, such as `__in`, `__out`, or `__inout` as variables, parameters, or function names.
 - Avoid single-letter template parameter names. Wrong: `_T`; correct: `_Tp`.
 
@@ -45,7 +41,6 @@ All non-public symbols must be C++ reserved identifiers:
 
 ## Comments
 
-- Use Doxygen-style `//! @brief` comments.
 - Documented functions must include `//! @brief`, `//! @param[in/out/in,out]` for every parameter, and `//! @return` for non-void functions.
 - The `@brief/@param/@return` description must accurately reflect the current functionality of the function.
 

--- a/docs/cccl/development/coding_guidelines.rst
+++ b/docs/cccl/development/coding_guidelines.rst
@@ -12,7 +12,7 @@ General
 
 #. Always prefer entities from ``cuda::std::`` over ``std::``
    and other functionality or macros from the ``<cuda/...>`` and ``<cuda/std/...>`` headers.
-   They work in host and device code, work with NVRTC, and help testing our implementation.
+   They generally work in host and device code, often work with NVRTC, and help testing our implementation.
 #. Use :doc:`CCCL internal macros <macro>` over compiler/vendor-specific keywords in library implementation
    headers. E.g., use ``_CCCL_HOST_DEVICE`` instead of ``__host__ __device__``, or ``_CCCL_FORCEINLINE``
    over ``__forceinline``. Generally, prefer ``_CCCL_HOST_API``, ``_CCCL_DEVICE_API``,

--- a/docs/cccl/development/coding_guidelines.rst
+++ b/docs/cccl/development/coding_guidelines.rst
@@ -51,7 +51,7 @@ libcu++
 #. All user-defined names for entities which are not part of the public API
    must be prefixed with ``__`` when they use ``snake_case``,
    and with ``_`` when they use ``PascalCase`` or ``ALL_CAPS``.
-   This avoids name collisions with user code and macros.
+   This turns them into C++ reserved identifiers to avoid name collisions with user code and macros.
 
 CUB
 ----

--- a/docs/cccl/development/coding_guidelines.rst
+++ b/docs/cccl/development/coding_guidelines.rst
@@ -1,0 +1,80 @@
+.. _cccl-development-coding-guidelines:
+
+CCCL C++ Coding Guidelines
+============================
+
+The following guidelines must generally be followed when contributing to any of the CCCL C++ libraries,
+including tests, benchmarks, examples and utility libraries.
+General guidelines apply universally, but may be overridden by library-specific or path-specific guidelines.
+
+General
+-------
+
+#. Always prefer entities from ``cuda::std::`` over ``std::``. They work in host and device code, work
+   with NVRTC, and help testing our implementation.
+#. Use :doc:`CCCL internal macros <macro>` over compiler/vendor-specific keywords in library implementation
+   headers. E.g., use ``_CCCL_HOST_DEVICE`` instead of ``__host__ __device__``, or ``_CCCL_FORCEINLINE``
+   over ``__forceinline``. Generally, prefer ``_CCCL_HOST_API``, ``_CCCL_DEVICE_API``,
+   ``_CCCL_HOST_DEVICE_API``, ``_CCCL_TILE_API``, or ``_CCCL_API`` for any function inside CCCL.
+   Examples and documentation must not use these macros and should support vendor
+   attributes and keywords instead. Tests should only use macros if they are strictly required for the
+   test to work. For instance, ``_CCCL_HOST_DEVICE`` may be required for tests targeting non-CUDA
+   backends.
+#. Fully qualify any reference to a libcu++ entity in any C++ library header with ``::cuda::std::``,
+   ``::cuda::``, etc. This avoids ambiguities when users define namespaces called ``cuda`` themselves.
+   Use just ``cuda::std::`` etc. in examples, tests and documentation.
+#. Fully qualify any references to a host standard library entity in any C++ library header with
+   ``::std::``. This avoids ambiguities with entities from ``::cuda::std::``. Use just ``std::`` in
+   examples, tests and documentation.
+#. Doxygen comments should start with ``//!``
+#. In documentation comments, we prefer the use of ``@`` to start Doxygen commands.
+#. Prefer ``@c`` when referring to code entities
+#. Macros for function attributes, like ``_CCCL_HOST_DEVICE``, should be ordered before declaration
+   specifiers like ``constexpr`` or ``static``
+#. Include libcu++ detail headers (starting with ``__``) also in downstream projects (like CUB, Thrust,
+   etc.) to reduce compile time. In tests and examples, always prefer the public headers.
+#. Comments should express what the code cannot say. They complement code. Before writing an
+   explanatory comment, consider whether refactoring the code could allow the code to express the same.
+   This avoids code and comments getting out of sync.
+#. Do not mark kernels with ``__global__`` but with ``_CCCL_KERNEL_ATTRIBUTES``
+#. All user-defined names for entities should use ``snake_case``, except for template parameters, which
+   use ``PascalCase``, and macros, which use ``ALL_CAPS``.
+
+libcu++
+-------
+
+#. Always fully qualify function calls, even to functions in the same namespace. This avoids ADL.
+#. Defaulted constructors should be marked with ``_CCCL_HIDE_FROM_ABI``
+#. libcu++ headers like ``<cuda/foo>`` are strict supersets of ``<cuda/std/foo>`` and thus always
+   include the corresponding ``<cuda/std/...>`` header.
+#. All user-defined names for entities which are not part of the public API
+   must be prefixed with ``__`` when they use ``snake_case``,
+   and with ``_`` when they use ``PascalCase`` or ``ALL_CAPS``.
+   This avoids name collisions with user code and macros.
+
+CUB
+----
+
+#. Entities in the public API, which are not macros, must be written in ``PascalCase``
+   to stay consistent with existing practice.
+#. Unit tests must use ``c2h::[host|device]_vector`` as containers over Thrust vectors,
+   since they handle OOM conditions gracefully on some testing systems.
+#. Header files use ``.cuh`` as file extension
+
+Thrust
+-------
+
+#. Header files use ``.h`` as file extension
+
+Licensing
+---------
+
+CCCL uses a mix of different licenses for historical reasons.
+
+#. Any net new file should be licensed under Apache-2.0 WITH LLVM-exception.
+#. For files with license headers, strongly prefer a 2-line SPDX header like:
+
+   .. code-block:: text
+
+      // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+      // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/docs/cccl/development/coding_guidelines.rst
+++ b/docs/cccl/development/coding_guidelines.rst
@@ -11,7 +11,7 @@ General
 -------
 
 #. Always prefer entities from ``cuda::std::`` over ``std::``
-   and other functionality or macros from the ``<cuda/...>` and ``<cuda/std/...>`` headers.
+   and other functionality or macros from the ``<cuda/...>`` and ``<cuda/std/...>`` headers.
    They work in host and device code, work with NVRTC, and help testing our implementation.
 #. Use :doc:`CCCL internal macros <macro>` over compiler/vendor-specific keywords in library implementation
    headers. E.g., use ``_CCCL_HOST_DEVICE`` instead of ``__host__ __device__``, or ``_CCCL_FORCEINLINE``

--- a/docs/cccl/development/coding_guidelines.rst
+++ b/docs/cccl/development/coding_guidelines.rst
@@ -53,6 +53,12 @@ libcu++
    and with ``_`` when they use ``PascalCase`` or ``ALL_CAPS``.
    This turns them into C++ reserved identifiers to avoid name collisions with user code and macros.
 
+CUB and Thrust
+--------------
+
+#. Non-public entities, which are not macros, should be put inside a ``detail`` namespace (preferred)
+   or prefixed with ``__``.
+
 CUB
 ----
 
@@ -63,7 +69,7 @@ CUB
 #. Header files use ``.cuh`` as file extension
 
 Thrust
--------
+------
 
 #. Header files use ``.h`` as file extension
 

--- a/docs/cccl/development/coding_guidelines.rst
+++ b/docs/cccl/development/coding_guidelines.rst
@@ -10,8 +10,9 @@ General guidelines apply universally, but may be overridden by library-specific 
 General
 -------
 
-#. Always prefer entities from ``cuda::std::`` over ``std::``. They work in host and device code, work
-   with NVRTC, and help testing our implementation.
+#. Always prefer entities from ``cuda::std::`` over ``std::``
+   and other functionality or macros from the ``<cuda/...>` and ``<cuda/std/...>`` headers.
+   They work in host and device code, work with NVRTC, and help testing our implementation.
 #. Use :doc:`CCCL internal macros <macro>` over compiler/vendor-specific keywords in library implementation
    headers. E.g., use ``_CCCL_HOST_DEVICE`` instead of ``__host__ __device__``, or ``_CCCL_FORCEINLINE``
    over ``__forceinline``. Generally, prefer ``_CCCL_HOST_API``, ``_CCCL_DEVICE_API``,

--- a/docs/cccl/development/index.rst
+++ b/docs/cccl/development/index.rst
@@ -7,6 +7,7 @@ CCCL Development Guide
    :hidden:
    :maxdepth: 1
 
+   coding_guidelines
    macro
    testing
    build_and_bisect_tools
@@ -17,6 +18,7 @@ This living document serves to describe the internal details and the development
 
 Documentation:
 
+- :doc:`CCCL C++ Coding Guidelines <coding_guidelines>`
 - :doc:`CCCL Internal Macros <macro>`
 - :doc:`CCCL Testing Utilities <testing>`
 - :doc:`CCCL Bisect And Targeted Build/Test Helpers <build_and_bisect_tools>`

--- a/docs/contributors/index.rst
+++ b/docs/contributors/index.rst
@@ -174,7 +174,7 @@ it's a false positive. Secrets are also scanned server-side in CI on ``main``.
 Creating a Pull Request
 --------------------------
 
-#. Push the local branch with your changes to your fork on GitHub:
+Push the local branch with your changes to your fork on GitHub:
 
    .. code-block:: bash
 

--- a/docs/contributors/index.rst
+++ b/docs/contributors/index.rst
@@ -72,6 +72,7 @@ Developer Guides
 
 For more information about architecture, design, and development practices, consult the following developer guides:
 
+- :doc:`CCCL Coding Guidelines </cccl/development/coding_guidelines>` - Our coding guidelines, must be followed
 - :doc:`CCCL Development Guide </cccl/development/index>` - Internal details and development process shared across CCCL libraries, mostly libcudacxx
 - :doc:`Thrust Systems </thrust/developer/systems>` - Overview of Thrust's backend systems and execution policies
 - :doc:`Thrust Developer CMake Options </thrust/developer/cmake_options>` - CMake options for Thrust development builds

--- a/docs/contributors/index.rst
+++ b/docs/contributors/index.rst
@@ -177,9 +177,9 @@ Creating a Pull Request
 
 Push the local branch with your changes to your fork on GitHub:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-      git push origin your-feature-branch
+   git push origin your-feature-branch
 
 See :doc:`how_tos/creating_a_pull_request` for further instructions.
 


### PR DESCRIPTION
Puts the C++ coding guidelines from our [wiki page](https://github.com/NVIDIA/cccl/wiki/Cpp-Coding-Guidelines) into the documentation and makes it accessible to agents.

This is a first step and will be followed by a PR that moves more rules from the `cccl-style` skill and the issue #2635 into the docs.

Starts work on: #2635