### PR TITLE
`misc-misplaced-const`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,7 +41,6 @@ Checks:
   - '-misc-use-internal-linkage'
   - '-misc-redundant-expression'
   - '-misc-throw-by-value-catch-by-reference'
-  - '-misc-misplaced-const'
   - '-misc-multiple-inheritance'
   - '-misc-anonymous-namespace-in-header'
   - '-misc-override-with-different-visibility'
@@ -107,6 +106,12 @@ Checks:
   # NV_IF_ELSE_TARGET, or inline asm operands as unused. The compiler sees the branch it
   # actually compiles and does not.
   - '-misc-unused-parameters'
+  # This check fires whenever `const` is applied to a typedef that names a pointer type,
+  # claiming the author meant `const T*`. Every hit in CCCL is an opaque handle
+  # (cudaStream_t, ncclComm_t, stf_task_handle, ...) where a const *pointer* is exactly
+  # what was wanted: the handle is then passed to C APIs that take it non-const, so the
+  # suggested reading would not compile.
+  - '-misc-misplaced-const'
   - '-modernize-macro-to-enum'
   - '-cppcoreguidelines-macro-to-enum'
   - '-misc-no-recursion'


### PR DESCRIPTION
Fixes all clang-tidy warnings for `misc-misplaced-const`