### PR TITLE
[libcu++] Fix `__builtin_bswapg` not being supported by nvcc

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/byteswap.h
+++ b/libcudacxx/include/cuda/std/__bit/byteswap.h
@@ -208,10 +208,14 @@ _CCCL_REQUIRES(is_integral_v<_Integer>)
   if constexpr (sizeof(_Integer) > 1)
   {
 #if defined(_CCCL_BUILTIN_BSWAPG)
-    return static_cast<_Integer>(_CCCL_BUILTIN_BSWAPG(__val));
-#else // ^^^ _CCCL_BUILTIN_BSWAPG ^^^ / vvv !_CCCL_BUILTIN_BSWAPG vvv
+#  if _CCCL_CUDA_COMPILER(NVCC)
+    _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+#  endif // _CCCL_CUDA_COMPILER(NVCC)
+    {
+      NV_IF_TARGET(NV_IS_HOST, ({ return static_cast<_Integer>(_CCCL_BUILTIN_BSWAPG(__val)); }))
+    }
+#endif // _CCCL_BUILTIN_BSWAPG
     return static_cast<_Integer>(::cuda::std::__byteswap_impl(::cuda::std::__to_unsigned_like(__val)));
-#endif // !_CCCL_BUILTIN_BSWAPG
   }
   else
   {


### PR DESCRIPTION
Fixes nvbug 6627603