### PR TITLE
`misc-predictable-rand`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,7 +46,6 @@ Checks:
   - '-misc-multiple-inheritance'
   - '-misc-anonymous-namespace-in-header'
   - '-misc-override-with-different-visibility'
-  - '-misc-predictable-rand'
   # END REMOVE ME
   # TODO(jfaibussowit):
   #

--- a/cudax/examples/vector_add.cu
+++ b/cudax/examples/vector_add.cu
@@ -34,6 +34,7 @@
  */
 
 #include <cstdio>
+#include <random>
 
 // For the CUDA runtime routines (prefixed with "cuda_")
 #include <cuda/std/span>
@@ -84,10 +85,12 @@ try
   cudax::vector<float> C(numElements); // output
 
   // Initialize the host input vectors
+  std::mt19937 gen{std::random_device{}()};
+  std::uniform_real_distribution<float> dist{0.0f, 1.0f};
   for (int i = 0; i < numElements; ++i)
   {
-    A[i] = static_cast<float>(rand()) / (float) RAND_MAX;
-    B[i] = static_cast<float>(rand()) / (float) RAND_MAX;
+    A[i] = dist(gen);
+    B[i] = dist(gen);
   }
 
   // Define the kernel launch parameters

--- a/thrust/testing/stable_sort_large.cu
+++ b/thrust/testing/stable_sort_large.cu
@@ -10,10 +10,10 @@ void _TestStableSortWithLargeKeys()
 
   thrust::host_vector<FixedVector<T, N>> h_keys(n);
 
+  const thrust::host_vector<T> values = unittest::random_integers<T>(n);
   for (size_t i = 0; i < n; i++)
   {
-    // XXX Use proper random number generation facility.
-    h_keys[i] = FixedVector<T, N>(rand());
+    h_keys[i] = FixedVector<T, N>(values[i]);
   }
 
   thrust::device_vector<FixedVector<T, N>> d_keys = h_keys;


### PR DESCRIPTION
Fixes all clang-tidy warnings for `misc-predictable-rand`