### PR TITLE
[STF] Harden scope guards: report-and-abort on guard-body failure, capture-guard fixes

### DIFF
--- a/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
@@ -73,7 +73,7 @@ public:
       cuda_try(cudaMallocHost(&result, s));
       SCOPE(fail)
       {
-        cudaFreeHost(&result);
+        cuda_safe_call(cudaFreeHost(result));
       };
       out = cuda_try<cudaGraphAddEmptyNode>(graph, nodes.data(), nodes.size());
     }

--- a/cudax/include/cuda/experimental/__stf/graph/graph_task.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/graph_task.cuh
@@ -421,7 +421,13 @@ public:
         // capture (throwing work follows EndCapture within this scope), so
         // only end a capture that is still active.
         cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
-        if (cudaStreamIsCapturing(capture_stream, &status) == cudaSuccess && status != cudaStreamCaptureStatusNone)
+        // cuda_safe_call: a failing status query here (e.g. a prior sticky
+        // error surfacing through this API) must not be mistaken for "not
+        // capturing" -- report and abort instead of skipping the EndCapture.
+        cuda_safe_call(cudaStreamIsCapturing(capture_stream, &status));
+        // != None on purpose: an Invalidated capture must still be ended to
+        // restore the stream.
+        if (status != cudaStreamCaptureStatusNone)
         {
           cudaGraph_t discarded = nullptr;
           cuda_safe_call(cudaStreamEndCapture(capture_stream, &discarded));
@@ -446,7 +452,13 @@ public:
         // graph sits in childGraph until set_child_graph takes ownership
         // (childGraph is nulled right after); destroy it rather than leak.
         cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
-        if (cudaStreamIsCapturing(capture_stream, &status) == cudaSuccess && status != cudaStreamCaptureStatusNone)
+        // cuda_safe_call: a failing status query here (e.g. a prior sticky
+        // error surfacing through this API) must not be mistaken for "not
+        // capturing" -- report and abort instead of skipping the EndCapture.
+        cuda_safe_call(cudaStreamIsCapturing(capture_stream, &status));
+        // != None on purpose: an Invalidated capture must still be ended to
+        // restore the stream.
+        if (status != cudaStreamCaptureStatusNone)
         {
           cudaGraph_t discarded = nullptr;
           cuda_safe_call(cudaStreamEndCapture(capture_stream, &discarded));
@@ -811,7 +823,13 @@ public:
         // capture (throwing work follows EndCapture within this scope), so
         // only end a capture that is still active.
         cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
-        if (cudaStreamIsCapturing(capture_stream, &status) == cudaSuccess && status != cudaStreamCaptureStatusNone)
+        // cuda_safe_call: a failing status query here (e.g. a prior sticky
+        // error surfacing through this API) must not be mistaken for "not
+        // capturing" -- report and abort instead of skipping the EndCapture.
+        cuda_safe_call(cudaStreamIsCapturing(capture_stream, &status));
+        // != None on purpose: an Invalidated capture must still be ended to
+        // restore the stream.
+        if (status != cudaStreamCaptureStatusNone)
         {
           cudaGraph_t discarded = nullptr;
           cuda_safe_call(cudaStreamEndCapture(capture_stream, &discarded));
@@ -845,7 +863,13 @@ public:
         // graph sits in childGraph until set_child_graph takes ownership
         // (childGraph is nulled right after); destroy it rather than leak.
         cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
-        if (cudaStreamIsCapturing(capture_stream, &status) == cudaSuccess && status != cudaStreamCaptureStatusNone)
+        // cuda_safe_call: a failing status query here (e.g. a prior sticky
+        // error surfacing through this API) must not be mistaken for "not
+        // capturing" -- report and abort instead of skipping the EndCapture.
+        cuda_safe_call(cudaStreamIsCapturing(capture_stream, &status));
+        // != None on purpose: an Invalidated capture must still be ended to
+        // restore the stream.
+        if (status != cudaStreamCaptureStatusNone)
         {
           cudaGraph_t discarded = nullptr;
           cuda_safe_call(cudaStreamEndCapture(capture_stream, &discarded));

--- a/cudax/include/cuda/experimental/__stf/graph/graph_task.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/graph_task.cuh
@@ -417,8 +417,15 @@ public:
       // capturing. EndCapture returns ctx_graph here — do not destroy it.
       SCOPE(fail)
       {
-        cudaGraph_t discarded = nullptr;
-        cuda_safe_call(cudaStreamEndCapture(capture_stream, &discarded));
+        // This guard can fire after the success path has already ended the
+        // capture (throwing work follows EndCapture within this scope), so
+        // only end a capture that is still active.
+        cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
+        if (cudaStreamIsCapturing(capture_stream, &status) == cudaSuccess && status != cudaStreamCaptureStatusNone)
+        {
+          cudaGraph_t discarded = nullptr;
+          cuda_safe_call(cudaStreamEndCapture(capture_stream, &discarded));
+        }
       };
 
       // Launch the user provided function
@@ -434,11 +441,23 @@ public:
       cuda_try<cudaStreamBeginCapture>(capture_stream, cudaStreamCaptureModeRelaxed);
       SCOPE(fail)
       {
-        cudaGraph_t discarded = nullptr;
-        cuda_safe_call(cudaStreamEndCapture(capture_stream, &discarded));
-        if (discarded)
+        // May fire after the success path already ended the capture; only
+        // end a capture that is still active. Past that point the captured
+        // graph sits in childGraph until set_child_graph takes ownership
+        // (childGraph is nulled right after); destroy it rather than leak.
+        cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
+        if (cudaStreamIsCapturing(capture_stream, &status) == cudaSuccess && status != cudaStreamCaptureStatusNone)
         {
-          cuda_safe_call(cudaGraphDestroy(discarded));
+          cudaGraph_t discarded = nullptr;
+          cuda_safe_call(cudaStreamEndCapture(capture_stream, &discarded));
+          if (discarded)
+          {
+            cuda_safe_call(cudaGraphDestroy(discarded));
+          }
+        }
+        else if (childGraph != nullptr)
+        {
+          cuda_safe_call(cudaGraphDestroy(childGraph));
         }
       };
 
@@ -450,6 +469,7 @@ public:
       // This implements the child graph of the `graph_task<>`, we will later
       // insert the proper dependencies around it
       set_child_graph(childGraph);
+      childGraph = nullptr; // owned by the task now; disarm the fail guard's cleanup
 #endif // _CCCL_CTK_AT_LEAST(12, 3)
     }
     else
@@ -787,8 +807,15 @@ public:
       // capturing. EndCapture returns ctx_graph here — do not destroy it.
       SCOPE(fail)
       {
-        cudaGraph_t discarded = nullptr;
-        cuda_safe_call(cudaStreamEndCapture(capture_stream, &discarded));
+        // This guard can fire after the success path has already ended the
+        // capture (throwing work follows EndCapture within this scope), so
+        // only end a capture that is still active.
+        cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
+        if (cudaStreamIsCapturing(capture_stream, &status) == cudaSuccess && status != cudaStreamCaptureStatusNone)
+        {
+          cudaGraph_t discarded = nullptr;
+          cuda_safe_call(cudaStreamEndCapture(capture_stream, &discarded));
+        }
       };
 
       // Launch the user provided function
@@ -813,11 +840,23 @@ public:
       cuda_try<cudaStreamBeginCapture>(capture_stream, cudaStreamCaptureModeRelaxed);
       SCOPE(fail)
       {
-        cudaGraph_t discarded = nullptr;
-        cuda_safe_call(cudaStreamEndCapture(capture_stream, &discarded));
-        if (discarded)
+        // May fire after the success path already ended the capture; only
+        // end a capture that is still active. Past that point the captured
+        // graph sits in childGraph until set_child_graph takes ownership
+        // (childGraph is nulled right after); destroy it rather than leak.
+        cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
+        if (cudaStreamIsCapturing(capture_stream, &status) == cudaSuccess && status != cudaStreamCaptureStatusNone)
         {
-          cuda_safe_call(cudaGraphDestroy(discarded));
+          cudaGraph_t discarded = nullptr;
+          cuda_safe_call(cudaStreamEndCapture(capture_stream, &discarded));
+          if (discarded)
+          {
+            cuda_safe_call(cudaGraphDestroy(discarded));
+          }
+        }
+        else if (childGraph != nullptr)
+        {
+          cuda_safe_call(cudaGraphDestroy(childGraph));
         }
       };
 
@@ -840,6 +879,7 @@ public:
       // dependencies, or data transfers, allocations etc.
       // Since this was captured, we will not destroy that graph (should we ?)
       set_child_graph(childGraph);
+      childGraph = nullptr; // owned by the task now; disarm the fail guard's cleanup
 #endif // _CCCL_CTK_AT_LEAST(12, 3)
     }
     else

--- a/cudax/include/cuda/experimental/__stf/internal/algorithm.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/algorithm.cuh
@@ -249,8 +249,17 @@ public:
     // instead. These resources need to be released later with .clear()
     auto adapter = setup_allocator(gctx, stream);
 
-    // Speaking of which.
-    SCOPE(exit)
+    // Speaking of which. clear() is documented throwing (its deallocations
+    // and the final stream synchronization go through cuda_try), so the two
+    // exits part ways: on success a failure to release propagates to the
+    // caller as an ordinary exception; on the exception path a secondary
+    // failure is reported and aborts (guard bodies run under
+    // on_throw(abort)) rather than reaching std::terminate bare.
+    SCOPE(success)
+    {
+      adapter.clear();
+    };
+    SCOPE(fail)
     {
       adapter.clear();
     };
@@ -309,8 +318,17 @@ public:
     // instead. These resources need to be released later with .clear()
     auto adapter = setup_allocator(gctx, stream);
 
-    // Speaking of which.
-    SCOPE(exit)
+    // Speaking of which. clear() is documented throwing (its deallocations
+    // and the final stream synchronization go through cuda_try), so the two
+    // exits part ways: on success a failure to release propagates to the
+    // caller as an ordinary exception; on the exception path a secondary
+    // failure is reported and aborts (guard bodies run under
+    // on_throw(abort)) rather than reaching std::terminate bare.
+    SCOPE(success)
+    {
+      adapter.clear();
+    };
+    SCOPE(fail)
     {
       adapter.clear();
     };

--- a/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
@@ -4381,9 +4381,10 @@ UNITTEST("type erasure")
  * @brief Automatically runs code when a scope is exited (`SCOPE(exit)`), exited by means of an exception
  * (`SCOPE(fail)`), or exited normally (`SCOPE(success)`).
  *
- * The code controlled by `SCOPE(exit)` and `SCOPE(fail)` must not throw. In debug builds (`NDEBUG` not
- * defined) those lambdas are invoked via `on_throw(abort)`; in release
- * builds they are called directly. The code controlled by `SCOPE(success)` may throw. In all cases the
+ * The code controlled by `SCOPE(exit)` and `SCOPE(fail)` must not throw. In every build type those
+ * lambdas are invoked via `on_throw(abort)`: a throw from a guard body is reported (message and
+ * location) and the program aborts, rather than reaching `std::terminate` bare through the guard's
+ * `noexcept` destructor. The code controlled by `SCOPE(success)` may throw. In all cases the
  * controlled code must return `void` (enforced at compile time).
  *
  * `SCOPE(exit)` runs its code at the natural termination of the current scope. Example: @snippet this SCOPE(exit)
@@ -4423,12 +4424,10 @@ template <class F>
 void invoke_nothrow(F& f, ::cuda::std::source_location loc)
 {
   static_assert(::cuda::std::is_void_v<decltype(f())>, "SCOPE requires a void-returning callable");
-#  ifndef NDEBUG
+  // All build types: a guard body that throws is reported and aborts. The guard destructors are
+  // noexcept, so the bare-call alternative is std::terminate with no diagnostics; the report is
+  // worth the try/catch frame, which costs nothing on the non-throwing path.
   on_throw(exception_policies::abort, loc) << f;
-#  else // ^^^ !NDEBUG ^^^ / vvv NDEBUG vvv
-  (void) loc;
-  f();
-#  endif // NDEBUG
 }
 
 template <typename F>


### PR DESCRIPTION
First PR of the scope-guard hardening campaign that followed #10807: an audit of all 148 `SCOPE` sites (four subsystem slices) found two systemic hazards and two local bugs. Design ruling applied throughout: grave failures in cleanup (STL OOM, CUDA errors on a dying context) abort loudly rather than convolute the code; but they must abort with a report, never reach `std::terminate` bare.

1. **Guard bodies now run under `on_throw(abort)` in every build type** (previously debug-only; NDEBUG called them bare inside the guards' `noexcept` destructors). A throwing guard body is reported with message and location, then aborts. One change in `invoke_nothrow` hardens every present and future SCOPE site; the try frame is free when nothing throws.

2. **graph_task capture guards were armed past their precondition**: throwing work follows `cudaStreamEndCapture` on the success path, so a late throw made the guard end a non-capturing stream and die mid-unwind. The guards now check `cudaStreamIsCapturing` first; the legacy (CTK < 12.3) pair also destroys the captured child graph when `set_child_graph` has not taken ownership, and adoption disarms the guard.

3. **`uncached_graph_allocator::allocate` rollback freed the wrong pointer** — `cudaFreeHost(&result)` (address of the local) instead of `cudaFreeHost(result)`; the ignored error return made it a silent pinned-memory leak on every failure path.

4. **`algorithm`'s `SCOPE(exit){ adapter.clear(); }`** called a documented-throwing `clear()` (against `adapters.cuh`'s own warning) on both paths. Split: `SCOPE(success)` lets a release failure propagate to the caller as an ordinary exception; `SCOPE(fail)` reports and aborts on a secondary failure.

Follow-ups tracked separately: examples/tests pedagogy pass (cfd.cu's throwing `EXPECT(fclose)` in a guard, 01-axpy-places' leak window), opt-in `ON_THROW(notify)` for guards that should survive failure (device restores, telemetry), and the sticky-error classification that gates the wider `cuda_safe_call` → `cuda_try` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
