### PR TITLE
[STF] finalize() completes even when the synchronize fails

### DIFF
--- a/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
@@ -363,14 +363,26 @@ public:
     // Make sure we release resources attached to this context
     state.release_ctx_resources(state.submitted_stream);
 
+    // Finalization has to complete even when the synchronize below reports a failure, which is
+    // the likely case rather than the exotic one: cudaStreamSynchronize is where asynchronous
+    // errors from earlier work surface. Leaving the context in `submitted` with its resources
+    // already released makes it unusable AND unretryable -- a second finalize() re-enters
+    // release_ctx_resources and trips its "already released" assertion. The guard is armed
+    // after that release so that a failure there still leaves the context retryable, which it
+    // is today: release() only sets its released flag once it has finished.
+    //
+    // The error still propagates; the caller simply gets a consistent context along with it.
+    SCOPE(exit)
+    {
+      state.submitted_stream = nullptr;
+      state.cleanup();
+      set_phase(backend_ctx_untyped::phase::finalized);
+    };
+
     if (state.blocking_finalize)
     {
       cuda_try(cudaStreamSynchronize(state.submitted_stream));
     }
-
-    state.submitted_stream = nullptr;
-    state.cleanup();
-    set_phase(backend_ctx_untyped::phase::finalized);
   }
 
   void submit(cudaStream_t stream = nullptr)

--- a/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
@@ -503,12 +503,25 @@ public:
     // Make sure we release resources attached to this context
     state.release_ctx_resources(state.submitted_stream);
 
+    // Finalization has to complete even when the synchronize below reports a failure, which is
+    // the likely case rather than the exotic one: cudaStreamSynchronize is where asynchronous
+    // errors from earlier work surface. Leaving the context in `submitted` with its resources
+    // already released makes it unusable AND unretryable -- a second finalize() re-enters
+    // release_ctx_resources and trips its "already released" assertion. The guard is armed
+    // after that release so that a failure there still leaves the context retryable, which it
+    // is today: release() only sets its released flag once it has finished.
+    //
+    // The error still propagates; the caller simply gets a consistent context along with it.
+    SCOPE(exit)
+    {
+      state.cleanup();
+      set_phase(backend_ctx_untyped::phase::finalized);
+    };
+
     if (state.blocking_finalize)
     {
       cuda_try<cudaStreamSynchronize>(state.submitted_stream);
     }
-    state.cleanup();
-    set_phase(backend_ctx_untyped::phase::finalized);
   }
 
   float get_submission_time_ms() const


### PR DESCRIPTION
Both backends had the same shape (`graph_ctx.cuh:351-373`, `stream_ctx.cuh:498-511`):

```cpp
state.release_ctx_resources(state.submitted_stream);
if (state.blocking_finalize)
{
  cuda_try(cudaStreamSynchronize(state.submitted_stream));   // throws
}
state.cleanup();
set_phase(backend_ctx_untyped::phase::finalized);
```

If the synchronize throws, `cleanup()` and `set_phase()` are skipped — and in the graph backend, so is clearing `submitted_stream`. The context is stranded in the `submitted` phase with its resources **already released**, which makes it both unusable and **unretryable**: a second `finalize()` re-enters `release_ctx_resources` and trips its `"Resources have already been released on this context"` assertion, or silently double-releases under `NDEBUG`.

## Why this is the likely path, not an exotic one

`cudaStreamSynchronize` is *where asynchronous errors surface*. Any kernel that faulted earlier in the context makes `finalize()` throw at exactly this line. So the common failure — a bad kernel — leaves the context permanently un-finalizable, and the user cannot even clean up afterwards.

## Fix

Move the tail into a `SCOPE(exit)` so finalization completes on both paths. The error still propagates; the caller now gets a consistent context *along with* it, instead of choosing between the two.

**The guard is armed after `release_ctx_resources`, not before, on purpose.** A failure inside `release()` should leave the context retryable, and today it does — `release()` sets its released flag only once it has finished, so nothing is marked done that was not done. Arming the guard earlier would mark a context finalized whose resources were never released.

The guard body cannot itself throw: `cleanup()` is a `vector::clear()` and `set_phase()` a plain assignment, so it is safe on the unwinding path.

## Provenance

Found while auditing the graph backend for counterparts of the stream-side fixes in #11235. The defect turned out to be in both — which is now the fourth instance of the same pattern in this campaign: shared state mutated across a throwing call with no repair on the failure path (see also `task::release()`'s half-updated dependency graph, and the divergent-sibling bugs in #11236 and #11229).

🤖 Generated with [Claude Code](https://claude.com/claude-code)