### PR TITLE
[CI] Add GB300 ARM64 nightly coverage for libcu++ and CUB

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -79,8 +79,6 @@ workflows:
   #
   # IMPORTANT: Do NOT delete or remove the `override:` key below, even when it is empty.
   override:
-    - {jobs: ['test'],      cpu: 'arm64', project: 'libcudacxx', std: 'max', cxx: 'gcc', gpu: 'gb300', sm: 'gpu'}
-    - {jobs: ['test_lid0'], cpu: 'arm64', project: 'cub',        std: 'max', cxx: 'gcc', gpu: 'gb300', sm: 'gpu'}
 
   pull_request:
     # Old CTK: Oldest/newest supported host compilers:

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -79,6 +79,8 @@ workflows:
   #
   # IMPORTANT: Do NOT delete or remove the `override:` key below, even when it is empty.
   override:
+    - {jobs: ['test'],      cpu: 'arm64', project: 'libcudacxx', std: 'max', cxx: 'gcc', gpu: 'gb300', sm: 'gpu'}
+    - {jobs: ['test_lid0'], cpu: 'arm64', project: 'cub',        std: 'max', cxx: 'gcc', gpu: 'gb300', sm: 'gpu'}
 
   pull_request:
     # Old CTK: Oldest/newest supported host compilers:
@@ -329,6 +331,9 @@ workflows:
     - {jobs: ['test'], project: 'cudax',      ctk: '13.X', std: 20, cxx: ['gcc', 'clang', 'msvc'], gpu: 'l4', args: '--enable-tile'}
       # RTX PRO 6000 coverage (limited due to small number of runners):
     - {jobs: ['test_nolid', 'test_lid0'], project: 'cub', std: 'max', cxx: 'gcc', gpu: 'rtxpro6000'}
+    # GB300 ARM64 coverage:
+    - {jobs: ['test'],      cpu: 'arm64', project: 'libcudacxx', std: 'max', cxx: 'gcc', gpu: 'gb300', sm: 'gpu'}
+    - {jobs: ['test_lid0'], cpu: 'arm64', project: 'cub',        std: 'max', cxx: 'gcc', gpu: 'gb300', sm: 'gpu'}
     # Misc:
     - {jobs: ['build'], cpu: 'arm64', project: ['libcudacxx', 'cub', 'thrust', 'cudax'], ctk: '12.X', std: 'all', cxx: ['gcc14', 'clang19']}
     - {jobs: ['build'], cpu: 'arm64', project: ['libcudacxx', 'cub', 'thrust', 'cudax'], ctk: '13.X', std: 'all', cxx: ['gcc', 'clang']}
@@ -908,6 +913,7 @@ gpus:
   rtx4090:    { name: 'RTX4090',     sm: 89,  runner: 'rtx4090-latest',    gpu_count: 1 } # 24 GB,  10 runners
   h100:       { name: 'H100',        sm: 90,  runner: 'h100-latest',       gpu_count: 1 } # 80 GB,  16 runners
   h100_2gpu:  { name: 'H100 2-GPU',  sm: 90,  runner: 'h100-latest',       gpu_count: 2, runner_id: 'h100' } # 2 x 80 GB
+  gb300:      { name: 'GB300',       sm: 103, runner: 'gb300-latest',      gpu_count: 1 }
   # Very small number of runners on loan from cuda-python while we wait for our order to arrive.
   # Limit jobs on these:
   rtxpro6000: { name: 'RTXPRO6000',  sm: 120, runner: 'rtxpro6000-latest', gpu_count: 1 }


### PR DESCRIPTION
## Description

Add minimal nightly coverage on the ARM64 GB300 runner (`linux-arm64-gpu-gb300-latest-1`, SM103):

- register the GB300 runner in the CI GPU matrix;
- run the libcu++ C++20 test suite;
- run the CUB C++20 host-launch (`lid0`) shard.

Both lanes use the current latest GCC/CUDA configuration and compile only for the attached GPU through `sm: gpu`. CUB is intentionally limited to `lid0` to keep use of the GB300 pool small.

## GB300 validation

The two nightly lanes were exercised through a temporary PR override with CUDA 13.3, GCC 15, C++20, and SM103:

- both ARM64 build producers passed;
- [CUB `lid0`](https://github.com/NVIDIA/cccl/actions/runs/33772817181/job/100749389673) passed 248/248 tests on its first attempt (17m28s);
- [libcu++](https://github.com/NVIDIA/cccl/actions/runs/33772817181/job/100749387639) passed on attempt 3 with 3,465 passes, 42 expected failures, and 328 unsupported tests (14m09s). Attempts [1](https://github.com/NVIDIA/cccl/actions/runs/33772817181/job/100720654892) and [2](https://github.com/NVIDIA/cccl/actions/runs/33772817181/job/100737346190) encountered transient CUDA device-loss errors.

The temporary override is now cleared. This PR contains only the permanent nightly matrix entries and GB300 runner registration.

## Local validation

- `python3 .github/actions/workflow-build/build-workflow.py ci/matrix.yaml --workflows pull_request`
- `python3 .github/actions/workflow-build/prepare-workflow-dispatch.py workflow/workflow.json`
- `python3 .github/actions/workflow-build/build-workflow.py ci/matrix.yaml --workflows nightly`
- `python3 .github/actions/workflow-build/prepare-workflow-dispatch.py workflow/workflow.json`
- `pre-commit run --files ci/matrix.yaml`

## Checklist

- [x] New or existing tests cover these changes.
- [x] Documentation is up to date; no documentation changes are required.
