### PR TITLE
[STF] SCOPE(exit, name), and SCOPE(exit) throw policy

### DIFF
--- a/cudax/examples/stf/cfd.cu
+++ b/cudax/examples/stf/cfd.cu
@@ -36,10 +36,23 @@ void writeplotfile(int m, int n, int scale)
   FILE* gnuplot = EXPECT(fopen("cfd.plt", "w"));
   // One guard, both outcomes: a failed close is a real error on the normal path, and best
   // effort while an exception is unwinding (a throwing guard body would abort the program).
+#ifdef STF_HAS_SCOPE_OUTCOME
+  // One guard, both outcomes: a failed close is a real error on the normal path, and best
+  // effort while unwinding (a guard body that throws there aborts the program).
   SCOPE(exit, failing)
   {
     failing ? (void) fclose(gnuplot) : (void) EXPECT(fclose(gnuplot) == 0);
   };
+#else // ^^^ C++20 ^^^ / vvv C++17 has no outcome parameter vvv
+  SCOPE(success)
+  {
+    EXPECT(fclose(gnuplot) == 0);
+  };
+  SCOPE(fail)
+  {
+    fclose(gnuplot);
+  };
+#endif // STF_HAS_SCOPE_OUTCOME
 
   fprintf(gnuplot,
           "set terminal pngcairo\n"

--- a/cudax/examples/stf/cfd.cu
+++ b/cudax/examples/stf/cfd.cu
@@ -34,9 +34,11 @@ double gettime()
 void writeplotfile(int m, int n, int scale)
 {
   FILE* gnuplot = EXPECT(fopen("cfd.plt", "w"));
-  SCOPE(exit)
+  // One guard, both outcomes: a failed close is a real error on the normal path, and best
+  // effort while an exception is unwinding (a throwing guard body would abort the program).
+  SCOPE(exit, failing)
   {
-    EXPECT(fclose(gnuplot) == 0);
+    failing ? (void) fclose(gnuplot) : (void) EXPECT(fclose(gnuplot) == 0);
   };
 
   fprintf(gnuplot,

--- a/cudax/include/cuda/experimental/__stf/internal/algorithm.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/algorithm.cuh
@@ -249,17 +249,11 @@ public:
     // instead. These resources need to be released later with .clear()
     auto adapter = setup_allocator(gctx, stream);
 
-    // Speaking of which. clear() is documented throwing (its deallocations
-    // and the final stream synchronization go through cuda_try), so the two
-    // exits part ways: on success a failure to release propagates to the
-    // caller as an ordinary exception; on the exception path a secondary
-    // failure is reported and aborts (guard bodies run under
-    // on_throw(abort)) rather than reaching std::terminate bare.
-    SCOPE(success)
-    {
-      adapter.clear();
-    };
-    SCOPE(fail)
+    // Speaking of which. clear() is documented throwing (its deallocations and the final
+    // stream synchronization go through cuda_try), which SCOPE(exit) now handles on its own:
+    // a failure while leaving normally propagates to the caller, and one while already
+    // unwinding is reported and aborts.
+    SCOPE(exit)
     {
       adapter.clear();
     };
@@ -318,17 +312,11 @@ public:
     // instead. These resources need to be released later with .clear()
     auto adapter = setup_allocator(gctx, stream);
 
-    // Speaking of which. clear() is documented throwing (its deallocations
-    // and the final stream synchronization go through cuda_try), so the two
-    // exits part ways: on success a failure to release propagates to the
-    // caller as an ordinary exception; on the exception path a secondary
-    // failure is reported and aborts (guard bodies run under
-    // on_throw(abort)) rather than reaching std::terminate bare.
-    SCOPE(success)
-    {
-      adapter.clear();
-    };
-    SCOPE(fail)
+    // Speaking of which. clear() is documented throwing (its deallocations and the final
+    // stream synchronization go through cuda_try), which SCOPE(exit) now handles on its own:
+    // a failure while leaving normally propagates to the caller, and one while already
+    // unwinding is reported and aborts.
+    SCOPE(exit)
     {
       adapter.clear();
     };

--- a/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
@@ -55,6 +55,7 @@
 #include <cuda/experimental/__stf/utility/source_location.cuh>
 #include <cuda/experimental/__stf/utility/traits.cuh>
 #include <cuda/experimental/__stf/utility/unittest.cuh>
+#include <cuda/experimental/__utility/scope.cuh>
 
 #include <any>
 #include <chrono>
@@ -4413,6 +4414,11 @@ UNITTEST("type erasure")
  * If two or more `SCOPE` declarations are present in the same scope, they will take effect in the reverse order of
  * their lexical order. Example: @snippet this SCOPE combinations
  *
+ * Implemented on `cuda::experimental::scope_exit`, `scope_fail` and `scope_success`
+ * (`cuda/experimental/__utility/scope.cuh`), which model the Library Fundamentals TS guards.
+ * SCOPE adds the call-site location and the rule that a throwing guard body is reported and
+ * aborts rather than escaping a `noexcept` destructor.
+ *
  *  See Also: https://en.cppreference.com/w/cpp/experimental/scope_exit,
  * https://en.cppreference.com/w/cpp/experimental/scope_fail,
  * https://en.cppreference.com/w/cpp/experimental/scope_success
@@ -4459,40 +4465,23 @@ void invoke_nothrow(F& f, ::cuda::std::source_location loc, bool failing = false
   }
 }
 
+// The three SCOPE flavors are thin adapters over cudax's Library Fundamentals TS scope
+// guards (cuda/experimental/__utility/scope.cuh), which already own the delicate parts:
+// arming, the relative uncaught_exceptions() comparison, move semantics, release(), and the
+// TS rule that the exit function still runs if copying the functor throws. What STF adds is
+// the call-site location and the report-and-abort discipline for a throwing guard body, both
+// of which live in the wrapper lambda below. Those wrappers are honestly `noexcept`, since
+// invoke_nothrow routes the body through on_throw(abort), which satisfies the TS guards'
+// requirement that the exit function not throw.
 template <typename F>
 auto operator->*(with_location<exit> where, F&& f)
 {
-  struct result
-  {
-    F f;
-    const ::cuda::std::source_location loc;
-    // Uncaught-exception count at construction; move sets -1 to disarm. The count is what
-    // lets `SCOPE(exit, name)` tell the body whether the scope is being left by an exception.
-    int exceptions = ::std::uncaught_exceptions();
-
-    result(F&& f, ::cuda::std::source_location loc)
-        : f(::cuda::std::forward<F>(f))
-        , loc(loc)
-    {}
-    result(result&) = delete;
-    result(result&& rhs)
-        : f(mv(rhs.f))
-        , loc(rhs.loc)
-        , exceptions(::cuda::std::exchange(rhs.exceptions, -1))
-    {}
-
-    ~result() noexcept
-    {
-      if (exceptions != -1)
-      {
-        // Relative comparison: an exception thrown BY THIS SCOPE, not one this scope was
-        // merely created during (a guard declared inside someone else's catch block, say).
-        invoke_nothrow(f, loc, ::std::uncaught_exceptions() > exceptions);
-      }
-    }
-  };
-
-  return result{::cuda::std::forward<F>(f), where.loc};
+  return ::cuda::experimental::scope_exit{
+    [__f = ::cuda::std::forward<F>(f), __loc = where.loc, __entry = ::std::uncaught_exceptions()]() mutable noexcept {
+      // Relative comparison: an exception thrown BY THIS SCOPE, not one the scope was merely
+      // created during (a guard declared inside somebody else's handler, say).
+      invoke_nothrow(__f, __loc, ::std::uncaught_exceptions() > __entry);
+    }};
 }
 
 template <typename F>
@@ -4502,76 +4491,26 @@ auto operator->*(with_location<fail> where, F&& f)
                 "SCOPE(fail) runs only when the scope is left by an exception, so its outcome is "
                 "already known and it takes no parameter. Write SCOPE(fail) { ... }, or use "
                 "SCOPE(exit, name) to branch on the outcome.");
-  struct result
-  {
-    F f;
-    const ::cuda::std::source_location loc;
-    // Expected uncaught count, or -1 when disarmed by move.
-    int exceptions;
-
-    result(F&& f, ::cuda::std::source_location loc, int exceptions)
-        : f(::cuda::std::forward<F>(f))
-        , loc(loc)
-        , exceptions(exceptions)
-    {}
-    result(result&) = delete;
-    result(result&& rhs)
-        : f(mv(rhs.f))
-        , loc(rhs.loc)
-        , exceptions(::cuda::std::exchange(rhs.exceptions, -1))
-    {}
-
-    ~result() noexcept
-    {
-      if (::std::uncaught_exceptions() == exceptions)
-      {
-        invoke_nothrow(f, loc);
-      }
-    }
-  };
-
-  // Run only if an exception is in flight: uncaught count is one above creation-time count.
-  return result{::cuda::std::forward<F>(f), where.loc, ::std::uncaught_exceptions() + 1};
+  return ::cuda::experimental::scope_fail{[__f = ::cuda::std::forward<F>(f), __loc = where.loc]() mutable noexcept {
+    invoke_nothrow(__f, __loc);
+  }};
 }
 
 template <typename F>
-auto operator->*(success, F&& f)
+auto operator->*(with_location<success> where, F&& f)
 {
   static_assert(::cuda::std::is_invocable_v<F&>,
                 "SCOPE(success) runs only when the scope is left normally, so its outcome is "
                 "already known and it takes no parameter. Write SCOPE(success) { ... }, or use "
                 "SCOPE(exit, name) to branch on the outcome.");
-  // success may throw, so it does not go through invoke_nothrow; keep the same void check.
-  static_assert(::cuda::std::is_void_v<decltype(::cuda::std::forward<F>(f)())>,
+  static_assert(::cuda::std::is_void_v<decltype(::cuda::std::declval<F&>()())>,
                 "SCOPE requires a void-returning callable");
-
-  struct result
-  {
-    F f;
-    // Expected uncaught count, or -1 when disarmed by move.
-    int exceptions;
-
-    result(F&& f, int exceptions)
-        : f(::cuda::std::forward<F>(f))
-        , exceptions(exceptions)
-    {}
-    result(result&) = delete;
-    result(result&& rhs)
-        : f(mv(rhs.f))
-        , exceptions(::cuda::std::exchange(rhs.exceptions, -1))
-    {}
-
-    // May throw — unlike exit/fail.
-    ~result() noexcept(false)
-    {
-      if (::std::uncaught_exceptions() == exceptions)
-      {
-        f();
-      }
-    }
-  };
-
-  return result{::cuda::std::forward<F>(f), ::std::uncaught_exceptions()};
+  // Unlike exit and fail, a success body may throw: the TS guard calls it unwrapped, so a
+  // failed commit propagates to the caller instead of aborting.
+  (void) where;
+  return ::cuda::experimental::scope_success{[__f = ::cuda::std::forward<F>(f)]() mutable {
+    __f();
+  }};
 }
 } // namespace detail::scope_guard_handler
 #endif // !_CCCL_DOXYGEN_INVOKED

--- a/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
@@ -55,7 +55,6 @@
 #include <cuda/experimental/__stf/utility/source_location.cuh>
 #include <cuda/experimental/__stf/utility/traits.cuh>
 #include <cuda/experimental/__stf/utility/unittest.cuh>
-#include <cuda/experimental/__utility/scope.cuh>
 
 #include <any>
 #include <chrono>
@@ -4414,11 +4413,6 @@ UNITTEST("type erasure")
  * If two or more `SCOPE` declarations are present in the same scope, they will take effect in the reverse order of
  * their lexical order. Example: @snippet this SCOPE combinations
  *
- * Implemented on `cuda::experimental::scope_exit`, `scope_fail` and `scope_success`
- * (`cuda/experimental/__utility/scope.cuh`), which model the Library Fundamentals TS guards.
- * SCOPE adds the call-site location and the rule that a throwing guard body is reported and
- * aborts rather than escaping a `noexcept` destructor.
- *
  *  See Also: https://en.cppreference.com/w/cpp/experimental/scope_exit,
  * https://en.cppreference.com/w/cpp/experimental/scope_fail,
  * https://en.cppreference.com/w/cpp/experimental/scope_success
@@ -4465,23 +4459,40 @@ void invoke_nothrow(F& f, ::cuda::std::source_location loc, bool failing = false
   }
 }
 
-// The three SCOPE flavors are thin adapters over cudax's Library Fundamentals TS scope
-// guards (cuda/experimental/__utility/scope.cuh), which already own the delicate parts:
-// arming, the relative uncaught_exceptions() comparison, move semantics, release(), and the
-// TS rule that the exit function still runs if copying the functor throws. What STF adds is
-// the call-site location and the report-and-abort discipline for a throwing guard body, both
-// of which live in the wrapper lambda below. Those wrappers are honestly `noexcept`, since
-// invoke_nothrow routes the body through on_throw(abort), which satisfies the TS guards'
-// requirement that the exit function not throw.
 template <typename F>
 auto operator->*(with_location<exit> where, F&& f)
 {
-  return ::cuda::experimental::scope_exit{
-    [__f = ::cuda::std::forward<F>(f), __loc = where.loc, __entry = ::std::uncaught_exceptions()]() mutable noexcept {
-      // Relative comparison: an exception thrown BY THIS SCOPE, not one the scope was merely
-      // created during (a guard declared inside somebody else's handler, say).
-      invoke_nothrow(__f, __loc, ::std::uncaught_exceptions() > __entry);
-    }};
+  struct result
+  {
+    F f;
+    const ::cuda::std::source_location loc;
+    // Uncaught-exception count at construction; move sets -1 to disarm. The count is what
+    // lets `SCOPE(exit, name)` tell the body whether the scope is being left by an exception.
+    int exceptions = ::std::uncaught_exceptions();
+
+    result(F&& f, ::cuda::std::source_location loc)
+        : f(::cuda::std::forward<F>(f))
+        , loc(loc)
+    {}
+    result(result&) = delete;
+    result(result&& rhs)
+        : f(mv(rhs.f))
+        , loc(rhs.loc)
+        , exceptions(::cuda::std::exchange(rhs.exceptions, -1))
+    {}
+
+    ~result() noexcept
+    {
+      if (exceptions != -1)
+      {
+        // Relative comparison: an exception thrown BY THIS SCOPE, not one this scope was
+        // merely created during (a guard declared inside someone else's catch block, say).
+        invoke_nothrow(f, loc, ::std::uncaught_exceptions() > exceptions);
+      }
+    }
+  };
+
+  return result{::cuda::std::forward<F>(f), where.loc};
 }
 
 template <typename F>
@@ -4491,26 +4502,76 @@ auto operator->*(with_location<fail> where, F&& f)
                 "SCOPE(fail) runs only when the scope is left by an exception, so its outcome is "
                 "already known and it takes no parameter. Write SCOPE(fail) { ... }, or use "
                 "SCOPE(exit, name) to branch on the outcome.");
-  return ::cuda::experimental::scope_fail{[__f = ::cuda::std::forward<F>(f), __loc = where.loc]() mutable noexcept {
-    invoke_nothrow(__f, __loc);
-  }};
+  struct result
+  {
+    F f;
+    const ::cuda::std::source_location loc;
+    // Expected uncaught count, or -1 when disarmed by move.
+    int exceptions;
+
+    result(F&& f, ::cuda::std::source_location loc, int exceptions)
+        : f(::cuda::std::forward<F>(f))
+        , loc(loc)
+        , exceptions(exceptions)
+    {}
+    result(result&) = delete;
+    result(result&& rhs)
+        : f(mv(rhs.f))
+        , loc(rhs.loc)
+        , exceptions(::cuda::std::exchange(rhs.exceptions, -1))
+    {}
+
+    ~result() noexcept
+    {
+      if (::std::uncaught_exceptions() == exceptions)
+      {
+        invoke_nothrow(f, loc);
+      }
+    }
+  };
+
+  // Run only if an exception is in flight: uncaught count is one above creation-time count.
+  return result{::cuda::std::forward<F>(f), where.loc, ::std::uncaught_exceptions() + 1};
 }
 
 template <typename F>
-auto operator->*(with_location<success> where, F&& f)
+auto operator->*(success, F&& f)
 {
   static_assert(::cuda::std::is_invocable_v<F&>,
                 "SCOPE(success) runs only when the scope is left normally, so its outcome is "
                 "already known and it takes no parameter. Write SCOPE(success) { ... }, or use "
                 "SCOPE(exit, name) to branch on the outcome.");
-  static_assert(::cuda::std::is_void_v<decltype(::cuda::std::declval<F&>()())>,
+  // success may throw, so it does not go through invoke_nothrow; keep the same void check.
+  static_assert(::cuda::std::is_void_v<decltype(::cuda::std::forward<F>(f)())>,
                 "SCOPE requires a void-returning callable");
-  // Unlike exit and fail, a success body may throw: the TS guard calls it unwrapped, so a
-  // failed commit propagates to the caller instead of aborting.
-  (void) where;
-  return ::cuda::experimental::scope_success{[__f = ::cuda::std::forward<F>(f)]() mutable {
-    __f();
-  }};
+
+  struct result
+  {
+    F f;
+    // Expected uncaught count, or -1 when disarmed by move.
+    int exceptions;
+
+    result(F&& f, int exceptions)
+        : f(::cuda::std::forward<F>(f))
+        , exceptions(exceptions)
+    {}
+    result(result&) = delete;
+    result(result&& rhs)
+        : f(mv(rhs.f))
+        , exceptions(::cuda::std::exchange(rhs.exceptions, -1))
+    {}
+
+    // May throw — unlike exit/fail.
+    ~result() noexcept(false)
+    {
+      if (::std::uncaught_exceptions() == exceptions)
+      {
+        f();
+      }
+    }
+  };
+
+  return result{::cuda::std::forward<F>(f), ::std::uncaught_exceptions()};
 }
 } // namespace detail::scope_guard_handler
 #endif // !_CCCL_DOXYGEN_INVOKED

--- a/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
@@ -4381,11 +4381,18 @@ UNITTEST("type erasure")
  * @brief Automatically runs code when a scope is exited (`SCOPE(exit)`), exited by means of an exception
  * (`SCOPE(fail)`), or exited normally (`SCOPE(success)`).
  *
- * The code controlled by `SCOPE(exit)` and `SCOPE(fail)` must not throw. In every build type those
- * lambdas are invoked via `on_throw(abort)`: a throw from a guard body is reported (message and
- * location) and the program aborts, rather than reaching `std::terminate` bare through the guard's
- * `noexcept` destructor. The code controlled by `SCOPE(success)` may throw. In all cases the
- * controlled code must return `void` (enforced at compile time).
+ * A guard body that throws is treated the way the language treats exceptions: one at a time is
+ * an error to report, two at once is fatal. `SCOPE(exit)` propagates a failure raised while the
+ * scope is being left NORMALLY, so a cleanup that fails on the happy path reaches the caller as
+ * an ordinary exception; a failure raised while the scope is ALREADY unwinding is reported
+ * (message and location) and aborts, since letting it escape would give `std::terminate` with no
+ * diagnostic. `SCOPE(fail)` runs only while unwinding and therefore always reports and aborts;
+ * `SCOPE(success)` runs only on the normal path and may throw. In all cases the controlled code
+ * must return `void` (enforced at compile time).
+ *
+ * One consequence worth knowing: inside a `noexcept` function, a `SCOPE(exit)` body that throws
+ * on the normal path ends the program through `std::terminate` without STF's report. Use
+ * `SCOPE(fail)` plus `SCOPE(success)` there if the distinction matters.
  *
  * `SCOPE(exit)` runs its code at the natural termination of the current scope. Example: @snippet this SCOPE(exit)
  *
@@ -4436,27 +4443,32 @@ enum class success
 {
 };
 
+// Calls the guard body, passing the outcome when `SCOPE(exit, name)` asked for it and nothing
+// when it did not. Whether a throw from here escapes is the caller's decision, not this one's.
 template <class F>
-void invoke_nothrow(F& f, ::cuda::std::source_location loc, bool failing = false)
+void invoke_body(F& f, bool failing)
 {
-  // `SCOPE(exit, name)` gives the body a bool parameter saying whether the scope is being left
-  // by an exception; `SCOPE(exit)` gives it none. All build types: a guard body that throws is
-  // reported and aborts, because the guard destructors are noexcept and the bare-call
-  // alternative is std::terminate with no diagnostics. The try frame costs nothing when the
-  // body does not throw.
   if constexpr (::cuda::std::is_invocable_v<F&, bool>)
   {
     static_assert(::cuda::std::is_void_v<decltype(f(failing))>, "SCOPE requires a void-returning callable");
-    on_throw(exception_policies::abort, loc) << [&] {
-      f(failing);
-    };
+    f(failing);
   }
   else
   {
     (void) failing;
     static_assert(::cuda::std::is_void_v<decltype(f())>, "SCOPE requires a void-returning callable");
-    on_throw(exception_policies::abort, loc) << f;
+    f();
   }
+}
+
+// Runs the body under `on_throw(abort)`: a throw is reported (message and location) and the
+// program aborts, rather than escaping a noexcept destructor as a bare std::terminate.
+template <class F>
+void invoke_nothrow(F& f, ::cuda::std::source_location loc, bool failing = false)
+{
+  on_throw(exception_policies::abort, loc) << [&] {
+    invoke_body(f, failing);
+  };
 }
 
 template <typename F>
@@ -4481,13 +4493,27 @@ auto operator->*(with_location<exit> where, F&& f)
         , exceptions(::cuda::std::exchange(rhs.exceptions, -1))
     {}
 
-    ~result() noexcept
+    // May throw: see below. Not `noexcept`, so a body that fails on the normal path reports
+    // the failure to the caller instead of ending the program.
+    ~result() noexcept(false)
     {
-      if (exceptions != -1)
+      if (exceptions == -1)
       {
-        // Relative comparison: an exception thrown BY THIS SCOPE, not one this scope was
-        // merely created during (a guard declared inside someone else's catch block, say).
-        invoke_nothrow(f, loc, ::std::uncaught_exceptions() > exceptions);
+        return;
+      }
+      // Relative comparison: an exception thrown BY THIS SCOPE, not one this scope was
+      // merely created during (a guard declared inside someone else's catch block, say).
+      if (::std::uncaught_exceptions() > exceptions)
+      {
+        // Already unwinding. A second exception here is the case the language itself gives
+        // up on, so report and abort rather than let it escape.
+        invoke_nothrow(f, loc, true);
+      }
+      else
+      {
+        // Leaving normally: a failed cleanup is an ordinary error, and the caller is in a
+        // position to handle it. Let it propagate.
+        invoke_body(f, false);
       }
     }
   };
@@ -4592,6 +4618,48 @@ UNITTEST("SCOPE(exit)")
   }
   EXPECT(done);
   //! [SCOPE(exit)]
+};
+
+UNITTEST("SCOPE(exit) throw policy")
+{
+  //! [SCOPE(exit) throw policy]
+  // Leaving normally: a failed cleanup is an ordinary error and reaches the caller.
+  bool propagated = false;
+  _CCCL_TRY
+  {
+    SCOPE(exit)
+    {
+      throw ::std::runtime_error("cleanup failed");
+    };
+  }
+  _CCCL_CATCH ([[maybe_unused]] const ::std::runtime_error& e)
+  {
+    propagated = true;
+  }
+  _CCCL_CATCH_ALL {}
+  EXPECT(propagated, "a SCOPE(exit) body that throws on the normal path must propagate");
+
+  // Leaving by exception: the guard runs, and the original exception is unaffected.
+  bool original = false;
+  int seen      = -1;
+  _CCCL_TRY
+  {
+    SCOPE(exit, failing)
+    {
+      seen = failing ? 1 : 0;
+    };
+    throw ::std::logic_error("original");
+  }
+  _CCCL_CATCH ([[maybe_unused]] const ::std::logic_error& e)
+  {
+    original = true;
+  }
+  _CCCL_CATCH_ALL {}
+  EXPECT(seen == 1, "the guard must see failing=true while unwinding");
+  EXPECT(original, "the original exception must survive the guard");
+  //! [SCOPE(exit) throw policy]
+
+  // A body that throws WHILE unwinding is reported and aborts; not testable in-process.
 };
 
 UNITTEST("SCOPE(exit, outcome)")

--- a/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
@@ -4425,9 +4425,20 @@ UNITTEST("type erasure")
  * https://en.cppreference.com/w/cpp/experimental/scope_success
  */
 ///@{
-#define SCOPE(kind, ...)                  \
-  auto CUDASTF_UNIQUE_NAME(scope_guard) = \
-    (::cuda::experimental::stf::detail::scope_guard_handler::kind) {}->*[&](__VA_OPT__(bool) __VA_ARGS__)
+// `SCOPE(exit, name)` needs __VA_OPT__, which is C++20 and is rejected in C++17 under
+// -pedantic-errors. Detected exactly as unittest.cuh detects it for UNITTEST.
+#if defined(__cplusplus) && __cplusplus >= 202002L
+#  define STF_HAS_SCOPE_OUTCOME 1
+#endif
+
+#ifdef STF_HAS_SCOPE_OUTCOME
+#  define SCOPE(kind, ...)                  \
+    auto CUDASTF_UNIQUE_NAME(scope_guard) = \
+      (::cuda::experimental::stf::detail::scope_guard_handler::kind) {}->*[&](__VA_OPT__(bool) __VA_ARGS__)
+#else // ^^^ __VA_OPT__ available ^^^ / vvv C++17: the outcome form is unavailable vvv
+#  define SCOPE(kind) \
+    auto CUDASTF_UNIQUE_NAME(scope_guard) = (::cuda::experimental::stf::detail::scope_guard_handler::kind) {}->*[&]()
+#endif // STF_HAS_SCOPE_OUTCOME
 ///@}
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
@@ -4464,7 +4475,7 @@ void invoke_body(F& f, bool failing)
 // Runs the body under `on_throw(abort)`: a throw is reported (message and location) and the
 // program aborts, rather than escaping a noexcept destructor as a bare std::terminate.
 template <class F>
-void invoke_nothrow(F& f, ::cuda::std::source_location loc, bool failing = false)
+void invoke_nothrow(F& f, ::cuda::std::source_location loc, bool failing = false) noexcept
 {
   on_throw(exception_policies::abort, loc) << [&] {
     invoke_body(f, failing);
@@ -4620,6 +4631,7 @@ UNITTEST("SCOPE(exit)")
   //! [SCOPE(exit)]
 };
 
+#  ifdef STF_HAS_SCOPE_OUTCOME
 UNITTEST("SCOPE(exit) throw policy")
 {
   //! [SCOPE(exit) throw policy]
@@ -4661,7 +4673,9 @@ UNITTEST("SCOPE(exit) throw policy")
 
   // A body that throws WHILE unwinding is reported and aborts; not testable in-process.
 };
+#  endif // STF_HAS_SCOPE_OUTCOME
 
+#  ifdef STF_HAS_SCOPE_OUTCOME
 UNITTEST("SCOPE(exit, outcome)")
 {
   //! [SCOPE(exit, outcome)]
@@ -4707,6 +4721,7 @@ UNITTEST("SCOPE(exit, outcome)")
   //  - SCOPE(fail, x) { ... };     // "SCOPE(fail) ... takes no parameter"
   //  - SCOPE(success, x) { ... };  // "SCOPE(success) ... takes no parameter"
 };
+#  endif // STF_HAS_SCOPE_OUTCOME
 
 UNITTEST("SCOPE(fail)")
 {

--- a/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
@@ -4389,6 +4389,21 @@ UNITTEST("type erasure")
  *
  * `SCOPE(exit)` runs its code at the natural termination of the current scope. Example: @snippet this SCOPE(exit)
  *
+ * `SCOPE(exit, name)` additionally names a `bool` parameter that is `true` when the scope is
+ * being left by an exception thrown within it, letting one guard serve both outcomes:
+ * @code
+ * SCOPE(exit, failing)
+ * {
+ *   failing ? discard(handle) : commit(handle);
+ * };
+ * @endcode
+ * The flag compares `std::uncaught_exceptions()` against its value at construction, so a guard
+ * declared inside somebody else's handler correctly reports `false`. `SCOPE(fail)` and
+ * `SCOPE(success)` reject the parameter: their outcome is already known by construction. The
+ * exception itself is not available to a guard (a destructor is not a handler, and
+ * `std::current_exception()` is null during unwinding); to react to the exception, wrap the
+ * region in `ON_THROW(policy)`.
+ *
  * `SCOPE(fail)` runs its code if and only if the current scope is left by means of throwing an exception. Example:
  * @snippet this SCOPE(fail)
  *
@@ -4403,8 +4418,9 @@ UNITTEST("type erasure")
  * https://en.cppreference.com/w/cpp/experimental/scope_success
  */
 ///@{
-#define SCOPE(kind) \
-  auto CUDASTF_UNIQUE_NAME(scope_guard) = (::cuda::experimental::stf::detail::scope_guard_handler::kind) {}->*[&]()
+#define SCOPE(kind, ...)                  \
+  auto CUDASTF_UNIQUE_NAME(scope_guard) = \
+    (::cuda::experimental::stf::detail::scope_guard_handler::kind) {}->*[&](__VA_OPT__(bool) __VA_ARGS__)
 ///@}
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
@@ -4421,13 +4437,26 @@ enum class success
 };
 
 template <class F>
-void invoke_nothrow(F& f, ::cuda::std::source_location loc)
+void invoke_nothrow(F& f, ::cuda::std::source_location loc, bool failing = false)
 {
-  static_assert(::cuda::std::is_void_v<decltype(f())>, "SCOPE requires a void-returning callable");
-  // All build types: a guard body that throws is reported and aborts. The guard destructors are
-  // noexcept, so the bare-call alternative is std::terminate with no diagnostics; the report is
-  // worth the try/catch frame, which costs nothing on the non-throwing path.
-  on_throw(exception_policies::abort, loc) << f;
+  // `SCOPE(exit, name)` gives the body a bool parameter saying whether the scope is being left
+  // by an exception; `SCOPE(exit)` gives it none. All build types: a guard body that throws is
+  // reported and aborts, because the guard destructors are noexcept and the bare-call
+  // alternative is std::terminate with no diagnostics. The try frame costs nothing when the
+  // body does not throw.
+  if constexpr (::cuda::std::is_invocable_v<F&, bool>)
+  {
+    static_assert(::cuda::std::is_void_v<decltype(f(failing))>, "SCOPE requires a void-returning callable");
+    on_throw(exception_policies::abort, loc) << [&] {
+      f(failing);
+    };
+  }
+  else
+  {
+    (void) failing;
+    static_assert(::cuda::std::is_void_v<decltype(f())>, "SCOPE requires a void-returning callable");
+    on_throw(exception_policies::abort, loc) << f;
+  }
 }
 
 template <typename F>
@@ -4437,8 +4466,9 @@ auto operator->*(with_location<exit> where, F&& f)
   {
     F f;
     const ::cuda::std::source_location loc;
-    // Armed when != -1; move sets -1 to disarm. Value is otherwise unused for exit.
-    int exceptions = 0;
+    // Uncaught-exception count at construction; move sets -1 to disarm. The count is what
+    // lets `SCOPE(exit, name)` tell the body whether the scope is being left by an exception.
+    int exceptions = ::std::uncaught_exceptions();
 
     result(F&& f, ::cuda::std::source_location loc)
         : f(::cuda::std::forward<F>(f))
@@ -4455,7 +4485,9 @@ auto operator->*(with_location<exit> where, F&& f)
     {
       if (exceptions != -1)
       {
-        invoke_nothrow(f, loc);
+        // Relative comparison: an exception thrown BY THIS SCOPE, not one this scope was
+        // merely created during (a guard declared inside someone else's catch block, say).
+        invoke_nothrow(f, loc, ::std::uncaught_exceptions() > exceptions);
       }
     }
   };
@@ -4466,6 +4498,10 @@ auto operator->*(with_location<exit> where, F&& f)
 template <typename F>
 auto operator->*(with_location<fail> where, F&& f)
 {
+  static_assert(::cuda::std::is_invocable_v<F&>,
+                "SCOPE(fail) runs only when the scope is left by an exception, so its outcome is "
+                "already known and it takes no parameter. Write SCOPE(fail) { ... }, or use "
+                "SCOPE(exit, name) to branch on the outcome.");
   struct result
   {
     F f;
@@ -4501,6 +4537,10 @@ auto operator->*(with_location<fail> where, F&& f)
 template <typename F>
 auto operator->*(success, F&& f)
 {
+  static_assert(::cuda::std::is_invocable_v<F&>,
+                "SCOPE(success) runs only when the scope is left normally, so its outcome is "
+                "already known and it takes no parameter. Write SCOPE(success) { ... }, or use "
+                "SCOPE(exit, name) to branch on the outcome.");
   // success may throw, so it does not go through invoke_nothrow; keep the same void check.
   static_assert(::cuda::std::is_void_v<decltype(::cuda::std::forward<F>(f)())>,
                 "SCOPE requires a void-returning callable");
@@ -4552,6 +4592,52 @@ UNITTEST("SCOPE(exit)")
   }
   EXPECT(done);
   //! [SCOPE(exit)]
+};
+
+UNITTEST("SCOPE(exit, outcome)")
+{
+  //! [SCOPE(exit, outcome)]
+  // One guard, both outcomes: the parameter is true only when the scope is left by an
+  // exception thrown inside it.
+  int seen = -1;
+  {
+    SCOPE(exit, failing)
+    {
+      seen = failing ? 1 : 0;
+    };
+  }
+  EXPECT(seen == 0, "normal exit must report not-failing");
+
+  _CCCL_TRY
+  {
+    SCOPE(exit, failing)
+    {
+      seen = failing ? 1 : 0;
+    };
+    throw 42;
+  }
+  _CCCL_CATCH_ALL {}
+  EXPECT(seen == 1, "exceptional exit must report failing");
+
+  // A guard created while somebody else's exception is being handled is NOT failing: the
+  // comparison is relative to the count at construction.
+  _CCCL_TRY
+  {
+    throw 7;
+  }
+  _CCCL_CATCH_ALL
+  {
+    SCOPE(exit, failing)
+    {
+      seen = failing ? 1 : 0;
+    };
+  }
+  EXPECT(seen == 0, "a guard inside a handler must not report failing");
+  //! [SCOPE(exit, outcome)]
+
+  // Negative-compile expectations (kept as comments next to the code they guard):
+  //  - SCOPE(fail, x) { ... };     // "SCOPE(fail) ... takes no parameter"
+  //  - SCOPE(success, x) { ... };  // "SCOPE(success) ... takes no parameter"
 };
 
 UNITTEST("SCOPE(fail)")

--- a/cudax/include/cuda/experimental/__stf/utility/pretty_print.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/pretty_print.cuh
@@ -102,9 +102,10 @@ void mdspan_to_vtk(mdspan_like s, const ::std::string& filename)
 {
   fprintf(stderr, "Writing slice of size to file %s\n", filename.c_str());
   FILE* f = EXPECT(fopen(filename.c_str(), "w+") != nullptr);
-  SCOPE(exit)
+  // One guard, both outcomes: checked close on the normal path, best effort while unwinding.
+  SCOPE(exit, failing)
   {
-    EXPECT(fclose(f) != -1);
+    failing ? (void) fclose(f) : (void) EXPECT(fclose(f) != -1);
   };
 
   EXPECT(fprintf(f, "# vtk DataFile Version 2.0\noutput\nASCII\n") != -1);

--- a/cudax/include/cuda/experimental/__stf/utility/pretty_print.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/pretty_print.cuh
@@ -103,10 +103,23 @@ void mdspan_to_vtk(mdspan_like s, const ::std::string& filename)
   fprintf(stderr, "Writing slice of size to file %s\n", filename.c_str());
   FILE* f = EXPECT(fopen(filename.c_str(), "w+") != nullptr);
   // One guard, both outcomes: checked close on the normal path, best effort while unwinding.
+#ifdef STF_HAS_SCOPE_OUTCOME
+  // One guard, both outcomes: a failed close is a real error on the normal path, and best
+  // effort while unwinding (a guard body that throws there aborts the program).
   SCOPE(exit, failing)
   {
-    failing ? (void) fclose(f) : (void) EXPECT(fclose(f) != -1);
+    failing ? (void) fclose(f) : (void) EXPECT(fclose(f) == 0);
   };
+#else // ^^^ C++20 ^^^ / vvv C++17 has no outcome parameter vvv
+  SCOPE(success)
+  {
+    EXPECT(fclose(f) == 0);
+  };
+  SCOPE(fail)
+  {
+    fclose(f);
+  };
+#endif // STF_HAS_SCOPE_OUTCOME
 
   EXPECT(fprintf(f, "# vtk DataFile Version 2.0\noutput\nASCII\n") != -1);
 


### PR DESCRIPTION
Two changes to `SCOPE`, one visible and one structural.

## 1. `SCOPE(exit, name)`: the guard body can ask whether the scope is failing

```cpp
SCOPE(exit, failing)
{
  failing ? (void) fclose(f) : (void) EXPECT(fclose(f) == 0);
};
```

`true` means the scope is being left by an exception thrown within it. `SCOPE(exit)` is untouched: with no argument the macro still expands to a nullary lambda, so every existing site is byte-identical.

The motivation is that several cleanups differ only slightly between the normal and exceptional paths, and saying so required a `SCOPE(fail)`/`SCOPE(success)` pair of near-duplicate bodies. `cfd.cu` and `pretty_print.cuh` (checked `fclose` on success, best effort while unwinding) are converted here as the first two.

**Correctness detail worth review:** the flag compares `std::uncaught_exceptions()` against its value at the guard's construction, not against zero, so a guard declared *inside somebody else's handler* correctly reports `false`. There is a unit test for that case, because the obvious implementation gets it wrong.

`SCOPE(fail)` and `SCOPE(success)` reject the parameter with a message pointing at `SCOPE(exit, name)`: their outcome is fixed by construction, so an argument there could only be a constant.

**The exception object is deliberately not offered.** A destructor is not a handler: `std::current_exception()` returns null during unwinding on every compiler in our matrix (verified on GCC 12 and 14, Clang 18, Apple Clang, and MSVC 19.43), the Itanium ABI's `caughtExceptions` list is empty at that point, and a bare `throw;` there calls `terminate`. Reacting to the exception itself is what `ON_THROW` is for, and the documentation now says so.

## 2. `SCOPE(exit)`: propagate a normal-path failure, abort only while unwinding

A guard body that throws is now treated the way the language treats exceptions: one at a time is an error to report, two at once is fatal.

- Leaving **normally**, a failing cleanup propagates to the caller as an ordinary exception.
- Leaving **by exception**, a second exception is reported (message and location) and aborts, since letting it escape gives `std::terminate` with no diagnostic.

`SCOPE(fail)` runs only while unwinding, so it still always aborts on a throwing body; `SCOPE(success)` is unchanged.

Several call sites had been hand-rolling exactly this. The two `algorithm.cuh` sites that split `adapter.clear()` into a `SCOPE(success)` and a `SCOPE(fail)` with **byte-identical bodies**, purely to get propagation on one path and abort on the other, collapse back to a single `SCOPE(exit)`. It also makes the `cfd.cu` and `pretty_print.cuh` conversions above behavior-preserving: a failed checked close reaches the caller again, as it did before.

Documented caveat: inside a `noexcept` function, a `SCOPE(exit)` body that throws on the normal path ends the program through `std::terminate` without STF's report. The `success`/`fail` pair remains available there.

## Note on a reverted third change

This PR briefly also reimplemented `SCOPE` on top of cudax's Library Fundamentals TS guards
(`cuda::experimental::scope_exit` and friends), removing 92 lines of hand-rolled machinery. That
is reverted here, because it triggers `Internal Compiler Error (codegen): "internal error during
structure layout!"` in nvcc 12.0 through 12.6. The minimal reproducer is eight lines:

```cpp
#include <cuda/experimental/__utility/scope.cuh>
int main()
{
  int state = 0;
  auto g = ::cuda::experimental::scope_exit{[&state, entry = 0]() mutable noexcept {
    state = entry;
  }};
  return state;
}
```

A reference capture and an init-capture together, in a lambda given to `scope_exit`; either
capture alone compiles. **Fixed in CTK 12.8 and later** (verified across twelve toolkit versions),
so the reuse can return once the supported floor moves, or sooner with a wrapper shaped to avoid
the pairing. Not filed as a bug, since no current compiler reproduces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
