### PR TITLE
[cudax] Delete group's copy/move cons + assign op

### DIFF
--- a/cudax/include/cuda/experimental/__coop/reduce.cuh
+++ b/cudax/include/cuda/experimental/__coop/reduce.cuh
@@ -57,7 +57,7 @@ _CCCL_DEVICE_API auto __reduce_impl(...)
 
 template <bool _Broadcasted, class _Hierarchy, class _Tp, ::cuda::std::size_t _Np, class _RedFn>
 [[nodiscard]] _CCCL_DEVICE_API auto __reduce_impl(
-  ::cuda::std::bool_constant<_Broadcasted>, this_thread<_Hierarchy>, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
+  ::cuda::std::bool_constant<_Broadcasted>, const this_thread<_Hierarchy>&, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
 {
   const auto __result = ::cub::ThreadReduce(__thread_data, __red_fn);
   if constexpr (_Broadcasted)
@@ -72,7 +72,10 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, ::cuda::std::size_t _N
 
 template <bool _Broadcasted, class _Hierarchy, class _Tp, ::cuda::std::size_t _Np, class _RedFn>
 [[nodiscard]] _CCCL_DEVICE_API auto __reduce_impl(
-  ::cuda::std::bool_constant<_Broadcasted>, this_warp<_Hierarchy> __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
+  ::cuda::std::bool_constant<_Broadcasted>,
+  const this_warp<_Hierarchy>& __group,
+  _Tp (&__thread_data)[_Np],
+  _RedFn __red_fn)
 {
   using _BlockExts = decltype(gpu_thread.extents(block, __group.hierarchy()));
   constexpr auto __nwarps_in_block =
@@ -100,7 +103,10 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, ::cuda::std::size_t _N
 
 template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np, class _RedFn>
 [[nodiscard]] _CCCL_DEVICE_API auto __reduce_impl(
-  ::cuda::std::bool_constant<_Broadcasted>, this_block<_Hierarchy> __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
+  ::cuda::std::bool_constant<_Broadcasted>,
+  const this_block<_Hierarchy>& __group,
+  _Tp (&__thread_data)[_Np],
+  _RedFn __red_fn)
 {
   using _BlockExts = decltype(gpu_thread.extents(block, __group.hierarchy()));
   static_assert(_BlockExts::rank_dynamic() == 0,
@@ -138,7 +144,10 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np,
 
 template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np, class _RedFn>
 [[nodiscard]] _CCCL_DEVICE_API auto __reduce_impl(
-  ::cuda::std::bool_constant<_Broadcasted>, this_cluster<_Hierarchy> __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
+  ::cuda::std::bool_constant<_Broadcasted>,
+  const this_cluster<_Hierarchy>& __group,
+  _Tp (&__thread_data)[_Np],
+  _RedFn __red_fn)
 {
   using _ClusterExts = decltype(block.extents(cluster, __group.hierarchy()));
   static_assert(_ClusterExts::rank_dynamic() == 0,
@@ -231,7 +240,10 @@ _CCCL_DEVICE ::cuda::std::array<_Tp, _Np> __reduce_grid_partials;
 
 template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np, class _RedFn>
 [[nodiscard]] _CCCL_DEVICE_API auto __reduce_impl(
-  ::cuda::std::bool_constant<_Broadcasted>, this_grid<_Hierarchy> __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
+  ::cuda::std::bool_constant<_Broadcasted>,
+  const this_grid<_Hierarchy>& __group,
+  _Tp (&__thread_data)[_Np],
+  _RedFn __red_fn)
 {
   using _GridExts = decltype(cluster.extents(grid, __group.hierarchy()));
   static_assert(_GridExts::rank_dynamic() == 0,
@@ -294,8 +306,8 @@ template <bool _Broadcasted, class _Hierarchy, class _Tp, cuda::std::size_t _Np,
 _CCCL_TEMPLATE(bool _Broadcasted, class _Group, class _Tp, ::cuda::std::size_t _Np, class _RedFn)
 _CCCL_REQUIRES(::cuda::std::is_same_v<thread_level, typename _Group::unit_type>
                  _CCCL_AND ::cuda::std::is_same_v<warp_level, typename _Group::level_type>)
-[[nodiscard]] _CCCL_DEVICE_API auto
-__reduce_impl(::cuda::std::bool_constant<_Broadcasted>, _Group __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
+[[nodiscard]] _CCCL_DEVICE_API auto __reduce_impl(
+  ::cuda::std::bool_constant<_Broadcasted>, const _Group& __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
 {
   using _MappingResult         = typename _Group::__mapping_result_type;
   const auto& __mapping_result = __group.__mapping_result();
@@ -328,10 +340,14 @@ __reduce_impl(::cuda::std::bool_constant<_Broadcasted>, _Group __group, _Tp (&__
 _CCCL_TEMPLATE(bool _Broadcasted, class _Group, class _Tp, ::cuda::std::size_t _Np, class _RedFn)
 _CCCL_REQUIRES(::cuda::std::is_same_v<warp_level, typename _Group::unit_type>
                  _CCCL_AND ::cuda::std::is_same_v<block_level, typename _Group::level_type>)
-[[nodiscard]] _CCCL_DEVICE_API auto
-__reduce_impl(::cuda::std::bool_constant<_Broadcasted>, _Group __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
+[[nodiscard]] _CCCL_DEVICE_API auto __reduce_impl(
+  ::cuda::std::bool_constant<_Broadcasted>, const _Group& __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
 {
-  constexpr auto __nwarps_in_group = warp.static_count(__group);
+  // Runtime-known references can't be used in constant expressions, so we create a view that can be used in a constant
+  // expression.
+  const group_view __group_view{__group};
+
+  constexpr auto __nwarps_in_group = warp.static_count(__group_view);
   static_assert(__nwarps_in_group != ::cuda::std::dynamic_extent,
                 "cuda::coop::reduce requires the group to have statically known size");
 
@@ -385,24 +401,17 @@ __reduce_impl(::cuda::std::bool_constant<_Broadcasted>, _Group __group, _Tp (&__
 
 template <class _Group, class _Tp, ::cuda::std::size_t _Np, class _RedFn>
 [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::optional<_Tp>
-reduce(_Group __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
+reduce(const _Group& __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
 {
-  static_assert(gpu_thread.static_count(__group) != ::cuda::std::dynamic_extent,
-                "cuda::coop::reduce requires the group to have statically known size");
-
   _CCCL_ASSERT(gpu_thread.is_part_of(__group), "Only threads that are part of the group can call cudax::coop::reduce");
-
   return ::cuda::experimental::coop::__reduce_impl(::cuda::std::false_type{}, __group, __thread_data, __red_fn);
 }
 
 template <class _Group, class _Tp, ::cuda::std::size_t _Np, class _RedFn>
-[[nodiscard]] _CCCL_DEVICE_API _Tp reduce(broadcasted_t, _Group __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
+[[nodiscard]] _CCCL_DEVICE_API _Tp
+reduce(broadcasted_t, const _Group& __group, _Tp (&__thread_data)[_Np], _RedFn __red_fn)
 {
-  static_assert(gpu_thread.static_count(__group) != ::cuda::std::dynamic_extent,
-                "cuda::coop::reduce requires the group to have statically known size");
-
   _CCCL_ASSERT(gpu_thread.is_part_of(__group), "Only threads that are part of the group can call cudax::coop::reduce");
-
   return ::cuda::experimental::coop::__reduce_impl(::cuda::std::true_type{}, __group, __thread_data, __red_fn);
 }
 } // namespace cuda::experimental::coop

--- a/cudax/include/cuda/experimental/__group/group.cuh
+++ b/cudax/include/cuda/experimental/__group/group.cuh
@@ -120,6 +120,12 @@ public:
           ::cuda::experimental::__make_synchronizer_instance(__unit, __parent, __mapping_result_, __synchronizer)}
   {}
 
+  // Groups can't be copied, moved nor assigned.
+  group(const group&)            = delete;
+  group(group&&)                 = delete;
+  group& operator=(const group&) = delete;
+  group& operator=(group&&)      = delete;
+
   // todo(dabayer): Delete copy constructor.
   // group(const group&) = delete;
 

--- a/cudax/include/cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh
@@ -65,27 +65,15 @@ inline constexpr thread_scope __barrier_scope_v = thread_scope_system;
 template <thread_scope _Sco, class _ComplFn>
 inline constexpr thread_scope __barrier_scope_v<barrier<_Sco, _ComplFn>> = _Sco;
 
-template <class _Barrier, class _Unit, bool _Owning = true>
-class __barrier_synchronizer_instance
+template <class _Barrier>
+class __barrier_synchronizer_instance_view
 {
   _Barrier* __barrier_;
 
 public:
-  [[nodiscard]] _CCCL_DEVICE_API static __barrier_synchronizer_instance invalid() noexcept
-  {
-    return __barrier_synchronizer_instance{nullptr};
-  }
-
-  _CCCL_DEVICE_API explicit __barrier_synchronizer_instance(_Barrier* __barrier) noexcept
+  _CCCL_DEVICE_API explicit __barrier_synchronizer_instance_view(_Barrier* __barrier) noexcept
       : __barrier_{__barrier}
   {}
-
-  // todo(dabayer): Delete copy constructor for owning variant and provide only move constructor.
-  // __barrier_synchronizer_instance(const __barrier_synchronizer_instance&) = delete;
-
-  // _CCCL_DEVICE_API __barrier_synchronizer_instance(__barrier_synchronizer_instance&& __other) noexcept
-  //    : __barrier_{::cuda::std::exchange(__other.__barrier_, )}
-  // {}
 
   template <class _MappingResult, class _Hierarchy>
   _CCCL_DEVICE_API void do_sync(const _MappingResult&, const _Hierarchy&) const noexcept
@@ -101,27 +89,62 @@ public:
 
   [[nodiscard]] _CCCL_DEVICE_API auto view() const noexcept
   {
-    return __barrier_synchronizer_instance<_Barrier, _Unit, /*is-owning*/ false>{__barrier_};
+    return *this;
   }
 
   template <class _MappingResult, class _Hierarchy>
-  _CCCL_DEVICE_API void deinit(const _MappingResult& __mapping_result, const _Hierarchy& __hier) noexcept
-  {
-    if constexpr (_Owning)
-    {
-      if (__barrier_ != nullptr)
-      {
-        ::cuda::std::size_t __thread_rank_in_unit = 0u;
-        if constexpr (!::cuda::std::is_same_v<_Unit, thread_level>)
-        {
-          __thread_rank_in_unit = gpu_thread.rank(_Unit{}, __hier);
-        }
+  _CCCL_DEVICE_API void deinit(const _MappingResult&, const _Hierarchy&) const noexcept
+  {}
+};
 
-        if (__mapping_result.unit_rank() == 0 && __thread_rank_in_unit == 0)
-        {
-          ::cuda::std::destroy_at(__barrier_);
-        }
-      }
+template <class _Barrier, class _Unit>
+class __barrier_synchronizer_instance
+{
+  _Barrier* __barrier_;
+
+public:
+  _CCCL_DEVICE_API explicit __barrier_synchronizer_instance(_Barrier* __barrier) noexcept
+      : __barrier_{__barrier}
+  {}
+
+  // This synchronizer instance doesn't provide copy/move/assignment methods.
+  __barrier_synchronizer_instance(const __barrier_synchronizer_instance&)            = delete;
+  __barrier_synchronizer_instance(__barrier_synchronizer_instance&&)                 = delete;
+  __barrier_synchronizer_instance& operator=(const __barrier_synchronizer_instance&) = delete;
+  __barrier_synchronizer_instance& operator=(__barrier_synchronizer_instance&&)      = delete;
+
+  template <class _MappingResult, class _Hierarchy>
+  _CCCL_DEVICE_API void do_sync(const _MappingResult&, const _Hierarchy&) const noexcept
+  {
+    __barrier_->arrive_and_wait();
+  }
+
+  template <class _MappingResult, class _Hierarchy>
+  _CCCL_DEVICE_API void do_sync_aligned(const _MappingResult&, const _Hierarchy&) const noexcept
+  {
+    __barrier_->arrive_and_wait();
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API __barrier_synchronizer_instance_view<_Barrier> view() const noexcept
+  {
+    return __barrier_synchronizer_instance_view<_Barrier>{__barrier_};
+  }
+
+  template <class _MappingResult, class _Hierarchy>
+  _CCCL_DEVICE_API void deinit(const _MappingResult& __mapping_result, const _Hierarchy& __hier) const noexcept
+  {
+    _CCCL_ASSERT(__mapping_result.is_valid(),
+                 "internal error - invoking deinit() from a thread that is not part of the group");
+
+    ::cuda::std::size_t __thread_rank_in_unit = 0u;
+    if constexpr (!::cuda::std::is_same_v<_Unit, thread_level>)
+    {
+      __thread_rank_in_unit = gpu_thread.rank(_Unit{}, __hier);
+    }
+
+    if (__mapping_result.unit_rank() == 0 && __thread_rank_in_unit == 0)
+    {
+      ::cuda::std::destroy_at(__barrier_);
     }
   }
 };

--- a/cudax/include/cuda/experimental/__group/this_group.cuh
+++ b/cudax/include/cuda/experimental/__group/this_group.cuh
@@ -134,6 +134,12 @@ public:
       : __hier_{::cuda::__unpack_hierarchy_if_needed(__hier_like)}
   {}
 
+  // Groups can't be copied, moved nor assigned.
+  __this_group_base(const __this_group_base&)            = delete;
+  __this_group_base(__this_group_base&&)                 = delete;
+  __this_group_base& operator=(const __this_group_base&) = delete;
+  __this_group_base& operator=(__this_group_base&&)      = delete;
+
   [[nodiscard]] _CCCL_DEVICE_API const hierarchy_type& hierarchy() const noexcept
   {
     return __hier_;

--- a/cudax/include/cuda/experimental/__group/virtual_group.cuh
+++ b/cudax/include/cuda/experimental/__group/virtual_group.cuh
@@ -131,6 +131,12 @@ public:
     _CCCL_ASSERT(__mapping_result_.is_valid(), "virtual_group requires all units to be part of the group");
   }
 
+  // Groups can't be copied, moved nor assigned.
+  virtual_group(const virtual_group&)            = delete;
+  virtual_group(virtual_group&&)                 = delete;
+  virtual_group& operator=(const virtual_group&) = delete;
+  virtual_group& operator=(virtual_group&&)      = delete;
+
   [[nodiscard]] _CCCL_DEVICE_API const hierarchy_type& hierarchy() const noexcept
   {
     return __hier_;

--- a/cudax/test/group/cooperative_algorithm.cu
+++ b/cudax/test/group/cooperative_algorithm.cu
@@ -30,13 +30,13 @@
 namespace
 {
 template <class Hierarchy, class T, cuda::std::size_t N>
-__device__ cuda::std::optional<T> sum(cudax::this_thread<Hierarchy> group, T (&array)[N])
+__device__ cuda::std::optional<T> sum(const cudax::this_thread<Hierarchy>& group, T (&array)[N])
 {
   return {cub::ThreadReduce(array, cuda::std::plus<T>{})};
 }
 
 template <class Hierarchy, class T, cuda::std::size_t N>
-__device__ cuda::std::optional<T> sum(cudax::this_warp<Hierarchy> group, T (&array)[N])
+__device__ cuda::std::optional<T> sum(const cudax::this_warp<Hierarchy>& group, T (&array)[N])
 {
   using WarpReduce = cub::WarpReduce<T>;
 
@@ -48,7 +48,7 @@ __device__ cuda::std::optional<T> sum(cudax::this_warp<Hierarchy> group, T (&arr
 }
 
 template <class Hierarchy, class T, cuda::std::size_t N>
-__device__ cuda::std::optional<T> sum(cudax::this_block<Hierarchy> group, T (&array)[N])
+__device__ cuda::std::optional<T> sum(const cudax::this_block<Hierarchy>& group, T (&array)[N])
 {
   using BlockExts = decltype(cuda::gpu_thread.extents(cuda::block, group.hierarchy()));
   static_assert(BlockExts::rank_dynamic() == 0, "This algorithm requires all static extents.");
@@ -66,7 +66,7 @@ __device__ cuda::std::optional<T> sum(cudax::this_block<Hierarchy> group, T (&ar
 }
 
 template <class Hierarchy, class T, cuda::std::size_t N>
-__device__ cuda::std::optional<T> sum(cudax::this_cluster<Hierarchy> group, T (&array)[N])
+__device__ cuda::std::optional<T> sum(const cudax::this_cluster<Hierarchy>& group, T (&array)[N])
 {
   using BlockExts = decltype(cuda::gpu_thread.extents(cuda::block, group.hierarchy()));
   static_assert(BlockExts::rank_dynamic() == 0, "This algorithm requires all static extents.");
@@ -118,7 +118,7 @@ __device__ cuda::std::optional<T> sum(cudax::this_cluster<Hierarchy> group, T (&
 
 // todo(dabayer): Add support for warp and cluster levels.
 template <class Group, class T, cuda::std::size_t N>
-__device__ cuda::std::optional<T> sum(Group group, T (&array)[N])
+__device__ cuda::std::optional<T> sum(const Group& group, T (&array)[N])
 {
   using Unit          = typename Group::unit_type;
   using MappingResult = typename Group::__mapping_result_type;

--- a/cudax/test/group/synchronizer/barrier_synchronizer.cu
+++ b/cudax/test/group/synchronizer/barrier_synchronizer.cu
@@ -114,14 +114,14 @@ __device__ void test_barrier_synchronizer(const Level& level, Config config)
     synchronizer_instance.do_sync_aligned(mapping_result, hierarchy);
 
     // Test view().
-    static_assert(cuda::std::is_same_v<cudax::__barrier_synchronizer_instance<Barrier, cuda::thread_level, false>,
+    static_assert(cuda::std::is_same_v<cudax::__barrier_synchronizer_instance_view<Barrier>,
                                        decltype(synchronizer_instance.view())>);
     static_assert(noexcept(synchronizer_instance.view()));
     auto synchronizer_instance_view = synchronizer_instance.view();
     synchronizer_instance_view.do_sync(mapping_result, hierarchy);
     synchronizer_instance_view.do_sync_aligned(mapping_result, hierarchy);
     (void) synchronizer_instance_view.view();
-    static_assert(cuda::std::is_same_v<cudax::__barrier_synchronizer_instance<Barrier, cuda::thread_level, false>,
+    static_assert(cuda::std::is_same_v<cudax::__barrier_synchronizer_instance_view<Barrier>,
                                        decltype(synchronizer_instance.view().view())>);
     synchronizer_instance_view.deinit(mapping_result, hierarchy); // should be noop
 


### PR DESCRIPTION
It doesn't make sense to have a copy constructor for a group, because you wouldn't be able to supply a new synchronizer for the group.

Moving a group could work, but it brings problems regarding conditional synchronizer destruction and synchronization, because a synchronizer can be in a moved-from state, which would cost some performance. And I don't have any use case for it yet.

Assigning a group is problematic, because basically every group has it's own signature, so it would work only under some very specific conditions.

So my idea is that if you need to pass a group, pass it by reference. If you need to pass it by copy, just pass a `group_view`.