### PR TITLE
Refactor CUB DeviceFind::{Lower,Upper}BoundSortedValues two-phase…

### DIFF
--- a/cub/cub/device/device_find.cuh
+++ b/cub/cub/device/device_find.cuh
@@ -796,6 +796,9 @@ struct DeviceFind
   //!   is a model of [Strict Weak Ordering] over the value types of both
   //!   iterator types.
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
+  //!
   //! @param[in] d_temp_storage
   //!   Device-accessible allocation of temporary storage. When `nullptr`, the
   //!   required allocation size is written to `temp_storage_bytes` and no work
@@ -822,9 +825,9 @@ struct DeviceFind
   //! @param[in] comp
   //!   Comparison function object (Strict Weak Ordering).
   //!
-  //! @param[in] stream
+  //! @param[in] env
   //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   //!
   //! [Random Access Iterator]: https://en.cppreference.com/w/cpp/iterator/random_access_iterator
@@ -835,7 +838,8 @@ struct DeviceFind
             typename ValuesIteratorT,
             typename ValuesNumItemsT,
             typename OutputIteratorT,
-            typename CompareOpT>
+            typename CompareOpT,
+            typename EnvT = ::cuda::std::execution::env<>>
   CUB_RUNTIME_FUNCTION static cudaError_t LowerBoundSortedValues(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -845,7 +849,7 @@ struct DeviceFind
     ValuesNumItemsT values_num_items,
     OutputIteratorT d_output,
     CompareOpT comp,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceFind::LowerBoundSortedValues");
 
@@ -853,16 +857,24 @@ struct DeviceFind
     using ValuesOffsetT = detail::choose_offset_t<ValuesNumItemsT>;
     using OffsetT       = ::cuda::std::common_type_t<RangeOffsetT, ValuesOffsetT>;
 
-    return detail::find_bound_sorted_values::dispatch<detail::find_bound_sorted_values::lower_bound_mode>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_range,
-      static_cast<OffsetT>(range_num_items),
-      d_values,
-      static_cast<OffsetT>(values_num_items),
-      d_output,
-      comp,
-      stream);
+    using default_policy_selector =
+      detail::find_bound_sorted_values::policy_selector_from_types<detail::it_value_t<RangeIteratorT>,
+                                                                   detail::it_value_t<ValuesIteratorT>>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::find_bound_sorted_values::dispatch<detail::find_bound_sorted_values::lower_bound_mode>(
+          storage,
+          bytes,
+          d_range,
+          static_cast<OffsetT>(range_num_items),
+          d_values,
+          static_cast<OffsetT>(values_num_items),
+          d_output,
+          comp,
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst
@@ -1036,6 +1048,9 @@ struct DeviceFind
   //!   is a model of [Strict Weak Ordering] over the value types of both
   //!   iterator types.
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
+  //!
   //! @param[in] d_temp_storage
   //!   Device-accessible allocation of temporary storage. When `nullptr`, the
   //!   required allocation size is written to `temp_storage_bytes` and no work
@@ -1062,9 +1077,9 @@ struct DeviceFind
   //! @param[in] comp
   //!   Comparison function object (Strict Weak Ordering).
   //!
-  //! @param[in] stream
+  //! @param[in] env
   //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   //!
   //! [Random Access Iterator]: https://en.cppreference.com/w/cpp/iterator/random_access_iterator
@@ -1075,7 +1090,8 @@ struct DeviceFind
             typename ValuesIteratorT,
             typename ValuesNumItemsT,
             typename OutputIteratorT,
-            typename CompareOpT>
+            typename CompareOpT,
+            typename EnvT = ::cuda::std::execution::env<>>
   CUB_RUNTIME_FUNCTION static cudaError_t UpperBoundSortedValues(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -1085,7 +1101,7 @@ struct DeviceFind
     ValuesNumItemsT values_num_items,
     OutputIteratorT d_output,
     CompareOpT comp,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceFind::UpperBoundSortedValues");
 
@@ -1093,16 +1109,24 @@ struct DeviceFind
     using ValuesOffsetT = detail::choose_offset_t<ValuesNumItemsT>;
     using OffsetT       = ::cuda::std::common_type_t<RangeOffsetT, ValuesOffsetT>;
 
-    return detail::find_bound_sorted_values::dispatch<detail::find_bound_sorted_values::upper_bound_mode>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_range,
-      static_cast<OffsetT>(range_num_items),
-      d_values,
-      static_cast<OffsetT>(values_num_items),
-      d_output,
-      comp,
-      stream);
+    using default_policy_selector =
+      detail::find_bound_sorted_values::policy_selector_from_types<detail::it_value_t<RangeIteratorT>,
+                                                                   detail::it_value_t<ValuesIteratorT>>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::find_bound_sorted_values::dispatch<detail::find_bound_sorted_values::upper_bound_mode>(
+          storage,
+          bytes,
+          d_range,
+          static_cast<OffsetT>(range_num_items),
+          d_values,
+          static_cast<OffsetT>(values_num_items),
+          d_output,
+          comp,
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst

--- a/cub/cub/device/device_find.cuh
+++ b/cub/cub/device/device_find.cuh
@@ -25,6 +25,7 @@
 #include <cuda/__functional/always_true_false.h>
 #include <cuda/__iterator/zip_iterator.h>
 #include <cuda/__nvtx/nvtx.h>
+#include <cuda/std/__concepts/relation.h>
 
 CUB_NAMESPACE_BEGIN
 
@@ -833,13 +834,15 @@ struct DeviceFind
   //! [Random Access Iterator]: https://en.cppreference.com/w/cpp/iterator/random_access_iterator
   //! [Strict Weak Ordering]: https://en.cppreference.com/w/cpp/concepts/strict_weak_order
   //! [Relation]: https://en.cppreference.com/w/cpp/concepts/relation
-  template <typename RangeIteratorT,
-            typename RangeNumItemsT,
-            typename ValuesIteratorT,
-            typename ValuesNumItemsT,
-            typename OutputIteratorT,
-            typename CompareOpT,
-            typename EnvT = ::cuda::std::execution::env<>>
+  _CCCL_TEMPLATE(typename RangeIteratorT,
+                 typename RangeNumItemsT,
+                 typename ValuesIteratorT,
+                 typename ValuesNumItemsT,
+                 typename OutputIteratorT,
+                 typename CompareOpT,
+                 typename EnvT = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES(
+    ::cuda::std::strict_weak_order<CompareOpT, detail::it_value_t<RangeIteratorT>, detail::it_value_t<ValuesIteratorT>>)
   CUB_RUNTIME_FUNCTION static cudaError_t LowerBoundSortedValues(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -1085,13 +1088,15 @@ struct DeviceFind
   //! [Random Access Iterator]: https://en.cppreference.com/w/cpp/iterator/random_access_iterator
   //! [Strict Weak Ordering]: https://en.cppreference.com/w/cpp/concepts/strict_weak_order
   //! [Relation]: https://en.cppreference.com/w/cpp/concepts/relation
-  template <typename RangeIteratorT,
-            typename RangeNumItemsT,
-            typename ValuesIteratorT,
-            typename ValuesNumItemsT,
-            typename OutputIteratorT,
-            typename CompareOpT,
-            typename EnvT = ::cuda::std::execution::env<>>
+  _CCCL_TEMPLATE(typename RangeIteratorT,
+                 typename RangeNumItemsT,
+                 typename ValuesIteratorT,
+                 typename ValuesNumItemsT,
+                 typename OutputIteratorT,
+                 typename CompareOpT,
+                 typename EnvT = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES(
+    ::cuda::std::strict_weak_order<CompareOpT, detail::it_value_t<RangeIteratorT>, detail::it_value_t<ValuesIteratorT>>)
   CUB_RUNTIME_FUNCTION static cudaError_t UpperBoundSortedValues(
     void* d_temp_storage,
     size_t& temp_storage_bytes,

--- a/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
@@ -11,6 +11,9 @@ struct stream_registry_factory_t;
 
 #include <thrust/device_vector.h>
 
+#include <cuda/devices>
+#include <cuda/std/execution>
+
 #include <sstream>
 
 #include "catch2_test_env_launch_helper.h"
@@ -100,6 +103,105 @@ CUB_TEST("Device LowerBoundSortedValues uses environment", "[find][device][binar
   REQUIRE(d_output == expected);
 }
 
+CUB_TEST("Device LowerBoundSortedValues works with user provided memory and environment",
+         "[find][device][binary-search]",
+         CUB_SMALL)
+{
+  auto d_range                     = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values                    = c2h::device_vector<int>{0, 3, 4, 7};
+  auto d_output                    = c2h::device_vector<int>(4);
+  c2h::device_vector<int> expected = {0, 2, 2, 4};
+
+  size_t expected_bytes_allocated{};
+  auto error = cub::DeviceFind::LowerBoundSortedValues(
+    nullptr,
+    expected_bytes_allocated,
+    d_range.begin(),
+    static_cast<int>(d_range.size()),
+    d_values.begin(),
+    static_cast<int>(d_values.size()),
+    d_output.begin(),
+    cuda::std::less{});
+  REQUIRE(error == cudaSuccess);
+  auto temp          = c2h::device_vector<uint8_t>(expected_bytes_allocated, thrust::no_init);
+  void* temp_storage = thrust::raw_pointer_cast(temp.data());
+
+  auto test_lower_bound_sorted_values = [&](const auto& env) {
+    size_t num_bytes = 0;
+    error            = cub::DeviceFind::LowerBoundSortedValues(
+      nullptr,
+      num_bytes,
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      cuda::std::less{},
+      env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(num_bytes == expected_bytes_allocated);
+
+    error = cub::DeviceFind::LowerBoundSortedValues(
+      temp_storage,
+      num_bytes,
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      cuda::std::less{},
+      env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(d_output == expected);
+  };
+
+  int current_device;
+  error = cudaGetDevice(&current_device);
+  REQUIRE(error == cudaSuccess);
+
+  SECTION("lower_bound_sorted_values works with cudaStream_t")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_lower_bound_sorted_values(stream.get());
+  }
+
+  SECTION("lower_bound_sorted_values works with cuda::stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_lower_bound_sorted_values(stream);
+  }
+
+  SECTION("lower_bound_sorted_values works with cuda::stream_ref")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    cuda::stream_ref stream_ref{stream};
+    test_lower_bound_sorted_values(stream_ref);
+  }
+
+  SECTION("lower_bound_sorted_values works with cuda::std::execution::env")
+  {
+    cuda::std::execution::env env{};
+    test_lower_bound_sorted_values(env);
+  }
+
+  SECTION("lower_bound_sorted_values works with cuda::execution::gpu")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_lower_bound_sorted_values(policy);
+  }
+
+  SECTION("lower_bound_sorted_values works with cuda::execution::gpu with stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_lower_bound_sorted_values(policy);
+  }
+}
+
 CUB_TEST("Device UpperBoundSortedValues uses environment", "[find][device][binary-search]", CUB_SMALL)
 {
   auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
@@ -132,6 +234,105 @@ CUB_TEST("Device UpperBoundSortedValues uses environment", "[find][device][binar
 
   c2h::device_vector<int> expected = {1, 2, 3, 4};
   REQUIRE(d_output == expected);
+}
+
+CUB_TEST("Device UpperBoundSortedValues works with user provided memory and environment",
+         "[find][device][binary-search]",
+         CUB_SMALL)
+{
+  auto d_range                     = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values                    = c2h::device_vector<int>{0, 3, 4, 7};
+  auto d_output                    = c2h::device_vector<int>(4);
+  c2h::device_vector<int> expected = {1, 2, 3, 4};
+
+  size_t expected_bytes_allocated{};
+  auto error = cub::DeviceFind::UpperBoundSortedValues(
+    nullptr,
+    expected_bytes_allocated,
+    d_range.begin(),
+    static_cast<int>(d_range.size()),
+    d_values.begin(),
+    static_cast<int>(d_values.size()),
+    d_output.begin(),
+    cuda::std::less{});
+  REQUIRE(error == cudaSuccess);
+  auto temp          = c2h::device_vector<uint8_t>(expected_bytes_allocated, thrust::no_init);
+  void* temp_storage = thrust::raw_pointer_cast(temp.data());
+
+  auto test_upper_bound_sorted_values = [&](const auto& env) {
+    size_t num_bytes = 0;
+    error            = cub::DeviceFind::UpperBoundSortedValues(
+      nullptr,
+      num_bytes,
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      cuda::std::less{},
+      env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(num_bytes == expected_bytes_allocated);
+
+    error = cub::DeviceFind::UpperBoundSortedValues(
+      temp_storage,
+      num_bytes,
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      cuda::std::less{},
+      env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(d_output == expected);
+  };
+
+  int current_device;
+  error = cudaGetDevice(&current_device);
+  REQUIRE(error == cudaSuccess);
+
+  SECTION("upper_bound_sorted_values works with cudaStream_t")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_upper_bound_sorted_values(stream.get());
+  }
+
+  SECTION("upper_bound_sorted_values works with cuda::stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_upper_bound_sorted_values(stream);
+  }
+
+  SECTION("upper_bound_sorted_values works with cuda::stream_ref")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    cuda::stream_ref stream_ref{stream};
+    test_upper_bound_sorted_values(stream_ref);
+  }
+
+  SECTION("upper_bound_sorted_values works with cuda::std::execution::env")
+  {
+    cuda::std::execution::env env{};
+    test_upper_bound_sorted_values(env);
+  }
+
+  SECTION("upper_bound_sorted_values works with cuda::execution::gpu")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_upper_bound_sorted_values(policy);
+  }
+
+  SECTION("upper_bound_sorted_values works with cuda::execution::gpu with stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_upper_bound_sorted_values(policy);
+  }
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2

--- a/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
@@ -67,7 +67,7 @@ CUB_TEST_CASE("Device UpperBoundSortedValues works with default environment", "[
   REQUIRE(d_output == expected);
 }
 
-#endif
+#endif // TEST_LAUNCH == 0
 
 CUB_TEST("Device LowerBoundSortedValues uses environment", "[find][device][binary-search]", CUB_SMALL)
 {
@@ -103,14 +103,50 @@ CUB_TEST("Device LowerBoundSortedValues uses environment", "[find][device][binar
   REQUIRE(d_output == expected);
 }
 
+CUB_TEST("Device UpperBoundSortedValues uses environment", "[find][device][binary-search]", CUB_SMALL)
+{
+  auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values = c2h::device_vector<int>{0, 3, 4, 7};
+  auto d_output = c2h::device_vector<int>(4);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceFind::UpperBoundSortedValues(
+      nullptr,
+      expected_bytes_allocated,
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      cuda::std::less{}));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_upper_bound_sorted_values(
+    d_range.begin(),
+    static_cast<int>(d_range.size()),
+    d_values.begin(),
+    static_cast<int>(d_values.size()),
+    d_output.begin(),
+    cuda::std::less{},
+    env);
+
+  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  REQUIRE(d_output == expected);
+}
+
+#if TEST_LAUNCH == 0
+
 CUB_TEST("Device LowerBoundSortedValues works with user provided memory and environment",
          "[find][device][binary-search]",
          CUB_SMALL)
 {
-  auto d_range                     = c2h::device_vector<int>{0, 2, 4, 6, 8};
-  auto d_values                    = c2h::device_vector<int>{0, 3, 4, 7};
-  auto d_output                    = c2h::device_vector<int>(4);
-  c2h::device_vector<int> expected = {0, 2, 2, 4};
+  auto d_range                           = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values                          = c2h::device_vector<int>{0, 3, 4, 7};
+  auto d_output                          = c2h::device_vector<int>(4);
+  const c2h::device_vector<int> expected = {0, 2, 2, 4};
 
   size_t expected_bytes_allocated{};
   auto error = cub::DeviceFind::LowerBoundSortedValues(
@@ -202,48 +238,14 @@ CUB_TEST("Device LowerBoundSortedValues works with user provided memory and envi
   }
 }
 
-CUB_TEST("Device UpperBoundSortedValues uses environment", "[find][device][binary-search]", CUB_SMALL)
-{
-  auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
-  auto d_values = c2h::device_vector<int>{0, 3, 4, 7};
-  auto d_output = c2h::device_vector<int>(4);
-
-  size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceFind::UpperBoundSortedValues(
-      nullptr,
-      expected_bytes_allocated,
-      d_range.begin(),
-      static_cast<int>(d_range.size()),
-      d_values.begin(),
-      static_cast<int>(d_values.size()),
-      d_output.begin(),
-      cuda::std::less{}));
-
-  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
-
-  device_upper_bound_sorted_values(
-    d_range.begin(),
-    static_cast<int>(d_range.size()),
-    d_values.begin(),
-    static_cast<int>(d_values.size()),
-    d_output.begin(),
-    cuda::std::less{},
-    env);
-
-  c2h::device_vector<int> expected = {1, 2, 3, 4};
-  REQUIRE(d_output == expected);
-}
-
 CUB_TEST("Device UpperBoundSortedValues works with user provided memory and environment",
          "[find][device][binary-search]",
          CUB_SMALL)
 {
-  auto d_range                     = c2h::device_vector<int>{0, 2, 4, 6, 8};
-  auto d_values                    = c2h::device_vector<int>{0, 3, 4, 7};
-  auto d_output                    = c2h::device_vector<int>(4);
-  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  auto d_range                           = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values                          = c2h::device_vector<int>{0, 3, 4, 7};
+  auto d_output                          = c2h::device_vector<int>(4);
+  const c2h::device_vector<int> expected = {1, 2, 3, 4};
 
   size_t expected_bytes_allocated{};
   auto error = cub::DeviceFind::UpperBoundSortedValues(
@@ -334,6 +336,174 @@ CUB_TEST("Device UpperBoundSortedValues works with user provided memory and envi
     test_upper_bound_sorted_values(policy);
   }
 }
+
+template <int ThreadsPerBlock>
+struct find_bound_sorted_values_tuning
+{
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::FindBoundSortedValuesPolicy
+  {
+    return {ThreadsPerBlock, 15, cub::LOAD_LDG};
+  }
+};
+
+using block_size_extracting_predicate_t = block_size_extracting_op<::cuda::always_false>;
+
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
+
+CUB_TEST("LowerBoundSortedValues can be tuned", "[find][device][binary-search]", CUB_SMALL, block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  auto d_range                                   = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values                                  = c2h::device_vector<int>{0, 3, 4, 7};
+  auto d_output                                  = c2h::device_vector<int>(4, thrust::no_init);
+  auto d_block_size                              = c2h::device_vector<unsigned int>(1, 0);
+  const c2h::device_vector<int> d_expected_lower = {0, 0, 0, 0};
+
+  block_size_extracting_predicate_t predicate{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env = cuda::execution::tune(find_bound_sorted_values_tuning<target_block_size>{});
+
+  SECTION("lower_bound_sorted_values can be tuned")
+  {
+    auto error = cub::DeviceFind::LowerBoundSortedValues(
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      predicate,
+      env);
+
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    REQUIRE(d_output == d_expected_lower); // predicate never matches
+    REQUIRE(d_block_size[0] == target_block_size);
+  }
+
+  SECTION("lower_bound_sorted_values can be tuned with user provided memory")
+  {
+    size_t num_bytes = 0;
+
+    auto error = cub::DeviceFind::LowerBoundSortedValues(
+      nullptr,
+      num_bytes,
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      predicate,
+      env);
+
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    d_block_size[0] = 0; // reset to 0 for phase 2
+
+    auto temp          = c2h::device_vector<uint8_t>(num_bytes, thrust::no_init);
+    void* temp_storage = thrust::raw_pointer_cast(temp.data());
+
+    error = cub::DeviceFind::LowerBoundSortedValues(
+      temp_storage,
+      num_bytes,
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      predicate,
+      env);
+
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    REQUIRE(d_output == d_expected_lower); // predicate never matches
+    REQUIRE(d_block_size[0] == target_block_size);
+  }
+}
+
+CUB_TEST("UpperBoundSortedValues can be tuned", "[find][device][binary-search]", CUB_SMALL, block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  auto d_range                                   = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values                                  = c2h::device_vector<int>{0, 3, 4, 7};
+  auto d_output                                  = c2h::device_vector<int>(4, thrust::no_init);
+  auto d_block_size                              = c2h::device_vector<unsigned int>(1, 0);
+  const c2h::device_vector<int> d_expected_upper = {5, 5, 5, 5};
+
+  block_size_extracting_predicate_t predicate{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env = cuda::execution::tune(find_bound_sorted_values_tuning<target_block_size>{});
+
+  SECTION("upper_bound_sorted_values can be tuned")
+  {
+    auto error = cub::DeviceFind::UpperBoundSortedValues(
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      predicate,
+      env);
+
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    REQUIRE(d_output == d_expected_upper); // predicate never matches
+    REQUIRE(d_block_size[0] == target_block_size);
+  }
+
+  SECTION("upper_bound_sorted_values can be tuned with user provided memory")
+  {
+    size_t num_bytes = 0;
+
+    auto error = cub::DeviceFind::UpperBoundSortedValues(
+      nullptr,
+      num_bytes,
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      predicate,
+      env);
+
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    d_block_size[0] = 0; // reset to 0 for phase 2
+
+    auto temp          = c2h::device_vector<uint8_t>(num_bytes, thrust::no_init);
+    void* temp_storage = thrust::raw_pointer_cast(temp.data());
+
+    error = cub::DeviceFind::UpperBoundSortedValues(
+      temp_storage,
+      num_bytes,
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      predicate,
+      env);
+
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    REQUIRE(d_output == d_expected_upper); // predicate never matches
+    REQUIRE(d_block_size[0] == target_block_size);
+  }
+}
+
+#endif // TEST_LAUNCH == 0
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
 CUB_TEST("Test FindBoundSortedValuesPolicy properties", "[find][device][binary-search]", CUB_SMALL)


### PR DESCRIPTION
…overloads to accept environments

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Part of #9875 (the DeviceFind row)<!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->
Refactors the two-phase `cub::DeviceFind::LowerBoundSortedValues` and `cub::DeviceFind::UpperBoundSortedValues` overloads to accept an execution environment instead of a `cudaStream_t`.

## Changes

- Replaces the explicit `cudaStream_t` argument in the two-phase overloads with the templated argument `const EnvT& env`.
- Adds tests covering user-provided temporary storage with the supported environment forms.

## Testing

All tests pass locally.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
