### PR TITLE
`misc-anonymous-namespace-in-header`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,7 +39,6 @@ Checks:
   - '-misc-const-correctness'
   - '-misc-use-anonymous-namespace'
   - '-misc-use-internal-linkage'
-  - '-misc-anonymous-namespace-in-header'
   # END REMOVE ME
   # TODO(jfaibussowit):
   #

--- a/cub/benchmarks/bench/segmented_topk/variable/common.cuh
+++ b/cub/benchmarks/bench/segmented_topk/variable/common.cuh
@@ -24,8 +24,6 @@
 // int32 would be rejected, as its type maximum exceeds the cap).
 using segment_size_t = cuda::std::int32_t;
 
-namespace
-{
 enum class pattern_kind : int
 {
   random = 0,
@@ -35,7 +33,7 @@ enum class pattern_kind : int
   pivot_tie
 };
 
-[[nodiscard]] pattern_kind string_to_pattern(const std::string& pattern)
+[[nodiscard]] inline pattern_kind string_to_pattern(const std::string& pattern)
 {
   if (pattern == "random")
   {
@@ -152,7 +150,6 @@ gen_data(int num_segments, pattern_kind pattern, const segment_size_t* d_seg_siz
 
   return d_keys;
 }
-} // namespace
 
 const std::vector<std::string> valid_patterns = {
   "random", "quantized_random", "relu_quantized", "tie_heavy", "pivot_tie"};

--- a/cudax/test/common/group_testing.cuh
+++ b/cudax/test/common/group_testing.cuh
@@ -20,6 +20,10 @@
 
 #include "testing.cuh"
 
+// global_barriers_storage is mutable device state. The unnamed namespace gives each
+// translation unit its own barrier storage; sharing one copy across translation units
+// would change the synchronization behavior of the tests.
+// NOLINTNEXTLINE(misc-anonymous-namespace-in-header)
 namespace
 {
 template <class T, cuda::std::size_t Id>

--- a/cudax/test/common/testing.cuh
+++ b/cudax/test/common/testing.cuh
@@ -49,8 +49,6 @@ struct StringMaker<dim3>
 };
 } // namespace Catch
 
-namespace
-{
 namespace test
 {
 inline int count_driver_stack()
@@ -95,7 +93,6 @@ struct ccclrt_test_fixture
   }
 };
 } // namespace test
-} // namespace
 
 // Test macro that should be used in all cccl-rt tests
 // It first empties the driver stack in case some other test has left it non-empty

--- a/cudax/test/common/utility.cuh
+++ b/cudax/test/common/utility.cuh
@@ -25,8 +25,6 @@
 
 #include "testing.cuh"
 
-namespace
-{
 namespace test
 {
 constexpr auto one_thread_dims = cuda::make_config(cuda::block_dims<1>(), cuda::grid_dims<1>());
@@ -147,5 +145,4 @@ struct empty_kernel
   __device__ void operator()() const noexcept {}
 };
 } // namespace test
-} // namespace
 #endif // __COMMON_UTILITY_H__

--- a/cudax/test/execution/common/checked_receiver.cuh
+++ b/cudax/test/execution/common/checked_receiver.cuh
@@ -21,8 +21,6 @@
 
 #include "testing.cuh"
 
-namespace
-{
 template <class... Values>
 struct checked_value_receiver
 {
@@ -216,4 +214,3 @@ struct proxy_value_receiver
 
 template <class Ty>
 _CCCL_DEDUCTION_GUIDE_ATTRIBUTES proxy_value_receiver(Ty&) -> proxy_value_receiver<Ty>;
-} // namespace

--- a/cudax/test/execution/common/dummy_scheduler.cuh
+++ b/cudax/test/execution/common/dummy_scheduler.cuh
@@ -18,8 +18,6 @@
 
 namespace ex = cuda::experimental::execution;
 
-namespace
-{
 namespace _dummy
 {
 template <class Domain>
@@ -104,4 +102,3 @@ _CCCL_HOST_DEVICE constexpr auto _attrs_t<Domain>::query(ex::get_completion_sche
   return dummy_scheduler<Domain>{};
 }
 } // namespace _dummy
-} // namespace

--- a/cudax/test/execution/common/error_scheduler.cuh
+++ b/cudax/test/execution/common/error_scheduler.cuh
@@ -16,8 +16,6 @@
 
 #include "testing.cuh" // IWYU pragma: keep
 
-namespace
-{
 struct _error_scheduler_attrs_t
 {
   template <class _Env>
@@ -131,4 +129,3 @@ public:
     return false;
   }
 };
-} // namespace

--- a/cudax/test/execution/common/stopped_scheduler.cuh
+++ b/cudax/test/execution/common/stopped_scheduler.cuh
@@ -16,8 +16,6 @@
 
 #include "testing.cuh" // IWYU pragma: keep
 
-namespace
-{
 struct _stopped_scheduler_attrs_t
 {
   template <class _Env>
@@ -117,4 +115,3 @@ public:
     return false;
   }
 };
-} // namespace

--- a/cudax/test/graph/graph_buffer_smoke.cu
+++ b/cudax/test/graph/graph_buffer_smoke.cu
@@ -24,8 +24,6 @@
 
 namespace
 {
-namespace test
-{
 // RAII wrapper around a pinned-memory allocation.
 template <typename T>
 struct pinned_array
@@ -59,7 +57,6 @@ struct pinned_array
     return __ptr[i];
   }
 };
-} // namespace test
 
 struct write_iota
 {
@@ -162,7 +159,7 @@ C2H_TEST("graph_buffer with zero-fill initializes to zero", "[graph][graph_buffe
 C2H_TEST("graph_buffer from span", "[graph][graph_buffer]")
 {
   cudax::stream s{cuda::device_ref{0}};
-  test::pinned_array<int> host_data{6};
+  pinned_array<int> host_data{6};
   for (int i = 0; i < 6; ++i)
   {
     host_data[i] = i + 1;
@@ -176,7 +173,7 @@ C2H_TEST("graph_buffer from span", "[graph][graph_buffer]")
 
   REQUIRE(buf.size() == 6);
 
-  test::pinned_array<int> result{6};
+  pinned_array<int> result{6};
   cudax::copy_bytes(pb, buf, cuda::std::span<int>{result.get(), 6});
 
   buf.destroy(pb);
@@ -203,7 +200,7 @@ C2H_TEST("graph_buffer from initializer_list", "[graph][graph_buffer]")
 
   REQUIRE(buf.size() == 4);
 
-  test::pinned_array<int> result{4};
+  pinned_array<int> result{4};
   cudax::copy_bytes(pb, buf, cuda::std::span<int>{result.get(), 4});
 
   buf.destroy(pb);
@@ -244,7 +241,7 @@ C2H_TEST("make_buffer factory with no_init", "[graph][graph_buffer]")
 C2H_TEST("graph_buffer on forked paths", "[graph][graph_buffer]")
 {
   cudax::stream s{cuda::device_ref{0}};
-  test::pinned_array<int> result_mem{1};
+  pinned_array<int> result_mem{1};
   int* result = result_mem.get();
 
   constexpr int N = 10;

--- a/cudax/test/graph/graph_node_ops_smoke.cu
+++ b/cudax/test/graph/graph_node_ops_smoke.cu
@@ -21,15 +21,13 @@
 
 namespace
 {
-namespace test
-{
 // ─── helpers ───────────────────────────────────────────────────────────────
 
 // RAII wrapper around a pinned-memory allocation of N elements of type T.
 template <typename T>
 struct pinned_array
 {
-  _malloc_pinned mem;
+  test::_malloc_pinned mem;
   std::size_t n;
 
   explicit pinned_array(std::size_t __n, T __init = T{})
@@ -72,7 +70,6 @@ struct count_down_and_stop
   }
 };
 #  endif // _CCCL_CTK_AT_LEAST(12, 4)
-} // namespace test
 } // namespace
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -84,7 +81,7 @@ C2H_TEST("graph fill_bytes sets every byte to the requested value", "[graph][fil
   cudax::stream s{cuda::device_ref{0}};
 
   constexpr std::size_t N = 64;
-  test::pinned_array<int> mem{N, static_cast<int>(0xDEADBEEF)};
+  pinned_array<int> mem{N, static_cast<int>(0xDEADBEEF)};
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
@@ -107,7 +104,7 @@ C2H_TEST("graph fill_bytes with non-zero value", "[graph][fill_bytes]")
   cudax::stream s{cuda::device_ref{0}};
 
   constexpr std::size_t N = 8;
-  test::pinned_array<unsigned char> mem{N};
+  pinned_array<unsigned char> mem{N};
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
@@ -133,8 +130,8 @@ C2H_TEST("graph copy_bytes copies data from source to destination", "[graph][cop
   cudax::stream s{cuda::device_ref{0}};
 
   constexpr std::size_t N = 32;
-  test::pinned_array<int> src{N};
-  test::pinned_array<int> dst{N, -1};
+  pinned_array<int> src{N};
+  pinned_array<int> dst{N, -1};
 
   for (std::size_t i = 0; i < N; ++i)
   {
@@ -161,8 +158,8 @@ C2H_TEST("graph copy_bytes can be chained after fill_bytes", "[graph][fill_bytes
   cudax::stream s{cuda::device_ref{0}};
 
   constexpr std::size_t N = 16;
-  test::pinned_array<unsigned char> src{N};
-  test::pinned_array<unsigned char> dst{N};
+  pinned_array<unsigned char> src{N};
+  pinned_array<unsigned char> dst{N};
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
@@ -239,7 +236,7 @@ C2H_TEST("graph host_launch with arguments", "[graph][host_launch]")
 C2H_TEST("graph host_launch can be chained with kernel nodes", "[graph][host_launch]")
 {
   cudax::stream s{cuda::device_ref{0}};
-  test::pinned_array<int> mem{1};
+  pinned_array<int> mem{1};
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
@@ -266,7 +263,7 @@ C2H_TEST("graph host_launch can be chained with kernel nodes", "[graph][host_lau
 C2H_TEST("graph host_launch can be launched multiple times", "[graph][host_launch]")
 {
   cudax::stream s{cuda::device_ref{0}};
-  test::pinned_array<int> mem{1};
+  pinned_array<int> mem{1};
   int* ptr = mem.get();
 
   cudax::graph_builder g;
@@ -320,7 +317,7 @@ C2H_TEST("graph record_event and wait(event_ref) impose ordering across independ
          "[graph][event_record][event_wait]")
 {
   cudax::stream s{cuda::device_ref{0}};
-  test::pinned_array<int> mem{1};
+  pinned_array<int> mem{1};
 
   cuda::event ev{cuda::device_ref{0}};
 
@@ -375,7 +372,7 @@ C2H_TEST("graph wait(event_ref) node has the correct node type", "[graph][event_
 C2H_TEST("graph insert_child_graph embeds a subgraph", "[graph][child_graph]")
 {
   cudax::stream s{cuda::device_ref{0}};
-  test::pinned_array<int> mem{1};
+  pinned_array<int> mem{1};
   int* val = mem.get();
 
   // Build the child graph: kernel that assigns 42.
@@ -403,7 +400,7 @@ C2H_TEST("graph insert_child_graph embeds a subgraph", "[graph][child_graph]")
 C2H_TEST("graph insert_child_graph with ownership transfer", "[graph][child_graph]")
 {
   cudax::stream s{cuda::device_ref{0}};
-  test::pinned_array<int> mem{1};
+  pinned_array<int> mem{1};
   int* val = mem.get();
 
   cudax::graph_builder child_g;
@@ -454,7 +451,7 @@ C2H_TEST("graph insert_child_graph node has the correct node type", "[graph][chi
 C2H_TEST("graph make_if_node body executes when handle is non-zero", "[graph][conditional][if_node]")
 {
   cudax::stream s{cuda::device_ref{0}};
-  test::pinned_array<int> mem{1};
+  pinned_array<int> mem{1};
   int* val = mem.get();
 
   cudax::graph_builder g;
@@ -479,7 +476,7 @@ C2H_TEST("graph make_if_node body executes when handle is non-zero", "[graph][co
 C2H_TEST("graph make_if_node body is skipped when handle is zero", "[graph][conditional][if_node]")
 {
   cudax::stream s{cuda::device_ref{0}};
-  test::pinned_array<int> mem{1};
+  pinned_array<int> mem{1};
   int* val = mem.get();
 
   cudax::graph_builder g;
@@ -504,7 +501,7 @@ C2H_TEST("graph make_if_node body is skipped when handle is zero", "[graph][cond
 C2H_TEST("graph make_while_node body executes the expected number of times", "[graph][conditional][while_node]")
 {
   cudax::stream s{cuda::device_ref{0}};
-  test::pinned_array<int> mem{1, 5}; // will be decremented to 0
+  pinned_array<int> mem{1, 5}; // will be decremented to 0
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
@@ -515,7 +512,7 @@ C2H_TEST("graph make_while_node body executes the expected number of times", "[g
   // Body: decrement counter and stop when done.
   {
     cudax::path_builder body_pb = cudax::start_path(body_graph);
-    cudax::launch(body_pb, test::one_thread_dims, test::count_down_and_stop{}, handle, mem.get());
+    cudax::launch(body_pb, test::one_thread_dims, count_down_and_stop{}, handle, mem.get());
   }
 
   auto exec = g.instantiate();
@@ -528,7 +525,7 @@ C2H_TEST("graph make_while_node body executes the expected number of times", "[g
 C2H_TEST("graph make_if_node with pre-constructed handle", "[graph][conditional][if_node]")
 {
   cudax::stream s{cuda::device_ref{0}};
-  test::pinned_array<int> mem{1};
+  pinned_array<int> mem{1};
   int* val = mem.get();
 
   cudax::graph_builder g;

--- a/libcudacxx/include/cuda/std/__tuple_dir/ignore.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/ignore.h
@@ -39,10 +39,10 @@ struct __ignore_t
   }
 };
 
-namespace
+inline namespace __cpo
 {
-_CCCL_GLOBAL_CONSTANT __ignore_t ignore = __ignore_t{};
-} // namespace
+_CCCL_GLOBAL_CONSTANT auto ignore = __ignore_t{};
+} // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/common/testing.cuh
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/common/testing.cuh
@@ -59,8 +59,6 @@ struct StringMaker<dim3>
 };
 } // namespace Catch
 
-namespace
-{
 namespace test
 {
 inline int count_driver_stack()
@@ -105,7 +103,6 @@ struct ccclrt_test_fixture
   }
 };
 } // namespace test
-} // namespace
 
 // Test macro that should be used in all cccl-rt tests
 // It first empties the driver stack in case some other test has left it non-empty

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/common/utility.cuh
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/common/utility.cuh
@@ -45,8 +45,6 @@ TEST_DEVICE_FUNC inline void ccclrt_require_impl(
   }
 }
 
-namespace
-{
 namespace test
 {
 template <typename T1, typename T2>
@@ -188,5 +186,4 @@ void launch_kernel_single_thread(cuda::stream_ref stream, Fn fn, Args... args)
   assert(cudaGetLastError() == cudaSuccess);
 }
 } // namespace test
-} // namespace
 #endif // __COMMON_UTILITY_H__

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/event/event_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/event/event_smoke.cu
@@ -18,8 +18,6 @@
 
 namespace
 {
-namespace test
-{
 cuda::event_ref fn_takes_event_ref(cuda::event_ref ref)
 {
   return ref;
@@ -53,7 +51,6 @@ void test_event_uses_explicit_device_when_current_device_differs()
 
   explicit_device_stream.sync();
 }
-} // namespace test
 } // namespace
 
 static_assert(!::cuda::std::is_default_constructible_v<cuda::event_ref>);
@@ -69,7 +66,7 @@ C2H_CCCLRT_TEST("can construct an event_ref from a cudaEvent_t", "[event]")
   CCCLRT_REQUIRE(ref.get() == ev);
   CCCLRT_REQUIRE(!!ref);
   // test implicit conversion from cudaEvent_t:
-  cuda::event_ref ref2 = ::test::fn_takes_event_ref(ev);
+  cuda::event_ref ref2 = fn_takes_event_ref(ev);
   CCCLRT_REQUIRE(ref2.get() == ev);
   CCCLRT_REQUIRE(::cudaEventDestroy(ev) == ::cudaSuccess);
   // test an empty event_ref:
@@ -138,8 +135,8 @@ C2H_CCCLRT_TEST("can construct an event with a device_ref", "[event]")
 
 C2H_CCCLRT_TEST("event device_ref constructors use the explicit device", "[event][multi_gpu]")
 {
-  ::test::test_event_uses_explicit_device_when_current_device_differs<cuda::event>();
-  ::test::test_event_uses_explicit_device_when_current_device_differs<cuda::timed_event>();
+  test_event_uses_explicit_device_when_current_device_differs<cuda::event>();
+  test_event_uses_explicit_device_when_current_device_differs<cuda::timed_event>();
 }
 
 C2H_CCCLRT_TEST("can wait on an event from another device", "[event][multi_gpu]")

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/pool_availability.cuh
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/pool_availability.cuh
@@ -17,8 +17,6 @@
 #include <testing.cuh>
 #include <utility.cuh>
 
-namespace
-{
 namespace test
 {
 template <typename PoolType>
@@ -75,7 +73,6 @@ void skip_if_unsupported_memory_pool()
 #endif // _CCCL_CTK_AT_LEAST(13, 0)
 }
 } // namespace test
-} // namespace
 
 template <typename ResourceType>
 void test_deallocate_async([[maybe_unused]] ResourceType& resource)

--- a/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -257,8 +257,6 @@ void gen_power_law_segment_offsets_host(seed_t seed, cuda::std::span<T> segment_
 template <typename T>
 void gen_power_law_segment_offsets_device(seed_t seed, cuda::std::span<T> segment_offsets, std::size_t elements);
 
-namespace
-{
 struct generator_base_t
 {
   seed_t m_seed{};
@@ -440,7 +438,6 @@ struct gen_t
   gen_uniform_t uniform{};
   gen_power_law_t power_law{};
 };
-} // namespace
 } // namespace detail
 
 inline detail::gen_t generate;
@@ -547,8 +544,6 @@ struct proclaims_copyable_arguments<less_then_t<T>> : ::cuda::std::true_type
 {};
 _CCCL_END_NAMESPACE_CUDA
 
-namespace
-{
 struct caching_allocator_t
 {
   using value_type = char;
@@ -731,33 +726,33 @@ private:
 };
 
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-auto policy(caching_allocator_t& alloc)
+inline auto policy(caching_allocator_t& alloc)
 {
   return thrust::cuda::par(alloc);
 }
-auto cuda_policy(caching_allocator_t& alloc)
+inline auto cuda_policy(caching_allocator_t& alloc)
 {
   return cuda::execution::gpu.with(cuda::mr::get_memory_resource, alloc);
 }
 #else
-auto policy(caching_allocator_t&)
+inline auto policy(caching_allocator_t&)
 {
   return thrust::device;
 }
 #endif
 
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-auto policy(caching_allocator_t& alloc, nvbench::launch& launch)
+inline auto policy(caching_allocator_t& alloc, nvbench::launch& launch)
 {
   return thrust::cuda::par(alloc).on(launch.get_stream());
 }
-auto cuda_policy(caching_allocator_t& alloc, nvbench::launch& launch)
+inline auto cuda_policy(caching_allocator_t& alloc, nvbench::launch& launch)
 {
   return cuda::execution::gpu.with(cuda::mr::get_memory_resource, alloc)
     .with(cuda::get_stream, launch.get_stream().get_stream());
 }
 #else
-auto policy(caching_allocator_t&, nvbench::launch&)
+inline auto policy(caching_allocator_t&, nvbench::launch&)
 {
   return thrust::device;
 }
@@ -774,4 +769,3 @@ auto cub_bench_env(caching_allocator_t& alloc, nvbench::launch& launch, MoreEnvs
     envs...};
 }
 #endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-} // namespace

--- a/thrust/testing/unittest/assertions.h
+++ b/thrust/testing/unittest/assertions.h
@@ -309,8 +309,6 @@ inline bool almost_equal(double a, double b, double a_tol, double r_tol)
   }
 }
 
-namespace
-{ // anonymous namespace
 template <typename>
 struct is_complex : public THRUST_NS_QUALIFIER::false_type
 {};
@@ -322,7 +320,6 @@ struct is_complex<THRUST_NS_QUALIFIER::complex<T>> : public THRUST_NS_QUALIFIER:
 template <typename T>
 struct is_complex<std::complex<T>> : public THRUST_NS_QUALIFIER::true_type
 {};
-} // namespace
 
 template <typename T1, typename T2>
 inline ::cuda::std::enable_if_t<is_complex<T1>::value && is_complex<T2>::value, bool>


### PR DESCRIPTION
Fixes all clang-tidy warnings for `misc-anonymous-namespace-in-header`