### PR TITLE
`misc-override-with-different-visibility`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -43,7 +43,6 @@ Checks:
   - '-misc-throw-by-value-catch-by-reference'
   - '-misc-multiple-inheritance'
   - '-misc-anonymous-namespace-in-header'
-  - '-misc-override-with-different-visibility'
   # END REMOVE ME
   # TODO(jfaibussowit):
   #

--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -297,6 +297,9 @@ struct CustomEqualsRangeMatcher : Catch::Matchers::MatcherBase<Range>
     return std::equal(begin(range), end(range), begin(other), Pred{});
   }
 
+  // Catch2 matchers must expose describe() publicly so that composing matchers
+  // (AllMatch, Contains, SizeIs, ...) can call it on a member matcher.
+  // NOLINTNEXTLINE(misc-override-with-different-visibility)
   std::string describe() const override
   {
     return "Equals: " + Catch::rangeToString(range);
@@ -503,6 +506,8 @@ struct vector_matcher : Catch::Matchers::MatcherGenericBase
     return comparison_result.total_mismatches == 0;
   }
 
+  // See the note on CustomEqualsRangeMatcher::describe above.
+  // NOLINTNEXTLINE(misc-override-with-different-visibility)
   std::string describe() const override
   {
     std::stringstream ss;

--- a/thrust/testing/unittest/cuda/testframework.h
+++ b/thrust/testing/unittest/cuda/testframework.h
@@ -12,14 +12,15 @@ class CUDATestDriver : public UnitTestDriver
 public:
   int current_device_architecture() const;
 
+  bool run_tests(const ArgumentSet& args, const ArgumentMap& kwargs) override;
+
+protected:
+  bool post_test_smoke_check(const UnitTest& test, bool concise) override;
+
 private:
   std::vector<int> target_devices(const ArgumentMap& kwargs);
 
   bool check_cuda_error(bool concise);
-
-  bool post_test_smoke_check(const UnitTest& test, bool concise) override;
-
-  bool run_tests(const ArgumentSet& args, const ArgumentMap& kwargs) override;
 };
 
 UnitTestDriver& driver_instance(thrust::system::cuda::tag);


### PR DESCRIPTION
Fixes all clang-tidy warnings for `misc-override-with-different-visibility`