### PR TITLE
Use the merge-base of a PR when comparing SASS changes, not the instantaneous main

### DIFF
--- a/.github/workflows/ci-workflow-pull-request.yml
+++ b/.github/workflows/ci-workflow-pull-request.yml
@@ -39,6 +39,7 @@ jobs:
       pull-requests: write
     outputs:
       base_sha: ${{ steps.export-pr-info.outputs.base_sha }}
+      merge_base_sha: ${{ steps.export-pr-info.outputs.merge_base_sha }}
       pr_number: ${{ steps.export-pr-info.outputs.pr_number }}
       workflow: ${{ steps.build-workflow.outputs.workflow }}
       matrix_enabled: ${{ steps.export-flags.outputs.matrix_enabled }}
@@ -71,15 +72,21 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
+          # `git merge-base` below needs the history of both sides.
+          fetch-depth: 0
           persist-credentials: false
       - name: Lookup PR info
         id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main
       - name: Export PR info
         id: export-pr-info
+        env:
+          BASE_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
         run: |
-          echo "base_sha=${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}" | tee -a "${GITHUB_OUTPUT}"
+          echo "base_sha=${BASE_SHA}" | tee -a "${GITHUB_OUTPUT}"
           echo "pr_number=${{ fromJSON(steps.get-pr-info.outputs.pr-info).number }}" | tee -a "${GITHUB_OUTPUT}"
+          git fetch origin "${BASE_SHA}" -q
+          echo "merge_base_sha=$(git merge-base "${BASE_SHA}" "${GITHUB_SHA}")" | tee -a "${GITHUB_OUTPUT}"
       - name: Build benchmark dispatch matrix
         id: build-bench-matrix
         run: |
@@ -179,16 +186,12 @@ jobs:
         id: branch-notes-dirt
         env:
           BASE_SHA: ${{ steps.export-pr-info.outputs.base_sha }}
+          merge_base_sha: ${{ steps.export-pr-info.outputs.merge_base_sha }}
         run: |
           if [[ -z "${BASE_SHA}" ]]; then
             echo "branch_notes_dirt=" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
-
-          echo "Fetch history and determine merge base..."
-          git fetch origin --unshallow -q || true
-          git fetch origin "${BASE_SHA}" -q
-          merge_base_sha=$(git merge-base "${GITHUB_SHA}" "${BASE_SHA}")
 
           echo "Head SHA: ${GITHUB_SHA}"
           echo "PR Base SHA: ${BASE_SHA}"
@@ -561,7 +564,7 @@ jobs:
       preset: ${{ matrix.preset }}
       archs: ${{ matrix.archs }}
       target_filters_json: ${{ matrix.target_filters_json }}
-      base_ref: ${{ needs.build-workflow.outputs.base_sha }}
+      base_ref: ${{ needs.build-workflow.outputs.merge_base_sha }}
 
   bench-results:
     name: Post benchmark results


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

closes https://github.com/NVIDIA/cccl/issues/11190

As mentioned in the issue, the root problem here is that the current sass diff checker will compare the branch against _current_ `main`. If your branch is behind `main` (and it almost always is), and `main` itself made changes to SASS, then to the checker it will appear as if it undid those changes, effectively producing a diff.
```
made changes to SASS
        V
        C -- D <- main
       /
A -- B -- E <- branch
```
The checker would compare D vs E and erroneously think that E undid C.

There are 2 ways to solve this:

1. Use the merge-base of the PR and main (the commit of `main` from which the PR was split from) as the baseline. Instead of comparing `E` vs `D`, we now compare `E` vs `B` which only includes the changes on the branch.
2. Use a synthetic merge commit between `main` and the PR as the PRs "current" state. So create a new commit or rebase:
```
made changes to SASS
        V
        C -- D <- main
       /      \
A -- B -- E ... F <- "HEAD" as seen by the sass diff checker 
          ^     ^
actual HEAD     |
                |
New, synthetic commit created by the sass diff checker by merging main
into the current branch
```
This also has the same effect as 1. but from the other angle. Instead of ignoring `C` we now merge it into our branch for the purposes of SASS diffing, and effectively only compare our own commits against `main`.

There are pros and cons of either approach:

Merge-base:

Pro: Always works
Con: If the combination of main + PR would actually produce diffs, then the checker wouldn't catch it. Similar to how merging a PR prior to `clang-tidy` updates may cause `main` to be broken for a bit until a follow-up fixes the issues.

Synthetic merge:

Pro: The most correct answer at all times
Con: Brittle, and doesn't work if there are merge failures
Con: Not clear how this should be handled when the script is run standalone since a new commit is actually made.

**So this PR implements option 1**

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
