### PR TITLE
[libcu++ tests] `misc-const-correctness`

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/algorithm/sample.cu
+++ b/libcudacxx/test/libcudacxx/cuda/algorithm/sample.cu
@@ -44,8 +44,8 @@ struct sample_kernel
       return;
     }
 
-    cuda::counting_iterator<cuda::std::size_t> first{0};
-    cuda::counting_iterator<cuda::std::size_t> last{n_};
+    const cuda::counting_iterator<cuda::std::size_t> first{0};
+    const cuda::counting_iterator<cuda::std::size_t> last{n_};
 
     auto end   = cuda::sample(first, last, out.begin(), k_, rng_);
     written[0] = end - out.begin();
@@ -109,8 +109,8 @@ struct batched_sample_kernel
     const auto rank = static_cast<cuda::std::size_t>(cuda::gpu_thread.rank(cuda::grid));
     const auto size = static_cast<cuda::std::size_t>(cuda::gpu_thread.count(cuda::grid));
 
-    cuda::counting_iterator<cuda::std::size_t> first{0};
-    cuda::counting_iterator<cuda::std::size_t> last{n_};
+    const cuda::counting_iterator<cuda::std::size_t> first{0};
+    const cuda::counting_iterator<cuda::std::size_t> last{n_};
 
     for (cuda::std::size_t i = rank; i < out.extent(0); i += size)
     {

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/common.cuh
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/common.cuh
@@ -51,7 +51,7 @@ inline int get_expected_value(uint8_t pattern_byte)
 template <typename Result>
 void check_result_and_erase(cuda::stream_ref stream, Result&& result, uint8_t pattern_byte = fill_byte)
 {
-  int expected = get_expected_value(pattern_byte);
+  const int expected = get_expected_value(pattern_byte);
 
   stream.sync();
   for (int& i : result)
@@ -64,7 +64,7 @@ void check_result_and_erase(cuda::stream_ref stream, Result&& result, uint8_t pa
 template <typename Layout = cuda::std::layout_right, typename Extents>
 auto make_buffer_for_mdspan(cuda::stream_ref stream, Extents extents, char value = 0)
 {
-  auto mapping = typename Layout::template mapping<decltype(extents)>{extents};
+  auto mapping = typename Layout::template mapping<Extents>{extents};
 
   auto buffer = make_pinned_memory_buffer<int>(stream, mapping.required_span_size());
 
@@ -76,14 +76,14 @@ auto make_buffer_for_mdspan(cuda::stream_ref stream, Extents extents, char value
 
 inline auto create_fake_strided_mdspan()
 {
-  cuda::std::dextents<size_t, 3> dynamic_extents{1, 2, 3};
-  cuda::std::array<size_t, 3> strides{12, 4, 1};
+  const cuda::std::dextents<size_t, 3> dynamic_extents{1, 2, 3};
+  const cuda::std::array<size_t, 3> strides{12, 4, 1};
 #if _CCCL_CUDACC_BELOW(12, 6)
   auto map = cuda::std::layout_stride::mapping{dynamic_extents, strides};
 #else
-  cuda::std::layout_stride::mapping map{dynamic_extents, strides};
+  const cuda::std::layout_stride::mapping map{dynamic_extents, strides};
 #endif
-  return cuda::std::mdspan<int, decltype(dynamic_extents), cuda::std::layout_stride>(nullptr, map);
+  return cuda::std::mdspan<int, cuda::std::dextents<size_t, 3>, cuda::std::layout_stride>(nullptr, map);
 };
 
 #endif // TEST_LIBCUDACXX_CCCLRT_ALGORITHM_COMMON_CUH

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/copy.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/copy.cu
@@ -16,7 +16,7 @@
 
 C2H_CCCLRT_TEST("1d Copy", "[algorithm]")
 {
-  cuda::stream _stream{cuda::device_ref{0}};
+  const cuda::stream _stream{cuda::device_ref{0}};
 
   SECTION("Device resource")
   {
@@ -196,7 +196,7 @@ C2H_CCCLRT_TEST("copy_bytes can copy between peer device buffers", "[algorithm][
     return;
   }
 
-  cuda::device_ref source_device{0};
+  const cuda::device_ref source_device{0};
   auto peers = source_device.peers();
   // This test exercises direct peer memory access; non-peer topologies have no legal device-to-device path to cover.
   if (peers.empty())
@@ -204,7 +204,7 @@ C2H_CCCLRT_TEST("copy_bytes can copy between peer device buffers", "[algorithm][
     return;
   }
 
-  cuda::device_ref destination_device = peers.front();
+  const cuda::device_ref destination_device = peers.front();
   // Device buffers are allocated from stream-ordered memory pools.
   if (!source_device.attribute(cuda::device_attributes::memory_pools_supported)
       || !destination_device.attribute(cuda::device_attributes::memory_pools_supported))
@@ -212,8 +212,8 @@ C2H_CCCLRT_TEST("copy_bytes can copy between peer device buffers", "[algorithm][
     return;
   }
 
-  cuda::stream source_stream{source_device};
-  cuda::stream destination_stream{destination_device};
+  const cuda::stream source_stream{source_device};
+  const cuda::stream destination_stream{destination_device};
   cuda::device_memory_pool source_pool{source_device};
   cuda::device_memory_pool destination_pool{destination_device};
   source_pool.enable_access_from(destination_device);
@@ -221,7 +221,7 @@ C2H_CCCLRT_TEST("copy_bytes can copy between peer device buffers", "[algorithm][
   auto source_resource      = source_pool.as_ref();
   auto destination_resource = destination_pool.as_ref();
 
-  int expected = get_expected_value(fill_byte);
+  const int expected = get_expected_value(fill_byte);
   int result{};
 
   {
@@ -234,7 +234,7 @@ C2H_CCCLRT_TEST("copy_bytes can copy between peer device buffers", "[algorithm][
     host_dst.get_unsynchronized(0) = 0;
 
     {
-      cuda::__ensure_current_context guard(source_device);
+      const cuda::__ensure_current_context guard(source_device);
       cuda::copy_bytes(source_stream, host_src, src);
     }
     source_stream.sync();
@@ -244,7 +244,7 @@ C2H_CCCLRT_TEST("copy_bytes can copy between peer device buffers", "[algorithm][
     config.dst_location_hint = destination_device;
 
     {
-      cuda::__ensure_current_context guard(destination_device);
+      const cuda::__ensure_current_context guard(destination_device);
       cuda::copy_bytes(destination_stream, src, dst, config);
       cuda::copy_bytes(destination_stream, dst, host_dst);
     }
@@ -296,7 +296,7 @@ void test_mdspan_copy_bytes(
 
 C2H_CCCLRT_TEST("Mdspan copy", "[algorithm]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
 
   SECTION("Different extents")
   {
@@ -318,7 +318,7 @@ C2H_CCCLRT_TEST("Mdspan copy", "[algorithm]")
 
 C2H_CCCLRT_TEST("Non exhaustive mdspan copy_bytes", "[algorithm]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   {
     auto fake_strided_mdspan = create_fake_strided_mdspan();
 

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/fill.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/fill.cu
@@ -12,7 +12,7 @@
 
 C2H_CCCLRT_TEST("Fill", "[algorithm]")
 {
-  cuda::stream _stream{cuda::device_ref{0}};
+  const cuda::stream _stream{cuda::device_ref{0}};
   SECTION("Host memory")
   {
     auto buffer = make_pinned_memory_buffer<int>(_stream, buffer_size);
@@ -39,19 +39,20 @@ C2H_CCCLRT_TEST("Fill", "[algorithm]")
 
 C2H_CCCLRT_TEST("Mdspan Fill", "[algorithm]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   {
-    cuda::std::dextents<size_t, 3> dynamic_extents{1, 2, 3};
+    const cuda::std::dextents<size_t, 3> dynamic_extents{1, 2, 3};
     auto buffer = make_buffer_for_mdspan(stream, dynamic_extents, 0);
-    cuda::std::mdspan<int, decltype(dynamic_extents)> dynamic_mdspan(buffer.data(), dynamic_extents);
+    cuda::std::mdspan<int, cuda::std::dextents<size_t, 3>> dynamic_mdspan(buffer.data(), dynamic_extents);
 
     cuda::fill_bytes(stream, dynamic_mdspan, fill_byte);
     check_result_and_erase(stream, buffer);
   }
   {
-    cuda::std::extents<size_t, 2, cuda::std::dynamic_extent, 4> mixed_extents{1};
+    const cuda::std::extents<size_t, 2, cuda::std::dynamic_extent, 4> mixed_extents{1};
     auto buffer = make_buffer_for_mdspan(stream, mixed_extents, 0);
-    cuda::std::mdspan<int, decltype(mixed_extents)> mixed_mdspan(buffer.data(), mixed_extents);
+    cuda::std::mdspan<int, cuda::std::extents<size_t, 2, cuda::std::dynamic_extent, 4>> mixed_mdspan(
+      buffer.data(), mixed_extents);
 
     cuda::fill_bytes(stream, cuda::std::move(mixed_mdspan), fill_byte);
     check_result_and_erase(stream, buffer);
@@ -60,7 +61,7 @@ C2H_CCCLRT_TEST("Mdspan Fill", "[algorithm]")
 
 C2H_CCCLRT_TEST("Non exhaustive mdspan fill_bytes", "[data_manipulation]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   {
     auto fake_strided_mdspan = create_fake_strided_mdspan();
 

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/common/host_device.cuh
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/common/host_device.cuh
@@ -24,7 +24,7 @@ void __global__ lambda_launcher(const Dims dims, const Lambda lambda)
 template <typename Comparator, unsigned int FilterArch>
 bool arch_filter(const cudaDeviceProp& props)
 {
-  int act_arch = props.major * 10 + props.minor;
+  const int act_arch = props.major * 10 + props.minor;
   if (Comparator()(act_arch, FilterArch))
   {
     return true;
@@ -74,7 +74,7 @@ void test_host_dev(const Dims& dims, const Lambda& lambda, const Filters&... fil
 
     if constexpr (Dims::has_level(cuda::cluster))
     {
-      dim3 cluster_dims{cuda::block.dims(cuda::cluster, dims)};
+      const dim3 cluster_dims{cuda::block.dims(cuda::cluster, dims)};
       config.attrs[config.numAttrs].id             = cudaLaunchAttributeClusterDimension;
       config.attrs[config.numAttrs].val.clusterDim = {cluster_dims.x, cluster_dims.y, cluster_dims.z};
       config.numAttrs                              = 1;

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/common/utility.cuh
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/common/utility.cuh
@@ -62,13 +62,13 @@ private:
 public:
   explicit _malloc_pinned(std::size_t size)
   {
-    cuda::__ensure_current_context guard(cuda::device_ref{0});
+    const cuda::__ensure_current_context guard(cuda::device_ref{0});
     _CCCL_TRY_RUNTIME_API(::cudaMallocHost, "failed to allocate pinned memory", &pv, size);
   }
 
   ~_malloc_pinned()
   {
-    cuda::__ensure_current_context guard(cuda::device_ref{0});
+    const cuda::__ensure_current_context guard(cuda::device_ref{0});
     [[maybe_unused]] auto status = ::cudaFreeHost(pv);
   }
 
@@ -143,7 +143,7 @@ struct atomic_add_one
 {
   TEST_DEVICE_FUNC void operator()(int* pi) const noexcept
   {
-    cuda::atomic_ref atomic_pi(*pi);
+    const cuda::atomic_ref atomic_pi(*pi);
     atomic_pi.fetch_add(1);
   }
 };
@@ -152,7 +152,7 @@ struct atomic_sub_one
 {
   TEST_DEVICE_FUNC void operator()(int* pi) const noexcept
   {
-    cuda::atomic_ref atomic_pi(*pi);
+    const cuda::atomic_ref atomic_pi(*pi);
     atomic_pi.fetch_sub(1);
   }
 };
@@ -161,7 +161,7 @@ struct spin_until_80
 {
   TEST_DEVICE_FUNC void operator()(int* pi) const noexcept
   {
-    cuda::atomic_ref atomic_pi(*pi);
+    const cuda::atomic_ref atomic_pi(*pi);
     while (atomic_pi.load() != 80)
       ;
   }
@@ -181,7 +181,7 @@ static __global__ void kernel_launcher(Fn fn, Args... args)
 template <class Fn, class... Args>
 void launch_kernel_single_thread(cuda::stream_ref stream, Fn fn, Args... args)
 {
-  cuda::__ensure_current_context guard(stream);
+  const cuda::__ensure_current_context guard(stream);
   kernel_launcher<<<1, 1, 0, stream.get()>>>(fn, args...);
   assert(cudaGetLastError() == cudaSuccess);
 }

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_traits.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_traits.c2h.cu
@@ -42,7 +42,7 @@ __global__ void arch_specific_kernel_mock_do_not_launch()
   }
   if (cuda::device::current_arch_traits().redux_intrinisic)
   {
-    [[maybe_unused]] int dummy1 = 0, dummy2 = 0;
+    [[maybe_unused]] int dummy1 = 0, dummy2 = 0; // NOLINT(misc-const-correctness)
     asm volatile("redux.sync.add.s32 %0, %1, 0xffffffff;" : "=r"(dummy1) : "r"(dummy2));
   }
   if (cuda::device::current_arch_traits().cp_async_supported)

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
@@ -21,7 +21,7 @@ namespace
 template <const auto& Attr, ::cudaDeviceAttr ExpectedAttr, class ExpectedResult>
 [[maybe_unused]] auto test_device_attribute()
 {
-  cuda::device_ref dev0(0);
+  const cuda::device_ref dev0(0);
   STATIC_REQUIRE(Attr == ExpectedAttr);
   STATIC_REQUIRE(::cuda::std::is_same_v<cuda::device_attribute_result_t<Attr>, ExpectedResult>);
 
@@ -35,7 +35,7 @@ template <const auto& Attr, ::cudaDeviceAttr ExpectedAttr, class ExpectedResult>
 
 C2H_CCCLRT_TEST("init", "[device]")
 {
-  cuda::device_ref dev{0};
+  const cuda::device_ref dev{0};
   dev.init();
   CCCLRT_REQUIRE(cuda::__driver::__isPrimaryCtxActive(cuda::__driver::__deviceGet(0)));
 }
@@ -287,9 +287,9 @@ C2H_CCCLRT_TEST("Smoke", "[device]")
 
     SECTION("Compute capability")
     {
-      cuda::compute_capability compute_cap = device_ref(0).attribute(attributes::compute_capability);
-      int compute_cap_major                = device_ref(0).attribute(attributes::compute_capability_major);
-      int compute_cap_minor                = device_ref(0).attribute(attributes::compute_capability_minor);
+      const cuda::compute_capability compute_cap = device_ref(0).attribute(attributes::compute_capability);
+      const int compute_cap_major                = device_ref(0).attribute(attributes::compute_capability_major);
+      const int compute_cap_minor                = device_ref(0).attribute(attributes::compute_capability_minor);
       CCCLRT_REQUIRE(compute_cap.get() == 10 * compute_cap_major + compute_cap_minor);
     }
 
@@ -366,8 +366,8 @@ C2H_CCCLRT_TEST("Device attributes use the explicit device when current device d
     return;
   }
 
-  cuda::device_ref current_device{0};
-  cuda::device_ref explicit_device{1};
+  const cuda::device_ref current_device{0};
+  const cuda::device_ref explicit_device{1};
 
   const auto expected_bus_id = cuda::__driver::__deviceGetAttribute(
     static_cast<::CUdevice_attribute>(cudaDevAttrPciBusId), cuda::__driver::__deviceGet(explicit_device.get()));
@@ -375,7 +375,7 @@ C2H_CCCLRT_TEST("Device attributes use the explicit device when current device d
     static_cast<::CUdevice_attribute>(cudaDevAttrPciDeviceId), cuda::__driver::__deviceGet(explicit_device.get()));
 
   {
-    cuda::__ensure_current_context guard(current_device);
+    const cuda::__ensure_current_context guard(current_device);
     CCCLRT_REQUIRE(explicit_device.attribute(cuda::device_attributes::pci_bus_id) == expected_bus_id);
     CCCLRT_REQUIRE(explicit_device.attribute(cuda::device_attributes::pci_device_id) == expected_device_id);
   }

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/locality_domains.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/locality_domains.c2h.cu
@@ -194,7 +194,7 @@ C2H_CCCLRT_TEST("locality domains", "[device][locality_domain]")
     // observe it.
     for (auto dev : cuda::devices)
     {
-      cuda::device_ref other{dev.get()};
+      const cuda::device_ref other{dev.get()};
       REQUIRE(other.__locality_domains().data() == dev.__locality_domains().data());
     }
   }
@@ -227,7 +227,7 @@ C2H_CCCLRT_TEST("locality domains", "[device][locality_domain]")
 
         // The fixture checks that the driver stack is empty at test exit, so the push must be undone
         // even if a check throws.
-        cuda::__ensure_current_context guard{domain};
+        const cuda::__ensure_current_context guard{domain};
         REQUIRE(cuda::__driver::__ctxGetCurrent() == ctx);
         REQUIRE(cuda::__driver::__ctxGetDevice() == expected_device);
       }

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/event/event_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/event/event_smoke.cu
@@ -31,19 +31,19 @@ void test_event_uses_explicit_device_when_current_device_differs()
     return;
   }
 
-  cuda::device_ref current_device{0};
+  const cuda::device_ref current_device{0};
   cuda::device_ref explicit_device{1};
 
-  cuda::stream explicit_device_stream{explicit_device};
+  const cuda::stream explicit_device_stream{explicit_device};
   CCCLRT_REQUIRE(explicit_device_stream.device() == explicit_device);
 
   Event ev = [&]() {
-    cuda::__ensure_current_context guard(current_device);
+    const cuda::__ensure_current_context guard(current_device);
     return Event(explicit_device);
   }();
 
   {
-    cuda::__ensure_current_context guard(current_device);
+    const cuda::__ensure_current_context guard(current_device);
     ev.record(explicit_device_stream);
     ev.sync();
     CCCLRT_REQUIRE(ev.is_done());
@@ -59,25 +59,25 @@ static_assert(!::cuda::std::is_default_constructible_v<cuda::timed_event>);
 
 C2H_CCCLRT_TEST("can construct an event_ref from a cudaEvent_t", "[event]")
 {
-  cuda::__ensure_current_context guard(cuda::device_ref{0});
+  const cuda::__ensure_current_context guard(cuda::device_ref{0});
   ::cudaEvent_t ev;
   CCCLRT_REQUIRE(::cudaEventCreate(&ev) == ::cudaSuccess);
-  cuda::event_ref ref(ev);
+  const cuda::event_ref ref(ev);
   CCCLRT_REQUIRE(ref.get() == ev);
   CCCLRT_REQUIRE(!!ref);
   // test implicit conversion from cudaEvent_t:
-  cuda::event_ref ref2 = fn_takes_event_ref(ev);
+  const cuda::event_ref ref2 = fn_takes_event_ref(ev);
   CCCLRT_REQUIRE(ref2.get() == ev);
   CCCLRT_REQUIRE(::cudaEventDestroy(ev) == ::cudaSuccess);
   // test an empty event_ref:
-  cuda::event_ref ref3(::cudaEvent_t{});
+  const cuda::event_ref ref3(::cudaEvent_t{});
   CCCLRT_REQUIRE(ref3.get() == ::cudaEvent_t{});
   CCCLRT_REQUIRE(!ref3);
 }
 
 C2H_CCCLRT_TEST("can copy construct an event_ref and compare for equality", "[event]")
 {
-  cuda::__ensure_current_context guard(cuda::device_ref{0});
+  const cuda::__ensure_current_context guard(cuda::device_ref{0});
   ::cudaEvent_t ev;
   CCCLRT_REQUIRE(::cudaEventCreate(&ev) == ::cudaSuccess);
   const cuda::event_ref ref(ev);
@@ -98,13 +98,13 @@ C2H_CCCLRT_TEST("can copy construct an event_ref and compare for equality", "[ev
 
 C2H_CCCLRT_TEST("can use event_ref to record and wait on an event", "[event]")
 {
-  cuda::__ensure_current_context guard(cuda::device_ref{0});
+  const cuda::__ensure_current_context guard(cuda::device_ref{0});
   ::cudaEvent_t ev;
   CCCLRT_REQUIRE(::cudaEventCreate(&ev) == ::cudaSuccess);
   const cuda::event_ref ref(ev);
 
   test::pinned<int> i(0);
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   ::test::launch_kernel_single_thread(stream, ::test::assign_42{}, i.get());
   ref.record(stream);
   ref.sync();
@@ -117,17 +117,17 @@ C2H_CCCLRT_TEST("can use event_ref to record and wait on an event", "[event]")
 
 C2H_CCCLRT_TEST("can construct an event with a stream_ref", "[event]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
-  cuda::event ev(static_cast<cuda::stream_ref>(stream));
+  const cuda::stream stream{cuda::device_ref{0}};
+  const cuda::event ev(static_cast<cuda::stream_ref>(stream));
   CCCLRT_REQUIRE(ev.get() != ::cudaEvent_t{});
 }
 
 C2H_CCCLRT_TEST("can construct an event with a device_ref", "[event]")
 {
-  cuda::device_ref device{0};
-  cuda::event ev(device);
+  const cuda::device_ref device{0};
+  const cuda::event ev(device);
   CCCLRT_REQUIRE(ev.get() != ::cudaEvent_t{});
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
   ev.record(stream);
   ev.sync();
   CCCLRT_REQUIRE(ev.is_done());
@@ -146,11 +146,11 @@ C2H_CCCLRT_TEST("can wait on an event from another device", "[event][multi_gpu]"
     return;
   }
 
-  cuda::device_ref event_device{0};
-  cuda::device_ref waiter_device{1};
+  const cuda::device_ref event_device{0};
+  const cuda::device_ref waiter_device{1};
 
-  cuda::stream event_stream{event_device};
-  cuda::stream waiter_stream{waiter_device};
+  const cuda::stream event_stream{event_device};
+  const cuda::stream waiter_stream{waiter_device};
 
   cuda::atomic<int> gate = 0;
   bool waiter_ran        = false;
@@ -159,10 +159,10 @@ C2H_CCCLRT_TEST("can wait on an event from another device", "[event][multi_gpu]"
     while (gate != 1)
       ;
   });
-  cuda::event ev(event_stream);
+  const cuda::event ev(event_stream);
 
   {
-    cuda::__ensure_current_context guard(event_device);
+    const cuda::__ensure_current_context guard(event_device);
     waiter_stream.wait(ev);
     cuda::host_launch(waiter_stream, [&waiter_ran]() {
       waiter_ran = true;
@@ -181,10 +181,10 @@ C2H_CCCLRT_TEST("can wait on an event from another device", "[event][multi_gpu]"
 
 C2H_CCCLRT_TEST("can wait on an event", "[event]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   ::test::pinned<int> i(0);
   ::test::launch_kernel_single_thread(stream, ::test::assign_42{}, i.get());
-  cuda::event ev(stream);
+  const cuda::event ev(stream);
   ev.sync();
   CCCLRT_REQUIRE(ev.is_done());
   CCCLRT_REQUIRE(*i == 42);
@@ -193,11 +193,11 @@ C2H_CCCLRT_TEST("can wait on an event", "[event]")
 
 C2H_CCCLRT_TEST("can take the difference of two timed_event objects", "[event]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   ::test::pinned<int> i(0);
-  cuda::timed_event start(stream);
+  const cuda::timed_event start(stream);
   ::test::launch_kernel_single_thread(stream, ::test::assign_42{}, i.get());
-  cuda::timed_event end(stream);
+  const cuda::timed_event end(stream);
   end.sync();
   CCCLRT_REQUIRE(end.is_done());
   CCCLRT_REQUIRE(*i == 42);
@@ -210,12 +210,12 @@ C2H_CCCLRT_TEST("can take the difference of two timed_event objects", "[event]")
 C2H_CCCLRT_TEST("can observe the event in not ready state", "[event]")
 {
   ::test::pinned<int> i(0);
-  ::cuda::atomic_ref atomic_i(*i);
+  ::cuda::atomic_ref atomic_i(*i); // NOLINT(misc-const-correctness)
 
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
 
   ::test::launch_kernel_single_thread(stream, ::test::spin_until_80{}, i.get());
-  cuda::event ev(stream);
+  const cuda::event ev(stream);
   CCCLRT_REQUIRE(!ev.is_done());
   atomic_i.store(80);
   ev.sync();

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/hierarchy/hierarchy_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/hierarchy/hierarchy_smoke.cu
@@ -388,24 +388,24 @@ __global__ void examples_kernel(Hierarchy hierarchy)
     CCCLRT_REQUIRE_DEVICE(block_index_in_grid == blockIdx);
   }
   {
-    int thread_rank_in_block = cuda::gpu_thread.rank(cuda::block, hierarchy);
-    int block_rank_in_grid   = cuda::block.rank(cuda::grid, hierarchy);
+    const int thread_rank_in_block = cuda::gpu_thread.rank(cuda::block, hierarchy);
+    const int block_rank_in_grid   = cuda::block.rank(cuda::grid, hierarchy);
   }
   {
     // Can be called with the instances of level types
-    int num_threads_in_block = static_cast<int>(cuda::gpu_thread.count(cuda::block));
-    int num_blocks_in_grid   = static_cast<int>(cuda::block.count(cuda::grid));
+    const int num_threads_in_block = static_cast<int>(cuda::gpu_thread.count(cuda::block));
+    const int num_blocks_in_grid   = static_cast<int>(cuda::block.count(cuda::grid));
 
     // Or using the level types as template arguments
-    int num_threads_in_grid = static_cast<int>(cuda::gpu_thread.count(cuda::grid));
+    const int num_threads_in_grid = static_cast<int>(cuda::gpu_thread.count(cuda::grid));
   }
   {
     // Can be called with the instances of level types
-    int thread_rank_in_block = static_cast<int>(cuda::gpu_thread.rank(cuda::block));
-    int block_rank_in_grid   = static_cast<int>(cuda::block.rank(cuda::grid));
+    const int thread_rank_in_block = static_cast<int>(cuda::gpu_thread.rank(cuda::block));
+    const int block_rank_in_grid   = static_cast<int>(cuda::block.rank(cuda::grid));
 
     // Or using the level types as template arguments
-    int thread_rank_in_grid = static_cast<int>(cuda::gpu_thread.rank(cuda::grid));
+    const int thread_rank_in_grid = static_cast<int>(cuda::gpu_thread.rank(cuda::grid));
   }
   {
     // Can be called with the instances of level types
@@ -507,7 +507,7 @@ C2H_TEST("Trivially constructable", "[hierarchy]")
 
 C2H_TEST("cuda::distribute", "[hierarchy]")
 {
-  unsigned numElements          = 50000;
+  const unsigned numElements    = 50000;
   constexpr int threadsPerBlock = 256;
   auto config                   = cuda::distribute<threadsPerBlock>(static_cast<int>(numElements));
 

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/dynamic_shared_memory.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/dynamic_shared_memory.cu
@@ -100,8 +100,8 @@ void test_span(cuda::stream_ref stream)
 
 C2H_TEST("Dynamic shared memory option", "[launch]")
 {
-  cuda::device_ref device = cuda::devices[0];
-  cuda::stream stream{device};
+  const cuda::device_ref device = cuda::devices[0];
+  const cuda::stream stream{device};
 
   test_ref(stream);
   test_span(stream);

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/host_launch.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/host_launch.cu
@@ -124,10 +124,10 @@ private:
 
 C2H_CCCLRT_TEST("Host launch", "")
 {
-  cuda::device_ref device{0};
+  const cuda::device_ref device{0};
   device.init();
 
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   SECTION("Ordinary function without arguments returning void")
   {
@@ -217,7 +217,7 @@ C2H_CCCLRT_TEST("Host launch", "")
 
   SECTION("Confirm no const added to the callable")
   {
-    lambda_wrapper wrapped_lambda([&]() {
+    lambda_wrapper wrapped_lambda([&]() { // NOLINT(misc-const-correctness)
       i = 21;
     });
 
@@ -289,14 +289,14 @@ C2H_CCCLRT_TEST("Host launch uses the stream device when current device differs"
     return;
   }
 
-  cuda::device_ref current_device{0};
-  cuda::device_ref explicit_device{1};
+  const cuda::device_ref current_device{0};
+  const cuda::device_ref explicit_device{1};
 
-  cuda::stream stream{explicit_device};
+  const cuda::stream stream{explicit_device};
   int value = 0;
 
   {
-    cuda::__ensure_current_context guard(current_device);
+    const cuda::__ensure_current_context guard(current_device);
     cuda::host_launch(stream, [&value]() {
       value = 42;
     });

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/logical_device_stream.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/logical_device_stream.c2h.cu
@@ -26,7 +26,7 @@ C2H_CCCLRT_TEST("Stream logical device without a green context", "[stream][logic
 
   SECTION("A stream on a device reports a device-backed logical device")
   {
-    cuda::stream str{device};
+    const cuda::stream str{device};
     const auto ldev = str.__logical_device();
 
     REQUIRE(ldev.kind() == cuda::__logical_device_ref::kinds::device);
@@ -37,22 +37,22 @@ C2H_CCCLRT_TEST("Stream logical device without a green context", "[stream][logic
 
   SECTION("The reported logical device equals one built from the device")
   {
-    cuda::stream str{device};
+    const cuda::stream str{device};
 
     REQUIRE(str.__logical_device() == cuda::__logical_device_ref{device});
   }
 
   SECTION("Two streams on the same device report the same logical device")
   {
-    cuda::stream str0{device};
-    cuda::stream str1{device};
+    const cuda::stream str0{device};
+    const cuda::stream str1{device};
 
     REQUIRE(str0.__logical_device() == str1.__logical_device());
   }
 
   SECTION("A stream created through the runtime reports its device")
   {
-    cuda::__ensure_current_context guard(device);
+    const cuda::__ensure_current_context guard(device);
     ::cudaStream_t handle{};
     CUDART(cudaStreamCreate(&handle));
 
@@ -66,8 +66,8 @@ C2H_CCCLRT_TEST("Stream logical device without a green context", "[stream][logic
   {
     // The fixture only checks that the stack is empty at the end of the test, so it does not catch
     // a query that pushes a context onto a non-empty stack.
-    cuda::stream str{device};
-    cuda::__ensure_current_context guard(device);
+    const cuda::stream str{device};
+    const cuda::__ensure_current_context guard(device);
 
     const auto before = ::test::count_driver_stack();
     (void) str.__logical_device();
@@ -79,7 +79,7 @@ C2H_CCCLRT_TEST("Stream logical device without a green context", "[stream][logic
     if (cuda::devices.size() > 1)
     {
       const auto second = cuda::devices[1];
-      cuda::stream str{second};
+      const cuda::stream str{second};
 
       REQUIRE(str.__logical_device() == cuda::__logical_device_ref{second});
       REQUIRE(str.__logical_device() != cuda::__logical_device_ref{device});
@@ -136,7 +136,7 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
   SECTION("The stream is valid and runs work")
   {
     auto ldev = ::make_logical_device(device);
-    cuda::stream str{static_cast<const cuda::__logical_device_ref&>(ldev)};
+    const cuda::stream str{static_cast<const cuda::__logical_device_ref&>(ldev)};
 
     REQUIRE(str.get() != nullptr);
 
@@ -149,7 +149,7 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
   SECTION("An owning logical_device selects the same overload")
   {
     auto ldev = ::make_logical_device(device);
-    cuda::stream str{ldev};
+    const cuda::stream str{ldev};
 
     ::test::pinned<int> value(0);
     ::test::launch_kernel_single_thread(str, ::test::assign_42{}, value.get());
@@ -160,7 +160,7 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
   SECTION("The stream reports the device that owns the green context")
   {
     auto ldev = ::make_logical_device(device);
-    cuda::stream str{ldev};
+    const cuda::stream str{ldev};
     REQUIRE(str.device() == device);
     REQUIRE(str.device() == ldev.underlying_device());
   }
@@ -170,7 +170,7 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
     // A green context stream rejects cuStreamGetCtx(), so a query that reaches for the legacy
     // context of the stream throws instead of reporting the green context.
     auto ldev = ::make_logical_device(device);
-    cuda::stream str{ldev};
+    const cuda::stream str{ldev};
 
     REQUIRE(str.__logical_device().kind() == cuda::__logical_device_ref::kinds::green_context);
     REQUIRE(str.__logical_device().green_context() == ldev.green_context());
@@ -180,7 +180,7 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
   SECTION("The reported logical device carries the context of the green context")
   {
     auto ldev = ::make_logical_device(device);
-    cuda::stream str{ldev};
+    const cuda::stream str{ldev};
 
     REQUIRE(str.__logical_device().context() == cuda::__driver::__ctxFromGreenCtx(ldev.green_context()));
     REQUIRE(str.__logical_device().context() != device.__primary_context());
@@ -189,7 +189,7 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
   SECTION("The reported logical device compares equal to the one the stream was built from")
   {
     auto ldev = ::make_logical_device(device);
-    cuda::stream str{ldev};
+    const cuda::stream str{ldev};
 
     REQUIRE(str.__logical_device() == static_cast<const cuda::__logical_device_ref&>(ldev));
   }
@@ -199,8 +199,8 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
     auto ldev0 = ::make_logical_device(device);
     auto ldev1 = ::make_logical_device(device);
 
-    cuda::stream str0{ldev0};
-    cuda::stream str1{ldev1};
+    const cuda::stream str0{ldev0};
+    const cuda::stream str1{ldev1};
 
     REQUIRE(str0.__logical_device() != str1.__logical_device());
   }
@@ -208,7 +208,7 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
   SECTION("A stream_ref reports the same logical device as the owning stream")
   {
     auto ldev = ::make_logical_device(device);
-    cuda::stream str{ldev};
+    const cuda::stream str{ldev};
     const cuda::stream_ref ref{str.get()};
 
     REQUIRE(ref.__logical_device() == str.__logical_device());
@@ -217,7 +217,7 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
   SECTION("The stream belongs to the context of the green context")
   {
     auto ldev = ::make_logical_device(device);
-    cuda::stream str{ldev};
+    const cuda::stream str{ldev};
 
     const auto green_ctx  = cuda::__driver::__ctxFromGreenCtx(ldev.green_context());
     const auto stream_ctx = cuda::__driver::__streamGetCtx(str.get());
@@ -227,7 +227,7 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
   SECTION("A device-backed logical device gives a stream on the primary context")
   {
     const cuda::__logical_device_ref ldev{device};
-    cuda::stream str{ldev};
+    const cuda::stream str{ldev};
 
     REQUIRE(str.get() != nullptr);
     REQUIRE(str.device() == device);
@@ -242,8 +242,8 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
   SECTION("A device-backed stream matches one built from the device_ref directly")
   {
     const cuda::__logical_device_ref ldev{device};
-    cuda::stream from_logical{ldev};
-    cuda::stream from_device{device};
+    const cuda::stream from_logical{ldev};
+    const cuda::stream from_device{device};
 
     REQUIRE(cuda::__driver::__streamGetCtx(from_logical.get()) == cuda::__driver::__streamGetCtx(from_device.get()));
   }
@@ -251,7 +251,7 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
   SECTION("The default priority is used when none is given")
   {
     auto ldev = ::make_logical_device(device);
-    cuda::stream str{ldev};
+    const cuda::stream str{ldev};
     REQUIRE(str.priority() == cuda::stream::default_priority);
   }
 
@@ -264,14 +264,14 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
     int least_priority{};
     int greatest_priority{};
     {
-      cuda::__ensure_current_context guard(device);
+      const cuda::__ensure_current_context guard(device);
       CUDART(cudaDeviceGetStreamPriorityRange(&least_priority, &greatest_priority));
     }
 
     if (least_priority != greatest_priority)
     {
       const auto priority = cuda::stream::default_priority - 1;
-      cuda::stream str{ldev, priority};
+      const cuda::stream str{ldev, priority};
       REQUIRE(str.priority() == priority);
     }
     else
@@ -285,8 +285,8 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
     auto ldev0 = ::make_logical_device(device);
     auto ldev1 = ::make_logical_device(device);
 
-    cuda::stream str0{ldev0};
-    cuda::stream str1{ldev1};
+    const cuda::stream str0{ldev0};
+    const cuda::stream str1{ldev1};
 
     REQUIRE(str0 != str1);
     REQUIRE(str0.id() != str1.id());
@@ -300,7 +300,7 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
     cuda::stream source{ldev};
     const auto handle = source.get();
 
-    cuda::stream destination{cuda::std::move(source)};
+    const cuda::stream destination{cuda::std::move(source)};
     REQUIRE(destination.get() == handle);
 
     ::test::pinned<int> value(0);
@@ -315,7 +315,7 @@ C2H_CCCLRT_TEST("Stream from a logical device", "[stream][logical_device]")
     {
       const auto second = cuda::devices[1];
       auto ldev         = ::make_logical_device(second);
-      cuda::stream str{ldev};
+      const cuda::stream str{ldev};
 
       REQUIRE(str.device() == second);
 
@@ -336,11 +336,11 @@ C2H_CCCLRT_TEST("Stream from a logical device supports dependencies", "[stream][
   }
 
   auto ldev = ::make_logical_device(cuda::devices[0]);
-  cuda::stream waiter{ldev};
-  cuda::stream waitee{ldev};
+  const cuda::stream waiter{ldev};
+  const cuda::stream waitee{ldev};
 
   ::test::pinned<int> value(0);
-  ::cuda::atomic_ref atomic_value(*value);
+  ::cuda::atomic_ref atomic_value(*value); // NOLINT(misc-const-correctness)
 
   ::test::launch_kernel_single_thread(waitee, ::test::spin_until_80{}, value.get());
   ::test::launch_kernel_single_thread(waitee, ::test::assign_42{}, value.get());

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
@@ -33,7 +33,7 @@ namespace
 
 void check_default_stream_invalid_context_message(::CUstream native_stream)
 {
-  cuda::stream_ref stream{native_stream};
+  const cuda::stream_ref stream{native_stream};
 
   CCCLRT_REQUIRE_THROWS_DEFAULT_STREAM_INVALID_CONTEXT(stream.sync());
   CCCLRT_REQUIRE_THROWS_DEFAULT_STREAM_INVALID_CONTEXT((void) stream.is_done());
@@ -45,7 +45,7 @@ void check_default_stream_invalid_context_message(::CUstream native_stream)
 
 C2H_CCCLRT_TEST("Can create a stream and launch work into it", "[stream]")
 {
-  cuda::stream str{cuda::device_ref{0}};
+  const cuda::stream str{cuda::device_ref{0}};
   ::test::pinned<int> i(0);
   ::test::launch_kernel_single_thread(str, ::test::assign_42{}, i.get());
   str.sync();
@@ -54,7 +54,7 @@ C2H_CCCLRT_TEST("Can create a stream and launch work into it", "[stream]")
 
 C2H_CCCLRT_TEST("From native handle", "[stream]")
 {
-  cuda::__ensure_current_context guard(cuda::device_ref{0});
+  const cuda::__ensure_current_context guard(cuda::device_ref{0});
   cudaStream_t handle;
   CUDART(cudaStreamCreate(&handle));
   {
@@ -76,7 +76,7 @@ void add_dependency_test(const StreamType& waiter, const StreamType& waitee)
 
   auto verify_dependency = [&](const auto& insert_dependency) {
     ::test::pinned<int> i(0);
-    ::cuda::atomic_ref atomic_i(*i);
+    ::cuda::atomic_ref atomic_i(*i); // NOLINT(misc-const-correctness)
 
     ::test::launch_kernel_single_thread(waitee, ::test::spin_until_80{}, i.get());
     ::test::launch_kernel_single_thread(waitee, ::test::assign_42{}, i.get());
@@ -92,7 +92,7 @@ void add_dependency_test(const StreamType& waiter, const StreamType& waitee)
   SECTION("Stream wait declared event")
   {
     verify_dependency([&]() {
-      cuda::event ev(waitee);
+      const cuda::event ev(waitee);
       waiter.wait(ev);
     });
   }
@@ -123,7 +123,7 @@ void add_dependency_test(const StreamType& waiter, const StreamType& waitee)
 
 C2H_CCCLRT_TEST("Can add dependency into a stream", "[stream]")
 {
-  cuda::stream waiter{cuda::device_ref{0}}, waitee{cuda::device_ref{0}};
+  const cuda::stream waiter{cuda::device_ref{0}}, waitee{cuda::device_ref{0}};
 
   add_dependency_test<cuda::stream>(waiter, waitee);
   add_dependency_test<cuda::stream_ref>(waiter, waitee);
@@ -131,20 +131,20 @@ C2H_CCCLRT_TEST("Can add dependency into a stream", "[stream]")
 
 C2H_CCCLRT_TEST("Stream priority", "[stream]")
 {
-  cuda::stream stream_default_prio{cuda::device_ref{0}};
+  const cuda::stream stream_default_prio{cuda::device_ref{0}};
   CCCLRT_REQUIRE(stream_default_prio.priority() == cuda::stream::default_priority);
 
   auto priority = cuda::stream::default_priority - 1;
-  cuda::stream stream{cuda::device_ref{0}, priority};
+  const cuda::stream stream{cuda::device_ref{0}, priority};
   CCCLRT_REQUIRE(stream.priority() == priority);
 }
 
 C2H_CCCLRT_TEST("Stream get device", "[stream]")
 {
-  cuda::stream dev0_stream(cuda::device_ref{0});
+  const cuda::stream dev0_stream(cuda::device_ref{0});
   CCCLRT_REQUIRE(dev0_stream.device() == 0);
 
-  cuda::__ensure_current_context guard(cuda::device_ref{*std::prev(cuda::devices.end())});
+  const cuda::__ensure_current_context guard(cuda::device_ref{*std::prev(cuda::devices.end())});
   cudaStream_t stream_handle;
   CUDART(cudaStreamCreate(&stream_handle));
   auto stream_cudart = cuda::stream::from_native_handle(stream_handle);
@@ -160,11 +160,11 @@ C2H_CCCLRT_TEST("Stream construction uses the explicit device", "[stream][multi_
     return;
   }
 
-  cuda::device_ref current_device{0};
+  const cuda::device_ref current_device{0};
   cuda::device_ref explicit_device{1};
 
   auto stream = [&]() {
-    cuda::__ensure_current_context guard(current_device);
+    const cuda::__ensure_current_context guard(current_device);
     return cuda::stream{explicit_device};
   }();
 
@@ -178,20 +178,20 @@ C2H_CCCLRT_TEST("Stream dependency uses the explicit stream device", "[stream][m
     return;
   }
 
-  cuda::device_ref current_device{0};
-  cuda::device_ref explicit_device{1};
+  const cuda::device_ref current_device{0};
+  const cuda::device_ref explicit_device{1};
 
-  cuda::stream waiter{explicit_device};
-  cuda::stream waitee{explicit_device};
+  const cuda::stream waiter{explicit_device};
+  const cuda::stream waitee{explicit_device};
 
   ::test::pinned<int> value(0);
-  ::cuda::atomic_ref atomic_value(*value);
+  ::cuda::atomic_ref atomic_value(*value); // NOLINT(misc-const-correctness)
 
   ::test::launch_kernel_single_thread(waitee, ::test::spin_until_80{}, value.get());
   ::test::launch_kernel_single_thread(waitee, ::test::assign_42{}, value.get());
 
   {
-    cuda::__ensure_current_context guard(current_device);
+    const cuda::__ensure_current_context guard(current_device);
     waiter.wait(waitee);
   }
 
@@ -209,8 +209,8 @@ C2H_CCCLRT_TEST("Stream ID", "[stream]")
   STATIC_REQUIRE(cuda::std::is_same_v<unsigned long long, cuda::std::underlying_type_t<cuda::stream_id>>);
   STATIC_REQUIRE(cuda::std::is_same_v<cuda::stream_id, decltype(cuda::std::declval<cuda::stream_ref>().id())>);
 
-  cuda::stream stream1{cuda::device_ref{0}};
-  cuda::stream stream2{cuda::device_ref{0}};
+  const cuda::stream stream1{cuda::device_ref{0}};
+  const cuda::stream stream2{cuda::device_ref{0}};
 
   // Test that id() returns a valid ID
   auto id1 = stream1.id();
@@ -235,9 +235,9 @@ C2H_CCCLRT_TEST("Stream ID", "[stream]")
   {
     // Test that stream_ref also supports id()
     // NULL stream needs a device to be set
-    cuda::__ensure_current_context guard(cuda::device_ref{0});
-    cuda::stream_ref ref1(::cudaStream_t{});
-    cuda::stream_ref ref2(stream1);
+    const cuda::__ensure_current_context guard(cuda::device_ref{0});
+    const cuda::stream_ref ref1(::cudaStream_t{});
+    const cuda::stream_ref ref2(stream1);
 
 #if _CCCL_COMPILER(NVHPC, <, 25, 11)
     CCCLRT_REQUIRE(cuda::std::to_underlying(ref1.id()) != cuda::std::to_underlying(ref2.id()));
@@ -264,13 +264,13 @@ C2H_CCCLRT_TEST("Stream hash", "[stream]")
 
   // A stream and a stream_ref that refer to the same stream are equal, so they
   // must hash equally.
-  cuda::stream_ref ref{stream};
+  const cuda::stream_ref ref{stream};
   CCCLRT_REQUIRE(ref == stream);
   CCCLRT_REQUIRE(std::hash<cuda::stream>{}(stream) == std::hash<cuda::stream_ref>{}(ref));
 
   // A moved-to stream owns the same underlying stream, so the hash follows it.
   auto hash_before = std::hash<cuda::stream>{}(stream);
-  cuda::stream moved{cuda::std::move(stream)};
+  const cuda::stream moved{cuda::std::move(stream)};
   CCCLRT_REQUIRE(std::hash<cuda::stream>{}(moved) == hash_before);
 }
 #endif // _CCCL_HAS_HOST_STD_LIB()
@@ -296,14 +296,14 @@ C2H_CCCLRT_TEST("Invalid stream", "[stream]")
   STATIC_REQUIRE(cuda::std::is_constructible_v<cuda::stream_ref, cuda::invalid_stream_t>);
   STATIC_REQUIRE(!cuda::std::is_convertible_v<cuda::invalid_stream_t, cuda::stream_ref>);
   {
-    cuda::stream_ref stream{cuda::invalid_stream};
+    const cuda::stream_ref stream{cuda::invalid_stream};
     CCCLRT_REQUIRE(stream.get() == (cudaStream_t) (~0ull)); // NOLINT(performance-no-int-to-ptr)
   }
 
   // 3. Test stream_ref comparisons
   {
-    cuda::stream_ref valid_stream{(cudaStream_t) (123ull)}; // NOLINT(performance-no-int-to-ptr)
-    cuda::stream_ref invalid_stream{cuda::invalid_stream};
+    const cuda::stream_ref valid_stream{(cudaStream_t) (123ull)}; // NOLINT(performance-no-int-to-ptr)
+    const cuda::stream_ref invalid_stream{cuda::invalid_stream};
 
     CCCLRT_REQUIRE(!(valid_stream == cuda::invalid_stream));
     CCCLRT_REQUIRE(invalid_stream == cuda::invalid_stream);

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/ensure_current_context.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/ensure_current_context.c2h.cu
@@ -23,7 +23,7 @@ namespace driver = cuda::__driver;
 void recursive_check_device_setter(int id)
 {
   int cudart_id;
-  cuda::__ensure_current_context setter(cuda::device_ref{id});
+  const cuda::__ensure_current_context setter(cuda::device_ref{id});
   CCCLRT_REQUIRE(test::count_driver_stack() == cuda::devices.size() - id);
   auto ctx = driver::__ctxGetCurrent();
   CUDART(cudaGetDevice(&cudart_id));
@@ -44,7 +44,7 @@ C2H_TEST("ensure current context", "[device]")
 {
   test::empty_driver_stack();
   // If possible use something different than CUDART default 0
-  int target_device = static_cast<int>(cuda::devices.size() - 1);
+  const int target_device = static_cast<int>(cuda::devices.size() - 1);
 
   SECTION("context setter")
   {
@@ -60,9 +60,9 @@ C2H_CCCLRT_TEST("ensure current context from a stream", "[device][stream]")
 
   SECTION("The pushed context is the one the stream was created on")
   {
-    cuda::stream str{device};
+    const cuda::stream str{device};
 
-    cuda::__ensure_current_context setter(cuda::stream_ref{str.get()});
+    const cuda::__ensure_current_context setter(cuda::stream_ref{str.get()});
 
     CCCLRT_REQUIRE(driver::__ctxGetCurrent() == device.__primary_context());
     CCCLRT_REQUIRE(test::count_driver_stack() == 1);
@@ -70,10 +70,10 @@ C2H_CCCLRT_TEST("ensure current context from a stream", "[device][stream]")
 
   SECTION("The context is popped again on destruction")
   {
-    cuda::stream str{device};
+    const cuda::stream str{device};
 
     {
-      cuda::__ensure_current_context setter(cuda::stream_ref{str.get()});
+      const cuda::__ensure_current_context setter(cuda::stream_ref{str.get()});
     }
 
     CCCLRT_REQUIRE(test::count_driver_stack() == 0);
@@ -84,9 +84,9 @@ C2H_CCCLRT_TEST("ensure current context from a stream", "[device][stream]")
     if (cuda::devices.size() > 1)
     {
       const auto second = cuda::devices[1];
-      cuda::stream str{second};
+      const cuda::stream str{second};
 
-      cuda::__ensure_current_context setter(cuda::stream_ref{str.get()});
+      const cuda::__ensure_current_context setter(cuda::stream_ref{str.get()});
 
       CCCLRT_REQUIRE(driver::__ctxGetCurrent() == second.__primary_context());
       CCCLRT_REQUIRE(driver::__ctxGetCurrent() != device.__primary_context());
@@ -112,13 +112,13 @@ C2H_CCCLRT_TEST("ensure current context from a green context stream", "[device][
   const auto device = cuda::devices[0];
   const auto gctx   = driver::__greenCtxCreate(driver::__deviceGet(device.get()));
   auto ldev         = cuda::__logical_device::from_native_handle(device, gctx);
-  cuda::stream str{ldev};
+  const cuda::stream str{ldev};
 
   const cuda::stream_ref ref{str.get()};
 
   SECTION("The constructor accepts a green context stream")
   {
-    cuda::__ensure_current_context setter(ref);
+    const cuda::__ensure_current_context setter(ref);
 
     CCCLRT_REQUIRE(test::count_driver_stack() == 1);
   }
@@ -127,7 +127,7 @@ C2H_CCCLRT_TEST("ensure current context from a green context stream", "[device][
   {
     // cuStreamGetCtx_v2() reports the green context of the stream. The pushed context is the
     // context of that green context, which is what __logical_device_ref also stores.
-    cuda::__ensure_current_context setter(ref);
+    const cuda::__ensure_current_context setter(ref);
 
     CCCLRT_REQUIRE(driver::__ctxGetCurrent() == driver::__ctxFromGreenCtx(gctx));
     CCCLRT_REQUIRE(driver::__ctxGetCurrent() != device.__primary_context());
@@ -135,7 +135,7 @@ C2H_CCCLRT_TEST("ensure current context from a green context stream", "[device][
 
   SECTION("The pushed context matches the logical device of the stream")
   {
-    cuda::__ensure_current_context setter(ref);
+    const cuda::__ensure_current_context setter(ref);
 
     CCCLRT_REQUIRE(driver::__ctxGetCurrent() == ref.__logical_device().context());
   }
@@ -143,7 +143,7 @@ C2H_CCCLRT_TEST("ensure current context from a green context stream", "[device][
   SECTION("The pushed context resolves to the device of the green context")
   {
     // A green context resolves to the device that owns it.
-    cuda::__ensure_current_context setter(ref);
+    const cuda::__ensure_current_context setter(ref);
 
     CCCLRT_REQUIRE(driver::__cudevice_to_ordinal(driver::__ctxGetDevice()) == device.get());
   }
@@ -151,7 +151,7 @@ C2H_CCCLRT_TEST("ensure current context from a green context stream", "[device][
   SECTION("The context is popped again on destruction")
   {
     {
-      cuda::__ensure_current_context setter(ref);
+      const cuda::__ensure_current_context setter(ref);
     }
 
     CCCLRT_REQUIRE(test::count_driver_stack() == 0);

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/access.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/access.cu
@@ -58,7 +58,7 @@ C2H_CCCLRT_TEST("cuda::buffer access and stream", "[container][buffer]", test_ty
     return;
   }
 
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   Resource resource = extract_properties<Buffer>::get_resource();
 
   SECTION("cuda::buffer::get_unsynchronized")
@@ -262,13 +262,13 @@ C2H_CCCLRT_TEST("cuda::buffer access and stream", "[container][buffer]", test_ty
     static_assert(noexcept(cuda::std::declval<const Buffer&>().memory_resource()));
 
     { // Returns the resource used during construction
-      Buffer buf{stream, resource, {T(1), T(42), T(1337), T(0)}};
+      const Buffer buf{stream, resource, {T(1), T(42), T(1337), T(0)}};
       const auto& mr = buf.memory_resource();
       CCCLRT_CHECK(mr == resource);
     }
 
     { // Works with empty buffer
-      Buffer buf{stream, resource, 0, cuda::no_init};
+      const Buffer buf{stream, resource, 0, cuda::no_init};
       const auto& mr = buf.memory_resource();
       CCCLRT_CHECK(mr == resource);
     }
@@ -292,7 +292,7 @@ C2H_CCCLRT_TEST("cuda::buffer access and stream", "[container][buffer]", test_ty
     CCCLRT_CHECK(buf.stream() == stream);
 
     {
-      cuda::stream other_stream{cuda::device_ref{0}};
+      const cuda::stream other_stream{cuda::device_ref{0}};
       buf.set_stream(other_stream);
       CCCLRT_CHECK(buf.stream() == other_stream);
       buf.set_stream(stream);
@@ -309,7 +309,7 @@ C2H_CCCLRT_TEST("cuda::buffer access and stream", "[container][buffer]", test_ty
       CCCLRT_CHECK(!buf.empty());
       CCCLRT_CHECK(buf.data() != nullptr);
 
-      cuda::stream destroy_stream{cuda::device_ref{0}};
+      const cuda::stream destroy_stream{cuda::device_ref{0}};
       destroy_stream.wait(stream);
       buf.destroy(destroy_stream);
       CCCLRT_CHECK(buf.empty());

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/capacity.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/capacity.cu
@@ -32,7 +32,7 @@ C2H_CCCLRT_TEST("cuda::buffer capacity", "[container][buffer]", test_types)
     return;
   }
 
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   Resource resource = extract_properties<Buffer>::get_resource();
 
   SECTION("cuda::buffer::empty")

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/constructor.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/constructor.cu
@@ -52,7 +52,7 @@ C2H_CCCLRT_TEST("cuda::buffer constructors", "[container][buffer]", test_types)
     return;
   }
 
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   Resource resource = extract_properties<Buffer>::get_resource();
 
   SECTION("Construction with explicit size")
@@ -225,7 +225,7 @@ C2H_CCCLRT_TEST("cuda::buffer constructors", "[container][buffer]", test_types)
     static_assert(!cuda::std::is_nothrow_copy_constructible<Buffer>::value);
     { // can be copy constructed from empty input
       const Buffer input{stream, resource, 0, cuda::no_init};
-      Buffer buf(input); // NOLINT(performance-unnecessary-copy-initialization)
+      const Buffer buf(input); // NOLINT(performance-unnecessary-copy-initialization)
       CCCLRT_CHECK(buf.empty());
       CCCLRT_CHECK(buf.alignment() == input.alignment());
     }
@@ -261,7 +261,7 @@ C2H_CCCLRT_TEST("cuda::buffer constructors", "[container][buffer]", test_types)
     { // can be move constructed with empty input
       Buffer input{stream, resource, 0, cuda::no_init};
       const auto expected_alignment = input.alignment();
-      Buffer buf(cuda::std::move(input));
+      const Buffer buf(cuda::std::move(input));
       CCCLRT_CHECK(buf.empty());
       CCCLRT_CHECK(input.empty());
       CCCLRT_CHECK(buf.alignment() == expected_alignment);
@@ -466,15 +466,15 @@ C2H_CCCLRT_TEST("cuda::buffer constructors", "[container][buffer]", test_types)
 
 C2H_CCCLRT_TEST("cuda::buffer constructors with legacy resource", "[container][buffer]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
-  cuda::mr::legacy_pinned_memory_resource resource;
+  const cuda::stream stream{cuda::device_ref{0}};
+  const cuda::mr::legacy_pinned_memory_resource resource;
   auto input = compare_data_initializer_list;
-  cuda::buffer<int, cuda::mr::device_accessible> buffer{stream, resource, input};
+  const cuda::buffer<int, cuda::mr::device_accessible> buffer{stream, resource, input};
   CCCLRT_CHECK(equal_range(buffer));
   STATIC_CHECK(!decltype(buffer)::properties_list::has_property(cuda::mr::host_accessible{}));
   STATIC_CHECK(decltype(buffer)::properties_list::has_property(cuda::mr::device_accessible{}));
 
-  cuda::buffer<int, cuda::mr::host_accessible> buffer2{stream, resource, input};
+  const cuda::buffer<int, cuda::mr::host_accessible> buffer2{stream, resource, input};
   auto buf2 = cuda::make_buffer(stream, resource, buffer2);
   CCCLRT_CHECK(equal_range(buffer2));
   STATIC_CHECK(decltype(buffer2)::properties_list::has_property(cuda::mr::host_accessible{}));
@@ -489,7 +489,7 @@ C2H_CCCLRT_TEST("cuda::make_buffer narrowing properties", "[container][buffer]")
     return;
   }
   auto resource = cuda::pinned_default_memory_pool();
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
 
   auto buf = cuda::make_buffer<int>(stream, resource, 0, cuda::no_init);
 
@@ -512,7 +512,7 @@ C2H_CCCLRT_TEST("cuda::make_buffer narrowing properties", "[container][buffer]")
 
 C2H_CCCLRT_TEST("cuda::make_buffer with memory_pool_ref", "[container][buffer]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   cuda::device_memory_pool pool{cuda::device_ref{0}};
   auto buf = cuda::make_buffer(stream, pool.as_ref(), 10, 42);
   CCCLRT_CHECK(buf.size() == 10);
@@ -522,7 +522,7 @@ C2H_CCCLRT_TEST("cuda::make_buffer with memory_pool_ref", "[container][buffer]")
 
 C2H_CCCLRT_TEST("cuda::make_buffer with shared_resource", "[container][buffer]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   auto shared_res = cuda::mr::make_shared_resource<cuda::device_memory_pool>(cuda::device_ref{0});
   auto buf        = cuda::make_buffer(stream, shared_res, 10, 42);
   CCCLRT_CHECK(buf.size() == 10);
@@ -534,8 +534,8 @@ C2H_CCCLRT_TEST("cuda::make_buffer with shared_resource", "[container][buffer]")
 
 C2H_CCCLRT_TEST("cuda::make_device_buffer", "[container][buffer]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
-  cuda::device_ref dev{0};
+  const cuda::stream stream{cuda::device_ref{0}};
+  const cuda::device_ref dev{0};
 
   SECTION("empty")
   {
@@ -604,13 +604,13 @@ C2H_CCCLRT_TEST("cuda::make_device_buffer uses the explicit device", "[container
     return;
   }
 
-  cuda::device_ref current_device{0};
-  cuda::device_ref explicit_device{1};
-  cuda::stream explicit_device_stream{explicit_device};
+  const cuda::device_ref current_device{0};
+  const cuda::device_ref explicit_device{1};
+  const cuda::stream explicit_device_stream{explicit_device};
   cuda::std::array<int, 6> input{1, 42, 1337, 0, 12, -1};
 
   {
-    cuda::__ensure_current_context guard{current_device};
+    const cuda::__ensure_current_context guard{current_device};
     auto buf = cuda::make_device_buffer<int>(explicit_device_stream, explicit_device, input);
 
     CCCLRT_CHECK(buf.size() == input.size());
@@ -636,7 +636,7 @@ C2H_CCCLRT_TEST("cuda::make_pinned_buffer", "[container][buffer]")
     return;
   }
 
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
 
   SECTION("empty")
   {

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/conversion.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/conversion.cu
@@ -36,21 +36,21 @@ C2H_CCCLRT_TEST("cuda::buffer conversion", "[container][buffer]", test_types)
     return;
   }
 
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   Resource resource = extract_properties<Buffer>::get_resource();
 
   SECTION("cuda::buffer construction with matching buffer")
   {
     { // can be copy constructed from empty input
       const MatchingBuffer input{stream, resource, 0, cuda::no_init};
-      Buffer buf(input);
+      const Buffer buf(input);
       CCCLRT_CHECK(buf.empty());
       CCCLRT_CHECK(input.empty());
     }
 
     { // can be copy constructed from non-empty input
       const MatchingBuffer input{stream, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
-      Buffer buf(input);
+      const Buffer buf(input);
       CCCLRT_CHECK(!buf.empty());
       CCCLRT_CHECK(equal_range(buf));
       CCCLRT_CHECK(equal_range(input));
@@ -58,7 +58,7 @@ C2H_CCCLRT_TEST("cuda::buffer conversion", "[container][buffer]", test_types)
 
     { // can be move constructed with empty input
       MatchingBuffer input{stream, resource, 0, cuda::no_init};
-      Buffer buf(cuda::std::move(input));
+      const Buffer buf(cuda::std::move(input));
       CCCLRT_CHECK(buf.empty());
       CCCLRT_CHECK(input.empty());
     }

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/copy.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/copy.cu
@@ -43,7 +43,7 @@ C2H_CCCLRT_TEST("cuda::buffer make_buffer", "[container][buffer]", test_types)
     return;
   }
 
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   Resource resource = extract_properties<Buffer>::get_resource();
 
   SECTION("Same resource and stream")
@@ -79,7 +79,7 @@ C2H_CCCLRT_TEST("cuda::buffer make_buffer", "[container][buffer]", test_types)
 
   SECTION("Different stream")
   {
-    cuda::stream other_stream{cuda::device_ref{0}};
+    const cuda::stream other_stream{cuda::device_ref{0}};
     { // empty input
       const Buffer input{stream, resource};
       const Buffer buf = cuda::make_buffer(other_stream, input.memory_resource(), input);
@@ -97,7 +97,7 @@ C2H_CCCLRT_TEST("cuda::buffer make_buffer", "[container][buffer]", test_types)
 
   SECTION("Different resource and stream")
   {
-    cuda::stream other_stream{cuda::device_ref{0}};
+    const cuda::stream other_stream{cuda::device_ref{0}};
     { // empty input
       const Buffer input{stream, resource};
       auto buf = cuda::make_buffer(other_stream, resource, input);
@@ -153,7 +153,7 @@ C2H_CCCLRT_TEST("cuda::buffer make_buffer", "[container][buffer]", test_types)
 
 C2H_CCCLRT_TEST("make_buffer variants", "[container][buffer]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   const cuda::buffer<int, cuda::mr::device_accessible, other_property> input{
     stream,
     cuda::device_default_memory_pool(cuda::device_ref{0}),
@@ -240,15 +240,15 @@ C2H_CCCLRT_TEST("cuda::buffer make_buffer uses the explicit device", "[container
     return;
   }
 
-  cuda::device_ref current_device{0};
-  cuda::device_ref explicit_device{1};
-  cuda::stream explicit_device_stream{explicit_device};
+  const cuda::device_ref current_device{0};
+  const cuda::device_ref explicit_device{1};
+  const cuda::stream explicit_device_stream{explicit_device};
   cuda::std::array<int, 6> input{1, 42, 1337, 0, 12, -1};
 
   {
-    cuda::__ensure_current_context guard{current_device};
+    const cuda::__ensure_current_context guard{current_device};
     auto resource = cuda::device_default_memory_pool(explicit_device);
-    cuda::device_buffer<int> source{explicit_device_stream, resource, input};
+    const cuda::device_buffer<int> source{explicit_device_stream, resource, input};
     auto copy = cuda::make_buffer(explicit_device_stream, resource, source);
 
     CCCLRT_CHECK(source.size() == input.size());
@@ -270,7 +270,7 @@ C2H_CCCLRT_TEST("cuda::buffer make_buffer copies between peer devices", "[contai
     return;
   }
 
-  cuda::device_ref source_device{0};
+  const cuda::device_ref source_device{0};
   auto peers = source_device.peers();
   // This test exercises direct peer memory access; non-peer topologies have no legal device-to-device path to cover.
   if (peers.empty())
@@ -278,7 +278,7 @@ C2H_CCCLRT_TEST("cuda::buffer make_buffer copies between peer devices", "[contai
     return;
   }
 
-  cuda::device_ref destination_device = peers.front();
+  const cuda::device_ref destination_device = peers.front();
   // Device buffers are allocated from stream-ordered memory pools.
   if (!source_device.attribute(cuda::device_attributes::memory_pools_supported)
       || !destination_device.attribute(cuda::device_attributes::memory_pools_supported))
@@ -286,8 +286,8 @@ C2H_CCCLRT_TEST("cuda::buffer make_buffer copies between peer devices", "[contai
     return;
   }
 
-  cuda::stream source_stream{source_device};
-  cuda::stream destination_stream{destination_device};
+  const cuda::stream source_stream{source_device};
+  const cuda::stream destination_stream{destination_device};
   cuda::device_memory_pool source_pool{source_device};
   cuda::device_memory_pool destination_pool{destination_device};
   source_pool.enable_access_from(destination_device);
@@ -296,7 +296,7 @@ C2H_CCCLRT_TEST("cuda::buffer make_buffer copies between peer devices", "[contai
   auto destination_resource = destination_pool.as_ref();
 
   {
-    cuda::device_buffer<int> source{source_stream, source_resource, compare_data_initializer_list};
+    const cuda::device_buffer<int> source{source_stream, source_resource, compare_data_initializer_list};
     destination_stream.wait(source_stream);
     auto copy = cuda::make_buffer(destination_stream, destination_resource, source);
 
@@ -314,9 +314,9 @@ C2H_CCCLRT_TEST("cuda::buffer make_buffer copies between peer devices", "[contai
 
 C2H_CCCLRT_TEST("make_buffer with legacy resource", "[container][buffer]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   auto resource = cuda::mr::legacy_pinned_memory_resource{};
-  cuda::buffer<int, cuda::mr::host_accessible> input{
+  const cuda::buffer<int, cuda::mr::host_accessible> input{
     stream, resource, {int(1), int(42), int(1337), int(0), int(12), int(-1)}};
   auto buf = cuda::make_buffer(input.stream(), resource, input);
   CCCLRT_CHECK(equal_range(buf));

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
@@ -70,7 +70,7 @@ bool equal_range(const Buffer& buf)
     {
       return false;
     }
-    cuda::__ensure_current_context guard{buf.stream()};
+    const cuda::__ensure_current_context guard{buf.stream()};
     check_equal_kernel<<<1, 1, 0, buf.stream().get()>>>(buf.begin());
     CCCLRT_CHECK(cudaGetLastError() == cudaSuccess);
     buf.stream().sync();
@@ -87,7 +87,7 @@ bool compare_value(const T& value, const T& expected)
   }
   else
   {
-    cuda::__ensure_current_context guard{cuda::device_ref{0}};
+    const cuda::__ensure_current_context guard{cuda::device_ref{0}};
     // copy the value to host
     T host_value;
     _CCCL_TRY_RUNTIME_API(
@@ -110,7 +110,7 @@ void assign_value(T& value, const T& input)
   }
   else
   {
-    cuda::__ensure_current_context guard{cuda::device_ref{0}};
+    const cuda::__ensure_current_context guard{cuda::device_ref{0}};
     // copy the input to device
     _CCCL_TRY_RUNTIME_API(
       ::cudaMemcpy,
@@ -156,7 +156,7 @@ bool equal_size_value(const Buffer& buf, const size_t size, const typename Buffe
     {
       return false;
     }
-    cuda::__ensure_current_context guard{buf.stream()};
+    const cuda::__ensure_current_context guard{buf.stream()};
     check_equal_value_kernel<<<1, 1, 0, buf.stream().get()>>>(buf.begin(), size, value);
     CCCLRT_CHECK(cudaGetLastError() == cudaSuccess);
     buf.stream().sync();

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/iterators.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/iterators.cu
@@ -40,7 +40,7 @@ C2H_CCCLRT_TEST("cuda::buffer iterators", "[container][buffer]", test_types)
     return;
   }
 
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   Resource resource = extract_properties<Buffer>::get_resource();
 
   SECTION("cuda::buffer::begin/end properties")

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/resizable_buffer.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/resizable_buffer.cu
@@ -50,8 +50,8 @@ C2H_CCCLRT_TEST("cuda::__resizable_buffer capacity and resize", "[container][buf
   static_assert(cuda::std::is_nothrow_move_constructible_v<buffer_t>);
   static_assert(cuda::std::is_constructible_v<buffer_t, base_t&&>);
 
-  cuda::device_ref device{0};
-  cuda::stream stream{device};
+  const cuda::device_ref device{0};
+  const cuda::stream stream{device};
   auto resource = cuda::device_default_memory_pool(device);
   static_assert(cuda::std::is_constructible_v<buffer_t, cuda::stream_ref, decltype(resource)&>);
 
@@ -131,7 +131,7 @@ C2H_CCCLRT_TEST("cuda::__resizable_buffer capacity and resize", "[container][buf
 
   SECTION("resize with reallocation")
   {
-    cuda::stream other_stream{device};
+    const cuda::stream other_stream{device};
     cuda::std::array<int, 6> values{1, 42, 1337, 0, 12, -1};
     buffer_t buf{stream, resource, values.begin(), values.end()};
     buf.resize(stream, 3, cuda::no_init);
@@ -156,7 +156,7 @@ C2H_CCCLRT_TEST("cuda::__resizable_buffer capacity and resize", "[container][buf
 
   SECTION("resize from empty logical size with reallocation")
   {
-    cuda::stream other_stream{device};
+    const cuda::stream other_stream{device};
     buffer_t buf{stream, resource, 3, cuda::no_init};
     buf.resize(stream, 0, cuda::no_init);
 
@@ -169,7 +169,7 @@ C2H_CCCLRT_TEST("cuda::__resizable_buffer capacity and resize", "[container][buf
 
   SECTION("resize_discard")
   {
-    cuda::stream other_stream{device};
+    const cuda::stream other_stream{device};
     cuda::std::array<int, 6> values{1, 42, 1337, 0, 12, -1};
     buffer_t buf{stream, resource, values.begin(), values.end()};
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/swap.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/swap.cu
@@ -30,7 +30,7 @@ C2H_CCCLRT_TEST("cuda::buffer swap", "[container][buffer]", test_types)
     return;
   }
 
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   Resource resource = extract_properties<Buffer>::get_resource();
   STATIC_REQUIRE(
     cuda::std::is_same_v<decltype(cuda::std::declval<Buffer&>().swap(cuda::std::declval<Buffer&>())), void>);

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/transform.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/transform.cu
@@ -33,7 +33,7 @@ C2H_TEST("DeviceTransform::Transform cuda::device_buffer", "[device][launch_tran
   using type          = int;
   const int num_items = 1 << 24;
 
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   cuda::device_memory_pool_ref resource = cuda::device_default_memory_pool(cuda::device_ref{0});
 
   cuda::device_buffer<type> a{stream, resource, num_items, cuda::no_init};
@@ -80,7 +80,7 @@ struct add_kernel
 
 C2H_CCCLRT_TEST("cuda::buffer launch transform", "[container][buffer]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   cuda::device_memory_pool_ref resource = cuda::device_default_memory_pool(cuda::device_ref{0});
 
   const cuda::std::array array = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};

--- a/libcudacxx/test/libcudacxx/cuda/containers/uninitialized_async_buffer.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/uninitialized_async_buffer.cu
@@ -63,7 +63,7 @@ C2H_TEST_LIST(
   static_assert(!cuda::std::is_copy_assignable<__uninitialized_async_buffer>::value);
 
   cuda::device_memory_pool_ref resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
 
   SECTION("construction")
   {
@@ -118,7 +118,7 @@ C2H_TEST_LIST(
     static_assert(!cuda::std::is_copy_assignable<__uninitialized_async_buffer>::value);
 
     {
-      cuda::stream other_stream{cuda::device_ref{0}};
+      const cuda::stream other_stream{cuda::device_ref{0}};
       __uninitialized_async_buffer input{resource, other_stream, 42};
       const TestType* ptr = input.data();
 
@@ -263,14 +263,14 @@ int test_async_device_memory_pool_ref::count = 0;
 
 C2H_TEST("__uninitialized_async_buffer's memory resource does not dangle", "[container]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   cuda::__uninitialized_async_buffer<int, ::cuda::mr::device_accessible> buffer{
     cuda::device_default_memory_pool(cuda::device_ref{0}), stream, 0};
 
   {
     CHECK(test_async_device_memory_pool_ref::count == 0);
 
-    cuda::__uninitialized_async_buffer<int, ::cuda::mr::device_accessible> src_buffer{
+    const cuda::__uninitialized_async_buffer<int, ::cuda::mr::device_accessible> src_buffer{
       test_async_device_memory_pool_ref{}, stream, 1024};
 
     CHECK(test_async_device_memory_pool_ref::count == 1);

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_synchronous_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_synchronous_resource.cu
@@ -35,7 +35,7 @@ TEMPLATE_TEST_CASE_METHOD(
     Counts expected{};
     CHECK(this->counts == expected);
     {
-      cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr{TestResource{42, this}};
+      const cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr{TestResource{42, this}};
       expected.new_count += is_big;
       ++expected.object_count;
       ++expected.move_count;
@@ -81,7 +81,7 @@ TEMPLATE_TEST_CASE_METHOD(
       CHECK(this->counts == expected);
 
       // Test inequality with different resource
-      cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr4{TestResource{43, this}};
+      const cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr4{TestResource{43, this}};
       expected.new_count += is_big;
       ++expected.object_count;
       ++expected.move_count;
@@ -103,8 +103,10 @@ TEMPLATE_TEST_CASE_METHOD(
     using AnyResource = cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data>;
 
     TestResource resource{42, this};
+    // NOLINTBEGIN(misc-const-correctness): default initialization without zero-initialization is under test
     AnyResource empty1;
     AnyResource empty2;
+    // NOLINTEND(misc-const-correctness)
 
     CHECK(!empty1.has_value());
     CHECK(!empty2.has_value());
@@ -128,7 +130,7 @@ TEMPLATE_TEST_CASE_METHOD(
     CHECK(!(populated != empty1));
 
     AnyResource source{resource};
-    AnyResource destination{std::move(source)};
+    const AnyResource destination{std::move(source)};
     CHECK(!source.has_value()); // NOLINT(bugprone-use-after-move)
     CHECK((source == empty1));
     CHECK((source != destination));
@@ -173,13 +175,13 @@ TEMPLATE_TEST_CASE_METHOD(
     CHECK(this->counts == expected);
     {
       TestResource resource1{42, this};
-      TestResource resource2{43, this};
+      const TestResource resource2{43, this};
       expected.object_count += 2;
       CHECK(this->counts == expected);
       CHECK(!(resource1 == resource2));
       ++expected.equal_to_count;
       CHECK(this->counts == expected);
-      cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr{resource1};
+      const cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr{resource1};
       expected.new_count += is_big;
       ++expected.object_count;
       ++expected.copy_count;
@@ -217,7 +219,7 @@ TEMPLATE_TEST_CASE_METHOD(
 
       // conversion from any_synchronous_resource to
       // cuda::mr::synchronous_resource_ref with narrowing:
-      cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data> ref2 = mr;
+      const cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data> ref2 = mr;
       CHECK(get_property(ref2, get_data{}) == 42);
 
       CHECK(this->counts == expected);
@@ -246,7 +248,7 @@ TEMPLATE_TEST_CASE_METHOD(
       cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data> ref{test};
       CHECK(this->counts == expected);
 
-      cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr = ref;
+      const cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr = ref;
       expected.new_count += is_big;
       ++expected.object_count;
       ++expected.copy_count;
@@ -273,14 +275,14 @@ TEMPLATE_TEST_CASE_METHOD(
     Counts expected{};
     CHECK(this->counts == expected);
     {
-      cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, extra_property, get_data> mr{
+      const cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, extra_property, get_data> mr{
         TestResource{42, this}};
       expected.new_count += is_big;
       ++expected.object_count;
       ++expected.move_count;
       CHECK(this->counts == expected);
 
-      cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr2 = mr;
+      const cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr2 = mr;
       expected.new_count += is_big;
       ++expected.object_count;
       ++expected.copy_count;
@@ -344,7 +346,7 @@ TEMPLATE_TEST_CASE_METHOD(
       ++expected.object_count;
       CHECK(this->counts == expected);
 
-      cuda::mr::resource_ref<::cuda::mr::host_accessible, get_data> ref{test};
+      const cuda::mr::resource_ref<::cuda::mr::host_accessible, get_data> ref{test};
       CHECK(this->counts == expected);
 
       cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr = ref;
@@ -375,7 +377,7 @@ TEMPLATE_TEST_CASE_METHOD(
     Counts expected{};
     CHECK(this->counts == expected);
     {
-      cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr =
+      const cuda::mr::any_synchronous_resource<::cuda::mr::host_accessible, get_data> mr =
         cuda::mr::make_any_synchronous_resource<TestResource, ::cuda::mr::host_accessible, get_data>(42, this);
       expected.new_count += is_big;
       ++expected.object_count;
@@ -398,12 +400,12 @@ TEMPLATE_TEST_CASE_METHOD(
   CHECK(get_property(ref, get_data{}) == 42);
 
   big_resource mr2{43, this};
-  cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data> ref2{mr2};
+  const cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data> ref2{mr2};
   ref = ref2;
   CHECK(ref.allocate_sync(this->bytes(100), this->align(8)) == this);
   CHECK(get_property(ref, get_data{}) == 43);
 
-  cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data, extra_property> ref3{mr};
+  const cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data, extra_property> ref3{mr};
   ref = ref3; // copy assignment with property narrowing
   CHECK(ref.allocate_sync(this->bytes(100), this->align(8)) == this);
   CHECK(get_property(ref, get_data{}) == 42);
@@ -426,7 +428,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "Empty property set", "[container][resou
 
   {
     cuda::mr::any_synchronous_resource<get_data> mr{TestResource{42, this}};
-    cuda::mr::any_synchronous_resource<> mr_sliced_off_to_empty{mr};
+    const cuda::mr::any_synchronous_resource<> mr_sliced_off_to_empty{mr};
     CHECK(mr.allocate_sync(this->bytes(100), this->align(8)) == this);
     CHECK(try_get_property(mr, get_data{}).value() == 42);
     CHECK(!try_get_property(mr, extra_property{}));

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
@@ -110,8 +110,8 @@ C2H_CCCLRT_TEST("device_memory_pool construction", "[memory_resource]")
 {
   test::skip_if_unsupported_memory_pool<cuda::device_memory_pool_ref>();
 
-  int current_device = 0;
-  cuda::__ensure_current_context guard{cuda::device_ref{current_device}};
+  const int current_device = 0;
+  const cuda::__ensure_current_context guard{cuda::device_ref{current_device}};
 
   int driver_version = 0;
   {
@@ -131,7 +131,7 @@ C2H_CCCLRT_TEST("device_memory_pool construction", "[memory_resource]")
   SECTION("Default construction")
   {
     {
-      test_resource default_constructed = cuda::device_default_memory_pool(cuda::device_ref{0});
+      const test_resource default_constructed = cuda::device_default_memory_pool(cuda::device_ref{0});
       CHECK(default_constructed.get() == current_default_pool);
       CHECK(ensure_release_threshold(default_constructed.get(), cuda::std::numeric_limits<size_t>::max()));
     }
@@ -173,7 +173,7 @@ C2H_CCCLRT_TEST("device_memory_pool construction", "[memory_resource]")
     _CCCL_TRY_RUNTIME_API(::cudaMemPoolCreate, "Failed to call cudaMemPoolCreate", &cuda_pool_handle, &pool_properties);
 
     {
-      test_resource from_cudaMemPool{cuda_pool_handle};
+      const test_resource from_cudaMemPool{cuda_pool_handle};
       CHECK(from_cudaMemPool.get() == cuda_pool_handle);
       CHECK(from_cudaMemPool.get() != current_default_pool);
     }
@@ -198,10 +198,10 @@ C2H_CCCLRT_TEST("device_memory_pool construction", "[memory_resource]")
 
   SECTION("Construct with initial pool size")
   {
-    cuda::memory_pool_properties props = {
+    const cuda::memory_pool_properties props = {
       42,
     };
-    cuda::device_memory_pool from_initial_pool_size{current_device, props};
+    const cuda::device_memory_pool from_initial_pool_size{current_device, props};
 
     ::cudaMemPool_t get = from_initial_pool_size.get();
     CHECK(get != current_default_pool);
@@ -218,11 +218,11 @@ C2H_CCCLRT_TEST("device_memory_pool construction", "[memory_resource]")
 
   SECTION("Construct with release threshold")
   {
-    cuda::memory_pool_properties props = {
+    const cuda::memory_pool_properties props = {
       20,
       42,
     };
-    cuda::device_memory_pool with_threshold{current_device, props};
+    const cuda::device_memory_pool with_threshold{current_device, props};
 
     ::cudaMemPool_t get = with_threshold.get();
     CHECK(get != current_default_pool);
@@ -244,12 +244,12 @@ C2H_CCCLRT_TEST("device_memory_pool construction", "[memory_resource]")
   {
     SECTION("Construct with allocation handle")
     {
-      cuda::memory_pool_properties props = {
+      const cuda::memory_pool_properties props = {
         20,
         42,
         ::cudaMemHandleTypePosixFileDescriptor,
       };
-      cuda::device_memory_pool with_allocation_handle{current_device, props};
+      const cuda::device_memory_pool with_allocation_handle{current_device, props};
 
       ::cudaMemPool_t get = with_allocation_handle.get();
       CHECK(get != current_default_pool);
@@ -271,7 +271,7 @@ static void ensure_device_ptr(void* ptr)
 {
   CHECK(ptr != nullptr);
   cudaPointerAttributes attributes;
-  cudaError_t status = cudaPointerGetAttributes(&attributes, ptr);
+  const cudaError_t status = cudaPointerGetAttributes(&attributes, ptr);
   CHECK(status == cudaSuccess);
   CHECK(attributes.type == cudaMemoryTypeDevice);
 }
@@ -282,7 +282,7 @@ C2H_CCCLRT_TEST("device_memory_pool allocation", "[memory_resource]")
 
   cudaStream_t raw_stream;
   {
-    cuda::__ensure_current_context guard{cuda::device_ref{0}};
+    const cuda::__ensure_current_context guard{cuda::device_ref{0}};
     cudaStreamCreate(&raw_stream);
   }
   cuda::device_memory_pool_ref res = cuda::device_default_memory_pool(cuda::device_ref{0});
@@ -304,7 +304,7 @@ C2H_CCCLRT_TEST("device_memory_pool allocation", "[memory_resource]")
   }
 
   { // allocate / deallocate
-    cuda::stream_ref stream{raw_stream};
+    const cuda::stream_ref stream{raw_stream};
 
     auto* ptr = res.allocate(stream, 42);
     static_assert(cuda::std::is_same<decltype(ptr), void*>::value);
@@ -316,7 +316,7 @@ C2H_CCCLRT_TEST("device_memory_pool allocation", "[memory_resource]")
   }
 
   { // allocate / deallocate with alignment
-    cuda::stream_ref stream{raw_stream};
+    const cuda::stream_ref stream{raw_stream};
 
     auto* ptr = res.allocate(stream, 42, 4);
     static_assert(cuda::std::is_same<decltype(ptr), void*>::value);
@@ -388,7 +388,7 @@ C2H_CCCLRT_TEST("device_memory_pool allocation", "[memory_resource]")
   }
 #endif // _CCCL_HAS_EXCEPTIONS()
   {
-    cuda::__ensure_current_context guard{cuda::device_ref{0}};
+    const cuda::__ensure_current_context guard{cuda::device_ref{0}};
     cudaStreamDestroy(raw_stream);
   }
 }
@@ -397,12 +397,12 @@ C2H_CCCLRT_TEST("device_memory_pool comparison", "[memory_resource]")
 {
   test::skip_if_unsupported_memory_pool<cuda::device_memory_pool_ref>();
 
-  int current_device = 0;
-  cuda::__ensure_current_context guard{cuda::device_ref{current_device}};
+  const int current_device = 0;
+  const cuda::__ensure_current_context guard{cuda::device_ref{current_device}};
 
-  cuda::device_memory_pool_ref first = cuda::device_default_memory_pool(cuda::device_ref{0});
+  const cuda::device_memory_pool_ref first = cuda::device_default_memory_pool(cuda::device_ref{0});
   { // comparison against a plain device_memory_pool_ref
-    cuda::device_memory_pool_ref second = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const cuda::device_memory_pool_ref second = cuda::device_default_memory_pool(cuda::device_ref{0});
     CHECK((first == second));
     CHECK(!(first != second));
   }
@@ -410,7 +410,7 @@ C2H_CCCLRT_TEST("device_memory_pool comparison", "[memory_resource]")
   { // default pools are cached per physical device
     if (cuda::devices.size() > 1)
     {
-      cuda::device_memory_pool_ref second = cuda::device_default_memory_pool(cuda::device_ref{1});
+      const cuda::device_memory_pool_ref second = cuda::device_default_memory_pool(cuda::device_ref{1});
       CHECK(first.get() != second.get());
       CHECK((first != second));
       CHECK(!(first == second));
@@ -428,14 +428,14 @@ C2H_CCCLRT_TEST("device_memory_pool comparison", "[memory_resource]")
       _CCCL_TRY_RUNTIME_API(
         ::cudaMemPoolCreate, "Failed to call cudaMemPoolCreate", &cuda_pool_handle, &pool_properties);
     }
-    cuda::device_memory_pool_ref second{cuda_pool_handle};
+    const cuda::device_memory_pool_ref second{cuda_pool_handle};
     CHECK((first != second));
     CHECK(!(first == second));
   }
 
   { // comparison against a device_memory_pool_ref wrapped inside a synchronous_resource_ref<device_accessible>
     cuda::device_memory_pool_ref second = cuda::device_default_memory_pool(cuda::device_ref{0});
-    cuda::mr::synchronous_resource_ref<::cuda::mr::device_accessible> second_ref{second};
+    const cuda::mr::synchronous_resource_ref<::cuda::mr::device_accessible> second_ref{second};
     CHECK((first == second_ref));
     CHECK(!(first != second_ref));
     CHECK((second_ref == first));
@@ -444,7 +444,7 @@ C2H_CCCLRT_TEST("device_memory_pool comparison", "[memory_resource]")
 
   { // comparison against a device_memory_pool_ref wrapped inside a resource_ref
     cuda::device_memory_pool_ref second = cuda::device_default_memory_pool(cuda::device_ref{0});
-    cuda::mr::resource_ref<::cuda::mr::device_accessible> second_ref{second};
+    const cuda::mr::resource_ref<::cuda::mr::device_accessible> second_ref{second};
 
     CHECK((first == second_ref));
     CHECK(!(first != second_ref));

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/locality_domain_memory_pool.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/locality_domain_memory_pool.cu
@@ -212,7 +212,7 @@ C2H_CCCLRT_TEST("locality domain memory pool", "[memory_resource][locality_domai
   {
     for (auto dev : cuda::devices)
     {
-      cuda::__ensure_current_context guard{dev};
+      const cuda::__ensure_current_context guard{dev};
 
       for (auto& domain : dev.__locality_domains())
       {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/managed_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/managed_memory_resource.cu
@@ -62,7 +62,7 @@ static void ensure_managed_ptr(void* ptr)
 {
   CHECK(ptr != nullptr);
   cudaPointerAttributes attributes;
-  cudaError_t status = cudaPointerGetAttributes(&attributes, ptr);
+  const cudaError_t status = cudaPointerGetAttributes(&attributes, ptr);
   CHECK(status == cudaSuccess);
   CHECK(attributes.type == cudaMemoryTypeManaged);
 }
@@ -81,8 +81,8 @@ C2H_CCCLRT_TEST_LIST("managed_memory_resource construction", "[memory_resource]"
 #if _CCCL_CTK_BELOW(13, 0)
   SECTION("Construct with flag")
   {
-    managed_resource defaulted{};
-    managed_resource with_flag{cudaMemAttachHost};
+    const managed_resource defaulted{};
+    const managed_resource with_flag{cudaMemAttachHost};
     CHECK(defaulted != with_flag);
   }
 #endif // _CCCL_CTK_BELOW(13, 0)
@@ -97,7 +97,7 @@ C2H_CCCLRT_TEST_LIST("managed_memory_resource allocation", "[memory_resource]", 
   }
 
   managed_resource res = get_resource<managed_resource>();
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
 
   { // allocate_sync / deallocate_sync
     auto* ptr = res.allocate_sync(42);
@@ -186,16 +186,16 @@ C2H_CCCLRT_TEST_LIST("managed_memory_resource comparison", "[memory_resource]", 
     test::skip_if_unsupported_memory_pool<managed_resource>();
   }
 
-  managed_resource first = get_resource<managed_resource>();
+  const managed_resource first = get_resource<managed_resource>();
   { // comparison against a plain managed_memory_resource
-    managed_resource second = get_resource<managed_resource>();
+    const managed_resource second = get_resource<managed_resource>();
     CHECK((first == second));
     CHECK(!(first != second));
   }
 
   if constexpr (cuda::std::is_same_v<managed_resource, cuda::mr::legacy_managed_memory_resource>)
   { // comparison against a plain legacy_managed_memory_resource with a different flags
-    managed_resource second = cuda::mr::legacy_managed_memory_resource{cudaMemAttachHost};
+    const managed_resource second = cuda::mr::legacy_managed_memory_resource{cudaMemAttachHost};
     CHECK((first != second));
     CHECK(!(first == second));
   }
@@ -211,7 +211,7 @@ C2H_CCCLRT_TEST_LIST("managed_memory_resource comparison", "[memory_resource]", 
 
   { // comparison against a managed_memory_resource wrapped inside a synchronous_resource_ref<device_accessible>
     managed_resource second = get_resource<managed_resource>();
-    cuda::mr::synchronous_resource_ref<::cuda::mr::device_accessible> second_ref{second};
+    const cuda::mr::synchronous_resource_ref<::cuda::mr::device_accessible> second_ref{second};
     CHECK((first == second_ref));
     CHECK(!(first != second_ref));
     CHECK((second_ref == first));

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
@@ -221,7 +221,7 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool construction", "[memory_resource]", TES
 
   SECTION("Construct from device id")
   {
-    memory_pool from_device = construct_pool<memory_pool>();
+    const memory_pool from_device = construct_pool<memory_pool>();
 
     ::cudaMemPool_t get = from_device.get();
     CHECK(get != current_default_pool);
@@ -243,8 +243,8 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool construction", "[memory_resource]", TES
 
   SECTION("Construct with empty properties")
   {
-    cuda::memory_pool_properties props{};
-    memory_pool from_defaulted_properties = construct_pool<memory_pool>(props);
+    const cuda::memory_pool_properties props{};
+    const memory_pool from_defaulted_properties = construct_pool<memory_pool>(props);
 
     ::cudaMemPool_t get = from_defaulted_properties.get();
     CHECK(get != current_default_pool);
@@ -265,8 +265,8 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool construction", "[memory_resource]", TES
 
   SECTION("Construct with initial pool size")
   {
-    cuda::memory_pool_properties props = {20, 42};
-    memory_pool with_threshold         = construct_pool<memory_pool>(props);
+    const cuda::memory_pool_properties props = {20, 42};
+    const memory_pool with_threshold         = construct_pool<memory_pool>(props);
 
     ::cudaMemPool_t get = with_threshold.get();
     CHECK(get != current_default_pool);
@@ -318,7 +318,7 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool construction", "[memory_resource]", TES
     ::cudaMemPool_t new_pool{};
     _CCCL_TRY_RUNTIME_API(::cudaMemPoolCreate, "Failed to call cudaMemPoolCreate", &new_pool, &pool_properties);
 
-    memory_pool from_handle = memory_pool::from_native_handle(new_pool);
+    const memory_pool from_handle = memory_pool::from_native_handle(new_pool);
     CHECK(from_handle.get() == new_pool);
   }
 }
@@ -328,8 +328,8 @@ C2H_CCCLRT_TEST_LIST("base_memory_pool construction", "[memory_resource]", TEST_
   using memory_pool = TestType;
   test::skip_if_unsupported_memory_pool<memory_pool>();
 
-  int current_device = 0;
-  cuda::__ensure_current_context guard{cuda::device_ref{current_device}};
+  const int current_device = 0;
+  const cuda::__ensure_current_context guard{cuda::device_ref{current_device}};
 
   int driver_version = 0;
   {
@@ -359,7 +359,7 @@ C2H_CCCLRT_TEST_LIST("base_memory_pool construction", "[memory_resource]", TEST_
     else
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
     {
-      memory_pool with_max_pool_size = construct_pool<memory_pool>(props);
+      const memory_pool with_max_pool_size = construct_pool<memory_pool>(props);
 
       ::cudaMemPool_t get = with_max_pool_size.get();
       CHECK(get != current_default_pool);
@@ -394,7 +394,7 @@ C2H_CCCLRT_TEST_LIST("base_memory_pool construction", "[memory_resource]", TEST_
         ::cudaFreeAsync, "Failed to deallocate with pool passed to cuda::device_memory_pool_ref", ptr, stream);
       // make an allocation larger than the max pool size
       // NOTE: currently cuda driver rounds up max size to 32MB. So we need to allocate 32MB + 1 byte.
-      cudaError_t status = ::cudaMallocAsync(&ptr, 33 << 20, get, stream);
+      const cudaError_t status = ::cudaMallocAsync(&ptr, 33 << 20, get, stream);
       CHECK(status == cudaErrorMemoryAllocation);
       CHECK(ptr == nullptr);
     }
@@ -438,9 +438,9 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool comparison", "[memory_resource]", TEST_
       current_device);
   }
 
-  memory_pool first = construct_pool<memory_pool>();
+  const memory_pool first = construct_pool<memory_pool>();
   { // comparison against a plain device_memory_pool
-    memory_pool second = construct_pool<memory_pool>();
+    const memory_pool second = construct_pool<memory_pool>();
     CHECK(first == first);
     CHECK(first != second);
   }
@@ -468,13 +468,13 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_T
 
     { // cudaMemPoolReuseFollowEventDependencies
       // Get the attribute value
-      bool attr = pool.attribute(cuda::memory_pool_attributes::reuse_follow_event_dependencies);
+      const bool attr = pool.attribute(cuda::memory_pool_attributes::reuse_follow_event_dependencies);
 
       // Set it to the opposite
       pool.set_attribute(cuda::memory_pool_attributes::reuse_follow_event_dependencies, !attr);
 
       // Retrieve again and verify it was changed
-      bool new_attr = pool.attribute(cuda::memory_pool_attributes::reuse_follow_event_dependencies);
+      const bool new_attr = pool.attribute(cuda::memory_pool_attributes::reuse_follow_event_dependencies);
       CHECK(attr == !new_attr);
 
       // Set it back
@@ -483,13 +483,13 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_T
 
     { // cudaMemPoolReuseAllowOpportunistic
       // Get the attribute value
-      bool attr = pool.attribute(cuda::memory_pool_attributes::reuse_allow_opportunistic);
+      const bool attr = pool.attribute(cuda::memory_pool_attributes::reuse_allow_opportunistic);
 
       // Set it to the opposite
       pool.set_attribute(cuda::memory_pool_attributes::reuse_allow_opportunistic, !attr);
 
       // Retrieve again and verify it was changed
-      bool new_attr = pool.attribute(cuda::memory_pool_attributes::reuse_allow_opportunistic);
+      const bool new_attr = pool.attribute(cuda::memory_pool_attributes::reuse_allow_opportunistic);
       CHECK(attr == !new_attr);
 
       // Set it back
@@ -498,13 +498,13 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_T
 
     { // cudaMemPoolReuseAllowInternalDependencies
       // Get the attribute value
-      bool attr = pool.attribute(cuda::memory_pool_attributes::reuse_allow_internal_dependencies);
+      const bool attr = pool.attribute(cuda::memory_pool_attributes::reuse_allow_internal_dependencies);
 
       // Set it to the opposite
       pool.set_attribute(cuda::memory_pool_attributes::reuse_allow_internal_dependencies, !attr);
 
       // Retrieve again and verify it was changed
-      bool new_attr = pool.attribute(cuda::memory_pool_attributes::reuse_allow_internal_dependencies);
+      const bool new_attr = pool.attribute(cuda::memory_pool_attributes::reuse_allow_internal_dependencies);
       CHECK(attr == !new_attr);
 
       // Set it back
@@ -513,13 +513,13 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_T
 
     { // cudaMemPoolAttrReleaseThreshold
       // Get the attribute value
-      size_t attr = pool.attribute(cuda::memory_pool_attributes::release_threshold);
+      const size_t attr = pool.attribute(cuda::memory_pool_attributes::release_threshold);
 
       // Set it to something else
       pool.set_attribute(cuda::memory_pool_attributes::release_threshold, 2 * attr);
 
       // Retrieve again and verify it was changed
-      size_t new_attr = pool.attribute(cuda::memory_pool_attributes::release_threshold);
+      const size_t new_attr = pool.attribute(cuda::memory_pool_attributes::release_threshold);
       CHECK(new_attr == 2 * attr);
 
       // Set it back
@@ -528,7 +528,7 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_T
 
     // prime the pool to a given size
     memory_resource resource{pool};
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
 
     // Allocate a buffer to prime
     auto* ptr = resource.allocate(stream, 256 * sizeof(int));
@@ -536,13 +536,13 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_T
 
     { // cudaMemPoolAttrReservedMemHigh
       // Get the attribute value
-      size_t attr = pool.attribute(cuda::memory_pool_attributes::reserved_mem_high);
+      const size_t attr = pool.attribute(cuda::memory_pool_attributes::reserved_mem_high);
 
       // Set it to zero as everything else is illegal
       pool.set_attribute(cuda::memory_pool_attributes::reserved_mem_high, 0);
 
       // Retrieve again and verify it was changed, which it wasn't...
-      size_t new_attr = pool.attribute(cuda::memory_pool_attributes::reserved_mem_high);
+      const size_t new_attr = pool.attribute(cuda::memory_pool_attributes::reserved_mem_high);
       CHECK(new_attr == attr);
 
 #if _CCCL_HAS_EXCEPTIONS()
@@ -565,13 +565,13 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_T
 
     { // cudaMemPoolAttrUsedMemHigh
       // Get the attribute value
-      size_t attr = pool.attribute(cuda::memory_pool_attributes::used_mem_high);
+      const size_t attr = pool.attribute(cuda::memory_pool_attributes::used_mem_high);
 
       // Set it to zero as everything else is illegal
       pool.set_attribute(cuda::memory_pool_attributes::used_mem_high, 0);
 
       // Retrieve again and verify it was changed, which it wasn't...
-      size_t new_attr = pool.attribute(cuda::memory_pool_attributes::used_mem_high);
+      const size_t new_attr = pool.attribute(cuda::memory_pool_attributes::used_mem_high);
       CHECK(new_attr == attr);
 
 #if _CCCL_HAS_EXCEPTIONS()
@@ -599,14 +599,14 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_T
 
     { // cudaMemPoolAttrReservedMemCurrent
       // Get the attribute value
-      size_t attr = pool.attribute(cuda::memory_pool_attributes::reserved_mem_current);
+      const size_t attr = pool.attribute(cuda::memory_pool_attributes::reserved_mem_current);
       CHECK(attr >= 2048 * sizeof(int));
       // cudaMemPoolAttrReservedMemCurrent cannot be set
     }
 
     { // cudaMemPoolAttrUsedMemCurrent
       // Get the attribute value
-      size_t attr = pool.attribute(cuda::memory_pool_attributes::used_mem_current);
+      const size_t attr = pool.attribute(cuda::memory_pool_attributes::used_mem_current);
       CHECK(attr == 2048 * sizeof(int));
       // cudaMemPoolAttrUsedMemCurrent cannot be set
     }
@@ -626,7 +626,7 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_T
 
     // prime the pool to a given size
     memory_resource resource{pool};
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
 
     // Allocate 2 buffers
     auto* ptr1 = resource.allocate(stream, 2048 * sizeof(int));
@@ -738,8 +738,8 @@ C2H_CCCLRT_TEST("device_memory_pool with allocation handle", "[memory_resource]"
   {
     return;
   }
-  cuda::memory_pool_properties props              = {20, 42, ::cudaMemHandleTypePosixFileDescriptor};
-  cuda::device_memory_pool with_allocation_handle = cuda::device_memory_pool(cuda::device_ref{0}, props);
+  const cuda::memory_pool_properties props              = {20, 42, ::cudaMemHandleTypePosixFileDescriptor};
+  const cuda::device_memory_pool with_allocation_handle = cuda::device_memory_pool(cuda::device_ref{0}, props);
 
   ::cudaMemPool_t current_default_pool{};
   {
@@ -774,8 +774,8 @@ C2H_CCCLRT_TEST("pinned_memory_pool with allocation handle", "[memory_resource]"
   {
     return;
   }
-  cuda::memory_pool_properties props              = {20, 42, ::cudaMemHandleTypePosixFileDescriptor};
-  cuda::pinned_memory_pool with_allocation_handle = cuda::pinned_memory_pool(0, props);
+  const cuda::memory_pool_properties props              = {20, 42, ::cudaMemHandleTypePosixFileDescriptor};
+  const cuda::pinned_memory_pool with_allocation_handle = cuda::pinned_memory_pool(0, props);
 
   ::cudaMemPool_t get = with_allocation_handle.get();
   CHECK(get != cuda::pinned_default_memory_pool().get());
@@ -802,14 +802,14 @@ C2H_CCCLRT_TEST("device_memory_pool conversion to resource_ref", "[memory_resour
 {
   test::skip_if_unsupported_memory_pool<cuda::device_memory_pool>();
 
-  int current_device = 0;
-  cuda::__ensure_current_context guard{cuda::device_ref{current_device}};
+  const int current_device = 0;
+  const cuda::__ensure_current_context guard{cuda::device_ref{current_device}};
 
   cuda::device_memory_pool pool{cuda::device_ref{0}};
-  cuda::mr::resource_ref<cuda::mr::device_accessible> ref1 = pool.as_ref();
+  const cuda::mr::resource_ref<cuda::mr::device_accessible> ref1 = pool.as_ref();
 
-  cuda::device_memory_pool_ref pool_ref                    = pool.as_ref();
-  cuda::mr::resource_ref<cuda::mr::device_accessible> ref2 = pool_ref;
+  cuda::device_memory_pool_ref pool_ref                          = pool.as_ref();
+  const cuda::mr::resource_ref<cuda::mr::device_accessible> ref2 = pool_ref;
   CHECK((ref1 == ref2));
 }
 
@@ -854,32 +854,32 @@ C2H_CCCLRT_TEST("pinned_memory_pool conversion to resource_ref", "[memory_resour
 {
   test::skip_if_unsupported_memory_pool<cuda::pinned_memory_pool>();
 
-  int current_device = 0;
-  cuda::__ensure_current_context guard{cuda::device_ref{current_device}};
+  const int current_device = 0;
+  const cuda::__ensure_current_context guard{cuda::device_ref{current_device}};
 
   cuda::pinned_memory_pool pool{0};
 
   { // host device accessible
-    cuda::mr::resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible> ref1 = pool.as_ref();
+    const cuda::mr::resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible> ref1 = pool.as_ref();
 
-    cuda::pinned_memory_pool_ref pool_ref                                               = pool.as_ref();
-    cuda::mr::resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible> ref2 = pool_ref;
+    cuda::pinned_memory_pool_ref pool_ref                                                     = pool.as_ref();
+    const cuda::mr::resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible> ref2 = pool_ref;
     CHECK((ref1 == ref2));
   }
 
   { // host  accessible
-    cuda::mr::resource_ref<cuda::mr::host_accessible> ref1 = pool.as_ref();
+    const cuda::mr::resource_ref<cuda::mr::host_accessible> ref1 = pool.as_ref();
 
-    cuda::pinned_memory_pool_ref pool_ref                  = pool.as_ref();
-    cuda::mr::resource_ref<cuda::mr::host_accessible> ref2 = pool_ref;
+    cuda::pinned_memory_pool_ref pool_ref                        = pool.as_ref();
+    const cuda::mr::resource_ref<cuda::mr::host_accessible> ref2 = pool_ref;
     CHECK((ref1 == ref2));
   }
 
   { // device accessible
-    cuda::mr::resource_ref<cuda::mr::device_accessible> ref1 = pool.as_ref();
+    const cuda::mr::resource_ref<cuda::mr::device_accessible> ref1 = pool.as_ref();
 
-    cuda::pinned_memory_pool_ref pool_ref                    = pool.as_ref();
-    cuda::mr::resource_ref<cuda::mr::device_accessible> ref2 = pool_ref;
+    cuda::pinned_memory_pool_ref pool_ref                          = pool.as_ref();
+    const cuda::mr::resource_ref<cuda::mr::device_accessible> ref2 = pool_ref;
     CHECK((ref1 == ref2));
   }
 }
@@ -889,14 +889,14 @@ C2H_CCCLRT_TEST("pinned_memory_pool conversion to resource_ref", "[memory_resour
 
 C2H_CCCLRT_TEST("device_memory_pool no_init constructor", "[memory_resource]")
 {
-  cuda::device_memory_pool pool(cuda::no_init);
+  const cuda::device_memory_pool pool(cuda::no_init);
   CHECK(pool.get() == nullptr);
 }
 
 #if _CCCL_CTK_AT_LEAST(12, 9)
 C2H_CCCLRT_TEST("pinned_memory_pool no_init constructor", "[memory_resource]")
 {
-  cuda::pinned_memory_pool pool(cuda::no_init);
+  const cuda::pinned_memory_pool pool(cuda::no_init);
   CHECK(pool.get() == nullptr);
 }
 #endif // _CCCL_CTK_AT_LEAST(12, 9)

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/pinned_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/pinned_memory_resource.cu
@@ -63,7 +63,7 @@ Resource get_resource()
 
 static bool cuda_malloc_host_reports_memory_type(cudaMemoryType type)
 {
-  cuda::__ensure_current_context guard(cuda::device_ref{0});
+  const cuda::__ensure_current_context guard(cuda::device_ref{0});
   void* cuda_malloc_host_ptr = nullptr;
   cudaError_t status         = cudaMallocHost(&cuda_malloc_host_ptr, 1);
   if (status != cudaSuccess || cuda_malloc_host_ptr == nullptr)
@@ -72,8 +72,8 @@ static bool cuda_malloc_host_reports_memory_type(cudaMemoryType type)
   }
 
   cudaPointerAttributes attributes;
-  status                  = cudaPointerGetAttributes(&attributes, cuda_malloc_host_ptr);
-  cudaError_t free_status = cudaFreeHost(cuda_malloc_host_ptr);
+  status                        = cudaPointerGetAttributes(&attributes, cuda_malloc_host_ptr);
+  const cudaError_t free_status = cudaFreeHost(cuda_malloc_host_ptr);
   CHECK(free_status == cudaSuccess);
 
   return status == cudaSuccess && free_status == cudaSuccess && attributes.type == type;
@@ -83,7 +83,7 @@ static void ensure_pinned_ptr(void* ptr)
 {
   CHECK(ptr != nullptr);
   cudaPointerAttributes attributes;
-  cudaError_t status = cudaPointerGetAttributes(&attributes, ptr);
+  const cudaError_t status = cudaPointerGetAttributes(&attributes, ptr);
   CHECK(status == cudaSuccess);
   if (attributes.type != cudaMemoryTypeHost)
   {
@@ -104,7 +104,7 @@ C2H_CCCLRT_TEST_LIST("pinned_memory_resource allocation", "[memory_resource]", T
   }
 
   pinned_resource res = get_resource<pinned_resource>();
-  cuda::stream stream{cuda::device_ref{0}};
+  cuda::stream stream{cuda::device_ref{0}}; // NOLINT(misc-const-correctness)
 
   { // allocate_sync / deallocate_sync
     auto* ptr = res.allocate_sync(42);
@@ -227,9 +227,9 @@ C2H_CCCLRT_TEST_LIST("pinned_memory_resource comparison", "[memory_resource]", T
     test::skip_if_unsupported_memory_pool<pinned_resource>();
   }
 
-  pinned_resource first = get_resource<pinned_resource>();
+  const pinned_resource first = get_resource<pinned_resource>();
   { // comparison against a plain pinned_memory_resource
-    pinned_resource second = get_resource<pinned_resource>();
+    const pinned_resource second = get_resource<pinned_resource>();
     CHECK((first == second));
     CHECK(!(first != second));
   }
@@ -247,7 +247,7 @@ C2H_CCCLRT_TEST_LIST("pinned_memory_resource comparison", "[memory_resource]", T
   if constexpr (cuda::mr::resource<pinned_resource>)
   { // comparison against a pinned_memory_resource wrapped inside a resource_ref
     pinned_resource second = get_resource<pinned_resource>();
-    cuda::mr::resource_ref<::cuda::mr::device_accessible> second_ref{second};
+    const cuda::mr::resource_ref<::cuda::mr::device_accessible> second_ref{second};
 
     CHECK((first == second_ref));
     CHECK(!(first != second_ref));

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/shared_memory_pools.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/shared_memory_pools.cu
@@ -115,13 +115,13 @@ C2H_CCCLRT_TEST_LIST("shared_memory_pool construction", "[memory_resource]", SHA
   {
     test::skip_if_unsupported_memory_pool<shared_pool>();
 
-    shared_pool pool = construct_shared_pool<shared_pool>();
+    const shared_pool pool = construct_shared_pool<shared_pool>();
     CHECK(pool.get() != nullptr);
   }
 
   SECTION("Construct with no_init")
   {
-    shared_pool pool(cuda::no_init);
+    const shared_pool pool(cuda::no_init);
     CHECK(pool.get() == nullptr);
   }
 
@@ -131,8 +131,8 @@ C2H_CCCLRT_TEST_LIST("shared_memory_pool construction", "[memory_resource]", SHA
 
     // Create an owning pool, release the handle, and wrap it via from_native_handle.
     cuda::device_memory_pool owning_pool{cuda::device_ref{0}};
-    cudaMemPool_t raw    = owning_pool.release();
-    shared_pool from_raw = shared_pool::from_native_handle(raw);
+    cudaMemPool_t raw          = owning_pool.release();
+    const shared_pool from_raw = shared_pool::from_native_handle(raw);
     CHECK(from_raw.get() == raw);
     // from_raw owns the handle and will destroy it on scope exit.
   }
@@ -150,7 +150,7 @@ C2H_CCCLRT_TEST_LIST("shared_memory_pool copy and move", "[memory_resource]", SH
 
   SECTION("Copy construction shares the pool")
   {
-    shared_pool copy(pool); // NOLINT(performance-unnecessary-copy-initialization)
+    const shared_pool copy(pool); // NOLINT(performance-unnecessary-copy-initialization)
     CHECK(copy.get() == handle);
     CHECK(pool.get() == handle);
   }
@@ -165,7 +165,7 @@ C2H_CCCLRT_TEST_LIST("shared_memory_pool copy and move", "[memory_resource]", SH
 
   SECTION("Move construction transfers ownership")
   {
-    shared_pool moved(cuda::std::move(pool));
+    const shared_pool moved(cuda::std::move(pool));
     CHECK(moved.get() == handle);
   }
 
@@ -181,8 +181,8 @@ C2H_CCCLRT_TEST_LIST("shared_memory_pool copy and move", "[memory_resource]", SH
     shared_pool outer = construct_shared_pool<shared_pool>();
     auto saved_handle = outer.get();
     {
-      shared_pool copy1(outer); // NOLINT(performance-unnecessary-copy-initialization)
-      shared_pool copy2(outer); // NOLINT(performance-unnecessary-copy-initialization)
+      const shared_pool copy1(outer); // NOLINT(performance-unnecessary-copy-initialization)
+      const shared_pool copy2(outer); // NOLINT(performance-unnecessary-copy-initialization)
       CHECK(copy1.get() == saved_handle);
       CHECK(copy2.get() == saved_handle);
       // copy1, copy2 destroyed here — pool should survive
@@ -202,8 +202,8 @@ C2H_CCCLRT_TEST_LIST("shared_memory_pool comparison", "[memory_resource]", SHARE
   using shared_pool = TestType;
   test::skip_if_unsupported_memory_pool<shared_pool>();
 
-  shared_pool pool1 = construct_shared_pool<shared_pool>();
-  shared_pool pool2 = construct_shared_pool<shared_pool>();
+  const shared_pool pool1 = construct_shared_pool<shared_pool>();
+  const shared_pool pool2 = construct_shared_pool<shared_pool>();
 
   SECTION("Different pools are not equal")
   {
@@ -212,7 +212,7 @@ C2H_CCCLRT_TEST_LIST("shared_memory_pool comparison", "[memory_resource]", SHARE
 
   SECTION("Copies are equal")
   {
-    shared_pool copy(pool1); // NOLINT(performance-unnecessary-copy-initialization)
+    const shared_pool copy(pool1); // NOLINT(performance-unnecessary-copy-initialization)
     CHECK(pool1 == copy);
   }
 
@@ -233,7 +233,7 @@ C2H_CCCLRT_TEST_LIST("shared_memory_pool operations", "[memory_resource]", SHARE
 
   SECTION("allocate and deallocate")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     void* ptr = pool.allocate(stream, 1024, cuda::mr::default_cuda_malloc_alignment);
     CHECK(ptr != nullptr);
     pool.deallocate(stream, ptr, 1024, cuda::mr::default_cuda_malloc_alignment);
@@ -249,7 +249,7 @@ C2H_CCCLRT_TEST_LIST("shared_memory_pool operations", "[memory_resource]", SHARE
 
   SECTION("trim_to")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     void* ptr = pool.allocate(stream, 2048 * sizeof(int));
     pool.deallocate(stream, ptr, 2048 * sizeof(int));
     stream.sync();
@@ -258,7 +258,7 @@ C2H_CCCLRT_TEST_LIST("shared_memory_pool operations", "[memory_resource]", SHARE
 
   SECTION("attribute access")
   {
-    size_t threshold = pool.attribute(cuda::memory_pool_attributes::release_threshold);
+    const size_t threshold = pool.attribute(cuda::memory_pool_attributes::release_threshold);
     CHECK(threshold == cuda::std::numeric_limits<size_t>::max());
 
 #if _CCCL_CTK_AT_LEAST(13, 3)
@@ -269,16 +269,16 @@ C2H_CCCLRT_TEST_LIST("shared_memory_pool operations", "[memory_resource]", SHARE
 
   SECTION("set_attribute")
   {
-    bool attr = pool.attribute(cuda::memory_pool_attributes::reuse_follow_event_dependencies);
+    const bool attr = pool.attribute(cuda::memory_pool_attributes::reuse_follow_event_dependencies);
     pool.set_attribute(cuda::memory_pool_attributes::reuse_follow_event_dependencies, !attr);
-    bool new_attr = pool.attribute(cuda::memory_pool_attributes::reuse_follow_event_dependencies);
+    const bool new_attr = pool.attribute(cuda::memory_pool_attributes::reuse_follow_event_dependencies);
     CHECK(attr == !new_attr);
   }
 
   SECTION("Operations work through a copy")
   {
     shared_pool copy(pool);
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     void* ptr = copy.allocate(stream, 512);
     CHECK(ptr != nullptr);
     copy.deallocate(stream, ptr, 512);
@@ -295,7 +295,7 @@ C2H_CCCLRT_TEST("shared_device_memory_pool satisfies resource_with", "[memory_re
   test::skip_if_unsupported_memory_pool<cuda::shared_device_memory_pool>();
 
   cuda::shared_device_memory_pool pool{cuda::device_ref{0}};
-  cuda::mr::resource_ref<cuda::mr::device_accessible> ref = pool;
+  const cuda::mr::resource_ref<cuda::mr::device_accessible> ref = pool;
   (void) ref;
 }
 
@@ -308,7 +308,7 @@ C2H_CCCLRT_TEST("shared_pinned_memory_pool satisfies resource_with", "[memory_re
   test::skip_if_unsupported_memory_pool<cuda::shared_pinned_memory_pool>();
 
   cuda::shared_pinned_memory_pool pool{0};
-  cuda::mr::resource_ref<cuda::mr::device_accessible, cuda::mr::host_accessible> ref = pool;
+  const cuda::mr::resource_ref<cuda::mr::device_accessible, cuda::mr::host_accessible> ref = pool;
   (void) ref;
 }
 #endif // _CCCL_CTK_AT_LEAST(12, 9)

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_block_ptr.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_block_ptr.cu
@@ -66,7 +66,7 @@ static_assert(cuda::std::is_move_assignable<cuda::mr::__shared_block_ptr<trivial
 
 C2H_CCCLRT_TEST("__shared_block_ptr default construction", "[memory_resource]")
 {
-  cuda::mr::__shared_block_ptr<trivial_payload> ptr;
+  const cuda::mr::__shared_block_ptr<trivial_payload> ptr;
   CHECK(!ptr);
 }
 
@@ -158,10 +158,10 @@ C2H_CCCLRT_TEST("__shared_block_ptr move assignment", "[memory_resource]")
 
 C2H_CCCLRT_TEST("__shared_block_ptr equality", "[memory_resource]")
 {
-  cuda::mr::__shared_block_ptr<trivial_payload> a(1);
-  cuda::mr::__shared_block_ptr<trivial_payload> b(2);
-  cuda::mr::__shared_block_ptr<trivial_payload> a_copy(a); // NOLINT(performance-unnecessary-copy-initialization)
-  cuda::mr::__shared_block_ptr<trivial_payload> null;
+  cuda::mr::__shared_block_ptr<trivial_payload> a(1); // NOLINT(misc-const-correctness)
+  const cuda::mr::__shared_block_ptr<trivial_payload> b(2);
+  const cuda::mr::__shared_block_ptr<trivial_payload> a_copy(a); // NOLINT(performance-unnecessary-copy-initialization)
+  const cuda::mr::__shared_block_ptr<trivial_payload> null;
 
   CHECK(a == a);
   CHECK(a == a_copy);
@@ -191,11 +191,13 @@ C2H_CCCLRT_TEST("__shared_block_ptr refcount multiple copies", "[memory_resource
 {
   counting_payload::__reset();
   {
-    cuda::mr::__shared_block_ptr<counting_payload> p1(42);
+    const cuda::mr::__shared_block_ptr<counting_payload> p1(42);
     {
-      cuda::mr::__shared_block_ptr<counting_payload> p2(p1); // NOLINT(performance-unnecessary-copy-initialization)
+      // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+      const cuda::mr::__shared_block_ptr<counting_payload> p2(p1);
       {
-        cuda::mr::__shared_block_ptr<counting_payload> p3(p2); // NOLINT(performance-unnecessary-copy-initialization)
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+        const cuda::mr::__shared_block_ptr<counting_payload> p3(p2);
         CHECK(counting_payload::__destruct_count == 0);
       }
       CHECK(counting_payload::__destruct_count == 0);
@@ -211,8 +213,9 @@ C2H_CCCLRT_TEST("__shared_block_ptr refcount multiple copies", "[memory_resource
 C2H_CCCLRT_TEST("__shared_block_ptr null copy and move", "[memory_resource]")
 {
   cuda::mr::__shared_block_ptr<trivial_payload> null;
-  cuda::mr::__shared_block_ptr<trivial_payload> null_copy(null); // NOLINT(performance-unnecessary-copy-initialization)
-  cuda::mr::__shared_block_ptr<trivial_payload> null_moved(cuda::std::move(null));
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+  const cuda::mr::__shared_block_ptr<trivial_payload> null_copy(null);
+  const cuda::mr::__shared_block_ptr<trivial_payload> null_moved(cuda::std::move(null));
 
   CHECK(!null_copy);
   CHECK(!null_moved);

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_block_ptr.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_block_ptr.cu
@@ -158,10 +158,12 @@ C2H_CCCLRT_TEST("__shared_block_ptr move assignment", "[memory_resource]")
 
 C2H_CCCLRT_TEST("__shared_block_ptr equality", "[memory_resource]")
 {
-  cuda::mr::__shared_block_ptr<trivial_payload> a(1); // NOLINT(misc-const-correctness)
-  const cuda::mr::__shared_block_ptr<trivial_payload> b(2);
-  const cuda::mr::__shared_block_ptr<trivial_payload> a_copy(a); // NOLINT(performance-unnecessary-copy-initialization)
-  const cuda::mr::__shared_block_ptr<trivial_payload> null;
+  // NOLINTBEGIN(misc-const-correctness)
+  cuda::mr::__shared_block_ptr<trivial_payload> a(1);
+  cuda::mr::__shared_block_ptr<trivial_payload> b(2);
+  cuda::mr::__shared_block_ptr<trivial_payload> a_copy(a); // NOLINT(performance-unnecessary-copy-initialization)
+  cuda::mr::__shared_block_ptr<trivial_payload> null;
+  // NOLINTEND(misc-const-correctness)
 
   CHECK(a == a);
   CHECK(a == a_copy);

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_resource.cu
@@ -62,7 +62,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
     Counts expected{};
     CHECK(this->counts == expected);
     {
-      cuda::mr::shared_resource mr{cuda::std::in_place_type<TestResource>, 42, this};
+      const cuda::mr::shared_resource mr{cuda::std::in_place_type<TestResource>, 42, this};
       ++expected.object_count;
       CHECK(this->counts == expected);
     }
@@ -88,7 +88,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       CHECK(mr == mr2); // pointers compare equal, no call to TestResource::operator==
       CHECK(this->counts == expected);
 
-      cuda::mr::shared_resource mr3{mr};
+      const cuda::mr::shared_resource mr3{mr};
       CHECK(this->counts == expected);
       CHECK(mr == mr3); // pointers compare equal, no call to TestResource::operator==
       CHECK(this->counts == expected);
@@ -98,7 +98,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       CHECK(mr2 == mr4); // pointers compare equal, no call to TestResource::operator==
       CHECK(this->counts == expected);
 
-      cuda::mr::shared_resource mr5{cuda::std::in_place_type<TestResource>, TestResource{42, this}};
+      const cuda::mr::shared_resource mr5{cuda::std::in_place_type<TestResource>, TestResource{42, this}};
       ++expected.object_count;
       ++expected.move_count;
       CHECK(mr4 == mr5); // pointers are not equal, calls TestResource::operator==
@@ -123,14 +123,14 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       CHECK(this->counts == expected);
 
       // Test get()
-      TestResource& ref = mr.get();
+      const TestResource& ref = mr.get();
       CHECK(ref.data == 42);
 
       // Test operator->
       CHECK(mr->data == 42);
 
       // Test operator*
-      TestResource& deref = *mr;
+      const TestResource& deref = *mr;
       CHECK(deref.data == 42);
 
       // Test const versions
@@ -200,7 +200,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
 
   SECTION("dynamic_accessibility_property forwards through shared_resource")
   {
-    cuda::mr::shared_resource mr{cuda::std::in_place_type<TestResource>, 42, this};
+    const cuda::mr::shared_resource mr{cuda::std::in_place_type<TestResource>, 42, this};
     CHECK(get_property(mr, cuda::mr::dynamic_accessibility_property{}) == cuda::mr::__memory_accessibility ::__host);
   }
 
@@ -213,7 +213,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
     this->align(alignof(int));
     {
       this->bytes(42 * sizeof(int));
-      cuda::stream stream{cuda::device_ref{0}};
+      const cuda::stream stream{cuda::device_ref{0}};
       cuda::__uninitialized_async_buffer<int, ::cuda::mr::host_accessible> buffer{
         cuda::mr::shared_resource<TestResource>(cuda::std::in_place_type<TestResource>, 42, this), stream, 42};
       ++expected.object_count;
@@ -224,7 +224,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       {
         // accounting for new storage
         this->bytes(1337 * sizeof(int));
-        cuda::__uninitialized_async_buffer<int, ::cuda::mr::host_accessible> other_buffer{
+        const cuda::__uninitialized_async_buffer<int, ::cuda::mr::host_accessible> other_buffer{
           buffer.memory_resource(), stream, 1337};
         ++expected.allocate_async_count;
         CHECK(this->counts == expected);
@@ -238,7 +238,8 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
 
       {
         // Moving the resource should not do anything
-        cuda::__uninitialized_async_buffer<int, ::cuda::mr::host_accessible> third_buffer = ::cuda::std::move(buffer);
+        const cuda::__uninitialized_async_buffer<int, ::cuda::mr::host_accessible> third_buffer =
+          ::cuda::std::move(buffer);
         CHECK(this->counts == expected);
       }
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/synchronous_adapter.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/synchronous_adapter.cu
@@ -49,7 +49,7 @@ struct explicit_dynamic_resource
 
 C2H_CCCLRT_TEST("synchronous_resource_adapter", "[memory_resource]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
 
   SECTION("Test wrapping a resource")
   {
@@ -92,7 +92,7 @@ C2H_CCCLRT_TEST("synchronous_resource_adapter", "[memory_resource]")
 
   SECTION("explicit dynamic_accessibility_property overrides template")
   {
-    cuda::mr::synchronous_resource_adapter<explicit_dynamic_resource> adapter{explicit_dynamic_resource{}};
+    const cuda::mr::synchronous_resource_adapter<explicit_dynamic_resource> adapter{explicit_dynamic_resource{}};
     STATIC_CHECK(cuda::has_property<decltype(adapter), cuda::mr::dynamic_accessibility_property>);
     CHECK(get_property(adapter, cuda::mr::dynamic_accessibility_property{})
           == cuda::mr::__memory_accessibility ::__device);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy.cu
@@ -120,7 +120,7 @@ C2H_TEST("cuda::std::copy", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
 
     test_copy(policy, input, output, converting);
@@ -136,7 +136,7 @@ C2H_TEST("cuda::std::copy", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy_if.cu
@@ -144,7 +144,7 @@ C2H_TEST("cuda::std::copy_if", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
 
     test_copy_if(policy, input, output, converting);
@@ -160,7 +160,7 @@ C2H_TEST("cuda::std::copy_if", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy_n.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy_n.cu
@@ -111,7 +111,7 @@ C2H_TEST("cuda::std::copy_n", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
 
     test_copy_n(policy, input, output, converting);
@@ -127,7 +127,7 @@ C2H_TEST("cuda::std::copy_n", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.fill/pstl_fill.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.fill/pstl_fill.cu
@@ -75,7 +75,7 @@ C2H_TEST("cuda::std::fill", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_fill(policy, output);
   }
@@ -89,7 +89,7 @@ C2H_TEST("cuda::std::fill", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.fill/pstl_fill_n.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.fill/pstl_fill_n.cu
@@ -80,7 +80,7 @@ C2H_TEST("cuda::std::fill_n", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_fill_n(policy, output);
   }
@@ -94,7 +94,7 @@ C2H_TEST("cuda::std::fill_n", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/pstl_generate.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/pstl_generate.cu
@@ -99,7 +99,7 @@ C2H_TEST("cuda::std::generate", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_generate(policy, output);
   }
@@ -113,7 +113,7 @@ C2H_TEST("cuda::std::generate", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/pstl_generate_n.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/pstl_generate_n.cu
@@ -102,7 +102,7 @@ C2H_TEST("cuda::std::generate_n", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_generate_n(policy, output);
   }
@@ -116,7 +116,7 @@ C2H_TEST("cuda::std::generate_n", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/is_partitioned.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/is_partitioned.cu
@@ -102,7 +102,7 @@ C2H_TEST("cuda::std::is_partitioned(iter, iter, pred)", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_is_partitioned(policy, input);
   }
@@ -116,7 +116,7 @@ C2H_TEST("cuda::std::is_partitioned(iter, iter, pred)", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition.cu
@@ -107,7 +107,7 @@ C2H_TEST("cuda::std::partition", "[parallel algorithm]", integral_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
 
     test_partition(policy, input);
@@ -123,7 +123,7 @@ C2H_TEST("cuda::std::partition", "[parallel algorithm]", integral_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition_copy.cu
@@ -184,7 +184,7 @@ C2H_TEST("cuda::std::partition_copy", "[parallel algorithm]", integral_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
 
     test_partition_copy(policy, input, output_true, output_false);
@@ -200,7 +200,7 @@ C2H_TEST("cuda::std::partition_copy", "[parallel algorithm]", integral_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_stable_partition.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_stable_partition.cu
@@ -80,7 +80,7 @@ C2H_TEST("cuda::std::stable_partition", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
 
     test_partition(policy, input);
@@ -96,7 +96,7 @@ C2H_TEST("cuda::std::stable_partition", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove.cu
@@ -101,7 +101,7 @@ C2H_TEST("cuda::std::remove", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_remove(policy, input);
   }
@@ -115,7 +115,7 @@ C2H_TEST("cuda::std::remove", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy.cu
@@ -144,7 +144,7 @@ C2H_TEST("cuda::std::remove_copy", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_remove_copy(policy, input, output, converting);
   }
@@ -158,7 +158,7 @@ C2H_TEST("cuda::std::remove_copy", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy_if.cu
@@ -146,7 +146,7 @@ C2H_TEST("cuda::std::remove_copy_if", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_remove_copy_if(policy, input, output, converting);
   }
@@ -160,7 +160,7 @@ C2H_TEST("cuda::std::remove_copy_if", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_if.cu
@@ -108,7 +108,7 @@ C2H_TEST("cuda::std::remove_if", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_remove_if(policy, input);
   }
@@ -122,7 +122,7 @@ C2H_TEST("cuda::std::remove_if", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace.cu
@@ -92,7 +92,7 @@ C2H_TEST("cuda::std::replace", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_replace(policy, input);
   }
@@ -106,7 +106,7 @@ C2H_TEST("cuda::std::replace", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_copy.cu
@@ -148,7 +148,7 @@ C2H_TEST("cuda::std::replace_copy", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_replace_copy(policy, input, output, converting);
   }
@@ -162,7 +162,7 @@ C2H_TEST("cuda::std::replace_copy", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_copy_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_copy_if.cu
@@ -149,7 +149,7 @@ C2H_TEST("cuda::std::replace_copy_if", "[parallel algorithm]", integral_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_replace_copy_if(policy, output);
   }
@@ -163,7 +163,7 @@ C2H_TEST("cuda::std::replace_copy_if", "[parallel algorithm]", integral_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_if.cu
@@ -102,7 +102,7 @@ C2H_TEST("cuda::std::replace_if", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_replace_if(policy, input);
   }
@@ -116,7 +116,7 @@ C2H_TEST("cuda::std::replace_if", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.reverse/pstl_reverse.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.reverse/pstl_reverse.cu
@@ -69,7 +69,7 @@ C2H_TEST("cuda::std::reverse", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_reverse(policy, input);
   }
@@ -83,7 +83,7 @@ C2H_TEST("cuda::std::reverse", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.reverse/pstl_reverse_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.reverse/pstl_reverse_copy.cu
@@ -120,7 +120,7 @@ C2H_TEST("cuda::std::reverse_copy", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_reverse_copy(policy, input, output, converting);
   }
@@ -134,7 +134,7 @@ C2H_TEST("cuda::std::reverse_copy", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.rotate/pstl_rotate.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.rotate/pstl_rotate.cu
@@ -93,7 +93,7 @@ C2H_TEST("cuda::std::rotate", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
 
     test_rotate(policy, input, size);
@@ -109,7 +109,7 @@ C2H_TEST("cuda::std::rotate", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.rotate/pstl_rotate_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.rotate/pstl_rotate_copy.cu
@@ -116,7 +116,7 @@ C2H_TEST("cuda::std::rotate_copy", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
 
     test_rotate_copy(policy, input, output);
@@ -132,7 +132,7 @@ C2H_TEST("cuda::std::rotate_copy", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.shift/pstl_shift_left.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.shift/pstl_shift_left.cu
@@ -107,7 +107,7 @@ C2H_TEST("cuda::std::shift_left", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
 
     test_shift_left(policy, input);
@@ -123,7 +123,7 @@ C2H_TEST("cuda::std::shift_left", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.shift/pstl_shift_right.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.shift/pstl_shift_right.cu
@@ -126,7 +126,7 @@ C2H_TEST("cuda::std::shift_right", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
 
     test_shift_right(policy, input);
@@ -142,7 +142,7 @@ C2H_TEST("cuda::std::shift_right", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.swap/pstl_swap_ranges.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.swap/pstl_swap_ranges.cu
@@ -98,7 +98,7 @@ C2H_TEST("cuda::std::swap_ranges", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
 
     test_swap_ranges(policy, input1, input2);
@@ -114,7 +114,7 @@ C2H_TEST("cuda::std::swap_ranges", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.transform/pstl_binary_transform.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.transform/pstl_binary_transform.cu
@@ -106,7 +106,7 @@ C2H_TEST("cuda::std::transform", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_transform(policy, output);
   }
@@ -120,7 +120,7 @@ C2H_TEST("cuda::std::transform", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.transform/pstl_unary_transform.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.transform/pstl_unary_transform.cu
@@ -87,7 +87,7 @@ C2H_TEST("cuda::std::transform", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_transform(policy, output);
   }
@@ -101,7 +101,7 @@ C2H_TEST("cuda::std::transform", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique.cu
@@ -76,7 +76,7 @@ C2H_TEST("cuda::std::unique", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_unique(policy, input);
   }
@@ -90,7 +90,7 @@ C2H_TEST("cuda::std::unique", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique_copy.cu
@@ -85,7 +85,7 @@ C2H_TEST("cuda::std::unique_copy", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_unique_copy(policy, input, output);
   }
@@ -99,7 +99,7 @@ C2H_TEST("cuda::std::unique_copy", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique_copy_pred.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique_copy_pred.cu
@@ -101,7 +101,7 @@ C2H_TEST("cuda::std::unique_copy", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_unique_copy(policy, input, output);
   }
@@ -115,7 +115,7 @@ C2H_TEST("cuda::std::unique_copy", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique_pred.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique_pred.cu
@@ -84,7 +84,7 @@ C2H_TEST("cuda::std::unique", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_unique(policy, input);
   }
@@ -98,7 +98,7 @@ C2H_TEST("cuda::std::unique", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.adjacent.find/pstl_adjacent_find.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.adjacent.find/pstl_adjacent_find.cu
@@ -65,7 +65,7 @@ C2H_TEST("cuda::std::adjacent_find(Iter, Iter)", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_adjacent_find(policy, input);
   }
@@ -79,7 +79,7 @@ C2H_TEST("cuda::std::adjacent_find(Iter, Iter)", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.adjacent.find/pstl_adjacent_find_pred.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.adjacent.find/pstl_adjacent_find_pred.cu
@@ -69,7 +69,7 @@ C2H_TEST("cuda::std::adjacent_find(Iter, Iter, comp)", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_adjacent_find(policy, input);
   }
@@ -83,7 +83,7 @@ C2H_TEST("cuda::std::adjacent_find(Iter, Iter, comp)", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.all_of/pstl_all_of.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.all_of/pstl_all_of.cu
@@ -85,7 +85,7 @@ C2H_TEST("cuda::std::all_of", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_all_of(policy);
   }
@@ -99,7 +99,7 @@ C2H_TEST("cuda::std::all_of", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.any_of/pstl_any_of.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.any_of/pstl_any_of.cu
@@ -85,7 +85,7 @@ C2H_TEST("cuda::std::any_of", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_any_of(policy);
   }
@@ -99,7 +99,7 @@ C2H_TEST("cuda::std::any_of", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.count/pstl_count.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.count/pstl_count.cu
@@ -60,7 +60,7 @@ C2H_TEST("cuda::std::count", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_count(policy);
   }
@@ -74,7 +74,7 @@ C2H_TEST("cuda::std::count", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.count/pstl_count_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.count/pstl_count_if.cu
@@ -69,7 +69,7 @@ C2H_TEST("cuda::std::count_if", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_count_if(policy);
   }
@@ -83,7 +83,7 @@ C2H_TEST("cuda::std::count_if", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/pstl_equal.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/pstl_equal.cu
@@ -65,7 +65,7 @@ C2H_TEST("cuda::std::equal(first1, last1, first2)", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_equal(policy);
   }
@@ -79,7 +79,7 @@ C2H_TEST("cuda::std::equal(first1, last1, first2)", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);
@@ -141,7 +141,7 @@ C2H_TEST("cuda::std::equal(first1, last1, first2, last2)", "[parallel algorithm]
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_equal2(policy);
   }
@@ -155,7 +155,7 @@ C2H_TEST("cuda::std::equal(first1, last1, first2, last2)", "[parallel algorithm]
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/pstl_equal_pred.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/pstl_equal_pred.cu
@@ -99,7 +99,7 @@ C2H_TEST("cuda::std::equal(first1, last1, first2, pred)", "[parallel algorithm]"
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_equal(policy);
   }
@@ -113,7 +113,7 @@ C2H_TEST("cuda::std::equal(first1, last1, first2, pred)", "[parallel algorithm]"
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);
@@ -201,7 +201,7 @@ C2H_TEST("cuda::std::equal(first1, last1, first2, last2, pred)", "[parallel algo
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_equal2(policy);
   }
@@ -215,7 +215,7 @@ C2H_TEST("cuda::std::equal(first1, last1, first2, last2, pred)", "[parallel algo
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find.cu
@@ -56,7 +56,7 @@ C2H_TEST("cuda::std::find", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_find(policy);
   }
@@ -70,7 +70,7 @@ C2H_TEST("cuda::std::find", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find_if.cu
@@ -57,7 +57,7 @@ C2H_TEST("cuda::std::find_if", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_find_if(policy);
   }
@@ -71,7 +71,7 @@ C2H_TEST("cuda::std::find_if", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find_if_not.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find_if_not.cu
@@ -78,7 +78,7 @@ C2H_TEST("cuda::std::find_if_not", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_find_if_not(policy);
   }
@@ -92,7 +92,7 @@ C2H_TEST("cuda::std::find_if_not", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.for_each/pstl_for_each.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.for_each/pstl_for_each.cu
@@ -42,7 +42,7 @@ struct mark_present_for_each
 template <class Policy>
 void test_for_each(const Policy& policy, thrust::device_vector<bool>& res)
 {
-  mark_present_for_each fn{thrust::raw_pointer_cast(res.data())};
+  const mark_present_for_each fn{thrust::raw_pointer_cast(res.data())};
 
   { // empty should not access anything
     cuda::std::for_each(policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), fn);
@@ -73,7 +73,7 @@ C2H_TEST("cuda::std::for_each", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_for_each(policy, res);
   }
@@ -87,7 +87,7 @@ C2H_TEST("cuda::std::for_each", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.for_each/pstl_for_each_n.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.for_each/pstl_for_each_n.cu
@@ -41,7 +41,7 @@ struct mark_present_for_each
 template <class Policy>
 void test_for_each_n(const Policy& policy, thrust::device_vector<bool>& res)
 {
-  mark_present_for_each fn{thrust::raw_pointer_cast(res.data())};
+  const mark_present_for_each fn{thrust::raw_pointer_cast(res.data())};
 
   { // empty should not access anything
     const auto result = cuda::std::for_each_n(policy, static_cast<int*>(nullptr), 0, fn);
@@ -75,7 +75,7 @@ C2H_TEST("cuda::std::for_each_n", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_for_each_n(policy, res);
   }
@@ -89,7 +89,7 @@ C2H_TEST("cuda::std::for_each_n", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.mismatch/pstl_mismatch.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.mismatch/pstl_mismatch.cu
@@ -65,7 +65,7 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2)", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_mismatch(policy);
   }
@@ -79,7 +79,7 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2)", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);
@@ -141,7 +141,7 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2, last2)", "[parallel algorit
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_mismatch2(policy);
   }
@@ -155,7 +155,7 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2, last2)", "[parallel algorit
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.mismatch/pstl_mismatch_pred.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.mismatch/pstl_mismatch_pred.cu
@@ -99,7 +99,7 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2)", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_mismatch(policy);
   }
@@ -113,7 +113,7 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2)", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);
@@ -190,7 +190,7 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2, last2, pred)", "[parallel a
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_mismatch2(policy);
   }
@@ -204,7 +204,7 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2, last2, pred)", "[parallel a
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.none_of/pstl_none_of.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.none_of/pstl_none_of.cu
@@ -85,7 +85,7 @@ C2H_TEST("cuda::std::none_of", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_none_of(policy);
   }
@@ -99,7 +99,7 @@ C2H_TEST("cuda::std::none_of", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap.cu
@@ -85,7 +85,7 @@ C2H_TEST("cuda::std::is_heap(iter, iter)", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_is_heap(policy, input);
   }
@@ -99,7 +99,7 @@ C2H_TEST("cuda::std::is_heap(iter, iter)", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_comp.cu
@@ -86,7 +86,7 @@ C2H_TEST("cuda::std::is_heap(iter, iter, comp)", "[parallel algorithm]", all_typ
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_is_heap(policy, input);
   }
@@ -100,7 +100,7 @@ C2H_TEST("cuda::std::is_heap(iter, iter, comp)", "[parallel algorithm]", all_typ
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_until.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_until.cu
@@ -89,7 +89,7 @@ C2H_TEST("cuda::std::is_heap_until(iter, iter)", "[parallel algorithm]", all_typ
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_is_heap_until(policy, input);
   }
@@ -103,7 +103,7 @@ C2H_TEST("cuda::std::is_heap_until(iter, iter)", "[parallel algorithm]", all_typ
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_until_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_until_comp.cu
@@ -91,7 +91,7 @@ C2H_TEST("cuda::std::is_heap_until(iter, iter, comp)", "[parallel algorithm]", a
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_is_heap_until(policy, input);
   }
@@ -105,7 +105,7 @@ C2H_TEST("cuda::std::is_heap_until(iter, iter, comp)", "[parallel algorithm]", a
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/pstl_merge.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/pstl_merge.cu
@@ -119,8 +119,8 @@ C2H_TEST("cuda::std::merge", "[parallel algorithm]")
   thrust::device_vector<int> in2(size2, thrust::no_init);
   thrust::device_vector<int> out(size1 + size2, thrust::no_init);
 
-  cuda::strided_iterator iter1{cuda::counting_iterator{0}, 2}; // [0,2,4,..., 2 * size1)
-  cuda::strided_iterator iter2{cuda::counting_iterator{1}, 2}; // [1,3,5,..., 2 * size2)
+  const cuda::strided_iterator iter1{cuda::counting_iterator{0}, 2}; // [0,2,4,..., 2 * size1)
+  const cuda::strided_iterator iter2{cuda::counting_iterator{1}, 2}; // [1,3,5,..., 2 * size2)
   cuda::std::copy_n(cuda::execution::gpu, iter1, size1, in1.begin());
   cuda::std::copy_n(cuda::execution::gpu, iter2, size2, in2.begin());
 
@@ -132,7 +132,7 @@ C2H_TEST("cuda::std::merge", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_merge(policy, in1, in2, out);
   }
@@ -146,7 +146,7 @@ C2H_TEST("cuda::std::merge", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/pstl_merge_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/pstl_merge_comp.cu
@@ -138,8 +138,10 @@ C2H_TEST("cuda::std::merge", "[parallel algorithm]")
   thrust::device_vector<int> in2(size2, thrust::no_init);
   thrust::device_vector<int> out(size1 + size2, thrust::no_init);
 
-  cuda::strided_iterator iter1{cuda::counting_iterator{2 * size1 - 2}, -2}; // [2 * size1 - 2, 2 * size1 - 4,..., 0]
-  cuda::strided_iterator iter2{cuda::counting_iterator{2 * size2 - 1}, -2}; // [2 * size2 - 1, 2 * size2 - 3,..., 1]
+  const cuda::strided_iterator iter1{cuda::counting_iterator{2 * size1 - 2}, -2}; // [2 * size1 - 2, 2 * size1 - 4,...,
+                                                                                  // 0]
+  const cuda::strided_iterator iter2{cuda::counting_iterator{2 * size2 - 1}, -2}; // [2 * size2 - 1, 2 * size2 - 3,...,
+                                                                                  // 1]
   cuda::std::copy_n(cuda::execution::gpu, iter1, size1, in1.begin());
   cuda::std::copy_n(cuda::execution::gpu, iter2, size2, in2.begin());
 
@@ -151,7 +153,7 @@ C2H_TEST("cuda::std::merge", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_merge(policy, in1, in2, out);
   }
@@ -165,7 +167,7 @@ C2H_TEST("cuda::std::merge", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/pstl_max_element.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/pstl_max_element.cu
@@ -91,7 +91,7 @@ C2H_TEST("cuda::std::max_element(Iter, Iter)", "[parallel algorithm]", all_types
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_max_element(policy, input);
   }
@@ -105,7 +105,7 @@ C2H_TEST("cuda::std::max_element(Iter, Iter)", "[parallel algorithm]", all_types
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/pstl_min_element.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/pstl_min_element.cu
@@ -91,7 +91,7 @@ C2H_TEST("cuda::std::min_element(Iter, Iter)", "[parallel algorithm]", all_types
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_min_element(policy, input);
   }
@@ -105,7 +105,7 @@ C2H_TEST("cuda::std::min_element(Iter, Iter)", "[parallel algorithm]", all_types
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl_is_sorted.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl_is_sorted.cu
@@ -78,7 +78,7 @@ C2H_TEST("cuda::std::is_sorted(iter, iter)", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_is_sorted(policy, input);
   }
@@ -92,7 +92,7 @@ C2H_TEST("cuda::std::is_sorted(iter, iter)", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl_is_sorted_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl_is_sorted_comp.cu
@@ -79,7 +79,7 @@ C2H_TEST("cuda::std::is_sorted(iter, iter)", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_is_sorted(policy, input);
   }
@@ -93,7 +93,7 @@ C2H_TEST("cuda::std::is_sorted(iter, iter)", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl_is_sorted_until.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl_is_sorted_until.cu
@@ -81,7 +81,7 @@ C2H_TEST("cuda::std::is_sorted_until(iter, iter)", "[parallel algorithm]", all_t
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_is_sorted_until(policy, input);
   }
@@ -95,7 +95,7 @@ C2H_TEST("cuda::std::is_sorted_until(iter, iter)", "[parallel algorithm]", all_t
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl_is_sorted_until_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl_is_sorted_until_comp.cu
@@ -82,7 +82,7 @@ C2H_TEST("cuda::std::is_sorted_until(iter, iter)", "[parallel algorithm]", all_t
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_is_sorted_until(policy, input);
   }
@@ -96,7 +96,7 @@ C2H_TEST("cuda::std::is_sorted_until(iter, iter)", "[parallel algorithm]", all_t
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/sort/pstl_sort.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/sort/pstl_sort.cu
@@ -76,7 +76,7 @@ C2H_TEST("cuda::std::sort(iter, iter)", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_sort(policy, input, data);
   }
@@ -90,7 +90,7 @@ C2H_TEST("cuda::std::sort(iter, iter)", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/sort/pstl_sort_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/sort/pstl_sort_comp.cu
@@ -78,7 +78,7 @@ C2H_TEST("cuda::std::sort(iter, iter)", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_sort(policy, input, data);
   }
@@ -92,7 +92,7 @@ C2H_TEST("cuda::std::sort(iter, iter)", "[parallel algorithm]", all_types)
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/pstl_adjacent_difference.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/pstl_adjacent_difference.cu
@@ -42,7 +42,7 @@ void test_adjacent_difference(
     CHECK(res == output.begin());
   }
 
-  cuda::constant_iterator<int> expected{1};
+  const cuda::constant_iterator<int> expected{1};
   {
     auto res = cuda::std::adjacent_difference(policy, input.begin(), input.end(), output.begin());
     CHECK(res == output.end());
@@ -80,7 +80,7 @@ C2H_TEST("cuda::std::adjacent_difference(Iter1, Iter1, Iter2, Init)", "[parallel
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_adjacent_difference(policy, input, output);
   }
@@ -94,7 +94,7 @@ C2H_TEST("cuda::std::adjacent_difference(Iter1, Iter1, Iter2, Init)", "[parallel
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/pstl_adjacent_difference_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/pstl_adjacent_difference_comp.cu
@@ -43,7 +43,7 @@ void test_adjacent_difference(
     CHECK(res == output.begin());
   }
 
-  cuda::constant_iterator<int> expected{1};
+  const cuda::constant_iterator<int> expected{1};
   {
     auto res = cuda::std::adjacent_difference(policy, input.begin(), input.end(), output.begin(), cuda::std::minus<>{});
     CHECK(res == output.end());
@@ -89,7 +89,7 @@ C2H_TEST("cuda::std::adjacent_difference(Iter1, Iter1, Iter2, Init)", "[parallel
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_adjacent_difference(policy, input, output);
   }
@@ -103,7 +103,7 @@ C2H_TEST("cuda::std::adjacent_difference(Iter1, Iter1, Iter2, Init)", "[parallel
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/pstl_exclusive_scan.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/pstl_exclusive_scan.cu
@@ -45,7 +45,7 @@ template <class Policy>
 void test_exclusive_scan(
   const Policy& policy, const thrust::device_vector<int>& input, thrust::device_vector<int>& output)
 {
-  cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
+  const cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
   { // empty should not access anything
     auto res = cuda::std::exclusive_scan(
       policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), static_cast<int*>(nullptr), 42);
@@ -96,7 +96,7 @@ C2H_TEST("cuda::std::exclusive_scan(Iter1, Iter1, Iter2, Init)", "[parallel algo
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_exclusive_scan(policy, input, output);
   }
@@ -110,7 +110,7 @@ C2H_TEST("cuda::std::exclusive_scan(Iter1, Iter1, Iter2, Init)", "[parallel algo
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/pstl_exclusive_scan_init_op.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/pstl_exclusive_scan_init_op.cu
@@ -45,7 +45,7 @@ template <class Policy>
 void test_exclusive_scan(
   const Policy& policy, const thrust::device_vector<int>& input, thrust::device_vector<int>& output)
 {
-  cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
+  const cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
   { // empty should not access anything
     auto res = cuda::std::exclusive_scan(
       policy,
@@ -113,7 +113,7 @@ C2H_TEST("cuda::std::exclusive_scan(Iter1, Iter1, Iter2, Init)", "[parallel algo
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_exclusive_scan(policy, input, output);
   }
@@ -127,7 +127,7 @@ C2H_TEST("cuda::std::exclusive_scan(Iter1, Iter1, Iter2, Init)", "[parallel algo
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/pstl_inclusive_scan.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/pstl_inclusive_scan.cu
@@ -44,7 +44,7 @@ template <class Policy>
 void test_inclusive_scan(
   const Policy& policy, const thrust::device_vector<int>& input, thrust::device_vector<int>& output)
 {
-  cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
+  const cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
   { // empty should not access anything
     auto res = cuda::std::inclusive_scan(
       policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), static_cast<int*>(nullptr));
@@ -81,7 +81,7 @@ C2H_TEST("cuda::std::inclusive_scan(Iter1, Iter1, Iter2)", "[parallel algorithm]
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_inclusive_scan(policy, input, output);
   }
@@ -95,7 +95,7 @@ C2H_TEST("cuda::std::inclusive_scan(Iter1, Iter1, Iter2)", "[parallel algorithm]
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/pstl_inclusive_scan_op.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/pstl_inclusive_scan_op.cu
@@ -45,7 +45,7 @@ template <class Policy>
 void test_inclusive_scan(
   const Policy& policy, const thrust::device_vector<int>& input, thrust::device_vector<int>& output)
 {
-  cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
+  const cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
   { // empty should not access anything
     auto res = cuda::std::inclusive_scan(
       policy,
@@ -108,7 +108,7 @@ C2H_TEST("cuda::std::inclusive_scan(Iter1, Iter1, Iter2, Op)", "[parallel algori
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_inclusive_scan(policy, input, output);
   }
@@ -122,7 +122,7 @@ C2H_TEST("cuda::std::inclusive_scan(Iter1, Iter1, Iter2, Op)", "[parallel algori
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/pstl_inclusive_scan_op_init.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/pstl_inclusive_scan_op_init.cu
@@ -45,7 +45,7 @@ template <class Policy>
 void test_inclusive_scan(
   const Policy& policy, const thrust::device_vector<int>& input, thrust::device_vector<int>& output)
 {
-  cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
+  const cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
   { // empty should not access anything
     auto res = cuda::std::inclusive_scan(
       policy,
@@ -153,7 +153,7 @@ C2H_TEST("cuda::std::inclusive_scan(Iter1, Iter1, Iter2, Op, Init)", "[parallel 
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_inclusive_scan(policy, input, output);
   }
@@ -167,7 +167,7 @@ C2H_TEST("cuda::std::inclusive_scan(Iter1, Iter1, Iter2, Op, Init)", "[parallel 
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/pstl_reduce.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/pstl_reduce.cu
@@ -70,7 +70,7 @@ C2H_TEST("cuda::std::reduce(Iter, Iter)", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_reduce(policy, data);
   }
@@ -84,7 +84,7 @@ C2H_TEST("cuda::std::reduce(Iter, Iter)", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);
@@ -137,7 +137,7 @@ C2H_TEST("cuda::std::reduce(Iter, Iter, Tp)", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_reduce_init(policy, data);
   }
@@ -151,7 +151,7 @@ C2H_TEST("cuda::std::reduce(Iter, Iter, Tp)", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);
@@ -214,7 +214,7 @@ C2H_TEST("cuda::std::reduce(Iter, Iter, Tp, Fn)", "[parallel algorithm]")
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_reduce_init_fn(policy, data);
   }
@@ -228,7 +228,7 @@ C2H_TEST("cuda::std::reduce(Iter, Iter, Tp, Fn)", "[parallel algorithm]")
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.exclusive.scan/pstl_transform_exclusive_scan.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.exclusive.scan/pstl_transform_exclusive_scan.cu
@@ -47,7 +47,7 @@ struct sum_of_int
 {
   TEST_DEVICE_FUNC constexpr int operator()(const int val) const noexcept
   { // Eulers sum with initial value and first element skipped, account for plus_two and start at one
-    plus_two<int> op{};
+    const plus_two<int> op{};
     return 42 + op(val) * (op(val) - 1) / 2 - op(1);
   }
 };
@@ -56,7 +56,7 @@ template <class Policy>
 void test_exclusive_scan(
   const Policy& policy, const thrust::device_vector<int>& input, thrust::device_vector<int>& output)
 {
-  cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
+  const cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
   { // empty should not access anything
     auto res = cuda::std::transform_exclusive_scan(
       policy,
@@ -187,7 +187,7 @@ C2H_TEST("cuda::std::transform_exclusive_scan(Iter1, Iter1, Iter2, Init)", "[par
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_exclusive_scan(policy, input, output);
   }
@@ -201,7 +201,7 @@ C2H_TEST("cuda::std::transform_exclusive_scan(Iter1, Iter1, Iter2, Init)", "[par
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.inclusive.scan/pstl_transform_inclusive_scan_op.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.inclusive.scan/pstl_transform_inclusive_scan_op.cu
@@ -45,7 +45,7 @@ struct sum_of_int
 {
   TEST_DEVICE_FUNC constexpr int operator()(const int val) const noexcept
   { // Eulers sum, account for plus_two and start at 1
-    plus_two<int> op{};
+    const plus_two<int> op{};
     return op(val) * (op(val) + 1) / 2 - op(1);
   }
 };
@@ -54,7 +54,7 @@ template <class Policy>
 void test_inclusive_scan(
   const Policy& policy, const thrust::device_vector<int>& input, thrust::device_vector<int>& output)
 {
-  cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
+  const cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
   { // empty should not access anything
     auto res = cuda::std::transform_inclusive_scan(
       policy,
@@ -152,7 +152,7 @@ C2H_TEST("cuda::std::transform_inclusive_scan(Iter1, Iter1, Iter2, Op)", "[paral
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_inclusive_scan(policy, input, output);
   }
@@ -166,7 +166,7 @@ C2H_TEST("cuda::std::transform_inclusive_scan(Iter1, Iter1, Iter2, Op)", "[paral
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.inclusive.scan/pstl_transform_inclusive_scan_op_init.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.inclusive.scan/pstl_transform_inclusive_scan_op_init.cu
@@ -45,7 +45,7 @@ struct sum_of_int
 {
   TEST_DEVICE_FUNC constexpr int operator()(const int val) const noexcept
   { // Eulers sum with initial value, account for plus_two and start at one
-    plus_two<int> op{};
+    const plus_two<int> op{};
     return 42 + op(val) * (op(val) + 1) / 2 - op(1);
   }
 };
@@ -54,7 +54,7 @@ template <class Policy>
 void test_inclusive_scan(
   const Policy& policy, const thrust::device_vector<int>& input, thrust::device_vector<int>& output)
 {
-  cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
+  const cuda::transform_iterator expected{cuda::counting_iterator{1}, sum_of_int{}};
   { // empty should not access anything
     auto res = cuda::std::transform_inclusive_scan(
       policy,
@@ -209,7 +209,7 @@ C2H_TEST("cuda::std::transform_inclusive_scan(Iter1, Iter1, Iter2, Op, Init)", "
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_inclusive_scan(policy, input, output);
   }
@@ -223,7 +223,7 @@ C2H_TEST("cuda::std::transform_inclusive_scan(Iter1, Iter1, Iter2, Op, Init)", "
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/pstl_transform_reduce_binary.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/pstl_transform_reduce_binary.cu
@@ -118,7 +118,7 @@ C2H_TEST("cuda::std::transform_reduce(Iter1, Iter1, Iter2, Init)", "[parallel al
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_transform_reduce(policy, input1, input2.begin());
     test_transform_reduce(policy, input1, ::cuda::constant_iterator<int>{1});
@@ -134,7 +134,7 @@ C2H_TEST("cuda::std::transform_reduce(Iter1, Iter1, Iter2, Init)", "[parallel al
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/pstl_transform_reduce_unary.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/pstl_transform_reduce_unary.cu
@@ -95,7 +95,7 @@ C2H_TEST("cuda::std::transform_reduce(Iter1, Iter1, Iter2, Init)", "[parallel al
 
   SECTION("with provided stream")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_transform_reduce(policy, input1.begin());
     test_transform_reduce(policy, ::cuda::counting_iterator<int>{1});
@@ -111,7 +111,7 @@ C2H_TEST("cuda::std::transform_reduce(Iter1, Iter1, Iter2, Init)", "[parallel al
 
   SECTION("with provided stream and memory_resource")
   {
-    cuda::stream stream{cuda::device_ref{0}};
+    const cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
     const auto policy =
       cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);


### PR DESCRIPTION
Part of the `misc-const-correctness` split of the umbrella branch `jacobf/2026-09-02/misc-const-correctness`.

This PR adds `const` to local variables under:
  - `libcudacxx/test/`

It does **not** enable the check. `misc-const-correctness` stays disabled in `.clang-tidy` until the final PR of the series.