### PR TITLE
`misc-redundant-expression`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,7 +39,6 @@ Checks:
   - '-misc-const-correctness'
   - '-misc-use-anonymous-namespace'
   - '-misc-use-internal-linkage'
-  - '-misc-redundant-expression'
   - '-misc-throw-by-value-catch-by-reference'
   - '-misc-misplaced-const'
   - '-misc-multiple-inheritance'

--- a/cudax/test/utility/optionally_static.cu
+++ b/cudax/test/utility/optionally_static.cu
@@ -20,6 +20,7 @@ TEST_CASE("optionally_static static value", "[utility]")
 {
   constexpr cudax::optionally_static<::std::size_t(42), 0> v1;
   static_assert(v1.get() == 42);
+  // NOLINTNEXTLINE(misc-redundant-expression): tests reflexivity of operator==
   static_assert(v1 == v1);
   static_assert(v1 == 42UL);
 

--- a/libcudacxx/include/cuda/std/__cmath/isnan.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnan.h
@@ -49,6 +49,8 @@ template <class _Tp>
     return ::isnan(__x);
   }
 #endif // !_CCCL_TILE_COMPILATION()
+  // x != x is the canonical NaN test: it is true only when x is NaN.
+  // NOLINTNEXTLINE(misc-redundant-expression)
   return __x != __x;
 }
 

--- a/thrust/testing/vector.cu
+++ b/thrust/testing/vector.cu
@@ -351,6 +351,7 @@ void TestVectorToAndFromHostVector()
 
   ASSERT_EQUAL(v, h);
 
+  // NOLINTNEXTLINE(misc-redundant-expression): self-assignment is what this test checks
   v = v;
 
   ASSERT_EQUAL(v, h);
@@ -404,6 +405,7 @@ void TestVectorToAndFromDeviceVector()
 
   ASSERT_EQUAL(v, h);
 
+  // NOLINTNEXTLINE(misc-redundant-expression): self-assignment is what this test checks
   v = v;
 
   ASSERT_EQUAL(v, h);

--- a/thrust/thrust/detail/complex/ccosh.h
+++ b/thrust/thrust/detail/complex/ccosh.h
@@ -59,6 +59,10 @@ namespace detail::complex
  * These values and the return value were taken from n1124.pdf.
  */
 
+// `y - y` is a deliberate IEEE-754 idiom, not a redundant expression: it yields +0.0 for a
+// finite y and propagates a NaN or raises invalid for an infinite y. C99 Annex G specifies
+// the complex functions in these terms.
+// NOLINTBEGIN(misc-redundant-expression)
 _CCCL_HOST_DEVICE inline thrust::complex<double> ccosh(const thrust::complex<double>& z)
 {
   const double huge = 8.98846567431157953864652595395e+307; // 0x1p1023
@@ -182,6 +186,7 @@ _CCCL_HOST_DEVICE inline thrust::complex<double> ccosh(const thrust::complex<dou
    */
   return (thrust::complex<double>((x * x) * (y - y), (x + x) * (y - y)));
 }
+// NOLINTEND(misc-redundant-expression)
 
 _CCCL_HOST_DEVICE inline thrust::complex<double> ccos(const thrust::complex<double>& z)
 {

--- a/thrust/thrust/detail/complex/ccoshf.h
+++ b/thrust/thrust/detail/complex/ccoshf.h
@@ -52,6 +52,10 @@ namespace detail::complex
 {
 using thrust::complex;
 
+// `y - y` is a deliberate IEEE-754 idiom, not a redundant expression: it yields +0.0 for a
+// finite y and propagates a NaN or raises invalid for an infinite y. C99 Annex G specifies
+// the complex functions in these terms.
+// NOLINTBEGIN(misc-redundant-expression)
 _CCCL_HOST_DEVICE inline complex<float> ccoshf(const complex<float>& z)
 {
   float x, y, h;
@@ -127,6 +131,7 @@ _CCCL_HOST_DEVICE inline complex<float> ccoshf(const complex<float>& z)
   }
   return (complex<float>((x * x) * (y - y), (x + x) * (y - y)));
 }
+// NOLINTEND(misc-redundant-expression)
 
 _CCCL_HOST_DEVICE inline complex<float> ccosf(const complex<float>& z)
 {

--- a/thrust/thrust/detail/complex/cexp.h
+++ b/thrust/thrust/detail/complex/cexp.h
@@ -98,6 +98,10 @@ _CCCL_HOST_DEVICE inline complex<double> ldexp_cexp(complex<double> z, int expt)
     complex<double>(::cuda::std::cos(y) * exp_x * scale1 * scale2, ::cuda::std::sin(y) * exp_x * scale1 * scale2));
 }
 
+// `y - y` is a deliberate IEEE-754 idiom, not a redundant expression: it yields +0.0 for a
+// finite y and propagates a NaN or raises invalid for an infinite y. C99 Annex G specifies
+// the complex functions in these terms.
+// NOLINTBEGIN(misc-redundant-expression)
 _CCCL_HOST_DEVICE inline complex<double> cexp(const complex<double>& z)
 {
   double x, y, exp_x;
@@ -164,6 +168,7 @@ _CCCL_HOST_DEVICE inline complex<double> cexp(const complex<double>& z)
     return (complex<double>(exp_x * ::cuda::std::cos(y), exp_x * ::cuda::std::sin(y)));
   }
 }
+// NOLINTEND(misc-redundant-expression)
 } // namespace detail::complex
 
 template <typename ValueType>

--- a/thrust/thrust/detail/complex/cexpf.h
+++ b/thrust/thrust/detail/complex/cexpf.h
@@ -81,6 +81,10 @@ _CCCL_HOST_DEVICE inline complex<float> ldexp_cexpf(complex<float> z, int expt)
   return (complex<float>(::cuda::std::cos(y) * exp_x * scale1 * scale2, ::cuda::std::sin(y) * exp_x * scale1 * scale2));
 }
 
+// `y - y` is a deliberate IEEE-754 idiom, not a redundant expression: it yields +0.0 for a
+// finite y and propagates a NaN or raises invalid for an infinite y. C99 Annex G specifies
+// the complex functions in these terms.
+// NOLINTBEGIN(misc-redundant-expression)
 _CCCL_HOST_DEVICE inline complex<float> cexpf(const complex<float>& z)
 {
   float x, y, exp_x;
@@ -146,6 +150,7 @@ _CCCL_HOST_DEVICE inline complex<float> cexpf(const complex<float>& z)
     return (complex<float>(exp_x * ::cuda::std::cos(y), exp_x * ::cuda::std::sin(y)));
   }
 }
+// NOLINTEND(misc-redundant-expression)
 } // namespace detail::complex
 
 template <>

--- a/thrust/thrust/detail/complex/csinh.h
+++ b/thrust/thrust/detail/complex/csinh.h
@@ -52,6 +52,10 @@ namespace detail::complex
 {
 using thrust::complex;
 
+// `y - y` is a deliberate IEEE-754 idiom, not a redundant expression: it yields +0.0 for a
+// finite y and propagates a NaN or raises invalid for an infinite y. C99 Annex G specifies
+// the complex functions in these terms.
+// NOLINTBEGIN(misc-redundant-expression)
 _CCCL_HOST_DEVICE inline complex<double> csinh(const complex<double>& z)
 {
   double x, y, h;
@@ -175,6 +179,7 @@ _CCCL_HOST_DEVICE inline complex<double> csinh(const complex<double>& z)
    */
   return (complex<double>((x * x) * (y - y), (x + x) * (y - y)));
 }
+// NOLINTEND(misc-redundant-expression)
 
 _CCCL_HOST_DEVICE inline complex<double> csin(complex<double> z)
 {

--- a/thrust/thrust/detail/complex/csinhf.h
+++ b/thrust/thrust/detail/complex/csinhf.h
@@ -53,6 +53,10 @@ namespace detail::complex
 {
 using thrust::complex;
 
+// `y - y` is a deliberate IEEE-754 idiom, not a redundant expression: it yields +0.0 for a
+// finite y and propagates a NaN or raises invalid for an infinite y. C99 Annex G specifies
+// the complex functions in these terms.
+// NOLINTBEGIN(misc-redundant-expression)
 _CCCL_HOST_DEVICE inline complex<float> csinhf(const complex<float>& z)
 {
   float x, y, h;
@@ -133,6 +137,7 @@ _CCCL_HOST_DEVICE inline complex<float> csinhf(const complex<float>& z)
 
   return (complex<float>((x * x) * (y - y), (x + x) * (y - y)));
 }
+// NOLINTEND(misc-redundant-expression)
 
 _CCCL_HOST_DEVICE inline complex<float> csinf(complex<float> z)
 {

--- a/thrust/thrust/detail/complex/csqrt.h
+++ b/thrust/thrust/detail/complex/csqrt.h
@@ -54,6 +54,11 @@ namespace detail::complex
 {
 using thrust::complex;
 
+// `b - b` and `(b - b) / (b - b)` are deliberate IEEE-754 idioms, not redundant
+// expressions: the former yields +0.0 for a finite b and propagates a NaN, and the latter
+// is 0/0, which produces a NaN and raises the invalid flag. C99 Annex G specifies the
+// complex functions in these terms.
+// NOLINTBEGIN(misc-redundant-expression)
 _CCCL_HOST_DEVICE inline complex<double> csqrt(const complex<double>& z)
 {
   complex<double> result;
@@ -148,6 +153,7 @@ _CCCL_HOST_DEVICE inline complex<double> csqrt(const complex<double>& z)
     return (result);
   }
 }
+// NOLINTEND(misc-redundant-expression)
 } // namespace detail::complex
 
 template <typename ValueType>

--- a/thrust/thrust/detail/complex/csqrtf.h
+++ b/thrust/thrust/detail/complex/csqrtf.h
@@ -54,6 +54,11 @@ namespace detail::complex
 {
 using thrust::complex;
 
+// `b - b` and `(b - b) / (b - b)` are deliberate IEEE-754 idioms, not redundant
+// expressions: the former yields +0.0 for a finite b and propagates a NaN, and the latter
+// is 0/0, which produces a NaN and raises the invalid flag. C99 Annex G specifies the
+// complex functions in these terms.
+// NOLINTBEGIN(misc-redundant-expression)
 _CCCL_HOST_DEVICE inline complex<float> csqrtf(const complex<float>& z)
 {
   float a = z.real(), b = z.imag();
@@ -150,6 +155,7 @@ _CCCL_HOST_DEVICE inline complex<float> csqrtf(const complex<float>& z)
     return (result);
   }
 }
+// NOLINTEND(misc-redundant-expression)
 } // namespace detail::complex
 
 template <>

--- a/thrust/thrust/detail/complex/ctanh.h
+++ b/thrust/thrust/detail/complex/ctanh.h
@@ -94,6 +94,10 @@ namespace detail::complex
 {
 using thrust::complex;
 
+// `y - y` is a deliberate IEEE-754 idiom, not a redundant expression: it yields +0.0 for a
+// finite y and propagates a NaN or raises invalid for an infinite y. C99 Annex G specifies
+// the complex functions in these terms.
+// NOLINTBEGIN(misc-redundant-expression)
 _CCCL_HOST_DEVICE inline complex<double> ctanh(const complex<double>& z)
 {
   double x, y;
@@ -162,6 +166,7 @@ _CCCL_HOST_DEVICE inline complex<double> ctanh(const complex<double>& z)
   denom = 1.0 + beta * s * s;
   return (complex<double>((beta * rho * s) / denom, t / denom));
 }
+// NOLINTEND(misc-redundant-expression)
 
 _CCCL_HOST_DEVICE inline complex<double> ctan(complex<double> z)
 {

--- a/thrust/thrust/detail/complex/ctanhf.h
+++ b/thrust/thrust/detail/complex/ctanhf.h
@@ -58,6 +58,10 @@ namespace detail::complex
 {
 using thrust::complex;
 
+// `y - y` is a deliberate IEEE-754 idiom, not a redundant expression: it yields +0.0 for a
+// finite y and propagates a NaN or raises invalid for an infinite y. C99 Annex G specifies
+// the complex functions in these terms.
+// NOLINTBEGIN(misc-redundant-expression)
 _CCCL_HOST_DEVICE inline complex<float> ctanhf(const complex<float>& z)
 {
   float x, y;
@@ -100,6 +104,7 @@ _CCCL_HOST_DEVICE inline complex<float> ctanhf(const complex<float>& z)
   denom = 1.0f + beta * s * s;
   return (complex<float>((beta * rho * s) / denom, t / denom));
 }
+// NOLINTEND(misc-redundant-expression)
 
 _CCCL_HOST_DEVICE inline complex<float> ctanf(complex<float> z)
 {


### PR DESCRIPTION
Fixes all clang-tidy warnings for `misc-redundant-expression`