### PR TITLE
[libcu++] Try and reuse as the same function for tuple SFINAE

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -182,6 +182,9 @@ public:
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::move(__t))
   {}
 
+  // NOTE: The SFINAE here is delicate and should not be changed without extensive testing
+  // We cannot change the SFINAE to class = enable_if because NVCC cannot differentiate the explicit/implicit overload
+  // We cannot change the __select_constructor _Constraints to a type alias because MSVC cannot handle that
   template <class... _UTypes,
             enable_if_t<_DisambiguateVariadic<_UTypes...>::value, int> = 0,
             __select_constructor _Constraints =
@@ -264,14 +267,6 @@ public:
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_TupleOfIteratorReferences>(__t))
   {}
   // NOLINTEND(bugprone-forwarding-reference-overload)
-
-  template <class _Tuple>
-  using _TupleLikeConstructible =
-    _ConstructorConstraint<__tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>>;
-
-  template <class _Tuple>
-  using _NothrowTupleLikeConstructible =
-    bool_constant<__tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<_Tuple>>;
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&>::value, int> = 0,
@@ -385,6 +380,14 @@ public:
             enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(const tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
+  template <class _Tuple>
+  using _TupleLikeConstructible =
+    _ConstructorConstraint<__tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>>;
+
+  template <class _Tuple>
+  using _NothrowTupleLikeConstructible =
+    bool_constant<__tuple_constraints<_Tp...>::template __nothrow_tuple_like_constructible_v<_Tuple>>;
 
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
   template <class _Tuple,

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -55,6 +55,26 @@ private:
 
   _BaseT __base_;
 
+#if _CCCL_COMPILER(MSVC)
+  // MSVC crashes when the disambiguation functions are called directly inside an enable_if while synthesizing
+  // the implicit deduction guides, so go through a variable template wrapped into a bool_constant
+  template <class... _UTypes>
+  using _DisambiguateVariadic =
+    bool_constant<__tuple_constraints<_Tp...>::template __disambiguate_variadic_v<_UTypes...>>;
+
+  template <class _UTuple>
+  using _DisambiguateTupleLike =
+    bool_constant<__tuple_constraints<_Tp...>::template __disambiguate_tuple_like_v<_UTuple>>;
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
+  template <class... _UTypes>
+  using _DisambiguateVariadic =
+    bool_constant<__tuple_constraints<_Tp...>::template __disambiguate_variadic_constructible<_UTypes...>()>;
+
+  template <class _UTuple>
+  using _DisambiguateTupleLike =
+    bool_constant<__tuple_constraints<_Tp...>::template __disambiguate_tuple_like<_UTuple>()>;
+#endif // !_CCCL_COMPILER(MSVC)
+
 public:
   template <size_t _Ip>
   _CCCL_API constexpr tuple_element_t<_Ip, tuple>& __get_impl() & noexcept
@@ -162,38 +182,39 @@ public:
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::move(__t))
   {}
 
-  template <class... _UTypes>
-  using _VariadicConstructible =
-    _ConstructorConstraint<__tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>()>;
-
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int>                      = 0, // Help Clang disambiguate for CTAD,
-            class _Constraints                                         = _VariadicConstructible<_UTypes...>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            enable_if_t<_DisambiguateVariadic<_UTypes...>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int>                      = 0, // Help Clang disambiguate for CTAD
-            class _Constraints                                         = _VariadicConstructible<_UTypes...>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            enable_if_t<_DisambiguateVariadic<_UTypes...>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(_UTypes&&... __u) noexcept((is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int>        = 0, // Help Clang disambiguate for CTAD
-            class _Constraints                           = _VariadicConstructible<_UTypes...>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            enable_if_t<_DisambiguateVariadic<_UTypes...>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(_UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _Alloc,
             class... _UTypes,
-            class _Constraints                                         = _VariadicConstructible<_UTypes...>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            enable_if_t<_DisambiguateVariadic<_UTypes...>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API inline tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
     (is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
@@ -201,8 +222,10 @@ public:
 
   template <class _Alloc,
             class... _UTypes,
-            class _Constraints                                         = _VariadicConstructible<_UTypes...>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            enable_if_t<_DisambiguateVariadic<_UTypes...>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API inline explicit tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
     (is_nothrow_constructible_v<_Tp, _UTypes> && ...))
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
@@ -211,8 +234,10 @@ public:
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Alloc,
             class... _UTypes,
-            class _Constraints                           = _VariadicConstructible<_UTypes...>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            enable_if_t<_DisambiguateVariadic<_UTypes...>::value, int> = 0,
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
@@ -241,18 +266,6 @@ public:
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
   template <class _Tuple>
-  using _DisambiguateTupleLike = bool_constant<
-    // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
-    !__is_cuda_std_ranges_subrange_v<remove_cvref_t<_Tuple>>
-    // Disambiguates the copy and move constructor
-    && !is_same_v<_Tuple, const tuple&>
-    && !is_same_v<_Tuple, tuple&&> //
-    // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
-    // [tuple#cnstr]-25.1: sizeof...(Types) is 2, (pair constructor)
-    // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
-    && __tuple_like_with_size<_Tuple, sizeof...(_Tp)>>;
-
-  template <class _Tuple>
   using _TupleLikeConstructible =
     _ConstructorConstraint<__tuple_constraints<_Tp...>::template __select_tuple_like_constructible_v<_Tuple>>;
 
@@ -262,103 +275,114 @@ public:
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&>::value, int> = 0,
-            class _Constraints                                         = _TupleLikeConstructible<tuple<_UTypes...>&>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(_NothrowTupleLikeConstructible<tuple<_UTypes...>&>::value)
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes&...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept((is_nothrow_constructible_v<_Tp, _UTypes&> && ...))
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&>::value, int> = 0,
-            class _Constraints                                         = _TupleLikeConstructible<tuple<_UTypes...>&>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
-  _CCCL_API explicit constexpr tuple(tuple<_UTypes...>& __t) noexcept(
-    _NothrowTupleLikeConstructible<tuple<_UTypes...>&>::value)
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes&...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
+  _CCCL_API explicit constexpr tuple(tuple<_UTypes...>& __t) noexcept((is_nothrow_constructible_v<_Tp, _UTypes&> && ...))
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&>::value, int> = 0,
-            class _Constraints                           = _TupleLikeConstructible<tuple<_UTypes...>&>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes&...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&>::value, int> = 0,
-            class _Constraints = _TupleLikeConstructible<const tuple<_UTypes...>&>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<const _UTypes&...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
-    _NothrowTupleLikeConstructible<const tuple<_UTypes...>&>::value)
+    (is_nothrow_constructible_v<_Tp, const _UTypes&> && ...))
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&>::value, int> = 0,
-            class _Constraints = _TupleLikeConstructible<const tuple<_UTypes...>&>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<const _UTypes&...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>& __t) noexcept(
-    _NothrowTupleLikeConstructible<const tuple<_UTypes...>&>::value)
+    (is_nothrow_constructible_v<_Tp, const _UTypes&> && ...))
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&>::value, int> = 0,
-            class _Constraints                           = _TupleLikeConstructible<const tuple<_UTypes...>&>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<const _UTypes&...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&&>::value, int> = 0,
-            class _Constraints                                         = _TupleLikeConstructible<tuple<_UTypes...>&&>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
-  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(_NothrowTupleLikeConstructible<tuple<_UTypes...>&&>::value)
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes&&...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
+  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept((is_nothrow_constructible_v<_Tp, _UTypes&&> && ...))
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&&>::value, int> = 0,
-            class _Constraints                                         = _TupleLikeConstructible<tuple<_UTypes...>&&>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes&&...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>&& __t) noexcept(
-    _NothrowTupleLikeConstructible<tuple<_UTypes...>&&>::value)
+    (is_nothrow_constructible_v<_Tp, _UTypes&&> && ...))
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<tuple<_UTypes...>&&>::value, int> = 0,
-            class _Constraints                           = _TupleLikeConstructible<tuple<_UTypes...>&&>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<_UTypes&&...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&&>::value, int> = 0,
-            class _Constraints = _TupleLikeConstructible<const tuple<_UTypes...>&&>,
-            enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<const _UTypes&&...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
-    _NothrowTupleLikeConstructible<const tuple<_UTypes...>&&>::value)
+    (is_nothrow_constructible_v<_Tp, const _UTypes&&> && ...))
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&&>::value, int> = 0,
-            class _Constraints = _TupleLikeConstructible<const tuple<_UTypes...>&&>,
-            enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<const _UTypes&&...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(
-    _NothrowTupleLikeConstructible<const tuple<_UTypes...>&&>::value)
+    (is_nothrow_constructible_v<_Tp, const _UTypes&&> && ...))
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
             enable_if_t<_DisambiguateTupleLike<const tuple<_UTypes...>&&>::value, int> = 0,
-            class _Constraints                           = _TupleLikeConstructible<const tuple<_UTypes...>&&>,
-            enable_if_t<_Constraints::__is_deleted, int> = 0>
+            __select_constructor _Constraints =
+              __tuple_constraints<_Tp...>::template __select_variadic_constructible<const _UTypes&&...>(),
+            enable_if_t<_ConstructorConstraint<_Constraints>::__is_deleted, int> = 0>
   constexpr tuple(const tuple<_UTypes...>&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
@@ -390,7 +414,7 @@ public:
 
   template <class _Alloc,
             class _Tuple,
-            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int>    = 0, // Help Clang disambiguate for CTAD
+            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int>    = 0,
             class _Constraints                                         = _TupleLikeConstructible<_Tuple>,
             enable_if_t<_Constraints::__can_construct_implicitly, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
@@ -400,7 +424,7 @@ public:
 
   template <class _Alloc,
             class _Tuple,
-            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int>    = 0, // Help Clang disambiguate for CTAD
+            enable_if_t<_DisambiguateTupleLike<_Tuple>::value, int>    = 0,
             class _Constraints                                         = _TupleLikeConstructible<_Tuple>,
             enable_if_t<_Constraints::__can_construct_explicitly, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t) noexcept(
@@ -442,11 +466,14 @@ public:
     return *this;
   }
 
+  template <bool _IsConst, class... _UTypes>
+  using _ConvertingAssignable =
+    bool_constant<__tuple_constraints<_Tp...>::template __select_converting_assignable<_IsConst, _UTypes...>()>;
+
   // [tuple.assign]-15
   template <class... _UTypes,
-            bool _Constraints = __tuple_constraints<
-              _Tp...>::template __select_converting_assignable</*__is_const=*/false, const _UTypes&...>(),
-            enable_if_t<_Constraints, int> = 0>
+            class _Constraints                    = _ConvertingAssignable</*__is_const=*/false, const _UTypes&...>,
+            enable_if_t<_Constraints::value, int> = 0>
   _CCCL_API constexpr tuple&
   operator=(const tuple<_UTypes...>& __t) noexcept((is_nothrow_assignable_v<_Tp&, const _UTypes&> && ...))
   {
@@ -456,9 +483,8 @@ public:
 
   // [tuple.assign]-18
   template <class... _UTypes,
-            bool _Constraints = __tuple_constraints<
-              _Tp...>::template __select_converting_assignable</*__is_const=*/true, const _UTypes&...>(),
-            enable_if_t<_Constraints, int> = 0>
+            class _Constraints                    = _ConvertingAssignable</*__is_const=*/true, const _UTypes&...>,
+            enable_if_t<_Constraints::value, int> = 0>
   _CCCL_API constexpr const tuple& operator=(const tuple<_UTypes...>& __t) const
     noexcept((is_nothrow_assignable_v<const _Tp&, const _UTypes&> && ...))
   {
@@ -468,9 +494,8 @@ public:
 
   // [tuple.assign]-21
   template <class... _UTypes,
-            bool _Constraints =
-              __tuple_constraints<_Tp...>::template __select_converting_assignable</*__is_const=*/false, _UTypes...>(),
-            enable_if_t<_Constraints, int> = 0>
+            class _Constraints                    = _ConvertingAssignable</*__is_const=*/false, _UTypes...>,
+            enable_if_t<_Constraints::value, int> = 0>
   _CCCL_API constexpr tuple& operator=(tuple<_UTypes...>&& __t) noexcept((is_nothrow_assignable_v<_Tp&, _UTypes> && ...))
   {
     ::cuda::std::__memberwise_forward_assign(
@@ -480,9 +505,8 @@ public:
 
   // [tuple.assign]-24
   template <class... _UTypes,
-            bool _Constraints =
-              __tuple_constraints<_Tp...>::template __select_converting_assignable</*__is_const=*/true, _UTypes...>(),
-            enable_if_t<_Constraints, int> = 0>
+            class _Constraints                    = _ConvertingAssignable</*__is_const=*/true, _UTypes...>,
+            enable_if_t<_Constraints::value, int> = 0>
   _CCCL_API constexpr const tuple& operator=(tuple<_UTypes...>&& __t) const
     noexcept((is_nothrow_assignable_v<const _Tp&, _UTypes> && ...))
   {
@@ -491,14 +515,21 @@ public:
     return *this;
   }
 
+  template <bool _IsConst, class _UTuple>
+  using _TupleLikeAssignable =
+    bool_constant<__tuple_constraints<_Tp...>::template __select_tuple_like_assignable<_IsConst, _UTuple>()>;
+
+  template <bool _IsConst, class _UTuple>
+  using _NothrowTupleLikeAssignable =
+    bool_constant<__tuple_constraints<_Tp...>::template __nothrow_tuple_like_assignable<_IsConst, _UTuple>()>;
+
   // [tuple.assign]-39
   template <class _UTuple,
             enable_if_t<!__is_cuda_std_tuple<remove_cvref_t<_UTuple>>, int> = 0,
-            bool _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_assignable</*__is_const=*/false, _UTuple>(),
-            enable_if_t<_Constraints, int> = 0>
-  _CCCL_API constexpr tuple& operator=(_UTuple&& __t) noexcept(
-    __tuple_constraints<_Tp...>::template __nothrow_tuple_like_assignable</*__is_const=*/false, _UTuple>())
+            class _Constraints                    = _TupleLikeAssignable</*__is_const=*/false, _UTuple>,
+            enable_if_t<_Constraints::value, int> = 0>
+  _CCCL_API constexpr tuple&
+  operator=(_UTuple&& __t) noexcept(_NothrowTupleLikeAssignable</*__is_const=*/false, _UTuple>::value)
   {
     ::cuda::std::__memberwise_tuple_assign(
       *this, ::cuda::std::forward<_UTuple>(__t), __make_tuple_indices_t<sizeof...(_Tp)>{});
@@ -508,11 +539,10 @@ public:
   // [tuple.assign]-42
   template <class _UTuple,
             enable_if_t<!__is_cuda_std_tuple<remove_cvref_t<_UTuple>>, int> = 0,
-            bool _Constraints =
-              __tuple_constraints<_Tp...>::template __select_tuple_like_assignable</*__is_const=*/true, _UTuple>(),
-            enable_if_t<_Constraints, int> = 0>
+            class _Constraints                    = _TupleLikeAssignable</*__is_const=*/true, _UTuple>,
+            enable_if_t<_Constraints::value, int> = 0>
   _CCCL_API constexpr const tuple& operator=(_UTuple&& __t) const
-    noexcept(__tuple_constraints<_Tp...>::template __nothrow_tuple_like_assignable</*__is_const=*/true, _UTuple>())
+    noexcept(_NothrowTupleLikeAssignable</*__is_const=*/true, _UTuple>::value)
   {
     ::cuda::std::__memberwise_tuple_assign(
       *this, ::cuda::std::forward<_UTuple>(__t), __make_tuple_indices_t<sizeof...(_Tp)>{});

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -240,6 +240,12 @@ struct __tuple_constraints
     {
       return __select_constructor::__invalid;
     }
+#if _CCCL_COMPILER(GCC, <, 8) // Old GCC eagerly instantiates __select_variadic_constructible
+    else if constexpr (!__disambiguate_variadic_constructible<_UTypes...>())
+    {
+      return __select_constructor::__invalid;
+    }
+#endif // _CCCL_COMPILER(GCC, <, 8)
     else if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
     { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
       return __select_constructor::__invalid;

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -136,49 +136,109 @@ struct __tuple_constraints
     }
   }
 
-  template <class... _UTypes, enable_if_t<sizeof...(_UTypes) != 1, int> = 0>
+  template <class... _UTypes>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool __disambiguate_variadic_constructible() noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (sizeof...(_Types) == 0)
+    {
+      return false;
+    }
+    else if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
+    {
+      return false;
+    }
+    else if constexpr (sizeof...(_Types) == 1)
+    { // [tuple.cnstr]-12.1: negation<is_same<remove_cvref_t<U0>, tuple>> if sizeof...(Types) is 1
+      using _U0 = __type_index_c<0, _UTypes...>;
+      using _T0 = __type_index_c<0, _Types...>;
+      return !is_same_v<remove_cvref_t<_U0>, tuple<_T0>>;
+    }
+    else if constexpr (sizeof...(_Types) == 2 || sizeof...(_Types) == 3)
+    { // [tuple.cnstr]-12.2: otherwise, if sizeof...(Types) is 2 or 3
+      // [tuple.cnstr]-13.3: !is_same_v<remove_cvref_t<U0>, allocator_arg_t> || is_same_v<remove_cvref_t<T0>,
+      // allocator_arg_t>>
+      using _U0 = __type_index_c<0, _UTypes...>;
+      using _T0 = __type_index_c<0, _Types...>;
+      return !is_same_v<remove_cvref_t<_U0>, allocator_arg_t> || is_same_v<remove_cvref_t<_T0>, allocator_arg_t>;
+    }
+    else
+    {
+      return true;
+    }
+    // NOLINTEND(bugprone-branch-clone)
+  }
+
+  template <class _UTuple>
+  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL bool __disambiguate_tuple_like() noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (sizeof...(_Types) == 0)
+    {
+      return false;
+    }
+    else if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
+    { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
+      return false;
+    }
+    else if constexpr (is_same_v<_UTuple, const tuple<_Types...>&> || is_same_v<_UTuple, tuple<_Types...>&&>)
+    { // Prefers the copy/move constructor
+      return false;
+    }
+    else if constexpr (!__tuple_like_with_size<_UTuple, sizeof...(_Types)>)
+    { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
+      // [tuple#cnstr]-25.1: sizeof...(Types) is 2, (pair constructor)
+      // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
+      return false;
+    }
+    else if constexpr (sizeof...(_Types) == 1)
+    {
+      using _U0 = tuple_element_t<0, remove_cvref_t<_UTuple>>;
+      using _T0 = __type_index_c<0, _Types...>;
+      if constexpr (__is_cuda_std_tuple<remove_cvref_t<_UTuple>> && is_same_v<_T0, _U0>)
+      { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1
+        // [tuple#cnstr]-21.3: is_same_v<T, U> is false
+        return false;
+      }
+      else if constexpr (is_constructible_v<_T0, _UTuple>)
+      { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
+        // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
+        return false;
+      }
+      else if constexpr (is_convertible_v<_UTuple, _T0>)
+      { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
+        // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
+        return false;
+      }
+      else
+      {
+        return true;
+      }
+    }
+    else
+    {
+      return true;
+    }
+    // NOLINTEND(bugprone-branch-clone)
+  }
+
+#if _CCCL_COMPILER(MSVC)
+  // MSVC crashes when the disambiguation functions are called directly inside an enable_if while synthesizing
+  // the implicit deduction guides, so go through a variable template wrapped into a bool_constant
+  template <class... _UTypes>
+  static constexpr bool __disambiguate_variadic_v = __disambiguate_variadic_constructible<_UTypes...>();
+
+  template <class _UTuple>
+  static constexpr bool __disambiguate_tuple_like_v = __disambiguate_tuple_like<_UTuple>();
+#endif // _CCCL_COMPILER(MSVC)
+
+  template <class... _UTypes>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor __select_variadic_constructible() noexcept
   {
     // NOLINTBEGIN(bugprone-branch-clone)
     if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
-    { // [tuple.cnstr]-13.1: sizeof...(Types) equals sizeof...(UTypes),
+    {
       return __select_constructor::__invalid;
-    }
-    else if constexpr (sizeof...(_Types) == 0)
-    { // [tuple.cnstr]-13.2: sizeof...(Types) >= 1,
-      return __select_constructor::__invalid;
-    }
-    else if constexpr (sizeof...(_Types) == 2 || sizeof...(_Types) == 3)
-    { // [tuple.cnstr]-12.2: otherwise, if sizeof...(Types) is 2 or 3
-      using _U0 = __type_index_c<0, _UTypes...>;
-      using _T0 = __type_index_c<0, _Types...>;
-      if constexpr (!is_same_v<remove_cvref_t<_U0>, allocator_arg_t> || is_same_v<remove_cvref_t<_T0>, allocator_arg_t>)
-      { // [tuple.cnstr]-13.3: !is_same_v<remove_cvref_t<U0>, allocator_arg_t> || is_same_v<remove_cvref_t<T0>,
-        // allocator_arg_t>>
-        if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
-        { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
-          return __select_constructor::__invalid;
-        }
-#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-        else if constexpr ((reference_constructs_from_temporary_v<_Types, _UTypes&&> || ...))
-        { // [tuple.cnstr]-15: This constructor is defined as deleted if
-          // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
-          return __select_constructor::__deleted;
-        }
-#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-        else if constexpr (!(is_convertible_v<_UTypes, _Types> && ...))
-        { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
-          return __select_constructor::__explicit;
-        }
-        else
-        {
-          return __select_constructor::__implicit;
-        }
-      }
-      else
-      {
-        return __select_constructor::__invalid;
-      }
     }
     else if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
     { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
@@ -198,60 +258,6 @@ struct __tuple_constraints
     else
     {
       return __select_constructor::__implicit;
-    }
-    // NOLINTEND(bugprone-branch-clone)
-  }
-
-  template <class _UType>
-  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor __select_variadic_constructible() noexcept
-  {
-    // NOLINTBEGIN(bugprone-branch-clone)
-    if constexpr (sizeof...(_Types) != 1)
-    { // [tuple.cnstr]-13.1: sizeof...(Types) equals sizeof...(UTypes),
-      return __select_constructor::__invalid;
-    }
-    else if constexpr (sizeof...(_Types) == 0)
-    { // [tuple.cnstr]-13.2: sizeof...(Types) >= 1,
-      return __select_constructor::__invalid;
-    }
-    else
-    {
-      using _Type = __type_index_c<0, _Types...>;
-      // Reject unpacking a tuple_of_iterator_references through the 1-arg variadic constructor so the
-      // dedicated constructor is used instead. Do allow it if the original type is a tuple_of_iterator_references
-      // though
-      if constexpr (__is_tuple_of_iterator_references_v<remove_cvref_t<_UType>>
-                    && !__is_tuple_of_iterator_references_v<remove_cvref_t<_Type>>)
-      {
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (is_same_v<remove_cvref_t<_UType>, tuple<_Type>>)
-      { // [tuple.cnstr]-12.1: negation<is_same<remove_cvref_t<U0>, tuple>> if sizeof...(Types) is 1
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (is_same_v<_UType, const _Type&> || is_same_v<_UType, _Type&&>)
-      {
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (!is_constructible_v<_Type, _UType>)
-      { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
-        return __select_constructor::__invalid;
-      }
-#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-      else if constexpr (reference_constructs_from_temporary_v<_Type, _UType&&>)
-      { // [tuple.cnstr]-15: This constructor is defined as deleted if
-        // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
-        return __select_constructor::__deleted;
-      }
-#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-      else if constexpr (!is_convertible_v<_UType, _Type>)
-      { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
-        return __select_constructor::__explicit;
-      }
-      else
-      {
-        return __select_constructor::__implicit;
-      }
     }
     // NOLINTEND(bugprone-branch-clone)
   }
@@ -277,10 +283,14 @@ struct __tuple_constraints
     { // MSVC has issues with constexpr variables here, so no constexpr variable
       using __arg_list        = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_UTypes)>;
       using __arg_constraints = decltype(::cuda::std::__tuple_get_constraints(__arg_list{}));
-      if constexpr (__arg_constraints::template __select_variadic_constructible<_UTypes...>()
-                      == __select_constructor::__invalid
-                    || __arg_constraints::template __select_variadic_constructible<_UTypes...>()
-                         == __select_constructor::__deleted)
+      if constexpr (!__arg_constraints::template __disambiguate_variadic_constructible<_UTypes...>())
+      {
+        return __select_constructor::__invalid;
+      }
+      else if constexpr (__arg_constraints::template __select_variadic_constructible<_UTypes...>()
+                           == __select_constructor::__invalid
+                         || __arg_constraints::template __select_variadic_constructible<_UTypes...>()
+                              == __select_constructor::__deleted)
       {
         return __select_constructor::__invalid;
       }
@@ -307,133 +317,8 @@ struct __tuple_constraints
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
   __select_tuple_like_constructible(__tuple_indices<_Indices...>) noexcept
   {
-    if constexpr (sizeof...(_Types) != sizeof...(_Indices))
-    {
-      return __select_constructor::__invalid;
-    }
-    else
-    {
-      using ::cuda::std::get;
-      // NOLINTBEGIN(bugprone-branch-clone)
-      if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
-      { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (is_same_v<_UTuple, const tuple<_Types...>&> || is_same_v<_UTuple, tuple<_Types...>&&>)
-      { // Prefers the copy/move constructor
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (sizeof...(_Types) == 0)
-      { // Avoids issues with the size 1 constructor below
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (!__tuple_like_with_size<_UTuple, sizeof...(_Types)>)
-      { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
-        // [tuple#cnstr]-25.1: sizeof...(Types) is 2,
-        // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (!(is_constructible_v<_Types, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
-      { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-        // [tuple.cnstr]-25.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-        // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-        return __select_constructor::__invalid;
-      }
-#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-      else if constexpr ((reference_constructs_from_temporary_v<_Types,
-                                                                decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))>
-                          || ...))
-      { // [tuple.cnstr]-23: This constructor is defined as deleted if
-        // [tuple.cnstr]-27: This constructor is defined as deleted if
-        // [tuple.cnstr]-31: This constructor is defined as deleted if
-        // (reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...) is true
-        return __select_constructor::__deleted;
-      }
-#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-      else if constexpr (!(is_convertible_v<decltype(get<_Indices>(::cuda::std::declval<_UTuple>())), _Types> && ...))
-      { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
-        // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
-        // [tuple.cnstr]-31: The expression inside explicit is equivalent to:
-        // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
-        return __select_constructor::__explicit;
-      }
-      else
-      {
-        return __select_constructor::__implicit;
-      }
-    }
-    // NOLINTEND(bugprone-branch-clone)
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _UTuple, size_t _Index>
-  [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
-  __select_tuple_like_constructible(__tuple_indices<_Index>) noexcept
-  {
-    if constexpr (sizeof...(_Types) != 1)
-    {
-      return __select_constructor::__invalid;
-    }
-    else
-    {
-      using _Type = __type_index_c<0, _Types...>;
-      using ::cuda::std::get;
-      // NOLINTBEGIN(bugprone-branch-clone)
-      if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
-      { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (is_same_v<_UTuple, const tuple<_Type>&> || is_same_v<_UTuple, tuple<_Type>&&>)
-      { // Prefers the copy/move constructor
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (!__tuple_like_with_size<_UTuple, 1>)
-      { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
-        // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (__is_cuda_std_tuple<remove_cvref_t<_UTuple>>
-                         && is_same_v<_Type, tuple_element_t<_Index, remove_cvref_t<_UTuple>>>)
-      { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1
-        // [tuple#cnstr]-21.3: is_same_v<T, U> is false
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (is_constructible_v<_Type, _UTuple>)
-      { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
-        // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (is_convertible_v<_UTuple, _Type>)
-      { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
-        // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
-        return __select_constructor::__invalid;
-      }
-      else if constexpr (!is_constructible_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
-      { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-        // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-        return __select_constructor::__invalid;
-      }
-#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-      else if constexpr (reference_constructs_from_temporary_v<_Type,
-                                                               decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
-      { // [tuple.cnstr]-23: This constructor is defined as deleted if
-        // [tuple.cnstr]-31: This constructor is defined as deleted if
-        // (reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...) is true
-        return __select_constructor::__deleted;
-      }
-#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-      else if constexpr (!is_convertible_v<decltype(get<_Index>(::cuda::std::declval<_UTuple>())), _Type>)
-      { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
-        // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
-        // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
-        return __select_constructor::__explicit;
-      }
-      else
-      {
-        return __select_constructor::__implicit;
-      }
-    }
-    // NOLINTEND(bugprone-branch-clone)
+    using ::cuda::std::get;
+    return __select_variadic_constructible<decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))...>();
   }
 
   template <class _UTuple>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -317,8 +317,17 @@ struct __tuple_constraints
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL __select_constructor
   __select_tuple_like_constructible(__tuple_indices<_Indices...>) noexcept
   {
-    using ::cuda::std::get;
-    return __select_variadic_constructible<decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))...>();
+#if _CCCL_COMPILER(GCC, <, 8) // Old GCC eagerly instantiates __select_tuple_like_constructible_impl
+    if constexpr (!__disambiguate_tuple_like<_UTuple>())
+    {
+      return __select_constructor::__invalid;
+    }
+    else
+#endif // _CCCL_COMPILER(GCC, <, 8)
+    {
+      using ::cuda::std::get;
+      return __select_variadic_constructible<decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))...>();
+    }
   }
 
   template <class _UTuple>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_leaf.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_leaf.h
@@ -63,15 +63,13 @@ enum class __tuple_leaf_specialization
 
 //! @brief Detects whether we need to synthesize the assignment operator for reference types or can use EBCO
 template <class _Tp>
-_CCCL_API constexpr __tuple_leaf_specialization __tuple_leaf_choose()
-{
-  return is_empty_v<_Tp> && !is_final_v<_Tp> ? __tuple_leaf_specialization::__empty_non_final
-       : __must_synthesize_assignment_v<_Tp>
-         ? __tuple_leaf_specialization::__synthesize_assignment
-         : __tuple_leaf_specialization::__default;
-}
+inline constexpr __tuple_leaf_specialization __tuple_leaf_choose =
+  is_empty_v<_Tp> && !is_final_v<_Tp> ? __tuple_leaf_specialization::__empty_non_final
+  : __must_synthesize_assignment_v<_Tp>
+    ? __tuple_leaf_specialization::__synthesize_assignment
+    : __tuple_leaf_specialization::__default;
 
-template <size_t _Ip, class _Hp, __tuple_leaf_specialization = __tuple_leaf_choose<_Hp>()>
+template <size_t _Ip, class _Hp, __tuple_leaf_specialization = __tuple_leaf_choose<_Hp>>
 class __tuple_leaf;
 
 _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/test_lazy_sfinae.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/test_lazy_sfinae.pass.cpp
@@ -112,10 +112,23 @@ TEST_FUNC void test_const_Types_lazy_sfinae()
   assert(cuda::std::get<0>(t).value == 42);
 }
 
+struct NonTupleLike
+{
+  int value;
+};
+
+TEST_FUNC void test_non_tuple_like_lazy_sfinae()
+{
+  NonTupleLike value{42};
+  cuda::std::tuple<NonTupleLike> tuple = cuda::std::make_tuple(value);
+  assert(cuda::std::get<0>(tuple).value == 42);
+}
+
 int main(int, char**)
 {
   test_tuple_like_lazy_sfinae();
   test_const_Types_lazy_sfinae();
+  test_non_tuple_like_lazy_sfinae();
 
   return 0;
 }


### PR DESCRIPTION
The core checks of whether a constructor is explicit, implicit or deleted are always the same.

So extract that into a common function and only have a function to disambiguate.

This should allow us only what we actually need. This greatly improves compile times with MatX

