### PR TITLE
[CI] Enable GB300 for manual benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -123,7 +123,7 @@ on:
 jobs:
   run:
     name: "Bench: ${{inputs.gpu}} ${{inputs.arch}} ${{inputs.launch_args}}"
-    runs-on: linux-amd64-gpu-${{ inputs.gpu }}-latest-1
+    runs-on: linux-${{ inputs.gpu == 'gb300' && 'arm64' || 'amd64' }}-gpu-${{ inputs.gpu }}-latest-1
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -343,7 +343,7 @@ jobs:
           mapfile -d '' -t bench_args < "/bench_args.txt"
 
           # NVBench compare deps:
-          ./ci/util/retry.sh 5 30 python3 -m pip install 'cuda-bench[compare]>=0.3.0'
+          ./ci/util/retry.sh 5 30 python3 -m pip install colorama jsondiff numpy tabulate
 
           ./ci/bench/bench.sh "${bench_args[@]}"
           EOF

--- a/ci/bench.template.yaml
+++ b/ci/bench.template.yaml
@@ -51,6 +51,7 @@ benchmarks:
     # - "l4"         # sm_89, 24 GB
     # - "rtx4090"    # sm_89, 24 GB
     # - "h100"       # sm_90, 80 GB
+    # - "gb300"      # sm_103, ARM64
     # - "rtxpro6000" # sm_120
 
   # Extra .devcontainer/launch.sh -d args

--- a/ci/bench.yaml
+++ b/ci/bench.yaml
@@ -51,6 +51,7 @@ benchmarks:
     # - "l4"         # sm_89, 24 GB
     # - "rtx4090"    # sm_89, 24 GB
     # - "h100"       # sm_90, 80 GB
+    # - "gb300"      # sm_103, ARM64
     # - "rtxpro6000" # sm_120
 
   # Extra .devcontainer/launch.sh -d args

--- a/ci/bench/README.md
+++ b/ci/bench/README.md
@@ -66,7 +66,7 @@ Python benchmarks live under `python/cuda_cccl/benchmarks/` and use `cuda.bench`
 For CUB-only comparisons, the caller's Python environment must provide the NVBench compare dependencies:
 
 ```bash
-python3 -m pip install 'cuda-bench[compare]>=0.3.0'
+python3 -m pip install colorama jsondiff numpy tabulate
 ```
 
 For Python benchmarks, `compare_paths.sh`:


### PR DESCRIPTION
## Description

Enable CUB benchmarks in the manual Benchmark Compare workflow to run on the ARM64 GB300 runner.

The `gpu` input is already free-form, but the workflow currently constructs every runner label with `linux-amd64`. Select `arm64` when `gpu=gb300`, producing `linux-arm64-gpu-gb300-latest-1`, while leaving all existing GPU selectors on AMD64.

List GB300 as an SM103 ARM64 option in both `ci/bench.yaml` and its canonical template so the workflow's documented GPU options remain complete without activating a benchmark request.

Install NVBench's pure-Python comparison dependencies directly for CUB-only runs. The `cuda-bench` package is not needed for CUB comparisons and has no ARM64 distribution; the comparison script itself is loaded from the NVBench source fetched by the CUB build. Python benchmarks still require the `cuda-bench` package and are not enabled on ARM64 by this PR.

The GB300 runner registration and access were added in #11185.

## Validation

- parsed `.github/workflows/bench.yml`, `ci/bench.yaml`, and `ci/bench.template.yaml` as YAML;
- confirmed `ci/bench.yaml` and `ci/bench.template.yaml` remain identical;
- `git diff --check upstream/main...HEAD`;
- `pre-commit run --files .github/workflows/bench.yml ci/bench.yaml ci/bench.template.yaml ci/bench/README.md`;
- [manual GB300 smoke run](https://github.com/NVIDIA/cccl/actions/runs/33805427673) confirmed assignment to `linux-arm64-gpu-gb300-latest-1` and successful ARM64 CUDA 13.3 devcontainer startup; it exposed the unavailable ARM64 `cuda-bench` package before the direct dependency fix in this PR.
