### PR TITLE
`modernize-loop-convert`

### DIFF
--- a/thrust/testing/set_difference.cu
+++ b/thrust/testing/set_difference.cu
@@ -82,10 +82,8 @@ void TestSetDifference(const size_t n)
   thrust::device_vector<T> d_a = h_a;
   thrust::device_vector<T> d_b = h_b;
 
-  for (size_t i = 0; i < num_sizes; i++)
+  for (const size_t size : sizes)
   {
-    size_t size = sizes[i];
-
     thrust::host_vector<T> h_result(n + size);
     thrust::device_vector<T> d_result(n + size);
 

--- a/thrust/testing/set_difference_by_key.cu
+++ b/thrust/testing/set_difference_by_key.cu
@@ -116,12 +116,11 @@ void TestSetDifferenceByKey(const size_t n)
   thrust::host_vector<T> random_keys = unittest::random_integers<unittest::int8_t>(n);
   thrust::host_vector<T> random_vals = unittest::random_integers<unittest::int8_t>(n);
 
-  size_t denominators[]   = {1, 2, 3, 4, 5, 6, 7, 8, 9};
-  size_t num_denominators = sizeof(denominators) / sizeof(size_t);
+  const size_t denominators[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  for (size_t i = 0; i < num_denominators; ++i)
+  for (const size_t denominator : denominators)
   {
-    size_t size_a = n / denominators[i];
+    const size_t size_a = n / denominator;
 
     thrust::host_vector<T> h_a_keys(random_keys.begin(), random_keys.begin() + size_a);
     thrust::host_vector<T> h_b_keys(random_keys.begin() + size_a, random_keys.end());

--- a/thrust/testing/set_intersection.cu
+++ b/thrust/testing/set_intersection.cu
@@ -84,10 +84,8 @@ void TestSetIntersection(const size_t n)
   thrust::device_vector<T> d_a = h_a;
   thrust::device_vector<T> d_b = h_b;
 
-  for (size_t i = 0; i < num_sizes; i++)
+  for (const size_t size : sizes)
   {
-    size_t size = sizes[i];
-
     thrust::host_vector<T> h_result(n + size);
     thrust::device_vector<T> d_result(n + size);
 

--- a/thrust/testing/set_intersection_by_key.cu
+++ b/thrust/testing/set_intersection_by_key.cu
@@ -99,12 +99,11 @@ void TestSetIntersectionByKey(const size_t n)
   thrust::host_vector<T> random_keys = unittest::random_integers<unittest::int8_t>(n);
   thrust::host_vector<T> random_vals = unittest::random_integers<unittest::int8_t>(n);
 
-  size_t denominators[]   = {1, 2, 3, 4, 5, 6, 7, 8, 9};
-  size_t num_denominators = sizeof(denominators) / sizeof(size_t);
+  const size_t denominators[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  for (size_t i = 0; i < num_denominators; ++i)
+  for (const size_t denominator : denominators)
   {
-    size_t size_a = n / denominators[i];
+    const size_t size_a = n / denominator;
 
     thrust::host_vector<T> h_a_keys(random_keys.begin(), random_keys.begin() + size_a);
     thrust::host_vector<T> h_b_keys(random_keys.begin() + size_a, random_keys.end());

--- a/thrust/testing/set_symmetric_difference.cu
+++ b/thrust/testing/set_symmetric_difference.cu
@@ -83,10 +83,8 @@ void TestSetSymmetricDifference(const size_t n)
   thrust::device_vector<T> d_a = h_a;
   thrust::device_vector<T> d_b = h_b;
 
-  for (size_t i = 0; i < num_sizes; i++)
+  for (const size_t size : sizes)
   {
-    size_t size = sizes[i];
-
     thrust::host_vector<T> h_result(n + size);
     thrust::device_vector<T> d_result(n + size);
 

--- a/thrust/testing/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/set_symmetric_difference_by_key.cu
@@ -111,12 +111,11 @@ void TestSetSymmetricDifferenceByKey(const size_t n)
   thrust::host_vector<T> random_keys = unittest::random_integers<unittest::int8_t>(n);
   thrust::host_vector<T> random_vals = unittest::random_integers<unittest::int8_t>(n);
 
-  size_t denominators[]   = {1, 2, 3, 4, 5, 6, 7, 8, 9};
-  size_t num_denominators = sizeof(denominators) / sizeof(size_t);
+  const size_t denominators[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  for (size_t i = 0; i < num_denominators; ++i)
+  for (const size_t denominator : denominators)
   {
-    size_t size_a = n / denominators[i];
+    const size_t size_a = n / denominator;
 
     thrust::host_vector<T> h_a_keys(random_keys.begin(), random_keys.begin() + size_a);
     thrust::host_vector<T> h_b_keys(random_keys.begin() + size_a, random_keys.end());

--- a/thrust/testing/set_union.cu
+++ b/thrust/testing/set_union.cu
@@ -100,10 +100,8 @@ void TestSetUnion(const size_t n)
   thrust::device_vector<T> d_a = h_a;
   thrust::device_vector<T> d_b = h_b;
 
-  for (size_t i = 0; i < num_sizes; i++)
+  for (const size_t size : sizes)
   {
-    size_t size = sizes[i];
-
     thrust::host_vector<T> h_result(n + size);
     thrust::device_vector<T> d_result(n + size);
 

--- a/thrust/testing/set_union_by_key.cu
+++ b/thrust/testing/set_union_by_key.cu
@@ -111,12 +111,11 @@ void TestSetUnionByKey(const size_t n)
   thrust::host_vector<T> random_keys = unittest::random_integers<unittest::int8_t>(n);
   thrust::host_vector<T> random_vals = unittest::random_integers<unittest::int8_t>(n);
 
-  size_t denominators[]   = {1, 2, 3, 4, 5, 6, 7, 8, 9};
-  size_t num_denominators = sizeof(denominators) / sizeof(size_t);
+  const size_t denominators[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  for (size_t i = 0; i < num_denominators; ++i)
+  for (const size_t denominator : denominators)
   {
-    size_t size_a = n / denominators[i];
+    const size_t size_a = n / denominator;
 
     thrust::host_vector<T> h_a_keys(random_keys.begin(), random_keys.begin() + size_a);
     thrust::host_vector<T> h_b_keys(random_keys.begin() + size_a, random_keys.end());


### PR DESCRIPTION
Fixes all clang-tidy warnings for `modernize-loop-convert`

This check should actually already have fired, but the previous code did not use `const` and so presumably the checker did not recognize the idiom. Once `misc-const-correctness` changed the induction variables to `const` it started firing