### PR TITLE
Add sm107 tunings for DeviceRunLengthEncode::NonTrivialRuns

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_rle_non_trivial_runs.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rle_non_trivial_runs.cuh
@@ -462,6 +462,54 @@ private:
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_lookback_policy(::cuda::compute_capability cc) const
     -> RleNonTrivialRunsLookbackPolicy
   {
+    // tunings from cub/benchmarks/bench/run_length_encode/non_trivial_runs.cu; raw measured values
+    if (cc >= ::cuda::compute_capability{10, 7} && cc < ::cuda::compute_capability{11, 0})
+    {
+      if (length_is_primitive && length_size == 4
+          && (key_is_primitive || key_type == type_t::int128 || key_type == type_t::uint128))
+      {
+        // 1-byte and 2-byte keys: the search winners regressed during verification, left untuned
+        if (key_size == 4 && key_type == type_t::float32)
+        {
+          // ipt_20.tpb_224.trp_1.ts_0.ld_0.ns_244.dcid_0.l2w_600  0.925  1.048  1.296  1.456
+          return RleNonTrivialRunsLookbackPolicy{
+            224,
+            20,
+            BLOCK_LOAD_WARP_TRANSPOSE,
+            LOAD_DEFAULT,
+            false,
+            BLOCK_SCAN_WARP_SCANS,
+            {LookbackDelayAlgorithm::no_delay, 244, 600}};
+        }
+        if (key_size == 4)
+        {
+          // ipt_20.tpb_224.trp_1.ts_0.ld_0.ns_1272.dcid_0.l2w_775  0.965  1.148  1.308  1.420
+          return RleNonTrivialRunsLookbackPolicy{
+            224,
+            20,
+            BLOCK_LOAD_WARP_TRANSPOSE,
+            LOAD_DEFAULT,
+            false,
+            BLOCK_SCAN_WARP_SCANS,
+            {LookbackDelayAlgorithm::no_delay, 1272, 775}};
+        }
+        // 8-byte keys: no sm107 win (float64's search winner regressed during verification), fall through
+        if (key_size == 16)
+        {
+          // ipt_13.tpb_224.trp_1.ts_0.ld_1.ns_652.dcid_0.l2w_530  0.989  1.008  1.341  1.396
+          return RleNonTrivialRunsLookbackPolicy{
+            224,
+            13,
+            BLOCK_LOAD_WARP_TRANSPOSE,
+            LOAD_CA,
+            false,
+            BLOCK_SCAN_WARP_SCANS,
+            {LookbackDelayAlgorithm::no_delay, 652, 530}};
+        }
+      }
+      // no tuning found, fall through to the SM100 tunings
+    }
+
     if (cc >= ::cuda::compute_capability{10, 0})
     {
       if (length_is_primitive && key_is_primitive && length_size == 4)


### PR DESCRIPTION
closes https://github.com/NVIDIA-dev/cccl_private/issues/737

verification [perf results](https://github.com/NVIDIA-dev/cccl_private/issues/737#issuecomment-5587503800)