### PR TITLE
[CI] Add manual Windows container publisher

### DIFF
--- a/.github/workflows/publish-windows-containers.yml
+++ b/.github/workflows/publish-windows-containers.yml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish Windows containers
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: publish-windows-containers
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Verify package
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      packages: read
+    steps:
+      - name: Require internal package
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          visibility="$(
+            gh api /orgs/NVIDIA/packages/container/cccl-windows-containers \
+              --jq '.visibility'
+          )"
+          if [[ "${visibility}" != "internal" ]]; then
+            echo "::error::Expected cccl-windows-containers to be internal; found ${visibility}."
+            exit 1
+          fi
+
+  publish:
+    name: Build and publish Windows containers
+    needs: preflight
+    permissions:
+      contents: read
+      packages: write
+    uses: rapidsai/devcontainers/.github/workflows/release-windows.yml@f0d3eebdef13157c4f6bd5ae8462c0194beac82f
+    with:
+      repo: ghcr.io/nvidia/cccl-windows-containers


### PR DESCRIPTION
## Description

Related: https://github.com/rapidsai/devcontainers/pull/760

Adds an on-demand workflow that builds, tests, and publishes the full Windows
devcontainer matrix to the internal
`ghcr.io/nvidia/cccl-windows-containers` package.

The workflow:

- can only be started manually;
- verifies that the destination package is internal before building;
- serializes publisher runs without cancelling an in-progress release;
- hard-codes the destination package;
- grants `packages: write` only to the reusable publishing job; and
- passes no CCCL repository or organization secrets.

The reusable workflow is pinned to the exact tested head of devcontainers #760.
Keep this PR in draft until that dependency merges, then update the pin if its
merge strategy produces a different commit.

Before the first dispatch, the package settings must grant `NVIDIA/cccl` Write
under **Manage Actions access**.

## Validation

- `pre-commit run --files .github/workflows/publish-windows-containers.yml`
- `actionlint .github/workflows/publish-windows-containers.yml`
- GitHub workflow JSON Schema validation
- Cross-repository E2E: https://github.com/NVIDIA/cccl/actions/runs/33660598173
- Internal package: https://github.com/orgs/NVIDIA/packages/container/package/cccl-windows-containers

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
