### PR TITLE
`misc-throw-by-value-catch-by-reference`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,7 +39,6 @@ Checks:
   - '-misc-const-correctness'
   - '-misc-use-anonymous-namespace'
   - '-misc-use-internal-linkage'
-  - '-misc-throw-by-value-catch-by-reference'
   - '-misc-anonymous-namespace-in-header'
   - '-misc-override-with-different-visibility'
   # END REMOVE ME

--- a/thrust/testing/unittest/assertions.h
+++ b/thrust/testing/unittest/assertions.h
@@ -70,7 +70,7 @@
   {                                                    \
     unittest::UnitTestKnownFailure f;                  \
     f << "[" << FILE_ ":" << LINE_ << "]";             \
-    throw f;                                           \
+    throw cuda::std::move(f);                          \
   }                                                    \
   /**/
 
@@ -125,7 +125,7 @@ void assert_equal(T1 a, T2 b, const std::string& filename = "unknown", int linen
     f << "[" << filename << ":" << lineno << "] ";
     f << "values are not equal: " << a << " " << b;
     f << " [type='" << type_name<T1>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -137,7 +137,7 @@ inline void assert_equal(char a, char b, const std::string& filename = "unknown"
     f << "[" << filename << ":" << lineno << "] ";
     f << "values are not equal: " << int(a) << " " << int(b);
     f << " [type='" << type_name<char>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -151,7 +151,7 @@ void assert_equal_quiet(const T1& a, const T2& b, const std::string& filename = 
     f << "[" << filename << ":" << lineno << "] ";
     f << "values are not equal";
     f << " [type='" << type_name<T1>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -166,7 +166,7 @@ void assert_not_equal(T1 a, T2 b, const std::string& filename = "unknown", int l
     f << "[" << filename << ":" << lineno << "] ";
     f << "values are equal: " << a << " " << b;
     f << " [type='" << type_name<T1>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -178,7 +178,7 @@ inline void assert_not_equal(char a, char b, const std::string& filename = "unkn
     f << "[" << filename << ":" << lineno << "] ";
     f << "values are equal: " << int(a) << " " << int(b);
     f << " [type='" << type_name<char>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -192,7 +192,7 @@ void assert_not_equal_quiet(const T1& a, const T2& b, const std::string& filenam
     f << "[" << filename << ":" << lineno << "] ";
     f << "values are equal";
     f << " [type='" << type_name<T1>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -205,7 +205,7 @@ void assert_less(T1 a, T2 b, const std::string& filename = "unknown", int lineno
     f << "[" << filename << ":" << lineno << "] ";
     f << a << " is greater or equal to " << b;
     f << " [type='" << type_name<T1>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -217,7 +217,7 @@ inline void assert_less(char a, char b, const std::string& filename = "unknown",
     f << "[" << filename << ":" << lineno << "] ";
     f << int(a) << " is greater than or equal to " << int(b);
     f << " [type='" << type_name<char>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -230,7 +230,7 @@ void assert_greater(T1 a, T2 b, const std::string& filename = "unknown", int lin
     f << "[" << filename << ":" << lineno << "] ";
     f << a << " is less than or equal to " << b;
     f << " [type='" << type_name<T1>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -242,7 +242,7 @@ inline void assert_greater(char a, char b, const std::string& filename = "unknow
     f << "[" << filename << ":" << lineno << "] ";
     f << int(a) << " is less than or equal to " << int(b);
     f << " [type='" << type_name<char>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -255,7 +255,7 @@ void assert_lequal(T1 a, T2 b, const std::string& filename = "unknown", int line
     f << "[" << filename << ":" << lineno << "] ";
     f << a << " is greater than " << b;
     f << " [type='" << type_name<T1>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -267,7 +267,7 @@ inline void assert_lequal(char a, char b, const std::string& filename = "unknown
     f << "[" << filename << ":" << lineno << "] ";
     f << int(a) << " is greater than " << int(b);
     f << " [type='" << type_name<char>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -280,7 +280,7 @@ void assert_gequal(T1 a, T2 b, const std::string& filename = "unknown", int line
     f << "[" << filename << ":" << lineno << "] ";
     f << a << " is less than " << b;
     f << " [type='" << type_name<T1>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -292,7 +292,7 @@ inline void assert_gequal(char a, char b, const std::string& filename = "unknown
     f << "[" << filename << ":" << lineno << "] ";
     f << int(a) << " is less than " << int(b);
     f << " [type='" << type_name<char>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -347,7 +347,7 @@ void assert_almost_equal(
     f << "[" << filename << ":" << lineno << "] ";
     f << "values are not approximately equal: " << a << " " << b;
     f << " [type='" << type_name<T1>() << "']";
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -470,7 +470,7 @@ void assert_equal(
 
   if (failure)
   {
-    throw f;
+    throw cuda::std::move(f);
   }
 }
 
@@ -740,19 +740,19 @@ inline void check_assert_throws(
     case did_not_throw: {
       unittest::UnitTestFailure f;
       f << "[" << file_name << ":" << line_number << "] did not throw anything";
-      throw f;
+      throw cuda::std::move(f);
     }
     case threw_wrong_type: {
       unittest::UnitTestFailure f;
       f << "[" << file_name << ":" << line_number << "] did not throw an "
         << "object of type " << exception_name;
-      throw f;
+      throw cuda::std::move(f);
     }
     case threw_right_type_but_wrong_value: {
       unittest::UnitTestFailure f;
       f << "[" << file_name << ":" << line_number << "] threw an object of the "
         << "correct type (" << exception_name << ") but wrong value";
-      throw f;
+      throw cuda::std::move(f);
     }
     case threw_right_type:
       break;
@@ -760,7 +760,7 @@ inline void check_assert_throws(
       unittest::UnitTestFailure f;
       f << "[" << file_name << ":" << line_number << "] encountered an "
         << "unknown error";
-      throw f;
+      throw cuda::std::move(f);
     }
   }
 }


### PR DESCRIPTION
Fixes all clang-tidy warnings for `misc-throw-by-value-catch-by-reference`