### PR TITLE
Add count NVHPC stdpar smoke test

### DIFF
--- a/test/stdpar/tests/count.cpp
+++ b/test/stdpar/tests/count.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cuda/version>
+
+#include <algorithm>
+#include <cstddef>
+#include <execution>
+#include <vector>
+
+// Ensure that we are indeed using the correct CCCL version
+static_assert(CCCL_MAJOR_VERSION == CMAKE_CCCL_VERSION_MAJOR);
+static_assert(CCCL_MINOR_VERSION == CMAKE_CCCL_VERSION_MINOR);
+static_assert(CCCL_PATCH_VERSION == CMAKE_CCCL_VERSION_PATCH);
+
+int main()
+{
+  constexpr std::size_t num_items = 1 << 16;
+  std::vector<int> values(num_items);
+  for (std::size_t i = 0; i < num_items; ++i)
+  {
+    values[i] = static_cast<int>(i % 4);
+  }
+
+  const auto matches        = std::count(std::execution::par, values.begin(), values.end(), 2);
+  const auto absent_matches = std::count(std::execution::par, values.begin(), values.end(), 4);
+  const auto empty_matches  = std::count(std::execution::par, values.begin(), values.begin(), 2);
+
+  if (matches != num_items / 4 || absent_matches != 0 || empty_matches != 0)
+  {
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Description

Part of #6486.

Add an NVHPC stdpar smoke test for `std::count` with `std::execution::par`. It covers multiple matches in deterministic nonuniform input, an absent value, and an empty range. Explicit failure returns remain effective under `NDEBUG`; static assertions check the CCCL version. Inspection of the existing CMake glob and target-registration logic shows that the file is included as `stdpar_test_count`; NVHPC configuration and CTest discovery were not run locally.

## Validation

- Local `pre-commit run --files test/stdpar/tests/count.cpp`: all applicable hooks passed, including clang-format and secret scanning. pre-commit.ci also reports successful completion.
- Local `git diff --check`, `git diff --cached --check`, and `git diff upstream/main...HEAD --check`: passed.
- **Supplementary only:** MSVC 19.39 compiled and executed the test successfully in C++17 and C++20 with `/O2 /DNDEBUG /W4 /Zc:preprocessor`, using the checkout's headers.
- **Not performed locally:** NVHPC compilation and GPU/CTest execution, because `nvc++` was unavailable. MSVC results do not establish NVHPC compatibility.

## AI assistance

Prepared with OpenAI Codex and personally reviewed by the contributor before marking the PR ready for review.

## Checklist

- [x] New or existing tests cover these changes.
- [x] No documentation changes are needed.
