### PR TITLE
`misc-unused-parameters`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -109,6 +109,7 @@ Checks:
   # single target branch, so it reports parameters that are used only inside NV_IF_TARGET,
   # NV_IF_ELSE_TARGET, or inline asm operands as unused. The compiler sees the branch it
   # actually compiles and does not.
+  - '-misc-unused-parameters'
   - '-modernize-macro-to-enum'
   - '-cppcoreguidelines-macro-to-enum'
   - '-misc-no-recursion'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,7 +39,6 @@ Checks:
   - '-misc-const-correctness'
   - '-misc-use-anonymous-namespace'
   - '-misc-use-internal-linkage'
-  - '-misc-unused-parameters'
   - '-misc-redundant-expression'
   - '-misc-unconventional-assign-operator'
   - '-misc-throw-by-value-catch-by-reference'
@@ -106,6 +105,10 @@ Checks:
   - '-bugprone-implicit-widening-of-multiplication-result'
   - '-misc-include-cleaner'
   - '-misc-header-include-cycle'
+  # Covered by -Wunused-parameter, which is the better tool here. clang-tidy analyzes a
+  # single target branch, so it reports parameters that are used only inside NV_IF_TARGET,
+  # NV_IF_ELSE_TARGET, or inline asm operands as unused. The compiler sees the branch it
+  # actually compiles and does not.
   - '-modernize-macro-to-enum'
   - '-cppcoreguidelines-macro-to-enum'
   - '-misc-no-recursion'


### PR DESCRIPTION
Fixes all clang-tidy warnings for `misc-unused-parameters`