### PR TITLE
Skip debugger tests when run with nvrtc

### DIFF
--- a/libcudacxx/test/debugging/CMakeLists.txt
+++ b/libcudacxx/test/debugging/CMakeLists.txt
@@ -92,7 +92,7 @@ endfunction()
 
 libcudacxx_init_debugger_testing(testing_enabled)
 
-if (NOT testing_enabled)
+if ((NOT testing_enabled) OR LIBCUDACXX_TEST_WITH_NVRTC)
   return()
 endif()
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Either the debugger pretty printers or the tests seemingly don't work with nvrtc. Skip them.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
