### PR TITLE
Fix analysis script score

### DIFF
--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -27,7 +27,7 @@ sensitivity = 0.5
 
 
 def get_bench_columns():
-    return ["variant", "elapsed", "center", "samples", "bw"]
+    return ["variant", "cccl", "elapsed", "center", "samples", "bw"]
 
 
 def get_extended_bench_columns():
@@ -110,6 +110,15 @@ def extract_rt_axes_values(df):
     return rt_axes_values
 
 
+def declared_rt_axes_values(df, declared_axes):
+    """The value list each runtime axis is weighted over.
+
+    `check_axis_space_recorded` has already established that the record covers
+    every axis the data has.
+    """
+    return {rt_axis: declared_axes[rt_axis] for rt_axis in get_rt_axes(df)}
+
+
 def extract_rt_space(df):
     rt_axes = get_rt_axes(df)
     rt_axes_values = []
@@ -131,29 +140,69 @@ def extract_complete_variants(df):
     return df.groupby("variant").filter(functools.partial(filter_variants, df))
 
 
-def compute_workload_score(rt_axes_values, rt_axes_ids, weights, row):
+def incomplete_variants(dfs):
+    """The variants that did not cover every workload the others did.
+
+    Judged over every subbench at once: dropping a variant from the one subbench
+    it is incomplete in leaves it in the ranking scored on what remains, which
+    is how a variant that regressed on the workloads it is missing comes out on
+    top. A workload NVBench skips is absent for every variant alike and so costs
+    nobody their completeness.
+    """
+    incomplete = set()
+    measured = set()
+    everywhere = None
+
+    for df in dfs.values():
+        if df.empty:
+            continue
+
+        rt_axes = get_rt_axes(df)
+        covered = set(df[rt_axes].drop_duplicates().itertuples(index=False))
+
+        present = set()
+        for variant, group in df.groupby("variant"):
+            present.add(variant)
+            if set(group[rt_axes].drop_duplicates().itertuples(index=False)) != covered:
+                incomplete.add(variant)
+
+        measured |= present
+        everywhere = present if everywhere is None else everywhere & present
+
+    # A variant that is missing a whole subbench is missing its workloads too.
+    return incomplete | (measured - (everywhere or set()))
+
+
+def compute_workload_weight(rt_axes_values, rt_axes_ids, weights, row):
     rt_workload = []
     for rt_axis in rt_axes_values:
         rt_workload.append("{}={}".format(rt_axis, row[rt_axis]))
 
-    weight = cccl.bench.get_workload_weight(
+    return cccl.bench.get_workload_weight(
         rt_workload, rt_axes_values, rt_axes_ids, weights
     )
-    return row["speedup"] * weight
 
 
 def compute_variant_score(rt_axes_values, rt_axes_ids, weight_matrix, group):
-    workload_score_closure = functools.partial(
-        compute_workload_score, rt_axes_values, rt_axes_ids, weight_matrix
+    """Return weighted speedup and total weight, similarly to bench.score."""
+    workload_weight_closure = functools.partial(
+        compute_workload_weight, rt_axes_values, rt_axes_ids, weight_matrix
     )
-    score_sum = group.apply(workload_score_closure, axis=1).sum()
-    return score_sum
+    workload_weights = group.apply(workload_weight_closure, axis=1)
+    return pd.Series(
+        {
+            "weighted_speedup": (workload_weights * group["speedup"]).sum(),
+            "weight": workload_weights.sum(),
+        }
+    )
 
 
-def extract_scores(dfs):
+def version_scores(dfs, declared_axes):
     rt_axes_values = {}
     for subbench in dfs:
-        rt_axes_values[subbench] = extract_rt_axes_values(dfs[subbench])
+        rt_axes_values[subbench] = declared_rt_axes_values(
+            dfs[subbench], declared_axes[subbench]
+        )
 
     rt_axes_ids = cccl.bench.compute_axes_ids(rt_axes_values)
     weights = cccl.bench.compute_weight_matrices(rt_axes_values, rt_axes_ids)
@@ -168,19 +217,53 @@ def extract_scores(dfs):
         )
         grouped = dfs[subbench].groupby("variant")
         scores = grouped.apply(score_closure, include_groups=False).reset_index()
-        scores.columns = ["variant", "score"]
-        stat = grouped.agg(
+        scores.columns = ["variant", "weighted_speedup", "weight"]
+        score_dfs.append(scores)
+    return score_dfs
+
+
+SCORE_COLUMNS = ["variant", "score", "mins", "means", "maxs"]
+
+
+def extract_scores(dfs, declared_axes):
+    score_dfs = []
+    for version in sorted({v for df in dfs.values() for v in df["cccl"].unique()}):
+        version_dfs = {}
+        for subbench in dfs:
+            subbench_df = dfs[subbench][dfs[subbench]["cccl"] == version]
+            if not subbench_df.empty:
+                version_dfs[subbench] = subbench_df
+
+        score_dfs += version_scores(
+            version_dfs,
+            {s: declared_axes[s][version] for s in version_dfs},
+        )
+
+    if not score_dfs:
+        return pd.DataFrame(columns=SCORE_COLUMNS)
+
+    # The weights are normalized across subbenches, so a variant's score is the
+    # ratio of the sums over all of them, not the mean of their ratios.
+    totals = (
+        pd.concat(score_dfs)
+        .groupby("variant")
+        .agg({"weighted_speedup": "sum", "weight": "sum"})
+    )
+    # The statistics describe the speedups themselves, so they come from every
+    # measurement at once rather than from an average of per-subbench averages.
+    stat = (
+        pd.concat(dfs.values())
+        .groupby("variant")
+        .agg(
             mins=("speedup", "min"), means=("speedup", "mean"), maxs=("speedup", "max")
         )
-        scores = pd.merge(scores, stat, on="variant")
-        score_dfs.append(scores)
-    score_df = pd.concat(score_dfs)
-    result = (
-        score_df.groupby("variant")
-        .agg({"score": "sum", "mins": "min", "means": "mean", "maxs": "max"})
-        .reset_index()
     )
-    return result.sort_values(by=["score"], ascending=False)
+    result = totals.join(stat).reset_index()
+    weight = result["weight"]
+    result["score"] = (result["weighted_speedup"] / weight.where(weight != 0)).fillna(
+        float("-inf")
+    )
+    return result[SCORE_COLUMNS].sort_values(by=["score"], ascending=False)
 
 
 def distributions_are_different(alpha, row):
@@ -220,6 +303,114 @@ def is_finite(x):
     return True
 
 
+def collect_declared_axes(declared_axes, algname, subbench, axes_values, source):
+    recorded = declared_axes.setdefault(subbench, {})
+
+    for version in axes_values:
+        if version in recorded and recorded[version] != axes_values[version]:
+            raise Exception(
+                "{} records a different axis space for {}.{} under CCCL {} than"
+                " another database does: {} vs {}".format(
+                    source,
+                    algname,
+                    subbench,
+                    version,
+                    axes_values[version],
+                    recorded[version],
+                )
+            )
+        recorded[version] = axes_values[version]
+
+
+def drop_unweighable_rows(df, declared_axes):
+    """Remove rows whose axis values the declared space has no position for.
+
+    Leaving them in would also cost every variant that correctly does not have
+    them, since `extract_complete_variants` drops a variant missing any
+    combination the frame contains.
+    """
+    if not declared_axes:
+        return df
+
+    keep = pd.Series(True, index=df.index)
+    for rt_axis in get_rt_axes(df):
+        if rt_axis in declared_axes:
+            keep &= df[rt_axis].isin(declared_axes[rt_axis])
+
+    return df[keep]
+
+
+def collect_measured_values(seen, subbench, df):
+    """Record which runtime values each CCCL version actually holds rows for."""
+    axes_df = df.drop(columns=["ctk", "gpu"])
+    versions = seen.setdefault(subbench, {})
+
+    for version in axes_df["cccl"].unique():
+        version_df = axes_df[axes_df["cccl"] == version]
+        axes = versions.setdefault(version, {})
+        for rt_axis in get_rt_axes(version_df):
+            axes.setdefault(rt_axis, set()).update(version_df[rt_axis].unique())
+
+
+def check_axis_space_recorded(algname, declared_axes, seen):
+    """Refuse to score rows whose declared axis space was never recorded.
+
+    Weights are positional, so without the space the benchmark declared there is
+    no way to know what a speedup was worth -- the values that happen to be in
+    the database are the whole space only if the campaign was not narrowed, and
+    nothing says whether it was. Checked once every database has been read: one
+    of them recording the space covers another one's rows.
+    """
+    missing = []
+    for subbench in sorted(seen):
+        for version in sorted(seen[subbench]):
+            declared = declared_axes.get(subbench, {}).get(version)
+            if not declared:
+                missing.append("{}.{} under CCCL {}".format(algname, subbench, version))
+                continue
+
+            for rt_axis in sorted(seen[subbench][version]):
+                if rt_axis not in declared:
+                    missing.append(
+                        "the {} axis of {}.{} under CCCL {}".format(
+                            rt_axis, algname, subbench, version
+                        )
+                    )
+
+    if missing:
+        raise Exception(
+            "no declared axis space is recorded for {}. It is recorded by the"
+            " tuning run that measures the rows, so a database written before"
+            " that has to be re-measured to be scored.".format("; ".join(missing))
+        )
+
+
+def report_undeclared_values(algname, declared_axes, seen):
+    """Say which rows the declared axis space has no position for.
+
+    `drop_unweighable_rows` leaves them out of the score; a campaign narrowed to
+    a value off the axis is rejected now, so only a database written before that
+    can hold them.
+    """
+    for subbench in sorted(seen):
+        for version in sorted(seen[subbench]):
+            declared = declared_axes[subbench][version]
+            for rt_axis, measured in sorted(seen[subbench][version].items()):
+                undeclared = sorted(measured - set(declared[rt_axis]))
+                if undeclared:
+                    print(
+                        "#### WARNING {}.{} holds rows measured at {}={} under CCCL"
+                        " {}, which the benchmark does not declare; they are left"
+                        " out of the score".format(
+                            algname,
+                            subbench,
+                            rt_axis,
+                            ", ".join(undeclared),
+                            version,
+                        )
+                    )
+
+
 def iterate_case_dfs(args, callable):
     storages = {}
     algnames = set()
@@ -241,7 +432,22 @@ def iterate_case_dfs(args, callable):
         if not pattern.match(algname):
             continue
 
+        # Read every database's record of the declared axis space before
+        # weighing any of them: one database recording it covers another one's
+        # rows, and a row can only be dropped once the space is known.
+        declared_axes: dict[str, dict[str, dict]] = {}
+        for file in storages:
+            for subbench in storages[file].subbenches(algname):
+                collect_declared_axes(
+                    declared_axes,
+                    algname,
+                    subbench,
+                    storages[file].axes_values(algname, subbench),
+                    file,
+                )
+
         case_dfs: dict[str, dict[str, pd.DataFrame]] = {}
+        measured_values: dict[str, dict[str, dict]] = {}
         for file in storages:
             storage = storages[file]
             for subbench in storage.subbenches(algname):
@@ -249,6 +455,8 @@ def iterate_case_dfs(args, callable):
 
                 df = df.map(lambda x: x if is_finite(x) else np.nan)
                 df = df.dropna(subset=["center"], how="all")
+
+                collect_measured_values(measured_values, subbench, df)
 
                 for _, row in df[["ctk", "cccl"]].drop_duplicates().iterrows():
                     ctk_version = row["ctk"]
@@ -260,7 +468,15 @@ def iterate_case_dfs(args, callable):
                     for gpu in ctk_cub_df["gpu"].unique():
                         target_df = ctk_cub_df[ctk_cub_df["gpu"] == gpu]
                         target_df = target_df.drop(columns=["ctk", "cccl", "gpu"])
+                        target_df = drop_unweighable_rows(
+                            target_df, declared_axes[subbench].get(cccl_version)
+                        )
                         target_df = compute_speedup(target_df)
+
+                        # Put the version back, once it is no longer a column
+                        # `compute_speedup` would match base against variant on.
+                        # `extract_scores` weighs each version on its own.
+                        target_df["cccl"] = cccl_version
 
                         for key in exact_values:
                             if key in target_df.columns:
@@ -287,11 +503,14 @@ def iterate_case_dfs(args, callable):
                                     [case_dfs[point_str][subbench], case_df]
                                 )
 
+        check_axis_space_recorded(algname, declared_axes, measured_values)
+        report_undeclared_values(algname, declared_axes, measured_values)
+
         for point_str in case_dfs:
-            callable(algname, point_str, case_dfs[point_str])
+            callable(algname, point_str, case_dfs[point_str], declared_axes)
 
 
-def case_top(alpha, N, algname, ct_point_name, case_dfs):
+def case_top(alpha, N, algname, ct_point_name, case_dfs, declared_axes):
     print("{}[{}]:".format(algname, ct_point_name))
 
     if alpha < 1.0:
@@ -300,17 +519,29 @@ def case_top(alpha, N, algname, ct_point_name, case_dfs):
                 alpha, case_dfs[subbench]
             )
 
-    for subbench in case_dfs:
-        case_dfs[subbench] = extract_complete_variants(case_dfs[subbench])
+    dropped = incomplete_variants(case_dfs)
+    if dropped:
+        listed = sorted(dropped)
+        print(
+            "dropped {} variant(s) that did not cover every workload: {}".format(
+                len(listed),
+                ", ".join(listed[:5]) + (", ..." if len(listed) > 5 else ""),
+            )
+        )
+        for subbench in case_dfs:
+            case_dfs[subbench] = case_dfs[subbench][
+                ~case_dfs[subbench]["variant"].isin(dropped)
+            ]
+
     with pd.option_context("display.max_rows", None):
-        print(extract_scores(case_dfs).head(N))
+        print(extract_scores(case_dfs, declared_axes).head(N))
 
 
 def top(args):
     iterate_case_dfs(args, functools.partial(case_top, args.alpha, args.top))
 
 
-def case_coverage(algname, ct_point_name, case_dfs):
+def case_coverage(algname, ct_point_name, case_dfs, declared_axes):
     num_variants = cccl.bench.Config().variant_space_size(algname)
     min_coverage = 100.0
     for subbench in case_dfs:
@@ -427,7 +658,7 @@ def parallel_coordinates_plot(df, title):
     plt.show()
 
 
-def case_coverage_plot(algname, ct_point_name, case_dfs):
+def case_coverage_plot(algname, ct_point_name, case_dfs, declared_axes):
     data_list = []
 
     for subbench in case_dfs:
@@ -459,7 +690,7 @@ def coverage_plot(args):
     iterate_case_dfs(args, case_coverage_plot)
 
 
-def case_pair_plot(algname, ct_point_name, case_dfs):
+def case_pair_plot(algname, ct_point_name, case_dfs, declared_axes):
     import seaborn as sns
 
     data_list = []
@@ -666,7 +897,7 @@ def ratio(data, ax):
             variant_ratio(data, variant, ax)
 
 
-def case_variants(pattern, mode, algname, ct_point_name, case_dfs):
+def case_variants(pattern, mode, algname, ct_point_name, case_dfs, declared_axes):
     for subbench in case_dfs:
         case_df = case_dfs[subbench]
         title = "{}[{}]:".format(algname + "/" + subbench, ct_point_name)
@@ -797,7 +1028,7 @@ def file_exists(value):
     return value
 
 
-def case_offload(algname, ct_point_name, case_dfs):
+def case_offload(algname, ct_point_name, case_dfs, declared_axes):
     for subbench in case_dfs:
         df = case_dfs[subbench]
         for rt_point in extract_rt_space(df):

--- a/benchmarks/scripts/cccl/bench/bench.py
+++ b/benchmarks/scripts/cccl/bench/bench.py
@@ -76,6 +76,48 @@ def json_benches(algname):
     return JsonCache().get_bench(algname)
 
 
+def store_bench_axes(conn, algname, subbench, axes_values, cccl):
+    with conn:
+        conn.execute("""
+        CREATE TABLE IF NOT EXISTS axes (
+            algorithm TEXT NOT NULL,
+            subbench TEXT NOT NULL,
+            cccl TEXT NOT NULL,
+            axis_values TEXT NOT NULL,
+            UNIQUE(algorithm, subbench, cccl)
+        );
+        """)
+
+        recorded = conn.execute(
+            "SELECT axis_values FROM axes WHERE algorithm=? AND subbench=? AND cccl=?;",
+            (algname, subbench, cccl),
+        ).fetchone()
+
+        conn.execute(
+            """
+        INSERT INTO axes (algorithm, subbench, cccl, axis_values)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(algorithm, subbench, cccl) DO UPDATE SET
+            axis_values = excluded.axis_values;
+        """,
+            (algname, subbench, cccl, json.dumps(axes_values)),
+        )
+
+    # `score` weighs over what the benchmark declares now, so the record has to
+    # follow it or `analyze.py` would stop reproducing the score this campaign
+    # is about to print. Rows measured under the old declaration are re-weighted
+    # against the new one, which is worth saying out loud.
+    if recorded and json.loads(recorded[0]) != axes_values:
+        print(
+            "#### WARNING {}.{} declared {} when this database was last written"
+            " and declares {} now, both as CCCL {}. `git describe` does not see"
+            " uncommitted edits, so the two cannot be told apart: measurements"
+            " already stored are re-weighted against the new axes.".format(
+                algname, subbench, json.loads(recorded[0]), axes_values, cccl
+            )
+        )
+
+
 def create_benches_tables(conn, subbench, bench_axes):
     with conn:
         conn.execute("""
@@ -389,11 +431,12 @@ class BenchCache:
         alg_name = bench_base.algorithm_name()
 
         if alg_name not in self.existing_tables:
-            subbench_axes_names = bench_base.axes_names()
-            for subbench in subbench_axes_names:
-                create_benches_tables(
-                    conn, subbench, {alg_name: subbench_axes_names[subbench]}
-                )
+            config = Config()
+            declared_axes_values = bench_base.declared_axes_values()
+            for subbench in declared_axes_values:
+                axes_values = declared_axes_values[subbench]
+                create_benches_tables(conn, subbench, {alg_name: axes_values})
+                store_bench_axes(conn, alg_name, subbench, axes_values, config.cccl)
                 self.existing_tables.add(alg_name)
 
     def push_bench_centers(self, bench, result, estimator):
@@ -590,15 +633,34 @@ class Bench:
     def bench_names(self):
         return [bench["name"] for bench in json_benches(self.algname)["benchmarks"]]
 
-    def axes_names(self):
-        subbench_names = {}
+    def declared_axes_values(self):
+        subbench_space = {}
         for bench in json_benches(self.algname)["benchmarks"]:
-            names = []
+            space = {}
             for axis in bench["axes"]:
-                names.append(get_axis_name(axis))
+                space[get_axis_name(axis)] = [
+                    value["input_string"] for value in axis["values"]
+                ]
+            subbench_space[bench["name"]] = space
+        return subbench_space
 
-            subbench_names[bench["name"]] = names
-        return subbench_names
+    def declared_rt_axes_values(self):
+        return self.axes_values({}, False)
+
+    def check_axis_values_declared(self, subbench, name, requested, axis):
+        declared = [value["input_string"] for value in axis["values"]]
+        undeclared = [value for value in requested if value not in declared]
+
+        if undeclared:
+            raise Exception(
+                "{}.{} does not declare {} on axis {}, which declares {}".format(
+                    self.algname,
+                    subbench,
+                    ", ".join(undeclared),
+                    name,
+                    ", ".join(declared),
+                )
+            )
 
     def axes_values(self, sub_space, ct):
         subbench_space = {}
@@ -616,6 +678,9 @@ class Bench:
 
                 axis_space = []
                 if name in sub_space:
+                    self.check_axis_values_declared(
+                        bench["name"], name, sub_space[name], axis
+                    )
                     for value in sub_space[name]:
                         axis_space.append(value)
                 else:
@@ -803,8 +868,9 @@ class Bench:
         if not speedups:
             return float("-inf")
 
-        rt_axes_ids = compute_axes_ids(rt_values)
-        weight_matrices = compute_weight_matrices(rt_values, rt_axes_ids)
+        declared_rt_values = self.declared_rt_axes_values()
+        rt_axes_ids = compute_axes_ids(declared_rt_values)
+        weight_matrices = compute_weight_matrices(declared_rt_values, rt_axes_ids)
 
         # For importance-ordered axis, score favors last speedups:
         # score = 15% of S16 + 25% of S20 + 29% of S24 + 31% of S28
@@ -835,7 +901,10 @@ class Bench:
                 rt_workload = state_to_rt_workload(bench, state)
                 weights = weight_matrices[bench]
                 weight = get_workload_weight(
-                    rt_workload, rt_values[bench], rt_axes_ids[bench], weights
+                    rt_workload,
+                    declared_rt_values[bench],
+                    rt_axes_ids[bench],
+                    weights,
                 )
                 score = score + weight * speedups[bench][state]
                 total_weight = total_weight + weight

--- a/benchmarks/scripts/cccl/bench/storage.py
+++ b/benchmarks/scripts/cccl/bench/storage.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sqlite3
 
@@ -72,6 +73,10 @@ class StorageBase:
     def store_df(self, algname, df):
         raise NotImplementedError
 
+    def axes_values(self, algname, subbench):
+        """The axis space each CCCL version declared for one subbench."""
+        raise NotImplementedError
+
 
 class SQLiteStorage(StorageBase):
     def __init__(self, db_path):
@@ -115,6 +120,23 @@ class SQLiteStorage(StorageBase):
     def store_df(self, algname, df):
         df["samples"] = df["samples"].apply(fpzip.compress)
         df.to_sql(algname, self.conn, if_exists="replace", index=False)
+
+    def axes_values(self, algname, subbench):
+        with self.conn:
+            table = self.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='axes'"
+            ).fetchone()
+            if not table:
+                # Written before the axis space was recorded at all. Callers
+                # fall back to the values the database does hold.
+                return {}
+
+            rows = self.conn.execute(
+                "SELECT cccl, axis_values FROM axes WHERE algorithm=? AND subbench=?",
+                (algname, subbench),
+            ).fetchall()
+
+        return {cccl: json.loads(axis_values) for cccl, axis_values in rows}
 
 
 class PostgreSQLConnectionWrapper:
@@ -229,6 +251,24 @@ if POSTGRES_AVAILABLE:
             raise NotImplementedError(
                 "DataFrame storage for PostgreSQL not yet implemented"
             )
+
+        def axes_values(self, algname, subbench):
+            with self.conn:
+                cur = self.conn.execute("""
+                    SELECT EXISTS (
+                        SELECT FROM information_schema.tables
+                        WHERE table_name = 'axes'
+                    );
+                """)
+                if not cur.fetchone()[0]:
+                    # Written before the axis space was recorded at all.
+                    return {}
+
+                cur = self.conn.execute(
+                    "SELECT cccl, axis_values FROM axes WHERE algorithm=? AND subbench=?",
+                    (algname, subbench),
+                )
+                return {cccl: json.loads(values) for cccl, values in cur.fetchall()}
 else:
     # Placeholder when psycopg2 is not available; callers check for None.
     PostgreSQLStorage = None  # type: ignore[assignment, misc]
@@ -267,6 +307,10 @@ class DualStorageWrapper:
     def alg_to_df(self, algname, subbench):
         # Read from primary only
         return self.primary.alg_to_df(algname, subbench)
+
+    def axes_values(self, algname, subbench):
+        # Read from primary only
+        return self.primary.axes_values(algname, subbench)
 
     def store_df(self, algname, df):
         # Write to both databases
@@ -397,3 +441,6 @@ class Storage:
 
     def alg_to_df(self, algname, subbench):
         return self.base.alg_to_df(algname, subbench)
+
+    def axes_values(self, algname, subbench):
+        return self.base.axes_values(algname, subbench)

--- a/benchmarks/scripts/tests/test_score.py
+++ b/benchmarks/scripts/tests/test_score.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Run with: `uvx --with numpy --with fpzip --with pandas --with pytest pytest -q benchmarks/scripts/tests/`
+# Run with: `uvx --with numpy --with fpzip --with matplotlib --with pandas --with scipy --with pytest pytest -q benchmarks/scripts/tests/`
 
-"""Tests for the workload weighting in `Bench.score`."""
+"""Tests for the axis space a score is weighed over, and the weighting itself."""
 
+import cccl.bench.bench as bench_module
 import pytest
 from cccl.bench.bench import Bench
 from cccl.bench.config import RangePoint, VariantPoint
@@ -16,10 +17,47 @@ SUBBENCH = "base"
 CT_WORKLOAD = "T{ct}=I32 OffsetT{ct}=I64"
 ELEMENTS = "Elements{io}"
 
-# The runtime axis as declared by the benchmark, i.e. what `rt_axes_values()`
-# reports. NVBench may skip some of these states at runtime, in which case they
-# never reach `speedups`.
+# The runtime axis as declared by the benchmark, i.e. what
+# `declared_rt_axes_values()` reports. A campaign may narrow it with `-a`, and
+# NVBench may skip some of the states it does ask for; neither reaches
+# `speedups`, and neither changes the weights.
 DECLARED = {SUBBENCH: {ELEMENTS: ["16", "20", "24", "28"]}}
+
+# What `--jsonlist-benches` would report for a benchmark declaring `DECLARED`.
+BENCHES = {
+    "benchmarks": [
+        {
+            "name": SUBBENCH,
+            "axes": [
+                {"name": "T{ct}", "flags": "", "values": [{"input_string": "I32"}]},
+                {
+                    "name": "OffsetT{ct}",
+                    "flags": "",
+                    "values": [{"input_string": "I64"}],
+                },
+                {
+                    "name": ELEMENTS,
+                    "flags": "",
+                    "values": [
+                        {"input_string": value}
+                        for value in DECLARED[SUBBENCH][ELEMENTS]
+                    ],
+                },
+            ],
+        }
+    ]
+}
+
+
+@pytest.fixture(autouse=True)
+def declared_benchmark(monkeypatch):
+    """Let `Bench` read its axis space the way it does from a real binary.
+
+    Stubbing `declared_rt_axes_values` instead would take the code under test
+    out of the test: what `score` weighs over moving off the caller-supplied
+    `rt_values` is the whole point.
+    """
+    monkeypatch.setattr(bench_module, "json_benches", lambda algname: BENCHES)
 
 
 class StubBench(Bench):
@@ -104,6 +142,26 @@ def test_relative_importance_does_not_depend_on_what_was_skipped():
         assert score - 1.0 == pytest.approx(declared_weight(value) / total)
 
 
+@pytest.mark.parametrize(
+    "asked_for", [["16", "20", "24", "28"], ["20", "24", "28"], ["24", "28"], ["28"]]
+)
+def test_narrowing_the_campaign_does_not_change_the_weights(asked_for):
+    """`-a` narrows what runs, not what a speedup is worth.
+
+    Weighing over what was asked for would move the smallest value asked for
+    onto the least importance anchor: a campaign narrowed to 2^24 and 2^28
+    would split them 38/62 instead of the 50/50 their positions on the declared
+    axis carry.
+    """
+    measured = {"24": 1.0, "28": 2.0}
+
+    narrowed = StubBench(measured).score(
+        [CT_WORKLOAD], {SUBBENCH: {ELEMENTS: asked_for}}, None, None
+    )
+
+    assert narrowed == pytest.approx(score_of(measured))
+
+
 def test_a_uniformly_faster_variant_beats_one_that_trades_a_regression():
     """2^24 and 2^28 carry almost the same weight in the declared axis.
 
@@ -115,3 +173,99 @@ def test_a_uniformly_faster_variant_beats_one_that_trades_a_regression():
     uniform = score_of({"24": 1.05, "28": 1.08})
 
     assert uniform > regressing
+
+
+def test_a_narrowing_naming_an_undeclared_value_is_rejected():
+    """`-a` replaces a value axis in NVBench rather than narrowing it.
+
+    An undeclared value would run, be stored, and only then have no position on
+    the axis to be weighed by. Quietly dropping it would hide the typo and
+    silently tune something other than what was asked for, so it is an error,
+    raised before anything is built.
+    """
+    with pytest.raises(Exception, match=r"does not declare 22 on axis Elements"):
+        StubBench({}).axes_values({ELEMENTS: ["20", "22", "28"]}, False)
+
+
+def test_a_narrowing_of_declared_values_is_kept_verbatim():
+    narrowed = StubBench({}).axes_values({ELEMENTS: ["20", "28"]}, False)
+
+    assert narrowed == {SUBBENCH: {ELEMENTS: ["20", "28"]}}
+
+
+def test_an_axis_the_narrowing_does_not_name_keeps_its_declared_values():
+    narrowed = StubBench({}).axes_values({}, False)
+
+    assert narrowed == DECLARED
+
+
+def subbench_stub(monkeypatch, subbenches):
+    """`--jsonlist-benches` for a benchmark file declaring several subbenches."""
+    monkeypatch.setattr(
+        bench_module,
+        "json_benches",
+        lambda algname: {
+            "benchmarks": [
+                {
+                    "name": name,
+                    "axes": [
+                        {
+                            "name": axis,
+                            "flags": "",
+                            "values": [{"input_string": v} for v in values],
+                        }
+                        for axis, values in axes.items()
+                    ],
+                }
+                for name, axes in subbenches.items()
+            ]
+        },
+    )
+
+
+def test_an_axis_split_across_subbenches_can_only_be_narrowed_to_shared_values(
+    monkeypatch,
+):
+    """`cub.bench.segmented_reduce` splits `SegmentSize` three ways.
+
+    NVBench would hand a value to a subbench that does not declare it and run
+    it there anyway, so a narrowing only one of them covers has to be rejected,
+    naming the subbench that cannot take it.
+    """
+    subbench_stub(
+        monkeypatch,
+        {
+            "small": {"SegmentSize": ["1", "16"]},
+            "large": {"SegmentSize": ["512", "65536"]},
+        },
+    )
+
+    with pytest.raises(Exception, match=r"\.large does not declare 16 on axis"):
+        StubBench({}).axes_values({"SegmentSize": ["16"]}, False)
+
+    assert StubBench({}).axes_values({}, False) == {
+        "small": {"SegmentSize": ["1", "16"]},
+        "large": {"SegmentSize": ["512", "65536"]},
+    }
+
+
+def test_an_axis_a_subbench_does_not_have_is_left_alone(monkeypatch):
+    """`segmented_sort.keys` gives `Entropy` to `power` and to neither sibling.
+
+    One `-a` is meant to be usable across a whole `-R` selection, so an axis a
+    benchmark does not have is ignored rather than rejected.
+    """
+    subbench_stub(
+        monkeypatch,
+        {
+            "power": {ELEMENTS: ["22", "26"], "Entropy": ["1.000", "0.201"]},
+            "small": {ELEMENTS: ["22", "26"]},
+        },
+    )
+
+    narrowed = StubBench({}).axes_values({"Entropy": ["1.000"]}, False)
+
+    assert narrowed == {
+        "power": {ELEMENTS: ["22", "26"], "Entropy": ["1.000"]},
+        "small": {ELEMENTS: ["22", "26"]},
+    }


### PR DESCRIPTION
To highlight the issue with current tuning infrastructure, let's modify `cccl_meta_bench.csv` to reduce search space:
```
cub.bench.select.unique_by_key,TUNE_ITEMS|ipt=11:11:1,TUNE_THREADS|tpb=256:256:1,TUNE_TRANSPOSE|trp=1:1:1,TUNE_LOAD|ld=0:0:1,TUNE_MAGIC_NS|ns=0:0:1,TUNE_DELAY_CONSTRUCTOR_ID|dcid=0:0:1,TUNE_L2_WRITE_LATENCY_NS|l2w=0:0:1
cub.bench.topk.keys,TUNE_ITEMS_PER_THREAD|ipt=9:9:1,TUNE_THREADS_PER_BLOCK|tpb=256:256:1,TUNE_BLOCK_LOAD_ALGORITHM|ld=1:1:1
cub.bench.segmented_scan.sum,TUNE_ITEMS|ipt=11:11:1,TUNE_THREADS|tpb=256:256:1,TUNE_TRANSPOSE|trp=1:1:1,TUNE_LOAD|ld=0:0:1,TUNE_MAX_SEGMENTS_PER_BLOCK|spb=512:512:1
```

Now, each of the algorithms has exactly one variant to try:

```bash
../benchmarks/scripts/search.py -R '^cub\.bench\.(reduce\.sum|select\.unique_by_key|topk\.keys|segmented_scan\.sum)$' -l
 ctk:  13.3.33
cccl:  v3.6.0.dev-326-g8df08c40fc
### Benchmarks
  * `cub.bench.reduce.sum`: 1 variants:
    * `ipt`: (16, 17, 1)
    * `tpb`: (256, 257, 1)
    * `ipv`: (2, 3, 1)
  * `cub.bench.segmented_scan.sum`: 1 variants:
    * `ipt`: (11, 12, 1)
    * `tpb`: (256, 257, 1)
    * `trp`: (1, 2, 1)
    * `ld`: (0, 1, 1)
    * `spb`: (512, 513, 1)
  * `cub.bench.select.unique_by_key`: 1 variants:
    * `ipt`: (11, 12, 1)
    * `tpb`: (256, 257, 1)
    * `trp`: (1, 2, 1)
    * `ld`: (0, 1, 1)
    * `ns`: (0, 1, 1)
    * `dcid`: (0, 1, 1)
    * `l2w`: (0, 1, 1)
  * `cub.bench.topk.keys`: 1 variants:
    * `ipt`: (9, 10, 1)
    * `tpb`: (256, 257, 1)
    * `ld`: (1, 2, 1)
```

Get old logic:

```bash
git restore --source=HEAD~1 benchmarks/scripts
```

Run search:

```bash
CUDA_VISIBLE_DEVICES=0 ../benchmarks/scripts/search.py -R '^cub\.bench\.(reduce\.sum|select\.unique_by_key|topk\.keys|segmented_scan\.sum)$' -a 'T{ct}=I32' -a 'KeyT{ct}=I32' -a 'ValueT{ct}=I32' -a 'OffsetT{ct}=I32' -a 'OutOffsetT{ct}=I32'

ctk:  13.3.33
cccl:  v3.6.0.dev-326-gd493706f12
cub.bench.reduce.sum.ipt_16.tpb_256.ipv_2 0.9875770041182139
cub.bench.segmented_scan.sum.ipt_11.tpb_256.trp_1.ld_0.spb_512 0.5256216191017927
cub.bench.select.unique_by_key.ipt_11.tpb_256.trp_1.ld_0.ns_0.dcid_0.l2w_0 1.095417921104343
cub.bench.topk.keys.ipt_9.tpb_256.ld_1 0.9652678423410188
```

Now, workload analysis:

```bash
../benchmarks/scripts/analyze.py cccl_meta_bench.db \
  -R '^cub\.bench\.(reduce\.sum|select\.unique_by_key|topk\.keys|segmented_scan\.sum)$' --top=3

cub.bench.select.unique_by_key[KeyT{ct}=I32, ValueT{ct}=I32, OffsetT{ct}=I32]:
                                          variant     score      mins     means      maxs
1  ipt_11.tpb_256.trp_1.ld_0.ns_0.dcid_0.l2w_0 ()  1.095418  0.986695  1.119157  1.334204
0                                         base ()  1.000000  1.000000  1.000000  1.000000


cub.bench.reduce.sum[T{ct}=I32, OffsetT{ct}=I32]:
                   variant     score    mins    means      maxs
0                  base ()  1.000000  1.0000  1.00000  1.000000
1  ipt_16.tpb_256.ipv_2 ()  0.987577  0.9606  0.98886  1.000047


cub.bench.topk.keys[KeyT{ct}=I32, OffsetT{ct}=I32, OutOffsetT{ct}=I32]:
                 variant     score      mins     means      maxs
0                base ()  0.899096  1.000000  1.000000  1.000000
1  ipt_9.tpb_256.ld_1 ()  0.867869  0.727273  0.958956  1.023438


cub.bench.segmented_scan.sum[T{ct}=I32, OffsetT{ct}=I32]:
                                variant     score      mins     means  maxs
0                               base ()  1.000000  1.000000  1.000000   1.0
1  ipt_11.tpb_256.trp_1.ld_0.spb_512 ()  0.525622  0.154812  0.509884   1.5
```

Problems with state of the main:

| algorithm | runtime axes | tuning (`search.py`) | analysis (`analyze.py`) | agree? |
|---|---|---|---|---|
| `reduce.sum` | 1 | 0.987577 | 0.987577 | yes |
| `select.unique_by_key` | 2 | 1.095418 | 1.095418 | yes |
| `segmented_scan.sum` | 2, two subbenches | 0.525622 | 0.525622 | yes |
| `topk.keys` | 3, **12 of 96 skipped** | 0.965268 | **0.867869** | **no, −10.09%** |

`TopK` score differs between analysis and search reports. 
This is a problem because: 
- we'll end up ignoring some variants that lead to speedup, and
- base measurement's score isn't 1.

This PR fixes tuning infrastructure for benchmarks that `skip` some runtime configurations.
That's not the only issue, though.

Second broken use case is around running tuning on a subset of axis values.
As an example, we might want to tune an algorithm specifically on `2^24 - 2^28` problems to accelerate search process.

Before diving into the problem, let's take a look at the data.
The database stores all axis values:

```
sqlite3 cccl_meta_bench.db 'SELECT DISTINCT "Elements{io}[pow2]" FROM "cub.bench.reduce.sum.base"'
16
20
24
28
```

The speedups are as follows:
| workload | base (µs) | variant (µs) | speedup | weight |
| --- | ---: | ---: | ---: | ---: |
| `Elements{io}[pow2]=16` | 4.096 | 4.096 | 1.0000 | 17.21% |
| `Elements{io}[pow2]=20` | 6.112 | 6.144 | 0.9948 | 26.12% |
| `Elements{io}[pow2]=24` | 49.152 | 51.168 | 0.9606 | 28.11% |
| `Elements{io}[pow2]=28` | 686.080 | 686.048 | 1.0000 | 28.56% |

The score is comptuted as:

```
numerator = 0.6 * 1.000 + 0.91 * 0.994 + 0.98 * 0.960 + 0.99 * 1.000 = 3.43
denominator = 0.6 + 0.91 + 0.98 + 0.99 = 3.48
score = 3.44 / 3.486 = 0.987
```

Let's now run tuning only on `2^24 - 2^28` values. 
Because for fair comparison, I need exact numbers, let's "emulate" this reduced run by pruning the database:

```bash
sqlite3 cccl_meta_bench.db 'DELETE FROM "cub.bench.reduce.sum.base" WHERE CAST("Elements{io}[pow2]" as INTEGER) < 24'
sqlite3 cccl_meta_bench.db 'SELECT DISTINCT "Elements{io}[pow2]" FROM "cub.bench.reduce.sum.base"'
24
28
```

The analysis now reports:

```bash
../benchmarks/scripts/analyze.py cccl_meta_bench.db -R '^cub\.bench\.reduce\.sum$' --top=3
cub.bench.reduce.sum[T{ct}=I32, OffsetT{ct}=I32]:
                   variant     score    mins     means      maxs
0                  base ()  1.000000  1.0000  1.000000  1.000000
1  ipt_16.tpb_256.ipv_2 ()  0.985067  0.9606  0.980324  1.000047
```

which is computed as:

```
numerator = 0.6 * 0.960 + 0.99 * 1.000 = 1.565
denominator = 0.6 + 0.99 = 1.589
score = 1.565 / 1.589 = 0.984
```

which is wrong. Note how we assigned weight of `0.6` to `2^24` result now. 
What should've happened is using the exact weights as in the full run:

```
numerator = 0.98 * 0.960 + 0.99 * 1.000 = 1.93
denominator = 0.98 + 0.99 = 1.97
score = 1.93 / 1.97 = 0.979
```

which is lower than `0.984` that analysis script reports today.
To fix this, we have to store declared axis values in the database.
This PR adds new table to do just that. 

Let's see how analysis and search scripts react to the change:

```bash
CUDA_VISIBLE_DEVICES=0 ../benchmarks/scripts/search.py -R '^cub\.bench\.(reduce\.sum|select\.unique_by_key|topk\.keys|segmented_scan\.sum)$' -a 'T{ct}=I32' -a 'KeyT{ct}=I32' -a 'ValueT{ct}=I32' -a 'OffsetT{ct}=I32' -a 'OutOffsetT{ct}=I32'

 ctk:  13.3.33
cccl:  v3.6.0.dev-326-gd493706f12
cub.bench.reduce.sum.ipt_16.tpb_256.ipv_2 0.9890998739695748
cub.bench.segmented_scan.sum.ipt_11.tpb_256.trp_1.ld_0.spb_512 0.5257079668037018
cub.bench.select.unique_by_key.ipt_11.tpb_256.trp_1.ld_0.ns_0.dcid_0.l2w_0 1.0956646438430324
cub.bench.topk.keys.ipt_9.tpb_256.ld_1 0.9654002014080975
```

and analysis:

```bash
../benchmarks/scripts/analyze.py cccl_meta_bench.db   -R '^cub\.bench\.(reduce\.sum|select\.unique_by_key|topk\.keys|segmented_scan\.sum)$' --top=3

cub.bench.topk.keys[KeyT{ct}=I32, OffsetT{ct}=I32, OutOffsetT{ct}=I32]:
                 variant   score      mins     means     maxs
0                base ()  1.0000  1.000000  1.000000  1.00000
1  ipt_9.tpb_256.ld_1 ()  0.9654  0.727273  0.959087  1.02381


cub.bench.reduce.sum[T{ct}=I32, OffsetT{ct}=I32]:
                   variant   score      mins     means  maxs
0                  base ()  1.0000  1.000000  1.000000   1.0
1  ipt_16.tpb_256.ipv_2 ()  0.9891  0.961226  0.990306   1.0


cub.bench.segmented_scan.sum[T{ct}=I32, OffsetT{ct}=I32]:
                                variant     score      mins     means  maxs
0                               base ()  1.000000  1.000000  1.000000   1.0
1  ipt_11.tpb_256.trp_1.ld_0.spb_512 ()  0.525708  0.155029  0.509961   1.5


cub.bench.select.unique_by_key[KeyT{ct}=I32, ValueT{ct}=I32, OffsetT{ct}=I32]:
                                          variant     score      mins     means      maxs
1  ipt_11.tpb_256.trp_1.ld_0.ns_0.dcid_0.l2w_0 ()  1.095665  0.986906  1.119392  1.336815
0                                         base ()  1.000000  1.000000  1.000000  1.000000
```

Now, tuning and analysis scores agree:

| algorithm | tuning (`search.py`) | analysis (`analyze.py`) | agree? |
| --- | ---: | ---: | --- |
| `reduce.sum` | 0.989100 | 0.989100 | yes |
| `select.unique_by_key` | 1.095665 | 1.095665 | yes |
| `segmented_scan.sum` | 0.525708 | 0.525708 | yes |
| `topk.keys` | 0.965400 | 0.965400 | **yes** |


For reduced run, the score is also calculated correctly:

```bash
../benchmarks/scripts/analyze.py cccl_meta_bench.db -R '^cub\.bench\.reduce\.sum$' --top=3
cub.bench.reduce.sum[T{ct}=I32, OffsetT{ct}=I32]:
                   variant     score      mins     means  maxs
0                  base ()  1.000000  1.000000  1.000000   1.0
1  ipt_16.tpb_256.ipv_2 ()  0.980765  0.961226  0.980613   1.0
```