### PR TITLE
[STF] Batch 3: notify, not abort, for non-essential cleanup

### DIFF
--- a/cudax/include/cuda/experimental/__places/exec/locality_domain.cuh
+++ b/cudax/include/cuda/experimental/__places/exec/locality_domain.cuh
@@ -513,10 +513,15 @@ public:
       {
         CUcontext primary_ctx = cuda_try<cuDevicePrimaryCtxRetain>(device);
         // Release on every exit path: a throwing resource query must not leak
-        // the retained primary-context reference.
+        // the retained primary-context reference. A failed release leaks that
+        // reference but leaves nothing unsafe to continue with, so report and
+        // carry on rather than abort a stack that is already unwinding.
         SCOPE(exit)
         {
-          cuda_try(cuDevicePrimaryCtxRelease(device));
+          ON_THROW(notify)
+          {
+            cuda_try(cuDevicePrimaryCtxRelease(device));
+          };
         };
         cuda_try(cuCtxGetDevResource(primary_ctx, &input, CU_DEV_RESOURCE_TYPE_SM));
       }


### PR DESCRIPTION
Third slice of the scope-guard audit that began with #11187 and continued in #11224.

## The question changed

The audit originally planned a mechanical sweep wrapping every fragile guard body in `ON_THROW(notify)`. That premise expired: since #11187 a guard body that throws **reports and aborts** rather than terminating silently, and since #11226 a `SCOPE(exit)` body that throws on the normal path propagates.

So the question at each remaining site is not "does this terminate?" but **"is this cleanup essential enough to justify killing the process while an exception is already in flight?"** Only cleanup whose failure makes it unsafe to continue should abort.

## Changed

**`locality_domain.cuh`** — a failed `cuDevicePrimaryCtxRelease` leaks the retained reference, but leaves nothing unsafe to continue with. Reports and resumes, original exception preserved.

## Unchanged — essential, still aborts

The five `cudaSetDevice(prev_dev)` restores in `data_place_impl.cuh` (×2) and `green_context.cuh` (×3). If a restore fails and execution continues, every later launch runs on the wrong device. That is silent corruption, and exactly the case that *should* abort.

## Why this is one site

A scan of every `SCOPE` body containing a throwing call finds 51, but they split:

| group | count | live hazard today? |
|---|---|---|
| body calls `cuda_try` (throws) | 6 | yes — 5 are the device restores above, 1 is this PR |
| body calls `cuda_safe_call` (aborts) | ~35 | no — masked |
| `EXPECT` inside `exception_policy.cuh` unit tests | 8 | no, deliberate |

The `cuda_safe_call` sites are not live hazards because that function aborts rather than throws. They become hazards the moment `cuda_safe_call` is migrated to `cuda_try` — which is why the audit sequences that migration last, after the guards are throw-safe.

## Split out

The `stream_task::end()` / `insert_event()` / `exec_place_scope` / `task::release()` work that was briefly on this branch now lives in its own PR, since making the teardown path nothrow from the leaves up is a separate story from classifying guard bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)