### PR TITLE
Make _CCCL_PP_THIRD variadic; use it to drop SCOPE's C++20 gate

### DIFF
--- a/cudax/examples/stf/cfd.cu
+++ b/cudax/examples/stf/cfd.cu
@@ -36,23 +36,10 @@ void writeplotfile(int m, int n, int scale)
   FILE* gnuplot = EXPECT(fopen("cfd.plt", "w"));
   // One guard, both outcomes: a failed close is a real error on the normal path, and best
   // effort while an exception is unwinding (a throwing guard body would abort the program).
-#ifdef STF_HAS_SCOPE_OUTCOME
-  // One guard, both outcomes: a failed close is a real error on the normal path, and best
-  // effort while unwinding (a guard body that throws there aborts the program).
   SCOPE(exit, failing)
   {
     failing ? (void) fclose(gnuplot) : (void) EXPECT(fclose(gnuplot) == 0);
   };
-#else // ^^^ C++20 ^^^ / vvv C++17 has no outcome parameter vvv
-  SCOPE(success)
-  {
-    EXPECT(fclose(gnuplot) == 0);
-  };
-  SCOPE(fail)
-  {
-    fclose(gnuplot);
-  };
-#endif // STF_HAS_SCOPE_OUTCOME
 
   fprintf(gnuplot,
           "set terminal pngcairo\n"

--- a/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/exception_policy.cuh
@@ -4425,20 +4425,17 @@ UNITTEST("type erasure")
  * https://en.cppreference.com/w/cpp/experimental/scope_success
  */
 ///@{
-// `SCOPE(exit, name)` needs __VA_OPT__, which is C++20 and is rejected in C++17 under
-// -pedantic-errors. Detected exactly as unittest.cuh detects it for UNITTEST.
-#if defined(__cplusplus) && __cplusplus >= 202002L
-#  define STF_HAS_SCOPE_OUTCOME 1
-#endif
-
-#ifdef STF_HAS_SCOPE_OUTCOME
-#  define SCOPE(kind, ...)                  \
-    auto CUDASTF_UNIQUE_NAME(scope_guard) = \
-      (::cuda::experimental::stf::detail::scope_guard_handler::kind) {}->*[&](__VA_OPT__(bool) __VA_ARGS__)
-#else // ^^^ __VA_OPT__ available ^^^ / vvv C++17: the outcome form is unavailable vvv
-#  define SCOPE(kind) \
-    auto CUDASTF_UNIQUE_NAME(scope_guard) = (::cuda::experimental::stf::detail::scope_guard_handler::kind) {}->*[&]()
-#endif // STF_HAS_SCOPE_OUTCOME
+// Emulates `__VA_OPT__(bool)`, which would otherwise confine the outcome form to C++20:
+// __VA_OPT__ is rejected in C++17 under -pedantic-errors. `_CCCL_PP_THIRD` yields `bool` only
+// when the caller supplied a name (pushing `bool` into the third slot) and nothing otherwise, so
+// `SCOPE(exit)` gets a genuinely empty parameter list -- which is what lets `SCOPE(fail)` and
+// `SCOPE(success)` keep rejecting a parameter. `_CCCL_PP_SECOND` then supplies the name itself,
+// or nothing. The trailing `~` and the padding commas feed the ellipses, which may not go empty
+// in C++17.
+#define SCOPE(...)                                                                             \
+  auto CUDASTF_UNIQUE_NAME(scope_guard) =                                                      \
+    (::cuda::experimental::stf::detail::scope_guard_handler::_CCCL_PP_FIRST(__VA_ARGS__, )) {} \
+      ->*[&](_CCCL_PP_THIRD(__VA_ARGS__, bool, , ~) _CCCL_PP_SECOND(__VA_ARGS__, , ))
 ///@}
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
@@ -4631,7 +4628,6 @@ UNITTEST("SCOPE(exit)")
   //! [SCOPE(exit)]
 };
 
-#  ifdef STF_HAS_SCOPE_OUTCOME
 UNITTEST("SCOPE(exit) throw policy")
 {
   //! [SCOPE(exit) throw policy]
@@ -4673,9 +4669,7 @@ UNITTEST("SCOPE(exit) throw policy")
 
   // A body that throws WHILE unwinding is reported and aborts; not testable in-process.
 };
-#  endif // STF_HAS_SCOPE_OUTCOME
 
-#  ifdef STF_HAS_SCOPE_OUTCOME
 UNITTEST("SCOPE(exit, outcome)")
 {
   //! [SCOPE(exit, outcome)]
@@ -4721,7 +4715,6 @@ UNITTEST("SCOPE(exit, outcome)")
   //  - SCOPE(fail, x) { ... };     // "SCOPE(fail) ... takes no parameter"
   //  - SCOPE(success, x) { ... };  // "SCOPE(success) ... takes no parameter"
 };
-#  endif // STF_HAS_SCOPE_OUTCOME
 
 UNITTEST("SCOPE(fail)")
 {

--- a/cudax/include/cuda/experimental/__stf/utility/pretty_print.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/pretty_print.cuh
@@ -103,23 +103,10 @@ void mdspan_to_vtk(mdspan_like s, const ::std::string& filename)
   fprintf(stderr, "Writing slice of size to file %s\n", filename.c_str());
   FILE* f = EXPECT(fopen(filename.c_str(), "w+") != nullptr);
   // One guard, both outcomes: checked close on the normal path, best effort while unwinding.
-#ifdef STF_HAS_SCOPE_OUTCOME
-  // One guard, both outcomes: a failed close is a real error on the normal path, and best
-  // effort while unwinding (a guard body that throws there aborts the program).
   SCOPE(exit, failing)
   {
     failing ? (void) fclose(f) : (void) EXPECT(fclose(f) == 0);
   };
-#else // ^^^ C++20 ^^^ / vvv C++17 has no outcome parameter vvv
-  SCOPE(success)
-  {
-    EXPECT(fclose(f) == 0);
-  };
-  SCOPE(fail)
-  {
-    fclose(f);
-  };
-#endif // STF_HAS_SCOPE_OUTCOME
 
   EXPECT(fprintf(f, "# vtk DataFile Version 2.0\noutput\nASCII\n") != -1);
 

--- a/libcudacxx/include/cuda/std/__cccl/preprocessor.h
+++ b/libcudacxx/include/cuda/std/__cccl/preprocessor.h
@@ -34,9 +34,9 @@ CCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING to suppress this warning.
 #define _CCCL_TO_STRING2(_STR) #_STR
 #define _CCCL_TO_STRING(_STR)  _CCCL_TO_STRING2(_STR)
 
-#define _CCCL_PP_FIRST(_FIRST, ...)      _FIRST
-#define _CCCL_PP_SECOND(_, _SECOND, ...) _SECOND
-#define _CCCL_PP_THIRD(_1, _2, _THIRD)   _THIRD
+#define _CCCL_PP_FIRST(_FIRST, ...)         _FIRST
+#define _CCCL_PP_SECOND(_, _SECOND, ...)    _SECOND
+#define _CCCL_PP_THIRD(_1, _2, _THIRD, ...) _THIRD
 
 #define _CCCL_PP_EXPAND(...) __VA_ARGS__
 #define _CCCL_PP_EAT(...)


### PR DESCRIPTION
## Summary

Two changes, the second motivating the first.

**`_CCCL_PP_THIRD` becomes variadic.** It was declared `(_1, _2, _THIRD)` with no trailing `...`, unlike its siblings `_CCCL_PP_FIRST` and `_CCCL_PP_SECOND`. That made it unusable as an argument-count dispatcher: any call carrying an extra argument is a "too many arguments provided to function-like macro invocation" error. It had **zero call sites** anywhere in the repo, so adding the ellipsis breaks nothing.

```diff
-#define _CCCL_PP_THIRD(_1, _2, _THIRD)   _THIRD
+#define _CCCL_PP_THIRD(_1, _2, _THIRD, ...) _THIRD
```

**`SCOPE` loses its C++20 gate.** The outcome form `SCOPE(exit, name)` — one guard serving both the normal and the unwinding path — was built on `__VA_OPT__`, which is C++20 and is rejected in C++17 under `-pedantic-errors`. It was therefore gated behind `STF_HAS_SCOPE_OUTCOME`, leaving C++17 users to write an `#ifdef` plus a fallback `SCOPE(success)`/`SCOPE(fail)` pair.

`_CCCL_PP_THIRD` emulates `__VA_OPT__(bool)` directly: supplying a name pushes `bool` into the third slot, so it appears only when asked for, and `_CCCL_PP_SECOND` supplies the name itself.

```cpp
#define SCOPE(...)                                                                             \
  auto CUDASTF_UNIQUE_NAME(scope_guard) =                                                      \
    (::cuda::experimental::stf::detail::scope_guard_handler::_CCCL_PP_FIRST(__VA_ARGS__, )) {} \
      ->*[&](_CCCL_PP_THIRD(__VA_ARGS__, bool, , ~) _CCCL_PP_SECOND(__VA_ARGS__, , ))
```

`SCOPE(exit)` still expands to a *genuinely empty* parameter list, not an unnamed `bool`. That is load-bearing rather than cosmetic: it is what lets `SCOPE(fail)` and `SCOPE(success)` keep `static_assert`ing that they take no parameter. The trailing `~` and padding commas feed the ellipses, which may not go empty in C++17.

`STF_HAS_SCOPE_OUTCOME` and all four of its `#ifdef` pairs are gone, and `SCOPE` collapses from two conditional definitions to one unconditional macro. Net −33 lines.

## Testing

- exception_policy unit tests: **19/19 in both C++17 and C++20**. C++17 previously ran only 17 — the two outcome tests were compiled out.
- Clean under `-std=c++17`/`-std=c++20 -pedantic-errors -Wall -Wextra` on gcc 9.2, gcc 14.2, clang 14.0, and Apple clang; and under `/std:c++17`/`/std:c++20 /Zc:preprocessor /permissive- /W4` on MSVC 19.43.
- MSVC's *traditional* preprocessor cannot express this dispatch, but that configuration is already rejected outright by `preprocessor.h`, which `#error`s on it.