### PR TITLE
`cuda::simd` Min/Max + ReLU

### DIFF
--- a/docs/libcudacxx/extended_api/simd.rst
+++ b/docs/libcudacxx/extended_api/simd.rst
@@ -10,6 +10,7 @@ SIMD
    simd/dot
    simd/saturating_add
    simd/abs_diff
+   simd/min_max_relu
 
 .. list-table::
    :widths: 25 45 30 30
@@ -32,5 +33,10 @@ SIMD
 
    * - :ref:`cuda::simd::abs_diff <libcudacxx-extended-api-simd-abs-diff>`
      - Performs element-wise absolute difference of two integer ``basic_vec`` objects
+     - CCCL 3.6.0
+     - CUDA 13.6
+
+   * - :ref:`cuda::simd::min_relu and cuda::simd::max_relu <libcudacxx-extended-api-simd-min-max-relu>`
+     - Perform rectified element-wise minimum or maximum of two or three signed integer ``basic_vec`` objects
      - CCCL 3.6.0
      - CUDA 13.6

--- a/docs/libcudacxx/extended_api/simd/min_max_relu.rst
+++ b/docs/libcudacxx/extended_api/simd/min_max_relu.rst
@@ -52,7 +52,7 @@ The three-input overloads are equivalent to:
    max_relu(a, b, c)[i] == cuda::std::max(cuda::std::max(cuda::std::max(a[i], b[i]), c[i]), T{0})
    min_relu(a, b, c)[i] == cuda::std::max(cuda::std::min(cuda::std::min(a[i], b[i]), c[i]), T{0})
 
-The functionalities map to [Dynamic Programming eXtension (DPX)](https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#dynamic-programming-extension-dpx-instructions) instructions.
+On supported GPU architectures, the optimized device paths map to `Dynamic Programming eXtension (DPX) <https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#dynamic-programming-extension-dpx-instructions>`__ instructions.
 
 **Parameters**
 

--- a/docs/libcudacxx/extended_api/simd/min_max_relu.rst
+++ b/docs/libcudacxx/extended_api/simd/min_max_relu.rst
@@ -1,0 +1,126 @@
+.. _libcudacxx-extended-api-simd-min-max-relu:
+
+``cuda::simd::min_relu`` and ``cuda::simd::max_relu``
+=====================================================
+
+Defined in the ``<cuda/simd>`` header.
+
+.. code:: cuda
+
+    namespace cuda::simd {
+
+    template <class T, class Abi>
+    [[nodiscard]] __host__ __device__ constexpr
+    cuda::std::simd::basic_vec<T, Abi> max_relu(
+        const cuda::std::simd::basic_vec<T, Abi>& lhs,
+        const cuda::std::simd::basic_vec<T, Abi>& rhs) noexcept;
+
+    template <class T, class Abi>
+    [[nodiscard]] __host__ __device__ constexpr
+    cuda::std::simd::basic_vec<T, Abi> min_relu(
+        const cuda::std::simd::basic_vec<T, Abi>& lhs,
+        const cuda::std::simd::basic_vec<T, Abi>& rhs) noexcept;
+
+    template <class T, class Abi>
+    [[nodiscard]] __host__ __device__ constexpr
+    cuda::std::simd::basic_vec<T, Abi> max_relu(
+        const cuda::std::simd::basic_vec<T, Abi>& a,
+        const cuda::std::simd::basic_vec<T, Abi>& b,
+        const cuda::std::simd::basic_vec<T, Abi>& c) noexcept;
+
+    template <class T, class Abi>
+    [[nodiscard]] __host__ __device__ constexpr
+    cuda::std::simd::basic_vec<T, Abi> min_relu(
+        const cuda::std::simd::basic_vec<T, Abi>& a,
+        const cuda::std::simd::basic_vec<T, Abi>& b,
+        const cuda::std::simd::basic_vec<T, Abi>& c) noexcept;
+
+   } // namespace cuda::simd
+
+The functions perform an element-wise minimum or maximum followed by ReLU.
+For each element ``i``, the two-input overloads are equivalent to:
+
+.. code:: cuda
+
+   max_relu(lhs, rhs)[i] == cuda::std::max(cuda::std::max(lhs[i], rhs[i]), T{0})
+   min_relu(lhs, rhs)[i] == cuda::std::max(cuda::std::min(lhs[i], rhs[i]), T{0})
+
+The three-input overloads are equivalent to:
+
+.. code:: cuda
+
+   max_relu(a, b, c)[i] == cuda::std::max(cuda::std::max(cuda::std::max(a[i], b[i]), c[i]), T{0})
+   min_relu(a, b, c)[i] == cuda::std::max(cuda::std::min(cuda::std::min(a[i], b[i]), c[i]), T{0})
+
+The functionalities map to [Dynamic Programming eXtension (DPX)](https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#dynamic-programming-extension-dpx-instructions) instructions.
+
+**Parameters**
+
+- ``lhs``, ``rhs``: The input vectors for the two-input overloads.
+- ``a``, ``b``, ``c``: The input vectors for the three-input overloads.
+
+**Return value**
+
+Returns a ``cuda::std::simd::basic_vec<T, Abi>`` containing the element-wise result.
+
+**Constraints**
+
+- ``T`` must be a signed integer type.
+
+**Performance considerations**
+
+The following cases are optimized on the device:
+
+- Signed 8-bit elements on ``SM107f`` and ``SM120f``:
+
+  - Two-input overload uses one ``VIMNMX.S8x4.RELU`` instruction per four elements.
+  - Three-input overload uses two ``VIMNMX.S8x4.RELU`` instructions per four elements.
+
+- Signed 16-bit elements:
+
+  - On ``SM90``, ``SM100``, ``SM103``, ``SM107``, and ``SM120``, each two-input overload uses one ``VIMNMX.S16x2.RELU`` instruction per two elements.
+  - On ``SM90``, ``SM100``, and ``SM103``, each three-input overload uses one ``VIMNMX3.S16x2.RELU`` instruction per two elements.
+  - On ``SM107`` and ``SM120``, each three-input overload uses two ``VIMNMX.S16x2.RELU`` instructions per two elements.
+
+- Signed 32-bit elements:
+
+  - On ``SM90``, ``SM100``, ``SM103``, ``SM107``, and ``SM120``, each two-input overload uses one ``VIMNMX.RELU`` instruction per element.
+  - On ``SM90``, ``SM100``, and ``SM103``, each three-input overload uses one ``VIMNMX3.RELU`` instruction per element.
+  - On ``SM107`` and ``SM120``, each three-input overload uses two ``VIMNMX.RELU`` instructions per element.
+
+Example
+-------
+
+.. code:: cuda
+
+    #include <cuda/simd>
+    #include <cuda/std/array>
+    #include <cuda/std/cassert>
+    #include <cuda/std/cstdint>
+
+    #include <cuda_runtime_api.h>
+
+    namespace simd = cuda::std::simd;
+
+    __global__ void kernel()
+    {
+        using vec_t = simd::basic_vec<int16_t, simd::fixed_size<2>>;
+
+        vec_t a(cuda::std::array<int16_t, 2>{-4, 8});
+        vec_t b(cuda::std::array<int16_t, 2>{-2, 3});
+        vec_t c(cuda::std::array<int16_t, 2>{-6, 5});
+
+        vec_t maximum = cuda::simd::max_relu(a, b, c);
+        vec_t minimum = cuda::simd::min_relu(a, b, c);
+
+        assert(maximum[0] == 0);
+        assert(maximum[1] == 8);
+        assert(minimum[0] == 0);
+        assert(minimum[1] == 3);
+    }
+
+    int main()
+    {
+        kernel<<<1, 1>>>();
+        cudaDeviceSynchronize();
+    }

--- a/libcudacxx/include/cuda/__simd/min_max_relu.h
+++ b/libcudacxx/include/cuda/__simd/min_max_relu.h
@@ -1,0 +1,324 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___SIMD_MIN_MAX_RELU_H
+#define _CUDA___SIMD_MIN_MAX_RELU_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__internal/features.h>
+#include <cuda/std/__simd/algorithm.h>
+#include <cuda/std/__simd/basic_vec.h>
+#include <cuda/std/__type_traits/is_signed_integer.h>
+#include <cuda/std/cstdint>
+#if _CCCL_HAS_SIMD_MIN_MAX_RELU()
+#  include <cuda/__simd/simd_intrinsics_array.h>
+#  include <cuda/std/__simd/specializations/simd_intrinsics_array.h>
+#endif // _CCCL_HAS_SIMD_MIN_MAX_RELU()
+
+#include <nv/target>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_SIMD
+
+// Depending on the compiler and the gpu architecture, the plain C++ code (without intrinsics) can generate or not the
+// expected SASS instructions. The instrinsic paths are preferred to always generate the optimal code.
+
+#if _CCCL_HAS_SIMD_MIN_MAX_RELU()
+
+template <typename _Tp, typename _Abi>
+struct __max_relu_operation
+{
+  template <typename _Storage>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr _Storage
+  operator()(const _Storage& __lhs, const _Storage& __rhs) const noexcept
+  {
+#  if _CCCL_HAS_SIMD_8BIT_PTX()
+    if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int8_t))
+    {
+      const auto __lhs_u    = ::cuda::std::simd::__to_unsigned_storage(__lhs);
+      const auto __rhs_u    = ::cuda::std::simd::__to_unsigned_storage(__rhs);
+      const auto __result_u = ::cuda::simd::__vmax_relu_8bit_x4(__lhs_u, __rhs_u);
+      return ::cuda::std::simd::__copy_from_unsigned_storage<_Storage>(__result_u);
+    }
+    else
+#  endif // _CCCL_HAS_SIMD_8BIT_PTX()
+      if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t))
+      {
+        const auto __lhs_u    = ::cuda::std::simd::__to_unsigned_storage(__lhs);
+        const auto __rhs_u    = ::cuda::std::simd::__to_unsigned_storage(__rhs);
+        const auto __result_u = ::cuda::simd::__vmax_relu_16bit_x2(__lhs_u, __rhs_u);
+        return ::cuda::std::simd::__copy_from_unsigned_storage<_Storage>(__result_u);
+      }
+      else
+      {
+        constexpr auto __size = ::cuda::std::simd::basic_vec<_Tp, _Abi>::size();
+        _Storage __result{};
+        _CCCL_PRAGMA_UNROLL_FULL()
+        for (::cuda::std::simd::__simd_size_type __i = 0; __i < __size; ++__i)
+        {
+          __result.__data[__i] = ::__vimax_s32_relu(__lhs.__data[__i], __rhs.__data[__i]);
+        }
+        return __result;
+      }
+  }
+
+  template <typename _Storage>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr _Storage
+  operator()(const _Storage& __a, const _Storage& __b, const _Storage& __c) const noexcept
+  {
+    if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t))
+    {
+      const auto __a_u      = ::cuda::std::simd::__to_unsigned_storage(__a);
+      const auto __b_u      = ::cuda::std::simd::__to_unsigned_storage(__b);
+      const auto __c_u      = ::cuda::std::simd::__to_unsigned_storage(__c);
+      const auto __result_u = ::cuda::simd::__vmax3_relu_16bit_x2(__a_u, __b_u, __c_u);
+      return ::cuda::std::simd::__copy_from_unsigned_storage<_Storage>(__result_u);
+    }
+    else
+    {
+      constexpr auto __size = ::cuda::std::simd::basic_vec<_Tp, _Abi>::size();
+      _Storage __result{};
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (::cuda::std::simd::__simd_size_type __i = 0; __i < __size; ++__i)
+      {
+        __result.__data[__i] = ::__vimax3_s32_relu(__a.__data[__i], __b.__data[__i], __c.__data[__i]);
+      }
+      return __result;
+    }
+  }
+};
+
+template <typename _Tp, typename _Abi>
+struct __min_relu_operation
+{
+  template <typename _Storage>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr _Storage
+  operator()(const _Storage& __lhs, const _Storage& __rhs) const noexcept
+  {
+#  if _CCCL_HAS_SIMD_8BIT_PTX()
+    if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int8_t))
+    {
+      const auto __lhs_u    = ::cuda::std::simd::__to_unsigned_storage(__lhs);
+      const auto __rhs_u    = ::cuda::std::simd::__to_unsigned_storage(__rhs);
+      const auto __result_u = ::cuda::simd::__vmin_relu_8bit_x4(__lhs_u, __rhs_u);
+      return ::cuda::std::simd::__copy_from_unsigned_storage<_Storage>(__result_u);
+    }
+    else
+#  endif // _CCCL_HAS_SIMD_8BIT_PTX()
+      if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t))
+      {
+        const auto __lhs_u    = ::cuda::std::simd::__to_unsigned_storage(__lhs);
+        const auto __rhs_u    = ::cuda::std::simd::__to_unsigned_storage(__rhs);
+        const auto __result_u = ::cuda::simd::__vmin_relu_16bit_x2(__lhs_u, __rhs_u);
+        return ::cuda::std::simd::__copy_from_unsigned_storage<_Storage>(__result_u);
+      }
+      else
+      {
+        constexpr auto __size = ::cuda::std::simd::basic_vec<_Tp, _Abi>::size();
+        _Storage __result{};
+        _CCCL_PRAGMA_UNROLL_FULL()
+        for (::cuda::std::simd::__simd_size_type __i = 0; __i < __size; ++__i)
+        {
+          __result.__data[__i] = ::__vimin_s32_relu(__lhs.__data[__i], __rhs.__data[__i]);
+        }
+        return __result;
+      }
+  }
+
+  template <typename _Storage>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr _Storage
+  operator()(const _Storage& __a, const _Storage& __b, const _Storage& __c) const noexcept
+  {
+    if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t))
+    {
+      const auto __a_u      = ::cuda::std::simd::__to_unsigned_storage(__a);
+      const auto __b_u      = ::cuda::std::simd::__to_unsigned_storage(__b);
+      const auto __c_u      = ::cuda::std::simd::__to_unsigned_storage(__c);
+      const auto __result_u = ::cuda::simd::__vmin3_relu_16bit_x2(__a_u, __b_u, __c_u);
+      return ::cuda::std::simd::__copy_from_unsigned_storage<_Storage>(__result_u);
+    }
+    else
+    {
+      constexpr auto __size = ::cuda::std::simd::basic_vec<_Tp, _Abi>::size();
+      _Storage __result{};
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (::cuda::std::simd::__simd_size_type __i = 0; __i < __size; ++__i)
+      {
+        __result.__data[__i] = ::__vimin3_s32_relu(__a.__data[__i], __b.__data[__i], __c.__data[__i]);
+      }
+      return __result;
+    }
+  }
+};
+
+#endif // _CCCL_HAS_SIMD_MIN_MAX_RELU()
+
+//! @brief Performs an element-wise maximum followed by ReLU.
+//! @param[in] __lhs The left-hand side input vector.
+//! @param[in] __rhs The right-hand side input vector.
+//! @return A vector containing max(lhs[i],rhs[i],0) for each element.
+_CCCL_TEMPLATE(typename _Tp, typename _Abi)
+_CCCL_REQUIRES(::cuda::std::__cccl_is_signed_integer_v<_Tp>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr ::cuda::std::simd::basic_vec<_Tp, _Abi> max_relu(
+  const ::cuda::std::simd::basic_vec<_Tp, _Abi>& __lhs, const ::cuda::std::simd::basic_vec<_Tp, _Abi>& __rhs) noexcept
+{
+#if _CCCL_HAS_SIMD_MIN_MAX_RELU()
+  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+  {
+#  if _CCCL_HAS_SIMD_8BIT_PTX()
+    if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int8_t))
+    {
+#    if (__cccl_ptx_isa >= 940ULL)
+      NV_IF_TARGET(NV_HAS_FEATURE_SM_107f,
+                   (return __simd_min_max_relu_impl(__lhs, __rhs, __max_relu_operation<_Tp, _Abi>{});)) // ADL
+#    endif // __cccl_ptx_isa >= 940ULL
+      NV_IF_TARGET(NV_HAS_FEATURE_SM_120f,
+                   (return __simd_min_max_relu_impl(__lhs, __rhs, __max_relu_operation<_Tp, _Abi>{});)) // ADL
+    }
+    else
+#  endif // _CCCL_HAS_SIMD_8BIT_PTX()
+      if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t) || sizeof(_Tp) == sizeof(::cuda::std::int32_t))
+      {
+        NV_IF_TARGET(NV_IS_DEVICE,
+                     (return __simd_min_max_relu_impl(__lhs, __rhs, __max_relu_operation<_Tp, _Abi>{});)) // ADL
+      }
+  }
+#endif // _CCCL_HAS_SIMD_MIN_MAX_RELU()
+
+  using __vec_t = ::cuda::std::simd::basic_vec<_Tp, _Abi>;
+  return ::cuda::std::simd::max(::cuda::std::simd::max(__lhs, __rhs), __vec_t{_Tp{0}});
+}
+
+//! @brief Performs an element-wise minimum followed by ReLU.
+//! @param[in] __lhs The left-hand side input vector.
+//! @param[in] __rhs The right-hand side input vector.
+//! @return A vector containing max(min(lhs[i],rhs[i]),0) for each element.
+_CCCL_TEMPLATE(typename _Tp, typename _Abi)
+_CCCL_REQUIRES(::cuda::std::__cccl_is_signed_integer_v<_Tp>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr ::cuda::std::simd::basic_vec<_Tp, _Abi> min_relu(
+  const ::cuda::std::simd::basic_vec<_Tp, _Abi>& __lhs, const ::cuda::std::simd::basic_vec<_Tp, _Abi>& __rhs) noexcept
+{
+#if _CCCL_HAS_SIMD_MIN_MAX_RELU()
+  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+  {
+#  if _CCCL_HAS_SIMD_8BIT_PTX()
+    if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int8_t))
+    {
+#    if (__cccl_ptx_isa >= 940ULL)
+      NV_IF_TARGET(NV_HAS_FEATURE_SM_107f,
+                   (return __simd_min_max_relu_impl(__lhs, __rhs, __min_relu_operation<_Tp, _Abi>{});)) // ADL
+#    endif // __cccl_ptx_isa >= 940ULL
+      NV_IF_TARGET(NV_HAS_FEATURE_SM_120f,
+                   (return __simd_min_max_relu_impl(__lhs, __rhs, __min_relu_operation<_Tp, _Abi>{});)) // ADL
+    }
+    else
+#  endif // _CCCL_HAS_SIMD_8BIT_PTX()
+      if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t) || sizeof(_Tp) == sizeof(::cuda::std::int32_t))
+      {
+        NV_IF_TARGET(NV_IS_DEVICE,
+                     (return __simd_min_max_relu_impl(__lhs, __rhs, __min_relu_operation<_Tp, _Abi>{});)) // ADL
+      }
+  }
+#endif // _CCCL_HAS_SIMD_MIN_MAX_RELU()
+
+  using __vec_t = ::cuda::std::simd::basic_vec<_Tp, _Abi>;
+  return ::cuda::std::simd::max(::cuda::std::simd::min(__lhs, __rhs), __vec_t{_Tp{0}});
+}
+
+//! @brief Performs an element-wise maximum of three vectors followed by ReLU.
+//! @param[in] __a The first input vector.
+//! @param[in] __b The second input vector.
+//! @param[in] __c The third input vector.
+//! @return A vector containing max(a[i],b[i],c[i],0) for each element.
+_CCCL_TEMPLATE(typename _Tp, typename _Abi)
+_CCCL_REQUIRES(::cuda::std::__cccl_is_signed_integer_v<_Tp>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr ::cuda::std::simd::basic_vec<_Tp, _Abi>
+max_relu(const ::cuda::std::simd::basic_vec<_Tp, _Abi>& __a,
+         const ::cuda::std::simd::basic_vec<_Tp, _Abi>& __b,
+         const ::cuda::std::simd::basic_vec<_Tp, _Abi>& __c) noexcept
+{
+#if _CCCL_HAS_SIMD_MIN_MAX_RELU()
+  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+  {
+#  if _CCCL_HAS_SIMD_8BIT_PTX()
+    if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int8_t))
+    {
+#    if (__cccl_ptx_isa >= 940ULL)
+      NV_IF_TARGET(NV_HAS_FEATURE_SM_107f, (return ::cuda::simd::max_relu(::cuda::simd::max_relu(__a, __b), __c);))
+#    endif // __cccl_ptx_isa >= 940ULL
+      NV_IF_TARGET(NV_HAS_FEATURE_SM_120f, (return ::cuda::simd::max_relu(::cuda::simd::max_relu(__a, __b), __c);))
+    }
+    else
+#  endif // _CCCL_HAS_SIMD_8BIT_PTX()
+      if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t) || sizeof(_Tp) == sizeof(::cuda::std::int32_t))
+      {
+        NV_IF_TARGET(NV_IS_DEVICE,
+                     (return __simd_min_max_relu_impl(__a, __b, __c, __max_relu_operation<_Tp, _Abi>{});)) // ADL
+      }
+  }
+#endif // _CCCL_HAS_SIMD_MIN_MAX_RELU()
+
+  using __vec_t = ::cuda::std::simd::basic_vec<_Tp, _Abi>;
+  return ::cuda::std::simd::max(::cuda::std::simd::max(::cuda::std::simd::max(__a, __b), __c), __vec_t{_Tp{0}});
+}
+
+//! @brief Performs an element-wise minimum of three vectors followed by ReLU.
+//! @param[in] __a The first input vector.
+//! @param[in] __b The second input vector.
+//! @param[in] __c The third input vector.
+//! @return A vector containing max(min(a[i],b[i],c[i]),0) for each element.
+_CCCL_TEMPLATE(typename _Tp, typename _Abi)
+_CCCL_REQUIRES(::cuda::std::__cccl_is_signed_integer_v<_Tp>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr ::cuda::std::simd::basic_vec<_Tp, _Abi>
+min_relu(const ::cuda::std::simd::basic_vec<_Tp, _Abi>& __a,
+         const ::cuda::std::simd::basic_vec<_Tp, _Abi>& __b,
+         const ::cuda::std::simd::basic_vec<_Tp, _Abi>& __c) noexcept
+{
+#if _CCCL_HAS_SIMD_MIN_MAX_RELU()
+  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+  {
+#  if _CCCL_HAS_SIMD_8BIT_PTX()
+    if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int8_t))
+    {
+#    if (__cccl_ptx_isa >= 940ULL)
+      NV_IF_TARGET(NV_HAS_FEATURE_SM_107f, (return ::cuda::simd::min_relu(::cuda::simd::min_relu(__a, __b), __c);))
+#    endif // __cccl_ptx_isa >= 940ULL
+      NV_IF_TARGET(NV_HAS_FEATURE_SM_120f, (return ::cuda::simd::min_relu(::cuda::simd::min_relu(__a, __b), __c);))
+    }
+    else
+#  endif // _CCCL_HAS_SIMD_8BIT_PTX()
+      if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t) || sizeof(_Tp) == sizeof(::cuda::std::int32_t))
+      {
+        NV_IF_TARGET(NV_IS_DEVICE,
+                     (return __simd_min_max_relu_impl(__a, __b, __c, __min_relu_operation<_Tp, _Abi>{});)) // ADL
+      }
+  }
+#endif // _CCCL_HAS_SIMD_MIN_MAX_RELU()
+
+  using __vec_t = ::cuda::std::simd::basic_vec<_Tp, _Abi>;
+  return ::cuda::std::simd::max(::cuda::std::simd::min(::cuda::std::simd::min(__a, __b), __c), __vec_t{_Tp{0}});
+}
+
+_CCCL_END_NAMESPACE_CUDA_SIMD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___SIMD_MIN_MAX_RELU_H

--- a/libcudacxx/include/cuda/__simd/min_max_relu.h
+++ b/libcudacxx/include/cuda/__simd/min_max_relu.h
@@ -39,7 +39,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_SIMD
 
 // Depending on the compiler and the gpu architecture, the plain C++ code (without intrinsics) can generate or not the
-// expected SASS instructions. The instrinsic paths are preferred to always generate the optimal code.
+// expected SASS instructions. The intrinsic paths are preferred to always generate the optimal code.
 
 #if _CCCL_HAS_SIMD_MIN_MAX_RELU()
 

--- a/libcudacxx/include/cuda/__simd/min_max_relu.h
+++ b/libcudacxx/include/cuda/__simd/min_max_relu.h
@@ -48,7 +48,7 @@ struct __max_relu_operation
 {
   template <typename _Storage>
   [[nodiscard]] _CCCL_DEVICE_API constexpr _Storage
-  operator()(const _Storage& __lhs, const _Storage& __rhs) const noexcept
+  _CCCL_STATIC_CALL_OPERATOR(const _Storage& __lhs, const _Storage& __rhs) noexcept
   {
 #  if _CCCL_HAS_SIMD_8BIT_PTX()
     if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int8_t))
@@ -111,7 +111,7 @@ struct __min_relu_operation
 {
   template <typename _Storage>
   [[nodiscard]] _CCCL_DEVICE_API constexpr _Storage
-  operator()(const _Storage& __lhs, const _Storage& __rhs) const noexcept
+  _CCCL_STATIC_CALL_OPERATOR(const _Storage& __lhs, const _Storage& __rhs) noexcept
   {
 #  if _CCCL_HAS_SIMD_8BIT_PTX()
     if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int8_t))
@@ -145,7 +145,7 @@ struct __min_relu_operation
 
   template <typename _Storage>
   [[nodiscard]] _CCCL_DEVICE_API constexpr _Storage
-  operator()(const _Storage& __a, const _Storage& __b, const _Storage& __c) const noexcept
+  _CCCL_STATIC_CALL_OPERATOR(const _Storage& __a, const _Storage& __b, const _Storage& __c) noexcept
   {
     if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t))
     {

--- a/libcudacxx/include/cuda/__simd/min_max_relu.h
+++ b/libcudacxx/include/cuda/__simd/min_max_relu.h
@@ -43,6 +43,35 @@ _CCCL_BEGIN_NAMESPACE_CUDA_SIMD
 
 #if _CCCL_HAS_SIMD_MIN_MAX_RELU()
 
+// CUDA [12.0, 13.3] ptxas generates incorrect SM90 code for dependent VIMNMX.RELU instructions.
+// The workaround consists in adding an identity LOP3 to break the dependency. CTK 13.4 fixes the issue.
+template <typename _Tp>
+[[nodiscard]] _CCCL_DEVICE_API inline _Tp __workaround_sm90_vimnmx_relu(_Tp __value) noexcept
+{
+#  if _CCCL_CTK_BELOW(13, 4)
+  NV_IF_TARGET(NV_IS_EXACTLY_SM_90, ({
+                 _Tp __result;
+                 asm volatile("lop3.b32 %0, %1, 0, 0, 0xF0;" : "=r"(__result) : "r"(__value));
+                 return __result;
+               }))
+#  endif // _CCCL_CTK_BELOW(13, 4)
+  return __value;
+}
+
+template <::cuda::std::size_t _Np>
+[[nodiscard]] _CCCL_DEVICE_API inline ::cuda::std::simd::__array_u32_t<_Np>
+__workaround_sm90_vimnmx_relu(::cuda::std::simd::__array_u32_t<_Np> __values) noexcept
+{
+#  if _CCCL_CTK_BELOW(13, 4)
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (::cuda::std::size_t __i = 0; __i < _Np; ++__i)
+  {
+    __values[__i] = ::cuda::simd::__workaround_sm90_vimnmx_relu(__values[__i]);
+  }
+#  endif // _CCCL_CTK_BELOW(13, 4)
+  return __values;
+}
+
 template <typename _Tp, typename _Abi>
 struct __max_relu_operation
 {
@@ -62,9 +91,10 @@ struct __max_relu_operation
 #  endif // _CCCL_HAS_SIMD_8BIT_PTX()
       if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t))
       {
-        const auto __lhs_u    = ::cuda::std::simd::__to_unsigned_storage(__lhs);
-        const auto __rhs_u    = ::cuda::std::simd::__to_unsigned_storage(__rhs);
-        const auto __result_u = ::cuda::simd::__vmax_relu_16bit_x2(__lhs_u, __rhs_u);
+        const auto __lhs_u        = ::cuda::std::simd::__to_unsigned_storage(__lhs);
+        const auto __rhs_u        = ::cuda::std::simd::__to_unsigned_storage(__rhs);
+        const auto __result_tmp_u = ::cuda::simd::__vmax_relu_16bit_x2(__lhs_u, __rhs_u);
+        const auto __result_u     = ::cuda::simd::__workaround_sm90_vimnmx_relu(__result_tmp_u);
         return ::cuda::std::simd::__copy_from_unsigned_storage<_Storage>(__result_u);
       }
       else
@@ -74,7 +104,8 @@ struct __max_relu_operation
         _CCCL_PRAGMA_UNROLL_FULL()
         for (::cuda::std::simd::__simd_size_type __i = 0; __i < __size; ++__i)
         {
-          __result.__data[__i] = ::__vimax_s32_relu(__lhs.__data[__i], __rhs.__data[__i]);
+          const auto __result_i = ::__vimax_s32_relu(__lhs.__data[__i], __rhs.__data[__i]);
+          __result.__data[__i]  = ::cuda::simd::__workaround_sm90_vimnmx_relu(__result_i);
         }
         return __result;
       }
@@ -82,14 +113,15 @@ struct __max_relu_operation
 
   template <typename _Storage>
   [[nodiscard]] _CCCL_DEVICE_API constexpr _Storage
-  operator()(const _Storage& __a, const _Storage& __b, const _Storage& __c) const noexcept
+  _CCCL_STATIC_CALL_OPERATOR(const _Storage& __a, const _Storage& __b, const _Storage& __c) noexcept
   {
     if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t))
     {
-      const auto __a_u      = ::cuda::std::simd::__to_unsigned_storage(__a);
-      const auto __b_u      = ::cuda::std::simd::__to_unsigned_storage(__b);
-      const auto __c_u      = ::cuda::std::simd::__to_unsigned_storage(__c);
-      const auto __result_u = ::cuda::simd::__vmax3_relu_16bit_x2(__a_u, __b_u, __c_u);
+      const auto __a_u          = ::cuda::std::simd::__to_unsigned_storage(__a);
+      const auto __b_u          = ::cuda::std::simd::__to_unsigned_storage(__b);
+      const auto __c_u          = ::cuda::std::simd::__to_unsigned_storage(__c);
+      const auto __result_tmp_u = ::cuda::simd::__vmax3_relu_16bit_x2(__a_u, __b_u, __c_u);
+      const auto __result_u     = ::cuda::simd::__workaround_sm90_vimnmx_relu(__result_tmp_u);
       return ::cuda::std::simd::__copy_from_unsigned_storage<_Storage>(__result_u);
     }
     else
@@ -99,7 +131,8 @@ struct __max_relu_operation
       _CCCL_PRAGMA_UNROLL_FULL()
       for (::cuda::std::simd::__simd_size_type __i = 0; __i < __size; ++__i)
       {
-        __result.__data[__i] = ::__vimax3_s32_relu(__a.__data[__i], __b.__data[__i], __c.__data[__i]);
+        const auto __result_i = ::__vimax3_s32_relu(__a.__data[__i], __b.__data[__i], __c.__data[__i]);
+        __result.__data[__i]  = ::cuda::simd::__workaround_sm90_vimnmx_relu(__result_i);
       }
       return __result;
     }
@@ -125,9 +158,10 @@ struct __min_relu_operation
 #  endif // _CCCL_HAS_SIMD_8BIT_PTX()
       if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t))
       {
-        const auto __lhs_u    = ::cuda::std::simd::__to_unsigned_storage(__lhs);
-        const auto __rhs_u    = ::cuda::std::simd::__to_unsigned_storage(__rhs);
-        const auto __result_u = ::cuda::simd::__vmin_relu_16bit_x2(__lhs_u, __rhs_u);
+        const auto __lhs_u        = ::cuda::std::simd::__to_unsigned_storage(__lhs);
+        const auto __rhs_u        = ::cuda::std::simd::__to_unsigned_storage(__rhs);
+        const auto __result_tmp_u = ::cuda::simd::__vmin_relu_16bit_x2(__lhs_u, __rhs_u);
+        const auto __result_u     = ::cuda::simd::__workaround_sm90_vimnmx_relu(__result_tmp_u);
         return ::cuda::std::simd::__copy_from_unsigned_storage<_Storage>(__result_u);
       }
       else
@@ -137,7 +171,8 @@ struct __min_relu_operation
         _CCCL_PRAGMA_UNROLL_FULL()
         for (::cuda::std::simd::__simd_size_type __i = 0; __i < __size; ++__i)
         {
-          __result.__data[__i] = ::__vimin_s32_relu(__lhs.__data[__i], __rhs.__data[__i]);
+          const auto __result_i = ::__vimin_s32_relu(__lhs.__data[__i], __rhs.__data[__i]);
+          __result.__data[__i]  = ::cuda::simd::__workaround_sm90_vimnmx_relu(__result_i);
         }
         return __result;
       }
@@ -149,10 +184,11 @@ struct __min_relu_operation
   {
     if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int16_t))
     {
-      const auto __a_u      = ::cuda::std::simd::__to_unsigned_storage(__a);
-      const auto __b_u      = ::cuda::std::simd::__to_unsigned_storage(__b);
-      const auto __c_u      = ::cuda::std::simd::__to_unsigned_storage(__c);
-      const auto __result_u = ::cuda::simd::__vmin3_relu_16bit_x2(__a_u, __b_u, __c_u);
+      const auto __a_u          = ::cuda::std::simd::__to_unsigned_storage(__a);
+      const auto __b_u          = ::cuda::std::simd::__to_unsigned_storage(__b);
+      const auto __c_u          = ::cuda::std::simd::__to_unsigned_storage(__c);
+      const auto __result_tmp_u = ::cuda::simd::__vmin3_relu_16bit_x2(__a_u, __b_u, __c_u);
+      const auto __result_u     = ::cuda::simd::__workaround_sm90_vimnmx_relu(__result_tmp_u);
       return ::cuda::std::simd::__copy_from_unsigned_storage<_Storage>(__result_u);
     }
     else
@@ -162,7 +198,8 @@ struct __min_relu_operation
       _CCCL_PRAGMA_UNROLL_FULL()
       for (::cuda::std::simd::__simd_size_type __i = 0; __i < __size; ++__i)
       {
-        __result.__data[__i] = ::__vimin3_s32_relu(__a.__data[__i], __b.__data[__i], __c.__data[__i]);
+        const auto __result_i = ::__vimin3_s32_relu(__a.__data[__i], __b.__data[__i], __c.__data[__i]);
+        __result.__data[__i]  = ::cuda::simd::__workaround_sm90_vimnmx_relu(__result_i);
       }
       return __result;
     }

--- a/libcudacxx/include/cuda/__simd/simd_intrinsics.h
+++ b/libcudacxx/include/cuda/__simd/simd_intrinsics.h
@@ -21,7 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_SIMD_SAT() || _CCCL_HAS_SIMD_VABSDIFF() || _CCCL_HAS_SIMD_IDOT()
+#if _CCCL_HAS_SIMD_SAT() || _CCCL_HAS_SIMD_VABSDIFF() || _CCCL_HAS_SIMD_IDOT() || _CCCL_HAS_SIMD_MIN_MAX_RELU()
 
 #  include <cuda/std/cstdint>
 
@@ -345,9 +345,51 @@ _CCCL_BEGIN_NAMESPACE_CUDA_SIMD
 
 #  endif // _CCCL_HAS_SIMD_VABSDIFF()
 
+#  if _CCCL_HAS_SIMD_MIN_MAX_RELU() && _CCCL_HAS_SIMD_8BIT_PTX()
+
+[[nodiscard]] _CCCL_DEVICE_API inline ::cuda::std::uint32_t __vmax_relu_s8x4(
+  [[maybe_unused]] const ::cuda::std::uint32_t __lhs, [[maybe_unused]] const ::cuda::std::uint32_t __rhs) noexcept
+{
+#    if (__cccl_ptx_isa >= 940ULL)
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_107f, ({
+                 ::cuda::std::uint32_t __result{};
+                 asm("max.relu.s8x4 %0, %1, %2;" : "=r"(__result) : "r"(__lhs), "r"(__rhs));
+                 return __result;
+               }))
+#    endif // __cccl_ptx_isa >= 940ULL
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_120f, ({
+                 ::cuda::std::uint32_t __result{};
+                 asm("max.relu.s8x4 %0, %1, %2;" : "=r"(__result) : "r"(__lhs), "r"(__rhs));
+                 return __result;
+               }))
+  _CCCL_VERIFY(false, "cuda::simd::__vmax_relu_s8x4: Unsupported architecture");
+  return ::cuda::std::uint32_t{};
+}
+
+[[nodiscard]] _CCCL_DEVICE_API inline ::cuda::std::uint32_t __vmin_relu_s8x4(
+  [[maybe_unused]] const ::cuda::std::uint32_t __lhs, [[maybe_unused]] const ::cuda::std::uint32_t __rhs) noexcept
+{
+#    if (__cccl_ptx_isa >= 940ULL)
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_107f, ({
+                 ::cuda::std::uint32_t __result{};
+                 asm("min.relu.s8x4 %0, %1, %2;" : "=r"(__result) : "r"(__lhs), "r"(__rhs));
+                 return __result;
+               }))
+#    endif // __cccl_ptx_isa >= 940ULL
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_120f, ({
+                 ::cuda::std::uint32_t __result{};
+                 asm("min.relu.s8x4 %0, %1, %2;" : "=r"(__result) : "r"(__lhs), "r"(__rhs));
+                 return __result;
+               }))
+  _CCCL_VERIFY(false, "cuda::simd::__vmin_relu_s8x4: Unsupported architecture");
+  return ::cuda::std::uint32_t{};
+}
+
+#  endif // _CCCL_HAS_SIMD_8BIT_PTX() && _CCCL_HAS_SIMD_MIN_MAX_RELU()
+
 _CCCL_END_NAMESPACE_CUDA_SIMD
 
 #  include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CCCL_HAS_SIMD_SAT() || _CCCL_HAS_SIMD_VABSDIFF() || _CCCL_HAS_SIMD_IDOT()
+#endif // _CCCL_HAS_SIMD_SAT() || _CCCL_HAS_SIMD_VABSDIFF() || _CCCL_HAS_SIMD_IDOT() || _CCCL_HAS_SIMD_MIN_MAX_RELU()
 #endif // _CUDA___SIMD_SIMD_INTRINSICS_H

--- a/libcudacxx/include/cuda/__simd/simd_intrinsics_array.h
+++ b/libcudacxx/include/cuda/__simd/simd_intrinsics_array.h
@@ -21,7 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_SIMD_SAT() || _CCCL_HAS_SIMD_VABSDIFF() || _CCCL_HAS_SIMD_IDOT()
+#if _CCCL_HAS_SIMD_SAT() || _CCCL_HAS_SIMD_VABSDIFF() || _CCCL_HAS_SIMD_IDOT() || _CCCL_HAS_SIMD_MIN_MAX_RELU()
 
 #  include <cuda/__simd/simd_intrinsics.h>
 #  include <cuda/std/__cstddef/types.h>
@@ -217,9 +217,99 @@ template <typename _Tp, ::cuda::std::size_t _Np>
 
 #  endif // _CCCL_HAS_SIMD_VABSDIFF()
 
+#  if _CCCL_HAS_SIMD_MIN_MAX_RELU()
+
+#    if _CCCL_HAS_SIMD_8BIT_PTX()
+
+template <::cuda::std::size_t _Np>
+[[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::std::simd::__array_u32_t<_Np> __vmax_relu_8bit_x4(
+  const ::cuda::std::simd::__array_u32_t<_Np>& __lhs_u, const ::cuda::std::simd::__array_u32_t<_Np>& __rhs_u) noexcept
+{
+  ::cuda::std::simd::__array_u32_t<_Np> __result_u;
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (::cuda::std::size_t __i = 0; __i < _Np; ++__i)
+  {
+    __result_u[__i] = ::cuda::simd::__vmax_relu_s8x4(__lhs_u[__i], __rhs_u[__i]);
+  }
+  return __result_u;
+}
+
+template <::cuda::std::size_t _Np>
+[[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::std::simd::__array_u32_t<_Np> __vmin_relu_8bit_x4(
+  const ::cuda::std::simd::__array_u32_t<_Np>& __lhs_u, const ::cuda::std::simd::__array_u32_t<_Np>& __rhs_u) noexcept
+{
+  ::cuda::std::simd::__array_u32_t<_Np> __result_u;
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (::cuda::std::size_t __i = 0; __i < _Np; ++__i)
+  {
+    __result_u[__i] = ::cuda::simd::__vmin_relu_s8x4(__lhs_u[__i], __rhs_u[__i]);
+  }
+  return __result_u;
+}
+
+#    endif // _CCCL_HAS_SIMD_8BIT_PTX()
+
+template <::cuda::std::size_t _Np>
+[[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::std::simd::__array_u32_t<_Np> __vmax_relu_16bit_x2(
+  const ::cuda::std::simd::__array_u32_t<_Np>& __lhs_u, const ::cuda::std::simd::__array_u32_t<_Np>& __rhs_u) noexcept
+{
+  ::cuda::std::simd::__array_u32_t<_Np> __result_u;
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (::cuda::std::size_t __i = 0; __i < _Np; ++__i)
+  {
+    __result_u[__i] = ::__vimax_s16x2_relu(__lhs_u[__i], __rhs_u[__i]);
+  }
+  return __result_u;
+}
+
+template <::cuda::std::size_t _Np>
+[[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::std::simd::__array_u32_t<_Np> __vmin_relu_16bit_x2(
+  const ::cuda::std::simd::__array_u32_t<_Np>& __lhs_u, const ::cuda::std::simd::__array_u32_t<_Np>& __rhs_u) noexcept
+{
+  ::cuda::std::simd::__array_u32_t<_Np> __result_u;
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (::cuda::std::size_t __i = 0; __i < _Np; ++__i)
+  {
+    __result_u[__i] = ::__vimin_s16x2_relu(__lhs_u[__i], __rhs_u[__i]);
+  }
+  return __result_u;
+}
+
+template <::cuda::std::size_t _Np>
+[[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::std::simd::__array_u32_t<_Np> __vmax3_relu_16bit_x2(
+  const ::cuda::std::simd::__array_u32_t<_Np>& __a_u,
+  const ::cuda::std::simd::__array_u32_t<_Np>& __b_u,
+  const ::cuda::std::simd::__array_u32_t<_Np>& __c_u) noexcept
+{
+  ::cuda::std::simd::__array_u32_t<_Np> __result_u;
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (::cuda::std::size_t __i = 0; __i < _Np; ++__i)
+  {
+    __result_u[__i] = ::__vimax3_s16x2_relu(__a_u[__i], __b_u[__i], __c_u[__i]);
+  }
+  return __result_u;
+}
+
+template <::cuda::std::size_t _Np>
+[[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::std::simd::__array_u32_t<_Np> __vmin3_relu_16bit_x2(
+  const ::cuda::std::simd::__array_u32_t<_Np>& __a_u,
+  const ::cuda::std::simd::__array_u32_t<_Np>& __b_u,
+  const ::cuda::std::simd::__array_u32_t<_Np>& __c_u) noexcept
+{
+  ::cuda::std::simd::__array_u32_t<_Np> __result_u;
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (::cuda::std::size_t __i = 0; __i < _Np; ++__i)
+  {
+    __result_u[__i] = ::__vimin3_s16x2_relu(__a_u[__i], __b_u[__i], __c_u[__i]);
+  }
+  return __result_u;
+}
+
+#  endif // _CCCL_HAS_SIMD_MIN_MAX_RELU()
+
 _CCCL_END_NAMESPACE_CUDA_SIMD
 
 #  include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CCCL_HAS_SIMD_SAT() || _CCCL_HAS_SIMD_VABSDIFF() || _CCCL_HAS_SIMD_IDOT()
+#endif // _CCCL_HAS_SIMD_SAT() || _CCCL_HAS_SIMD_VABSDIFF() || _CCCL_HAS_SIMD_IDOT() || _CCCL_HAS_SIMD_MIN_MAX_RELU()
 #endif // _CUDA___SIMD_SIMD_INTRINSICS_ARRAY_H

--- a/libcudacxx/include/cuda/simd
+++ b/libcudacxx/include/cuda/simd
@@ -23,6 +23,7 @@
 
 #include <cuda/__simd/abs_diff.h>
 #include <cuda/__simd/dot.h>
+#include <cuda/__simd/min_max_relu.h>
 #include <cuda/__simd/saturating_add.h>
 #include <cuda/std/__simd_>
 

--- a/libcudacxx/include/cuda/std/__internal/features.h
+++ b/libcudacxx/include/cuda/std/__internal/features.h
@@ -138,6 +138,8 @@
   ((_CCCL_HAS_SIMD_IDOT_INTRINSICS() || _CCCL_HAS_SIMD_IDOT_PTX()) && _CCCL_CUDA_COMPILATION() \
    && !_CCCL_TILE_COMPILATION())
 
+#define _CCCL_HAS_SIMD_MIN_MAX_RELU() (_CCCL_HAS_CTK() && _CCCL_CUDA_COMPILATION() && !_CCCL_TILE_COMPILATION())
+
 // Third party libraries
 
 #if (__has_include(<dlpack/dlpack.h>) || __has_include(<dlpack.h>)) && \

--- a/libcudacxx/include/cuda/std/__simd/basic_vec.h
+++ b/libcudacxx/include/cuda/std/__simd/basic_vec.h
@@ -141,6 +141,20 @@ private:
     return basic_vec{__operation(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
+  template <typename _Operation>
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec
+  __simd_min_max_relu_impl(const basic_vec& __lhs, const basic_vec& __rhs, const _Operation& __operation) noexcept
+  {
+    return basic_vec{__operation(__lhs.__s_, __rhs.__s_), __storage_tag};
+  }
+
+  template <typename _Operation>
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec __simd_min_max_relu_impl(
+    const basic_vec& __a, const basic_vec& __b, const basic_vec& __c, const _Operation& __operation) noexcept
+  {
+    return basic_vec{__operation(__a.__s_, __b.__s_, __c.__s_), __storage_tag};
+  }
+
   template <typename _Up, typename _UAbi, typename _Operation>
   [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr basic_vec __abs_diff_impl(
     const basic_vec<_Up, _UAbi>& __lhs, const basic_vec<_Up, _UAbi>& __rhs, const _Operation& __operation) noexcept

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.non_std/min_max_relu.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.non_std/min_max_relu.pass.cpp
@@ -1,0 +1,176 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/simd>
+
+// template<class T, class Abi>
+//   constexpr basic_vec<T, Abi> cuda::simd::max_relu(
+//     const basic_vec<T, Abi>& lhs, const basic_vec<T, Abi>& rhs) noexcept;
+//
+// template<class T, class Abi>
+//   constexpr basic_vec<T, Abi> cuda::simd::min_relu(
+//     const basic_vec<T, Abi>& lhs, const basic_vec<T, Abi>& rhs) noexcept;
+//
+// template<class T, class Abi>
+//   constexpr basic_vec<T, Abi> cuda::simd::max_relu(
+//     const basic_vec<T, Abi>& a, const basic_vec<T, Abi>& b, const basic_vec<T, Abi>& c) noexcept;
+//
+// template<class T, class Abi>
+//   constexpr basic_vec<T, Abi> cuda::simd::min_relu(
+//     const basic_vec<T, Abi>& a, const basic_vec<T, Abi>& b, const basic_vec<T, Abi>& c) noexcept;
+
+#include <cuda/simd>
+#include <cuda/std/algorithm>
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+namespace simd = cuda::std::simd;
+
+template <typename T, int N>
+using fixed_size_vec = simd::basic_vec<T, simd::fixed_size<N>>;
+
+template <typename Vec, typename = void>
+inline constexpr bool has_min_max_relu_2 = false;
+
+template <typename Vec>
+inline constexpr bool has_min_max_relu_2<
+  Vec,
+  cuda::std::void_t<decltype(cuda::simd::min_relu(cuda::std::declval<Vec>(), cuda::std::declval<Vec>())),
+                    decltype(cuda::simd::max_relu(cuda::std::declval<Vec>(), cuda::std::declval<Vec>()))>> = true;
+
+template <typename Vec, typename = void>
+inline constexpr bool has_min_max_relu_3 = false;
+
+template <typename Vec>
+inline constexpr bool has_min_max_relu_3<
+  Vec,
+  cuda::std::void_t<
+    decltype(cuda::simd::min_relu(cuda::std::declval<Vec>(), cuda::std::declval<Vec>(), cuda::std::declval<Vec>())),
+    decltype(cuda::simd::max_relu(cuda::std::declval<Vec>(), cuda::std::declval<Vec>(), cuda::std::declval<Vec>()))>> =
+  true;
+
+template <typename T>
+TEST_FUNC constexpr T scalar_max_relu(T lhs, T rhs)
+{
+  return cuda::std::max(cuda::std::max(lhs, rhs), T{0});
+}
+
+template <typename T>
+TEST_FUNC constexpr T scalar_min_relu(T lhs, T rhs)
+{
+  return cuda::std::max(cuda::std::min(lhs, rhs), T{0});
+}
+
+template <typename T>
+TEST_FUNC constexpr T scalar_max_relu(T a, T b, T c)
+{
+  return cuda::std::max(cuda::std::max(cuda::std::max(a, b), c), T{0});
+}
+
+template <typename T>
+TEST_FUNC constexpr T scalar_min_relu(T a, T b, T c)
+{
+  return cuda::std::max(cuda::std::min(cuda::std::min(a, b), c), T{0});
+}
+
+template <typename T, int N>
+TEST_FUNC constexpr void
+test_values(cuda::std::array<T, N> a_values, cuda::std::array<T, N> b_values, cuda::std::array<T, N> c_values)
+{
+  using vec_t = fixed_size_vec<T, N>;
+  vec_t a(a_values);
+  vec_t b(b_values);
+  vec_t c(c_values);
+
+  static_assert(cuda::std::is_same_v<decltype(cuda::simd::max_relu(a, b)), vec_t>);
+  static_assert(cuda::std::is_same_v<decltype(cuda::simd::min_relu(a, b)), vec_t>);
+  static_assert(cuda::std::is_same_v<decltype(cuda::simd::max_relu(a, b, c)), vec_t>);
+  static_assert(cuda::std::is_same_v<decltype(cuda::simd::min_relu(a, b, c)), vec_t>);
+  static_assert(noexcept(cuda::simd::max_relu(a, b)));
+  static_assert(noexcept(cuda::simd::min_relu(a, b)));
+  static_assert(noexcept(cuda::simd::max_relu(a, b, c)));
+  static_assert(noexcept(cuda::simd::min_relu(a, b, c)));
+
+  vec_t max2 = cuda::simd::max_relu(a, b);
+  vec_t min2 = cuda::simd::min_relu(a, b);
+  vec_t max3 = cuda::simd::max_relu(a, b, c);
+  vec_t min3 = cuda::simd::min_relu(a, b, c);
+  for (int i = 0; i < N; ++i)
+  {
+    assert(max2[i] == scalar_max_relu(a_values[i], b_values[i]));
+    assert(min2[i] == scalar_min_relu(a_values[i], b_values[i]));
+    assert(max3[i] == scalar_max_relu(a_values[i], b_values[i], c_values[i]));
+    assert(min3[i] == scalar_min_relu(a_values[i], b_values[i], c_values[i]));
+  }
+}
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_size()
+{
+  constexpr auto min_val = cuda::std::numeric_limits<T>::min();
+  constexpr auto max_val = cuda::std::numeric_limits<T>::max();
+
+  cuda::std::array<T, N> a_values{min_val, max_val, T{-10}};
+  cuda::std::array<T, N> b_values{max_val, min_val, T{-20}};
+  cuda::std::array<T, N> c_values{T{0}, T{-1}, T{20}};
+  if constexpr (N > 3)
+  {
+    a_values[3] = T{-5};
+    b_values[3] = T{-5};
+    c_values[3] = T{-5};
+  }
+  if constexpr (N > 4)
+  {
+    a_values[4] = T{0};
+    b_values[4] = T{0};
+    c_values[4] = T{0};
+  }
+  test_values<T, N>(a_values, b_values, c_values);
+}
+
+template <typename T>
+TEST_FUNC constexpr void test()
+{
+  test_size<T, 3>();
+  test_size<T, 4>();
+  test_size<T, 5>();
+}
+
+TEST_FUNC constexpr bool test_all()
+{
+  static_assert(!has_min_max_relu_2<fixed_size_vec<unsigned, 4>>);
+  static_assert(!has_min_max_relu_3<fixed_size_vec<unsigned, 4>>);
+  static_assert(!has_min_max_relu_2<fixed_size_vec<float, 4>>);
+  static_assert(!has_min_max_relu_3<fixed_size_vec<float, 4>>);
+
+  test<signed char>();
+  test<signed short>();
+  test<signed int>();
+  test<signed long>();
+  test<signed long long>();
+#if _CCCL_HAS_INT128()
+  test<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  assert(test_all());
+  static_assert(test_all());
+
+  return 0;
+}

--- a/libcudacxx/test/simd_codegen/CMakeLists.txt
+++ b/libcudacxx/test/simd_codegen/CMakeLists.txt
@@ -96,6 +96,7 @@ if (libcudacxx_codegen_filecheck_simd_sass)
         REMOVE_ITEM simd_codegen_sass_tests
         "${CMAKE_CURRENT_SOURCE_DIR}/integer/arithmetic_u8x4.cu"
         "${CMAKE_CURRENT_SOURCE_DIR}/min_max/min_max_i8x4.cu"
+        "${CMAKE_CURRENT_SOURCE_DIR}/min_max/min_max_relu_i8x4.cu"
       )
     else()
       file(

--- a/libcudacxx/test/simd_codegen/min_max/min_max_relu.cu
+++ b/libcudacxx/test/simd_codegen/min_max/min_max_relu.cu
@@ -15,27 +15,6 @@ namespace simd = cuda::std::simd;
 
 using Vec_s32_x1 = simd::basic_vec<cuda::std::int32_t, simd::fixed_size<1>>;
 using Vec_s16_x2 = simd::basic_vec<cuda::std::int16_t, simd::fixed_size<2>>;
-using Vec_s8_x4  = simd::basic_vec<cuda::std::int8_t, simd::fixed_size<4>>;
-
-__device__ Vec_s8_x4 test_max_relu_s8_x4(Vec_s8_x4 a, Vec_s8_x4 b)
-{
-  return cuda::simd::max_relu(a, b);
-}
-
-__device__ Vec_s8_x4 test_min_relu_s8_x4(Vec_s8_x4 a, Vec_s8_x4 b)
-{
-  return cuda::simd::min_relu(a, b);
-}
-
-__device__ Vec_s8_x4 test_max_relu_s8_x4_3way(Vec_s8_x4 a, Vec_s8_x4 b, Vec_s8_x4 c)
-{
-  return cuda::simd::max_relu(a, b, c);
-}
-
-__device__ Vec_s8_x4 test_min_relu_s8_x4_3way(Vec_s8_x4 a, Vec_s8_x4 b, Vec_s8_x4 c)
-{
-  return cuda::simd::min_relu(a, b, c);
-}
 
 __device__ Vec_s16_x2 test_max_relu_s16_x2(Vec_s16_x2 a, Vec_s16_x2 b)
 {
@@ -142,25 +121,5 @@ __device__ Vec_s32_x1 test_min_relu_s32_3way(Vec_s32_x1 a, Vec_s32_x1 b, Vec_s32
 ; SM103: {{.*VIMNMX\.S16x2\.RELU.*!PT.*}}
 ; SM107: {{.*VIMNMX\.S16x2\.RELU.*!PT.*}}
 ; SM120: {{.*VIMNMX\.S16x2\.RELU.*!PT.*}}
-
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_min_relu_s8_x4_3way.*}}
-; SM107f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
-; SM107f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
-; SM120f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
-; SM120f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
-
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_max_relu_s8_x4_3way.*}}
-; SM107f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
-; SM107f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
-; SM120f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
-; SM120f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
-
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_min_relu_s8_x4.*}}
-; SM107f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
-; SM120f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
-
-; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_max_relu_s8_x4.*}}
-; SM107f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
-; SM120f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
 
 */

--- a/libcudacxx/test/simd_codegen/min_max/min_max_relu.cu
+++ b/libcudacxx/test/simd_codegen/min_max/min_max_relu.cu
@@ -1,0 +1,166 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/simd> // IWYU pragma: keep
+#include <cuda/std/cstdint>
+
+namespace simd = cuda::std::simd;
+
+using Vec_s32_x1 = simd::basic_vec<cuda::std::int32_t, simd::fixed_size<1>>;
+using Vec_s16_x2 = simd::basic_vec<cuda::std::int16_t, simd::fixed_size<2>>;
+using Vec_s8_x4  = simd::basic_vec<cuda::std::int8_t, simd::fixed_size<4>>;
+
+__device__ Vec_s8_x4 test_max_relu_s8_x4(Vec_s8_x4 a, Vec_s8_x4 b)
+{
+  return cuda::simd::max_relu(a, b);
+}
+
+__device__ Vec_s8_x4 test_min_relu_s8_x4(Vec_s8_x4 a, Vec_s8_x4 b)
+{
+  return cuda::simd::min_relu(a, b);
+}
+
+__device__ Vec_s8_x4 test_max_relu_s8_x4_3way(Vec_s8_x4 a, Vec_s8_x4 b, Vec_s8_x4 c)
+{
+  return cuda::simd::max_relu(a, b, c);
+}
+
+__device__ Vec_s8_x4 test_min_relu_s8_x4_3way(Vec_s8_x4 a, Vec_s8_x4 b, Vec_s8_x4 c)
+{
+  return cuda::simd::min_relu(a, b, c);
+}
+
+__device__ Vec_s16_x2 test_max_relu_s16_x2(Vec_s16_x2 a, Vec_s16_x2 b)
+{
+  return cuda::simd::max_relu(a, b);
+}
+
+__device__ Vec_s16_x2 test_min_relu_s16_x2(Vec_s16_x2 a, Vec_s16_x2 b)
+{
+  return cuda::simd::min_relu(a, b);
+}
+
+__device__ Vec_s16_x2 test_max_relu_s16_x2_3way(Vec_s16_x2 a, Vec_s16_x2 b, Vec_s16_x2 c)
+{
+  return cuda::simd::max_relu(a, b, c);
+}
+
+__device__ Vec_s16_x2 test_min_relu_s16_x2_3way(Vec_s16_x2 a, Vec_s16_x2 b, Vec_s16_x2 c)
+{
+  return cuda::simd::min_relu(a, b, c);
+}
+
+__device__ Vec_s32_x1 test_max_relu_s32(Vec_s32_x1 a, Vec_s32_x1 b)
+{
+  return cuda::simd::max_relu(a, b);
+}
+
+__device__ Vec_s32_x1 test_min_relu_s32(Vec_s32_x1 a, Vec_s32_x1 b)
+{
+  return cuda::simd::min_relu(a, b);
+}
+
+__device__ Vec_s32_x1 test_max_relu_s32_3way(Vec_s32_x1 a, Vec_s32_x1 b, Vec_s32_x1 c)
+{
+  return cuda::simd::max_relu(a, b, c);
+}
+
+__device__ Vec_s32_x1 test_min_relu_s32_3way(Vec_s32_x1 a, Vec_s32_x1 b, Vec_s32_x1 c)
+{
+  return cuda::simd::min_relu(a, b, c);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_min_relu_s32_3way.*}}
+; SM90: {{.*VIMNMX3\.RELU.*PT.*}}
+; SM100: {{.*VIMNMX3\.RELU.*PT.*}}
+; SM103: {{.*VIMNMX3\.RELU.*PT.*}}
+; SM107: {{.*VIMNMX.*RELU.*PT.*}}
+; SM107: {{.*VIMNMX.*RELU.*PT.*}}
+; SM120: {{.*VIMNMX.*RELU.*PT.*}}
+; SM120: {{.*VIMNMX.*RELU.*PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_max_relu_s32_3way.*}}
+; SM90: {{.*VIMNMX3\.RELU.*!PT.*}}
+; SM100: {{.*VIMNMX3\.RELU.*!PT.*}}
+; SM103: {{.*VIMNMX3\.RELU.*!PT.*}}
+; SM107: {{.*VIMNMX.*RELU.*!PT.*}}
+; SM107: {{.*VIMNMX.*RELU.*!PT.*}}
+; SM120: {{.*VIMNMX.*RELU.*!PT.*}}
+; SM120: {{.*VIMNMX.*RELU.*!PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_min_relu_s32.*}}
+; SM90: {{.*VIMNMX.*RELU.*PT.*}}
+; SM100: {{.*VIMNMX.*RELU.*PT.*}}
+; SM103: {{.*VIMNMX.*RELU.*PT.*}}
+; SM107: {{.*VIMNMX.*RELU.*PT.*}}
+; SM120: {{.*VIMNMX.*RELU.*PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_max_relu_s32.*}}
+; SM90: {{.*VIMNMX.*RELU.*!PT.*}}
+; SM100: {{.*VIMNMX.*RELU.*!PT.*}}
+; SM103: {{.*VIMNMX.*RELU.*!PT.*}}
+; SM107: {{.*VIMNMX.*RELU.*!PT.*}}
+; SM120: {{.*VIMNMX.*RELU.*!PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_min_relu_s16_x2_3way.*}}
+; SM90: {{.*VIMNMX3\.S16x2\.RELU.*PT.*}}
+; SM100: {{.*VIMNMX3\.S16x2\.RELU.*PT.*}}
+; SM103: {{.*VIMNMX3\.S16x2\.RELU.*PT.*}}
+; SM107: {{.*VIMNMX\.S16x2\.RELU.*PT.*}}
+; SM107: {{.*VIMNMX\.S16x2\.RELU.*PT.*}}
+; SM120: {{.*VIMNMX\.S16x2\.RELU.*PT.*}}
+; SM120: {{.*VIMNMX\.S16x2\.RELU.*PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_max_relu_s16_x2_3way.*}}
+; SM90: {{.*VIMNMX3\.S16x2\.RELU.*!PT.*}}
+; SM100: {{.*VIMNMX3\.S16x2\.RELU.*!PT.*}}
+; SM103: {{.*VIMNMX3\.S16x2\.RELU.*!PT.*}}
+; SM107: {{.*VIMNMX\.S16x2\.RELU.*!PT.*}}
+; SM107: {{.*VIMNMX\.S16x2\.RELU.*!PT.*}}
+; SM120: {{.*VIMNMX\.S16x2\.RELU.*!PT.*}}
+; SM120: {{.*VIMNMX\.S16x2\.RELU.*!PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_min_relu_s16_x2.*}}
+; SM90: {{.*VIMNMX\.S16x2\.RELU.*PT.*}}
+; SM100: {{.*VIMNMX\.S16x2\.RELU.*PT.*}}
+; SM103: {{.*VIMNMX\.S16x2\.RELU.*PT.*}}
+; SM107: {{.*VIMNMX\.S16x2\.RELU.*PT.*}}
+; SM120: {{.*VIMNMX\.S16x2\.RELU.*PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_max_relu_s16_x2.*}}
+; SM90: {{.*VIMNMX\.S16x2\.RELU.*!PT.*}}
+; SM100: {{.*VIMNMX\.S16x2\.RELU.*!PT.*}}
+; SM103: {{.*VIMNMX\.S16x2\.RELU.*!PT.*}}
+; SM107: {{.*VIMNMX\.S16x2\.RELU.*!PT.*}}
+; SM120: {{.*VIMNMX\.S16x2\.RELU.*!PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_min_relu_s8_x4_3way.*}}
+; SM107f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
+; SM107f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
+; SM120f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
+; SM120f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_max_relu_s8_x4_3way.*}}
+; SM107f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
+; SM107f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
+; SM120f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
+; SM120f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_min_relu_s8_x4.*}}
+; SM107f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
+; SM120f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_max_relu_s8_x4.*}}
+; SM107f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
+; SM120f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
+
+*/

--- a/libcudacxx/test/simd_codegen/min_max/min_max_relu_i8x4.cu
+++ b/libcudacxx/test/simd_codegen/min_max/min_max_relu_i8x4.cu
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/simd> // IWYU pragma: keep
+#include <cuda/std/cstdint>
+
+namespace simd = cuda::std::simd;
+
+using Vec_s8_x4 = simd::basic_vec<cuda::std::int8_t, simd::fixed_size<4>>;
+
+__device__ Vec_s8_x4 test_max_relu_s8_x4(Vec_s8_x4 a, Vec_s8_x4 b)
+{
+  return cuda::simd::max_relu(a, b);
+}
+
+__device__ Vec_s8_x4 test_min_relu_s8_x4(Vec_s8_x4 a, Vec_s8_x4 b)
+{
+  return cuda::simd::min_relu(a, b);
+}
+
+__device__ Vec_s8_x4 test_max_relu_s8_x4_3way(Vec_s8_x4 a, Vec_s8_x4 b, Vec_s8_x4 c)
+{
+  return cuda::simd::max_relu(a, b, c);
+}
+
+__device__ Vec_s8_x4 test_min_relu_s8_x4_3way(Vec_s8_x4 a, Vec_s8_x4 b, Vec_s8_x4 c)
+{
+  return cuda::simd::min_relu(a, b, c);
+}
+
+/*
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_min_relu_s8_x4_3way.*}}
+; SM107f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
+; SM107f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
+; SM120f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
+; SM120f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_max_relu_s8_x4_3way.*}}
+; SM107f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
+; SM107f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
+; SM120f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
+; SM120f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_min_relu_s8_x4.*}}
+; SM107f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
+; SM120f: {{.*VIMNMX\.S8x4\.RELU.*PT.*}}
+
+; SMXX-LABEL: {{[[:space:]]*}}Function : {{.*test_max_relu_s8_x4.*}}
+; SM107f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
+; SM120f: {{.*VIMNMX\.S8x4\.RELU.*!PT.*}}
+
+*/


### PR DESCRIPTION
## Description

The PR adds the functionalities to generate the [Dynamic Programming eXtension (DPX)](https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#dynamic-programming-extension-dpx-instructions) instructions related to `min/max` + ReLU with `cuda::std::simd` vectors.

The instructions are available on SM90+ for `s32`, `s16x2` + SM120/SM107 for `s8x4`.