### PR TITLE
Handle state appropriately in TransformIterator ops

### DIFF
--- a/python/cuda_cccl/cuda/compute/_jit.py
+++ b/python/cuda_cccl/cuda/compute/_jit.py
@@ -1015,6 +1015,11 @@ class _StatefulOp(OpAdapter):
     def get_state(self):
         return self._state.to_bytes()
 
+    @property
+    def state_alignment(self) -> int:
+        # State is packed device-array pointers; see _compile_stateful_op.
+        return np.dtype(np.intp).alignment
+
     def compile(self, input_types, output_type=None) -> Op:
         transformed_func = _transform_function_ast(self._func, self._state.names)
         return _compile_stateful_op(

--- a/python/cuda_cccl/cuda/compute/iterators/_base.py
+++ b/python/cuda_cccl/cuda/compute/iterators/_base.py
@@ -246,6 +246,42 @@ def _deterministic_suffix(kind: Hashable) -> str:
     return hashlib.sha256(kind_str.encode()).hexdigest()[:16]
 
 
+def compose_state_blobs(
+    blobs: list[tuple[bytes, int]],
+) -> tuple[bytes, int, list[int]]:
+    """
+    Concatenate raw (state_bytes, state_alignment) blobs with proper padding.
+
+    Args:
+        blobs: List of (state_bytes, state_alignment) pairs to compose
+
+    Returns:
+        Tuple of:
+        - combined_state_bytes: Concatenated state bytes with padding
+        - combined_alignment: Maximum alignment requirement
+        - offsets: List of byte offsets for each blob
+    """
+    if not blobs:
+        return (b"", 1, [])
+
+    offsets = []
+    current_offset = 0
+    combined = b""
+
+    for state, align in blobs:
+        # Add padding to meet alignment requirement
+        padding = (align - (current_offset % align)) % align
+        combined += b"\x00" * padding
+        current_offset += padding
+
+        offsets.append(current_offset)
+        combined += state
+        current_offset += len(state)
+
+    max_alignment = max(align for _, align in blobs)
+    return (combined, max_alignment, offsets)
+
+
 def compose_iterator_states(
     iterators: list[IteratorBase],
 ) -> tuple[bytes, int, list[int]]:
@@ -264,28 +300,9 @@ def compose_iterator_states(
         - combined_alignment: Maximum alignment requirement
         - offsets: List of byte offsets for each iterator's state
     """
-    if not iterators:
-        return (b"", 1, [])
-
-    states = [bytes(memoryview(it.state)) for it in iterators]
-    alignments = [it.state_alignment for it in iterators]
-
-    offsets = []
-    current_offset = 0
-    combined = b""
-
-    for state, align in zip(states, alignments):
-        # Add padding to meet alignment requirement
-        padding = (align - (current_offset % align)) % align
-        combined += b"\x00" * padding
-        current_offset += padding
-
-        offsets.append(current_offset)
-        combined += state
-        current_offset += len(state)
-
-    max_alignment = max(alignments)
-    return (combined, max_alignment, offsets)
+    return compose_state_blobs(
+        [(bytes(memoryview(it.state)), it.state_alignment) for it in iterators]
+    )
 
 
 cache_with_registered_key_functions.register(IteratorBase, lambda it: it.kind)

--- a/python/cuda_cccl/cuda/compute/iterators/_transform.py
+++ b/python/cuda_cccl/cuda/compute/iterators/_transform.py
@@ -12,7 +12,7 @@ from .._bindings import Op, OpKind
 from .._cpp_compile import compile_cpp_op_code, make_variable_declaration
 from ..op import make_op_adapter
 from ..types import TypeDescriptor, signature_from_annotations
-from ._base import IteratorBase
+from ._base import IteratorBase, compose_state_blobs
 from ._common import CUDA_PREAMBLE, ensure_iterator
 
 
@@ -46,6 +46,7 @@ class TransformIterator(IteratorBase):
         "_value_type",
         "_is_input",
         "_compiled_op",
+        "_op_state_offset",
     ]
 
     def __init__(
@@ -98,9 +99,30 @@ class TransformIterator(IteratorBase):
         assert value_type is not None
         self._value_type = value_type
 
+        # A stateful transform_op's state is folded into this
+        # iterator's own device state, alongside the underlying iterator's
+        # state, so that the generated deref glue (see _make_input_deref_op /
+        # _make_output_deref_op) has a pointer to hand the op as its `state`
+        # argument.
+        op_state = self._transform_op.get_state()
+        self._op_state_offset: int | None
+        if op_state:
+            underlying_state = bytes(memoryview(self._underlying.state))
+            state_bytes, state_alignment, offsets = compose_state_blobs(
+                [
+                    (underlying_state, self._underlying.state_alignment),
+                    (op_state, self._transform_op.state_alignment),
+                ]
+            )
+            self._op_state_offset = offsets[1]
+        else:
+            state_bytes = bytes(self._underlying.state)
+            state_alignment = self._underlying.state_alignment
+            self._op_state_offset = None
+
         super().__init__(
-            state_bytes=bytes(self._underlying.state),
-            state_alignment=self._underlying.state_alignment,
+            state_bytes=state_bytes,
+            state_alignment=state_alignment,
             value_type=value_type,
         )
 
@@ -160,16 +182,23 @@ class TransformIterator(IteratorBase):
         symbol = self._make_input_deref_symbol()
         temp_decl = make_variable_declaration(self._underlying.value_type, "temp")
 
+        if compiled_op.operator_type == OpKind.STATEFUL:
+            op_decl = f'extern "C" __device__ void {compiled_op.name}(void* state, void* input, void* output);'
+            op_call = f"{compiled_op.name}(static_cast<char*>(state) + {self._op_state_offset}, &temp, result);"
+        else:
+            op_decl = f'extern "C" __device__ void {compiled_op.name}(void* input, void* output);'
+            op_call = f"{compiled_op.name}(&temp, result);"
+
         source = dedent(f"""
             {CUDA_PREAMBLE}
 
             extern "C" __device__ void {child_op.name}(void* state, void* result);
-            extern "C" __device__ void {compiled_op.name}(void* input, void* output);
+            {op_decl}
 
             extern "C" __device__ void {symbol}(void* state, void* result) {{
                 {temp_decl}
                 {child_op.name}(state, &temp);
-                {compiled_op.name}(&temp, result);
+                {op_call}
             }}
         """).strip()
 
@@ -200,15 +229,22 @@ class TransformIterator(IteratorBase):
         symbol = self._make_output_deref_symbol()
         temp_decl = make_variable_declaration(self._underlying.value_type, "temp")
 
+        if compiled_op.operator_type == OpKind.STATEFUL:
+            op_decl = f'extern "C" __device__ void {compiled_op.name}(void* state, void* input, void* output);'
+            op_call = f"{compiled_op.name}(static_cast<char*>(state) + {self._op_state_offset}, value, &temp);"
+        else:
+            op_decl = f'extern "C" __device__ void {compiled_op.name}(void* input, void* output);'
+            op_call = f"{compiled_op.name}(value, &temp);"
+
         source = dedent(f"""
             {CUDA_PREAMBLE}
 
             extern "C" __device__ void {child_op.name}(void* state, void* value);
-            extern "C" __device__ void {compiled_op.name}(void* input, void* output);
+            {op_decl}
 
             extern "C" __device__ void {symbol}(void* state, void* value) {{
                 {temp_decl}
-                {compiled_op.name}(value, &temp);
+                {op_call}
                 {child_op.name}(state, &temp);
             }}
         """).strip()

--- a/python/cuda_cccl/cuda/compute/iterators/_transform.py
+++ b/python/cuda_cccl/cuda/compute/iterators/_transform.py
@@ -105,9 +105,9 @@ class TransformIterator(IteratorBase):
         # _make_output_deref_op) has a pointer to hand the op as its `state`
         # argument.
         op_state = self._transform_op.get_state()
+        underlying_state = bytes(memoryview(self._underlying.state))
         self._op_state_offset: int | None
         if op_state:
-            underlying_state = bytes(memoryview(self._underlying.state))
             state_bytes, state_alignment, offsets = compose_state_blobs(
                 [
                     (underlying_state, self._underlying.state_alignment),
@@ -116,7 +116,7 @@ class TransformIterator(IteratorBase):
             )
             self._op_state_offset = offsets[1]
         else:
-            state_bytes = bytes(self._underlying.state)
+            state_bytes = underlying_state
             state_alignment = self._underlying.state_alignment
             self._op_state_offset = None
 
@@ -144,6 +144,25 @@ class TransformIterator(IteratorBase):
                 output_type,
             )
         return self._compiled_op[key]
+
+    def _op_decl_and_call(
+        self, compiled_op: Op, input_expr: str, output_expr: str
+    ) -> tuple[str, str]:
+        """Return (extern declaration, call statement) for `compiled_op`.
+
+        Handles both the stateless 2-argument `(input, output)` and stateful
+        3-argument `(state, input, output)` calling conventions -- shared by
+        _make_input_deref_op and _make_output_deref_op so the two prototypes
+        only need to agree in one place.
+        """
+        if compiled_op.operator_type == OpKind.STATEFUL:
+            decl = f'extern "C" __device__ void {compiled_op.name}(void* state, void* input, void* output);'
+            state_expr = f"static_cast<char*>(state) + {self._op_state_offset}"
+            call = f"{compiled_op.name}({state_expr}, {input_expr}, {output_expr});"
+        else:
+            decl = f'extern "C" __device__ void {compiled_op.name}(void* input, void* output);'
+            call = f"{compiled_op.name}({input_expr}, {output_expr});"
+        return decl, call
 
     def _make_advance_op(self) -> Op:
         """Provide Op for advance that delegates to underlying iterator."""
@@ -182,12 +201,7 @@ class TransformIterator(IteratorBase):
         symbol = self._make_input_deref_symbol()
         temp_decl = make_variable_declaration(self._underlying.value_type, "temp")
 
-        if compiled_op.operator_type == OpKind.STATEFUL:
-            op_decl = f'extern "C" __device__ void {compiled_op.name}(void* state, void* input, void* output);'
-            op_call = f"{compiled_op.name}(static_cast<char*>(state) + {self._op_state_offset}, &temp, result);"
-        else:
-            op_decl = f'extern "C" __device__ void {compiled_op.name}(void* input, void* output);'
-            op_call = f"{compiled_op.name}(&temp, result);"
+        op_decl, op_call = self._op_decl_and_call(compiled_op, "&temp", "result")
 
         source = dedent(f"""
             {CUDA_PREAMBLE}
@@ -229,12 +243,7 @@ class TransformIterator(IteratorBase):
         symbol = self._make_output_deref_symbol()
         temp_decl = make_variable_declaration(self._underlying.value_type, "temp")
 
-        if compiled_op.operator_type == OpKind.STATEFUL:
-            op_decl = f'extern "C" __device__ void {compiled_op.name}(void* state, void* input, void* output);'
-            op_call = f"{compiled_op.name}(static_cast<char*>(state) + {self._op_state_offset}, value, &temp);"
-        else:
-            op_decl = f'extern "C" __device__ void {compiled_op.name}(void* input, void* output);'
-            op_call = f"{compiled_op.name}(value, &temp);"
+        op_decl, op_call = self._op_decl_and_call(compiled_op, "value", "&temp")
 
         source = dedent(f"""
             {CUDA_PREAMBLE}

--- a/python/cuda_cccl/cuda/compute/op.py
+++ b/python/cuda_cccl/cuda/compute/op.py
@@ -51,6 +51,11 @@ class _OpAdapter:
         """
         return b""
 
+    @property
+    def state_alignment(self) -> int:
+        """Return the alignment requirement of the op's state bytes."""
+        return 1
+
     def get_return_type(self, input_types):
         """Get the return type for this op given input types."""
         raise NotImplementedError(
@@ -166,6 +171,11 @@ class RawOp(_OpAdapter):
     def get_state(self) -> bytes:
         """Return the op's state bytes."""
         return self._state
+
+    @property
+    def state_alignment(self) -> int:
+        """Return the alignment requirement of the op's state bytes."""
+        return self._state_alignment
 
     @property
     def _identity(self):

--- a/python/cuda_cccl/cuda/compute/op.py
+++ b/python/cuda_cccl/cuda/compute/op.py
@@ -149,6 +149,15 @@ class RawOp(_OpAdapter):
         state_alignment: int = 1,
         extra_ltoirs: list[bytes | DeviceCode] | None = None,
     ):
+        if (
+            not isinstance(state_alignment, int)
+            or state_alignment < 1
+            or (state_alignment & (state_alignment - 1)) != 0
+        ):
+            raise ValueError(
+                "state_alignment must be a positive power of two, "
+                f"got {state_alignment!r}"
+            )
         self._ltoir = ltoir
         self._name = name
         self._state = state
@@ -179,10 +188,19 @@ class RawOp(_OpAdapter):
 
     @property
     def _identity(self):
+        # The actual *value* of the state bytes never affects the compiled
+        # LTO-IR/glue code -- only their length (which fixes offsets baked
+        # into generated deref code, see TransformIterator) and alignment
+        # do. Keying the cache on the state's value would force a full
+        # rebuild for every distinct runtime state (e.g. every distinct `n`
+        # in a `sum(x) * (1/n)` mean), defeating the point of passing it as
+        # state rather than baking it into the LTO-IR. Mirrors how iterator
+        # state_bytes are excluded from IteratorBase.kind for the same
+        # reason.
         return (
             self._ltoir,
             self._name,
-            self._state,
+            len(self._state),
             self._state_alignment,
             tuple(self._extra_ltoirs),
         )

--- a/python/cuda_cccl/tests/compute/test_iterators.py
+++ b/python/cuda_cccl/tests/compute/test_iterators.py
@@ -18,6 +18,8 @@ from cuda.compute.iterators import (
     CountingIterator,
     ReverseIterator,
     TransformIterator,
+    TransformOutputIterator,
+    ZipIterator,
 )
 
 
@@ -220,4 +222,107 @@ def test_transform_iterator_with_zip_iterator():
     result = d_output.copy_to_host()[0]
     expected = (h_a + h_b).sum()
 
+    assert result == expected, f"Expected {expected}, got {result}"
+
+
+def test_transform_output_iterator_with_stateful_closure():
+    """Numba-path counterpart of test_raw_op.py's
+    test_cpp_stateful_op_with_transform_output_iterator: a stateful Python
+    callable (closing over a device array) used as a TransformOutputIterator's
+    transform op must receive its state."""
+    scale_factor = DeviceArray.from_numpy(np.array([3], dtype=np.int32))
+
+    def scale_by_state(x):
+        return x * scale_factor[0]
+
+    num_items = 10
+    h_input = np.arange(num_items, dtype=np.int32)
+    d_input = DeviceArray.from_numpy(h_input)
+    d_output = DeviceArray.empty(1, np.int32)
+
+    output_iterator = TransformOutputIterator(
+        d_output, scale_by_state, output_value_type=cuda.compute.types.int32
+    )
+
+    h_init = np.array(0, dtype=np.int32)
+    cuda.compute.reduce_into(
+        d_in=d_input,
+        d_out=output_iterator,
+        num_items=num_items,
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
+
+    result = d_output.copy_to_host()[0]
+    expected = int(np.sum(h_input)) * 3
+    assert result == expected, f"Expected {expected}, got {result}"
+
+
+def test_transform_iterator_with_stateful_closure():
+    """Numba-path counterpart of test_raw_op.py's
+    test_cpp_stateful_op_with_transform_input_iterator."""
+    scale_factor = DeviceArray.from_numpy(np.array([3], dtype=np.int32))
+
+    def scale_by_state(x):
+        return x * scale_factor[0]
+
+    num_items = 10
+    h_input = np.arange(num_items, dtype=np.int32)
+    d_input = DeviceArray.from_numpy(h_input)
+    d_output = DeviceArray.empty(1, np.int32)
+
+    transform_iter = TransformIterator(
+        d_input, scale_by_state, value_type=cuda.compute.types.int32
+    )
+
+    h_init = np.array(0, dtype=np.int32)
+    cuda.compute.reduce_into(
+        d_in=transform_iter,
+        d_out=d_output,
+        num_items=num_items,
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
+
+    result = d_output.copy_to_host()[0]
+    expected = int(np.sum(h_input)) * 3
+    assert result == expected, f"Expected {expected}, got {result}"
+
+
+def test_transform_iterator_stateful_closure_nested_in_zip():
+    """Numba-path counterpart of test_raw_op.py's
+    test_cpp_stateful_op_transform_nested_in_zip: a stateful TransformIterator
+    nested inside ZipIterator, which treats its children's state opaquely."""
+    scale_factor = DeviceArray.from_numpy(np.array([3], dtype=np.int32))
+
+    def scale_by_state(x):
+        return x * scale_factor[0]
+
+    def add_pair(pair):
+        return pair[0] + pair[1]
+
+    num_items = 10
+    h_x = np.arange(num_items, dtype=np.int32)
+    h_y = np.arange(num_items, dtype=np.int32) * 100
+    d_x = DeviceArray.from_numpy(h_x)
+    d_y = DeviceArray.from_numpy(h_y)
+
+    scaled_x = TransformIterator(
+        d_x, scale_by_state, value_type=cuda.compute.types.int32
+    )
+    zipped = ZipIterator(scaled_x, d_y)
+    combined = TransformIterator(zipped, add_pair)
+
+    d_output = DeviceArray.empty(1, np.int32)
+    h_init = np.array(0, dtype=np.int32)
+    cuda.compute.reduce_into(
+        d_in=combined,
+        d_out=d_output,
+        num_items=num_items,
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
+
+    result = d_output.copy_to_host()[0]
+    expected = int((h_x * 3 + h_y).sum())
     assert result == expected, f"Expected {expected}, got {result}"

--- a/python/cuda_cccl/tests/compute/test_raw_op.py
+++ b/python/cuda_cccl/tests/compute/test_raw_op.py
@@ -523,3 +523,145 @@ def test_cpp_stateful_op_select_with_counter():
     assert np.array_equal(selected_values, expected_selected), (
         "Selected values don't match"
     )
+
+
+def test_cpp_stateful_op_with_transform_output_iterator():
+    """Regression test: a stateful RawOp used as a TransformOutputIterator's
+    transform op must receive its state.
+
+    This mirrors computing a mean as sum(x) * (1/n): the scale factor lives
+    in the RawOp's state and is applied to the reduction result by a
+    TransformOutputIterator.
+    """
+    from cuda.compute import OpKind, TransformOutputIterator
+
+    scale_factor = np.array([3], dtype=np.int32)
+    state_data = scale_factor.tobytes()
+    state_alignment = np.dtype(np.int32).alignment
+
+    cpp_source = """
+    extern "C" __device__ void scale_by_state(void* state, void* input, void* output) {
+        int factor = *static_cast<int*>(state);
+        *static_cast<int*>(output) = *static_cast<int*>(input) * factor;
+    }
+    """
+
+    op = make_cpp_stateful_op(cpp_source, state_data, "scale_by_state", state_alignment)
+
+    num_items = 10
+    h_input = np.arange(num_items, dtype=np.int32)
+    d_input = DeviceArray.from_numpy(h_input)
+    d_output = DeviceArray.empty(1, np.int32)
+
+    output_iterator = TransformOutputIterator(
+        d_output, op, output_value_type=types.int32
+    )
+
+    h_init = np.array(0, dtype=np.int32)
+    cuda.compute.reduce_into(
+        d_in=d_input,
+        d_out=output_iterator,
+        num_items=num_items,
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
+
+    result = d_output.copy_to_host()[0]
+    expected = int(np.sum(h_input)) * 3
+    assert result == expected, f"Expected {expected}, got {result}"
+
+
+def test_cpp_stateful_op_with_transform_input_iterator():
+    """Regression test: a stateful RawOp used as a TransformIterator's
+    (input-side) transform op must receive its state."""
+    from cuda.compute import OpKind, TransformIterator
+
+    scale_factor = np.array([3], dtype=np.int32)
+    state_data = scale_factor.tobytes()
+    state_alignment = np.dtype(np.int32).alignment
+
+    cpp_source = """
+    extern "C" __device__ void scale_by_state(void* state, void* input, void* output) {
+        int factor = *static_cast<int*>(state);
+        *static_cast<int*>(output) = *static_cast<int*>(input) * factor;
+    }
+    """
+
+    op = make_cpp_stateful_op(cpp_source, state_data, "scale_by_state", state_alignment)
+
+    num_items = 10
+    h_input = np.arange(num_items, dtype=np.int32)
+    d_input = DeviceArray.from_numpy(h_input)
+    d_output = DeviceArray.empty(1, np.int32)
+
+    transform_iter = TransformIterator(d_input, op, value_type=types.int32)
+
+    h_init = np.array(0, dtype=np.int32)
+    cuda.compute.reduce_into(
+        d_in=transform_iter,
+        d_out=d_output,
+        num_items=num_items,
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
+
+    result = d_output.copy_to_host()[0]
+    expected = int(np.sum(h_input)) * 3
+    assert result == expected, f"Expected {expected}, got {result}"
+
+
+def test_cpp_stateful_op_transform_nested_in_zip():
+    """Regression test: a stateful RawOp's state must still be correctly
+    composed when its TransformIterator is nested inside another compound
+    iterator (here, ZipIterator), which treats its children's `.state` /
+    `.state_alignment` opaquely."""
+    from cuda.compute import OpKind, TransformIterator, ZipIterator
+
+    # Stateful op: scales its input by a state-provided factor.
+    scale_factor = np.array([3], dtype=np.int32)
+    state_data = scale_factor.tobytes()
+    state_alignment = np.dtype(np.int32).alignment
+
+    scale_source = """
+    extern "C" __device__ void scale_by_state(void* state, void* input, void* output) {
+        int factor = *static_cast<int*>(state);
+        *static_cast<int*>(output) = *static_cast<int*>(input) * factor;
+    }
+    """
+    scale_op = make_cpp_stateful_op(
+        scale_source, state_data, "scale_by_state", state_alignment
+    )
+
+    # Stateless op: sums the two fields of the zipped pair.
+    add_source = """
+    struct Pair { int field_0; int field_1; };
+    extern "C" __device__ void add_pair(void* input, void* output) {
+        Pair* p = static_cast<Pair*>(input);
+        *static_cast<int*>(output) = p->field_0 + p->field_1;
+    }
+    """
+    add_op = make_cpp_op(add_source, "add_pair")
+
+    num_items = 10
+    h_x = np.arange(num_items, dtype=np.int32)
+    h_y = np.arange(num_items, dtype=np.int32) * 100
+    d_x = DeviceArray.from_numpy(h_x)
+    d_y = DeviceArray.from_numpy(h_y)
+
+    scaled_x = TransformIterator(d_x, scale_op, value_type=types.int32)
+    zipped = ZipIterator(scaled_x, d_y)
+    combined = TransformIterator(zipped, add_op, value_type=types.int32)
+
+    d_output = DeviceArray.empty(1, np.int32)
+    h_init = np.array(0, dtype=np.int32)
+    cuda.compute.reduce_into(
+        d_in=combined,
+        d_out=d_output,
+        num_items=num_items,
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
+
+    result = d_output.copy_to_host()[0]
+    expected = int((h_x * 3 + h_y).sum())
+    assert result == expected, f"Expected {expected}, got {result}"


### PR DESCRIPTION
## Description

`TransformIterator` currently ignores its `op` state, instead using only the underlying iterator's state to compose its state bytes. This PR makes it so that if the op of a `TransformIterator` is stateful, we combine the op state with the underlying iterator's state. The dereference operator is modified to decompose the states and handle them appropriately.

Closes https://github.com/NVIDIA/cccl/issues/11142




## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
