### PR TITLE
Ignore last element in exclusive scan

### DIFF
--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -343,9 +343,20 @@ struct AgentScan
 
     if constexpr (IS_LAST_TILE)
     {
-      // Fill last element with the first element because collectives are
-      // not suffix guarded.
-      BlockLoadT(temp_storage.load).Load(d_in + tile_offset, items, num_remaining, *(d_in + tile_offset));
+      if constexpr (IS_INCLUSIVE)
+      {
+        // Fill last element with the first element because collectives are
+        // not suffix guarded.
+        BlockLoadT(temp_storage.load).Load(d_in + tile_offset, items, num_remaining, *(d_in + tile_offset));
+      }
+      else
+      {
+        // Ignore the last element of the input, as it doesn't contribute to the result
+        // We use init_value instead of the first element to avoid the edge case where
+        // only the last element is inside a new tile.
+        BlockLoadT(temp_storage.load)
+          .Load(d_in + tile_offset, items, static_cast<int>(num_remaining) - 1, static_cast<AccumT>(init_value));
+      }
     }
     else
     {

--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -1247,8 +1247,10 @@ struct TilePrefixCallbackOp
 
     // Perform a segmented reduction to get the prefix for the current window.
     // Use the swizzled scan operator because we are now scanning *down* towards thread0.
+    // Treat OOB tiles as singleton ranges so we don't call the scan_op for values that are not part of the input.
 
-    int tail_flag = (predecessor_status == StatusWord(SCAN_TILE_INCLUSIVE));
+    int tail_flag = (predecessor_status == StatusWord(SCAN_TILE_INCLUSIVE))
+                 || (predecessor_status == StatusWord(SCAN_TILE_OOB));
     window_aggregate =
       WarpReduceT(temp_storage.warp_reduce).TailSegmentedReduce(value, tail_flag, SwizzleScanOp<ScanOpT>(scan_op));
   }
@@ -1283,7 +1285,10 @@ private:
 
       // Update exclusive tile prefix with the window prefix
       ProcessWindow(predecessor_idx, predecessor_status, window_aggregate, construct_delay());
-      exclusive_prefix = scan_op(window_aggregate, exclusive_prefix);
+      if (predecessor_status != StatusWord(SCAN_TILE_OOB))
+      {
+        exclusive_prefix = scan_op(window_aggregate, exclusive_prefix);
+      }
     }
 
     // Compute the inclusive tile prefix and update the status for this tile
@@ -1329,7 +1334,9 @@ private:
       }
     }
 
-    const int tail_flag = (static_cast<int>(threadIdx.x) == anchor_tile_lane);
+    // mark everything before the anchor (= higher lanes) as tail, so we don't execute unnecessary scan_op calls
+    // especially OOB values before the first tile
+    const int tail_flag = (static_cast<int>(threadIdx.x) >= anchor_tile_lane);
     exclusive_prefix =
       WarpReduceT(temp_storage.warp_reduce).TailSegmentedReduce(value, tail_flag, SwizzleScanOp<ScanOpT>(scan_op));
 

--- a/cub/cub/block/specializations/block_scan_warp_scans.cuh
+++ b/cub/cub/block/specializations/block_scan_warp_scans.cuh
@@ -218,11 +218,13 @@ struct BlockScanWarpScans
   {
     T warp_prefix = ComputeWarpPrefix(scan_op, warp_aggregate, block_aggregate);
 
-    warp_prefix = scan_op(initial_value, warp_prefix);
-
     if (warp_id == 0)
     {
       warp_prefix = initial_value;
+    }
+    else
+    {
+      warp_prefix = scan_op(initial_value, warp_prefix);
     }
 
     return warp_prefix;

--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -240,8 +240,12 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
         (local_aggr =
            warp_reduce_t{temp_storage}.Reduce(regTmpStates[idx].value, scan_op, warp_right_aggregates_count);))
 
-      // We never initialized aggrExclusiveCtaCur when starting look ahead at tile 0
-      aggrExclusiveCtaCur = idxTileCur == 0 ? local_aggr : scan_op(aggrExclusiveCtaCur, local_aggr);
+      // We never initialized aggrExclusiveCtaCur when starting look ahead at tile 0.
+      // The reduction result and aggrExclusiveCtaCur are only valid in lane 0, so only lane 0 may call scan_op on them.
+      if (laneIdx == 0)
+      {
+        aggrExclusiveCtaCur = idxTileCur == 0 ? local_aggr : scan_op(aggrExclusiveCtaCur, local_aggr);
+      }
       idxTileCur += warp_right_aggregates_count;
 
       // we can only continue on the next 32 tile states, if we consumed all 32 of this iteration
@@ -310,16 +314,24 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
       const AccumT value      = use_value ? regTmpStates[idx].value : cuda::identity_element<ScanOpT, AccumT>();
       const AccumT local_aggr = warp_reduce_t{temp_storage}.Reduce(value, scan_op);
 
+      // The reduction result and aggrExclusiveCtaCur are only valid in lane 0, so only lane 0 may call scan_op on them.
       if (expected_count == 32)
       {
-        aggrExclusiveCtaCur = idxTileCur == 0 ? local_aggr : scan_op(aggrExclusiveCtaCur, local_aggr);
+        if (laneIdx == 0)
+        {
+          aggrExclusiveCtaCur = idxTileCur == 0 ? local_aggr : scan_op(aggrExclusiveCtaCur, local_aggr);
+        }
         idxTileCur += 32;
       }
       else
       {
-        const AccumT full_aggr = idxTileCur == 0 ? local_aggr : scan_op(aggrExclusiveCtaCur, local_aggr);
-        idxTilePrev            = idxTileCur;
-        aggrExclusiveCtaPrev   = aggrExclusiveCtaCur;
+        AccumT full_aggr = local_aggr; // must only be valid in lane_0
+        if (laneIdx == 0 && idxTileCur != 0)
+        {
+          full_aggr = scan_op(aggrExclusiveCtaCur, local_aggr);
+        }
+        idxTilePrev          = idxTileCur;
+        aggrExclusiveCtaPrev = aggrExclusiveCtaCur;
         return full_aggr;
       }
     }

--- a/cub/cub/detail/warpspeed/squad/load_store.cuh
+++ b/cub/cub/detail/warpspeed/squad/load_store.cuh
@@ -100,6 +100,13 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE CpAsyncOobInfo<Tp> prepareCpAsyncOob(Tp* ptrG
 template <typename ResourceTp, typename Tp>
 _CCCL_DEVICE_API void squadLoadBulk(Squad squad, SmemRef<ResourceTp>& refDestSmem, CpAsyncOobInfo<Tp> cpAsyncOobInfo)
 {
+  if (cpAsyncOobInfo.origCopySizeBytes == 0)
+  {
+    // no bulk copy has been performed so we don't need to update the tx count of any barrier
+    // this happens in exclusive scans where the last element is in a new tile
+    return;
+  }
+
   ::cuda::std::byte* ptrSmem = refDestSmem.data().inout;
   _CCCL_ASSERT(::cuda::is_aligned(ptrSmem, 16), "");
   ::cuda::std::uint64_t* ptrBar = refDestSmem.ptrCurBarrierRelease();

--- a/cub/cub/detail/warpspeed/squad/load_store.cuh
+++ b/cub/cub/detail/warpspeed/squad/load_store.cuh
@@ -100,13 +100,6 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE CpAsyncOobInfo<Tp> prepareCpAsyncOob(Tp* ptrG
 template <typename ResourceTp, typename Tp>
 _CCCL_DEVICE_API void squadLoadBulk(Squad squad, SmemRef<ResourceTp>& refDestSmem, CpAsyncOobInfo<Tp> cpAsyncOobInfo)
 {
-  if (cpAsyncOobInfo.origCopySizeBytes == 0)
-  {
-    // no bulk copy has been performed so we don't need to update the tx count of any barrier
-    // this happens in exclusive scans where the last element is in a new tile
-    return;
-  }
-
   ::cuda::std::byte* ptrSmem = refDestSmem.data().inout;
   _CCCL_ASSERT(::cuda::is_aligned(ptrSmem, 16), "");
   ::cuda::std::uint64_t* ptrBar = refDestSmem.ptrCurBarrierRelease();

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -306,6 +306,7 @@ struct DeviceScan
   //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place.
   //!   The range ``[d_in, d_in + num_items)`` and ``[d_out, d_out + num_items)``
   //!   shall not overlap in any other way.
+  //! - The last input item does not contribute to the result of an exclusive scan and is not read.
   //! - @devicestorage
   //!
   //! Snippet
@@ -416,6 +417,7 @@ struct DeviceScan
   //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place.
   //!   The range ``[d_in, d_in + num_items)`` and ``[d_out, d_out + num_items)``
   //!   shall not overlap in any other way.
+  //! - The last input item does not contribute to the result of an exclusive scan and is not read.
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -486,6 +488,7 @@ struct DeviceScan
   //!   addition of floating-point types). Results for pseudo-associative
   //!   operators may vary from run to run. Additional details can be found in
   //!   the @lookback description.
+  //! - The last input item does not contribute to the result of an exclusive scan and is not read.
   //! - @devicestorage
   //!
   //! Snippet
@@ -573,6 +576,7 @@ struct DeviceScan
   //!   addition of floating-point types). Results for pseudo-associative
   //!   operators may vary from run to run. Additional details can be found in
   //!   the @lookback description.
+  //! - The last input item does not contribute to the result of an exclusive scan and is not read.
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -633,6 +637,7 @@ struct DeviceScan
   //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place. The
   //!   range ``[d_in, d_in + num_items)`` and ``[d_out, d_out + num_items)``
   //!   shall not overlap in any other way.
+  //! - The last input item does not contribute to the result of an exclusive scan and is not read.
   //! - @devicestorage
   //!
   //! Snippet
@@ -766,6 +771,7 @@ struct DeviceScan
   //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place. The
   //!   range ``[d_in, d_in + num_items)`` and ``[d_out, d_out + num_items)``
   //!   shall not overlap in any other way.
+  //! - The last input item does not contribute to the result of an exclusive scan and is not read.
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -862,6 +868,7 @@ struct DeviceScan
   //!   addition of floating-point types). Results for pseudo-associative
   //!   operators may vary from run to run. Additional details can be found in
   //!   the @lookback description.
+  //! - The last input item does not contribute to the result of an exclusive scan and is not read.
   //! - @devicestorage
   //!
   //! Snippet
@@ -977,6 +984,7 @@ struct DeviceScan
   //!   addition of floating-point types). Results for pseudo-associative
   //!   operators may vary from run to run. Additional details can be found in
   //!   the @lookback description.
+  //! - The last input item does not contribute to the result of an exclusive scan and is not read.
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -1050,6 +1058,7 @@ struct DeviceScan
   //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place.
   //!   The range ``[d_in, d_in + num_items)`` and ``[d_out, d_out + num_items)``
   //!   shall not overlap in any other way.
+  //! - The last input item does not contribute to the result of an exclusive scan and is not read.
   //! - @devicestorage
   //!
   //! Snippet
@@ -1189,6 +1198,7 @@ struct DeviceScan
   //!   addition of floating-point types). Results for pseudo-associative
   //!   operators may vary from run to run. Additional details can be found in
   //!   the @lookback description.
+  //! - The last input item does not contribute to the result of an exclusive scan and is not read.
   //! - @devicestorage
   //!
   //! Snippet
@@ -1311,6 +1321,7 @@ struct DeviceScan
   //!   addition of floating-point types). Results for pseudo-associative
   //!   operators may vary from run to run. Additional details can be found in
   //!   the @lookback description.
+  //! - The last input item does not contribute to the result of an exclusive scan and is not read.
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -1393,6 +1404,7 @@ struct DeviceScan
   //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place.
   //!   The range ``[d_in, d_in + num_items)`` and ``[d_out, d_out + num_items)``
   //!   shall not overlap in any other way.
+  //! - The last input item does not contribute to the result of an exclusive scan and is not read.
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++

--- a/cub/cub/device/dispatch/kernels/kernel_scan_lookahead.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_lookahead.cuh
@@ -312,7 +312,19 @@ struct lookahead_scan_closure
     const warpspeed::CpAsyncOobInfo<InputT>& loadInfo) const
   {
     warpspeed::SmemRef refInOutW = phaseInOutW.acquireRef();
+    if constexpr (isInclusive)
+    {
     warpspeed::squadLoadBulk(squad, refInOutW, loadInfo);
+    }
+    else
+    {
+      // in exclusive scans, we might be loading no data at all
+      // if the tile consists just of the last element
+      if (loadInfo.origCopySizeBytes > 0)
+      {
+        warpspeed::squadLoadBulk(squad, refInOutW, loadInfo);
+      }
+    }
   }
 
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void lookahead(

--- a/cub/cub/device/dispatch/kernels/kernel_scan_lookahead.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_lookahead.cuh
@@ -358,7 +358,7 @@ struct lookahead_scan_closure
     warpspeed::SmemPhase<thread_and_warp_aggr_t>& phaseThreadAndWarpAggrW,
     int valid_items,
     bool is_first_tile,
-    bool is_last_tile, // TODO(bgruber): should we dispatch on is_last_tile outside this function and compile it twice?
+    bool is_partial_tile, // TODO(bgruber): should we dispatch on this outside the function and compile it twice?
     const warpspeed::CpAsyncOobInfo<InputT>& loadInfo,
     int idxTile,
     int num_tiles) const
@@ -383,7 +383,7 @@ struct lookahead_scan_closure
       warpspeed::squadLoadSmem(squad, regInput, smem_data_start);
 
       // Reduce across thread and warp
-      if (is_last_tile)
+      if (is_partial_tile)
       {
         // TODO(bgruber): for operators where we know the identity we can probably optimize this better
         regThreadAggr = __cub_detail::ThreadReducePartial(regInput, scan_op, valid_items_this_thread);
@@ -423,7 +423,7 @@ struct lookahead_scan_closure
       regSquadAggr = refThreadAndWarpAggrW.data()[squadReduce.threadCount()];
     }
 
-    if (is_last_tile)
+    if (is_partial_tile)
     {
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int i = 1; i < squadReduce.warpCount(); ++i)
@@ -781,9 +781,12 @@ struct lookahead_scan_closure
       _CCCL_ASSERT(idxTileBase < params.numElem, "");
       const int valid_items =
         static_cast<int>(cuda::std::min(params.numElem - idxTileBase, ::cuda::std::size_t(tile_size)));
-      const bool is_last_tile = valid_items < tile_size;
+      const bool is_partial_tile = valid_items < tile_size;
+      const bool is_last_tile    = idxTileBase + ::cuda::std::size_t(valid_items) >= params.numElem;
+      // In exclusive scans, ignore the last element, see AgentScan::ConsumeTile
+      const int load_items = (!isInclusive && is_last_tile) ? valid_items - 1 : valid_items;
       const warpspeed::CpAsyncOobInfo loadInfo =
-        warpspeed::prepareCpAsyncOob(const_cast<InputT*>(params.ptrIn) + idxTileBase, valid_items);
+        warpspeed::prepareCpAsyncOob(const_cast<InputT*>(params.ptrIn) + idxTileBase, load_items);
 
       if (squad == squadLoad)
       {
@@ -811,7 +814,7 @@ struct lookahead_scan_closure
           phaseThreadAndWarpAggrW,
           valid_items,
           is_first_tile,
-          is_last_tile,
+          is_partial_tile,
           loadInfo,
           idxTile,
           numTiles);
@@ -825,7 +828,7 @@ struct lookahead_scan_closure
       if (squad == squadScanStore)
       {
         static_assert(tile_size % squadScanStore.threadCount() == 0);
-        if (is_last_tile)
+        if (is_partial_tile)
         {
           scan_and_store_tile<true>(
             squad,

--- a/cub/cub/device/dispatch/kernels/kernel_scan_lookahead.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_lookahead.cuh
@@ -217,6 +217,25 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void fillWithIdentity(Tp (&regAggrInclusive)[
   }
 }
 
+template <typename Tp, size_t ElemPerThread>
+_CCCL_DEVICE_API _CCCL_FORCEINLINE void
+replaceSingleItem(const warpspeed::Squad& squad, Tp (&regAggrInclusive)[ElemPerThread], int index, const Tp& value)
+{
+  constexpr int elem_per_thread = static_cast<int>(ElemPerThread);
+  const int index_this_thread   = index - squad.threadRank() * elem_per_thread;
+  if (index_this_thread >= 0 && index_this_thread < elem_per_thread)
+  {
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < elem_per_thread; ++i)
+    {
+      if (i == index_this_thread)
+      {
+        regAggrInclusive[i] = value;
+      }
+    }
+  }
+}
+
 template <bool IsInclusive, bool IsLastTile, typename Tp, size_t ElemPerThread, typename ScanOpT>
 _CCCL_DEVICE_API _CCCL_FORCEINLINE void
 threadScanPartial(Tp (&regAggrInclusive)[ElemPerThread], ScanOpT& scan_op, Tp prefix, bool use_prefix, int valid_items)
@@ -314,7 +333,7 @@ struct lookahead_scan_closure
     warpspeed::SmemRef refInOutW = phaseInOutW.acquireRef();
     if constexpr (isInclusive)
     {
-    warpspeed::squadLoadBulk(squad, refInOutW, loadInfo);
+      warpspeed::squadLoadBulk(squad, refInOutW, loadInfo);
     }
     else
     {
@@ -370,7 +389,7 @@ struct lookahead_scan_closure
     warpspeed::SmemPhase<thread_and_warp_aggr_t>& phaseThreadAndWarpAggrW,
     int valid_items,
     bool is_first_tile,
-    bool is_partial_tile, // TODO(bgruber): should we dispatch on this outside the function and compile it twice?
+    bool is_last_tile, // TODO(bgruber): should we dispatch on is_last_tile outside the function and compile it twice?
     const warpspeed::CpAsyncOobInfo<InputT>& loadInfo,
     int idxTile,
     int num_tiles) const
@@ -380,7 +399,8 @@ struct lookahead_scan_closure
     const int valid_threads_this_warp =
       cuda::std::clamp(::cuda::ceil_div(valid_items, elemPerThread) - squad.warpRank() * 32, 0, 32);
     const int valid_warps = ::cuda::ceil_div(valid_items, elemPerThread * 32);
-    _CCCL_ASSERT(0 < valid_warps && valid_warps <= squad.warpCount(), "");
+    // valid_warps can be 0 for exclusive scans where the last tile consists of a single element
+    _CCCL_ASSERT(0 <= valid_warps && valid_warps <= squad.warpCount(), "");
 
     // Load tile from shared memory and reduce across thread and warp
     AccumT regThreadAggr;
@@ -395,7 +415,7 @@ struct lookahead_scan_closure
       warpspeed::squadLoadSmem(squad, regInput, smem_data_start);
 
       // Reduce across thread and warp
-      if (is_partial_tile)
+      if (is_last_tile)
       {
         // TODO(bgruber): for operators where we know the identity we can probably optimize this better
         regThreadAggr = __cub_detail::ThreadReducePartial(regInput, scan_op, valid_items_this_thread);
@@ -435,7 +455,7 @@ struct lookahead_scan_closure
       regSquadAggr = refThreadAndWarpAggrW.data()[squadReduce.threadCount()];
     }
 
-    if (is_partial_tile)
+    if (is_last_tile)
     {
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int i = 1; i < squadReduce.warpCount(); ++i)
@@ -663,6 +683,13 @@ struct lookahead_scan_closure
       regAggrInclusive,
       reinterpret_cast<const InputT*>(&refInOutRW.data().inout[0] + loadInfo.smemStartSkipBytes));
 
+    if constexpr (IsLastTile && !isInclusive)
+    {
+      // the last element was not loaded to smem, so replace it by init value
+      // its actual value doesn't matter, since we discard it
+      replaceSingleItem(squad, regAggrInclusive, valid_items - 1, static_cast<AccumT>(real_init_value));
+    }
+
     // Perform inclusive scan of register array in current thread.
     // warp_0/thread_0 in the first tile when there is no initial value, we MUST NOT use aggrExclusive
     const bool use_prefix = hasInit ? true : !(is_first_tile && squad.threadRank() == 0);
@@ -793,9 +820,8 @@ struct lookahead_scan_closure
       _CCCL_ASSERT(idxTileBase < params.numElem, "");
       const int valid_items =
         static_cast<int>(cuda::std::min(params.numElem - idxTileBase, ::cuda::std::size_t(tile_size)));
-      const bool is_partial_tile = valid_items < tile_size;
-      const bool is_last_tile    = idxTileBase + ::cuda::std::size_t(valid_items) >= params.numElem;
-      // In exclusive scans, ignore the last element, see AgentScan::ConsumeTile
+      const bool is_last_tile = idxTileBase + ::cuda::std::size_t(valid_items) >= params.numElem;
+      // In exclusive scans, ignore the last element
       const int load_items = (!isInclusive && is_last_tile) ? valid_items - 1 : valid_items;
       const warpspeed::CpAsyncOobInfo loadInfo =
         warpspeed::prepareCpAsyncOob(const_cast<InputT*>(params.ptrIn) + idxTileBase, load_items);
@@ -824,9 +850,9 @@ struct lookahead_scan_closure
           squad,
           phaseInOutRW,
           phaseThreadAndWarpAggrW,
-          valid_items,
+          load_items,
           is_first_tile,
-          is_partial_tile,
+          is_last_tile,
           loadInfo,
           idxTile,
           numTiles);
@@ -840,7 +866,7 @@ struct lookahead_scan_closure
       if (squad == squadScanStore)
       {
         static_assert(tile_size % squadScanStore.threadCount() == 0);
-        if (is_partial_tile)
+        if (is_last_tile)
         {
           scan_and_store_tile<true>(
             squad,

--- a/cub/cub/device/dispatch/kernels/kernel_scan_lookahead.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_lookahead.cuh
@@ -399,8 +399,7 @@ struct lookahead_scan_closure
     const int valid_threads_this_warp =
       cuda::std::clamp(::cuda::ceil_div(valid_items, elemPerThread) - squad.warpRank() * 32, 0, 32);
     const int valid_warps = ::cuda::ceil_div(valid_items, elemPerThread * 32);
-    // valid_warps can be 0 for exclusive scans where the last tile consists of a single element
-    _CCCL_ASSERT(0 <= valid_warps && valid_warps <= squad.warpCount(), "");
+    _CCCL_ASSERT(0 < valid_warps && valid_warps <= squad.warpCount(), "");
 
     // Load tile from shared memory and reduce across thread and warp
     AccumT regThreadAggr;
@@ -413,6 +412,16 @@ struct lookahead_scan_closure
         reinterpret_cast<const InputT*>(&refInOutRW.data().inout[0] + loadInfo.smemStartSkipBytes);
       // in the last tile, we load some invalid elements, but don't process them later
       warpspeed::squadLoadSmem(squad, regInput, smem_data_start);
+
+      if constexpr (!isInclusive)
+      {
+        if (is_last_tile)
+        {
+          // the last element was not loaded to smem, so replace it by init value. Its actual value doesn't matter,
+          // since the aggregate of the last tile is never used, but it must not be garbage passed to scan_op
+          replaceSingleItem(squad, regInput, valid_items - 1, static_cast<AccumT>(real_init_value));
+        }
+      }
 
       // Reduce across thread and warp
       if (is_last_tile)
@@ -850,7 +859,7 @@ struct lookahead_scan_closure
           squad,
           phaseInOutRW,
           phaseThreadAndWarpAggrW,
-          load_items,
+          valid_items,
           is_first_tile,
           is_last_tile,
           loadInfo,

--- a/cub/test/catch2_test_device_exclusive_scan_last_item.cu
+++ b/cub/test/catch2_test_device_exclusive_scan_last_item.cu
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/device/device_scan.cuh>
+
+#include <thrust/copy.h>
+
+#include <cuda/std/functional>
+
+#include <cstdint>
+
+#include "catch2_test_device_scan.cuh"
+#include "catch2_test_launch_helper.h"
+#include "cub_test_macros.h"
+
+// %PARAM% TEST_LAUNCH lid 0
+
+DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::ExclusiveScan, device_exclusive_scan);
+
+// trivially constructible types to allow uninitialized thrust vector
+using types = c2h::type_list<std::int32_t, std::int64_t>;
+
+// The last element must not be read in an exclusive scan, to be confirmed by compute-sanitizer initcheck
+CUB_TEST("Device exclusive scan ignores last input element", "[scan][device]", CUB_SMALL, types)
+{
+  using type     = c2h::get<0, TestType>;
+  using offset_t = std::int32_t;
+  using op_t     = ::cuda::std::plus<>;
+
+  const offset_t initialized_size =
+    GENERATE_COPY(values({0, 1, 2, 31, 32, 33, 1023, 1024, 1025, 4095, 4096, 4097}), take(3, random(1, 1'000'000)));
+  const offset_t size = initialized_size + 1;
+  CAPTURE(size, c2h::type_name<type>());
+
+  c2h::device_vector<type> input(initialized_size);
+  c2h::gen(C2H_SEED(1), input);
+  // Initialize all but the last value of the device vector
+  c2h::device_vector<type> data(size, thrust::no_init);
+  thrust::copy(c2h::device_policy, input.cbegin(), input.cend(), data.begin());
+  auto d_data = thrust::raw_pointer_cast(data.data());
+
+  c2h::host_vector<type> host_input(input);
+  host_input.push_back(type{}); // the last value doesn't matter here either
+  c2h::host_vector<type> expected(size);
+
+  type init_value{};
+  compute_exclusive_scan_reference(host_input.cbegin(), host_input.cend(), expected.begin(), init_value, op_t{});
+
+  device_exclusive_scan(d_data, d_data, op_t{}, init_value, size);
+
+  REQUIRE_THAT_QUIET(expected, Equals(data));
+}

--- a/cub/test/catch2_test_device_exclusive_scan_last_item.cu
+++ b/cub/test/catch2_test_device_exclusive_scan_last_item.cu
@@ -5,6 +5,7 @@
 
 #include <thrust/copy.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/std/functional>
 
 #include <cstdint>
@@ -18,14 +19,14 @@
 DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::ExclusiveScan, device_exclusive_scan);
 
 // trivially constructible types to allow uninitialized thrust vector
-using types = c2h::type_list<std::int32_t, std::int64_t>;
+using types    = c2h::type_list<std::int32_t, std::int64_t>;
+using offset_t = std::int32_t;
 
 // The last element must not be read in an exclusive scan, to be confirmed by compute-sanitizer initcheck
 CUB_TEST("Device exclusive scan ignores last input element", "[scan][device]", CUB_SMALL, types)
 {
-  using type     = c2h::get<0, TestType>;
-  using offset_t = std::int32_t;
-  using op_t     = ::cuda::std::plus<>;
+  using type = c2h::get<0, TestType>;
+  using op_t = ::cuda::std::plus<>;
 
   const offset_t initialized_size =
     GENERATE_COPY(values({0, 1, 2, 31, 32, 33, 1023, 1024, 1025, 4095, 4096, 4097}), take(3, random(1, 1'000'000)));
@@ -49,4 +50,109 @@ CUB_TEST("Device exclusive scan ignores last input element", "[scan][device]", C
   device_exclusive_scan(d_data, d_data, op_t{}, init_value, size);
 
   REQUIRE_THAT_QUIET(expected, Equals(data));
+}
+
+constexpr int valid_value   = 1;
+constexpr int invalid_value = 2;
+
+// an operator that only expects the value 1 and only ever returns 1
+// and records if it ever was passed any other value.
+struct checking_op
+{
+  template <typename T>
+  __device__ T operator()(T lhs, T rhs) const
+  {
+    if (lhs != valid_value || rhs != valid_value)
+    {
+      *invalid = true;
+    }
+    return valid_value;
+  }
+  bool* invalid;
+};
+
+// The lookahead scan algorithm is only compiled when these hold, see `can_use_lookahead` in
+// cub/device/dispatch/tuning/tuning_scan.cuh. Requesting it through the tuning environment bypasses that check, so we
+// have to mirror the conditions here to avoid instantiating a kernel that cannot be built.
+#if __cccl_ptx_isa >= 860 && defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED) \
+  && !(_CCCL_COMPILER(MSVC) && _CCCL_CUDA_COMPILER(NVCC, <, 13, 1)) && !defined(CCCL_DISABLE_WARPSPEED_SCAN)
+#  define TEST_HAS_LOOKAHEAD_SCAN 1
+#else
+#  define TEST_HAS_LOOKAHEAD_SCAN 0
+#endif
+
+//! Requests the lookahead scan algorithm wherever it is supported, with a tuning small enough to fit into the
+//! architecture independent shared memory limit.
+//!
+//! The default tuning picks lookback for this test: `checking_op` is a user-defined operator, for which the sm_120
+//! tuning raises `items_per_thread` to 127. The resulting tile no longer fits into 48 KiB, so `can_use_lookahead`
+//! rejects lookahead and silently falls back. Without this tuning, the test would never exercise lookahead on sm_120.
+template <typename T>
+struct lookahead_tuning
+{
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> cub::ScanPolicy
+  {
+    // The policy is instantiated for every compiled architecture, so fall back to the default tuning wherever
+    // lookahead is unavailable.
+    const bool supported =
+      TEST_HAS_LOOKAHEAD_SCAN && cc >= ::cuda::compute_capability{9, 0} // codegen bug in nvcc below 13.4 on GB20x, see
+                                                                        // https://github.com/NVIDIA/cccl/issues/8528
+      && !(_CCCL_CUDACC_BELOW(13, 4) && cc == ::cuda::compute_capability{12, 0});
+    if (!supported)
+    {
+      return cub::detail::scan::
+        policy_selector_from_types<T*, T*, T, cub::detail::choose_offset_t<offset_t>, checking_op>{}(cc);
+    }
+
+    // 256 / sizeof(T) - 1 items per thread is what the sm_100 tuning uses and keeps us within 48 KiB.
+    // Aggregate init instead of designated init, because the test is also compiled as C++17.
+    return cub::ScanPolicy{
+      cub::ScanAlgorithm::lookahead,
+      {},
+      cub::ScanLookaheadPolicy{/* reduce_and_scan_warps */ 4,
+                               /* items_per_thread */ 256 / int{sizeof(T)} - 1,
+                               /* lookahead_items_per_thread */ 4}};
+  }
+};
+
+template <typename T, typename EnvT>
+void check_scan_op_receives_only_valid_values(offset_t size, const EnvT& env)
+{
+  constexpr offset_t padding = 100;
+
+  c2h::device_vector<T> data(size, valid_value);
+  data.resize(size + padding, invalid_value);
+
+  c2h::host_vector<T> expected(size + 1, valid_value);
+  expected.resize(size + padding, invalid_value);
+
+  c2h::device_vector<bool> accessed(1, false);
+  auto d_data = thrust::raw_pointer_cast(data.data());
+  REQUIRE(cudaSuccess
+          == cub::DeviceScan::ExclusiveScan(
+            d_data, d_data, checking_op{accessed.data().get()}, static_cast<T>(valid_value), size + 1, env));
+
+  REQUIRE_THAT_QUIET(expected, Equals(data));
+  REQUIRE(accessed.front() == false);
+}
+
+CUB_TEST("Device exclusive scan operator only receives valid values", "[scan][device]", CUB_SMALL, types)
+{
+  using type = c2h::get<0, TestType>;
+
+  // 1 << 19 spans more than the 32 tiles a lookahead step covers for all tunings used here, so the lookahead warp has
+  // to combine tile aggregates across several steps, including partially filled windows of tile states
+  const offset_t size = GENERATE_COPY(
+    values({0, 1, 2, 31, 32, 33, 1023, 1024, 1025, 4095, 4096, 4097, 1 << 19}), take(3, random(1, 1'000'000)));
+  CAPTURE(size, c2h::type_name<type>());
+
+  SECTION("default tuning")
+  {
+    check_scan_op_receives_only_valid_values<type>(size, ::cuda::std::execution::env<>{});
+  }
+
+  SECTION("lookahead tuning")
+  {
+    check_scan_op_receives_only_valid_values<type>(size, ::cuda::execution::tune(lookahead_tuning<type>{}));
+  }
 }


### PR DESCRIPTION
## Description

This fixes both the lookback and the lookahead scan by ignoring the last element of the input. I validated the issue is correctly highlighted by the test under compute-sanitizer --tool initcheck --check-bulk-copy yes

*Note:* The regression test would not fully cover every case in CI, since the warpspeed path is not executed by compute-sanitizer tests it seems.

I also added another test that ensures no invalid values get passed to the scan operator, which also necessitates a few additional changes to how OOB values get handled.

closes #876

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
