### PR TITLE
Remove forced NVCC -t=100 from CI

### DIFF
--- a/.devcontainer/cuda12.0-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc10/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc11/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc12/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.0-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc13/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.0-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc7/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.0-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc8/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.0-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc9/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.0-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm14/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc10/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc11/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc12/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc13/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-gcc14/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc14/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc7/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc8/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc9/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm14/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm15/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm16/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-llvm17/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm17/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-llvm18/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm18/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-llvm19/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm19/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-llvm21/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm21/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9-llvm22/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm22/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9ext-gcc14/devcontainer.json
+++ b/.devcontainer/cuda12.9ext-gcc14/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9ext-llvm20/devcontainer.json
+++ b/.devcontainer/cuda12.9ext-llvm20/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9ext-llvm21/devcontainer.json
+++ b/.devcontainer/cuda12.9ext-llvm21/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda12.9ext-llvm22/devcontainer.json
+++ b/.devcontainer/cuda12.9ext-llvm22/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc11/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc12/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0-gcc13/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc13/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0-gcc14/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc14/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0-gcc15/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc15/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0-llvm15/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm15/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0-llvm16/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm16/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0-llvm17/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm17/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0-llvm18/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm18/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0-llvm19/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm19/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0-llvm20/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm20/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0ext-gcc14/devcontainer.json
+++ b/.devcontainer/cuda13.0ext-gcc14/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.0ext-llvm20/devcontainer.json
+++ b/.devcontainer/cuda13.0ext-llvm20/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.1-nvhpc26.3/devcontainer.json
+++ b/.devcontainer/cuda13.1-nvhpc26.3/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.2-nvhpc26.5/devcontainer.json
+++ b/.devcontainer/cuda13.2-nvhpc26.5/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3-gcc11/devcontainer.json
+++ b/.devcontainer/cuda13.3-gcc11/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3-gcc12/devcontainer.json
+++ b/.devcontainer/cuda13.3-gcc12/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3-gcc13/devcontainer.json
+++ b/.devcontainer/cuda13.3-gcc13/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3-gcc14/devcontainer.json
+++ b/.devcontainer/cuda13.3-gcc14/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3-gcc15/devcontainer.json
+++ b/.devcontainer/cuda13.3-gcc15/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3-llvm15/devcontainer.json
+++ b/.devcontainer/cuda13.3-llvm15/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3-llvm16/devcontainer.json
+++ b/.devcontainer/cuda13.3-llvm16/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3-llvm17/devcontainer.json
+++ b/.devcontainer/cuda13.3-llvm17/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3-llvm18/devcontainer.json
+++ b/.devcontainer/cuda13.3-llvm18/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3-llvm19/devcontainer.json
+++ b/.devcontainer/cuda13.3-llvm19/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3-llvm20/devcontainer.json
+++ b/.devcontainer/cuda13.3-llvm20/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3-llvm21/devcontainer.json
+++ b/.devcontainer/cuda13.3-llvm21/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3ext-gcc14/devcontainer.json
+++ b/.devcontainer/cuda13.3ext-gcc14/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3ext-gcc15/devcontainer.json
+++ b/.devcontainer/cuda13.3ext-gcc15/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3ext-llvm20/devcontainer.json
+++ b/.devcontainer/cuda13.3ext-llvm20/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda13.3ext-llvm21/devcontainer.json
+++ b/.devcontainer/cuda13.3ext-llvm21/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda99.8-gcc15/devcontainer.json
+++ b/.devcontainer/cuda99.8-gcc15/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda99.8-llvm21/devcontainer.json
+++ b/.devcontainer/cuda99.8-llvm21/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda99.9-gcc15/devcontainer.json
+++ b/.devcontainer/cuda99.9-gcc15/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/cuda99.9-llvm21/devcontainer.json
+++ b/.devcontainer/cuda99.9-llvm21/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,6 @@
     "AWS_IDP_URL": "https://token.rapids.nvidia.com",
     "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/rapids-token-sccache-devs",
     "CI": "${localEnv:CI}",
-    "NVCC_APPEND_FLAGS": "-t=100",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE": "${localEnv:SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE:true}",
     "SCCACHE_DIST_MAX_RETRIES": "${localEnv:SCCACHE_DIST_MAX_RETRIES:4}",

--- a/.github/actions/workflow-run-job-windows/action.yml
+++ b/.github/actions/workflow-run-job-windows/action.yml
@@ -240,7 +240,6 @@ runs:
           --env "GITHUB_RUN_ID=$GITHUB_RUN_ID" \
           --env "GITHUB_SHA=$GITHUB_SHA" \
           --env "JOB_ID=${{inputs.id}}" \
-          --env "NVCC_APPEND_FLAGS=-t=100" \
           --env "RUNNER_TEMP=${{env.RUNNER_TEMP_HOST}}" \
           --env "SCCACHE_BUCKET=${{env.SCCACHE_BUCKET}}" \
           --env "SCCACHE_IDLE_TIMEOUT=${{env.SCCACHE_IDLE_TIMEOUT}}" \


### PR DESCRIPTION
## Summary

- remove `NVCC_APPEND_FLAGS=-t=100` from the devcontainer template and regenerate all checked-in variants
- remove the equivalent hardcoded Windows CI injection
- return NVCC to its default internal scheduling while retaining the build's outer Ninja parallelism

## Why

A local A/B reproduction of the failing CUDA 13.3 / GCC 15 `cub-lid1` shard used 16 CPUs, `ninja -j15`, all major architectures, 64 GiB RAM, 8 GiB swap, and an empty sccache:

| NVCC setting | Result | Wall time | Peak memory |
| --- | --- | ---: | ---: |
| default | completed all 943 edges | 60m 39.8s | 31.8 GiB |
| `-t=100` | failed with 3 OOM-killed children | 48m 32.1s | 64 GiB RAM + 8 GiB swap |

At the same 48m 32s elapsed point, the default run had completed 562 Ninja outputs versus 535 with `-t=100`.

This removes the global override so CI can validate default NVCC behavior on the real builders.

## Testing

- `.devcontainer/make_devcontainers.sh --clean` (idempotent; post-generation tree clean)
- all generated `devcontainer.json` files parse with `jq`
- Windows action parses as YAML
- repository commit hooks pass
