### PR TITLE
Add coding guideline: use `THRUST_NS_QUALIFIER/CUB_NS_QUALIFIER` for full qualification

### DIFF
--- a/docs/cccl/development/coding_guidelines.rst
+++ b/docs/cccl/development/coding_guidelines.rst
@@ -58,6 +58,9 @@ CUB and Thrust
 
 #. Non-public entities, which are not macros, should be put inside a ``detail`` namespace (preferred)
    or prefixed with ``__``.
+#. Any full qualification of a CUB or Thrust entity must use ``THRUST_NS_QUALIFIER::`` instead of ``::thrust::``,
+   and ``CUB_NS_QUALIFIER::`` instead of ``::cub::``.
+   This avoids lookup failures when a user defines a wrapped namespace.
 
 CUB
 ----


### PR DESCRIPTION
## Summary
- Add a coding guideline requiring `THRUST_NS_QUALIFIER::` / `CUB_NS_QUALIFIER::` instead of `::thrust::` / `::cub::` for full qualification of CUB/Thrust entities, since the latter can fail lookup when a user wraps these namespaces.

---
🤖 This PR was authored by Claude Code.