### PR TITLE
`misc-definitions-in-headers`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,7 +46,6 @@ Checks:
   - '-misc-misplaced-const'
   - '-misc-multiple-inheritance'
   - '-misc-anonymous-namespace-in-header'
-  - '-misc-definitions-in-headers'
   - '-misc-override-with-different-visibility'
   - '-misc-predictable-rand'
   - '-misc-unused-alias-decls'

--- a/c/parallel/test/test_util.h
+++ b/c/parallel/test/test_util.h
@@ -236,7 +236,7 @@ cccl_type_info get_type_info()
   return info;
 }
 
-std::string type_enum_to_name(cccl_type_enum type)
+inline std::string type_enum_to_name(cccl_type_enum type)
 {
   switch (type)
   {

--- a/cub/test/cmake/nvrtc_args.h.in
+++ b/cub/test/cmake/nvrtc_args.h.in
@@ -1,6 +1,6 @@
 #pragma once
 
-const char* NVRTC_CUB_PATH        = "-I@CMAKE_SOURCE_DIR@/cub";
-const char* NVRTC_THRUST_PATH     = "-I@CMAKE_SOURCE_DIR@/thrust";
-const char* NVRTC_LIBCUDACXX_PATH = "-I@CMAKE_SOURCE_DIR@/libcudacxx/include";
-const char* NVRTC_CTK_PATH        = "-I@CUDAToolkit_INCLUDE_DIRS@";
+inline constexpr const char* NVRTC_CUB_PATH        = "-I@CMAKE_SOURCE_DIR@/cub";
+inline constexpr const char* NVRTC_THRUST_PATH     = "-I@CMAKE_SOURCE_DIR@/thrust";
+inline constexpr const char* NVRTC_LIBCUDACXX_PATH = "-I@CMAKE_SOURCE_DIR@/libcudacxx/include";
+inline constexpr const char* NVRTC_CTK_PATH        = "-I@CUDAToolkit_INCLUDE_DIRS@";

--- a/libcudacxx/test/support/test_pstl.h
+++ b/libcudacxx/test/support/test_pstl.h
@@ -216,13 +216,13 @@ using pstl_numerics_types =
 // We want to use thrust::sequence
 
 #if _LIBCUDACXX_HAS_NVFP16()
-TEST_FUNC __half operator*(const __half lhs, const size_t rhs) noexcept
+inline TEST_FUNC __half operator*(const __half lhs, const size_t rhs) noexcept
 {
   return ::__float2half(::__half2float(lhs) * static_cast<float>(rhs));
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
 #if _LIBCUDACXX_HAS_NVBF16()
-TEST_FUNC __nv_bfloat16 operator*(const __nv_bfloat16 lhs, const size_t rhs) noexcept
+inline TEST_FUNC __nv_bfloat16 operator*(const __nv_bfloat16 lhs, const size_t rhs) noexcept
 {
   return ::__float2bfloat16(::__bfloat162float(lhs) * static_cast<float>(rhs));
 }

--- a/thrust/examples/include/timer.h
+++ b/thrust/examples/include/timer.h
@@ -15,7 +15,7 @@
 
 #  include <cuda_runtime_api.h>
 
-void cuda_safe_call(cudaError_t error, const std::string& message = "")
+inline void cuda_safe_call(cudaError_t error, const std::string& message = "")
 {
   if (error)
   {

--- a/thrust/testing/unittest/assertions.h
+++ b/thrust/testing/unittest/assertions.h
@@ -129,7 +129,7 @@ void assert_equal(T1 a, T2 b, const std::string& filename = "unknown", int linen
   }
 }
 
-void assert_equal(char a, char b, const std::string& filename = "unknown", int lineno = -1)
+inline void assert_equal(char a, char b, const std::string& filename = "unknown", int lineno = -1)
 {
   if (!(a == b))
   {
@@ -170,7 +170,7 @@ void assert_not_equal(T1 a, T2 b, const std::string& filename = "unknown", int l
   }
 }
 
-void assert_not_equal(char a, char b, const std::string& filename = "unknown", int lineno = -1)
+inline void assert_not_equal(char a, char b, const std::string& filename = "unknown", int lineno = -1)
 {
   if (a == b)
   {
@@ -209,7 +209,7 @@ void assert_less(T1 a, T2 b, const std::string& filename = "unknown", int lineno
   }
 }
 
-void assert_less(char a, char b, const std::string& filename = "unknown", int lineno = -1)
+inline void assert_less(char a, char b, const std::string& filename = "unknown", int lineno = -1)
 {
   if (!(a < b))
   {
@@ -234,7 +234,7 @@ void assert_greater(T1 a, T2 b, const std::string& filename = "unknown", int lin
   }
 }
 
-void assert_greater(char a, char b, const std::string& filename = "unknown", int lineno = -1)
+inline void assert_greater(char a, char b, const std::string& filename = "unknown", int lineno = -1)
 {
   if (!(a > b))
   {
@@ -259,7 +259,7 @@ void assert_lequal(T1 a, T2 b, const std::string& filename = "unknown", int line
   }
 }
 
-void assert_lequal(char a, char b, const std::string& filename = "unknown", int lineno = -1)
+inline void assert_lequal(char a, char b, const std::string& filename = "unknown", int lineno = -1)
 {
   if (!(a <= b))
   {
@@ -284,7 +284,7 @@ void assert_gequal(T1 a, T2 b, const std::string& filename = "unknown", int line
   }
 }
 
-void assert_gequal(char a, char b, const std::string& filename = "unknown", int lineno = -1)
+inline void assert_gequal(char a, char b, const std::string& filename = "unknown", int lineno = -1)
 {
   if (!(a >= b))
   {
@@ -297,7 +297,7 @@ void assert_gequal(char a, char b, const std::string& filename = "unknown", int 
 }
 
 // will catch everything implicitly convertible to a double
-bool almost_equal(double a, double b, double a_tol, double r_tol)
+inline bool almost_equal(double a, double b, double a_tol, double r_tol)
 {
   if (std::abs(a - b) > r_tol * (std::abs(a) + std::abs(b)) + a_tol)
   {
@@ -732,7 +732,7 @@ enum threw_status
   threw_right_type
 };
 
-void check_assert_throws(
+inline void check_assert_throws(
   threw_status s, std::string const& exception_name, std::string const& file_name = "unknown", int line_number = -1)
 {
   switch (s)


### PR DESCRIPTION
Fixes all clang-tidy warnings for `misc-definitions-in-headers`