### PR TITLE
[CUB] A more efficient `WarpReduce` dispatch

### DIFF
--- a/cub/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -26,8 +26,7 @@
 #include <cub/warp/specializations/warp_redux.cuh>
 
 #include <cuda/__cmath/pow2.h>
-#include <cuda/__functional/maximum.h>
-#include <cuda/__functional/minimum.h>
+#include <cuda/__functional/operator_properties.h>
 #include <cuda/__ptx/instructions/get_sreg.h>
 #include <cuda/std/__bit/countr.h>
 #include <cuda/std/__functional/operations.h>
@@ -445,7 +444,7 @@ struct WarpReduceShfl
   /**
    * @brief Reduction
    *
-   * @tparam ALL_LANES_VALID
+   * @tparam AllValidLanes
    *   Whether all lanes in each warp are contributing a valid fold of items
    *
    * @param[in] input
@@ -457,22 +456,28 @@ struct WarpReduceShfl
    * @param[in] reduction_op
    *   Binary reduction operator
    */
-  template <bool ALL_LANES_VALID, typename ReductionOp>
+  template <bool AllValidLanes, typename ReductionOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE T Reduce(T input, int valid_items, ReductionOp reduction_op)
   {
     // Dispatch to more efficient intrinsics when applicable
-    if constexpr (ALL_LANES_VALID && is_warp_redux_op_supported<ReductionOp, T>)
+    constexpr bool has_identity = ::cuda::has_identity_element_v<ReductionOp, T>;
+    const int last_lane         = (AllValidLanes) ? LOGICAL_WARP_THREADS - 1 : valid_items - 1;
+    T reduce_value              = input;
+
+    if constexpr ((AllValidLanes || has_identity) && is_warp_redux_op_supported<ReductionOp, T>)
     {
-      if (const auto output = cub::detail::warp_redux(input, member_mask, reduction_op))
+      if constexpr (!AllValidLanes)
+      {
+        reduce_value = lane_id <= last_lane ? input : ::cuda::identity_element<ReductionOp, T>();
+      }
+      if (const auto output = cub::detail::warp_redux(reduce_value, member_mask, reduction_op))
       {
         return *output;
       }
     }
-    T output = input;
     // Template-iterate reduction steps
-    const int last_lane = (ALL_LANES_VALID) ? LOGICAL_WARP_THREADS - 1 : valid_items - 1;
-    ReduceStep(output, reduction_op, last_lane, constant_v<0>);
-    return output;
+    ReduceStep(reduce_value, reduction_op, last_lane, constant_v<0>);
+    return reduce_value;
   }
 
   /**

--- a/cub/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -464,7 +464,7 @@ struct WarpReduceShfl
     const int last_lane         = (AllValidLanes) ? LOGICAL_WARP_THREADS - 1 : valid_items - 1;
     T reduce_value              = input;
 
-    if constexpr ((AllValidLanes || has_identity) && is_warp_redux_op_supported<ReductionOp, T>)
+    if constexpr (IS_ARCH_WARP && (AllValidLanes || has_identity) && is_warp_redux_op_supported<ReductionOp, T>)
     {
       if constexpr (!AllValidLanes)
       {


### PR DESCRIPTION
## Description

@pauleonix noted that warp `redux` is slower than shuffle-based reduction when the logical warp is less than the physical warp.

https://github.com/NVIDIA/cccl/blob/10333e66d829bf3a8fc1cfee536accfd610b60d7/cub/cub/warp/specializations/warp_reduce_batched_wspro.cuh#L84-L87

This implies that the current logic in `WarpReduce` is not efficient

https://github.com/NVIDIA/cccl/blob/10333e66d829bf3a8fc1cfee536accfd610b60d7/cub/cub/warp/specializations/warp_reduce_shfl.cuh#L464-L470

(`ALL_LANES_VALID` only describes whether every lane in that logical warp has valid input).

Tested independently,  warp `redux` is ~30% slower for 16 lanes, and ~60% slower for 8 lanes, while ~3x faster for 32 lanes.

----

The PR enables warp `redux` only when:

- logical warp == physical warp
- warp `redux` is available (considering supported reduce_op/data type)
- All lanes are valid OR the identity element is available. This also helps simplifying the logic in https://github.com/NVIDIA/cccl/pull/9101