### PR TITLE
[Backport branch/3.4.x] Deduplicate and extend nightly/weekly workflows. (#11074)

### DIFF
--- a/.github/workflows/ci-matrix-build.yml
+++ b/.github/workflows/ci-matrix-build.yml
@@ -47,7 +47,7 @@ jobs:
   build-workflow:
     name: Build workflow from matrix
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'NVIDIA/cccl' }}
+    if: ${{ github.repository == 'NVIDIA/cccl' || github.repository == 'NVIDIA-dev/cccl_private' }}
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/ci-matrix-build.yml
+++ b/.github/workflows/ci-matrix-build.yml
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reusable workflow that builds the CI matrix from ci/matrix.yaml and dispatches
+# all build/test job groups. Shared by the nightly and weekly scheduled workflows,
+# which only differ in the matrix `workflows` value and Slack alert preference.
+name: "CI/Matrix Build"
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+on:
+  workflow_call:
+    inputs:
+      workflows:
+        description: "Space separated list of workflows in the matrix file to run (e.g. 'nightly' or 'weekly')."
+        type: string
+        required: true
+      enable_slack_alert:
+        description: "When true, also post failure notifications to the alert Slack channel (secrets.SLACK_CHANNEL_CI_ALERT) in addition to the log channel."
+        type: boolean
+        default: false
+      matrix_branch:
+        description: "Branch (in this repo) to checkout into '.private' so its matrix file can be sideloaded. When empty, no extra checkout is performed and 'matrix_file' is read from the current checkout."
+        type: string
+        default: ''
+    outputs:
+      failure_message:
+        description: "Prepared workflow failure notification text, populated when verify-workflow detects failures."
+        value: ${{ jobs.verify-workflow.outputs.failure_message }}
+
+jobs:
+
+  build-workflow:
+    name: Build workflow from matrix
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'NVIDIA/cccl' }}
+    permissions:
+      contents: read
+    outputs:
+      workflow: ${{ steps.build-workflow.outputs.workflow }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Checkout matrix branch into .private
+        if: ${{ inputs.matrix_branch != '' }}
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.matrix_branch }}
+          path: .private
+      - name: Build workflow
+        id: build-workflow
+        uses: ./.github/actions/workflow-build
+        with:
+          workflows: ${{ inputs.workflows }}
+          # When sideloading from another branch, the matrix checkout is prefixed with
+          # '.private'. Otherwise use the path as-is from the current checkout
+          # (e.g. 'ci/matrix.yaml' for the default callers).
+          matrix_file: ${{ inputs.matrix_branch != '' && '.private/ci/matrix.yaml' || 'ci/matrix.yaml' }}
+          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
+          slack_alert: ${{ inputs.enable_slack_alert == true && secrets.SLACK_CHANNEL_CI_ALERT || '' }}
+
+  dispatch-groups-linux-two-stage:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+    with:
+      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
+
+  dispatch-groups-windows-two-stage:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
+    with:
+      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
+
+  dispatch-groups-linux-standalone:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
+    with:
+      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
+
+  dispatch-groups-windows-standalone:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
+    with:
+      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
+
+  verify-workflow:
+    name: Verify and summarize workflow results
+    if: ${{ always() && !cancelled() }}
+    needs:
+      - build-workflow
+      - dispatch-groups-linux-two-stage
+      - dispatch-groups-windows-two-stage
+      - dispatch-groups-linux-standalone
+      - dispatch-groups-windows-standalone
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      failure_message: ${{ steps.check-workflow.outputs.failure_message }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Check workflow success
+        id: check-workflow
+        uses: ./.github/actions/workflow-results
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
+          slack_alert: ${{ inputs.enable_slack_alert == true && secrets.SLACK_CHANNEL_CI_ALERT || '' }}

--- a/.github/workflows/ci-workflow-custom.yml
+++ b/.github/workflows/ci-workflow-custom.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,9 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Weekly scheduled workflow. Delegates matrix building and job dispatch (with
-# Slack alert notifications) to .github/workflows/ci-matrix-build.yml.
-name: weekly
+# On-demand workflow that sideloads a CI matrix file from a different branch of
+# this repo and runs the full nightly build matrix defined there. Unlike the
+# scheduled workflows, this always builds a full matrix (no inspect-changes) and
+# fetches the specified branch into '.private' inside ci-matrix-build so the
+# sideloaded matrix file is available to the workflow-build step.
+name: custom
 
 defaults:
   run:
@@ -23,8 +26,11 @@ defaults:
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 8 * * 0" # Every Sunday at 00:00 PST, 03:00 EST, 08:00 UTC
+    inputs:
+      matrix_branch:
+        description: "Branch (in this repo) containing the CI matrix file to sideload."
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
@@ -36,5 +42,6 @@ jobs:
     uses: ./.github/workflows/ci-matrix-build.yml
     secrets: inherit
     with:
-      workflows: weekly
-      enable_slack_alert: true
+      workflows: nightly
+      matrix_branch: ${{ inputs.matrix_branch }}
+      matrix_file: ${{ inputs.matrix_path }}

--- a/.github/workflows/ci-workflow-nightly.yml
+++ b/.github/workflows/ci-workflow-nightly.yml
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is the main workflow that runs on every PR and push to main
+# Nightly scheduled workflow. Delegates matrix building and job dispatch to
+# .github/workflows/ci-matrix-build.yml, then runs nightly-only third-party
+# builds plus failure analysis and Slack notification.
 name: nightly
 
 defaults:
@@ -30,114 +32,12 @@ concurrency:
 
 jobs:
 
-  build-workflow:
-    name: Build workflow from matrix
-    runs-on: ubuntu-latest
-    if: ${{ github.repository == 'NVIDIA/cccl' }}
-    permissions:
-      contents: read
-    outputs:
-      workflow: ${{ steps.build-workflow.outputs.workflow }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Build workflow
-        id: build-workflow
-        uses: ./.github/actions/workflow-build
-        with:
-          workflows: nightly
-          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
-          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
-          slack_alert: ${{ secrets.SLACK_CHANNEL_CI_ALERT }}
-
-  dispatch-groups-linux-two-stage:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+  matrix-build:
+    name: Build & dispatch CI matrix
+    uses: ./.github/workflows/ci-matrix-build.yml
+    secrets: inherit
     with:
-      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
-
-  dispatch-groups-windows-two-stage:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
-    with:
-      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
-
-  dispatch-groups-linux-standalone:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
-    with:
-      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
-
-  dispatch-groups-windows-standalone:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
-    with:
-      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
-
-  verify-workflow:
-    name: Verify and summarize workflow results
-    if: ${{ always() && !cancelled() }}
-    needs:
-      - build-workflow
-      - dispatch-groups-linux-two-stage
-      - dispatch-groups-windows-two-stage
-      - dispatch-groups-linux-standalone
-      - dispatch-groups-windows-standalone
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Check workflow success
-        id: check-workflow
-        uses: ./.github/actions/workflow-results
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
-          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
-          slack_alert: ${{ secrets.SLACK_CHANNEL_CI_ALERT }}
+      workflows: nightly
 
   build-rapids:
     name: Build RAPIDS


### PR DESCRIPTION
Cherry-picks:
* [CI] Allow running ci-matrix-build.yml with other repositories (#11107)
* Deduplicate and extend nightly/weekly workflows. (#11074)

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
