### PR TITLE
Simplify radix sort agent a bit

### DIFF
--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -327,138 +327,6 @@ struct AgentRadixSortDownsweep
   }
 
   /**
-   * Load a tile of keys (specialized for full tile, block load)
-   */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(
-    bit_ordered_type (&keys)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    bit_ordered_type oob_item,
-    ::cuda::std::true_type is_full_tile,
-    ::cuda::std::false_type warp_striped)
-  {
-    BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys);
-
-    __syncthreads();
-  }
-
-  /**
-   * Load a tile of keys (specialized for partial tile, block load)
-   */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(
-    bit_ordered_type (&keys)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    bit_ordered_type oob_item,
-    ::cuda::std::false_type is_full_tile,
-    ::cuda::std::false_type warp_striped)
-  {
-    // Register pressure work-around: moving valid_items through shfl prevents compiler
-    // from reusing guards/addressing from prior guarded loads
-    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
-
-    BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys, valid_items, oob_item);
-
-    __syncthreads();
-  }
-
-  /**
-   * Load a tile of keys (specialized for full tile, warp-striped load)
-   */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(
-    bit_ordered_type (&keys)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    bit_ordered_type oob_item,
-    ::cuda::std::true_type is_full_tile,
-    ::cuda::std::true_type warp_striped)
-  {
-    LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys);
-  }
-
-  /**
-   * Load a tile of keys (specialized for partial tile, warp-striped load)
-   */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(
-    bit_ordered_type (&keys)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    bit_ordered_type oob_item,
-    ::cuda::std::false_type is_full_tile,
-    ::cuda::std::true_type warp_striped)
-  {
-    // Register pressure work-around: moving valid_items through shfl prevents compiler
-    // from reusing guards/addressing from prior guarded loads
-    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
-
-    LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys, valid_items, oob_item);
-  }
-
-  /**
-   * Load a tile of values (specialized for full tile, block load)
-   */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
-    ValueT (&values)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    ::cuda::std::true_type is_full_tile,
-    ::cuda::std::false_type warp_striped)
-  {
-    BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values);
-
-    __syncthreads();
-  }
-
-  /**
-   * Load a tile of values (specialized for partial tile, block load)
-   */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
-    ValueT (&values)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    ::cuda::std::false_type is_full_tile,
-    ::cuda::std::false_type warp_striped)
-  {
-    // Register pressure work-around: moving valid_items through shfl prevents compiler
-    // from reusing guards/addressing from prior guarded loads
-    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
-
-    BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values, valid_items);
-
-    __syncthreads();
-  }
-
-  /**
-   * Load a tile of items (specialized for full tile, warp-striped load)
-   */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
-    ValueT (&values)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    ::cuda::std::true_type is_full_tile,
-    ::cuda::std::true_type warp_striped)
-  {
-    LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values);
-  }
-
-  /**
-   * Load a tile of items (specialized for partial tile, warp-striped load)
-   */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
-    ValueT (&values)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    ::cuda::std::false_type is_full_tile,
-    ::cuda::std::true_type warp_striped)
-  {
-    // Register pressure work-around: moving valid_items through shfl prevents compiler
-    // from reusing guards/addressing from prior guarded loads
-    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
-
-    LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values, valid_items);
-  }
-
-  /**
    * Truck along associated values
    */
   template <bool FULL_TILE>
@@ -466,29 +334,42 @@ struct AgentRadixSortDownsweep
     OffsetT (&relative_bin_offsets)[ITEMS_PER_THREAD],
     int (&ranks)[ITEMS_PER_THREAD],
     OffsetT block_offset,
-    OffsetT valid_items,
-    ::cuda::std::false_type /*is_keys_only*/)
+    OffsetT valid_items)
   {
     ValueT values[ITEMS_PER_THREAD];
 
     __syncthreads();
 
-    LoadValues(values, block_offset, valid_items, bool_constant_v<FULL_TILE>, bool_constant_v<LOAD_WARP_STRIPED>);
+    if constexpr (FULL_TILE)
+    {
+      if constexpr (LOAD_WARP_STRIPED)
+      {
+        LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values);
+      }
+      else
+      {
+        BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values);
+        __syncthreads();
+      }
+    }
+    else
+    {
+      // Register pressure work-around: moving valid_items through shfl prevents compiler
+      // from reusing guards/addressing from prior guarded loads
+      valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
+      if constexpr (LOAD_WARP_STRIPED)
+      {
+        LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values, valid_items);
+      }
+      else
+      {
+        BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values, valid_items);
+        __syncthreads();
+      }
+    }
 
     ScatterValues<FULL_TILE>(values, relative_bin_offsets, ranks, valid_items);
   }
-
-  /**
-   * Truck along associated values (specialized for key-only sorting)
-   */
-  template <bool FULL_TILE>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void GatherScatterValues(
-    OffsetT (& /*relative_bin_offsets*/)[ITEMS_PER_THREAD],
-    int (& /*ranks*/)[ITEMS_PER_THREAD],
-    OffsetT /*block_offset*/,
-    OffsetT /*valid_items*/,
-    ::cuda::std::true_type /*is_keys_only*/)
-  {}
 
   /**
    * Process tile
@@ -505,8 +386,33 @@ struct AgentRadixSortDownsweep
       IS_DESCENDING ? traits::min_raw_binary_key(decomposer) : traits::max_raw_binary_key(decomposer);
 
     // Load tile of keys
-    LoadKeys(
-      keys, block_offset, valid_items, default_key, bool_constant_v<FULL_TILE>, bool_constant_v<LOAD_WARP_STRIPED>);
+    if constexpr (FULL_TILE)
+    {
+      if constexpr (LOAD_WARP_STRIPED)
+      {
+        LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys);
+      }
+      else
+      {
+        BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys);
+        __syncthreads();
+      }
+    }
+    else
+    {
+      // Register pressure work-around: moving valid_items through shfl prevents compiler
+      // from reusing guards/addressing from prior guarded loads
+      valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
+      if constexpr (LOAD_WARP_STRIPED)
+      {
+        LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys, valid_items, oob_item);
+      }
+      else
+      {
+        BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys, valid_items, oob_item);
+        __syncthreads();
+      }
+    }
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int KEY = 0; KEY < ITEMS_PER_THREAD; KEY++)
@@ -581,7 +487,10 @@ struct AgentRadixSortDownsweep
     ScatterKeys<FULL_TILE>(keys, relative_bin_offsets, ranks, valid_items);
 
     // Gather/scatter values
-    GatherScatterValues<FULL_TILE>(relative_bin_offsets, ranks, block_offset, valid_items, bool_constant_v<KEYS_ONLY>);
+    if constexpr (!KEYS_ONLY)
+    {
+      GatherScatterValues<FULL_TILE>(relative_bin_offsets, ranks, block_offset, valid_items);
+    }
   }
 
   //---------------------------------------------------------------------

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -405,11 +405,11 @@ struct AgentRadixSortDownsweep
       valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
       if constexpr (LOAD_WARP_STRIPED)
       {
-        LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys, valid_items, oob_item);
+        LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys, valid_items, default_key);
       }
       else
       {
-        BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys, valid_items, oob_item);
+        BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys, valid_items, default_key);
         __syncthreads();
       }
     }

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -327,135 +327,87 @@ struct AgentRadixSortDownsweep
   }
 
   /**
-   * Load a tile of keys (specialized for full tile, block load)
+   * Load a tile of keys (specialized for full tile)
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(
     bit_ordered_type (&keys)[ITEMS_PER_THREAD],
     OffsetT block_offset,
     OffsetT valid_items,
     bit_ordered_type oob_item,
-    ::cuda::std::true_type is_full_tile,
-    ::cuda::std::false_type warp_striped)
+    ::cuda::std::true_type is_full_tile)
   {
-    BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys);
-
-    __syncthreads();
+    if constexpr (LOAD_WARP_STRIPED)
+    {
+      LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys);
+    }
+    else
+    {
+      BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys);
+      __syncthreads();
+    }
   }
 
   /**
-   * Load a tile of keys (specialized for partial tile, block load)
+   * Load a tile of keys (specialized for partial tile)
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(
     bit_ordered_type (&keys)[ITEMS_PER_THREAD],
     OffsetT block_offset,
     OffsetT valid_items,
     bit_ordered_type oob_item,
-    ::cuda::std::false_type is_full_tile,
-    ::cuda::std::false_type warp_striped)
+    ::cuda::std::false_type is_full_tile)
   {
     // Register pressure work-around: moving valid_items through shfl prevents compiler
     // from reusing guards/addressing from prior guarded loads
     valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
 
-    BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys, valid_items, oob_item);
-
-    __syncthreads();
+    if constexpr (LOAD_WARP_STRIPED)
+    {
+      LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys, valid_items, oob_item);
+    }
+    else
+    {
+      BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys, valid_items, oob_item);
+      __syncthreads();
+    }
   }
 
   /**
-   * Load a tile of keys (specialized for full tile, warp-striped load)
+   * Load a tile of values (specialized for full tile)
    */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(
-    bit_ordered_type (&keys)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    bit_ordered_type oob_item,
-    ::cuda::std::true_type is_full_tile,
-    ::cuda::std::true_type warp_striped)
+  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
+    ValueT (&values)[ITEMS_PER_THREAD], OffsetT block_offset, OffsetT valid_items, ::cuda::std::true_type is_full_tile)
   {
-    LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys);
+    if constexpr (LOAD_WARP_STRIPED)
+    {
+      LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values);
+    }
+    else
+    {
+      BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values);
+      __syncthreads();
+    }
   }
 
   /**
-   * Load a tile of keys (specialized for partial tile, warp-striped load)
+   * Load a tile of values (specialized for partial tile)
    */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(
-    bit_ordered_type (&keys)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    bit_ordered_type oob_item,
-    ::cuda::std::false_type is_full_tile,
-    ::cuda::std::true_type warp_striped)
+  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
+    ValueT (&values)[ITEMS_PER_THREAD], OffsetT block_offset, OffsetT valid_items, ::cuda::std::false_type is_full_tile)
   {
     // Register pressure work-around: moving valid_items through shfl prevents compiler
     // from reusing guards/addressing from prior guarded loads
     valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
 
-    LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys, valid_items, oob_item);
-  }
-
-  /**
-   * Load a tile of values (specialized for full tile, block load)
-   */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
-    ValueT (&values)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    ::cuda::std::true_type is_full_tile,
-    ::cuda::std::false_type warp_striped)
-  {
-    BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values);
-
-    __syncthreads();
-  }
-
-  /**
-   * Load a tile of values (specialized for partial tile, block load)
-   */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
-    ValueT (&values)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    ::cuda::std::false_type is_full_tile,
-    ::cuda::std::false_type warp_striped)
-  {
-    // Register pressure work-around: moving valid_items through shfl prevents compiler
-    // from reusing guards/addressing from prior guarded loads
-    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
-
-    BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values, valid_items);
-
-    __syncthreads();
-  }
-
-  /**
-   * Load a tile of items (specialized for full tile, warp-striped load)
-   */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
-    ValueT (&values)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    ::cuda::std::true_type is_full_tile,
-    ::cuda::std::true_type warp_striped)
-  {
-    LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values);
-  }
-
-  /**
-   * Load a tile of items (specialized for partial tile, warp-striped load)
-   */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
-    ValueT (&values)[ITEMS_PER_THREAD],
-    OffsetT block_offset,
-    OffsetT valid_items,
-    ::cuda::std::false_type is_full_tile,
-    ::cuda::std::true_type warp_striped)
-  {
-    // Register pressure work-around: moving valid_items through shfl prevents compiler
-    // from reusing guards/addressing from prior guarded loads
-    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
-
-    LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values, valid_items);
+    if constexpr (LOAD_WARP_STRIPED)
+    {
+      LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values, valid_items);
+    }
+    else
+    {
+      BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values, valid_items);
+      __syncthreads();
+    }
   }
 
   /**
@@ -472,7 +424,7 @@ struct AgentRadixSortDownsweep
 
     __syncthreads();
 
-    LoadValues(values, block_offset, valid_items, bool_constant_v<FULL_TILE>, bool_constant_v<LOAD_WARP_STRIPED>);
+    LoadValues(values, block_offset, valid_items, bool_constant_v<FULL_TILE>);
 
     ScatterValues<FULL_TILE>(values, relative_bin_offsets, ranks, valid_items);
   }
@@ -492,8 +444,7 @@ struct AgentRadixSortDownsweep
       IS_DESCENDING ? traits::min_raw_binary_key(decomposer) : traits::max_raw_binary_key(decomposer);
 
     // Load tile of keys
-    LoadKeys(
-      keys, block_offset, valid_items, default_key, bool_constant_v<FULL_TILE>, bool_constant_v<LOAD_WARP_STRIPED>);
+    LoadKeys(keys, block_offset, valid_items, default_key, bool_constant_v<FULL_TILE>);
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int KEY = 0; KEY < ITEMS_PER_THREAD; KEY++)

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -327,6 +327,138 @@ struct AgentRadixSortDownsweep
   }
 
   /**
+   * Load a tile of keys (specialized for full tile, block load)
+   */
+  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(
+    bit_ordered_type (&keys)[ITEMS_PER_THREAD],
+    OffsetT block_offset,
+    OffsetT valid_items,
+    bit_ordered_type oob_item,
+    ::cuda::std::true_type is_full_tile,
+    ::cuda::std::false_type warp_striped)
+  {
+    BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys);
+
+    __syncthreads();
+  }
+
+  /**
+   * Load a tile of keys (specialized for partial tile, block load)
+   */
+  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(
+    bit_ordered_type (&keys)[ITEMS_PER_THREAD],
+    OffsetT block_offset,
+    OffsetT valid_items,
+    bit_ordered_type oob_item,
+    ::cuda::std::false_type is_full_tile,
+    ::cuda::std::false_type warp_striped)
+  {
+    // Register pressure work-around: moving valid_items through shfl prevents compiler
+    // from reusing guards/addressing from prior guarded loads
+    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
+
+    BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys, valid_items, oob_item);
+
+    __syncthreads();
+  }
+
+  /**
+   * Load a tile of keys (specialized for full tile, warp-striped load)
+   */
+  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(
+    bit_ordered_type (&keys)[ITEMS_PER_THREAD],
+    OffsetT block_offset,
+    OffsetT valid_items,
+    bit_ordered_type oob_item,
+    ::cuda::std::true_type is_full_tile,
+    ::cuda::std::true_type warp_striped)
+  {
+    LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys);
+  }
+
+  /**
+   * Load a tile of keys (specialized for partial tile, warp-striped load)
+   */
+  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(
+    bit_ordered_type (&keys)[ITEMS_PER_THREAD],
+    OffsetT block_offset,
+    OffsetT valid_items,
+    bit_ordered_type oob_item,
+    ::cuda::std::false_type is_full_tile,
+    ::cuda::std::true_type warp_striped)
+  {
+    // Register pressure work-around: moving valid_items through shfl prevents compiler
+    // from reusing guards/addressing from prior guarded loads
+    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
+
+    LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys, valid_items, oob_item);
+  }
+
+  /**
+   * Load a tile of values (specialized for full tile, block load)
+   */
+  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
+    ValueT (&values)[ITEMS_PER_THREAD],
+    OffsetT block_offset,
+    OffsetT valid_items,
+    ::cuda::std::true_type is_full_tile,
+    ::cuda::std::false_type warp_striped)
+  {
+    BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values);
+
+    __syncthreads();
+  }
+
+  /**
+   * Load a tile of values (specialized for partial tile, block load)
+   */
+  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
+    ValueT (&values)[ITEMS_PER_THREAD],
+    OffsetT block_offset,
+    OffsetT valid_items,
+    ::cuda::std::false_type is_full_tile,
+    ::cuda::std::false_type warp_striped)
+  {
+    // Register pressure work-around: moving valid_items through shfl prevents compiler
+    // from reusing guards/addressing from prior guarded loads
+    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
+
+    BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values, valid_items);
+
+    __syncthreads();
+  }
+
+  /**
+   * Load a tile of items (specialized for full tile, warp-striped load)
+   */
+  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
+    ValueT (&values)[ITEMS_PER_THREAD],
+    OffsetT block_offset,
+    OffsetT valid_items,
+    ::cuda::std::true_type is_full_tile,
+    ::cuda::std::true_type warp_striped)
+  {
+    LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values);
+  }
+
+  /**
+   * Load a tile of items (specialized for partial tile, warp-striped load)
+   */
+  _CCCL_DEVICE _CCCL_FORCEINLINE void LoadValues(
+    ValueT (&values)[ITEMS_PER_THREAD],
+    OffsetT block_offset,
+    OffsetT valid_items,
+    ::cuda::std::false_type is_full_tile,
+    ::cuda::std::true_type warp_striped)
+  {
+    // Register pressure work-around: moving valid_items through shfl prevents compiler
+    // from reusing guards/addressing from prior guarded loads
+    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
+
+    LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values, valid_items);
+  }
+
+  /**
    * Truck along associated values
    */
   template <bool FULL_TILE>
@@ -340,33 +472,7 @@ struct AgentRadixSortDownsweep
 
     __syncthreads();
 
-    if constexpr (FULL_TILE)
-    {
-      if constexpr (LOAD_WARP_STRIPED)
-      {
-        LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values);
-      }
-      else
-      {
-        BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values);
-        __syncthreads();
-      }
-    }
-    else
-    {
-      // Register pressure work-around: moving valid_items through shfl prevents compiler
-      // from reusing guards/addressing from prior guarded loads
-      valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
-      if constexpr (LOAD_WARP_STRIPED)
-      {
-        LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values, valid_items);
-      }
-      else
-      {
-        BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values, valid_items);
-        __syncthreads();
-      }
-    }
+    LoadValues(values, block_offset, valid_items, bool_constant_v<FULL_TILE>, bool_constant_v<LOAD_WARP_STRIPED>);
 
     ScatterValues<FULL_TILE>(values, relative_bin_offsets, ranks, valid_items);
   }
@@ -386,33 +492,8 @@ struct AgentRadixSortDownsweep
       IS_DESCENDING ? traits::min_raw_binary_key(decomposer) : traits::max_raw_binary_key(decomposer);
 
     // Load tile of keys
-    if constexpr (FULL_TILE)
-    {
-      if constexpr (LOAD_WARP_STRIPED)
-      {
-        LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys);
-      }
-      else
-      {
-        BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys);
-        __syncthreads();
-      }
-    }
-    else
-    {
-      // Register pressure work-around: moving valid_items through shfl prevents compiler
-      // from reusing guards/addressing from prior guarded loads
-      valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
-      if constexpr (LOAD_WARP_STRIPED)
-      {
-        LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys, valid_items, default_key);
-      }
-      else
-      {
-        BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys, valid_items, default_key);
-        __syncthreads();
-      }
-    }
+    LoadKeys(
+      keys, block_offset, valid_items, default_key, bool_constant_v<FULL_TILE>, bool_constant_v<LOAD_WARP_STRIPED>);
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int KEY = 0; KEY < ITEMS_PER_THREAD; KEY++)

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -641,8 +641,7 @@ struct AgentRadixSortOnesweep
     }
   }
 
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  GatherScatterValues(int (&ranks)[ITEMS_PER_THREAD], ::cuda::std::false_type keys_only)
+  _CCCL_DEVICE _CCCL_FORCEINLINE void GatherScatterValues(int (&ranks)[ITEMS_PER_THREAD])
   {
     // compute digits corresponding to the keys
     int digits[ITEMS_PER_THREAD];
@@ -659,10 +658,6 @@ struct AgentRadixSortOnesweep
     __syncthreads();
     ScatterValuesGlobal(digits);
   }
-
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  GatherScatterValues(int (&ranks)[ITEMS_PER_THREAD], ::cuda::std::true_type keys_only)
-  {}
 
   _CCCL_DEVICE _CCCL_FORCEINLINE void Process()
   {
@@ -693,7 +688,10 @@ struct AgentRadixSortOnesweep
     ScatterKeysGlobal();
 
     // scatter values if necessary
-    GatherScatterValues(ranks, bool_constant_v<KEYS_ONLY>);
+    if constexpr (!KEYS_ONLY)
+    {
+      GatherScatterValues(ranks);
+    }
   }
 
   _CCCL_DEVICE _CCCL_FORCEINLINE //


### PR DESCRIPTION
Pulled out of #4881.

- [x] The PR "was verified to produce byte-identical SASS across sm_75/86/90/120 for both cub.bench.radix_sort.keys.base and cub.bench.radix_sort.pairs.base."