### PR TITLE
Optimize lookahead scan

### DIFF
--- a/cub/cub/device/dispatch/kernels/kernel_scan_lookahead.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_lookahead.cuh
@@ -589,6 +589,16 @@ struct lookahead_scan_closure
     // It has an undefined value in
     // - tile*::warp0::lane0
 
+    // Acquire refInOut for the remainder of scope. We do this here already, before acquiring refAggrExclusiveCta, since
+    // the former SMEM resource is usually available sooner then the exclusive aggregate coming from the lookback
+    warpspeed::SmemRef refInOutRW = phaseInOutRW.acquireRef();
+
+    // We are always loading a full tile even for the last tile, so we are loading invalid data
+    warpspeed::squadLoadSmem(
+      squad,
+      regAggrInclusive,
+      reinterpret_cast<const InputT*>(&refInOutRW.data().inout[0] + loadInfo.smemStartSkipBytes));
+
     // Include aggregate of previous tiles
     {
       // important: we have to acquire the resource for the first tile as well to prevent a hang
@@ -641,15 +651,6 @@ struct lookahead_scan_closure
     // - tile0::warp0::lane0
 
     // Scan across elements allocated to this thread
-
-    // Acquire refInOut for remainder of scope.
-    warpspeed::SmemRef refInOutRW = phaseInOutRW.acquireRef();
-
-    // We are always loading a full tile even for the last tile, so we are loading invalid data
-    warpspeed::squadLoadSmem(
-      squad,
-      regAggrInclusive,
-      reinterpret_cast<const InputT*>(&refInOutRW.data().inout[0] + loadInfo.smemStartSkipBytes));
 
     // Perform inclusive scan of register array in current thread.
     // warp_0/thread_0 in the first tile when there is no initial value, we MUST NOT use aggrExclusive


### PR DESCRIPTION
Hide SMEM load latency of tile items by wait on lookback prefix. This idea came out of observations while working on #11257.

But B200 does not seem to like it:
```
## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I64      |      2^16      |  11.261 us |       0.49% |  11.257 us |       0.40% |   -0.005 us |  -0.04% |  🔵 SAME  |
|   I8    |      I64      |      2^20      |  12.932 us |       5.89% |  12.129 us |       8.36% |   -0.803 us |  -6.21% |  🟢 FAST  |
|   I8    |      I64      |      2^24      |  27.652 us |       0.60% |  29.005 us |       3.34% |    1.353 us |   4.89% |  🔴 SLOW  |
|   I8    |      I64      |      2^28      | 209.313 us |       0.47% | 226.632 us |       0.48% |   17.318 us |   8.27% |  🔴 SLOW  |
|   I8    |      I64      |      2^32      |   3.174 ms |       0.30% |   3.474 ms |       0.05% |  300.127 us |   9.46% |  🔴 SLOW  |
|   I16   |      I64      |      2^16      |  11.212 us |       0.75% |  11.211 us |       0.67% |   -0.001 us |  -0.01% |  🔵 SAME  |
|   I16   |      I64      |      2^20      |  13.197 us |       3.53% |  12.523 us |       7.97% |   -0.674 us |  -5.11% |  🟢 FAST  |
|   I16   |      I64      |      2^24      |  27.418 us |       2.81% |  27.171 us |       3.37% |   -0.248 us |  -0.90% |  🔵 SAME  |
|   I16   |      I64      |      2^28      | 214.026 us |       0.59% | 218.846 us |       0.59% |    4.821 us |   2.25% |  🔴 SLOW  |
|   I16   |      I64      |      2^32      |   3.254 ms |       1.26% |   3.337 ms |       1.40% |   82.461 us |   2.53% |  🔴 SLOW  |
|   I32   |      I64      |      2^16      |  10.117 us |      10.08% |   9.616 us |       8.52% |   -0.501 us |  -4.95% |  🔵 SAME  |
|   I32   |      I64      |      2^20      |  13.722 us |       6.17% |  13.639 us |       5.95% |   -0.083 us |  -0.60% |  🔵 SAME  |
|   I32   |      I64      |      2^24      |  34.067 us |       3.34% |  36.278 us |       3.25% |    2.212 us |   6.49% |  🔴 SLOW  |
|   I32   |      I64      |      2^28      | 322.625 us |       0.54% | 321.354 us |       0.48% |   -1.270 us |  -0.39% |  🔵 SAME  |
|   I32   |      I64      |      2^32      |   4.966 ms |       0.94% |   5.154 ms |       1.18% |  187.966 us |   3.78% |  🔴 SLOW  |
|   I64   |      I64      |      2^16      |  12.524 us |       8.03% |  11.275 us |       1.69% |   -1.249 us |  -9.97% |  🟢 FAST  |
|   I64   |      I64      |      2^20      |  15.884 us |       5.75% |  15.233 us |       3.38% |   -0.650 us |  -4.09% |  🟢 FAST  |
|   I64   |      I64      |      2^24      |  53.717 us |       2.09% |  55.054 us |       2.13% |    1.337 us |   2.49% |  🔴 SLOW  |
|   I64   |      I64      |      2^28      | 626.104 us |       0.32% | 626.435 us |       0.28% |    0.331 us |   0.05% |  🔵 SAME  |
|   I64   |      I64      |      2^32      |  10.245 ms |       0.78% |   9.962 ms |       0.61% | -283.006 us |  -2.76% |  🟢 FAST  |
|  I128   |      I64      |      2^16      |  13.186 us |       3.71% |  13.007 us |       5.53% |   -0.179 us |  -1.35% |  🔵 SAME  |
|  I128   |      I64      |      2^20      |  21.550 us |       1.63% |  21.515 us |       0.91% |   -0.035 us |  -0.16% |  🔵 SAME  |
|  I128   |      I64      |      2^24      | 148.731 us |       0.81% | 149.197 us |       0.75% |    0.466 us |   0.31% |  🔵 SAME  |
|  I128   |      I64      |      2^28      |   2.064 ms |       0.15% |   2.073 ms |       0.15% |    8.438 us |   0.41% |  🔴 SLOW  |
|  I128   |      I64      |      2^32      |  32.609 ms |       0.03% |  32.754 ms |       0.03% |  144.491 us |   0.44% |  🔴 SLOW  |
|   F32   |      I64      |      2^16      |  10.863 us |       7.37% |  10.870 us |       7.65% |    0.007 us |   0.06% |  🔵 SAME  |
|   F32   |      I64      |      2^20      |  13.508 us |       5.43% |  13.661 us |       5.86% |    0.153 us |   1.13% |  🔵 SAME  |
|   F32   |      I64      |      2^24      |  35.869 us |       3.67% |  37.275 us |       2.88% |    1.406 us |   3.92% |  🔴 SLOW  |
|   F32   |      I64      |      2^28      | 321.164 us |       0.46% | 320.268 us |       0.42% |   -0.896 us |  -0.28% |  🔵 SAME  |
|   F32   |      I64      |      2^32      |   4.858 ms |       0.79% |   4.841 ms |       0.85% |  -17.051 us |  -0.35% |  🔵 SAME  |
|   F64   |      I64      |      2^16      |  11.314 us |       3.19% |  11.294 us |       2.56% |   -0.020 us |  -0.18% |  🔵 SAME  |
|   F64   |      I64      |      2^20      |  15.658 us |       4.68% |  15.438 us |       2.72% |   -0.220 us |  -1.40% |  🔵 SAME  |
|   F64   |      I64      |      2^24      |  54.866 us |       1.81% |  56.319 us |       2.03% |    1.453 us |   2.65% |  🔴 SLOW  |
|   F64   |      I64      |      2^28      | 622.916 us |       0.23% | 623.241 us |       0.24% |    0.325 us |   0.05% |  🔵 SAME  |
|   F64   |      I64      |      2^32      |   9.830 ms |       0.46% |   9.724 ms |       0.20% | -105.819 us |  -1.08% |  🟢 FAST  |
|   C32   |      I64      |      2^16      |  11.264 us |       1.01% |  11.260 us |       0.66% |   -0.004 us |  -0.03% |  🔵 SAME  |
|   C32   |      I64      |      2^20      |  15.342 us |       0.81% |  15.311 us |       2.73% |   -0.031 us |  -0.20% |  🔵 SAME  |
|   C32   |      I64      |      2^24      |  54.205 us |       2.47% |  55.366 us |       2.00% |    1.161 us |   2.14% |  🔴 SLOW  |
|   C32   |      I64      |      2^28      | 622.553 us |       0.21% | 623.234 us |       0.19% |    0.681 us |   0.11% |  🔵 SAME  |
|   C32   |      I64      |      2^32      |   9.709 ms |       0.04% |   9.743 ms |       0.10% |   33.132 us |   0.34% |  🔴 SLOW  |
|   F16   |      I64      |      2^16      |  11.264 us |       1.52% |  11.255 us |       0.86% |   -0.010 us |  -0.09% |  🔵 SAME  |
|   F16   |      I64      |      2^20      |  13.300 us |       0.43% |  13.204 us |       3.34% |   -0.096 us |  -0.72% |  🟢 FAST  |
|   F16   |      I64      |      2^24      |  28.389 us |       3.55% |  27.841 us |       2.83% |   -0.548 us |  -1.93% |  🔵 SAME  |
|   F16   |      I64      |      2^28      | 227.279 us |       0.49% | 228.592 us |       0.47% |    1.312 us |   0.58% |  🔴 SLOW  |
|   F16   |      I64      |      2^32      |   3.355 ms |       0.77% |   3.374 ms |       0.68% |   19.715 us |   0.59% |  🔵 SAME  |
|  BF16   |      I64      |      2^16      |  11.265 us |       0.58% |  11.255 us |       0.60% |   -0.010 us |  -0.09% |  🔵 SAME  |
|  BF16   |      I64      |      2^20      |  13.298 us |       0.86% |  13.170 us |       3.84% |   -0.128 us |  -0.96% |  🟢 FAST  |
|  BF16   |      I64      |      2^24      |  28.404 us |       3.66% |  27.934 us |       2.87% |   -0.470 us |  -1.65% |  🔵 SAME  |
|  BF16   |      I64      |      2^28      | 227.426 us |       0.51% | 228.461 us |       0.48% |    1.035 us |   0.46% |  🔵 SAME  |
|  BF16   |      I64      |      2^32      |   3.355 ms |       0.75% |   3.374 ms |       0.72% |   19.725 us |   0.59% |  🔵 SAME  |
```