### PR TITLE
`misc-multiple-inheritance`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,7 +41,6 @@ Checks:
   - '-misc-use-internal-linkage'
   - '-misc-redundant-expression'
   - '-misc-throw-by-value-catch-by-reference'
-  - '-misc-multiple-inheritance'
   - '-misc-anonymous-namespace-in-header'
   - '-misc-override-with-different-visibility'
   - '-misc-predictable-rand'
@@ -112,6 +111,12 @@ Checks:
   # what was wanted: the handle is then passed to C APIs that take it non-const, so the
   # suggested reading would not compile.
   - '-misc-misplaced-const'
+  # This check flags any class with more than one non-pure-virtual base. CCCL relies on
+  # exactly that for the empty base optimization (__compressed_pair, __mdspan_ebco,
+  # __tuple_impl, counting_iterator, ...) and for CRTP policy mixins (custom_type_t). The
+  # _CCCL_DECLSPEC_EMPTY_BASES macro exists solely to make this pattern pack correctly on
+  # MSVC. Removing a base would add storage and break the ABI, so there is no fix to apply.
+  - '-misc-multiple-inheritance'
   - '-modernize-macro-to-enum'
   - '-cppcoreguidelines-macro-to-enum'
   - '-misc-no-recursion'


### PR DESCRIPTION
Fixes all clang-tidy warnings for `misc-multiple-inheritance`