### PR TITLE
[libcu++] `misc-const-correctness`

### DIFF
--- a/libcudacxx/include/cuda/__algorithm/sample.h
+++ b/libcudacxx/include/cuda/__algorithm/sample.h
@@ -58,7 +58,7 @@ template <class _PopulationIterator, class _SampleIterator, class _Distance, cla
   _Distance __n_int,
   _UniformRandomNumberGenerator& __g)
 {
-  ::cuda::std::uniform_real_distribution<double> __uniform{};
+  ::cuda::std::uniform_real_distribution<double> __uniform{}; // NOLINT(misc-const-correctness)
 
   auto __top    = static_cast<double>(__N_int - __n_int);
   auto __N_real = static_cast<double>(__N_int);
@@ -132,7 +132,7 @@ template <class _PopulationIterator, class _SampleIterator, class _Distance, cla
   _Distance __n_int,
   _UniformRandomNumberGenerator& __g)
 {
-  ::cuda::std::uniform_real_distribution<double> __uniform{};
+  ::cuda::std::uniform_real_distribution<double> __uniform{}; // NOLINT(misc-const-correctness)
 
   // Index of the next candidate element. Method D never moves it backwards, so the output is stable.
   auto __index = _Distance{0};

--- a/libcudacxx/include/cuda/__barrier/barrier_arrive_tx.h
+++ b/libcudacxx/include/cuda/__barrier/barrier_arrive_tx.h
@@ -52,7 +52,7 @@ extern "C" _CCCL_DEVICE void __cuda_ptx_barrier_arrive_tx_is_not_supported_befor
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#contents-of-the-mbarrier-object
   _CCCL_ASSERT(__transaction_count_update <= (1 << 20) - 1, "Transaction count update cannot exceed 2^20 - 1.");
 
-  barrier<thread_scope_block>::arrival_token __token = {};
+  barrier<thread_scope_block>::arrival_token __token = {}; // NOLINT(misc-const-correctness)
   // On architectures pre-sm90, arrive_tx is not supported.
   // We do not check for the statespace of the barrier here. This is
   // on purpose. This allows debugging tools like memcheck/racecheck

--- a/libcudacxx/include/cuda/__barrier/barrier_block_scope.h
+++ b/libcudacxx/include/cuda/__barrier/barrier_block_scope.h
@@ -167,13 +167,13 @@ private:
       return __barrier.arrive(__update);
     }
 
-    unsigned int __mask    = ::__activemask();
-    unsigned int __activeA = ::__match_any_sync(__mask, __update);
-    unsigned int __activeB = ::__match_any_sync(__mask, reinterpret_cast<::cuda::std::uintptr_t>(&__barrier));
-    unsigned int __active  = __activeA & __activeB;
-    int __inc              = static_cast<int>(::cuda::std::popcount(__active) * __update);
+    const unsigned int __mask    = ::__activemask();
+    const unsigned int __activeA = ::__match_any_sync(__mask, __update);
+    const unsigned int __activeB = ::__match_any_sync(__mask, reinterpret_cast<::cuda::std::uintptr_t>(&__barrier));
+    const unsigned int __active  = __activeA & __activeB;
+    const int __inc              = static_cast<int>(::cuda::std::popcount(__active) * __update);
 
-    int __leader = static_cast<int>(::__ffs(static_cast<int>(__active))) - 1;
+    const int __leader = static_cast<int>(::__ffs(static_cast<int>(__active))) - 1;
     // All threads in mask synchronize here, establishing cummulativity to the __leader:
     ::__syncwarp(__mask);
     arrival_token __token = {};

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -181,7 +181,7 @@ private:
     static_assert(::cuda::std::contiguous_iterator<_Iter>, "Non contiguous iterators are not supported");
     // TODO use batched memcpy for non-contiguous iterators, it allows to
     // specify stream ordered access
-    ::cuda::__ensure_current_context __guard(__buf_.stream());
+    const ::cuda::__ensure_current_context __guard(__buf_.stream());
     ::cuda::__driver::__memcpyAsync(
       __dest, ::cuda::std::to_address(__first), sizeof(_Tp) * __count, __buf_.stream().get());
   }
@@ -842,7 +842,7 @@ template <typename _BufferTo, typename _BufferFrom>
 _CCCL_HOST_API void __copy_cross_buffers(
   stream_ref __stream, _BufferTo& __to, const _BufferFrom& __from, typename _BufferFrom::size_type __count)
 {
-  ::cuda::__ensure_current_context __guard(__stream);
+  const ::cuda::__ensure_current_context __guard(__stream);
   __stream.wait(__from.stream());
   ::cuda::__driver::__memcpyAsync(
     __to.__unwrapped_begin(),
@@ -904,7 +904,7 @@ _CCCL_HOST_API void __fill_n(cuda::stream_ref __stream, _Tp* __first, ::cuda::st
   else
   {
 #  if _CCCL_CUDA_COMPILATION()
-    ::cuda::__ensure_current_context __guard(__stream);
+    const ::cuda::__ensure_current_context __guard(__stream);
     CUB_NS_QUALIFIER::DeviceTransform::Fill(__first, __count, __value, __stream.get());
 #  else // ^^^ _CCCL_CUDA_COMPILATION() ^^^ / vvv !_CCCL_CUDA_COMPILATION() vvv
     static_assert(::cuda::__driver::__cu_driver_memsetable<_Tp>,

--- a/libcudacxx/include/cuda/__device/physical_device.h
+++ b/libcudacxx/include/cuda/__device/physical_device.h
@@ -112,8 +112,8 @@ class __physical_device
       // group of peers is needed (for cases other than peer access control)
       if (__other_id != __id)
       {
-        device_ref __dev{__id};
-        device_ref __other_dev{__other_id};
+        const device_ref __dev{__id};
+        const device_ref __other_dev{__other_id};
 
         // While in almost all practical applications peer access should be symmetrical,
         // it is possible to build a system with one directional peer access, check

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -153,7 +153,7 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 {
   void* __fn;
   ::CUdriverProcAddressQueryResult __result;
-  ::CUresult __status = __get_proc_addr_fn(
+  const ::CUresult __status = __get_proc_addr_fn(
     __name, &__fn, ::cuda::__driver::__make_version(__major, __minor), ::CU_GET_PROC_ADDRESS_DEFAULT, &__result);
   if (__status != ::CUDA_SUCCESS || __result != ::CU_GET_PROC_ADDRESS_SUCCESS)
   {
@@ -182,7 +182,7 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 template <typename Fn, typename... Args>
 _CCCL_HOST_API inline void __call_driver_fn(Fn __fn, const char* __err_msg, Args... __args)
 {
-  ::CUresult __status = __fn(__args...);
+  const ::CUresult __status = __fn(__args...);
   if (__status != ::CUDA_SUCCESS)
   {
     _CCCL_THROW(::cuda::cuda_error, static_cast<::cudaError_t>(__status), __err_msg);
@@ -235,7 +235,7 @@ __get_driver_entry_point(const char* __name, [[maybe_unused]] int __major = 12, 
 
 [[nodiscard]] _CCCL_HOST_API inline int __getVersion()
 {
-  static int __version = []() {
+  static const int __version = []() {
     int __v;
     auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDriverGetVersion);
     ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to check CUDA driver version", &__v);
@@ -285,7 +285,7 @@ _CCCL_HOST_API inline void __deviceGetName(char* __name_out, int __len, int __or
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceGetName);
 
   // TODO CUdevice is just an int, we probably could just cast, but for now do the safe thing
-  ::CUdevice __dev = __deviceGet(__ordinal);
+  const ::CUdevice __dev = __deviceGet(__ordinal);
   ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to query the name of a device", __name_out, __len, __dev);
 }
 
@@ -293,7 +293,7 @@ _CCCL_HOST_API inline void __deviceGetName(char* __name_out, int __len, int __or
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceTotalMem);
   ::std::size_t __result;
-  ::CUdevice __dev = __deviceGet(__ordinal);
+  const ::CUdevice __dev = __deviceGet(__ordinal);
   ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to query total memory of a device", &__result, __dev);
   return static_cast<::cuda::std::size_t>(__result);
 }

--- a/libcudacxx/include/cuda/__event/event.h
+++ b/libcudacxx/include/cuda/__event/event.h
@@ -155,7 +155,7 @@ private:
   _CCCL_HOST_API explicit event(device_ref __device, unsigned __flags)
       : event_ref(::cudaEvent_t{})
   {
-    [[maybe_unused]] __ensure_current_context __ctx_setter(__device);
+    [[maybe_unused]] const __ensure_current_context __ctx_setter(__device);
     __event_ = ::cuda::__driver::__eventCreate(static_cast<unsigned>(__flags));
   }
 };

--- a/libcudacxx/include/cuda/__event/event_ref.h
+++ b/libcudacxx/include/cuda/__event/event_ref.h
@@ -91,7 +91,7 @@ public:
   [[nodiscard]] _CCCL_HOST_API bool is_done() const
   {
     _CCCL_ASSERT(__event_ != nullptr, "cuda::event_ref::sync no event set");
-    ::cudaError_t __status = ::cuda::__driver::__eventQueryNoThrow(__event_);
+    const ::cudaError_t __status = ::cuda::__driver::__eventQueryNoThrow(__event_);
     if (__status == ::cudaSuccess)
     {
       return true;

--- a/libcudacxx/include/cuda/__execution/require.h
+++ b/libcudacxx/include/cuda/__execution/require.h
@@ -63,7 +63,7 @@ template <class... _Requirements>
   // clang < 19 doesn't like this code
   // since the only requirements we currently allow are in determinism.h and
   // all of them are stateless, let's ignore incoming parameters
-  ::cuda::std::execution::env<_Requirements...> __env{};
+  const ::cuda::std::execution::env<_Requirements...> __env{};
 
   return ::cuda::std::execution::prop{__get_requirements_t{}, __env};
 }

--- a/libcudacxx/include/cuda/__hierarchy/queries/count.h
+++ b/libcudacxx/include/cuda/__hierarchy/queries/count.h
@@ -66,7 +66,7 @@ struct __count_query_native<block_level, cluster_level>
   template <class _Tp>
   [[nodiscard]] _CCCL_DEVICE_API static _Tp __call() noexcept
   {
-    unsigned __count = 1;
+    unsigned __count = 1; // NOLINT(misc-const-correctness)
     NV_IF_TARGET(NV_PROVIDES_SM_90, (__count = ::__clusterSizeInBlocks();))
     return static_cast<_Tp>(__count);
   }

--- a/libcudacxx/include/cuda/__hierarchy/queries/extents.h
+++ b/libcudacxx/include/cuda/__hierarchy/queries/extents.h
@@ -128,7 +128,7 @@ template <class _Tp, class _Unit, class _Level, class _Hierarchy>
 
   // Remove dependency on runtime storage. This makes the queries work for hierarchy levels with all static extents
   // in constant evaluated context.
-  _CurrExts __curr_exts{};
+  _CurrExts __curr_exts{}; // NOLINT(misc-const-correctness)
   if constexpr (_CurrExts::rank_dynamic() > 0)
   {
     __curr_exts = ::cuda::__hierarchy_extents_cast<_Tp>(__hier.level(_NextLevel{}).extents());
@@ -211,7 +211,7 @@ struct __extents_query_native<block_level, cluster_level>
   template <class _Tp>
   [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, _Tp> __call() noexcept
   {
-    ::dim3 __dims{1u, 1u, 1u};
+    ::dim3 __dims{1u, 1u, 1u}; // NOLINT(misc-const-correctness)
     NV_IF_TARGET(NV_PROVIDES_SM_90, (__dims = ::__clusterDim();))
     return ::cuda::std::dims<3, _Tp>{static_cast<_Tp>(__dims.x), static_cast<_Tp>(__dims.y), static_cast<_Tp>(__dims.z)};
   }
@@ -234,7 +234,7 @@ struct __extents_query_native<cluster_level, grid_level>
   template <class _Tp>
   [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, _Tp> __call() noexcept
   {
-    ::dim3 __dims{gridDim};
+    ::dim3 __dims{gridDim}; // NOLINT(misc-const-correctness)
     NV_IF_TARGET(NV_PROVIDES_SM_90, (__dims = ::__clusterGridDimInClusters();))
     return ::cuda::std::dims<3, _Tp>{static_cast<_Tp>(__dims.x), static_cast<_Tp>(__dims.y), static_cast<_Tp>(__dims.z)};
   }
@@ -283,7 +283,7 @@ struct __extents_query<warp_level, _Level>
       static_assert(__static_thread_count >= 32, "_Hierarchy doesn't contain enough threads to fill a single warp");
 
       constexpr auto __static_warp_count = ::cuda::ceil_div(__static_thread_count, 32);
-      ::cuda::std::extents<_Tp, __static_warp_count> __curr_exts{};
+      const ::cuda::std::extents<_Tp, __static_warp_count> __curr_exts{};
       if constexpr (::cuda::std::is_same_v<_Level, block_level>)
       {
         return __curr_exts;

--- a/libcudacxx/include/cuda/__hierarchy/queries/index.h
+++ b/libcudacxx/include/cuda/__hierarchy/queries/index.h
@@ -113,7 +113,7 @@ struct __index_query_native<block_level, cluster_level>
   template <class _Tp>
   [[nodiscard]] _CCCL_DEVICE_API static hierarchy_query_result<_Tp> __call() noexcept
   {
-    ::dim3 __idx{0u, 0u, 0u};
+    ::dim3 __idx{0u, 0u, 0u}; // NOLINT(misc-const-correctness)
     NV_IF_TARGET(NV_PROVIDES_SM_90, (__idx = ::__clusterRelativeBlockIdx();))
     return {static_cast<_Tp>(__idx.x), static_cast<_Tp>(__idx.y), static_cast<_Tp>(__idx.z)};
   }
@@ -135,7 +135,7 @@ struct __index_query_native<cluster_level, grid_level>
   template <class _Tp>
   [[nodiscard]] _CCCL_DEVICE_API static hierarchy_query_result<_Tp> __call() noexcept
   {
-    ::dim3 __idx{blockIdx};
+    ::dim3 __idx{blockIdx}; // NOLINT(misc-const-correctness)
     NV_IF_TARGET(NV_PROVIDES_SM_90, (__idx = ::__clusterIdx();))
     return {static_cast<_Tp>(__idx.x), static_cast<_Tp>(__idx.y), static_cast<_Tp>(__idx.z)};
   }

--- a/libcudacxx/include/cuda/__hierarchy/queries/rank.h
+++ b/libcudacxx/include/cuda/__hierarchy/queries/rank.h
@@ -99,7 +99,7 @@ struct __rank_query_native<block_level, cluster_level>
   template <class _Tp>
   [[nodiscard]] _CCCL_DEVICE_API static _Tp __call() noexcept
   {
-    unsigned __rank = 0;
+    unsigned __rank = 0; // NOLINT(misc-const-correctness)
     NV_IF_TARGET(NV_PROVIDES_SM_90, (__rank = ::__clusterRelativeBlockRank();))
     return static_cast<_Tp>(__rank);
   }

--- a/libcudacxx/include/cuda/__launch/configuration.h
+++ b/libcudacxx/include/cuda/__launch/configuration.h
@@ -716,7 +716,7 @@ template <typename BottomUnit, typename... Levels, typename... Opts>
 template <int _ThreadsPerBlock>
 constexpr auto distribute(int numElements) noexcept
 {
-  int blocksPerGrid = (numElements + _ThreadsPerBlock - 1) / _ThreadsPerBlock;
+  const int blocksPerGrid = (numElements + _ThreadsPerBlock - 1) / _ThreadsPerBlock;
   return make_config(make_hierarchy(grid_dims(blocksPerGrid), block_dims<_ThreadsPerBlock>()));
 }
 
@@ -778,7 +778,7 @@ template <typename Dimensions, typename... Options>
 {
   return ::cuda::std::apply(
     [&](auto&... config_options) {
-      cudaError_t __status = cudaSuccess;
+      cudaError_t __status = cudaSuccess; // NOLINT(misc-const-correctness)
 
       // Use short-cutting && to skip the rest on error, is this too
       // convoluted?

--- a/libcudacxx/include/cuda/__launch/launch.h
+++ b/libcudacxx/include/cuda/__launch/launch.h
@@ -398,7 +398,7 @@ _CCCL_HOST_API auto __launch_impl(_Dst&& __dst, _Config __conf, ::CUfunction __k
   __config.attrs    = &__attrs[0];
   __config.numAttrs = 0;
 
-  ::cudaError_t __status = __detail::apply_kernel_config(__conf, __config, __kernel);
+  const ::cudaError_t __status = __detail::apply_kernel_config(__conf, __config, __kernel);
   if (__status != ::cudaSuccess)
   {
     _CCCL_THROW(::cuda::cuda_error, __status, "Failed to prepare a launch configuration");
@@ -492,7 +492,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            const _Kernel& __kernel,
                            _Args&&... __args)
 {
-  __ensure_current_context __dev_setter{__submitter};
+  const __ensure_current_context __dev_setter{__submitter};
   auto __combined = __conf.combine_with_default(__kernel);
   auto __launcher = ::cuda::__get_kernel_launcher<_Kernel,
                                                   decltype(__combined),
@@ -555,7 +555,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            void (*__kernel)(kernel_config<_Dimensions, _Config...>, _ExpArgs...),
                            _ActArgs&&... __args)
 {
-  __ensure_current_context __dev_setter{__submitter};
+  const __ensure_current_context __dev_setter{__submitter};
   return ::cuda::__launch_impl<kernel_config<_Dimensions, _Config...>,
                                _ExpArgs...>(
     cuda::__forward_or_cast_to_stream_ref<_Submitter>(__submitter), //
@@ -611,7 +611,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            void (*__kernel)(_ExpArgs...),
                            _ActArgs&&... __args)
 {
-  __ensure_current_context __dev_setter{__submitter};
+  const __ensure_current_context __dev_setter{__submitter};
   return ::cuda::__launch_impl<_ExpArgs...>(
     cuda::__forward_or_cast_to_stream_ref<_Submitter>(__submitter), //
     __conf,

--- a/libcudacxx/include/cuda/__mdspan/host_device_accessor.h
+++ b/libcudacxx/include/cuda/__mdspan/host_device_accessor.h
@@ -349,7 +349,7 @@ public:
   {
     _CCCL_IF_NOT_CONSTEVAL_DEFAULT
     {
-      bool __is_valid = true;
+      bool __is_valid = true; // NOLINT(misc-const-correctness)
       NV_IF_TARGET(NV_IS_HOST, (__is_valid = __is_device_accessible_pointer_from_host(__p);))
       _CCCL_ASSERT(__is_valid,
                    "device_accessor (mdspan): data handle doesn't point to a valid device or managed memory");
@@ -470,7 +470,7 @@ public:
   {
     _CCCL_IF_NOT_CONSTEVAL_DEFAULT
     {
-      bool __is_valid = true;
+      bool __is_valid = true; // NOLINT(misc-const-correctness)
       NV_IF_ELSE_TARGET(NV_IS_HOST, (__is_valid = __is_managed_pointer(__p);), (return true;))
       _CCCL_ASSERT(__is_valid, "managed_accessor (mdspan): data handle doesn't point to a valid managed memory");
       return !__is_valid;

--- a/libcudacxx/include/cuda/__mdspan/shared_memory_accessor.h
+++ b/libcudacxx/include/cuda/__mdspan/shared_memory_accessor.h
@@ -195,9 +195,9 @@ public:
   {
     [[maybe_unused]] bool __is_valid = true;
     NV_IF_TARGET(NV_IS_DEVICE,
-                 (bool __is_shared_mem     = ::cuda::device::is_address_from(__p, device::address_space::shared);
-                  bool __exceeds_smem_size = __size_bytes > ::cuda::__max_smem_allocation_bytes();
-                  __is_valid               = __is_shared_mem && !__exceeds_smem_size;))
+                 (bool __is_shared_mem           = ::cuda::device::is_address_from(__p, device::address_space::shared);
+                  const bool __exceeds_smem_size = __size_bytes > ::cuda::__max_smem_allocation_bytes();
+                  __is_valid                     = __is_shared_mem && !__exceeds_smem_size;))
     _CCCL_ASSERT(__is_valid, "shared_memory_accessor (mdspan): data handle doesn't point to a valid shared memory");
     _CCCL_VERIFY_DEVICE_ONLY_USAGE();
     return !__is_valid;

--- a/libcudacxx/include/cuda/__memory/address_space.h
+++ b/libcudacxx/include/cuda/__memory/address_space.h
@@ -111,7 +111,7 @@ template <typename = void>
       return static_cast<bool>(__ret);
 #  else // ^^^ _CCCL_CUDA_COMPILER(NVCC, <, 12, 3) || _CCCL_CUDA_COMPILER(NVRTC, <, 12, 3) ^^^ /
         // vvv !_CCCL_CUDA_COMPILER(NVCC, <, 12, 3) && !_CCCL_CUDA_COMPILER(NVRTC, <, 12, 3) vvv
-      bool __p = static_cast<bool>(::__isGlobal(__ptr));
+      const bool __p = static_cast<bool>(::__isGlobal(__ptr));
       if (__p)
       {
         _CCCL_ASSUME(__p);
@@ -133,7 +133,7 @@ template <typename = void>
       return static_cast<bool>(__ret);
 #  else // ^^^ _CCCL_CUDA_COMPILER(NVCC, <, 12, 3) || _CCCL_CUDA_COMPILER(NVRTC, <, 12, 3) ^^^ /
         // vvv !_CCCL_CUDA_COMPILER(NVCC, <, 12, 3) && !_CCCL_CUDA_COMPILER(NVRTC, <, 12, 3) vvv
-      bool __p = static_cast<bool>(::__isConstant(__ptr));
+      const bool __p = static_cast<bool>(::__isConstant(__ptr));
       if (__p)
       {
         _CCCL_ASSUME(__p);
@@ -158,7 +158,7 @@ template <typename = void>
 #    if _CCCL_IS_LOCAL_WORKAROUND_13_1_ENABLED
       bool __p = ::cuda::device::__is_local_cuda_13_1_workaround(__ptr);
 #    else // ^^^ _CCCL_IS_LOCAL_WORKAROUND_13_1_ENABLED ^^^ / vvv other NVCC/NVRTC versions vvv
-      bool __p = static_cast<bool>(::__isLocal(__ptr));
+      const bool __p = static_cast<bool>(::__isLocal(__ptr));
 #    endif // ^^^ other NVCC/NVRTC versions ^^^
       if (__p)
       {
@@ -233,7 +233,7 @@ template <typename = void>
 #    if _CCCL_IS_SHARED_WORKAROUND_12_9_TO_13_1_ENABLED
       bool __p = ::cuda::device::__is_shared_cuda_12_9_workaround(__ptr);
 #    else // ^^^ _CCCL_IS_SHARED_WORKAROUND_12_9_TO_13_1_ENABLED ^^^ / vvv other NVCC/NVRTC versions vvv
-      bool __p = static_cast<bool>(::__isShared(__ptr));
+      const bool __p = static_cast<bool>(::__isShared(__ptr));
 #    endif // ^^^ other NVCC/NVRTC versions ^^^
       if (__p)
       {

--- a/libcudacxx/include/cuda/__memory/get_device_address.h
+++ b/libcudacxx/include/cuda/__memory/get_device_address.h
@@ -64,7 +64,7 @@ template <class _Tp>
 template <class _Tp>
 [[nodiscard]] _CCCL_HOST_API inline _Tp* get_device_address(_Tp& __device_object, device_ref __device)
 {
-  __ensure_current_context __ctx{__device};
+  const __ensure_current_context __ctx{__device};
   void* __device_ptr{};
   _CCCL_TRY_RUNTIME_API(
     ::cudaGetSymbolAddress,

--- a/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
@@ -129,9 +129,9 @@ static_assert(::cuda::std::is_trivially_destructible_v<device_memory_pool_ref>);
 //! @returns The default memory pool of the specified device.
 [[nodiscard]] _CCCL_HOST_API inline device_memory_pool_ref& device_default_memory_pool(::cuda::device_ref __device)
 {
-  static ::cuda::std::unique_ptr<__default_device_memory_pool[]> __pools_{
+  static const ::cuda::std::unique_ptr<__default_device_memory_pool[]> __pools_{
     ::new __default_device_memory_pool[::cuda::__physical_devices_count()]};
-  return __pools_[__device.get()].__get(__device);
+  return __pools_[static_cast<::cuda::std::size_t>(__device.get())].__get(__device);
 }
 
 //! @rst

--- a/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
+++ b/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
@@ -447,7 +447,7 @@ struct memory_pool_properties
   }
 
   ::CUmemoryPool __cuda_pool_handle{};
-  ::cudaError_t __error = ::cuda::__driver::__mempoolCreateNoThrow(&__cuda_pool_handle, &__pool_properties);
+  const ::cudaError_t __error = ::cuda::__driver::__mempoolCreateNoThrow(&__cuda_pool_handle, &__pool_properties);
   if (__error != ::cudaSuccess)
   {
     auto __device = __location.type == ::CU_MEM_LOCATION_TYPE_DEVICE ? __location.id : 0;
@@ -466,7 +466,7 @@ struct memory_pool_properties
   // We need to use a new stream so we do not wait on other work
   if (__properties.initial_pool_size != 0)
   {
-    ::CUdeviceptr __ptr = ::cuda::__driver::__mallocFromPoolAsync(
+    const ::CUdeviceptr __ptr = ::cuda::__driver::__mallocFromPoolAsync(
       __properties.initial_pool_size, __cuda_pool_handle, __cccl_allocation_stream().get());
     _CCCL_TRY_DRIVER_API(
       ::cuda::__driver::__freeAsyncNoThrow,
@@ -515,7 +515,8 @@ public:
       _CCCL_THROW(::std::invalid_argument, "Invalid alignment passed to __memory_pool_base::allocate_sync.");
     }
 
-    ::CUdeviceptr __ptr = ::cuda::__driver::__mallocFromPoolAsync(__bytes, __pool_, __cccl_allocation_stream().get());
+    const ::CUdeviceptr __ptr =
+      ::cuda::__driver::__mallocFromPoolAsync(__bytes, __pool_, __cccl_allocation_stream().get());
     __cccl_allocation_stream().sync();
     return reinterpret_cast<void*>(__ptr); // NOLINT(performance-no-int-to-ptr)
   }
@@ -570,7 +571,7 @@ public:
   //! @returns Pointer to the newly allocated memory.
   [[nodiscard]] _CCCL_HOST_API void* allocate(const ::cuda::stream_ref __stream, const size_t __bytes)
   {
-    ::CUdeviceptr __ptr = ::cuda::__driver::__mallocFromPoolAsync(__bytes, __pool_, __stream.get());
+    const ::CUdeviceptr __ptr = ::cuda::__driver::__mallocFromPoolAsync(__bytes, __pool_, __stream.get());
     return reinterpret_cast<void*>(__ptr); // NOLINT(performance-no-int-to-ptr)
   }
 

--- a/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
@@ -78,8 +78,8 @@ public:
                   "Invalid alignment passed to legacy_managed_memory_resource::allocate_sync.");
     }
 
-    ::cuda::__ensure_current_context __guard(__device_);
-    ::CUdeviceptr __ptr = ::cuda::__driver::__mallocManaged(__bytes, __flags_);
+    const ::cuda::__ensure_current_context __guard(__device_);
+    const ::CUdeviceptr __ptr = ::cuda::__driver::__mallocManaged(__bytes, __flags_);
     return reinterpret_cast<void*>(__ptr); // NOLINT(performance-no-int-to-ptr)
   }
 

--- a/libcudacxx/include/cuda/__memory_resource/legacy_pinned_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_pinned_memory_resource.h
@@ -68,7 +68,7 @@ public:
       _CCCL_THROW(::std::invalid_argument, "Invalid alignment passed to legacy_pinned_memory_resource::allocate_sync.");
     }
 
-    ::cuda::__ensure_current_context __guard(__device_);
+    const ::cuda::__ensure_current_context __guard(__device_);
     void* __ptr = ::cuda::__driver::__mallocHost(__bytes);
     return __ptr;
   }

--- a/libcudacxx/include/cuda/__numeric/overflow_cast.h
+++ b/libcudacxx/include/cuda/__numeric/overflow_cast.h
@@ -44,7 +44,7 @@ _CCCL_TEMPLATE(class _To, class _From)
 _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_To> _CCCL_AND ::cuda::std::__cccl_is_cv_integer_v<_From>)
 [[nodiscard]] _CCCL_API constexpr overflow_result<_To> overflow_cast(const _From& __from) noexcept
 {
-  bool __overflow = false;
+  bool __overflow = false; // NOLINT(misc-const-correctness)
   if constexpr (!__is_integer_representable_v<_From, _To>)
   {
     __overflow = !::cuda::std::in_range<_To>(__from);

--- a/libcudacxx/include/cuda/__random/feistel_bijection.h
+++ b/libcudacxx/include/cuda/__random/feistel_bijection.h
@@ -64,7 +64,7 @@ public:
     __R_bits_ = __total_bits - __L_bits_;
     __R_mask_ = (1ull << __R_bits_) - 1;
 
-    ::cuda::std::uniform_int_distribution<uint32_t> __dist{};
+    ::cuda::std::uniform_int_distribution<uint32_t> __dist{}; // NOLINT(misc-const-correctness)
     _CCCL_PRAGMA_UNROLL_FULL()
     for (auto& __key : __keys_)
     {
@@ -87,13 +87,13 @@ public:
     {
       constexpr uint64_t __m0  = 0xD2B74407B1CE6E93;
       const uint64_t __product = __m0 * __L;
-      uint32_t __F_k           = (__product >> 32) ^ __key;
-      uint32_t __B_k           = static_cast<uint32_t>(__product);
-      uint32_t __L_prime       = __F_k ^ __R;
+      const uint32_t __F_k     = (__product >> 32) ^ __key;
+      const uint32_t __B_k     = static_cast<uint32_t>(__product);
+      const uint32_t __L_prime = __F_k ^ __R;
 
-      uint32_t __R_prime = (__B_k << (__R_bits_ - __L_bits_)) | __R >> __L_bits_;
-      __L                = __L_prime & __L_mask_;
-      __R                = __R_prime & __R_mask_;
+      const uint32_t __R_prime = (__B_k << (__R_bits_ - __L_bits_)) | __R >> __L_bits_;
+      __L                      = __L_prime & __L_mask_;
+      __R                      = __R_prime & __R_mask_;
     }
     // Combine the left and right sides together to get result
     return (static_cast<uint64_t>(__L) << __R_bits_) | static_cast<uint64_t>(__R);

--- a/libcudacxx/include/cuda/__stream/internal_streams.h
+++ b/libcudacxx/include/cuda/__stream/internal_streams.h
@@ -41,7 +41,7 @@ inline ::cuda::stream_ref __cccl_allocation_stream() noexcept
 {
   // Intentionally leak the stream here to avoid stream destruction when the program exits, which is not guaraneed to
   // work.
-  static ::cuda::stream_ref __stream = []() {
+  static const ::cuda::stream_ref __stream = []() {
     ::cuda::stream __str{::cuda::device_ref{0}};
     return __str.release();
   }();

--- a/libcudacxx/include/cuda/__stream/stream.h
+++ b/libcudacxx/include/cuda/__stream/stream.h
@@ -49,7 +49,7 @@ struct stream : stream_ref
   _CCCL_HOST_API explicit stream(device_ref __dev, int __priority = default_priority)
       : stream_ref(::cuda::__invalid_stream())
   {
-    [[maybe_unused]] __ensure_current_context __ctx_setter(__dev);
+    const __ensure_current_context __ctx_setter(__dev);
     __stream = ::cuda::__driver::__streamCreateWithPriority(cudaStreamNonBlocking, __priority);
   }
 

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -207,7 +207,7 @@ public:
     _CCCL_ASSERT(__stream != ::cuda::__invalid_stream(), "cuda::stream_ref::wait invalid stream passed");
     if (*this != __other)
     {
-      event __tmp(__other);
+      const event __tmp(__other);
       wait(__tmp);
     }
   }
@@ -385,7 +385,7 @@ _CCCL_HOST_API inline event::event(stream_ref __stream, event_flags __flags)
 _CCCL_HOST_API inline event::event(stream_ref __stream, unsigned __flags)
     : event_ref(::cudaEvent_t{})
 {
-  [[maybe_unused]] __ensure_current_context __ctx_setter(__stream);
+  [[maybe_unused]] const __ensure_current_context __ctx_setter(__stream);
   __event_ = ::cuda::__driver::__eventCreate(static_cast<unsigned>(__flags));
 }
 

--- a/libcudacxx/include/cuda/__utility/__basic_any/basic_any_value.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/basic_any_value.h
@@ -429,7 +429,7 @@ private:
 
   _CCCL_HOST_DEVICE_API void __release_()
   {
-    __vptr_for<_Interface> __vptr = nullptr;
+    const __vptr_for<_Interface> __vptr = nullptr;
     __vptr_.__set(__vptr, false);
   }
 
@@ -468,7 +468,7 @@ private:
       }
     }
 
-    __vptr_for<_Interface> __vptr = ::cuda::__get_vtable_ptr_for<_Interface, _Tp>();
+    const __vptr_for<_Interface> __vptr = ::cuda::__get_vtable_ptr_for<_Interface, _Tp>();
     __vptr_.__set(__vptr, __is_small<_Tp, __movable>(__size_, __align_));
     return *::cuda::std::launder(static_cast<_Tp*>(__get_optr()));
   }

--- a/libcudacxx/include/cuda/std/__algorithm/shuffle.h
+++ b/libcudacxx/include/cuda/std/__algorithm/shuffle.h
@@ -42,7 +42,7 @@ __shuffle(_RandomAccessIterator __first, _Sentinel __last_sentinel, _UniformRand
   difference_type __d  = __last - __first;
   if (__d > 1)
   {
-    _Dp __uid;
+    _Dp __uid; // NOLINT(misc-const-correctness)
     for (--__last, (void) --__d; __first < __last; ++__first, (void) --__d)
     {
       difference_type __i = __uid(__g, _Pp(0, __d));

--- a/libcudacxx/include/cuda/std/__atomic/functions/dispatch.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/dispatch.h
@@ -285,7 +285,7 @@ __cuda_atomic_store_dispatch(_Backend __backend, _Type* __ptr, _Up __val, memory
   using __proxy_tag            = __cuda_atomic_deduce_bitwise_tag_t<__value_type>;
   __proxy_pointee* __ptr_proxy = reinterpret_cast<__proxy_pointee*>(__ptr);
   __value_type __store         = __val;
-  __proxy_t* __val_proxy       = reinterpret_cast<__proxy_t*>(&__store);
+  const __proxy_t* __val_proxy = reinterpret_cast<__proxy_t*>(&__store);
 #if _CCCL_CUDA_COMPILATION()
   if constexpr (_Backend::__requires_local_memory_workaround)
   {
@@ -333,7 +333,7 @@ template <class _Backend, class _Type, class _Cas, class _Sco>
   using __proxy_tag            = __cuda_atomic_deduce_bitwise_tag_t<__value_type>;
   __proxy_pointee* __ptr_proxy = reinterpret_cast<__proxy_pointee*>(__ptr);
   __proxy_t* __exp_proxy       = reinterpret_cast<__proxy_t*>(__exp);
-  __proxy_t* __des_proxy       = reinterpret_cast<__proxy_t*>(&__des);
+  const __proxy_t* __des_proxy = reinterpret_cast<__proxy_t*>(&__des);
 #if _CCCL_CUDA_COMPILATION()
   if constexpr (_Backend::__requires_local_memory_workaround)
   {
@@ -374,7 +374,7 @@ _CCCL_HOST_DEVICE_API void __cuda_atomic_exchange_dispatch(
   using __proxy_tag _CCCL_NODEBUG     = __cuda_atomic_deduce_bitwise_tag_t<__value_type>;
   __proxy_pointee* __ptr_proxy        = reinterpret_cast<__proxy_pointee*>(__ptr);
   __proxy_t* __old_proxy              = reinterpret_cast<__proxy_t*>(&__old);
-  __proxy_t* __new_proxy              = reinterpret_cast<__proxy_t*>(&__new);
+  __proxy_t* __new_proxy              = reinterpret_cast<__proxy_t*>(&__new); // NOLINT(misc-const-correctness)
 #if _CCCL_CUDA_COMPILATION()
   if constexpr (_Backend::__requires_local_memory_workaround)
   {
@@ -425,7 +425,7 @@ __cuda_atomic_fetch_add_dispatch(_Backend __backend, _Type* __ptr, _Up __op, mem
   __value_type __dst{};
   __proxy_pointee* __ptr_proxy = reinterpret_cast<__proxy_pointee*>(__ptr);
   __proxy_t* __dst_proxy       = reinterpret_cast<__proxy_t*>(&__dst);
-  __proxy_t* __op_proxy        = reinterpret_cast<__proxy_t*>(&__op);
+  const __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
 #if _CCCL_CUDA_COMPILATION()
   if constexpr (_Backend::__requires_local_memory_workaround)
   {
@@ -465,7 +465,7 @@ __cuda_atomic_fetch_and_dispatch(_Backend __backend, _Type* __ptr, _Up __op, mem
   __value_type __dst{};
   __proxy_pointee* __ptr_proxy = reinterpret_cast<__proxy_pointee*>(__ptr);
   __proxy_t* __dst_proxy       = reinterpret_cast<__proxy_t*>(&__dst);
-  __proxy_t* __op_proxy        = reinterpret_cast<__proxy_t*>(&__op);
+  const __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
 #if _CCCL_CUDA_COMPILATION()
   if constexpr (_Backend::__requires_local_memory_workaround)
   {
@@ -505,7 +505,7 @@ __cuda_atomic_fetch_max_dispatch(_Backend __backend, _Type* __ptr, _Up __op, mem
   __value_type __dst{};
   __proxy_pointee* __ptr_proxy = reinterpret_cast<__proxy_pointee*>(__ptr);
   __proxy_t* __dst_proxy       = reinterpret_cast<__proxy_t*>(&__dst);
-  __proxy_t* __op_proxy        = reinterpret_cast<__proxy_t*>(&__op);
+  const __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
 #if _CCCL_CUDA_COMPILATION()
   if constexpr (_Backend::__requires_local_memory_workaround)
   {
@@ -545,7 +545,7 @@ __cuda_atomic_fetch_min_dispatch(_Backend __backend, _Type* __ptr, _Up __op, mem
   __value_type __dst{};
   __proxy_pointee* __ptr_proxy = reinterpret_cast<__proxy_pointee*>(__ptr);
   __proxy_t* __dst_proxy       = reinterpret_cast<__proxy_t*>(&__dst);
-  __proxy_t* __op_proxy        = reinterpret_cast<__proxy_t*>(&__op);
+  const __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
 #if _CCCL_CUDA_COMPILATION()
   if constexpr (_Backend::__requires_local_memory_workaround)
   {
@@ -585,7 +585,7 @@ __cuda_atomic_fetch_or_dispatch(_Backend __backend, _Type* __ptr, _Up __op, memo
   __value_type __dst{};
   __proxy_pointee* __ptr_proxy = reinterpret_cast<__proxy_pointee*>(__ptr);
   __proxy_t* __dst_proxy       = reinterpret_cast<__proxy_t*>(&__dst);
-  __proxy_t* __op_proxy        = reinterpret_cast<__proxy_t*>(&__op);
+  const __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
 #if _CCCL_CUDA_COMPILATION()
   if constexpr (_Backend::__requires_local_memory_workaround)
   {
@@ -625,7 +625,7 @@ __cuda_atomic_fetch_xor_dispatch(_Backend __backend, _Type* __ptr, _Up __op, mem
   __value_type __dst{};
   __proxy_pointee* __ptr_proxy = reinterpret_cast<__proxy_pointee*>(__ptr);
   __proxy_t* __dst_proxy       = reinterpret_cast<__proxy_t*>(&__dst);
-  __proxy_t* __op_proxy        = reinterpret_cast<__proxy_t*>(&__op);
+  const __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
 #if _CCCL_CUDA_COMPILATION()
   if constexpr (_Backend::__requires_local_memory_workaround)
   {

--- a/libcudacxx/include/cuda/std/__complex/complex.h
+++ b/libcudacxx/include/cuda/std/__complex/complex.h
@@ -301,16 +301,16 @@ template <class _Tp>
   // Avoid floating point operations that are invalid during constant evaluation
   _CCCL_IF_CONSTEVAL
   {
-    bool __z_zero = __a == _Tp(0) && __b == _Tp(0);
-    bool __w_zero = __c == _Tp(0) && __d == _Tp(0);
-    bool __z_inf  = ::cuda::std::isinf(__a) || ::cuda::std::isinf(__b);
-    bool __w_inf  = ::cuda::std::isinf(__c) || ::cuda::std::isinf(__d);
-    bool __z_nan  = !__z_inf
-                 && ((::cuda::std::isnan(__a) && ::cuda::std::isnan(__b)) || (::cuda::std::isnan(__a) && __b == _Tp(0))
-                     || (__a == _Tp(0) && ::cuda::std::isnan(__b)));
-    bool __w_nan  = !__w_inf
-                 && ((::cuda::std::isnan(__c) && ::cuda::std::isnan(__d)) || (::cuda::std::isnan(__c) && __d == _Tp(0))
-                     || (__c == _Tp(0) && ::cuda::std::isnan(__d)));
+    const bool __z_zero = __a == _Tp(0) && __b == _Tp(0);
+    const bool __w_zero = __c == _Tp(0) && __d == _Tp(0);
+    const bool __z_inf  = ::cuda::std::isinf(__a) || ::cuda::std::isinf(__b);
+    const bool __w_inf  = ::cuda::std::isinf(__c) || ::cuda::std::isinf(__d);
+    const bool __z_nan  = !__z_inf
+                       && ((::cuda::std::isnan(__a) && ::cuda::std::isnan(__b))
+                           || (::cuda::std::isnan(__a) && __b == _Tp(0)) || (__a == _Tp(0) && ::cuda::std::isnan(__b)));
+    const bool __w_nan  = !__w_inf
+                       && ((::cuda::std::isnan(__c) && ::cuda::std::isnan(__d))
+                           || (::cuda::std::isnan(__c) && __d == _Tp(0)) || (__c == _Tp(0) && ::cuda::std::isnan(__d)));
     if (__z_nan || __w_nan)
     {
       return complex<_Tp>(numeric_limits<_Tp>::quiet_NaN(), _Tp(0));
@@ -323,8 +323,8 @@ template <class _Tp>
       }
       return complex<_Tp>(numeric_limits<_Tp>::infinity(), numeric_limits<_Tp>::infinity());
     }
-    bool __z_nonzero_nan = !__z_inf && !__z_nan && (::cuda::std::isnan(__a) || ::cuda::std::isnan(__b));
-    bool __w_nonzero_nan = !__w_inf && !__w_nan && (::cuda::std::isnan(__c) || ::cuda::std::isnan(__d));
+    const bool __z_nonzero_nan = !__z_inf && !__z_nan && (::cuda::std::isnan(__a) || ::cuda::std::isnan(__b));
+    const bool __w_nonzero_nan = !__w_inf && !__w_nan && (::cuda::std::isnan(__c) || ::cuda::std::isnan(__d));
     if (__z_nonzero_nan || __w_nonzero_nan)
     {
       return complex<_Tp>(numeric_limits<_Tp>::quiet_NaN(), _Tp(0));

--- a/libcudacxx/include/cuda/std/__complex/logarithms.h
+++ b/libcudacxx/include/cuda/std/__complex/logarithms.h
@@ -106,8 +106,8 @@ template <class _Tp>
   const _Tp __real_abs = ::cuda::std::fabs(__x.real());
   const _Tp __imag_abs = ::cuda::std::fabs(__x.imag());
 
-  _Tp __max = (__real_abs > __imag_abs) ? __real_abs : __imag_abs;
-  _Tp __min = (__real_abs > __imag_abs) ? __imag_abs : __real_abs;
+  const _Tp __max = (__real_abs > __imag_abs) ? __real_abs : __imag_abs;
+  const _Tp __min = (__real_abs > __imag_abs) ? __imag_abs : __real_abs;
 
   // We would like to range reduce these values so that abs(x) ~ 1, as we'll take the log of this.
   // The below code inlines and removes these two calls:
@@ -118,12 +118,12 @@ template <class _Tp>
   int32_t __exp = static_cast<int32_t>(::cuda::std::bit_cast<__uint_t>(__max) >> __mant_nbits) - __exp_bias + 1;
 
   // Quick frexp:
-  __uint_t __max_reduced_as_uint = (::cuda::std::bit_cast<__uint_t>(__max) & __mant_mask) | __exp_mask_of_half;
-  _Tp __max_reduced              = ::cuda::std::bit_cast<_Tp>(__max_reduced_as_uint);
+  const __uint_t __max_reduced_as_uint = (::cuda::std::bit_cast<__uint_t>(__max) & __mant_mask) | __exp_mask_of_half;
+  _Tp __max_reduced                    = ::cuda::std::bit_cast<_Tp>(__max_reduced_as_uint);
 
   // Create an exponent for an inline ldexp(__min, -__exp)
-  __uint_t __exp_neg_as_uint = (static_cast<__uint_t>(__exp_bias - __exp) << __mant_nbits);
-  _Tp __exp_neg              = ::cuda::std::bit_cast<_Tp>(__exp_neg_as_uint);
+  const __uint_t __exp_neg_as_uint = (static_cast<__uint_t>(__exp_bias - __exp) << __mant_nbits);
+  const _Tp __exp_neg              = ::cuda::std::bit_cast<_Tp>(__exp_neg_as_uint);
 
   _Tp __min_reduced = __min * __exp_neg;
 
@@ -146,25 +146,27 @@ template <class _Tp>
         // and split it into two separate multiplications.
         // Inlined version of this code:
         //   __min_reduced = ::cuda::std::ldexp(__min, -__exp);
-        __uint_t __ldexp_factor_2_uint = (static_cast<__uint_t>(__exp_bias + __mant_nbits - __exp) << __mant_nbits);
-        __uint_t __two_m_mant_bits     = static_cast<__uint_t>(-__mant_nbits + __exp_bias) << __mant_nbits;
+        const __uint_t __ldexp_factor_2_uint =
+          (static_cast<__uint_t>(__exp_bias + __mant_nbits - __exp) << __mant_nbits);
+        const __uint_t __two_m_mant_bits = static_cast<__uint_t>(-__mant_nbits + __exp_bias) << __mant_nbits;
 
-        _Tp __ldexp_factor_1 = ::cuda::std::bit_cast<_Tp>(__two_m_mant_bits); // 2^(-__mant_nbits)
-        _Tp __ldexp_factor_2 = ::cuda::std::bit_cast<_Tp>(__ldexp_factor_2_uint);
-        __min_reduced        = (__min * __ldexp_factor_1) * __ldexp_factor_2;
+        const _Tp __ldexp_factor_1 = ::cuda::std::bit_cast<_Tp>(__two_m_mant_bits); // 2^(-__mant_nbits)
+        const _Tp __ldexp_factor_2 = ::cuda::std::bit_cast<_Tp>(__ldexp_factor_2_uint);
+        __min_reduced              = (__min * __ldexp_factor_1) * __ldexp_factor_2;
       }
       else
       {
         // __max is denormal (so __min is also denormal or 0.0)
         // Scale things up by 2^__mant_nbits then do the fast ldexp.
-        __uint_t __two_mant_bits = static_cast<__uint_t>(__mant_nbits + __exp_bias) << __mant_nbits;
-        _Tp __ldexp_factor       = ::cuda::std::bit_cast<_Tp>(__two_mant_bits);
-        __max_reduced            = __max * __ldexp_factor; // 2^__mant_nbits
-        __min_reduced            = __min * __ldexp_factor; // 2^__mant_nbits;
+        const __uint_t __two_mant_bits = static_cast<__uint_t>(__mant_nbits + __exp_bias) << __mant_nbits;
+        const _Tp __ldexp_factor       = ::cuda::std::bit_cast<_Tp>(__two_mant_bits);
+        __max_reduced                  = __max * __ldexp_factor; // 2^__mant_nbits
+        __min_reduced                  = __min * __ldexp_factor; // 2^__mant_nbits;
 
-        int32_t __exp_no_denorm_bias =
+        const int32_t __exp_no_denorm_bias =
           static_cast<int32_t>(::cuda::std::bit_cast<__uint_t>(__max_reduced) >> __mant_nbits) - __exp_bias + 1;
-        __uint_t ldexp_factor_no_denorm_bias = static_cast<__uint_t>(__exp_bias - __exp_no_denorm_bias) << __mant_nbits;
+        const __uint_t ldexp_factor_no_denorm_bias =
+          static_cast<__uint_t>(__exp_bias - __exp_no_denorm_bias) << __mant_nbits;
 
         __max_reduced *= ::cuda::std::bit_cast<_Tp>(ldexp_factor_no_denorm_bias);
         __min_reduced *= ::cuda::std::bit_cast<_Tp>(ldexp_factor_no_denorm_bias);
@@ -194,14 +196,14 @@ template <class _Tp>
   // To prevent this we instead calculate:
   //        ((real^2 +  imag^2) - 1)
   // accurately and use log1p.
-  _Tp max_2_hi = __max_reduced * __max_reduced;
-  _Tp max_2_lo = ::cuda::std::fma(__max_reduced, __max_reduced, -max_2_hi);
+  const _Tp max_2_hi = __max_reduced * __max_reduced;
+  const _Tp max_2_lo = ::cuda::std::fma(__max_reduced, __max_reduced, -max_2_hi);
 
-  _Tp min_2_hi = __min_reduced * __min_reduced;
-  _Tp min_2_lo = ::cuda::std::fma(__min_reduced, __min_reduced, -min_2_hi);
+  const _Tp min_2_hi = __min_reduced * __min_reduced;
+  const _Tp min_2_lo = ::cuda::std::fma(__min_reduced, __min_reduced, -min_2_hi);
 
-  _Tp sum_hi = max_2_hi + min_2_hi;
-  _Tp sum_lo = min_2_hi + (max_2_hi - sum_hi);
+  _Tp sum_hi       = max_2_hi + min_2_hi;
+  const _Tp sum_lo = min_2_hi + (max_2_hi - sum_hi);
 
   // Exact where it matters, with the previous range reduction.
   sum_hi -= _Tp(1.0);
@@ -231,7 +233,7 @@ template <class _Tp>
   }
 
   // __hypot_sq_scaled is now in [-0.25, 0.5], we can use a log1p polynomial estimate.
-  _Tp __log1p_poly = __internal_unsafe_log1p_poly(__hypot_sq_scaled);
+  const _Tp __log1p_poly = __internal_unsafe_log1p_poly(__hypot_sq_scaled);
 
   // Scale our answer back up.
   _Tp __abs_rescaled = ::cuda::std::fma(__numbers<_Tp>::__ln2(), __exp_d, __log1p_poly);

--- a/libcudacxx/include/cuda/std/__execution/policy.h
+++ b/libcudacxx/include/cuda/std/__execution/policy.h
@@ -139,7 +139,7 @@ struct __execution_policy_base : env<__unwrap_reference_t<_Envs>...>
       // We must reject prvalue cuda::stream because they are not copyable
       static_assert(!is_same_v<remove_cvref_t<_Value>, ::cuda::stream> || is_lvalue_reference_v<_Value>,
                     "cuda::stream is not copyable. It must be passed as a cuda::stream_ref");
-      ::cuda::stream_ref __stream{__value};
+      const ::cuda::stream_ref __stream{__value};
       return __with(prop{__tag, __stream}, ::cuda::std::make_index_sequence<sizeof...(_Envs)>());
     }
     else if constexpr (is_same_v<remove_cvref_t<_Tag>, ::cuda::mr::get_memory_resource_t>)

--- a/libcudacxx/include/cuda/std/__iterator/advance.h
+++ b/libcudacxx/include/cuda/std/__iterator/advance.h
@@ -41,7 +41,8 @@ template <class _InputIter,
 _CCCL_API constexpr void advance(_InputIter& __i, _Distance __orig_n)
 {
   using _Difference = typename iterator_traits<_InputIter>::difference_type;
-  _Difference __n   = static_cast<_Difference>(::cuda::std::__convert_to_integral(__orig_n));
+  // NOLINTNEXTLINE(misc-const-correctness)
+  _Difference __n = static_cast<_Difference>(::cuda::std::__convert_to_integral(__orig_n));
   if constexpr (__has_random_access_traversal<_InputIter>) // To support pointers to incomplete types
   {
     __i += __n;

--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -257,7 +257,7 @@ public:
       : _DynamicValues{}
   {
     static_assert((sizeof...(_DynVals) == __size_), "Invalid number of values.");
-    _TDynamic __values[__size_] = {static_cast<_TDynamic>(__vals)...};
+    const _TDynamic __values[__size_] = {static_cast<_TDynamic>(__vals)...};
     for (size_t __i = 0; __i < __size_; __i++)
     {
       _TStatic __static_val = _StaticValues::__get(__i);

--- a/libcudacxx/include/cuda/std/__mdspan/layout_right.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_right.h
@@ -184,7 +184,7 @@ public:
 
   [[nodiscard]] _CCCL_API constexpr index_type required_span_size() const noexcept
   {
-    index_type __size = 1;
+    index_type __size = 1; // NOLINT(misc-const-correctness)
     if constexpr (extents_type::rank() > 0) // MSVC raises a warning even with __r != extents_type::rank()
     {
       for (size_t __r = 0; __r < extents_type::rank(); __r++)

--- a/libcudacxx/include/cuda/std/__memory/align.h
+++ b/libcudacxx/include/cuda/std/__memory/align.h
@@ -43,10 +43,10 @@ _CCCL_HOST_DEVICE_API inline void* align(size_t __alignment, size_t __size, void
     return nullptr;
   }
 
-  char* __char_ptr    = static_cast<char*>(__ptr);
-  char* __aligned_ptr = reinterpret_cast<char*>( // NOLINT(performance-no-int-to-ptr)
+  char* __char_ptr          = static_cast<char*>(__ptr);
+  const char* __aligned_ptr = reinterpret_cast<char*>( // NOLINT(performance-no-int-to-ptr)
     reinterpret_cast<uintptr_t>(__char_ptr + (__alignment - 1)) & -__alignment);
-  const size_t __diff = static_cast<size_t>(__aligned_ptr - __char_ptr);
+  const size_t __diff       = static_cast<size_t>(__aligned_ptr - __char_ptr);
   if (__diff > (__space - __size))
   {
     return nullptr;

--- a/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
@@ -75,10 +75,10 @@ struct __pstl_dispatch<__pstl_algorithm::__merge, __execution_backend::__cuda>
     const auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     const auto __ctx    = ::cuda::std::execution::__pstl_ensure_current_ctx_for(__policy);
 
-    iter_difference_t<_InputIterator1> __count1 = ::cuda::std::distance(__first1, __last1);
-    iter_difference_t<_InputIterator2> __count2 = ::cuda::std::distance(__first2, __last2);
-    auto __ret                                  = __result + static_cast<iter_difference_t<_OutputIterator>>(__count1)
-                                                + static_cast<iter_difference_t<_OutputIterator>>(__count2);
+    const iter_difference_t<_InputIterator1> __count1 = ::cuda::std::distance(__first1, __last1);
+    const iter_difference_t<_InputIterator2> __count2 = ::cuda::std::distance(__first2, __last2);
+    auto __ret = __result + static_cast<iter_difference_t<_OutputIterator>>(__count1)
+               + static_cast<iter_difference_t<_OutputIterator>>(__count2);
 
     // We pass the policy as an environment to DeviceMerge
     _CCCL_TRY_RUNTIME_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/temporary_storage.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/temporary_storage.h
@@ -110,7 +110,7 @@ class __temporary_storage
   __get_storage(void* __ptr, const _Sizes... __elements_stored) noexcept
   {
     array<void*, 1 + sizeof...(_StoredTypes)> __storage{__ptr};
-    array<size_t, sizeof...(_StoredTypes)> __num_elements{static_cast<size_t>(__elements_stored)...};
+    const array<size_t, sizeof...(_StoredTypes)> __num_elements{static_cast<size_t>(__elements_stored)...};
     return __get_storage<0>(__storage, __num_elements);
   }
 

--- a/libcudacxx/include/cuda/std/__random/binomial_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/binomial_distribution.h
@@ -128,7 +128,7 @@ public:
     {
       return __pr.__t_;
     }
-    uniform_real_distribution<double> __gen;
+    uniform_real_distribution<double> __gen; // NOLINT(misc-const-correctness)
     double __u = __gen(__g) - __pr.__pr_;
     if (__u < 0)
     {

--- a/libcudacxx/include/cuda/std/__random/negative_binomial_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/negative_binomial_distribution.h
@@ -108,7 +108,7 @@ public:
     // overflow __f below to use this technique.
     if (__k <= 21 * __p && sizeof(_IntType) > 1)
     {
-      bernoulli_distribution __gen(__p);
+      bernoulli_distribution __gen(__p); // NOLINT(misc-const-correctness)
       result_type __f = 0;
       result_type __s = 0;
       while (__s < __k)

--- a/libcudacxx/include/cuda/std/__random/normal_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/normal_distribution.h
@@ -210,7 +210,7 @@ public:
     result_type __vp = 0;
     int __v_hot_int  = 0;
     __is >> __mean >> __stddev >> __v_hot_int;
-    bool __v_hot = __v_hot_int != 0;
+    const bool __v_hot = __v_hot_int != 0;
     if (__v_hot)
     {
       __is >> __vp;

--- a/libcudacxx/include/cuda/std/__random/philox_engine.h
+++ b/libcudacxx/include/cuda/std/__random/philox_engine.h
@@ -265,9 +265,9 @@ public:
       {
         break;
       }
-      result_type __new_x_j = (__x_[__j] + (__increment & max()) + __carry) & max();
-      __carry               = (__new_x_j < __x_[__j]) ? 1 : 0;
-      __x_[__j]             = __new_x_j;
+      const result_type __new_x_j = (__x_[__j] + (__increment & max()) + __carry) & max();
+      __carry                     = (__new_x_j < __x_[__j]) ? 1 : 0;
+      __x_[__j]                   = __new_x_j;
       if constexpr (word_size < 64)
       {
         __increment >>= word_size;

--- a/libcudacxx/include/cuda/std/__random/poisson_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/poisson_distribution.h
@@ -75,17 +75,17 @@ public:
       }
       else
       {
-        __s_        = ::cuda::std::sqrt(__mean_);
-        __d_        = 6 * __mean_ * __mean_;
-        __l_        = ::cuda::std::trunc(__mean_ - 1.1484);
-        __omega_    = .3989423 / __s_;
-        double __b1 = .4166667E-1 / __mean_;
-        double __b2 = .3 * __b1 * __b1;
-        __c3_       = .1428571 * __b1 * __b2;
-        __c2_       = __b2 - 15. * __c3_;
-        __c1_       = __b1 - 6. * __b2 + 45. * __c3_;
-        __c0_       = 1. - __b1 + 3. * __b2 - 15. * __c3_;
-        __c_        = .1069 / __mean_;
+        __s_              = ::cuda::std::sqrt(__mean_);
+        __d_              = 6 * __mean_ * __mean_;
+        __l_              = ::cuda::std::trunc(__mean_ - 1.1484);
+        __omega_          = .3989423 / __s_;
+        double __b1       = .4166667E-1 / __mean_;
+        const double __b2 = .3 * __b1 * __b1;
+        __c3_             = .1428571 * __b1 * __b2;
+        __c2_             = __b2 - 15. * __c3_;
+        __c1_             = __b1 - 6. * __b2 + 45. * __c3_;
+        __c0_             = 1. - __b1 + 3. * __b2 - 15. * __c3_;
+        __c_              = .1069 / __mean_;
       }
     }
 
@@ -165,7 +165,7 @@ public:
   {
     static_assert(__cccl_random_is_valid_urng<_URNG>);
     double __tx = 0;
-    uniform_real_distribution<double> __urd{};
+    uniform_real_distribution<double> __urd{}; // NOLINT(misc-const-correctness)
     if (__pr.__mean_ < 10)
     {
       for (double __p = __urd(__urng); __p > __pr.__l_; ++__tx)
@@ -223,7 +223,7 @@ public:
         {
           double __del = .8333333E-1 / __tx;
           __del -= 4.8 * __del * __del * __del;
-          double __v = __difmuk / __tx;
+          const double __v = __difmuk / __tx;
           if (::cuda::std::abs(__v) > 0.25)
           {
             __px = __tx * ::cuda::std::log(1 + __v) - __difmuk - __del;
@@ -241,9 +241,9 @@ public:
           }
           __py = .3989423 / ::cuda::std::sqrt(__tx);
         }
-        double __r  = (0.5 - __difmuk) / __pr.__s_;
-        double __r2 = __r * __r;
-        double __fx = -0.5 * __r2;
+        double __r        = (0.5 - __difmuk) / __pr.__s_;
+        double __r2       = __r * __r;
+        const double __fx = -0.5 * __r2;
         double __fy = __pr.__omega_ * (((__pr.__c3_ * __r2 + __pr.__c2_) * __r2 + __pr.__c1_) * __r2 + __pr.__c0_);
         if (__using_exp_dist)
         {

--- a/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
+++ b/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
@@ -42,7 +42,7 @@ template <class _CharT>
 _CCCL_API constexpr _CharT*
 __cccl_strcpy_impl_constexpr(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src) noexcept
 {
-  _CharT* __dst_it = __dst;
+  _CharT* __dst_it = __dst; // NOLINT(misc-const-correctness)
   while ((*__dst_it++ = *__src++) != _CharT('\0'))
   {
   }
@@ -80,7 +80,7 @@ template <class _CharT>
 _CCCL_API constexpr _CharT*
 __cccl_strncpy_impl_constexpr(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src, size_t __n) noexcept
 {
-  _CharT* __dst_it = __dst;
+  _CharT* __dst_it = __dst; // NOLINT(misc-const-correctness)
   while (__n--)
   {
     if ((*__dst_it++ = *__src++) == _CharT('\0')) // NOLINT(bugprone-assignment-in-if-condition)


### PR DESCRIPTION
Part of the `misc-const-correctness` split of the umbrella branch `jacobf/2026-09-02/misc-const-correctness`.

This PR adds `const` to local variables under:
  - `libcudacxx/include/`

It does **not** enable the check. `misc-const-correctness` stays disabled in `.clang-tidy` until the final PR of the series.