### PR TITLE
[libu++] Investigate tuple compile time improvements

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -162,13 +162,10 @@ public:
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::move(__t))
   {}
 
-  template <class... _UTypes>
-  static constexpr __select_constructor __select_variadic_constructible_v =
-    __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>();
-
   template <class... _UTypes,
             enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD,
-            __select_constructor _Constraints     = __select_variadic_constructible_v<_UTypes...>,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
@@ -176,7 +173,8 @@ public:
 
   template <class... _UTypes,
             enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints     = __select_variadic_constructible_v<_UTypes...>,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
@@ -185,14 +183,16 @@ public:
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
             enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints     = __select_variadic_constructible_v<_UTypes...>,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(_UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Constraints = __select_variadic_constructible_v<_UTypes...>,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API inline tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
     (is_nothrow_constructible_v<_Tp, _UTypes> && ...))
@@ -201,7 +201,8 @@ public:
 
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Constraints = __select_variadic_constructible_v<_UTypes...>,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API inline explicit tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
     (is_nothrow_constructible_v<_Tp, _UTypes> && ...))
@@ -211,7 +212,8 @@ public:
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Constraints = __select_variadic_constructible_v<_UTypes...>,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
@@ -241,7 +243,7 @@ public:
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
   template <class _Tuple>
-  static constexpr bool __disambiguate_tuple_like_v =
+  using _DisambiguateTupleLike = bool_constant<
     // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
     !__is_cuda_std_ranges_subrange_v<remove_cvref_t<_Tuple>>
     // Disambiguates the copy and move constructor
@@ -250,141 +252,150 @@ public:
     // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
     // [tuple#cnstr]-25.1: sizeof...(Types) is 2,
     // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
-    && __tuple_like_with_size<_Tuple, sizeof...(_Tp)>;
-
-  template <class _UTuple>
-  static constexpr __select_constructor __select_tuple_like_constructible_v =
-    __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_UTuple>(
-      __make_tuple_indices_t<sizeof...(_Tp)>{});
-
-  template <class _UTuple>
-  static constexpr bool __nothrow_tuple_like_constructible_v =
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible<_UTuple>(
-      __make_tuple_indices_t<sizeof...(_Tp)>{});
+    && __tuple_like_with_size<_Tuple, sizeof...(_Tp)>>;
 
   template <class... _UTypes,
-            enable_if_t<__disambiguate_tuple_like_v<tuple<_UTypes...>&>, int> = 0,
-            __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
+            enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(__nothrow_tuple_like_constructible_v<tuple<_UTypes...>&>)
+  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<tuple<_UTypes...>&>)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
-            enable_if_t<__disambiguate_tuple_like_v<tuple<_UTypes...>&>, int> = 0,
-            __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
+            enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>& __t) noexcept(
-    __nothrow_tuple_like_constructible_v<tuple<_UTypes...>&>)
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<tuple<_UTypes...>&>)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            enable_if_t<__disambiguate_tuple_like_v<tuple<_UTypes...>&>, int> = 0,
-            __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
+            enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            enable_if_t<__disambiguate_tuple_like_v<const tuple<_UTypes...>&>, int> = 0,
-            __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
+            enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
-    __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&>)
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&>)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
-            enable_if_t<__disambiguate_tuple_like_v<const tuple<_UTypes...>&>, int> = 0,
-            __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
+            enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
-    __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&>)
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&>)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            enable_if_t<__disambiguate_tuple_like_v<const tuple<_UTypes...>&>, int> = 0,
-            __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
+            enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            enable_if_t<__disambiguate_tuple_like_v<tuple<_UTypes...>&&>, int> = 0,
-            __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
+            enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&&>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(__nothrow_tuple_like_constructible_v<tuple<_UTypes...>&&>)
+  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<tuple<_UTypes...>&&>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
-            enable_if_t<__disambiguate_tuple_like_v<tuple<_UTypes...>&&>, int> = 0,
-            __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
+            enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&&>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>&& __t) noexcept(
-    __nothrow_tuple_like_constructible_v<tuple<_UTypes...>&&>)
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<tuple<_UTypes...>&&>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            enable_if_t<__disambiguate_tuple_like_v<tuple<_UTypes...>&&>, int> = 0,
-            __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
+            enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&&>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            enable_if_t<__disambiguate_tuple_like_v<const tuple<_UTypes...>&&>, int> = 0,
-            __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
+            enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&&>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
-    __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&&>)
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&&>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
-            enable_if_t<__disambiguate_tuple_like_v<const tuple<_UTypes...>&&>, int> = 0,
-            __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
+            enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&&>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
-    __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&&>)
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&&>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            enable_if_t<__disambiguate_tuple_like_v<const tuple<_UTypes...>&&>, int> = 0,
-            __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
+            enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&&>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(const tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
   template <class _Tuple,
-            enable_if_t<__disambiguate_tuple_like_v<_Tuple>, int> = 0,
-            __select_constructor _Constraints                     = __select_tuple_like_constructible_v<_Tuple>,
+            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(__nothrow_tuple_like_constructible_v<_Tuple>)
+  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
 
   template <class _Tuple,
-            enable_if_t<__disambiguate_tuple_like_v<_Tuple>, int> = 0,
-            __select_constructor _Constraints                     = __select_tuple_like_constructible_v<_Tuple>,
+            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
-  _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(__nothrow_tuple_like_constructible_v<_Tuple>)
+  _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Tuple,
-            enable_if_t<__disambiguate_tuple_like_v<_Tuple>, int> = 0,
-            __select_constructor _Constraints                     = __select_tuple_like_constructible_v<_Tuple>,
+            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(_Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
@@ -392,29 +403,32 @@ public:
 
   template <class _Alloc,
             class _Tuple,
-            enable_if_t<__disambiguate_tuple_like_v<_Tuple>, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints                     = __select_tuple_like_constructible_v<_Tuple>,
+            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
-    __nothrow_tuple_like_constructible_v<_Tuple>)
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
   {}
 
   template <class _Alloc,
             class _Tuple,
-            enable_if_t<__disambiguate_tuple_like_v<_Tuple>, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints                     = __select_tuple_like_constructible_v<_Tuple>,
+            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
-    __nothrow_tuple_like_constructible_v<_Tuple>)
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Alloc,
             class _Tuple,
-            enable_if_t<__disambiguate_tuple_like_v<_Tuple>, int> = 0,
-            __select_constructor _Constraints                     = __select_tuple_like_constructible_v<_Tuple>,
+            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -248,7 +248,7 @@ public:
     && !is_same_v<_Tuple, const tuple&>
     && !is_same_v<_Tuple, tuple&&> //
     // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
-    // [tuple#cnstr]-25.1: sizeof...(Types) is 2,
+    // [tuple#cnstr]-25.1: sizeof...(Types) is 2, (pair constructor)
     // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
     && __tuple_like_with_size<_Tuple, sizeof...(_Tp)>>;
 
@@ -444,8 +444,8 @@ public:
 
   // [tuple.assign]-15
   template <class... _UTypes,
-            bool _Constraints = __tuple_constraints<_Tp...>::template //
-            __select_converting_assignable</*__is_const=*/false, const _UTypes&...>(),
+            bool _Constraints = __tuple_constraints<
+              _Tp...>::template __select_converting_assignable</*__is_const=*/false, const _UTypes&...>(),
             enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr tuple&
   operator=(const tuple<_UTypes...>& __t) noexcept((is_nothrow_assignable_v<_Tp&, const _UTypes&> && ...))
@@ -456,8 +456,8 @@ public:
 
   // [tuple.assign]-18
   template <class... _UTypes,
-            bool _Constraints = __tuple_constraints<_Tp...>::template //
-            __select_converting_assignable</*__is_const=*/true, const _UTypes&...>(),
+            bool _Constraints = __tuple_constraints<
+              _Tp...>::template __select_converting_assignable</*__is_const=*/true, const _UTypes&...>(),
             enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr const tuple& operator=(const tuple<_UTypes...>& __t) const
     noexcept((is_nothrow_assignable_v<const _Tp&, const _UTypes&> && ...))
@@ -468,8 +468,8 @@ public:
 
   // [tuple.assign]-21
   template <class... _UTypes,
-            bool _Constraints = __tuple_constraints<_Tp...>::template //
-            __select_converting_assignable</*__is_const=*/false, _UTypes...>(),
+            bool _Constraints =
+              __tuple_constraints<_Tp...>::template __select_converting_assignable</*__is_const=*/false, _UTypes...>(),
             enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr tuple& operator=(tuple<_UTypes...>&& __t) noexcept((is_nothrow_assignable_v<_Tp&, _UTypes> && ...))
   {
@@ -480,8 +480,8 @@ public:
 
   // [tuple.assign]-24
   template <class... _UTypes,
-            bool _Constraints = __tuple_constraints<_Tp...>::template //
-            __select_converting_assignable</*__is_const=*/true, _UTypes...>(),
+            bool _Constraints =
+              __tuple_constraints<_Tp...>::template __select_converting_assignable</*__is_const=*/true, _UTypes...>(),
             enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr const tuple& operator=(tuple<_UTypes...>&& __t) const
     noexcept((is_nothrow_assignable_v<const _Tp&, _UTypes> && ...))

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -162,10 +162,13 @@ public:
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::move(__t))
   {}
 
+  template <class... _UTypes>
+  static constexpr __select_constructor __select_variadic_constructible_v =
+    __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>();
+
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD,
+            __select_constructor _Constraints     = __select_variadic_constructible_v<_UTypes...>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
@@ -173,8 +176,7 @@ public:
 
   template <class... _UTypes,
             enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            __select_constructor _Constraints     = __select_variadic_constructible_v<_UTypes...>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
@@ -183,16 +185,14 @@ public:
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
             enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            __select_constructor _Constraints     = __select_variadic_constructible_v<_UTypes...>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(_UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            __select_constructor _Constraints = __select_variadic_constructible_v<_UTypes...>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API inline tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
     (is_nothrow_constructible_v<_Tp, _UTypes> && ...))
@@ -201,8 +201,7 @@ public:
 
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            __select_constructor _Constraints = __select_variadic_constructible_v<_UTypes...>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API inline explicit tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
     (is_nothrow_constructible_v<_Tp, _UTypes> && ...))
@@ -212,8 +211,7 @@ public:
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            __select_constructor _Constraints = __select_variadic_constructible_v<_UTypes...>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
@@ -242,114 +240,107 @@ public:
   {}
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
-  // MSVC needs this to be a type
   template <class _UTuple>
-  using _NothrowTupleLikeConstruction =
-    bool_constant<__tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible<_UTuple>>;
+  static constexpr __select_constructor __select_tuple_like_constructible_v =
+    __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_UTuple>(
+      __make_tuple_indices_t<sizeof...(_Tp)>{});
+
+  template <class _UTuple>
+  static constexpr bool __nothrow_tuple_like_constructible_v =
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible<_UTuple>(
+      __make_tuple_indices_t<sizeof...(_Types)>{});
 
   template <class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<tuple<_UTypes...>&>(),
+            __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(_NothrowTupleLikeConstruction<tuple<_UTypes...>&>::value)
+  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(__nothrow_tuple_like_constructible_v<tuple<_UTypes...>&>)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<tuple<_UTypes...>&>(),
+            __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>& __t) noexcept(
-    _NothrowTupleLikeConstruction<tuple<_UTypes...>&>::value)
+    __nothrow_tuple_like_constructible_v<tuple<_UTypes...>&>)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<tuple<_UTypes...>&>(),
+            __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<const tuple<_UTypes...>&>(),
+            __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
-    _NothrowTupleLikeConstruction<const tuple<_UTypes...>&>::value)
+    __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&>)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<const tuple<_UTypes...>&>(),
+            __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
-    _NothrowTupleLikeConstruction<const tuple<_UTypes...>&>::value)
+    __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&>)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<const tuple<_UTypes...>&>(),
+            __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<tuple<_UTypes...>&&>(),
+            __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(_NothrowTupleLikeConstruction<tuple<_UTypes...>&&>::value)
+  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(__nothrow_tuple_like_constructible_v<tuple<_UTypes...>&&>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<tuple<_UTypes...>&&>(),
+            __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>&& __t) noexcept(
-    _NothrowTupleLikeConstruction<tuple<_UTypes...>&&>::value)
+    __nothrow_tuple_like_constructible_v<tuple<_UTypes...>&&>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<tuple<_UTypes...>&&>(),
+            __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<const tuple<_UTypes...>&&>(),
+            __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
-    _NothrowTupleLikeConstruction<const tuple<_UTypes...>&&>::value)
+    __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&&>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<const tuple<_UTypes...>&&>(),
+            __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
-    _NothrowTupleLikeConstruction<const tuple<_UTypes...>&&>::value)
+    __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&&>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<const tuple<_UTypes...>&&>(),
+            __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(const tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
-  // We cannot instantiate __tuple_constraints<_Tp...>::template __select_tuple_like_constructible eagerly because the
+  // We cannot instantiate __select_tuple_like_constructible_v eagerly because the
   // leads to recursive constraints We need to SFINAE the constructor away before instantiating the traits
   template <class _Tuple>
   using __disambiguate_tuple_like =
@@ -358,27 +349,24 @@ public:
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_Tuple>(),
+            __select_constructor _Constraints                          = __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLikeConstruction<_Tuple>::value)
+  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(__nothrow_tuple_like_constructible_v<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
 
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_Tuple>(),
+            __select_constructor _Constraints                          = __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
-  _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLikeConstruction<_Tuple>::value)
+  _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(__nothrow_tuple_like_constructible_v<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_Tuple>(),
+            __select_constructor _Constraints                          = __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(_Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
@@ -387,22 +375,20 @@ public:
   template <class _Alloc,
             class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_Tuple>(),
+            __select_constructor _Constraints                          = __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
-    _NothrowTupleLikeConstruction<_Tuple>::value)
+    __nothrow_tuple_like_constructible_v<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
   {}
 
   template <class _Alloc,
             class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_Tuple>(),
+            __select_constructor _Constraints                          = __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
-    _NothrowTupleLikeConstruction<_Tuple>::value)
+    __nothrow_tuple_like_constructible_v<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
   {}
 
@@ -410,8 +396,7 @@ public:
   template <class _Alloc,
             class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_Tuple>(),
+            __select_constructor _Constraints                          = __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -240,6 +240,18 @@ public:
   {}
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
+  template <class _Tuple>
+  static constexpr bool __disambiguate_tuple_like_v =
+    // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
+    !__is_cuda_std_ranges_subrange_v<remove_cvref_t<_Tuple>>
+    // Disambiguates the copy and move constructor
+    && !is_same_v<_Tuple, const tuple&>
+    && !is_same_v<_Tuple, tuple&&> //
+    // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
+    // [tuple#cnstr]-25.1: sizeof...(Types) is 2,
+    // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
+    && __tuple_like_with_size<_Tuple, sizeof...(_Tp)>;
+
   template <class _UTuple>
   static constexpr __select_constructor __select_tuple_like_constructible_v =
     __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_UTuple>(
@@ -248,9 +260,10 @@ public:
   template <class _UTuple>
   static constexpr bool __nothrow_tuple_like_constructible_v =
     __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible<_UTuple>(
-      __make_tuple_indices_t<sizeof...(_Types)>{});
+      __make_tuple_indices_t<sizeof...(_Tp)>{});
 
   template <class... _UTypes,
+            enable_if_t<__disambiguate_tuple_like_v<tuple<_UTypes...>&>, int> = 0,
             __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(__nothrow_tuple_like_constructible_v<tuple<_UTypes...>&>)
@@ -258,6 +271,7 @@ public:
   {}
 
   template <class... _UTypes,
+            enable_if_t<__disambiguate_tuple_like_v<tuple<_UTypes...>&>, int> = 0,
             __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>& __t) noexcept(
@@ -267,12 +281,14 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
+            enable_if_t<__disambiguate_tuple_like_v<tuple<_UTypes...>&>, int> = 0,
             __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
+            enable_if_t<__disambiguate_tuple_like_v<const tuple<_UTypes...>&>, int> = 0,
             __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
@@ -281,6 +297,7 @@ public:
   {}
 
   template <class... _UTypes,
+            enable_if_t<__disambiguate_tuple_like_v<const tuple<_UTypes...>&>, int> = 0,
             __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
@@ -290,12 +307,14 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
+            enable_if_t<__disambiguate_tuple_like_v<const tuple<_UTypes...>&>, int> = 0,
             __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
+            enable_if_t<__disambiguate_tuple_like_v<tuple<_UTypes...>&&>, int> = 0,
             __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(__nothrow_tuple_like_constructible_v<tuple<_UTypes...>&&>)
@@ -303,6 +322,7 @@ public:
   {}
 
   template <class... _UTypes,
+            enable_if_t<__disambiguate_tuple_like_v<tuple<_UTypes...>&&>, int> = 0,
             __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>&& __t) noexcept(
@@ -312,12 +332,14 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
+            enable_if_t<__disambiguate_tuple_like_v<tuple<_UTypes...>&&>, int> = 0,
             __select_constructor _Constraints = __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
+            enable_if_t<__disambiguate_tuple_like_v<const tuple<_UTypes...>&&>, int> = 0,
             __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
@@ -326,6 +348,7 @@ public:
   {}
 
   template <class... _UTypes,
+            enable_if_t<__disambiguate_tuple_like_v<const tuple<_UTypes...>&&>, int> = 0,
             __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
@@ -335,29 +358,24 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
+            enable_if_t<__disambiguate_tuple_like_v<const tuple<_UTypes...>&&>, int> = 0,
             __select_constructor _Constraints = __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(const tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
-  // We cannot instantiate __select_tuple_like_constructible_v eagerly because the
-  // leads to recursive constraints We need to SFINAE the constructor away before instantiating the traits
-  template <class _Tuple>
-  using __disambiguate_tuple_like =
-    bool_constant<!is_same_v<remove_cvref_t<_Tuple>, tuple> && __tuple_like_with_size<_Tuple, sizeof...(_Tp)>>;
-
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
   template <class _Tuple,
-            enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Constraints                          = __select_tuple_like_constructible_v<_Tuple>,
+            enable_if_t<__disambiguate_tuple_like_v<_Tuple>, int> = 0,
+            __select_constructor _Constraints                     = __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(__nothrow_tuple_like_constructible_v<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
 
   template <class _Tuple,
-            enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Constraints                          = __select_tuple_like_constructible_v<_Tuple>,
+            enable_if_t<__disambiguate_tuple_like_v<_Tuple>, int> = 0,
+            __select_constructor _Constraints                     = __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(__nothrow_tuple_like_constructible_v<_Tuple>)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
@@ -365,8 +383,8 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Tuple,
-            enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Constraints                          = __select_tuple_like_constructible_v<_Tuple>,
+            enable_if_t<__disambiguate_tuple_like_v<_Tuple>, int> = 0,
+            __select_constructor _Constraints                     = __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(_Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
@@ -374,8 +392,8 @@ public:
 
   template <class _Alloc,
             class _Tuple,
-            enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints                          = __select_tuple_like_constructible_v<_Tuple>,
+            enable_if_t<__disambiguate_tuple_like_v<_Tuple>, int> = 0, // Help Clang disambiguate for CTAD
+            __select_constructor _Constraints                     = __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
     __nothrow_tuple_like_constructible_v<_Tuple>)
@@ -384,8 +402,8 @@ public:
 
   template <class _Alloc,
             class _Tuple,
-            enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints                          = __select_tuple_like_constructible_v<_Tuple>,
+            enable_if_t<__disambiguate_tuple_like_v<_Tuple>, int> = 0, // Help Clang disambiguate for CTAD
+            __select_constructor _Constraints                     = __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
     __nothrow_tuple_like_constructible_v<_Tuple>)
@@ -395,8 +413,8 @@ public:
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Alloc,
             class _Tuple,
-            enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            __select_constructor _Constraints                          = __select_tuple_like_constructible_v<_Tuple>,
+            enable_if_t<__disambiguate_tuple_like_v<_Tuple>, int> = 0,
+            __select_constructor _Constraints                     = __select_tuple_like_constructible_v<_Tuple>,
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -242,24 +242,23 @@ public:
   {}
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
-  template <class _UTuple>
-  using _TupleLikeConstraints = typename __tuple_constraints<_Tp...>::template __tuple_like_construction<_UTuple>;
-
   // MSVC needs this to be a type
   template <class _UTuple>
   using _NothrowTupleLikeConstruction =
     bool_constant<__tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible<_UTuple>>;
 
   template <class... _UTypes,
-            class _Constraints                                         = _TupleLikeConstraints<tuple<_UTypes...>&>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<tuple<_UTypes...>&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(_NothrowTupleLikeConstruction<tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
-            class _Constraints                                         = _TupleLikeConstraints<tuple<_UTypes...>&>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<tuple<_UTypes...>&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>& __t) noexcept(
     _NothrowTupleLikeConstruction<tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
@@ -267,22 +266,25 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            class _Constraints                           = _TupleLikeConstraints<tuple<_UTypes...>&>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<tuple<_UTypes...>&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            class _Constraints = _TupleLikeConstraints<const tuple<_UTypes...>&>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<const tuple<_UTypes...>&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
     _NothrowTupleLikeConstruction<const tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
-            class _Constraints = _TupleLikeConstraints<const tuple<_UTypes...>&>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<const tuple<_UTypes...>&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
     _NothrowTupleLikeConstruction<const tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
@@ -290,21 +292,24 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            class _Constraints                           = _TupleLikeConstraints<const tuple<_UTypes...>&>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<const tuple<_UTypes...>&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            class _Constraints                                         = _TupleLikeConstraints<tuple<_UTypes...>&&>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<tuple<_UTypes...>&&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(_NothrowTupleLikeConstruction<tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
-            class _Constraints                                         = _TupleLikeConstraints<tuple<_UTypes...>&&>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<tuple<_UTypes...>&&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>&& __t) noexcept(
     _NothrowTupleLikeConstruction<tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
@@ -312,22 +317,25 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            class _Constraints                           = _TupleLikeConstraints<tuple<_UTypes...>&&>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<tuple<_UTypes...>&&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
-            class _Constraints = _TupleLikeConstraints<const tuple<_UTypes...>&&>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<const tuple<_UTypes...>&&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
     _NothrowTupleLikeConstruction<const tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
-            class _Constraints = _TupleLikeConstraints<const tuple<_UTypes...>&&>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<const tuple<_UTypes...>&&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
     _NothrowTupleLikeConstruction<const tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
@@ -335,13 +343,14 @@ public:
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            class _Constraints                           = _TupleLikeConstraints<const tuple<_UTypes...>&&>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<const tuple<_UTypes...>&&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(const tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
-  // We cannot instantiate _TupleLikeConstraints eagerly because the leads to recursive constraints
-  // We need to SFINAE the constructor away before instantiating the traits
+  // We cannot instantiate __tuple_constraints<_Tp...>::template __select_tuple_like_constructible eagerly because the
+  // leads to recursive constraints We need to SFINAE the constructor away before instantiating the traits
   template <class _Tuple>
   using __disambiguate_tuple_like =
     bool_constant<!is_same_v<remove_cvref_t<_Tuple>, tuple> && __tuple_like_with_size<_Tuple, sizeof...(_Tp)>>;
@@ -349,16 +358,18 @@ public:
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_Tuple>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLikeConstruction<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
 
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_Tuple>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLikeConstruction<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
@@ -366,8 +377,9 @@ public:
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
-            enable_if_t<_Constraints::__is_deleted, int>               = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_Tuple>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(_Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
   // NOLINTEND(bugprone-forwarding-reference-overload)
@@ -375,8 +387,9 @@ public:
   template <class _Alloc,
             class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
-            class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_Tuple>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
     _NothrowTupleLikeConstruction<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
@@ -385,8 +398,9 @@ public:
   template <class _Alloc,
             class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
-            class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_Tuple>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
     _NothrowTupleLikeConstruction<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
@@ -396,8 +410,9 @@ public:
   template <class _Alloc,
             class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
-            class _Constraints                                         = _TupleLikeConstraints<_Tuple>,
-            enable_if_t<_Constraints::__is_deleted, int>               = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible<_Tuple>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -162,38 +162,38 @@ public:
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::move(__t))
   {}
 
+  template <class... _UTypes>
+  using _VariadicConstructible =
+    _ConstructorConstraint<__tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>()>;
+
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
+            enable_if_t<sizeof...(_Tp) != 0, int>                      = 0, // Help Clang disambiguate for CTAD,
+            class _Constraints                                         = _VariadicConstructible<_UTypes...>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
+            enable_if_t<sizeof...(_Tp) != 0, int>                      = 0, // Help Clang disambiguate for CTAD
+            class _Constraints                                         = _VariadicConstructible<_UTypes...>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
-            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
+            enable_if_t<sizeof...(_Tp) != 0, int>        = 0, // Help Clang disambiguate for CTAD
+            class _Constraints                           = _VariadicConstructible<_UTypes...>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr tuple(_UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
+            class _Constraints                                         = _VariadicConstructible<_UTypes...>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API inline tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
     (is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
@@ -201,9 +201,8 @@ public:
 
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
+            class _Constraints                                         = _VariadicConstructible<_UTypes...>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API inline explicit tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
     (is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
@@ -212,9 +211,8 @@ public:
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
-            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
+            class _Constraints                           = _VariadicConstructible<_UTypes...>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
@@ -254,172 +252,159 @@ public:
     // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
     && __tuple_like_with_size<_Tuple, sizeof...(_Tp)>>;
 
+  template <class _Tuple>
+  using _TupleLikeConstructible =
+    _ConstructorConstraint<__tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>>;
+
+  template <class _Tuple>
+  using _NothrowTupleLikeConstructible =
+    bool_constant<__tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<_Tuple>>;
+
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<tuple<_UTypes...>&>)
+            class _Constraints                                         = _TupleLikeConstructible<tuple<_UTypes...>&>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(_NothrowTupleLikeConstructible<tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
+            class _Constraints                                         = _TupleLikeConstructible<tuple<_UTypes...>&>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<tuple<_UTypes...>&>)
+    _NothrowTupleLikeConstructible<tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<tuple<_UTypes...>&>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
+            class _Constraints                           = _TupleLikeConstructible<tuple<_UTypes...>&>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
+            class _Constraints = _TupleLikeConstructible<const tuple<_UTypes...>&>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&>)
+    _NothrowTupleLikeConstructible<const tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
+            class _Constraints = _TupleLikeConstructible<const tuple<_UTypes...>&>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&>)
+    _NothrowTupleLikeConstructible<const tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<const tuple<_UTypes...>&>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
+            class _Constraints                           = _TupleLikeConstructible<const tuple<_UTypes...>&>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&&>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<tuple<_UTypes...>&&>)
+            class _Constraints                                         = _TupleLikeConstructible<tuple<_UTypes...>&&>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(_NothrowTupleLikeConstructible<tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&&>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
+            class _Constraints                                         = _TupleLikeConstructible<tuple<_UTypes...>&&>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>&& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<tuple<_UTypes...>&&>)
+    _NothrowTupleLikeConstructible<tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&&>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<tuple<_UTypes...>&&>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
+            class _Constraints                           = _TupleLikeConstructible<tuple<_UTypes...>&&>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&&>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
+            class _Constraints = _TupleLikeConstructible<const tuple<_UTypes...>&&>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&&>)
+    _NothrowTupleLikeConstructible<const tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&&>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
+            class _Constraints = _TupleLikeConstructible<const tuple<_UTypes...>&&>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<const tuple<_UTypes...>&&>)
+    _NothrowTupleLikeConstructible<const tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&&>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<const tuple<_UTypes...>&&>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
+            class _Constraints                           = _TupleLikeConstructible<const tuple<_UTypes...>&&>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr tuple(const tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
   template <class _Tuple,
-            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<_Tuple>)
+            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int>    = 0,
+            class _Constraints                                         = _TupleLikeConstructible<_Tuple>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLikeConstructible<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
 
   template <class _Tuple,
-            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
-  _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<_Tuple>)
+            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int>    = 0,
+            class _Constraints                                         = _TupleLikeConstructible<_Tuple>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+  _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLikeConstructible<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Tuple,
             enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
+            class _Constraints                                      = _TupleLikeConstructible<_Tuple>,
+            enable_if_t<_Constraints::__is_deleted, int>            = 0>
   constexpr tuple(_Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
   template <class _Alloc,
             class _Tuple,
-            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
+            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int>    = 0, // Help Clang disambiguate for CTAD
+            class _Constraints                                         = _TupleLikeConstructible<_Tuple>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<_Tuple>)
+    _NothrowTupleLikeConstructible<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
   {}
 
   template <class _Alloc,
             class _Tuple,
-            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
+            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int>    = 0, // Help Clang disambiguate for CTAD
+            class _Constraints                                         = _TupleLikeConstructible<_Tuple>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<_Tuple>)
+    _NothrowTupleLikeConstructible<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
   {}
 
@@ -427,9 +412,8 @@ public:
   template <class _Alloc,
             class _Tuple,
             enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int> = 0,
-            __select_constructor _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>,
-            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
+            class _Constraints                                      = _TupleLikeConstructible<_Tuple>,
+            enable_if_t<_Constraints::__is_deleted, int>            = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _Tuple&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -116,22 +116,22 @@ public:
       : __base_(allocator_arg_t(), __a)
   {}
 
-  template <class _Constraints = typename __tuple_constraints<_Tp...>::__variadic_copy_construction,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  template <__select_constructor _Constraints = __tuple_constraints<_Tp...>::__select_variadic_copy_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const _Tp&... __t) noexcept((is_nothrow_copy_constructible_v<_Tp> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, __t...)
   {}
 
-  template <class _Constraints = typename __tuple_constraints<_Tp...>::__variadic_copy_construction,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+  template <__select_constructor _Constraints = __tuple_constraints<_Tp...>::__select_variadic_copy_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const _Tp&... __t) noexcept((is_nothrow_copy_constructible_v<_Tp> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, __t...)
   {}
 
   template <class _Alloc,
             enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            class _Constraints                    = typename __tuple_constraints<_Tp...>::__variadic_copy_construction,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints     = __tuple_constraints<_Tp...>::__select_variadic_copy_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, const _Tp&... __t) noexcept(
     (is_nothrow_copy_constructible_v<_Tp> && ...))
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, __t...)
@@ -139,24 +139,24 @@ public:
 
   template <class _Alloc,
             enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            class _Constraints                    = typename __tuple_constraints<_Tp...>::__variadic_copy_construction,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints     = __tuple_constraints<_Tp...>::__select_variadic_copy_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t, const _Alloc& __a, const _Tp&... __t) noexcept(
     (is_nothrow_copy_constructible_v<_Tp> && ...))
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, __t...)
   {}
 
   template <class _Alloc,
-            class _Constraints = typename __tuple_constraints<_Tp...>::__variadic_copy_construction,
-            enable_if_t<_Constraints::__can_construct, int> = 0>
+            __select_constructor _Constraints = __tuple_constraints<_Tp...>::__select_variadic_copy_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, const tuple& __t) noexcept(
     (is_nothrow_copy_constructible_v<_Tp> && ...))
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, __t)
   {}
 
   template <class _Alloc,
-            class _Constraints = typename __tuple_constraints<_Tp...>::__variadic_move_construction,
-            enable_if_t<_Constraints::__can_construct, int> = 0>
+            __select_constructor _Constraints = __tuple_constraints<_Tp...>::__select_variadic_move_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, tuple&& __t) noexcept(
     (is_nothrow_move_constructible_v<_Tp> && ...))
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::move(__t))

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -421,8 +421,8 @@ public:
   _CCCL_HIDE_FROM_ABI tuple& operator=(tuple&& __t)      = default;
 
   // [tuple.assign]-5
-  template <class _Constraints = typename __tuple_constraints<_Tp...>::__const_copy_assignable,
-            enable_if_t<_Constraints::__can_assign, int> = 0>
+  template <bool _Constraints              = __tuple_constraints<_Tp...>::__all_const_copy_assignable,
+            enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr const tuple& operator=(const tuple& __t) const
     noexcept((is_nothrow_copy_assignable_v<const _Tp> && ...))
   {
@@ -431,8 +431,8 @@ public:
   }
 
   // [tuple.assign]-12
-  template <class _Constraints = typename __tuple_constraints<_Tp...>::__const_move_assignable,
-            enable_if_t<_Constraints::__can_assign, int> = 0>
+  template <bool _Constraints              = __tuple_constraints<_Tp...>::__all_const_move_assignable,
+            enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr const tuple& operator=(tuple&& __t) const
     noexcept((is_nothrow_assignable_v<const _Tp&, _Tp> && ...))
   {
@@ -441,14 +441,11 @@ public:
     return *this;
   }
 
-  template <bool _IsConst, class... _UTypes>
-  using _ConvertingAssignable =
-    typename __tuple_constraints<_Tp...>::template __converting_assignable<_IsConst, _UTypes...>;
-
   // [tuple.assign]-15
   template <class... _UTypes,
-            class _Constraints = _ConvertingAssignable</*__is_const=*/false, const _UTypes&...>,
-            enable_if_t<_Constraints::__can_assign, int> = 0>
+            bool _Constraints = __tuple_constraints<_Tp...>::template //
+            __select_converting_assignable</*__is_const=*/false, const _UTypes&...>(),
+            enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr tuple&
   operator=(const tuple<_UTypes...>& __t) noexcept((is_nothrow_assignable_v<_Tp&, const _UTypes&> && ...))
   {
@@ -458,8 +455,9 @@ public:
 
   // [tuple.assign]-18
   template <class... _UTypes,
-            class _Constraints = _ConvertingAssignable</*__is_const=*/true, const _UTypes&...>,
-            enable_if_t<_Constraints::__can_assign, int> = 0>
+            bool _Constraints = __tuple_constraints<_Tp...>::template //
+            __select_converting_assignable</*__is_const=*/true, const _UTypes&...>(),
+            enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr const tuple& operator=(const tuple<_UTypes...>& __t) const
     noexcept((is_nothrow_assignable_v<const _Tp&, const _UTypes&> && ...))
   {
@@ -469,8 +467,9 @@ public:
 
   // [tuple.assign]-21
   template <class... _UTypes,
-            class _Constraints                           = _ConvertingAssignable</*__is_const=*/false, _UTypes...>,
-            enable_if_t<_Constraints::__can_assign, int> = 0>
+            bool _Constraints = __tuple_constraints<_Tp...>::template //
+            __select_converting_assignable</*__is_const=*/false, _UTypes...>(),
+            enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr tuple& operator=(tuple<_UTypes...>&& __t) noexcept((is_nothrow_assignable_v<_Tp&, _UTypes> && ...))
   {
     ::cuda::std::__memberwise_forward_assign(
@@ -480,8 +479,9 @@ public:
 
   // [tuple.assign]-24
   template <class... _UTypes,
-            class _Constraints                           = _ConvertingAssignable</*__is_const=*/true, _UTypes...>,
-            enable_if_t<_Constraints::__can_assign, int> = 0>
+            bool _Constraints = __tuple_constraints<_Tp...>::template //
+            __select_converting_assignable</*__is_const=*/true, _UTypes...>(),
+            enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr const tuple& operator=(tuple<_UTypes...>&& __t) const
     noexcept((is_nothrow_assignable_v<const _Tp&, _UTypes> && ...))
   {
@@ -490,17 +490,14 @@ public:
     return *this;
   }
 
-  template <bool _IsConst, class _UTuple>
-  using _TupleLikeAssignable =
-    typename __tuple_constraints<_Tp...>::template __tuple_like_assignable<_IsConst, _UTuple>;
-
   // [tuple.assign]-39
   template <class _UTuple,
             enable_if_t<!__is_cuda_std_tuple<remove_cvref_t<_UTuple>>, int> = 0,
-            class _Constraints                           = _TupleLikeAssignable</*__is_const=*/false, _UTuple>,
-            enable_if_t<_Constraints::__can_assign, int> = 0>
+            bool _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_assignable</*__is_const=*/false, _UTuple>(),
+            enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr tuple& operator=(_UTuple&& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_assignable</*__is_const=*/false, _UTuple>)
+    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_assignable</*__is_const=*/false, _UTuple>())
   {
     ::cuda::std::__memberwise_tuple_assign(
       *this, ::cuda::std::forward<_UTuple>(__t), __make_tuple_indices_t<sizeof...(_Tp)>{});
@@ -510,10 +507,11 @@ public:
   // [tuple.assign]-42
   template <class _UTuple,
             enable_if_t<!__is_cuda_std_tuple<remove_cvref_t<_UTuple>>, int> = 0,
-            class _Constraints                           = _TupleLikeAssignable</*__is_const=*/true, _UTuple>,
-            enable_if_t<_Constraints::__can_assign, int> = 0>
+            bool _Constraints =
+              __tuple_constraints<_Tp...>::template __select_tuple_like_assignable</*__is_const=*/true, _UTuple>(),
+            enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr const tuple& operator=(_UTuple&& __t) const
-    noexcept(__tuple_constraints<_Tp...>::template __nothrow_tuple_like_assignable</*__is_const=*/true, _UTuple>)
+    noexcept(__tuple_constraints<_Tp...>::template __nothrow_tuple_like_assignable</*__is_const=*/true, _UTuple>())
   {
     ::cuda::std::__memberwise_tuple_assign(
       *this, ::cuda::std::forward<_UTuple>(__t), __make_tuple_indices_t<sizeof...(_Tp)>{});

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -162,37 +162,38 @@ public:
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::move(__t))
   {}
 
-  template <class... _UTypes>
-  using _VariadicConstraints = typename __tuple_constraints<_Tp...>::template __variadic_construction<_UTypes...>;
-
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int>                      = 0, // Help Clang disambiguate for CTAD
-            class _Constraints                                         = _VariadicConstraints<_UTypes...>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int>                      = 0, // Help Clang disambiguate for CTAD
-            class _Constraints                                         = _VariadicConstraints<_UTypes...>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int>        = 0, // Help Clang disambiguate for CTAD
-            class _Constraints                           = _VariadicConstraints<_UTypes...>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(_UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _Alloc,
             class... _UTypes,
-            class _Constraints                                         = _VariadicConstraints<_UTypes...>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API inline tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
     (is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
@@ -200,8 +201,9 @@ public:
 
   template <class _Alloc,
             class... _UTypes,
-            class _Constraints                                         = _VariadicConstraints<_UTypes...>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API inline explicit tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
     (is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
@@ -210,20 +212,18 @@ public:
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Alloc,
             class... _UTypes,
-            class _Constraints                           = _VariadicConstraints<_UTypes...>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
-  template <class... _UTypes>
-  using _VariadicConstraintsLessRank =
-    typename __tuple_constraints<_Tp...>::template __variadic_construction_less_rank<_UTypes...>;
-
   template <class... _UTypes,
-            enable_if_t<(sizeof...(_UTypes) < sizeof...(_Tp)), int>    = 0,
-            enable_if_t<(sizeof...(_UTypes) != 0), int>                = 0,
-            class _Constraints                                         = _VariadicConstraintsLessRank<_UTypes...>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            enable_if_t<(sizeof...(_UTypes) < sizeof...(_Tp)), int> = 0,
+            enable_if_t<(sizeof...(_UTypes) != 0), int>             = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible_less_rank<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(_UTypes&&... __u)
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -435,25 +435,15 @@ struct __tuple_constraints
     }
     // NOLINTEND(bugprone-branch-clone)
   }
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _UTuple>
-  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
-  __select_tuple_like_constructible() noexcept
-  {
-    return __select_tuple_like_constructible<_UTuple>(__make_tuple_indices_t<sizeof...(_Types)>{});
-  }
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UTuple, size_t... _Indices>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool
-  __nothrow_tuple_like_constructible_(__tuple_indices<_Indices...>) noexcept
+  __nothrow_tuple_like_constructible(__tuple_indices<_Indices...>) noexcept
   {
     using ::cuda::std::get;
     return (is_nothrow_constructible_v<_Types, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...);
   }
-  template <class _UTuple>
-  static constexpr bool __nothrow_tuple_like_constructible =
-    __nothrow_tuple_like_constructible_<_UTuple>(__make_tuple_indices_t<sizeof...(_Types)>{});
 
   // Assignments
   static constexpr bool __all_copy_assignable = (is_copy_assignable_v<_Types> && ...);

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -435,9 +435,13 @@ struct __tuple_constraints
     }
     // NOLINTEND(bugprone-branch-clone)
   }
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _UTuple>
-  using __tuple_like_construction =
-    _ConstructorConstraint<__select_tuple_like_constructible<_UTuple>(__make_tuple_indices_t<sizeof...(_Types)>{})>;
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
+  __select_tuple_like_constructible() noexcept
+  {
+    return __select_tuple_like_constructible<_UTuple>(__make_tuple_indices_t<sizeof...(_Types)>{});
+  }
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UTuple, size_t... _Indices>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -460,9 +460,9 @@ struct __tuple_constraints
   static constexpr bool __all_move_assignable = (is_move_assignable_v<_Types> && ...);
 
   // [tuple.assign]-5: is_copy_assignable_v<const Types> is true for all i.
-  using __const_copy_assignable = _AssignmentConstraint<(is_copy_assignable_v<const _Types> && ...)>;
+  static constexpr bool __all_const_copy_assignable = (is_copy_assignable_v<const _Types> && ...);
   // [tuple.assign]-12: is_assignable_v<const Types&, Types> is true for all i.
-  using __const_move_assignable = _AssignmentConstraint<(is_assignable_v<const _Types&, _Types> && ...)>;
+  static constexpr bool __all_const_move_assignable = (is_assignable_v<const _Types&, _Types> && ...);
 
   template <bool _IsConst, class... _UTypes>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool __select_converting_assignable() noexcept
@@ -488,8 +488,6 @@ struct __tuple_constraints
     }
     // NOLINTEND(bugprone-branch-clone)
   }
-  template <bool _IsConst, class... _UTypes>
-  using __converting_assignable = _AssignmentConstraint<__select_converting_assignable<_IsConst, _UTypes...>()>;
 
   _CCCL_EXEC_CHECK_DISABLE
   template <bool _IsConst, class _UTuple, size_t... _Indices>
@@ -521,14 +519,17 @@ struct __tuple_constraints
     }
     // NOLINTEND(bugprone-branch-clone)
   }
+  _CCCL_EXEC_CHECK_DISABLE
   template <bool _IsConst, class _UTuple>
-  using __tuple_like_assignable = _AssignmentConstraint<__select_tuple_like_assignable<_IsConst, _UTuple>(
-    __make_tuple_indices_t<sizeof...(_Types)>{})>;
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool __select_tuple_like_assignable() noexcept
+  {
+    return __select_tuple_like_assignable<_IsConst, _UTuple>(__make_tuple_indices_t<sizeof...(_Types)>{});
+  }
 
   _CCCL_EXEC_CHECK_DISABLE
   template <bool _IsConst, class _UTuple, size_t... _Indices>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool
-  __nothrow_tuple_like_assignable_(__tuple_indices<_Indices...>) noexcept
+  __nothrow_tuple_like_assignable(__tuple_indices<_Indices...>) noexcept
   {
     using ::cuda::std::get;
     if constexpr (_IsConst)
@@ -540,9 +541,12 @@ struct __tuple_constraints
       return (is_nothrow_assignable_v<_Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...);
     }
   }
+  _CCCL_EXEC_CHECK_DISABLE
   template <bool _IsConst, class _UTuple>
-  static constexpr bool __nothrow_tuple_like_assignable =
-    __nothrow_tuple_like_assignable_<_IsConst, _UTuple>(__make_tuple_indices_t<sizeof...(_Types)>{});
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool __nothrow_tuple_like_assignable() noexcept
+  {
+    return __nothrow_tuple_like_assignable<_IsConst, _UTuple>(__make_tuple_indices_t<sizeof...(_Types)>{});
+  }
 
   // Comparisons
   template <class... _UTypes>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -255,8 +255,6 @@ struct __tuple_constraints
     }
     // NOLINTEND(bugprone-branch-clone)
   }
-  template <class... _UTypes>
-  using __variadic_construction = _ConstructorConstraint<__select_variadic_constructible<_UTypes...>()>;
 
   template <class... _UTypes>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
@@ -303,9 +301,6 @@ struct __tuple_constraints
     }
     // NOLINTEND(bugprone-branch-clone)
   }
-  template <class... _UTypes>
-  using __variadic_construction_less_rank =
-    _ConstructorConstraint<__select_variadic_constructible_less_rank<_UTypes...>()>;
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UTuple, size_t... _Indices>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -436,6 +436,10 @@ struct __tuple_constraints
     // NOLINTEND(bugprone-branch-clone)
   }
 
+  template <class _UTuple>
+  static constexpr __select_constructor __select_tuple_like_constructible_v =
+    __select_tuple_like_constructible<_UTuple>(__make_tuple_indices_t<sizeof...(_Types)>{});
+
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UTuple, size_t... _Indices>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool
@@ -444,6 +448,10 @@ struct __tuple_constraints
     using ::cuda::std::get;
     return (is_nothrow_constructible_v<_Types, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...);
   }
+
+  template <class _UTuple>
+  static constexpr bool __nothrow_tuple_like_constructible_v =
+    __nothrow_tuple_like_constructible<_UTuple>(__make_tuple_indices_t<sizeof...(_Types)>{});
 
   // Assignments
   static constexpr bool __all_copy_assignable = (is_copy_assignable_v<_Types> && ...);

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -117,8 +117,8 @@ struct __tuple_constraints
       return __select_constructor::__explicit;
     }
   }
-  using __variadic_copy_construction = _ConstructorConstraint<__select_variadic_copy_constructible()>;
 
+  template <int = 0>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
   __select_variadic_move_constructible() noexcept
   {
@@ -135,7 +135,6 @@ struct __tuple_constraints
       return __select_constructor::__explicit;
     }
   }
-  using __variadic_move_construction = _ConstructorConstraint<__select_variadic_move_constructible()>;
 
   template <class... _UTypes, enable_if_t<sizeof...(_UTypes) != 1, int> = 0>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor __select_variadic_constructible() noexcept

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -152,9 +152,6 @@ struct __pair_constraints
     // NOLINTEND(bugprone-branch-clone)
   }
 
-  template <class _UPair>
-  using __pair_like_construction = _ConstructorConstraint<__select_pair_like_constructible<_UPair>()>;
-
   _CCCL_EXEC_CHECK_DISABLE
   template <bool _IsConst, class _UPair>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool __select_pair_like_assignable() noexcept
@@ -197,9 +194,6 @@ struct __pair_constraints
     }
     // NOLINTEND(bugprone-branch-clone)
   }
-
-  template <bool _IsConst, class _UPair>
-  using __pair_like_assignment = _AssignmentConstraint<__select_pair_like_assignable<_IsConst, _UPair>()>;
 };
 
 // base class to ensure `is_trivially_copyable` when possible
@@ -382,14 +376,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   constexpr pair(_U1&&, _U2&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
-  template <class _UPair>
-  using __pair_like_constructible = typename __pair_constraints<_T1, _T2>::template __pair_like_construction<_UPair>;
-
   // converting constructors
   template <class _U1,
             class _U2,
-            class _Constraints                                         = __pair_like_constructible<pair<_U1, _U2>&>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<pair<_U1, _U2>&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1&> && is_nothrow_constructible_v<_T2, _U2&>)
       : __base(__p.first, __p.second)
@@ -397,8 +389,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            class _Constraints                                         = __pair_like_constructible<pair<_U1, _U2>&>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<pair<_U1, _U2>&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1&> && is_nothrow_constructible_v<_T2, _U2&>)
       : __base(__p.first, __p.second)
@@ -407,15 +400,17 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            class _Constraints                           = __pair_like_constructible<pair<_U1, _U2>&>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<pair<_U1, _U2>&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr pair(pair<_U1, _U2>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
-            class _Constraints = __pair_like_constructible<const pair<_U1, _U2>&>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<const pair<_U1, _U2>&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(const pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
@@ -423,8 +418,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            class _Constraints = __pair_like_constructible<const pair<_U1, _U2>&>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<const pair<_U1, _U2>&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(const pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
@@ -433,15 +429,17 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            class _Constraints                           = __pair_like_constructible<const pair<_U1, _U2>&>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<const pair<_U1, _U2>&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr pair(const pair<_U1, _U2>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
-            class _Constraints                                         = __pair_like_constructible<pair<_U1, _U2>&&>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<pair<_U1, _U2>&&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
@@ -449,8 +447,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            class _Constraints                                         = __pair_like_constructible<pair<_U1, _U2>&&>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<pair<_U1, _U2>&&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
@@ -459,15 +458,17 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            class _Constraints                           = __pair_like_constructible<pair<_U1, _U2>&&>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<pair<_U1, _U2>&&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr pair(pair<_U1, _U2>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
-            class _Constraints = __pair_like_constructible<const pair<_U1, _U2>&&>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<const pair<_U1, _U2>&&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(const pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1> && is_nothrow_constructible_v<_T2, const _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
@@ -475,8 +476,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            class _Constraints = __pair_like_constructible<const pair<_U1, _U2>&&>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<const pair<_U1, _U2>&&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(const pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1> && is_nothrow_constructible_v<_T2, const _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
@@ -485,8 +487,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            class _Constraints                           = __pair_like_constructible<const pair<_U1, _U2>&&>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<const pair<_U1, _U2>&&>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr pair(const pair<_U1, _U2>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
@@ -494,8 +497,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
-            class _Constraints                                         = __pair_like_constructible<_UPair>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<_UPair>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(_UPair&& __p) noexcept(
     is_nothrow_constructible_v<_T1, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
     && is_nothrow_constructible_v<_T2, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)
@@ -512,8 +516,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
-            class _Constraints                                         = __pair_like_constructible<_UPair>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<_UPair>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(_UPair&& __p) noexcept(
     is_nothrow_constructible_v<_T1, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
     && is_nothrow_constructible_v<_T2, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)
@@ -524,8 +529,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
-            class _Constraints                                         = __pair_like_constructible<_UPair>,
-            enable_if_t<_Constraints::__is_deleted, int>               = 0>
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_constructible<_UPair>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   _CCCL_API constexpr pair(_UPair&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
   // NOLINTEND(bugprone-forwarding-reference-overload)
@@ -594,17 +600,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
     return *this;
   }
 
-  template <bool _IsConst, class _UPair>
-  using __pair_like_assignable =
-    typename __pair_constraints<_T1, _T2>::template __pair_like_assignment<_IsConst, _UPair>;
-
   // ``get`` will specifically only move the sub-object, it's therefore OK to
   // "move" the outer pair twice
   // NOLINTBEGIN(bugprone-use-after-move)
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
-            class _Constraints                           = __pair_like_assignable</*__is_const=*/false, _UPair>,
-            enable_if_t<_Constraints::__can_assign, int> = 0>
+            bool _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_assignable</*__is_const=*/false, _UPair>(),
+            enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr pair& operator=(_UPair&& __p) noexcept(
     is_nothrow_assignable_v<_T1&, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
     && is_nothrow_assignable_v<_T2&, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)
@@ -617,8 +620,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
-            class _Constraints                           = __pair_like_assignable</*__is_const=*/true, _UPair>,
-            enable_if_t<_Constraints::__can_assign, int> = 0>
+            bool _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_pair_like_assignable</*__is_const=*/true, _UPair>(),
+            enable_if_t<_Constraints, int> = 0>
   _CCCL_API constexpr const pair& operator=(_UPair&& __p) const noexcept(
     is_nothrow_assignable_v<const _T1&, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
     && is_nothrow_assignable_v<const _T2&, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -108,9 +108,6 @@ struct __pair_constraints
     // NOLINTEND(bugprone-branch-clone)
   }
 
-  template <class _U1, class _U2>
-  using __variadic_construction = _ConstructorConstraint<__select_variadic_constructible<_U1, _U2>()>;
-
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor __select_pair_like_constructible() noexcept
@@ -356,29 +353,32 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
       : __base(__t1, __t2)
   {}
 
-  template <class _U1          = _T1,
-            class _U2          = _T2,
-            class _Constraints = typename __pair_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+  template <class _U1 = _T1,
+            class _U2 = _T2,
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_variadic_constructible<_U1, _U2>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::forward<_U1>(__u1), ::cuda::std::forward<_U2>(__u2))
   {}
 
-  template <class _U1          = _T1,
-            class _U2          = _T2,
-            class _Constraints = typename __pair_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+  template <class _U1 = _T1,
+            class _U2 = _T2,
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_variadic_constructible<_U1, _U2>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::forward<_U1>(__u1), ::cuda::std::forward<_U2>(__u2))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  template <class _U1          = _T1,
-            class _U2          = _T2,
-            class _Constraints = typename __pair_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+  template <class _U1 = _T1,
+            class _U2 = _T2,
+            __select_constructor _Constraints =
+              __pair_constraints<_T1, _T2>::template __select_variadic_constructible<_U1, _U2>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr pair(_U1&&, _U2&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -343,42 +343,42 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   _CCCL_HIDE_FROM_ABI pair(pair&&)      = default;
 
   // element wise constructors
-  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__variadic_copy_construction,
-            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
+  template <__select_constructor _Constraints = __tuple_constraints<_T1, _T2>::__select_variadic_copy_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(const _T1& __t1, const _T2& __t2) noexcept(
     is_nothrow_copy_constructible_v<_T1> && is_nothrow_copy_constructible_v<_T2>)
       : __base(__t1, __t2)
   {}
-  template <class _Constraint = typename __tuple_constraints<_T1, _T2>::__variadic_copy_construction,
-            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
+  template <__select_constructor _Constraints = __tuple_constraints<_T1, _T2>::__select_variadic_copy_constructible(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(const _T1& __t1, const _T2& __t2) noexcept(
     is_nothrow_copy_constructible_v<_T1> && is_nothrow_copy_constructible_v<_T2>)
       : __base(__t1, __t2)
   {}
 
-  template <class _U1         = _T1,
-            class _U2         = _T2,
-            class _Constraint = typename __pair_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
-            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
+  template <class _U1          = _T1,
+            class _U2          = _T2,
+            class _Constraints = typename __pair_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::forward<_U1>(__u1), ::cuda::std::forward<_U2>(__u2))
   {}
 
-  template <class _U1         = _T1,
-            class _U2         = _T2,
-            class _Constraint = typename __pair_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
-            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
+  template <class _U1          = _T1,
+            class _U2          = _T2,
+            class _Constraints = typename __pair_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::forward<_U1>(__u1), ::cuda::std::forward<_U2>(__u2))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  template <class _U1         = _T1,
-            class _U2         = _T2,
-            class _Constraint = typename __pair_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
-            enable_if_t<_Constraint::__is_deleted, int> = 0>
+  template <class _U1          = _T1,
+            class _U2          = _T2,
+            class _Constraints = typename __pair_constraints<_T1, _T2>::template __variadic_construction<_U1, _U2>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr pair(_U1&&, _U2&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
@@ -388,8 +388,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   // converting constructors
   template <class _U1,
             class _U2,
-            class _Constraint                                         = __pair_like_constructible<pair<_U1, _U2>&>,
-            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
+            class _Constraints                                         = __pair_like_constructible<pair<_U1, _U2>&>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1&> && is_nothrow_constructible_v<_T2, _U2&>)
       : __base(__p.first, __p.second)
@@ -397,8 +397,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            class _Constraint                                         = __pair_like_constructible<pair<_U1, _U2>&>,
-            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
+            class _Constraints                                         = __pair_like_constructible<pair<_U1, _U2>&>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1&> && is_nothrow_constructible_v<_T2, _U2&>)
       : __base(__p.first, __p.second)
@@ -407,15 +407,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            class _Constraint                           = __pair_like_constructible<pair<_U1, _U2>&>,
-            enable_if_t<_Constraint::__is_deleted, int> = 0>
+            class _Constraints                           = __pair_like_constructible<pair<_U1, _U2>&>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr pair(pair<_U1, _U2>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
-            class _Constraint = __pair_like_constructible<const pair<_U1, _U2>&>,
-            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
+            class _Constraints = __pair_like_constructible<const pair<_U1, _U2>&>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(const pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
@@ -423,8 +423,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            class _Constraint = __pair_like_constructible<const pair<_U1, _U2>&>,
-            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
+            class _Constraints = __pair_like_constructible<const pair<_U1, _U2>&>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(const pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
@@ -433,15 +433,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            class _Constraint                           = __pair_like_constructible<const pair<_U1, _U2>&>,
-            enable_if_t<_Constraint::__is_deleted, int> = 0>
+            class _Constraints                           = __pair_like_constructible<const pair<_U1, _U2>&>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr pair(const pair<_U1, _U2>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
-            class _Constraint                                         = __pair_like_constructible<pair<_U1, _U2>&&>,
-            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
+            class _Constraints                                         = __pair_like_constructible<pair<_U1, _U2>&&>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
@@ -449,8 +449,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            class _Constraint                                         = __pair_like_constructible<pair<_U1, _U2>&&>,
-            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
+            class _Constraints                                         = __pair_like_constructible<pair<_U1, _U2>&&>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
@@ -459,15 +459,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            class _Constraint                           = __pair_like_constructible<pair<_U1, _U2>&&>,
-            enable_if_t<_Constraint::__is_deleted, int> = 0>
+            class _Constraints                           = __pair_like_constructible<pair<_U1, _U2>&&>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr pair(pair<_U1, _U2>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
-            class _Constraint = __pair_like_constructible<const pair<_U1, _U2>&&>,
-            enable_if_t<_Constraint::__can_construct_implicitly, int> = 0>
+            class _Constraints = __pair_like_constructible<const pair<_U1, _U2>&&>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(const pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1> && is_nothrow_constructible_v<_T2, const _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
@@ -475,8 +475,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            class _Constraint = __pair_like_constructible<const pair<_U1, _U2>&&>,
-            enable_if_t<_Constraint::__can_construct_explicitly, int> = 0>
+            class _Constraints = __pair_like_constructible<const pair<_U1, _U2>&&>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(const pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1> && is_nothrow_constructible_v<_T2, const _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
@@ -485,8 +485,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _U1,
             class _U2,
-            class _Constraint                           = __pair_like_constructible<const pair<_U1, _U2>&&>,
-            enable_if_t<_Constraint::__is_deleted, int> = 0>
+            class _Constraints                           = __pair_like_constructible<const pair<_U1, _U2>&&>,
+            enable_if_t<_Constraints::__is_deleted, int> = 0>
   constexpr pair(const pair<_U1, _U2>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
@@ -494,8 +494,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
-            class _Constraint                                          = __pair_like_constructible<_UPair>,
-            enable_if_t<_Constraint::__can_construct_implicitly, int>  = 0>
+            class _Constraints                                         = __pair_like_constructible<_UPair>,
+            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr pair(_UPair&& __p) noexcept(
     is_nothrow_constructible_v<_T1, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
     && is_nothrow_constructible_v<_T2, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)
@@ -512,8 +512,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
-            class _Constraint                                          = __pair_like_constructible<_UPair>,
-            enable_if_t<_Constraint::__can_construct_explicitly, int>  = 0>
+            class _Constraints                                         = __pair_like_constructible<_UPair>,
+            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr pair(_UPair&& __p) noexcept(
     is_nothrow_constructible_v<_T1, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
     && is_nothrow_constructible_v<_T2, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)
@@ -524,8 +524,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
-            class _Constraint                                          = __pair_like_constructible<_UPair>,
-            enable_if_t<_Constraint::__is_deleted, int>                = 0>
+            class _Constraints                                         = __pair_like_constructible<_UPair>,
+            enable_if_t<_Constraints::__is_deleted, int>               = 0>
   _CCCL_API constexpr pair(_UPair&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
   // NOLINTEND(bugprone-forwarding-reference-overload)
@@ -603,8 +603,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   // NOLINTBEGIN(bugprone-use-after-move)
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
-            class _Constraint                           = __pair_like_assignable</*__is_const=*/false, _UPair>,
-            enable_if_t<_Constraint::__can_assign, int> = 0>
+            class _Constraints                           = __pair_like_assignable</*__is_const=*/false, _UPair>,
+            enable_if_t<_Constraints::__can_assign, int> = 0>
   _CCCL_API constexpr pair& operator=(_UPair&& __p) noexcept(
     is_nothrow_assignable_v<_T1&, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
     && is_nothrow_assignable_v<_T2&, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)
@@ -617,8 +617,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
-            class _Constraint                           = __pair_like_assignable</*__is_const=*/true, _UPair>,
-            enable_if_t<_Constraint::__can_assign, int> = 0>
+            class _Constraints                           = __pair_like_assignable</*__is_const=*/true, _UPair>,
+            enable_if_t<_Constraints::__can_assign, int> = 0>
   _CCCL_API constexpr const pair& operator=(_UPair&& __p) const noexcept(
     is_nothrow_assignable_v<const _T1&, decltype(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)))>
     && is_nothrow_assignable_v<const _T2&, decltype(::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))>)


### PR DESCRIPTION
`cuda::std::tuple` has come up as one of the more costly types in some of the tested third party projects.

This tries to improve the compile time of the various constructor SFINAE which has been a large part of the cost.

The idea is to move type definitions out of `__tuple_constraints` which makes that struct really cheap.

It also helps to only compile the constraints when necessary.

We also try to disambiguate a bit earlier so that we do not have to compile the full `__select_tuple_like_constructible` so often