### PR TITLE
[libcudacxx] Fix complex pretty-printers for packed half layouts

### DIFF
--- a/libcudacxx/share/libcudacxx/gdb/complex.py
+++ b/libcudacxx/share/libcudacxx/gdb/complex.py
@@ -33,8 +33,15 @@ class ComplexPrinter:
         self.type_name = cccl_common.public_type_name(self.type)
 
     def children(self) -> Iterator[tuple[str, gdb.Value]]:
-        yield "real", self.value["__re_"]
-        yield "imag", self.value["__im_"]
+        try:
+            real = self.value["__re_"]
+            imag = self.value["__im_"]
+        except gdb.error:
+            packed = self.value["__repr_"]
+            real = packed["x"]
+            imag = packed["y"]
+        yield "real", real
+        yield "imag", imag
 
     def to_string(self) -> str:
         return self.type_name

--- a/libcudacxx/share/libcudacxx/gdb/complex.py
+++ b/libcudacxx/share/libcudacxx/gdb/complex.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import struct
 from collections.abc import Iterator
 from types import ModuleType
 
@@ -15,6 +16,33 @@ import gdb
 import gdb.printing
 
 _COMPLEX_NAMES = frozenset({"cuda::complex", "cuda::std::complex"})
+_PACKED_BITS_FIELD = "__x"
+
+
+def decode_packed_half(bits: int, type_name: str) -> float:
+    """Decode the 16-bit pattern of a __half or __nv_bfloat16 into a float.
+
+    A packed complex stores its parts as CUDA 16-bit floating-point types whose
+    only member is the raw bit pattern, so the debugger would otherwise show an
+    integer. Every __half and __nv_bfloat16 value is exactly representable as a
+    32-bit float: a __nv_bfloat16 is the upper half of one, and a __half is IEEE
+    binary16.
+    """
+    bits &= 0xFFFF
+    if "bfloat16" in type_name:
+        return struct.unpack("<f", struct.pack("<I", bits << 16))[0]
+    return struct.unpack("<e", struct.pack("<H", bits))[0]
+
+
+def _as_float(part: gdb.Value) -> gdb.Value:
+    """Return a packed __half / __nv_bfloat16 part as a float gdb.Value."""
+    part_type = cccl_common.canonical_type(part.type)
+    try:
+        bits = int(part[_PACKED_BITS_FIELD])
+    except gdb.error:
+        return part
+    decoded = decode_packed_half(bits, str(part_type))
+    return gdb.Value(decoded).cast(gdb.lookup_type("float"))
 
 
 def _is_cuda_complex(value_type: gdb.Type) -> bool:
@@ -38,8 +66,8 @@ class ComplexPrinter:
             imag = self.value["__im_"]
         except gdb.error:
             packed = self.value["__repr_"]
-            real = packed["x"]
-            imag = packed["y"]
+            real = _as_float(packed["x"])
+            imag = _as_float(packed["y"])
         yield "real", real
         yield "imag", imag
 

--- a/libcudacxx/share/libcudacxx/gdb/complex.py
+++ b/libcudacxx/share/libcudacxx/gdb/complex.py
@@ -19,30 +19,46 @@ _COMPLEX_NAMES = frozenset({"cuda::complex", "cuda::std::complex"})
 _PACKED_BITS_FIELD = "__x"
 
 
-def decode_packed_half(bits: int, type_name: str) -> float:
-    """Decode the 16-bit pattern of a __half or __nv_bfloat16 into a float.
+def decode_packed_halves(
+    x_bits: int, y_bits: int, type_name: str
+) -> tuple[float, float]:
+    """Decode both 16-bit patterns of a packed complex into a pair of floats.
 
     A packed complex stores its parts as CUDA 16-bit floating-point types whose
     only member is the raw bit pattern, so the debugger would otherwise show an
     integer. Every __half and __nv_bfloat16 value is exactly representable as a
-    32-bit float: a __nv_bfloat16 is the upper half of one, and a __half is IEEE
-    binary16.
+    32-bit float: a __half is IEEE binary16, and a __nv_bfloat16 is the upper
+    half of a binary32 whose lower half the pad bytes below supply.
     """
-    bits &= 0xFFFF
     if "bfloat16" in type_name:
-        return struct.unpack("<f", struct.pack("<I", bits << 16))[0]
-    return struct.unpack("<e", struct.pack("<H", bits))[0]
+        return struct.unpack("<2f", struct.pack("<2xH2xH", x_bits, y_bits))
+    return struct.unpack("<2e", struct.pack("<2H", x_bits, y_bits))
 
 
-def _as_float(part: gdb.Value) -> gdb.Value:
-    """Return a packed __half / __nv_bfloat16 part as a float gdb.Value."""
+def _packed_bits(part: gdb.Value) -> int | None:
+    """Return the raw bit pattern of a packed part, or None if it has none."""
     part_type = cccl_common.canonical_type(part.type)
-    try:
-        bits = int(part[_PACKED_BITS_FIELD])
-    except gdb.error:
-        return part
-    decoded = decode_packed_half(bits, str(part_type))
-    return gdb.Value(decoded).cast(gdb.lookup_type("float"))
+    # A packed part is a class type, but fields() raises on anything scalar.
+    if part_type.code not in (gdb.TYPE_CODE_STRUCT, gdb.TYPE_CODE_UNION):
+        return None
+    if not any(field.name == _PACKED_BITS_FIELD for field in part_type.fields()):
+        return None
+    return int(part[_PACKED_BITS_FIELD])
+
+
+def _packed_parts(packed: gdb.Value) -> tuple[gdb.Value, gdb.Value]:
+    """Return the parts of a packed complex as floats, or unchanged."""
+    x = packed["x"]
+    y = packed["y"]
+    x_bits = _packed_bits(x)
+    y_bits = _packed_bits(y)
+    if x_bits is None or y_bits is None:
+        return x, y
+    real, imag = decode_packed_halves(
+        x_bits, y_bits, str(cccl_common.canonical_type(x.type))
+    )
+    float_type = gdb.lookup_type("float")
+    return gdb.Value(real).cast(float_type), gdb.Value(imag).cast(float_type)
 
 
 def _is_cuda_complex(value_type: gdb.Type) -> bool:
@@ -61,13 +77,12 @@ class ComplexPrinter:
         self.type_name = cccl_common.public_type_name(self.type)
 
     def children(self) -> Iterator[tuple[str, gdb.Value]]:
-        try:
+        fields = {field.name for field in self.type.fields()}
+        if {"__re_", "__im_"} <= fields:
             real = self.value["__re_"]
             imag = self.value["__im_"]
-        except gdb.error:
-            packed = self.value["__repr_"]
-            real = _as_float(packed["x"])
-            imag = _as_float(packed["y"])
+        else:
+            real, imag = _packed_parts(self.value["__repr_"])
         yield "real", real
         yield "imag", imag
 

--- a/libcudacxx/share/libcudacxx/lldb/complex.py
+++ b/libcudacxx/share/libcudacxx/lldb/complex.py
@@ -17,6 +17,13 @@ _CHILD_NAMES = ("real", "imag")
 InternalDict = dict[str, object]
 
 
+def _raw_child(value: lldb.SBValue, name: str) -> lldb.SBValue:
+    child = value.GetChildMemberWithName(name)
+    if child.IsValid():
+        return child.GetNonSyntheticValue()
+    return child
+
+
 def is_cuda_complex(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
     type_name = cccl_common.canonical_type_name(value_type)
     return _COMPLEX_PATTERN.fullmatch(type_name) is not None
@@ -39,17 +46,17 @@ class ComplexSyntheticProvider:
             or ""
         )
         self.parts: list[lldb.SBValue] = []
-        real = self.value.GetChildMemberWithName("__re_")
-        imag = self.value.GetChildMemberWithName("__im_")
+        real = _raw_child(self.value, "__re_")
+        imag = _raw_child(self.value, "__im_")
+        if not real.IsValid() or not imag.IsValid():
+            packed = _raw_child(self.value, "__repr_")
+            if not packed.IsValid():
+                return False
+            real = _raw_child(packed, "x")
+            imag = _raw_child(packed, "y")
         if not real.IsValid() or not imag.IsValid():
             return False
-        scalar_type = real.GetType()
-        self.parts = [
-            self.value.CreateChildAtOffset("real", 0, scalar_type),
-            self.value.CreateChildAtOffset(
-                "imag", scalar_type.GetByteSize(), scalar_type
-            ),
-        ]
+        self.parts = [real.Clone("real"), imag.Clone("imag")]
         return True
 
     def num_children(self) -> int:

--- a/libcudacxx/share/libcudacxx/lldb/complex.py
+++ b/libcudacxx/share/libcudacxx/lldb/complex.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import re
+import struct
 
 import cccl_common
 
@@ -14,6 +15,7 @@ import lldb
 
 _COMPLEX_PATTERN = re.compile(r"^cuda::(?:std::)?complex<.+>$")
 _CHILD_NAMES = ("real", "imag")
+_PACKED_BITS_FIELD = "__x"
 InternalDict = dict[str, object]
 
 
@@ -22,6 +24,39 @@ def _raw_child(value: lldb.SBValue, name: str) -> lldb.SBValue:
     if child.IsValid():
         return child.GetNonSyntheticValue()
     return child
+
+
+def decode_packed_half(bits: int, type_name: str) -> float:
+    """Decode the 16-bit pattern of a __half or __nv_bfloat16 into a float.
+
+    A packed complex stores its parts as CUDA 16-bit floating-point types whose
+    only member is the raw bit pattern, so the debugger would otherwise show an
+    integer. Every __half and __nv_bfloat16 value is exactly representable as a
+    32-bit float: a __nv_bfloat16 is the upper half of one, and a __half is IEEE
+    binary16.
+    """
+    bits &= 0xFFFF
+    if "bfloat16" in type_name:
+        return struct.unpack("<f", struct.pack("<I", bits << 16))[0]
+    return struct.unpack("<e", struct.pack("<H", bits))[0]
+
+
+def _as_float(part: lldb.SBValue, name: str) -> lldb.SBValue:
+    """Return a packed __half / __nv_bfloat16 part as a float child."""
+    raw = _raw_child(part, _PACKED_BITS_FIELD)
+    if not raw.IsValid():
+        return part.Clone(name)
+    decoded = decode_packed_half(
+        raw.GetValueAsUnsigned(), cccl_common.canonical_type_name(part.GetType())
+    )
+    float_bits = struct.unpack("<I", struct.pack("<f", decoded))[0]
+    target = part.GetTarget()
+    data = lldb.SBData.CreateDataFromUInt32Array(
+        target.GetByteOrder(), target.GetAddressByteSize(), [float_bits]
+    )
+    return part.CreateValueFromData(
+        name, data, target.GetBasicType(lldb.eBasicTypeFloat)
+    )
 
 
 def is_cuda_complex(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
@@ -48,15 +83,17 @@ class ComplexSyntheticProvider:
         self.parts: list[lldb.SBValue] = []
         real = _raw_child(self.value, "__re_")
         imag = _raw_child(self.value, "__im_")
-        if not real.IsValid() or not imag.IsValid():
-            packed = _raw_child(self.value, "__repr_")
-            if not packed.IsValid():
-                return False
-            real = _raw_child(packed, "x")
-            imag = _raw_child(packed, "y")
+        if real.IsValid() and imag.IsValid():
+            self.parts = [real.Clone("real"), imag.Clone("imag")]
+            return True
+        packed = _raw_child(self.value, "__repr_")
+        if not packed.IsValid():
+            return False
+        real = _raw_child(packed, "x")
+        imag = _raw_child(packed, "y")
         if not real.IsValid() or not imag.IsValid():
             return False
-        self.parts = [real.Clone("real"), imag.Clone("imag")]
+        self.parts = [_as_float(real, "real"), _as_float(imag, "imag")]
         return True
 
     def num_children(self) -> int:

--- a/libcudacxx/share/libcudacxx/lldb/complex.py
+++ b/libcudacxx/share/libcudacxx/lldb/complex.py
@@ -26,37 +26,43 @@ def _raw_child(value: lldb.SBValue, name: str) -> lldb.SBValue:
     return child
 
 
-def decode_packed_half(bits: int, type_name: str) -> float:
-    """Decode the 16-bit pattern of a __half or __nv_bfloat16 into a float.
+def decode_packed_halves(
+    x_bits: int, y_bits: int, type_name: str
+) -> tuple[float, float]:
+    """Decode both 16-bit patterns of a packed complex into a pair of floats.
 
     A packed complex stores its parts as CUDA 16-bit floating-point types whose
     only member is the raw bit pattern, so the debugger would otherwise show an
     integer. Every __half and __nv_bfloat16 value is exactly representable as a
-    32-bit float: a __nv_bfloat16 is the upper half of one, and a __half is IEEE
-    binary16.
+    32-bit float: a __half is IEEE binary16, and a __nv_bfloat16 is the upper
+    half of a binary32 whose lower half the pad bytes below supply.
     """
-    bits &= 0xFFFF
     if "bfloat16" in type_name:
-        return struct.unpack("<f", struct.pack("<I", bits << 16))[0]
-    return struct.unpack("<e", struct.pack("<H", bits))[0]
+        return struct.unpack("<2f", struct.pack("<2xH2xH", x_bits, y_bits))
+    return struct.unpack("<2e", struct.pack("<2H", x_bits, y_bits))
 
 
-def _as_float(part: lldb.SBValue, name: str) -> lldb.SBValue:
-    """Return a packed __half / __nv_bfloat16 part as a float child."""
-    raw = _raw_child(part, _PACKED_BITS_FIELD)
-    if not raw.IsValid():
-        return part.Clone(name)
-    decoded = decode_packed_half(
-        raw.GetValueAsUnsigned(), cccl_common.canonical_type_name(part.GetType())
+def _as_floats(real: lldb.SBValue, imag: lldb.SBValue) -> list[lldb.SBValue]:
+    """Return the packed parts as float children, or unchanged."""
+    raw_real = _raw_child(real, _PACKED_BITS_FIELD)
+    raw_imag = _raw_child(imag, _PACKED_BITS_FIELD)
+    if not raw_real.IsValid() or not raw_imag.IsValid():
+        return [part.Clone(name) for name, part in zip(_CHILD_NAMES, (real, imag))]
+    decoded = decode_packed_halves(
+        raw_real.GetValueAsUnsigned(),
+        raw_imag.GetValueAsUnsigned(),
+        cccl_common.canonical_type_name(real.GetType()),
     )
-    float_bits = struct.unpack("<I", struct.pack("<f", decoded))[0]
-    target = part.GetTarget()
-    data = lldb.SBData.CreateDataFromUInt32Array(
-        target.GetByteOrder(), target.GetAddressByteSize(), [float_bits]
-    )
-    return part.CreateValueFromData(
-        name, data, target.GetBasicType(lldb.eBasicTypeFloat)
-    )
+    target = real.GetTarget()
+    float_type = target.GetBasicType(lldb.eBasicTypeFloat)
+    parts = []
+    for name, part, value in zip(_CHILD_NAMES, (real, imag), decoded):
+        float_bits = struct.unpack("<I", struct.pack("<f", value))[0]
+        data = lldb.SBData.CreateDataFromUInt32Array(
+            target.GetByteOrder(), target.GetAddressByteSize(), [float_bits]
+        )
+        parts.append(part.CreateValueFromData(name, data, float_type))
+    return parts
 
 
 def is_cuda_complex(value_type: lldb.SBType, _internal_dict: InternalDict) -> bool:
@@ -93,7 +99,7 @@ class ComplexSyntheticProvider:
         imag = _raw_child(packed, "y")
         if not real.IsValid() or not imag.IsValid():
             return False
-        self.parts = [_as_float(real, "real"), _as_float(imag, "imag")]
+        self.parts = _as_floats(real, imag)
         return True
 
     def num_children(self) -> int:

--- a/libcudacxx/test/debugging/complex/CMakeLists.txt
+++ b/libcudacxx/test/debugging/complex/CMakeLists.txt
@@ -5,6 +5,8 @@ libcudacxx_add_pretty_printer_test(
     # gersemi: off
     --case inspect_std_default complex.std.default value
     --case inspect_std_double complex.std.double value
+    --case inspect_std_half complex.std.half value
+    --case inspect_std_bfloat16 complex.std.bfloat16 value
     --case inspect_cuda_float complex.cuda.float value
     --case inspect_alias complex.alias value
     --case inspect_nested complex.nested values

--- a/libcudacxx/test/debugging/complex/gdb.expected
+++ b/libcudacxx/test/debugging/complex/gdb.expected
@@ -10,6 +10,26 @@ cuda::std::complex<double> = {
   imag = -2.25
 }
 =============== complex.std.double end ===============
+=============== complex.std.half begin ===============
+cuda::std::complex<__half> = {
+  real = {
+    __x = 15872
+  },
+  imag = {
+    __x = 49280
+  }
+}
+=============== complex.std.half end ===============
+=============== complex.std.bfloat16 begin ===============
+cuda::std::complex<__nv_bfloat16> = {
+  real = {
+    __x = 16320
+  },
+  imag = {
+    __x = 49168
+  }
+}
+=============== complex.std.bfloat16 end ===============
 =============== complex.cuda.float begin ===============
 cuda::complex<float> = {
   real = 0.5,

--- a/libcudacxx/test/debugging/complex/gdb.expected
+++ b/libcudacxx/test/debugging/complex/gdb.expected
@@ -12,22 +12,14 @@ cuda::std::complex<double> = {
 =============== complex.std.double end ===============
 =============== complex.std.half begin ===============
 cuda::std::complex<__half> = {
-  real = {
-    __x = 15872
-  },
-  imag = {
-    __x = 49280
-  }
+  real = 1.5,
+  imag = -2.25
 }
 =============== complex.std.half end ===============
 =============== complex.std.bfloat16 begin ===============
 cuda::std::complex<__nv_bfloat16> = {
-  real = {
-    __x = 16320
-  },
-  imag = {
-    __x = 49168
-  }
+  real = 1.5,
+  imag = -2.25
 }
 =============== complex.std.bfloat16 end ===============
 =============== complex.cuda.float begin ===============

--- a/libcudacxx/test/debugging/complex/lldb.expected
+++ b/libcudacxx/test/debugging/complex/lldb.expected
@@ -4,6 +4,18 @@
 =============== complex.std.double begin ===============
 (cuda::std::complex<double>) <address> (real = 1.5, imag = -2.25)
 =============== complex.std.double end ===============
+=============== complex.std.half begin ===============
+(cuda::std::complex<__half>) <address>: {
+  real = (__x = 15872)
+  imag = (__x = 49280)
+}
+=============== complex.std.half end ===============
+=============== complex.std.bfloat16 begin ===============
+(cuda::std::complex<__nv_bfloat16>) <address>: {
+  real = (__x = 16320)
+  imag = (__x = 49168)
+}
+=============== complex.std.bfloat16 end ===============
 =============== complex.cuda.float begin ===============
 (cuda::complex<float>) <address> (real = 0.5, imag = 42.5)
 =============== complex.cuda.float end ===============

--- a/libcudacxx/test/debugging/complex/lldb.expected
+++ b/libcudacxx/test/debugging/complex/lldb.expected
@@ -5,16 +5,10 @@
 (cuda::std::complex<double>) <address> (real = 1.5, imag = -2.25)
 =============== complex.std.double end ===============
 =============== complex.std.half begin ===============
-(cuda::std::complex<__half>) <address>: {
-  real = (__x = 15872)
-  imag = (__x = 49280)
-}
+(cuda::std::complex<__half>) <address> (real = 1.5, imag = -2.25)
 =============== complex.std.half end ===============
 =============== complex.std.bfloat16 begin ===============
-(cuda::std::complex<__nv_bfloat16>) <address>: {
-  real = (__x = 16320)
-  imag = (__x = 49168)
-}
+(cuda::std::complex<__nv_bfloat16>) <address> (real = 1.5, imag = -2.25)
 =============== complex.std.bfloat16 end ===============
 =============== complex.cuda.float begin ===============
 (cuda::complex<float>) <address> (real = 0.5, imag = 42.5)

--- a/libcudacxx/test/debugging/complex/source.cu
+++ b/libcudacxx/test/debugging/complex/source.cu
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
 #include <cuda/__complex_>
 #include <cuda/std/array>
 #include <cuda/std/complex>
@@ -19,6 +22,16 @@ using complex_alias = cuda::std::complex<float>;
 }
 
 [[gnu::noinline]] void inspect_std_double(const cuda::std::complex<double>& value)
+{
+  KEEP_FOR_DEBUGGER(value);
+}
+
+[[gnu::noinline]] void inspect_std_half(const cuda::std::complex<__half>& value)
+{
+  KEEP_FOR_DEBUGGER(value);
+}
+
+[[gnu::noinline]] void inspect_std_bfloat16(const cuda::std::complex<__nv_bfloat16>& value)
 {
   KEEP_FOR_DEBUGGER(value);
 }
@@ -52,6 +65,8 @@ int main()
 {
   const cuda::std::complex<float> std_default{};
   const cuda::std::complex<double> std_double{1.5, -2.25};
+  const cuda::std::complex<__half> std_half{::__float2half(1.5f), ::__float2half(-2.25f)};
+  const cuda::std::complex<__nv_bfloat16> std_bfloat16{::__float2bfloat16(1.5f), ::__float2bfloat16(-2.25f)};
   const cuda::complex<float> cuda_float{0.5f, 42.5f};
   const complex_alias alias{-3.5f, 0.25f};
   const cuda::std::array<cuda::std::complex<float>, 2> nested = {{{13.5f, -5.5f}, {0.25f, 88.5f}}};
@@ -59,6 +74,8 @@ int main()
 
   inspect_std_default(std_default);
   inspect_std_double(std_double);
+  inspect_std_half(std_half);
+  inspect_std_bfloat16(std_bfloat16);
   inspect_cuda_float(cuda_float);
   inspect_alias(alias);
   inspect_nested(nested);


### PR DESCRIPTION
## Description

closes #11221

Fixes the GDB and LLDB pretty-printers for the packed libcu++ complex specializations:

- `cuda::std::complex<__half>`
- `cuda::std::complex<__nv_bfloat16>`

The generic complex layout stores `__re_` and `__im_`, while these specializations store a packed `__repr_` whose `x` and `y` children are the real and imaginary components. Both existing printers assumed the generic layout.

This change makes the printers layout-driven:

- GDB uses `__re_`/`__im_` when present and falls back to `__repr_.x`/`__repr_.y`.
- LLDB reads non-synthetic object children, applies the same fallback, and clones the actual values as `real` and `imag` instead of synthesizing children by byte offset.
- The debugger fixture and GDB/LLDB goldens now cover both packed layouts with exactly representable values.

## Validation

- Full pre-commit gate on the six changed files, including the repository secret scan, formatting, Ruff, mypy, and codespell.
- Python bytecode compilation and focused mock-object tests for generic and packed GDB/LLDB paths.
- Real LLDB execution against a host-side layout probe, confirming the packed children render as `real` and `imag` with the expected raw half/bfloat16 values.

This macOS host has no CUDA Toolkit or GDB, so the repository's Linux CUDA debugger CI remains the end-to-end validation for the CUDA-compiled GDB golden.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
