### PR TITLE
`misc-unconventional-assign-operator`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,7 +41,6 @@ Checks:
   - '-misc-use-internal-linkage'
   - '-misc-unused-parameters'
   - '-misc-redundant-expression'
-  - '-misc-unconventional-assign-operator'
   - '-misc-throw-by-value-catch-by-reference'
   - '-misc-misplaced-const'
   - '-misc-multiple-inheritance'
@@ -223,7 +222,6 @@ Checks:
   # REVIEW ME: This warns about any usage of operator[], suggesting usage of .at() instead. Could
   - '-cppcoreguidelines-pro-bounds-avoid-unchecked-container-access'
   - '-cppcoreguidelines-narrowing-conversions'
-  # Covered by misc-unconventional-assign-operator
   - '-cppcoreguidelines-c-copy-assignment-signature'
   # Covered by performance-noexcept-swap
   - '-cppcoreguidelines-noexcept-swap'

--- a/libcudacxx/include/cuda/__utility/__basic_any/basic_any_value.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/basic_any_value.h
@@ -228,6 +228,9 @@ public:
   //! __basic_any(cuda::std::move(__other)).swap(*this);
   //! return *this;
   //! @endcode
+  // The return type is already __basic_any&; __assign_from returns *this, which the check
+  // does not follow.
+  // NOLINTBEGIN(misc-unconventional-assign-operator)
   _CCCL_TEMPLATE(class _OtherInterface)
   _CCCL_REQUIRES((!::cuda::std::same_as<_OtherInterface, _Interface>)
                    _CCCL_AND __any_convertible_to<__basic_any<_OtherInterface>, __basic_any>)
@@ -235,6 +238,7 @@ public:
   {
     return __assign_from(::cuda::std::move(__other));
   }
+  // NOLINTEND(misc-unconventional-assign-operator)
 
   //! @brief Converting copy assignment operator from a compatible `__basic_any`
   //! object.
@@ -245,6 +249,7 @@ public:
   //! __basic_any(__other).swap(*this);
   //! return *this;
   //! @endcode
+  // NOLINTBEGIN(misc-unconventional-assign-operator): __assign_from returns *this
   _CCCL_TEMPLATE(class _OtherInterface)
   _CCCL_REQUIRES((!::cuda::std::same_as<_OtherInterface, _Interface>)
                    _CCCL_AND __any_convertible_to<__basic_any<_OtherInterface> const&, __basic_any>)
@@ -252,6 +257,7 @@ public:
   {
     return __assign_from(__other);
   }
+  // NOLINTEND(misc-unconventional-assign-operator)
 #else
   // nvcc 12.0 has a bug with its concepts implementation where substitution occurs too
   // early here causing a hard error. So we use SFINAE to work around it.

--- a/libcudacxx/include/cuda/std/__utility/constant_wrapper.h
+++ b/libcudacxx/include/cuda/std/__utility/constant_wrapper.h
@@ -384,6 +384,9 @@ struct __constant_wrapper : __cw_operators
 
   static constexpr decltype((_Xp)) value = (_Xp);
 
+  // [const.wrap.class] mandates this signature: operator= is a constant-expression
+  // operation that yields a new constant_wrapper, so it must not return *this.
+  // NOLINTBEGIN(misc-unconventional-assign-operator)
   _CCCL_TEMPLATE(class _Rp)
   _CCCL_REQUIRES(__is_constexpr_param_v<_Rp>)
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr decltype(__constant_wrapper<_LIBCUDACXX_AUTO_CAST(value = _Rp::value)>{})
@@ -391,6 +394,7 @@ struct __constant_wrapper : __cw_operators
   {
     return {};
   }
+  // NOLINTEND(misc-unconventional-assign-operator)
 
   _CCCL_HOST_DEVICE_API constexpr operator decltype(value)() const noexcept
   {

--- a/thrust/testing/copy.cu
+++ b/thrust/testing/copy.cu
@@ -704,6 +704,9 @@ struct only_set_when_expected_it
     return *this;
   }
 
+  // Write-only test proxy: assignment records that the expected value was written.
+  // There is no meaningful object to return.
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator)
   _CCCL_DEVICE void operator=(long long value) const
   {
     if (value == expected)

--- a/thrust/testing/cpp/adjacent_difference.cu
+++ b/thrust/testing/cpp/adjacent_difference.cu
@@ -34,6 +34,9 @@ struct detect_wrong_difference
     return *this;
   }
 
+  // Write-only test proxy: assignment records whether the difference was as expected.
+  // There is no meaningful object to return.
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator)
   _CCCL_DEVICE void operator=(long long difference) const
   {
     if (difference != 1)

--- a/thrust/testing/scan.cu
+++ b/thrust/testing/scan.cu
@@ -567,6 +567,9 @@ struct only_set_when_expected_it
     return *this;
   }
 
+  // Write-only test proxy: assignment records that the expected value was written.
+  // There is no meaningful object to return.
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator)
   _CCCL_DEVICE void operator=(long long value) const
   {
     if (value == expected)

--- a/thrust/thrust/detail/pointer.h
+++ b/thrust/thrust/detail/pointer.h
@@ -215,11 +215,16 @@ public:
   // assignment
 
   // NOTE: This is needed so that Thrust smart pointers can be used in `std::unique_ptr`.
+  //
+  // pointer is a CRTP base, so derived_type& is the correct return type. Returning pointer&
+  // instead would slice off the derived type.
+  // NOLINTBEGIN(misc-unconventional-assign-operator): CRTP base, see above
   _CCCL_HOST_DEVICE derived_type& operator=(::cuda::std::nullptr_t)
   {
     super_t::base_reference() = nullptr;
     return static_cast<derived_type&>(*this);
   }
+  // NOLINTEND(misc-unconventional-assign-operator)
 
   /*! Assignment operator allows assigning from another pointer-like object whose element type
    *  is convertible to \c Element.
@@ -230,6 +235,7 @@ public:
    *  \tparam OtherPointer The tag associated with \p OtherPointer shall be convertible to \p Tag,
    *                       and its element type shall be convertible to \p Element.
    */
+  // NOLINTBEGIN(misc-unconventional-assign-operator): CRTP base, see above
   template <typename OtherPointer>
   _CCCL_HOST_DEVICE detail::enable_if_pointer_is_convertible_t<OtherPointer, pointer, derived_type&>
   operator=(const OtherPointer& other)
@@ -237,6 +243,7 @@ public:
     super_t::base_reference() = ::cuda::std::to_address(other);
     return static_cast<derived_type&>(*this);
   }
+  // NOLINTEND(misc-unconventional-assign-operator)
 
   // observers
 

--- a/thrust/thrust/detail/reference.h
+++ b/thrust/thrust/detail/reference.h
@@ -121,6 +121,11 @@ public:
    *
    *  \return <tt>*this</tt>.
    */
+  // A reference refers to an object elsewhere, so assigning through a const reference
+  // writes the referent and not the proxy. This mirrors std::vector<bool>::reference and is
+  // what `*it = x` needs for output iterators. derived_type& is the CRTP derived type, so
+  // returning reference& instead would slice.
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator)
   _CCCL_HOST_DEVICE const derived_type& operator=(reference const& other) const
   {
     assign_from(&other);
@@ -138,6 +143,7 @@ public:
    *
    *  \return <tt>*this</tt>.
    */
+  // NOLINTBEGIN(misc-unconventional-assign-operator): proxy reference, see above
   template <
     typename OtherElement,
     typename OtherPointer,
@@ -150,6 +156,7 @@ public:
     assign_from(&other);
     return derived();
   }
+  // NOLINTEND(misc-unconventional-assign-operator)
 
   /*! Assign \p rhs to the object referred to by this \p tagged_reference.
    *
@@ -157,6 +164,7 @@ public:
    *
    *  \return <tt>*this</tt>.
    */
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator): proxy reference, see above
   _CCCL_HOST_DEVICE const derived_type& operator=(value_type const& rhs) const
   {
     assign_from(&rhs);
@@ -547,6 +555,10 @@ public:
    *
    *  \return <tt>*this</tt>.
    */
+  // A tagged_reference refers to an object elsewhere, so assigning through a const
+  // reference writes the referent and not the proxy. This mirrors
+  // std::vector<bool>::reference and is what `*it = x` needs for output iterators.
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator)
   _CCCL_HOST_DEVICE const tagged_reference& operator=(tagged_reference const& other) const
   {
     return base_type::operator=(other);
@@ -562,11 +574,13 @@ public:
    *
    *  \return <tt>*this</tt>.
    */
+  // NOLINTBEGIN(misc-unconventional-assign-operator): proxy reference, see above
   template <typename OtherElement, typename OtherTag>
   _CCCL_HOST_DEVICE const tagged_reference& operator=(tagged_reference<OtherElement, OtherTag> const& other) const
   {
     return base_type::operator=(other);
   }
+  // NOLINTEND(misc-unconventional-assign-operator)
 
   /*! Assign \p rhs to the object referred to by this \p tagged_reference.
    *
@@ -574,6 +588,7 @@ public:
    *
    *  \return <tt>*this</tt>.
    */
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator): proxy reference, see above
   _CCCL_HOST_DEVICE const tagged_reference& operator=(value_type const& rhs) const
   {
     return base_type::operator=(rhs);

--- a/thrust/thrust/device_reference.h
+++ b/thrust/thrust/device_reference.h
@@ -274,6 +274,10 @@ public:
       : super_t(ptr)
   {}
 
+  // A device_reference refers to an object in device memory, so assigning through a const
+  // reference writes the referent and not the proxy. This mirrors
+  // std::vector<bool>::reference and is what `*it = x` needs for output iterators.
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator)
   _CCCL_HOST_DEVICE const device_reference& operator=(const device_reference& other) const
   {
     return super_t::operator=(other);
@@ -290,11 +294,13 @@ public:
    *     .. versionadded:: 2.2.0
    *  \endverbatim
    */
+  // NOLINTBEGIN(misc-unconventional-assign-operator): proxy reference, see above
   template <typename OtherT>
   _CCCL_HOST_DEVICE const device_reference& operator=(const device_reference<OtherT>& other) const
   {
     return super_t::operator=(other);
   }
+  // NOLINTEND(misc-unconventional-assign-operator)
 
   /*! Assignment operator assigns the value of the given value to the
    *  value referenced by this \p device_reference.
@@ -306,6 +312,7 @@ public:
    *     .. versionadded:: 2.2.0
    *  \endverbatim
    */
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator): proxy reference, see above
   _CCCL_HOST_DEVICE const device_reference& operator=(const value_type& x) const
   {
     return super_t::operator=(x);

--- a/thrust/thrust/iterator/tabulate_output_iterator.h
+++ b/thrust/thrust/iterator/tabulate_output_iterator.h
@@ -36,6 +36,9 @@ public:
       , index(index)
   {}
 
+  // Write-only proxy: assignment invokes fun with the index and the assigned value.
+  // Returning by value keeps the proxy usable in a chained `*it = a = b` expression.
+  // NOLINTBEGIN(misc-unconventional-assign-operator)
   _CCCL_EXEC_CHECK_DISABLE
   template <typename T>
   _CCCL_HOST_DEVICE tabulate_output_iterator_proxy operator=(const T& x)
@@ -43,6 +46,7 @@ public:
     fun(index, x);
     return *this;
   }
+  // NOLINTEND(misc-unconventional-assign-operator)
 
 private:
   BinaryFunction fun;

--- a/thrust/thrust/iterator/transform_input_output_iterator.h
+++ b/thrust/thrust/iterator/transform_input_output_iterator.h
@@ -51,6 +51,9 @@ public:
     return input_function(*io);
   }
 
+  // Read-write proxy: assignment transforms x and forwards it to the wrapped iterator.
+  // Returning by value keeps the proxy usable in a chained `*it = a = b` expression.
+  // NOLINTBEGIN(misc-unconventional-assign-operator)
   _CCCL_EXEC_CHECK_DISABLE
   template <typename T>
   _CCCL_HOST_DEVICE transform_input_output_iterator_proxy operator=(const T& x)
@@ -65,6 +68,7 @@ public:
     *io = output_function(x);
     return *this;
   }
+  // NOLINTEND(misc-unconventional-assign-operator)
 
 private:
   Iterator io;

--- a/thrust/thrust/iterator/transform_output_iterator.h
+++ b/thrust/thrust/iterator/transform_output_iterator.h
@@ -38,6 +38,9 @@ public:
       , fun(fun)
   {}
 
+  // Write-only proxy: assignment transforms x and forwards it to the wrapped iterator.
+  // Returning by value keeps the proxy usable in a chained `*it = a = b` expression.
+  // NOLINTBEGIN(misc-unconventional-assign-operator)
   _CCCL_EXEC_CHECK_DISABLE
   template <typename T>
   _CCCL_HOST_DEVICE transform_output_iterator_proxy operator=(const T& x)
@@ -45,6 +48,7 @@ public:
     *out = fun(x);
     return *this;
   }
+  // NOLINTEND(misc-unconventional-assign-operator)
 
 private:
   OutputIterator out;

--- a/thrust/thrust/system/detail/error_code.inl
+++ b/thrust/thrust/system/detail/error_code.inl
@@ -51,6 +51,8 @@ void error_code ::assign(int val, const error_category& cat)
   m_cat = &cat;
 } // end error_code::assign()
 
+// The enable_if_t below is error_code& after substitution, as the MSVC branch spells out.
+// NOLINTBEGIN(misc-unconventional-assign-operator)
 template <typename ErrorCodeEnum>
 // XXX WAR msvc's problem with enable_if
 #if !_CCCL_COMPILER(MSVC)
@@ -63,6 +65,7 @@ error_code ::operator=(ErrorCodeEnum e)
   *this = make_error_code(e);
   return *this;
 } // end error_code::operator=()
+// NOLINTEND(misc-unconventional-assign-operator)
 
 void error_code ::clear()
 {

--- a/thrust/thrust/system/detail/error_condition.inl
+++ b/thrust/thrust/system/detail/error_condition.inl
@@ -52,6 +52,9 @@ void error_condition ::assign(int val, const error_category& cat)
   m_cat = &cat;
 } // end error_category::assign()
 
+// The enable_if_t below is error_condition& after substitution, as the MSVC branch spells
+// out.
+// NOLINTBEGIN(misc-unconventional-assign-operator)
 template <typename ErrorConditionEnum>
 // XXX WAR msvc's problem with enable_if
 #if !_CCCL_COMPILER(MSVC)
@@ -64,6 +67,7 @@ error_condition ::operator=(ErrorConditionEnum e)
   *this = make_error_condition(e);
   return *this;
 } // end error_condition::operator=()
+// NOLINTEND(misc-unconventional-assign-operator)
 
 void error_condition ::clear()
 {

--- a/thrust/thrust/system/error_code.h
+++ b/thrust/thrust/system/error_code.h
@@ -255,6 +255,8 @@ public:
 
   /*! \post <tt>*this == make_error_code(e)</tt>.
    */
+  // The enable_if_t below is error_code& after substitution, as the MSVC branch spells out.
+  // NOLINTBEGIN(misc-unconventional-assign-operator)
   template <typename ErrorCodeEnum>
 // XXX WAR msvc's problem with enable_if
 #if !_CCCL_COMPILER(MSVC)
@@ -263,6 +265,7 @@ public:
   error_code&
 #endif // !_CCCL_COMPILER(MSVC)
   operator=(ErrorCodeEnum e);
+  // NOLINTEND(misc-unconventional-assign-operator)
 
   /*! \post <tt>value() == 0</tt> and <tt>category() == system_category()</tt>.
    */
@@ -376,6 +379,9 @@ public:
    *  \note This operator shall not participate in overload resolution unless
    *        <tt>is_error_condition_enum<ErrorConditionEnum>::value</tt> is <tt>true</tt>.
    */
+  // The enable_if_t below is error_condition& after substitution, as the MSVC branch
+  // spells out.
+  // NOLINTBEGIN(misc-unconventional-assign-operator)
   template <typename ErrorConditionEnum>
 // XXX WAR msvc's problem with enable_if
 #if !_CCCL_COMPILER(MSVC)
@@ -384,6 +390,7 @@ public:
   error_condition&
 #endif // !_CCCL_COMPILER(MSVC)
   operator=(ErrorConditionEnum e);
+  // NOLINTEND(misc-unconventional-assign-operator)
 
   /*! Clears this \p error_code object.
    *  \post <tt>value == 0</tt>


### PR DESCRIPTION
Fixes all clang-tidy warnings for `misc-unconventional-assign-operator`