### PR TITLE
Run the Windows test payloads in a minimal sibling container

### DIFF
--- a/ci/windows/build_common.psm1
+++ b/ci/windows/build_common.psm1
@@ -14,6 +14,10 @@ Param(
 
 $ErrorActionPreference = "Stop"
 
+# Invoke-Checked lives in build_common_python.psm1, which the minimal test
+# container can also import; re-exported below.
+Import-Module "$PSScriptRoot/build_common_python.psm1"
+
 # We need the full path to cl because otherwise cmake will replace CMAKE_CXX_COMPILER with the full path
 # and keep CMAKE_CUDA_HOST_COMPILER at "cl" which breaks our cmake script
 $script:HOST_COMPILER  = (Get-Command "cl").source -replace '\\','/'
@@ -207,26 +211,6 @@ function configure_and_build_preset {
 
     configure_preset $BUILD_NAME $PRESET $LOCAL_CMAKE_OPTIONS
     build_preset $BUILD_NAME $PRESET
-}
-
-function Invoke-Checked {
-    <#
-    .SYNOPSIS
-        Runs a script block and throws if the last native command in it exits
-        non-zero. $ErrorActionPreference = "Stop" does not make native commands
-        (python/pip/pytest/...) throw, so their $LASTEXITCODE must be checked
-        explicitly; this wraps that boilerplate into one call.
-    .EXAMPLE
-        Invoke-Checked { & $python -m pip install pytest } "pip install failed"
-    #>
-    param(
-        [Parameter(Mandatory, Position = 0)][scriptblock]$ScriptBlock,
-        [Parameter(Position = 1)][string]$ErrorMessage = "Native command failed"
-    )
-    & $ScriptBlock
-    if ($LASTEXITCODE -ne 0) {
-        throw "$ErrorMessage (exit code $LASTEXITCODE)"
-    }
 }
 
 Export-ModuleMember -Function configure_preset, build_preset, test_preset, configure_and_build_preset, Invoke-Checked

--- a/ci/windows/build_common_python.psm1
+++ b/ci/windows/build_common_python.psm1
@@ -1,3 +1,28 @@
+# Windows PowerShell 5.1 in a bare image may still default to TLS 1.0, which
+# astral.sh and aka.ms both reject.
+[Net.ServicePointManager]::SecurityProtocol =
+    [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+function Invoke-Checked {
+    <#
+    .SYNOPSIS
+        Runs a script block and throws if the last native command in it exits
+        non-zero. $ErrorActionPreference = "Stop" does not make native commands
+        (python/pip/pytest/...) throw, so their $LASTEXITCODE must be checked
+        explicitly; this wraps that boilerplate into one call.
+    .EXAMPLE
+        Invoke-Checked { & $python -m pip install pytest } "pip install failed"
+    #>
+    param(
+        [Parameter(Mandatory, Position = 0)][scriptblock]$ScriptBlock,
+        [Parameter(Position = 1)][string]$ErrorMessage = "Native command failed"
+    )
+    & $ScriptBlock
+    if ($LASTEXITCODE -ne 0) {
+        throw "$ErrorMessage (exit code $LASTEXITCODE)"
+    }
+}
+
 function Get-Python {
     <#
     .SYNOPSIS
@@ -70,6 +95,9 @@ function Get-CudaMajor {
         $pathMatch = [regex]::Match($env:CUDA_PATH, 'v?(\d+)(?:\.\d+)?')
         if ($pathMatch.Success) { return $pathMatch.Groups[1].Value }
     }
+    # The minimal test container has no CUDA toolkit at all, by design, so the
+    # caller passes the version resolved outside it.
+    if ($env:CCCL_CUDA_VERSION -match '^(\d+)\.') { return $Matches[1] }
     return '13'
 }
 
@@ -90,6 +118,8 @@ function Get-CudaVersion {
         $pathMatch = [regex]::Match($env:CUDA_PATH, 'v?(\d+\.\d+)')
         if ($pathMatch.Success) { return $pathMatch.Groups[1].Value }
     }
+    # See Get-CudaMajor.
+    if ($env:CCCL_CUDA_VERSION -match '^\d+\.\d+$') { return $env:CCCL_CUDA_VERSION }
     return '13.0'
 }
 
@@ -243,4 +273,72 @@ $indented
     return $pathMatches[0]
 }
 
-Export-ModuleMember -Function Get-Python, Get-CudaMajor, Set-CtkPin, Get-CtkExtraFlavor, Convert-ToUnixPath, Get-RepoRoot, Get-CudaCcclWheel, Get-OnePathMatch
+function Install-MsvcRuntime {
+    <#
+    .SYNOPSIS
+        Ensures the MSVC runtime redistributable is present.
+    .DESCRIPTION
+        Server Core ships no MSVC runtime, and every C++ Python extension used by
+        the test lanes links against it -- numba's _typeconv and
+        cccl.c.parallel.dll among them. It is a Windows prerequisite rather than
+        a packaging gap, so install it instead of expecting a wheel to carry it.
+        vcruntime140*.dll ship next to some interpreters, which makes
+        msvcp140.dll the reliable probe.
+
+        A no-op wherever the runtime already exists, so it costs nothing in the
+        devcontainer.
+    #>
+    $msvcp = Join-Path $env:SystemRoot 'System32\msvcp140.dll'
+    if (Test-Path $msvcp) { return }
+
+    Write-Host "Installing the MSVC runtime redistributable..."
+    $installer = Join-Path $env:TEMP 'vc_redist.x64.exe'
+    Invoke-WebRequest -UseBasicParsing `
+        -Uri 'https://aka.ms/vs/17/release/vc_redist.x64.exe' -OutFile $installer
+    Start-Process -Wait -FilePath $installer -ArgumentList '/quiet', '/norestart'
+    if (-not (Test-Path $msvcp)) {
+        throw "vc_redist.x64.exe did not install msvcp140.dll."
+    }
+}
+
+function Assert-MinimalEnvironment {
+    <#
+    .SYNOPSIS
+        Proves the claim the minimal container exists to make: that nothing here
+        but Python and the wheel's declared dependencies is available.
+    .DESCRIPTION
+        Without this the isolation is merely assumed -- swap the base image for
+        one carrying a toolchain and every lane would keep passing while testing
+        nothing. A no-op outside the container, where a compiler and a CUDA
+        toolkit are legitimately present.
+
+        The MSVC *runtime* the payload installs is deliberately not checked: it
+        is a Windows prerequisite, not a compiler.
+    #>
+    if ($env:CCCL_INSIDE_MINIMAL_CONTAINER -ne '1') { return }
+
+    $found = @()
+    foreach ($tool in @('cl.exe', 'link.exe', 'nvcc.exe')) {
+        $cmd = Get-Command $tool -ErrorAction SilentlyContinue
+        if ($cmd) { $found += "$tool ($($cmd.Source))" }
+    }
+    if ($env:CUDA_PATH) { $found += "CUDA_PATH=$($env:CUDA_PATH)" }
+    # Guarded: Join-Path throws on a null root, and with ErrorActionPreference
+    # Stop that would mask the check it is part of.
+    if ($env:ProgramFiles) {
+        $ctkDir = Join-Path $env:ProgramFiles 'NVIDIA GPU Computing Toolkit\CUDA'
+        if (Test-Path $ctkDir) { $found += $ctkDir }
+    }
+
+    if ($found.Count -gt 0) {
+        $list = ($found | ForEach-Object { "    $_" }) -join "`n"
+        throw (
+            "This is supposed to be a minimal environment, but it provides:`n$list`n" +
+            "The lane cannot tell whether cuda.compute depends only on its declared " +
+            "pip dependencies while these are present. Check the container image."
+        )
+    }
+    Write-Host "Minimal environment confirmed: no host compiler, no system CUDA toolkit."
+}
+
+Export-ModuleMember -Function Invoke-Checked, Get-Python, Assert-MinimalEnvironment, Install-MsvcRuntime, Get-CudaMajor, Get-CudaVersion, Set-CtkPin, Get-CtkExtraFlavor, Convert-ToUnixPath, Get-RepoRoot, Get-CudaCcclWheel, Get-OnePathMatch

--- a/ci/windows/run_compute_minimal_tests.ps1
+++ b/ci/windows/run_compute_minimal_tests.ps1
@@ -1,0 +1,89 @@
+<#
+.SYNOPSIS
+    Test payload: the numba-free (minimal extra) cuda.compute suite.
+.DESCRIPTION
+    Invoked by ci/windows/test_cuda_compute_minimal_python.ps1, which has already put the
+    cuda_cccl wheel in wheelhouse/. This normally runs in the minimal container;
+    see "Testing Python in a minimal container" in
+    docs/infrastructure/ci/references/ci_scripts.rst.
+
+    build_common.psm1 must NOT be imported here: it resolves cl.exe at import
+    time, which by design does not exist in the minimal image.
+#>
+Param(
+    [Parameter(Mandatory = $true)]
+    [Alias("py-version")]
+    [ValidatePattern("^\d+\.\d+t?$")]
+    [string]$PyVersion,
+
+    [Alias("ctk-mode")]
+    [string]$CtkMode = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot/build_common_python.psm1"
+
+Assert-MinimalEnvironment
+
+Install-MsvcRuntime
+
+$python = Get-Python -Version $PyVersion
+$cudaMajor = Get-CudaMajor
+$ctkFlavor = Get-CtkExtraFlavor $CtkMode
+Set-CtkPin $CtkMode
+
+$repoRoot = Get-RepoRoot
+$wheelPath = Get-OnePathMatch -Path (Join-Path $repoRoot 'wheelhouse') -Pattern '^cuda_cccl-.*\.whl' -File
+
+# Install cuda_cccl with the minimal CUDA extra. This intentionally avoids the
+# full cu* extras because those pull in numba/numba-cuda.
+Invoke-Checked { & $python -m pip install -U pip pytest pytest-xdist } "Failed to install pytest / pytest-xdist"
+Invoke-Checked { & $python -m pip install "$wheelPath[minimal-$ctkFlavor$cudaMajor]" } "Failed to install cuda_cccl minimal extra"
+
+Push-Location (Join-Path $repoRoot "python/cuda_cccl/tests")
+try {
+    Invoke-Checked { & $python -m pytest -n 6 -v compute/test_no_numba.py } "test_no_numba.py failed"
+
+    if ($PyVersion -eq "3.14t") {
+        # Select only tests that support the minimal extra so pytest does not
+        # collect tests that import numba-cuda and re-enable the GIL. These tests
+        # provide their own worker threads, so keep pytest itself in a single
+        # process. The serialization node-ids are module-skipped on the v2
+        # backend today and will start running there automatically once v2 gains
+        # serialization support.
+        Invoke-Checked {
+            & $python -m pytest -n 0 -v `
+                compute/test_free_threading_stress.py `
+                compute/test_multi_cc_serialization.py::test_aot_build_result_load_failure_is_shared_and_retryable `
+                compute/test_multi_cc_serialization.py::test_aot_serialization_waits_for_canonical_first_load
+        } "free-threading stress / serialization tests failed"
+
+        # Broad thread-safety sweep (pytest-run-parallel): re-run the numba-free
+        # functional suite with each test executed concurrently across threads
+        # (barrier-synchronized start), stressing the process-wide build cache,
+        # single-flight coordination, and the Cython bindings from many threads at
+        # once. Complements test_free_threading_stress.py above, which targets
+        # specific shared-object scenarios by hand. -n 0 so the threads share one
+        # interpreter.
+        #
+        # --parallel-threads=2 matches CuPy's free-threading CI (the closest GPU
+        # precedent); a small fixed count bounds GPU-memory pressure from
+        # concurrent kernels and stays reproducible across runners, unlike =auto
+        # (the runner's logical-core count).
+        #
+        # pytest-run-parallel is only used by this sweep, so install it on the
+        # 3.14t path rather than for every minimal (e.g. non-free-threaded 3.14)
+        # run.
+        Invoke-Checked { & $python -m pip install pytest-run-parallel } "Failed to install pytest-run-parallel"
+
+        # Fail fast if the interpreter is not actually GIL-free (wrong build /
+        # PYTHON_GIL=1): pytest-run-parallel does NOT catch a GIL that is enabled
+        # from the start -- it would run threads GIL-serialized and pass
+        # vacuously. (A GIL *re-enabled mid-run* by a non-free-threaded import IS
+        # caught by the plugin, which is why we do not pass --ignore-gil-enabled.)
+        Invoke-Checked { & $python -c "import sys; assert not sys._is_gil_enabled(), 'GIL is enabled; parallel sweep has no signal'" } "interpreter is not GIL-free; parallel sweep has no signal"
+        Invoke-Checked { & $python -m pytest -n 0 -v --parallel-threads=2 compute/test_no_numba.py } "parallel-threads sweep failed"
+    }
+}
+finally { Pop-Location }

--- a/ci/windows/run_compute_tests.ps1
+++ b/ci/windows/run_compute_tests.ps1
@@ -1,0 +1,55 @@
+<#
+.SYNOPSIS
+    Test payload: the cuda.compute pytest suite.
+.DESCRIPTION
+    Invoked by ci/windows/test_cuda_compute_python.ps1, which has already put the
+    cuda_cccl wheel in wheelhouse/. This normally runs in the minimal container;
+    see "Testing Python in a minimal container" in
+    docs/infrastructure/ci/references/ci_scripts.rst.
+
+    build_common.psm1 must NOT be imported here: it resolves cl.exe at import
+    time, which by design does not exist in the minimal image.
+#>
+Param(
+    [Parameter(Mandatory = $true)]
+    [Alias("py-version")]
+    [ValidatePattern("^\d+\.\d+t?$")]
+    [string]$PyVersion,
+
+    [Alias("ctk-mode")]
+    [string]$CtkMode = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot/build_common_python.psm1"
+
+Assert-MinimalEnvironment
+
+Install-MsvcRuntime
+
+$python = Get-Python -Version $PyVersion
+$cudaMajor = Get-CudaMajor
+$ctkFlavor = Get-CtkExtraFlavor $CtkMode
+
+# Pin cuda-toolkit to the lane's CTK minor (-ctk-mode latest opts out).
+Set-CtkPin $CtkMode
+
+$repoRoot = Get-RepoRoot
+$wheelPath = Get-OnePathMatch -Path (Join-Path $repoRoot 'wheelhouse') -Pattern '^cuda_cccl-.*\.whl' -File
+
+Invoke-Checked { & $python -m pip install -U pip pytest pytest-xdist } "Failed to install pytest / pytest-xdist"
+Invoke-Checked { & $python -m pip install "$wheelPath[test-$ctkFlavor$cudaMajor]" } "Failed to install cuda_cccl test extra"
+
+Push-Location (Join-Path $repoRoot "python/cuda_cccl/tests")
+try {
+    Invoke-Checked { & $python -m pytest -n 6 -v compute/ -m "not large and not free_threading" } "compute tests (not large) failed"
+    Invoke-Checked { & $python -m pytest -n 0 -v compute/ -m "large and not free_threading" } "compute tests (large) failed"
+
+    # ml_dtypes (the NumPy bfloat16 extension dtype) is deliberately not in the
+    # test extras, so the sweeps above match a user's default install, where the
+    # bfloat16 tests skip themselves. Install it last and run them explicitly.
+    Invoke-Checked { & $python -m pip install ml_dtypes } "Failed to install ml_dtypes"
+    Invoke-Checked { & $python -m pytest -n 6 -v compute/test_bfloat16.py } "bfloat16 tests failed"
+}
+finally { Pop-Location }

--- a/ci/windows/run_examples_tests.ps1
+++ b/ci/windows/run_examples_tests.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+    Test payload: the cuda.compute examples and benchmark smoke tests.
+.DESCRIPTION
+    Invoked by ci/windows/test_cuda_cccl_examples_python.ps1, which has already put the
+    cuda_cccl wheel in wheelhouse/. This normally runs in the minimal container;
+    see "Testing Python in a minimal container" in
+    docs/infrastructure/ci/references/ci_scripts.rst.
+
+    build_common.psm1 must NOT be imported here: it resolves cl.exe at import
+    time, which by design does not exist in the minimal image.
+#>
+Param(
+    [Parameter(Mandatory = $true)]
+    [Alias("py-version")]
+    [ValidatePattern("^\d+\.\d+t?$")]
+    [string]$PyVersion,
+
+    [Alias("ctk-mode")]
+    [string]$CtkMode = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot/build_common_python.psm1"
+
+Assert-MinimalEnvironment
+
+Install-MsvcRuntime
+
+$python = Get-Python -Version $PyVersion
+$cudaMajor = Get-CudaMajor
+$ctkFlavor = Get-CtkExtraFlavor $CtkMode
+Set-CtkPin $CtkMode
+
+$repoRoot = Get-RepoRoot
+$wheelPath = Get-OnePathMatch -Path (Join-Path $repoRoot 'wheelhouse') -Pattern '^cuda_cccl-.*\.whl' -File
+
+# pytest-benchmark is for the host-benchmark smoke test below.
+Invoke-Checked { & $python -m pip install -U pip pytest pytest-xdist pytest-benchmark } "Failed to install pytest / pytest-xdist / pytest-benchmark"
+# CuPy is required by the cuda.compute examples and is not part of the test extras.
+# It resolves curand/cublas/... through cuda-pathfinder at first use and nothing
+# else installs them, so request its own `ctk` extra on the pip-toolkit lanes.
+# sysctk lanes stay bare: the system toolkit provides them there.
+$cupyReq = "cupy-cuda${cudaMajor}x"
+if ($ctkFlavor -eq 'cu') { $cupyReq = "${cupyReq}[ctk]" }
+Invoke-Checked { & $python -m pip install "${wheelPath}[test-$ctkFlavor$cudaMajor]" $cupyReq } "Failed to install cuda_cccl test extra / cupy"
+
+Push-Location (Join-Path $repoRoot "python/cuda_cccl/tests")
+try {
+    Invoke-Checked { & $python -m pytest -n 6 test_examples.py } "examples tests failed"
+}
+finally { Pop-Location }
+
+# Smoke-test the host-overhead benchmark harness: run every benchmark case
+# exactly once (pass/fail only, no timing) so harness rot fails CI here instead
+# of silently surviving until someone runs the perf suite. --benchmark-disable
+# makes pytest-benchmark invoke each benchmarked callable a single time. This
+# lane already installs cupy + numba (for the examples), which the benchmark
+# suite also needs, so only pytest-benchmark is added above.
+Push-Location (Join-Path $repoRoot "python/cuda_cccl/benchmarks/compute/host")
+try {
+    Invoke-Checked { & $python -m pytest -v --benchmark-disable . } "host benchmark smoke test failed"
+}
+finally { Pop-Location }

--- a/ci/windows/run_headers_tests.ps1
+++ b/ci/windows/run_headers_tests.ps1
@@ -1,0 +1,46 @@
+<#
+.SYNOPSIS
+    Test payload: the cuda.cccl.headers suite.
+.DESCRIPTION
+    Invoked by ci/windows/test_cuda_cccl_headers_python.ps1, which has already put the
+    cuda_cccl wheel in wheelhouse/. This normally runs in the minimal container;
+    see "Testing Python in a minimal container" in
+    docs/infrastructure/ci/references/ci_scripts.rst.
+
+    build_common.psm1 must NOT be imported here: it resolves cl.exe at import
+    time, which by design does not exist in the minimal image.
+#>
+Param(
+    [Parameter(Mandatory = $true)]
+    [Alias("py-version")]
+    [ValidatePattern("^\d+\.\d+t?$")]
+    [string]$PyVersion,
+
+    [Alias("ctk-mode")]
+    [string]$CtkMode = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot/build_common_python.psm1"
+
+Assert-MinimalEnvironment
+
+# cuda.cccl is pure Python, so no MSVC runtime is needed here.
+
+$python = Get-Python -Version $PyVersion
+$cudaMajor = Get-CudaMajor
+$ctkFlavor = Get-CtkExtraFlavor $CtkMode
+Set-CtkPin $CtkMode
+
+$repoRoot = Get-RepoRoot
+$wheelPath = Get-OnePathMatch -Path (Join-Path $repoRoot 'wheelhouse') -Pattern '^cuda_cccl-.*\.whl' -File
+
+Invoke-Checked { & $python -m pip install -U pip pytest pytest-xdist } "Failed to install pytest / pytest-xdist"
+Invoke-Checked { & $python -m pip install "${wheelPath}[test-$ctkFlavor$cudaMajor]" } "Failed to install cuda_cccl test extra"
+
+Push-Location (Join-Path $repoRoot "python/cuda_cccl/tests")
+try {
+    Invoke-Checked { & $python -m pytest -n auto -v headers/ } "headers tests failed"
+}
+finally { Pop-Location }

--- a/ci/windows/run_in_minimal_container.ps1
+++ b/ci/windows/run_in_minimal_container.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+    Run a CI script inside a deliberately minimal sibling container.
+.DESCRIPTION
+    See "Testing Python in a minimal container" in
+    docs/infrastructure/ci/references/ci_scripts.rst for what this buys and why
+    the lanes are split this way.
+.PARAMETER Script
+    Repo-relative path to the script to run, e.g. 'ci\windows\run_compute_tests.ps1'.
+    Repo-relative so it resolves the same on both sides of the mount.
+.PARAMETER ScriptArgs
+    Arguments forwarded to that script.
+#>
+Param(
+    [Parameter(Mandatory = $true)]
+    [string]$Script,
+
+    [string[]]$ScriptArgs = @()
+)
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot/build_common_python.psm1"
+
+$image = if ($env:CCCL_MINIMAL_CONTAINER_IMAGE) {
+    $env:CCCL_MINIMAL_CONTAINER_IMAGE
+} else {
+    # The image must match the host kernel, because GPU access requires process
+    # isolation. The devcontainer images are LTSC 2022, so this is too.
+    'mcr.microsoft.com/windows/servercore:ltsc2022'
+}
+
+# The host daemon resolves the bind-mount source, so it must be a host path.
+# The CI action sets both of these for exactly this purpose.
+$hostWorkspace = $env:HOST_WORKSPACE
+$containerWorkspace = $env:CONTAINER_WORKSPACE
+if (-not $hostWorkspace) {
+    throw "HOST_WORKSPACE is not set; required to bind-mount the workspace into a sibling container."
+}
+if (-not $containerWorkspace) {
+    throw "CONTAINER_WORKSPACE is not set; required to bind-mount the workspace into a sibling container."
+}
+
+if ([System.IO.Path]::IsPathRooted($Script)) {
+    throw "Script '$Script' must be a path relative to the repo root."
+}
+
+# The whole approach rests on reaching the host daemon; say so plainly rather
+# than failing somewhere inside `docker run`.
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    throw "docker CLI not found in the devcontainer image; cannot launch a sibling container."
+}
+
+# Windows exposes GPUs as a whole device class rather than individually, and
+# only under process isolation. Every lane that reaches this helper is a GPU
+# lane, so request the class unconditionally; docker fails loudly if it is
+# absent.
+$gpuArgs = @(
+    '--isolation=process',
+    '--device', 'class/5B45201D-F2F2-4F3B-85BB-30FF1F953599'
+)
+
+# There is no nvcc in the sibling, so hand it the version resolved out here.
+$cudaVersion = Get-CudaVersion
+
+$payload = Join-Path $containerWorkspace $Script
+
+$dockerArgs = @(
+    'run', '--rm', '-i'
+) + $gpuArgs + @(
+    '--mount', "type=bind,source=$hostWorkspace,target=$containerWorkspace",
+    '--workdir', $containerWorkspace,
+    '--env', "CCCL_CUDA_VERSION=$cudaVersion",
+    '--env', "CCCL_PYTHON_USE_V2=$($env:CCCL_PYTHON_USE_V2)",
+    '--env', "GITHUB_ACTIONS=$($env:GITHUB_ACTIONS)",
+    '--env', 'PYTHONDONTWRITEBYTECODE=1',
+    # Tells the payload it is the isolated side, and so must prove it (see
+    # Assert-MinimalEnvironment in build_common_python.psm1).
+    '--env', 'CCCL_INSIDE_MINIMAL_CONTAINER=1',
+    $image,
+    'powershell.exe', '-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass',
+    '-File', $payload
+) + $ScriptArgs
+
+Write-Host "Running in minimal container: $image"
+Write-Host "  docker $($dockerArgs -join ' ')"
+& docker @dockerArgs
+exit $LASTEXITCODE

--- a/ci/windows/test_cuda_cccl_examples_python.ps1
+++ b/ci/windows/test_cuda_cccl_examples_python.ps1
@@ -1,3 +1,12 @@
+<#
+.SYNOPSIS
+    Entry point for the Windows cuda.compute examples test lane.
+.DESCRIPTION
+    Provisions the cuda_cccl wheel, then runs the test payload -- by default in a
+    minimal sibling container, except in `sysctk` mode or when
+    CCCL_MINIMAL_CONTAINER=0. See "Testing Python in a minimal container" in
+    docs/infrastructure/ci/references/ci_scripts.rst.
+#>
 Param(
     [Parameter(Mandatory = $true)]
     [Alias("py-version")]
@@ -10,41 +19,21 @@ Param(
 
 $ErrorActionPreference = "Stop"
 
-# Import shared helpers
-Import-Module "$PSScriptRoot/build_common.psm1"
 Import-Module "$PSScriptRoot/build_common_python.psm1"
 
-$python = Get-Python -Version $PyVersion
-$cudaMajor = Get-CudaMajor
-$ctkFlavor = Get-CtkExtraFlavor $CtkMode
+# Needs gh and the workflow helpers, which the minimal container lacks.
+$null = Get-CudaCcclWheel
 
-# Pin cuda-toolkit to the container's CTK minor (-ctk-mode latest
-# opts out). See build_common_python.psm1.
-Set-CtkPin $CtkMode
+$payloadArgs = @('-py-version', $PyVersion)
+if ($CtkMode) { $payloadArgs += @('-ctk-mode', $CtkMode) }
 
-$repoRoot = Get-RepoRoot
-
-${wheelPath} = Get-CudaCcclWheel
-
-# pytest-benchmark is for the host-benchmark smoke test below.
-Invoke-Checked { & $python -m pip install -U pip pytest pytest-xdist pytest-benchmark } "Failed to install pytest / pytest-xdist / pytest-benchmark"
-# CuPy is required by the cuda.compute examples and is not part of the test extras
-Invoke-Checked { & $python -m pip install "${wheelPath}[test-$ctkFlavor$cudaMajor]" "cupy-cuda${cudaMajor}x" } "Failed to install cuda_cccl test extra / cupy"
-
-Push-Location (Join-Path $repoRoot "python/cuda_cccl/tests")
-try {
-    Invoke-Checked { & $python -m pytest -n 6 test_examples.py } "examples tests failed"
+if (((Get-CtkExtraFlavor $CtkMode) -ne 'sysctk') -and ($env:CCCL_MINIMAL_CONTAINER -ne '0')) {
+    & "$PSScriptRoot/run_in_minimal_container.ps1" `
+        -Script 'ci\windows\run_examples_tests.ps1' `
+        -ScriptArgs $payloadArgs
+} else {
+    # By name, not @payloadArgs: array splatting binds positionally, so the
+    # payload would receive the literal "-py-version" as its version.
+    & "$PSScriptRoot/run_examples_tests.ps1" -PyVersion $PyVersion -CtkMode $CtkMode
 }
-finally { Pop-Location }
-
-# Smoke-test the host-overhead benchmark harness: run every benchmark case
-# exactly once (pass/fail only, no timing) so harness rot fails CI here instead
-# of silently surviving until someone runs the perf suite. --benchmark-disable
-# makes pytest-benchmark invoke each benchmarked callable a single time. This
-# lane already installs cupy + numba (for the examples), which the benchmark
-# suite also needs, so only pytest-benchmark is added above.
-Push-Location (Join-Path $repoRoot "python/cuda_cccl/benchmarks/compute/host")
-try {
-    Invoke-Checked { & $python -m pytest -v --benchmark-disable . } "host benchmark smoke test failed"
-}
-finally { Pop-Location }
+exit $LASTEXITCODE

--- a/ci/windows/test_cuda_cccl_headers_python.ps1
+++ b/ci/windows/test_cuda_cccl_headers_python.ps1
@@ -1,3 +1,12 @@
+<#
+.SYNOPSIS
+    Entry point for the Windows cuda.cccl.headers test lane.
+.DESCRIPTION
+    Provisions the cuda_cccl wheel, then runs the test payload -- by default in a
+    minimal sibling container, except in `sysctk` mode or when
+    CCCL_MINIMAL_CONTAINER=0. See "Testing Python in a minimal container" in
+    docs/infrastructure/ci/references/ci_scripts.rst.
+#>
 Param(
     [Parameter(Mandatory = $true)]
     [Alias("py-version")]
@@ -10,27 +19,25 @@ Param(
 
 $ErrorActionPreference = "Stop"
 
-# Import shared helpers
-Import-Module "$PSScriptRoot/build_common.psm1"
 Import-Module "$PSScriptRoot/build_common_python.psm1"
 
-$python = Get-Python -Version $PyVersion
-$cudaMajor = Get-CudaMajor
-$ctkFlavor = Get-CtkExtraFlavor $CtkMode
+# The only lane on this path that does not need a GPU: it asserts that headers
+# shipped in the wheel are on disk, and never launches a kernel.
+$env:CCCL_MINIMAL_CONTAINER_NO_GPU = '1'
 
-# Pin cuda-toolkit to the container's CTK minor (-ctk-mode latest
-# opts out). See build_common_python.psm1.
-Set-CtkPin $CtkMode
+# Needs gh and the workflow helpers, which the minimal container lacks.
+$null = Get-CudaCcclWheel
 
-$repoRoot = Get-RepoRoot
+$payloadArgs = @('-py-version', $PyVersion)
+if ($CtkMode) { $payloadArgs += @('-ctk-mode', $CtkMode) }
 
-${wheelPath} = Get-CudaCcclWheel
-
-Invoke-Checked { & $python -m pip install -U pip pytest pytest-xdist } "Failed to install pytest / pytest-xdist"
-Invoke-Checked { & $python -m pip install "${wheelPath}[test-$ctkFlavor$cudaMajor]" } "Failed to install cuda_cccl test extra"
-
-Push-Location (Join-Path $repoRoot "python/cuda_cccl/tests")
-try {
-    Invoke-Checked { & $python -m pytest -n auto -v headers/ } "headers tests failed"
+if (((Get-CtkExtraFlavor $CtkMode) -ne 'sysctk') -and ($env:CCCL_MINIMAL_CONTAINER -ne '0')) {
+    & "$PSScriptRoot/run_in_minimal_container.ps1" `
+        -Script 'ci\windows\run_headers_tests.ps1' `
+        -ScriptArgs $payloadArgs
+} else {
+    # By name, not @payloadArgs: array splatting binds positionally, so the
+    # payload would receive the literal "-py-version" as its version.
+    & "$PSScriptRoot/run_headers_tests.ps1" -PyVersion $PyVersion -CtkMode $CtkMode
 }
-finally { Pop-Location }
+exit $LASTEXITCODE

--- a/ci/windows/test_cuda_compute_minimal_python.ps1
+++ b/ci/windows/test_cuda_compute_minimal_python.ps1
@@ -1,3 +1,12 @@
+<#
+.SYNOPSIS
+    Entry point for the Windows numba-free (minimal extra) cuda.compute test lane.
+.DESCRIPTION
+    Provisions the cuda_cccl wheel, then runs the test payload -- by default in a
+    minimal sibling container, except in `sysctk` mode or when
+    CCCL_MINIMAL_CONTAINER=0. See "Testing Python in a minimal container" in
+    docs/infrastructure/ci/references/ci_scripts.rst.
+#>
 Param(
     [Parameter(Mandatory = $true)]
     [Alias("py-version")]
@@ -10,70 +19,21 @@ Param(
 
 $ErrorActionPreference = "Stop"
 
-# Import shared helpers
-Import-Module "$PSScriptRoot/build_common.psm1"
 Import-Module "$PSScriptRoot/build_common_python.psm1"
 
-$python = Get-Python -Version $PyVersion
-$cudaMajor = Get-CudaMajor
-$ctkFlavor = Get-CtkExtraFlavor $CtkMode
+# Needs gh and the workflow helpers, which the minimal container lacks.
+$null = Get-CudaCcclWheel
 
-# Pin cuda-toolkit to the container's CTK minor (-ctk-mode latest
-# opts out). See build_common_python.psm1.
-Set-CtkPin $CtkMode
+$payloadArgs = @('-py-version', $PyVersion)
+if ($CtkMode) { $payloadArgs += @('-ctk-mode', $CtkMode) }
 
-$repoRoot = Get-RepoRoot
-
-$wheelPath = Get-CudaCcclWheel
-
-# Install cuda_cccl with the minimal CUDA extra. This intentionally avoids the
-# full cu* extras because those pull in numba/numba-cuda.
-Invoke-Checked { & $python -m pip install -U pip pytest pytest-xdist } "Failed to install pytest / pytest-xdist"
-Invoke-Checked { & $python -m pip install "$wheelPath[minimal-$ctkFlavor$cudaMajor]" } "Failed to install cuda_cccl minimal extra"
-
-Push-Location (Join-Path $repoRoot "python/cuda_cccl/tests")
-try {
-    Invoke-Checked { & $python -m pytest -n 6 -v compute/test_no_numba.py } "test_no_numba.py failed"
-
-    if ($PyVersion -eq "3.14t") {
-        # Select only tests that support the minimal extra so pytest does not
-        # collect tests that import numba-cuda and re-enable the GIL. These tests
-        # provide their own worker threads, so keep pytest itself in a single
-        # process. The serialization node-ids are module-skipped on the v2
-        # backend today and will start running there automatically once v2 gains
-        # serialization support.
-        Invoke-Checked {
-            & $python -m pytest -n 0 -v `
-                compute/test_free_threading_stress.py `
-                compute/test_multi_cc_serialization.py::test_aot_build_result_load_failure_is_shared_and_retryable `
-                compute/test_multi_cc_serialization.py::test_aot_serialization_waits_for_canonical_first_load
-        } "free-threading stress / serialization tests failed"
-
-        # Broad thread-safety sweep (pytest-run-parallel): re-run the numba-free
-        # functional suite with each test executed concurrently across threads
-        # (barrier-synchronized start), stressing the process-wide build cache,
-        # single-flight coordination, and the Cython bindings from many threads at
-        # once. Complements test_free_threading_stress.py above, which targets
-        # specific shared-object scenarios by hand. -n 0 so the threads share one
-        # interpreter.
-        #
-        # --parallel-threads=2 matches CuPy's free-threading CI (the closest GPU
-        # precedent); a small fixed count bounds GPU-memory pressure from
-        # concurrent kernels and stays reproducible across runners, unlike =auto
-        # (the runner's logical-core count).
-        #
-        # pytest-run-parallel is only used by this sweep, so install it on the
-        # 3.14t path rather than for every minimal (e.g. non-free-threaded 3.14)
-        # run.
-        Invoke-Checked { & $python -m pip install pytest-run-parallel } "Failed to install pytest-run-parallel"
-
-        # Fail fast if the interpreter is not actually GIL-free (wrong build /
-        # PYTHON_GIL=1): pytest-run-parallel does NOT catch a GIL that is enabled
-        # from the start -- it would run threads GIL-serialized and pass
-        # vacuously. (A GIL *re-enabled mid-run* by a non-free-threaded import IS
-        # caught by the plugin, which is why we do not pass --ignore-gil-enabled.)
-        Invoke-Checked { & $python -c "import sys; assert not sys._is_gil_enabled(), 'GIL is enabled; parallel sweep has no signal'" } "interpreter is not GIL-free; parallel sweep has no signal"
-        Invoke-Checked { & $python -m pytest -n 0 -v --parallel-threads=2 compute/test_no_numba.py } "parallel-threads sweep failed"
-    }
+if (((Get-CtkExtraFlavor $CtkMode) -ne 'sysctk') -and ($env:CCCL_MINIMAL_CONTAINER -ne '0')) {
+    & "$PSScriptRoot/run_in_minimal_container.ps1" `
+        -Script 'ci\windows\run_compute_minimal_tests.ps1' `
+        -ScriptArgs $payloadArgs
+} else {
+    # By name, not @payloadArgs: array splatting binds positionally, so the
+    # payload would receive the literal "-py-version" as its version.
+    & "$PSScriptRoot/run_compute_minimal_tests.ps1" -PyVersion $PyVersion -CtkMode $CtkMode
 }
-finally { Pop-Location }
+exit $LASTEXITCODE

--- a/ci/windows/test_cuda_compute_python.ps1
+++ b/ci/windows/test_cuda_compute_python.ps1
@@ -1,3 +1,12 @@
+<#
+.SYNOPSIS
+    Entry point for the Windows cuda.compute test lanes.
+.DESCRIPTION
+    Provisions the cuda_cccl wheel, then runs the test payload -- by default in a
+    minimal sibling container, except in `sysctk` mode or when
+    CCCL_MINIMAL_CONTAINER=0. See "Testing Python in a minimal container" in
+    docs/infrastructure/ci/references/ci_scripts.rst.
+#>
 Param(
     [Parameter(Mandatory = $true)]
     [Alias("py-version")]
@@ -10,35 +19,21 @@ Param(
 
 $ErrorActionPreference = "Stop"
 
-# Import shared helpers
-Import-Module "$PSScriptRoot/build_common.psm1"
 Import-Module "$PSScriptRoot/build_common_python.psm1"
 
-$python = Get-Python -Version $PyVersion
-$cudaMajor = Get-CudaMajor
-$ctkFlavor = Get-CtkExtraFlavor $CtkMode
+# Needs gh and the workflow helpers, which the minimal container lacks.
+$null = Get-CudaCcclWheel
 
-# Pin cuda-toolkit to the container's CTK minor (-ctk-mode latest
-# opts out). See build_common_python.psm1.
-Set-CtkPin $CtkMode
+$payloadArgs = @('-py-version', $PyVersion)
+if ($CtkMode) { $payloadArgs += @('-ctk-mode', $CtkMode) }
 
-$repoRoot = Get-RepoRoot
-
-$wheelPath = Get-CudaCcclWheel
-
-Invoke-Checked { & $python -m pip install -U pip pytest pytest-xdist } "Failed to install pytest / pytest-xdist"
-Invoke-Checked { & $python -m pip install "$wheelPath[test-$ctkFlavor$cudaMajor]" } "Failed to install cuda_cccl test extra"
-
-Push-Location (Join-Path $repoRoot "python/cuda_cccl/tests")
-try {
-    Invoke-Checked { & $python -m pytest -n 6 -v compute/ -m "not large and not free_threading" } "compute tests (not large) failed"
-    Invoke-Checked { & $python -m pytest -n 0 -v compute/ -m "large and not free_threading" } "compute tests (large) failed"
-
-    # The bfloat16 tests require ml_dtypes (the NumPy bfloat16 extension dtype),
-    # which is deliberately not part of the test extras so that the sweeps above
-    # run in an environment matching a user's default install (where the bfloat16
-    # tests skip themselves). Install it last and run those tests explicitly.
-    Invoke-Checked { & $python -m pip install ml_dtypes } "Failed to install ml_dtypes"
-    Invoke-Checked { & $python -m pytest -n 6 -v compute/test_bfloat16.py } "bfloat16 tests failed"
+if (((Get-CtkExtraFlavor $CtkMode) -ne 'sysctk') -and ($env:CCCL_MINIMAL_CONTAINER -ne '0')) {
+    & "$PSScriptRoot/run_in_minimal_container.ps1" `
+        -Script 'ci\windows\run_compute_tests.ps1' `
+        -ScriptArgs $payloadArgs
+} else {
+    # By name, not @payloadArgs: array splatting binds positionally, so the
+    # payload would receive the literal "-py-version" as its version.
+    & "$PSScriptRoot/run_compute_tests.ps1" -PyVersion $PyVersion -CtkMode $CtkMode
 }
-finally { Pop-Location }
+exit $LASTEXITCODE

--- a/docs/infrastructure/ci/references/ci_scripts.rst
+++ b/docs/infrastructure/ci/references/ci_scripts.rst
@@ -48,13 +48,25 @@ dependencies.
 
 The Python test lanes therefore fetch the wheel in the devcontainer (which needs ``gh``)
 and then run the test payload in a sibling container holding nothing but Python, launched
-through the host's docker daemon by ``ci/util/python/run_in_minimal_container.sh``. This
-is the same docker-outside-of-docker arrangement the wheel builds already use. An undeclared
+through the host's docker daemon -- by ci/util/python/run_in_minimal_container.sh on
+Linux and ci/windows/run_in_minimal_container.ps1 on Windows. This is the same
+docker-outside-of-docker arrangement the wheel builds already use. An undeclared
 dependency fails there instead of passing silently. The same applies to both the v1
 (NVRTC) and v2 (HostJIT) backends.
 
-The sibling is handed the specific GPUs the driver reports, rather than ``--gpus all``,
-which would reach GPUs belonging to other jobs on a shared runner.
+The two platforms differ only where they must. Linux hands the sibling the specific GPUs
+the driver reports, since ``--gpus all`` would reach GPUs belonging to other jobs on a
+shared runner. Windows exposes GPUs as a whole device class and only under process
+isolation, and its image must match the host kernel -- the devcontainer images are
+LTSC 2022, so the sibling defaults to ``mcr.microsoft.com/windows/servercore:ltsc2022``.
+
+Windows needs one more thing. ``python:3.14-slim`` still ships glibc and libstdc++,
+because every C/C++ Python extension links against them; Server Core ships neither of
+the Windows equivalents, since ``msvcp140.dll`` and ``vcruntime140*.dll`` come from the
+MSVC redistributable rather than from Windows itself. Without them numba and
+``cccl.c.parallel.dll`` both fail to load. The Windows payload installs the
+redistributable before running anything, which leaves the comparison the lane exists to
+make intact: still no compiler, still no CUDA toolkit.
 
 ``test_headers`` is the one lane here that needs no GPU -- it asserts that headers
 shipped in the wheel are on disk and never launches a kernel -- so its entry point sets
@@ -62,8 +74,9 @@ shipped in the wheel are on disk and never launches a kernel -- so its entry poi
 devices.
 
 Each lane is therefore two scripts: an entry point that provisions the wheel and
-dispatches (``ci/test_<lane>.sh``), and a payload that must survive in the minimal image
-(``ci/util/python/run_<lane>_tests.sh``). Set ``CCCL_MINIMAL_CONTAINER=0`` to run the payload in the
+dispatches (``ci/test_<lane>.sh``, or ``ci/windows/test_<lane>.ps1``), and a payload that
+must survive in the minimal image (``ci/util/python/run_<lane>_tests.sh``, or
+``ci/windows/run_<lane>.ps1``). Set ``CCCL_MINIMAL_CONTAINER=0`` to run the payload in the
 devcontainer instead, which is useful locally and for comparing the two environments.
 
 These lanes deliberately stay in the devcontainer, because they need what it provides:


### PR DESCRIPTION
Follow up to https://github.com/NVIDIA/cccl/pull/11018. The changes in this PR are pretty much entirely vibe coded as I don't know any powershell.

Each Windows Python test lane splits into an entry point that provisions the wheel and a payload that runs in a sibling container holding nothing but Python, launched through the host's Docker daemon.

Two things differ from Linux because Windows requires it. GPUs are exposed as a whole device class rather than individually, and only under process isolation. And the sibling image must match the host kernel: the Windows devcontainer images report os.version 10.0.20348, so the default is `servercore:ltsc2022`.

Server Core also ships no MSVC runtime, which every C++ Python extension used here links against, so `Install-MsvcRuntime` fetches the redistributable. That is a Windows prerequisite rather than a packaging gap, and it leaves the comparison the lane exists to make intact: still no compiler, still no CUDA toolkit. The headers lane skips it, since `cuda.cccl` is pure Python.

`run_*.ps1` payloads deliberately do not import `build_common.psm1`: it resolves `cl.exe` at import time, which by design does not exist in the minimal image. `Get-CudaVersion` and `Get-CudaMajor` fall back to `CCCL_CUDA_VERSION`, since there is no `nvcc` in there either.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
