### PR TITLE
Enable the clang-tidy misc category

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,6 +35,21 @@ Checks:
   # This is just noise
   - '-bugprone-signed-char-misuse'
   - '-bugprone-multi-level-implicit-pointer-conversion'
+  - 'misc-*'
+  - '-misc-const-correctness'
+  - '-misc-use-anonymous-namespace'
+  - '-misc-use-internal-linkage'
+  - '-misc-unused-parameters'
+  - '-misc-redundant-expression'
+  - '-misc-unconventional-assign-operator'
+  - '-misc-throw-by-value-catch-by-reference'
+  - '-misc-misplaced-const'
+  - '-misc-multiple-inheritance'
+  - '-misc-anonymous-namespace-in-header'
+  - '-misc-definitions-in-headers'
+  - '-misc-override-with-different-visibility'
+  - '-misc-predictable-rand'
+  - '-misc-unused-alias-decls'
   # END REMOVE ME
   # TODO(jfaibussowit):
   #


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Enable the `misc-*` category while disabling all the checks that need fixes (as per https://github.com/NVIDIA/cccl/pull/11034)

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
