### PR TITLE
`misc-unused-alias-decls`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,7 +49,6 @@ Checks:
   - '-misc-definitions-in-headers'
   - '-misc-override-with-different-visibility'
   - '-misc-predictable-rand'
-  - '-misc-unused-alias-decls'
   # END REMOVE ME
   # TODO(jfaibussowit):
   #

--- a/cudax/test/execution/test_trampoline_scheduler.cu
+++ b/cudax/test/execution/test_trampoline_scheduler.cu
@@ -13,9 +13,9 @@
 #include "./common/retry.cuh"
 #include "testing.cuh"
 
-namespace ex = ::cuda::experimental::execution;
-
 #if !_CCCL_DEVICE_COMPILATION()
+
+namespace ex = ::cuda::experimental::execution;
 
 namespace
 {


### PR DESCRIPTION
Fixes all clang-tidy warnings for `misc-unused-alias-decls`