### PR TITLE
[CUB] `misc-const-correctness`

### DIFF
--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -97,11 +97,11 @@ LoadVectorAndFunnelShiftR(uint32_t const* aligned_ptr, uint32_t bit_shift, uint4
 
   if constexpr (!PTR_IS_FOUR_BYTE_ALIGNED)
   {
-    uint32_t tail = aligned_ptr[4];
-    data_out.x    = __funnelshift_r(data_out.x, data_out.y, bit_shift);
-    data_out.y    = __funnelshift_r(data_out.y, data_out.z, bit_shift);
-    data_out.z    = __funnelshift_r(data_out.z, data_out.w, bit_shift);
-    data_out.w    = __funnelshift_r(data_out.w, tail, bit_shift);
+    const uint32_t tail = aligned_ptr[4];
+    data_out.x          = __funnelshift_r(data_out.x, data_out.y, bit_shift);
+    data_out.y          = __funnelshift_r(data_out.y, data_out.z, bit_shift);
+    data_out.z          = __funnelshift_r(data_out.z, data_out.w, bit_shift);
+    data_out.w          = __funnelshift_r(data_out.w, tail, bit_shift);
   }
 }
 
@@ -113,9 +113,9 @@ LoadVectorAndFunnelShiftR(uint32_t const* aligned_ptr, uint32_t bit_shift, uint2
 
   if constexpr (!PTR_IS_FOUR_BYTE_ALIGNED)
   {
-    uint32_t tail = aligned_ptr[2];
-    data_out.x    = __funnelshift_r(data_out.x, data_out.y, bit_shift);
-    data_out.y    = __funnelshift_r(data_out.y, tail, bit_shift);
+    const uint32_t tail = aligned_ptr[2];
+    data_out.x          = __funnelshift_r(data_out.x, data_out.y, bit_shift);
+    data_out.y          = __funnelshift_r(data_out.y, tail, bit_shift);
   }
 }
 
@@ -127,8 +127,8 @@ LoadVectorAndFunnelShiftR(uint32_t const* aligned_ptr, uint32_t bit_shift, uint3
 
   if constexpr (!PTR_IS_FOUR_BYTE_ALIGNED)
   {
-    uint32_t tail = aligned_ptr[1];
-    data_out      = __funnelshift_r(data_out, tail, bit_shift);
+    const uint32_t tail = aligned_ptr[1];
+    data_out            = __funnelshift_r(data_out, tail, bit_shift);
   }
 }
 
@@ -213,15 +213,15 @@ GetAlignedPtrs(const void* in_begin, void* out_begin, ByteOffsetT num_bytes)
   char* out_chars_aligned = out_ptr - alignment_offset;
 
   // The number of extra bytes preceding `in_ptr` that are loaded but dropped
-  uint32_t in_extra_bytes = reinterpret_cast<uintptr_t>(in_ptr) % in_datatype_size;
+  const uint32_t in_extra_bytes = reinterpret_cast<uintptr_t>(in_ptr) % in_datatype_size;
 
   // The offset required by `LoadVector`:
   // If the input pointer is not aligned, we load data from the last aligned address preceding the
   // pointer. That is, loading up to (in_datatype_size-1) bytes before `in_ptr`
-  uint32_t in_offset_req = in_extra_bytes;
+  const uint32_t in_offset_req = in_extra_bytes;
 
   // Bytes after `out_chars_aligned` to the first VectorT-aligned address at or after `out_begin`
-  uint32_t out_start_aligned = ::cuda::round_up(in_offset_req + alignment_offset, out_datatype_size);
+  const uint32_t out_start_aligned = ::cuda::round_up(in_offset_req + alignment_offset, out_datatype_size);
 
   // Compute the beginning of the aligned ranges (output and input pointers)
   VectorT* out_aligned_begin   = reinterpret_cast<VectorT*>(out_chars_aligned + out_start_aligned);
@@ -231,8 +231,8 @@ GetAlignedPtrs(const void* in_begin, void* out_begin, ByteOffsetT num_bytes)
   // bytes after the last byte that is copied. That is, we always load four bytes up to the next
   // aligned input address at a time. E.g., if the last byte loaded is one byte past the last
   // aligned address we'll also load the three bytes after that byte.
-  uint32_t in_extra_bytes_from_aligned = (reinterpret_cast<uintptr_t>(in_aligned_begin) % in_datatype_size);
-  uint32_t in_end_padding_req          = (in_datatype_size - in_extra_bytes_from_aligned) % in_datatype_size;
+  const uint32_t in_extra_bytes_from_aligned = (reinterpret_cast<uintptr_t>(in_aligned_begin) % in_datatype_size);
+  const uint32_t in_end_padding_req          = (in_datatype_size - in_extra_bytes_from_aligned) % in_datatype_size;
 
   // Bytes after `out_chars_aligned` to the last VectorT-aligned
   // address at (or before) `out_begin` + `num_bytes`
@@ -788,8 +788,8 @@ private:
     {
       if (blev_buffer_offset < num_blev_buffers)
       {
-        BlockBufferOffsetT tile_buffer_id = buffers_by_size_class[blev_buffer_offset].buffer_id;
-        block_offset[i]                   = ::cuda::ceil_div(+tile_buffer_sizes[tile_buffer_id], BLOCK_LEVEL_TILE_SIZE);
+        const BlockBufferOffsetT tile_buffer_id = buffers_by_size_class[blev_buffer_offset].buffer_id;
+        block_offset[i] = ::cuda::ceil_div(+tile_buffer_sizes[tile_buffer_id], BLOCK_LEVEL_TILE_SIZE);
       }
       else
       {
@@ -826,7 +826,7 @@ private:
     {
       if (blev_buffer_offset < num_blev_buffers)
       {
-        BlockBufferOffsetT tile_buffer_id                         = buffers_by_size_class[blev_buffer_offset].buffer_id;
+        const BlockBufferOffsetT tile_buffer_id                   = buffers_by_size_class[blev_buffer_offset].buffer_id;
         blev_buffer_srcs[tile_buffer_offset + blev_buffer_offset] = tile_buffer_srcs[tile_buffer_id];
         blev_buffer_dsts[tile_buffer_offset + blev_buffer_offset] = tile_buffer_dsts[tile_buffer_id];
         blev_buffer_sizes[tile_buffer_offset + blev_buffer_offset]        = tile_buffer_sizes[tile_buffer_id];
@@ -998,7 +998,7 @@ public:
     BufferOffsetT buffer_offset = tile_id * BUFFERS_PER_BLOCK;
 
     // Indicates whether all of this tiles items are within bounds
-    bool is_full_tile = buffer_offset + BUFFERS_PER_BLOCK < num_buffers;
+    const bool is_full_tile = buffer_offset + BUFFERS_PER_BLOCK < num_buffers;
 
     // Load the buffer sizes of this tile's buffers
     BufferSizeIteratorT tile_buffer_sizes_it = buffer_sizes_it + buffer_offset;
@@ -1102,7 +1102,7 @@ public:
       size_class_agg.get(WLEV_SIZE_CLASS));
 
     // Perform batch memcpy for all the buffers that require thread-level collaboration
-    uint32_t num_tlev_buffers = size_class_agg.get(TLEV_SIZE_CLASS);
+    const uint32_t num_tlev_buffers = size_class_agg.get(TLEV_SIZE_CLASS);
     BatchMemcpyTLEVBuffers(
       temp_storage.staged.buffers_by_size_class, tile_buffer_srcs, tile_buffer_dsts, num_tlev_buffers);
   }

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -255,7 +255,7 @@ struct agent_batched_topk_worker_per_segment
         }
 
         // Load Values (if applicable)
-        [[maybe_unused]] value_t thread_values[items_per_thread];
+        [[maybe_unused]] value_t thread_values[items_per_thread]; // NOLINT(misc-const-correctness)
 
         if constexpr (!is_keys_only)
         {

--- a/cub/cub/agent/agent_find.cuh
+++ b/cub/cub/agent/agent_find.cuh
@@ -91,7 +91,7 @@ struct agent_t
 
     // vectorized loads begin
     auto load_ptr = reinterpret_cast<const VectorT*>(d_in + tile_offset + (threadIdx.x * VecSize));
-    CacheModifiedInputIterator<LoadModifier, VectorT> d_vec_in(load_ptr);
+    const CacheModifiedInputIterator<LoadModifier, VectorT> d_vec_in(load_ptr);
 
     alignas(VectorT) unsigned char input_bytes[ItemsPerThread * sizeof(InputT)];
     auto* vec_items = reinterpret_cast<VectorT*>(input_bytes);

--- a/cub/cub/agent/agent_find_bound_sorted_values.cuh
+++ b/cub/cub/agent/agent_find_bound_sorted_values.cuh
@@ -163,7 +163,7 @@ struct agent_t
 
     const auto partition_comp = Mode::make_partition_comp(compare_op);
 
-    int d0_thread = ItemsPerThread * static_cast<int>(threadIdx.x);
+    int d0_thread = ItemsPerThread * static_cast<int>(threadIdx.x); // NOLINT(misc-const-correctness)
     if constexpr (!IsFullTile)
     {
       d0_thread = ::cuda::std::min(d0_thread, total_in_tile);

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -386,14 +386,14 @@ struct AgentHistogram
     if constexpr (NumActiveChannels == 1)
     {
       using AliasedVecs = VecT[vecs_per_thread];
-      WrappedVecsIteratorT d_wrapped_vecs(reinterpret_cast<VecT*>(d_native_samples + block_offset));
+      const WrappedVecsIteratorT d_wrapped_vecs(reinterpret_cast<VecT*>(d_native_samples + block_offset));
       // Load using a wrapped vec iterator
       BlockLoadVecT{temp_storage.vec_load}.Load(d_wrapped_vecs, reinterpret_cast<AliasedVecs&>(samples));
     }
     else
     {
       using AliasedPixels = PixelT[pixels_per_thread];
-      WrappedPixelIteratorT d_wrapped_pixels(reinterpret_cast<PixelT*>(d_native_samples + block_offset));
+      const WrappedPixelIteratorT d_wrapped_pixels(reinterpret_cast<PixelT*>(d_native_samples + block_offset));
       // Load using a wrapped pixel iterator
       BlockLoadPixelT{temp_storage.pixel_load}.Load(d_wrapped_pixels, reinterpret_cast<AliasedPixels&>(samples));
     }
@@ -423,8 +423,8 @@ struct AgentHistogram
       {
         // Load partially-full, aligned tile using the pixel iterator
         using AliasedPixels = PixelT[pixels_per_thread];
-        WrappedPixelIteratorT d_wrapped_pixels((PixelT*) (d_native_samples + block_offset));
-        int valid_pixels = valid_samples / NumChannels;
+        const WrappedPixelIteratorT d_wrapped_pixels((PixelT*) (d_native_samples + block_offset));
+        const int valid_pixels = valid_samples / NumChannels;
 
         // Load using a wrapped pixel iterator
         BlockLoadPixelT{temp_storage.pixel_load}.Load(
@@ -511,7 +511,7 @@ struct AgentHistogram
     while (tile_idx < num_tiles)
     {
       int row             = tile_idx / tiles_per_row;
-      int col             = tile_idx - (row * tiles_per_row);
+      const int col       = tile_idx - (row * tiles_per_row);
       OffsetT row_offset  = row * row_stride_samples;
       OffsetT col_offset  = (col * tile_samples);
       OffsetT tile_offset = row_offset + col_offset;

--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -192,7 +192,7 @@ struct agent_t
 
     // Now find the merge path for each of the threads.
     // We can use int type here, because the number of items in shared memory is limited.
-    int diag0_thread = ItemsPerThread * static_cast<int>(threadIdx.x);
+    int diag0_thread = ItemsPerThread * static_cast<int>(threadIdx.x); // NOLINT(misc-const-correctness)
     if constexpr (IsFullTile)
     {
       _CCCL_ASSERT(num_remaining == items_per_tile, "");

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -511,7 +511,7 @@ struct AgentMerge
 
     // preload items into registers already
     //
-    [[maybe_unused]] ValueT items_local[ITEMS_PER_THREAD];
+    [[maybe_unused]] ValueT items_local[ITEMS_PER_THREAD]; // NOLINT(misc-const-correctness)
     if constexpr (!KEYS_ONLY)
     {
       if (ping)

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -276,7 +276,7 @@ struct AgentRadixSortDownsweep
     for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
     {
       bit_ordered_type key       = temp_storage.keys_and_offsets.exchange_keys[threadIdx.x + (ITEM * BLOCK_THREADS)];
-      uint32_t digit             = digit_extractor().Digit(key);
+      const uint32_t digit       = digit_extractor().Digit(key);
       relative_bin_offsets[ITEM] = temp_storage.keys_and_offsets.relative_bin_offsets[digit];
 
       key = bit_ordered_conversion::from_bit_ordered(decomposer, key);
@@ -440,7 +440,7 @@ struct AgentRadixSortDownsweep
     OffsetT relative_bin_offsets[ITEMS_PER_THREAD];
 
     // Assign default (min/max) value to all keys
-    bit_ordered_type default_key =
+    const bit_ordered_type default_key =
       IS_DESCENDING ? traits::min_raw_binary_key(decomposer) : traits::max_raw_binary_key(decomposer);
 
     // Load tile of keys
@@ -462,7 +462,7 @@ struct AgentRadixSortDownsweep
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
     {
-      int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
+      const int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
       if ((BLOCK_THREADS == RADIX_DIGITS) || (bin_idx < RADIX_DIGITS))
       {
         // Store exclusive prefix
@@ -478,7 +478,7 @@ struct AgentRadixSortDownsweep
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
     {
-      int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
+      const int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
       if ((BLOCK_THREADS == RADIX_DIGITS) || (bin_idx < RADIX_DIGITS))
       {
         if (IS_DESCENDING)
@@ -504,7 +504,7 @@ struct AgentRadixSortDownsweep
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
     {
-      int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
+      const int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
       if ((BLOCK_THREADS == RADIX_DIGITS) || (bin_idx < RADIX_DIGITS))
       {
         bin_offset[track] -= exclusive_digit_prefix[track];
@@ -601,7 +601,7 @@ struct AgentRadixSortDownsweep
     {
       this->bin_offset[track] = bin_offset[track];
 
-      int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
+      const int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
       if ((BLOCK_THREADS == RADIX_DIGITS) || (bin_idx < RADIX_DIGITS))
       {
         // Short circuit if the histogram has only bin counts of only zeros or problem-size

--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -184,7 +184,7 @@ struct AgentRadixSortHistogram
   _CCCL_DEVICE _CCCL_FORCEINLINE void LoadTileKeys(OffsetT tile_offset, bit_ordered_type (&keys)[ITEMS_PER_THREAD])
   {
     // tile_offset < num_items always, hence the line below works
-    bool full_tile = num_items - tile_offset >= TILE_ITEMS;
+    const bool full_tile = num_items - tile_offset >= TILE_ITEMS;
     if (full_tile)
     {
       LoadDirectStriped<BLOCK_THREADS>(threadIdx.x, d_keys_in + tile_offset, keys);
@@ -205,7 +205,7 @@ struct AgentRadixSortHistogram
   _CCCL_DEVICE _CCCL_FORCEINLINE void
   AccumulateSharedHistograms(OffsetT tile_offset, bit_ordered_type (&keys)[ITEMS_PER_THREAD])
   {
-    int part = ::cuda::ptx::get_sreg_laneid() % NUM_PARTS;
+    const int part = ::cuda::ptx::get_sreg_laneid() % NUM_PARTS;
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int current_bit = begin_bit, pass = 0; current_bit < end_bit; current_bit += RADIX_BITS, ++pass)
@@ -215,7 +215,7 @@ struct AgentRadixSortHistogram
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int u = 0; u < ITEMS_PER_THREAD; ++u)
       {
-        uint32_t bin = digit_extractor(current_bit, num_bits).Digit(keys[u]);
+        const uint32_t bin = digit_extractor(current_bit, num_bits).Digit(keys[u]);
         // Using cuda::atomic<> results in lower performance on GP100,
         // so atomicAdd() is used instead.
         atomicAdd(&s.bins[pass][bin][part], 1);

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -261,7 +261,7 @@ struct AgentRadixSortOnesweep
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int u = 0; u < BINS_PER_THREAD; ++u)
     {
-      int bin = ThreadBin(u);
+      const int bin = ThreadBin(u);
       if (FULL_BINS || bin < RADIX_DIGITS)
       {
         // write the local sum into the bin
@@ -307,7 +307,7 @@ struct AgentRadixSortOnesweep
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int u = 0; u < BINS_PER_THREAD; ++u)
     {
-      int bin = ThreadBin(u);
+      const int bin = ThreadBin(u);
       if (FULL_BINS || bin < RADIX_DIGITS)
       {
         PortionOffsetT inc_sum = bins[u];
@@ -367,7 +367,7 @@ struct AgentRadixSortOnesweep
     }
     else
     {
-      int tile_items = num_items - tile_offset;
+      const int tile_items = num_items - tile_offset;
       LoadDirectWarpStriped(threadIdx.x, d_values_in + tile_offset, values, tile_items);
     }
   }
@@ -412,14 +412,14 @@ struct AgentRadixSortOnesweep
     // short-circuit handling; note that global look-back is still required
 
     // compute offsets
-    uint32_t common_bin = Digit(keys[0]);
+    const uint32_t common_bin = Digit(keys[0]);
     int offsets[BINS_PER_THREAD];
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int u = 0; u < BINS_PER_THREAD; ++u)
     {
-      int bin    = ThreadBin(u);
-      offsets[u] = bin > common_bin ? TILE_ITEMS : 0;
+      const int bin = ThreadBin(u);
+      offsets[u]    = bin > common_bin ? TILE_ITEMS : 0;
     }
 
     // global lookback
@@ -442,7 +442,7 @@ struct AgentRadixSortOnesweep
     }
     else
     {
-      int tile_items = num_items - block_idx * TILE_ITEMS;
+      const int tile_items = num_items - block_idx * TILE_ITEMS;
       StoreDirectWarpStriped(threadIdx.x, d_keys_out + global_offset, keys, tile_items);
     }
 
@@ -457,7 +457,7 @@ struct AgentRadixSortOnesweep
       }
       else
       {
-        int tile_items = num_items - block_idx * TILE_ITEMS;
+        const int tile_items = num_items - block_idx * TILE_ITEMS;
         StoreDirectWarpStriped(threadIdx.x, d_values_out + global_offset, values, tile_items);
       }
     }
@@ -494,7 +494,7 @@ struct AgentRadixSortOnesweep
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int u = 0; u < BINS_PER_THREAD; ++u)
     {
-      int bin = ThreadBin(u);
+      const int bin = ThreadBin(u);
       if (FULL_BINS || bin < RADIX_DIGITS)
       {
         s.global_offsets[bin] = d_bins_in[bin] - offsets[u];
@@ -504,13 +504,13 @@ struct AgentRadixSortOnesweep
 
   _CCCL_DEVICE _CCCL_FORCEINLINE void UpdateBinsGlobal(int (&bins)[BINS_PER_THREAD], int (&offsets)[BINS_PER_THREAD])
   {
-    bool last_block = (block_idx + 1) * TILE_ITEMS >= num_items;
+    const bool last_block = (block_idx + 1) * TILE_ITEMS >= num_items;
     if (d_bins_out != nullptr && last_block)
     {
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int u = 0; u < BINS_PER_THREAD; ++u)
       {
-        int bin = ThreadBin(u);
+        const int bin = ThreadBin(u);
         if (FULL_BINS || bin < RADIX_DIGITS)
         {
           d_bins_out[bin] = s.global_offsets[bin] + offsets[u] + bins[u];
@@ -522,14 +522,14 @@ struct AgentRadixSortOnesweep
   template <bool FULL_TILE>
   _CCCL_DEVICE _CCCL_FORCEINLINE void ScatterKeysGlobalDirect()
   {
-    int tile_items = FULL_TILE ? TILE_ITEMS : num_items - block_idx * TILE_ITEMS;
+    const int tile_items = FULL_TILE ? TILE_ITEMS : num_items - block_idx * TILE_ITEMS;
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int u = 0; u < ITEMS_PER_THREAD; ++u)
     {
-      int idx              = threadIdx.x + u * BLOCK_THREADS;
-      bit_ordered_type key = s.keys_out[idx];
-      OffsetT global_idx   = idx + s.global_offsets[Digit(key)];
+      const int idx              = threadIdx.x + u * BLOCK_THREADS;
+      const bit_ordered_type key = s.keys_out[idx];
+      OffsetT global_idx         = idx + s.global_offsets[Digit(key)];
       if (FULL_TILE || idx < tile_items)
       {
         d_keys_out[global_idx] = Twiddle::Out(key, decomposer);
@@ -541,12 +541,12 @@ struct AgentRadixSortOnesweep
   template <bool FULL_TILE>
   _CCCL_DEVICE _CCCL_FORCEINLINE void ScatterValuesGlobalDirect(int (&digits)[ITEMS_PER_THREAD])
   {
-    int tile_items = FULL_TILE ? TILE_ITEMS : num_items - block_idx * TILE_ITEMS;
+    const int tile_items = FULL_TILE ? TILE_ITEMS : num_items - block_idx * TILE_ITEMS;
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int u = 0; u < ITEMS_PER_THREAD; ++u)
     {
-      int idx            = threadIdx.x + u * BLOCK_THREADS;
+      const int idx      = threadIdx.x + u * BLOCK_THREADS;
       ValueT value       = s.values_out[idx];
       OffsetT global_idx = idx + s.global_offsets[digits[u]];
       if (FULL_TILE || idx < tile_items)
@@ -573,7 +573,7 @@ struct AgentRadixSortOnesweep
       bit_ordered_type key     = s.keys_out[idx];
       bit_ordered_type key_out = Twiddle::Out(key, decomposer);
       OffsetT global_idx       = idx + s.global_offsets[Digit(key)];
-      int last_lane            = WARP_THREADS - 1;
+      const int last_lane      = WARP_THREADS - 1;
       int num_writes           = WARP_THREADS;
       if (lane == last_lane)
       {
@@ -587,7 +587,7 @@ struct AgentRadixSortOnesweep
       warp_offset += num_writes;
     }
     {
-      int num_writes = warp_end - warp_offset;
+      const int num_writes = warp_end - warp_offset;
       if (lane < num_writes)
       {
         int idx              = warp_offset + lane;
@@ -636,8 +636,8 @@ struct AgentRadixSortOnesweep
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int u = 0; u < ITEMS_PER_THREAD; ++u)
     {
-      int idx   = threadIdx.x + u * BLOCK_THREADS;
-      digits[u] = Digit(s.keys_out[idx]);
+      const int idx = threadIdx.x + u * BLOCK_THREADS;
+      digits[u]     = Digit(s.keys_out[idx]);
     }
   }
 

--- a/cub/cub/agent/agent_radix_sort_upsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_upsweep.cuh
@@ -216,16 +216,18 @@ struct AgentRadixSortUpsweep
   _CCCL_DEVICE _CCCL_FORCEINLINE void Bucket(bit_ordered_type key)
   {
     // Perform transform op
+    // `Digit()` takes a mutable reference for the decomposer overload.
+    // NOLINTNEXTLINE(misc-const-correctness)
     bit_ordered_type converted_key = bit_ordered_conversion::to_bit_ordered(decomposer, key);
 
     // Extract current digit bits
-    uint32_t digit = digit_extractor().Digit(converted_key);
+    const uint32_t digit = digit_extractor().Digit(converted_key);
 
     // Get sub-counter offset
-    uint32_t sub_counter = digit & (PACKING_RATIO - 1);
+    const uint32_t sub_counter = digit & (PACKING_RATIO - 1);
 
     // Get row offset
-    uint32_t row_offset = digit >> LOG_PACKING_RATIO;
+    const uint32_t row_offset = digit >> LOG_PACKING_RATIO;
     _CCCL_ASSERT(row_offset < COUNTER_LANES, "");
 
     // Increment counter
@@ -266,8 +268,8 @@ struct AgentRadixSortUpsweep
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE void UnpackDigitCounts()
   {
-    unsigned int warp_id  = threadIdx.x >> LOG_WARP_THREADS;
-    unsigned int warp_tid = ::cuda::ptx::get_sreg_laneid();
+    const unsigned int warp_id  = threadIdx.x >> LOG_WARP_THREADS;
+    const unsigned int warp_tid = ::cuda::ptx::get_sreg_laneid();
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int LANE = 0; LANE < LANES_PER_WARP; LANE++)
@@ -317,7 +319,7 @@ struct AgentRadixSortUpsweep
     for (OffsetT offset = threadIdx.x; offset < block_end - block_offset; offset += BLOCK_THREADS)
     {
       // Load and bucket key
-      bit_ordered_type key = d_keys_in[block_offset + offset];
+      const bit_ordered_type key = d_keys_in[block_offset + offset];
       Bucket(key);
     }
   }
@@ -389,22 +391,22 @@ struct AgentRadixSortUpsweep
   template <bool IS_DESCENDING>
   _CCCL_DEVICE _CCCL_FORCEINLINE void ExtractCounts(OffsetT* counters, int bin_stride = 1, int bin_offset = 0)
   {
-    unsigned int warp_id  = threadIdx.x >> LOG_WARP_THREADS;
-    unsigned int warp_tid = ::cuda::ptx::get_sreg_laneid();
+    const unsigned int warp_id  = threadIdx.x >> LOG_WARP_THREADS;
+    const unsigned int warp_tid = ::cuda::ptx::get_sreg_laneid();
 
     // Place unpacked digit counters in shared memory
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int LANE = 0; LANE < LANES_PER_WARP; LANE++)
     {
-      int counter_lane = (LANE * WARPS) + warp_id;
+      const int counter_lane = (LANE * WARPS) + warp_id;
       if (counter_lane < COUNTER_LANES)
       {
-        int digit_row = counter_lane << LOG_PACKING_RATIO;
+        const int digit_row = counter_lane << LOG_PACKING_RATIO;
 
         _CCCL_PRAGMA_UNROLL_FULL()
         for (int UNPACKED_COUNTER = 0; UNPACKED_COUNTER < PACKING_RATIO; UNPACKED_COUNTER++)
         {
-          int bin_idx = digit_row + UNPACKED_COUNTER;
+          const int bin_idx = digit_row + UNPACKED_COUNTER;
 
           temp_storage.block_counters[warp_tid][bin_idx] = local_counts[LANE][UNPACKED_COUNTER];
         }
@@ -469,22 +471,22 @@ struct AgentRadixSortUpsweep
   template <int BINS_TRACKED_PER_THREAD>
   _CCCL_DEVICE _CCCL_FORCEINLINE void ExtractCounts(OffsetT (&bin_count)[BINS_TRACKED_PER_THREAD])
   {
-    unsigned int warp_id  = threadIdx.x >> LOG_WARP_THREADS;
-    unsigned int warp_tid = ::cuda::ptx::get_sreg_laneid();
+    const unsigned int warp_id  = threadIdx.x >> LOG_WARP_THREADS;
+    const unsigned int warp_tid = ::cuda::ptx::get_sreg_laneid();
 
     // Place unpacked digit counters in shared memory
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int LANE = 0; LANE < LANES_PER_WARP; LANE++)
     {
-      int counter_lane = (LANE * WARPS) + warp_id;
+      const int counter_lane = (LANE * WARPS) + warp_id;
       if (counter_lane < COUNTER_LANES)
       {
-        int digit_row = counter_lane << LOG_PACKING_RATIO;
+        const int digit_row = counter_lane << LOG_PACKING_RATIO;
 
         _CCCL_PRAGMA_UNROLL_FULL()
         for (int UNPACKED_COUNTER = 0; UNPACKED_COUNTER < PACKING_RATIO; UNPACKED_COUNTER++)
         {
-          int bin_idx = digit_row + UNPACKED_COUNTER;
+          const int bin_idx = digit_row + UNPACKED_COUNTER;
 
           temp_storage.block_counters[warp_tid][bin_idx] = local_counts[LANE][UNPACKED_COUNTER];
         }
@@ -497,7 +499,7 @@ struct AgentRadixSortUpsweep
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
     {
-      int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
+      const int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
 
       if ((BLOCK_THREADS == RADIX_DIGITS) || (bin_idx < RADIX_DIGITS))
       {

--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -306,7 +306,7 @@ struct AgentReduceImpl
     {
       // Fabricate a vectorized input iterator
       InputT* d_in_unqualified = const_cast<InputT*>(d_in) + block_offset + (lane_id * vec_size);
-      CacheModifiedInputIterator<AgentReducePolicy::LOAD_MODIFIER, VectorT, OffsetT> d_vec_in(
+      const CacheModifiedInputIterator<AgentReducePolicy::LOAD_MODIFIER, VectorT, OffsetT> d_vec_in(
         reinterpret_cast<VectorT*>(d_in_unqualified));
 
       // Load items as vector items
@@ -366,7 +366,7 @@ struct AgentReduceImpl
     // Continue reading items (block-striped)
     while (thread_offset < valid_items)
     {
-      InputT item(d_wrapped_in[block_offset + thread_offset]); // NOLINT(bugprone-misplaced-widening-cast)
+      const InputT item(d_wrapped_in[block_offset + thread_offset]); // NOLINT(bugprone-misplaced-widening-cast)
 
       thread_aggregate = reduction_op(thread_aggregate, transform_op(item));
       thread_offset += NumThreads;
@@ -389,7 +389,7 @@ struct AgentReduceImpl
     if (even_share.block_end - even_share.block_offset < TILE_ITEMS)
     {
       // First tile isn't full (not all threads have valid items)
-      int valid_items = even_share.block_end - even_share.block_offset;
+      int valid_items = even_share.block_end - even_share.block_offset; // NOLINT(misc-const-correctness)
       ConsumePartialTile<true>(thread_aggregate, even_share.block_offset, valid_items);
 
       // For Warp Reduction, we need to explicitly handle the valid_items,
@@ -474,7 +474,7 @@ private:
     // Consume a partially-full tile
     if (even_share.block_offset < even_share.block_end)
     {
-      int valid_items = even_share.block_end - even_share.block_offset;
+      const int valid_items = even_share.block_end - even_share.block_offset;
       ConsumePartialTile<false>(thread_aggregate, even_share.block_offset, valid_items);
     }
   }

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -431,7 +431,7 @@ struct AgentReduceByKey
 
     for (int item = static_cast<int>(threadIdx.x); item < num_tile_segments; item += BLOCK_THREADS)
     {
-      KeyValuePairT pair                                = temp_storage.raw_exchange.Alias()[item];
+      const KeyValuePairT pair                          = temp_storage.raw_exchange.Alias()[item];
       d_unique_out[num_tile_segments_prefix + item]     = pair.key; // NOLINT(bugprone-misplaced-widening-cast)
       d_aggregates_out[num_tile_segments_prefix + item] = pair.value; // NOLINT(bugprone-misplaced-widening-cast)
     }
@@ -553,13 +553,13 @@ struct AgentReduceByKey
     if (IS_LAST_TILE)
     {
       // Use custom flag operator to additionally flag the first out-of-bounds item
-      GuardedInequalityWrapper<EqualityOpT> flag_op(equality_op, num_remaining);
+      const GuardedInequalityWrapper<EqualityOpT> flag_op(equality_op, num_remaining);
       BlockDiscontinuityKeys(temp_storage.scan_storage.discontinuity)
         .FlagHeads(head_flags, keys, prev_keys, flag_op, tile_predecessor);
     }
     else
     {
-      InequalityWrapper<EqualityOpT> flag_op(equality_op);
+      const InequalityWrapper<EqualityOpT> flag_op(equality_op);
       BlockDiscontinuityKeys(temp_storage.scan_storage.discontinuity)
         .FlagHeads(head_flags, keys, prev_keys, flag_op, tile_predecessor);
     }
@@ -732,7 +732,7 @@ struct AgentReduceByKey
     // block
 
     // Current tile index
-    int tile_idx = static_cast<int>(start_tile + blockIdx.x);
+    const int tile_idx = static_cast<int>(start_tile + blockIdx.x);
 
     // Global offset for the current tile
     OffsetT tile_offset = OffsetT(TILE_ITEMS) * tile_idx;

--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -345,7 +345,7 @@ struct AgentRle
     bool head_flags[ITEMS_PER_THREAD];
     bool tail_flags[ITEMS_PER_THREAD];
 
-    OobInequalityOp<LAST_TILE> inequality_op(num_remaining, equality_op);
+    const OobInequalityOp<LAST_TILE> inequality_op(num_remaining, equality_op);
 
     if (FIRST_TILE && LAST_TILE)
     {
@@ -432,8 +432,8 @@ struct AgentRle
     LengthOffsetPair (&lengths_and_num_runs)[ITEMS_PER_THREAD])
   {
     // Perform warpscans
-    unsigned int warp_id = ((WARPS == 1) ? 0 : threadIdx.x / WARP_THREADS);
-    int lane_id          = static_cast<int>(::cuda::ptx::get_sreg_laneid());
+    const unsigned int warp_id = ((WARPS == 1) ? 0 : threadIdx.x / WARP_THREADS);
+    const int lane_id          = static_cast<int>(::cuda::ptx::get_sreg_laneid());
 
     LengthOffsetPair identity;
     identity.key   = 0;
@@ -450,7 +450,7 @@ struct AgentRle
     //      number of non-trivial runs starts in this thread
     // `thread_aggregate.val`:
     //      number of items in the last non-trivial run in this thread
-    LengthOffsetPair thread_aggregate = cub::ThreadReduce(lengths_and_num_runs, scan_op);
+    const LengthOffsetPair thread_aggregate = cub::ThreadReduce(lengths_and_num_runs, scan_op);
     WarpScanPairs(temp_storage.aliasable.scan_storage.warp_scan[warp_id])
       .Scan(thread_aggregate, thread_inclusive, thread_exclusive_in_warp, identity, scan_op);
 
@@ -517,8 +517,8 @@ struct AgentRle
     LengthOffsetPair (&lengths_and_offsets)[ITEMS_PER_THREAD],
     ::cuda::std::true_type is_warp_time_slice)
   {
-    unsigned int warp_id = ((WARPS == 1) ? 0 : threadIdx.x / WARP_THREADS);
-    int lane_id          = static_cast<int>(::cuda::ptx::get_sreg_laneid());
+    const unsigned int warp_id = ((WARPS == 1) ? 0 : threadIdx.x / WARP_THREADS);
+    const int lane_id          = static_cast<int>(::cuda::ptx::get_sreg_laneid());
 
     // Locally compact items within the warp (first warp)
     if (warp_id == 0)
@@ -587,8 +587,8 @@ struct AgentRle
     LengthOffsetPair (&lengths_and_offsets)[ITEMS_PER_THREAD],
     ::cuda::std::false_type is_warp_time_slice)
   {
-    unsigned int warp_id = ((WARPS == 1) ? 0 : threadIdx.x / WARP_THREADS);
-    int lane_id          = static_cast<int>(::cuda::ptx::get_sreg_laneid());
+    const unsigned int warp_id = ((WARPS == 1) ? 0 : threadIdx.x / WARP_THREADS);
+    const int lane_id          = static_cast<int>(::cuda::ptx::get_sreg_laneid());
 
     // Unzip
     OffsetT run_offsets[ITEMS_PER_THREAD];
@@ -921,7 +921,7 @@ struct AgentRle
       // First warp computes tile prefix in lane 0
       TilePrefixCallbackOpT prefix_op(
         tile_status, temp_storage.aliasable.scan_storage.prefix, ::cuda::std::plus<>{}, tile_idx);
-      unsigned int warp_id = ((WARPS == 1) ? 0 : threadIdx.x / WARP_THREADS);
+      const unsigned int warp_id = ((WARPS == 1) ? 0 : threadIdx.x / WARP_THREADS);
       if (warp_id == 0)
       {
         prefix_op(tile_aggregate);
@@ -933,10 +933,10 @@ struct AgentRle
 
       __syncthreads();
 
-      LengthOffsetPair tile_exclusive_in_global = temp_storage.tile_exclusive;
+      const LengthOffsetPair tile_exclusive_in_global = temp_storage.tile_exclusive;
 
       // Update thread_exclusive_in_warp to fold in warp and tile run-lengths
-      LengthOffsetPair thread_exclusive = scan_op(tile_exclusive_in_global, warp_exclusive_in_tile);
+      const LengthOffsetPair thread_exclusive = scan_op(tile_exclusive_in_global, warp_exclusive_in_tile);
       if (thread_exclusive_in_warp.key == 0)
       {
         // If there are no non-trivial runs starts in the previous warp threads, then
@@ -1012,7 +1012,7 @@ struct AgentRle
   ConsumeRange(int num_tiles, ScanTileStateT& tile_status, NumRunsIteratorT d_num_runs_out)
   {
     // Blocks are launched in increasing order, so just assign one tile per block
-    int tile_idx          = static_cast<int>((blockIdx.x * gridDim.y) + blockIdx.y); // Current tile index
+    const int tile_idx    = static_cast<int>((blockIdx.x * gridDim.y) + blockIdx.y); // Current tile index
     OffsetT tile_offset   = static_cast<OffsetT>(tile_idx) * static_cast<OffsetT>(TILE_ITEMS);
     OffsetT num_remaining = num_items - tile_offset; // Remaining items (including this tile)
 
@@ -1024,7 +1024,8 @@ struct AgentRle
     else if (num_remaining > 0)
     {
       // The last tile (possibly partially-full)
-      LengthOffsetPair running_total = ConsumeTile<true>(num_items, num_remaining, tile_idx, tile_offset, tile_status);
+      const LengthOffsetPair running_total =
+        ConsumeTile<true>(num_items, num_remaining, tile_idx, tile_offset, tile_status);
 
       if (threadIdx.x == 0)
       {

--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -409,7 +409,7 @@ struct AgentScan
     // block
 
     // Current tile index
-    int tile_idx = static_cast<int>(start_tile + blockIdx.x);
+    const int tile_idx = static_cast<int>(start_tile + blockIdx.x);
 
     // Global offset for the current tile
     OffsetT tile_offset = OffsetT(TILE_ITEMS) * tile_idx;

--- a/cub/cub/agent/agent_scan_by_key.cuh
+++ b/cub/cub/agent/agent_scan_by_key.cuh
@@ -373,7 +373,7 @@ struct AgentScanByKey
     }
     else
     {
-      KeyT tile_pred_key = (threadIdx.x == 0) ? d_keys_prev_in[tile_idx] : KeyT();
+      const KeyT tile_pred_key = (threadIdx.x == 0) ? d_keys_prev_in[tile_idx] : KeyT();
 
       BlockDiscontinuityKeysT(storage.scan_storage.discontinuity)
         .FlagHeads(segment_flags, keys, inequality_op, tile_pred_key);
@@ -443,7 +443,7 @@ struct AgentScanByKey
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE void ConsumeRange(OffsetT num_items, ScanTileStateT& tile_state, int start_tile)
   {
-    int tile_idx          = static_cast<int>(blockIdx.x);
+    const int tile_idx    = static_cast<int>(blockIdx.x);
     OffsetT tile_base     = OffsetT(ITEMS_PER_TILE) * tile_idx;
     OffsetT num_remaining = num_items - tile_base;
 

--- a/cub/cub/agent/agent_segmented_radix_sort.cuh
+++ b/cub/cub/agent/agent_segmented_radix_sort.cuh
@@ -185,7 +185,7 @@ struct AgentSegmentedRadixSort
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
       {
-        int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
+        const int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
 
         if ((BLOCK_THREADS == RADIX_DIGITS) || (bin_idx < RADIX_DIGITS))
         {
@@ -198,7 +198,7 @@ struct AgentSegmentedRadixSort
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
       {
-        int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
+        const int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
 
         if ((BLOCK_THREADS == RADIX_DIGITS) || (bin_idx < RADIX_DIGITS))
         {
@@ -219,7 +219,7 @@ struct AgentSegmentedRadixSort
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
       {
-        int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
+        const int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
 
         if ((BLOCK_THREADS == RADIX_DIGITS) || (bin_idx < RADIX_DIGITS))
         {
@@ -232,7 +232,7 @@ struct AgentSegmentedRadixSort
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
       {
-        int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
+        const int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
 
         if ((BLOCK_THREADS == RADIX_DIGITS) || (bin_idx < RADIX_DIGITS))
         {

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -589,7 +589,7 @@ struct AgentSelectIf
       if constexpr (IS_LAST_TILE && !use_flag_fixup_code_path)
       {
         // Use custom flag operator to additionally flag the first out-of-bounds item
-        guarded_inequality_op<EqualityOpT> flag_op{equality_op, num_tile_items};
+        const guarded_inequality_op<EqualityOpT> flag_op{equality_op, num_tile_items};
 
         // Set head selection_flags.  First tile sets the first flag for the first item
         BlockDiscontinuityT(temp_storage.scan_storage.discontinuity).FlagHeads(selection_flags, items, flag_op);
@@ -614,7 +614,7 @@ struct AgentSelectIf
       if constexpr (IS_LAST_TILE && !use_flag_fixup_code_path)
       {
         // Use custom flag operator to additionally flag the first out-of-bounds item
-        guarded_inequality_op<EqualityOpT> flag_op{equality_op, num_tile_items};
+        const guarded_inequality_op<EqualityOpT> flag_op{equality_op, num_tile_items};
 
         // Set head selection_flags.  First tile sets the first flag for the first item
         BlockDiscontinuityT(temp_storage.scan_storage.discontinuity)
@@ -705,7 +705,7 @@ struct AgentSelectIf
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
     {
-      int local_scatter_offset = selection_indices[ITEM] - num_selections_prefix;
+      const int local_scatter_offset = selection_indices[ITEM] - num_selections_prefix;
       if (selection_flags[ITEM])
       {
         temp_storage.raw_exchange.Alias()[local_scatter_offset] = items[ITEM];
@@ -798,16 +798,16 @@ struct AgentSelectIf
   {
     __syncthreads();
 
-    int tile_num_rejections = num_tile_items - num_tile_selections;
+    const int tile_num_rejections = num_tile_items - num_tile_selections;
 
     // Scatter items to shared memory (rejections first)
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
     {
-      int item_idx            = (threadIdx.x * ITEMS_PER_THREAD) + ITEM;
-      int local_selection_idx = selection_indices[ITEM] - num_selections_prefix;
-      int local_rejection_idx = item_idx - local_selection_idx;
-      int local_scatter_offset =
+      const int item_idx            = (threadIdx.x * ITEMS_PER_THREAD) + ITEM;
+      const int local_selection_idx = selection_indices[ITEM] - num_selections_prefix;
+      const int local_rejection_idx = item_idx - local_selection_idx;
+      const int local_scatter_offset =
         (selection_flags[ITEM]) ? tile_num_rejections + local_selection_idx : local_rejection_idx;
 
       temp_storage.raw_exchange.Alias()[local_scatter_offset] = items[ITEM];
@@ -839,13 +839,13 @@ struct AgentSelectIf
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
     {
-      int item_idx      = (ITEM * BLOCK_THREADS) + threadIdx.x;
-      int rejection_idx = item_idx;
-      int selection_idx = item_idx - tile_num_rejections;
-      OffsetT scatter_offset =
+      const int item_idx      = (ITEM * BLOCK_THREADS) + threadIdx.x;
+      const int rejection_idx = item_idx;
+      const int selection_idx = item_idx - tile_num_rejections;
+      const OffsetT scatter_offset =
         (item_idx < tile_num_rejections) ? num_rejected_prefix + rejection_idx : num_selections_prefix + selection_idx;
 
-      InputT item = temp_storage.raw_exchange.Alias()[item_idx];
+      const InputT item = temp_storage.raw_exchange.Alias()[item_idx];
 
       if (!IS_LAST_TILE || (item_idx < num_tile_items))
       {
@@ -879,10 +879,10 @@ struct AgentSelectIf
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
     {
-      int item_idx      = (ITEM * BLOCK_THREADS) + threadIdx.x;
-      int rejection_idx = item_idx;
-      int selection_idx = item_idx - tile_num_rejections;
-      total_offset_t scatter_offset =
+      const int item_idx      = (ITEM * BLOCK_THREADS) + threadIdx.x;
+      const int rejection_idx = item_idx;
+      const int selection_idx = item_idx - tile_num_rejections;
+      const total_offset_t scatter_offset =
         (item_idx < tile_num_rejections)
           ? (streaming_context.num_total_items(num_items) - streaming_context.num_previously_rejected()
              - static_cast<total_offset_t>(num_rejected_prefix) - static_cast<total_offset_t>(rejection_idx)
@@ -890,7 +890,7 @@ struct AgentSelectIf
           : (streaming_context.num_previously_selected() + static_cast<total_offset_t>(num_selections_prefix)
              + static_cast<total_offset_t>(selection_idx));
 
-      InputT item = temp_storage.raw_exchange.Alias()[item_idx];
+      const InputT item = temp_storage.raw_exchange.Alias()[item_idx];
       if (!IS_LAST_TILE || (item_idx < num_tile_items))
       {
         partitioned_out_it[scatter_offset] = item;
@@ -1012,7 +1012,7 @@ struct AgentSelectIf
     // Discount any out-of-bounds selections
     if (IS_LAST_TILE)
     {
-      int num_discount = TILE_ITEMS - num_tile_items;
+      const int num_discount = TILE_ITEMS - num_tile_items;
       num_selections -= num_discount;
       num_tile_selections -= num_discount;
     }

--- a/cub/cub/agent/agent_three_way_partition.cuh
+++ b/cub/cub/agent/agent_three_way_partition.cuh
@@ -313,7 +313,7 @@ struct AgentThreeWayPartition
     // Scatter items to shared memory (rejections first)
     for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
     {
-      int item_idx = (threadIdx.x * ITEMS_PER_THREAD) + ITEM;
+      const int item_idx = (threadIdx.x * ITEMS_PER_THREAD) + ITEM;
 
       const OffsetT first_items_selection_indices  = AccumPackHelperT::first(items_selection_indices[ITEM]);
       const OffsetT second_items_selection_indices = AccumPackHelperT::second(items_selection_indices[ITEM]);
@@ -333,9 +333,9 @@ struct AgentThreeWayPartition
         else
         {
           // Medium item
-          int local_selection_idx = (first_items_selection_indices - num_first_selections_prefix)
-                                  + (second_items_selection_indices - num_second_selections_prefix);
-          local_scatter_offset    = second_item_end + item_idx - local_selection_idx;
+          const int local_selection_idx = (first_items_selection_indices - num_first_selections_prefix)
+                                        + (second_items_selection_indices - num_second_selections_prefix);
+          local_scatter_offset          = second_item_end + item_idx - local_selection_idx;
         }
 
         temp_storage.raw_exchange.Alias()[local_scatter_offset] = items[ITEM];
@@ -354,11 +354,11 @@ struct AgentThreeWayPartition
     // NOLINTEND(bugprone-misplaced-widening-cast)
     for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
     {
-      int item_idx = (ITEM * BLOCK_THREADS) + threadIdx.x;
+      const int item_idx = (ITEM * BLOCK_THREADS) + threadIdx.x;
 
       if (!IS_LAST_TILE || (item_idx < num_tile_items))
       {
-        InputT item = temp_storage.raw_exchange.Alias()[item_idx];
+        const InputT item = temp_storage.raw_exchange.Alias()[item_idx];
 
         if (item_idx < first_item_end)
         {
@@ -370,7 +370,7 @@ struct AgentThreeWayPartition
         }
         else
         {
-          int rejection_idx              = item_idx - second_item_end;
+          const int rejection_idx        = item_idx - second_item_end;
           unselected_base[rejection_idx] = item;
         }
       }

--- a/cub/cub/agent/agent_topk.cuh
+++ b/cub/cub/agent/agent_topk.cuh
@@ -137,7 +137,7 @@ set_kth_key_bits(key_prefix_storage_t<KeyT>& prefix, const int pass, const int b
   {
     using bits_t        = typename Traits<KeyT>::UnsignedBits;
     const int start_bit = calc_start_bit<KeyT, BitsPerPass>(pass);
-    bits_t bucket       = bin_index;
+    const bits_t bucket = bin_index;
     prefix.bits |= static_cast<bits_t>(bucket) << start_bit;
   }
   else
@@ -657,8 +657,8 @@ struct AgentTopK
     bool is_last_block = false;
     if (threadIdx.x == 0)
     {
-      unsigned int finished = atomicInc(&counter->finished_block_cnt, gridDim.x - 1);
-      is_last_block         = (finished == (gridDim.x - 1));
+      const unsigned int finished = atomicInc(&counter->finished_block_cnt, gridDim.x - 1);
+      is_last_block               = (finished == (gridDim.x - 1));
     }
 
     // syncthreads ensures that the BlockLoad for loading the global histogram can reuse the temporary storage

--- a/cub/cub/agent/agent_unique_by_key.cuh
+++ b/cub/cub/agent/agent_unique_by_key.cuh
@@ -254,7 +254,7 @@ struct AgentUniqueByKey
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
     {
-      int local_scatter_offset = selection_indices[ITEM] - num_selections_prefix;
+      const int local_scatter_offset = selection_indices[ITEM] - num_selections_prefix;
       if (selection_flags[ITEM])
       {
         GetShared(tag)[local_scatter_offset] = items[ITEM];
@@ -361,7 +361,7 @@ struct AgentUniqueByKey
     // Do not count any out-of-bounds selections
     if constexpr (IS_LAST_TILE)
     {
-      int num_discount = ITEMS_PER_TILE - num_tile_items;
+      const int num_discount = ITEMS_PER_TILE - num_tile_items;
       num_tile_selections -= num_discount;
     }
     num_selections = num_tile_selections;
@@ -447,7 +447,7 @@ struct AgentUniqueByKey
 
     __syncthreads();
 
-    KeyT tile_predecessor = d_keys_in[tile_offset - 1];
+    const KeyT tile_predecessor = d_keys_in[tile_offset - 1];
     BlockDiscontinuityKeys(temp_storage.scan_storage.discontinuity)
       .FlagHeads(selection_flags, keys, inequality_op, tile_predecessor);
 
@@ -476,7 +476,7 @@ struct AgentUniqueByKey
 
     if constexpr (IS_LAST_TILE)
     {
-      int num_discount = ITEMS_PER_TILE - num_tile_items;
+      const int num_discount = ITEMS_PER_TILE - num_tile_items;
       num_tile_selections -= num_discount;
       num_selections -= num_discount;
     }
@@ -561,7 +561,7 @@ struct AgentUniqueByKey
   ConsumeRange(int num_tiles, ScanTileStateT& tile_state, NumSelectedIteratorT d_num_selected_out)
   {
     // Blocks are launched in increasing order, so just assign one tile per block
-    int tile_idx = static_cast<int>((blockIdx.x * gridDim.y) + blockIdx.y); // Current tile index
+    const int tile_idx = static_cast<int>((blockIdx.x * gridDim.y) + blockIdx.y); // Current tile index
 
     // Global offset for the current tile
     OffsetT tile_offset = static_cast<OffsetT>(tile_idx) * static_cast<OffsetT>(ITEMS_PER_TILE);
@@ -572,8 +572,8 @@ struct AgentUniqueByKey
     }
     else
     {
-      int num_remaining      = static_cast<int>(num_items - tile_offset);
-      OffsetT num_selections = ConsumeTile<true>(num_remaining, tile_idx, tile_offset, tile_state);
+      const int num_remaining = static_cast<int>(num_items - tile_offset);
+      OffsetT num_selections  = ConsumeTile<true>(num_remaining, tile_idx, tile_offset, tile_state);
       if (threadIdx.x == 0)
       {
         *d_num_selected_out = num_selections;

--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -540,8 +540,8 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr size_t num_tiles_to_num_tile_state
 _CCCL_HOST_DEVICE _CCCL_FORCEINLINE cudaError_t tile_state_allocation_size(
   size_t& temp_storage_bytes, size_t bytes_per_description, size_t bytes_per_payload, size_t num_tiles)
 {
-  size_t num_tile_states = num_tiles_to_num_tile_states(num_tiles);
-  size_t allocation_sizes[]{
+  const size_t num_tile_states = num_tiles_to_num_tile_states(num_tiles);
+  const size_t allocation_sizes[]{
     // bytes needed for tile status descriptors
     num_tile_states * bytes_per_description,
     // bytes needed for partials
@@ -562,8 +562,8 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE cudaError_t tile_state_init(
   size_t temp_storage_bytes,
   void* (&allocations)[3])
 {
-  size_t num_tile_states = num_tiles_to_num_tile_states(num_tiles);
-  size_t allocation_sizes[]{
+  const size_t num_tile_states = num_tiles_to_num_tile_states(num_tiles);
+  const size_t allocation_sizes[]{
     // bytes needed for tile status descriptors
     num_tile_states * bytes_per_description,
     // bytes needed for partials
@@ -666,7 +666,7 @@ struct ScanTileState<T, true>
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE void InitializeStatus(int num_tiles)
   {
-    int tile_idx = static_cast<int>((blockIdx.x * blockDim.x) + threadIdx.x);
+    const int tile_idx = static_cast<int>((blockIdx.x * blockDim.x) + threadIdx.x);
 
     TxnWord val                = TxnWord();
     TileDescriptor* descriptor = reinterpret_cast<TileDescriptor*>(&val);
@@ -789,8 +789,8 @@ public:
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE T LoadValid(int tile_idx)
   {
-    TxnWord alias                  = d_tile_descriptors[TILE_STATUS_PADDING + tile_idx];
-    TileDescriptor tile_descriptor = reinterpret_cast<TileDescriptor&>(alias);
+    TxnWord alias                        = d_tile_descriptors[TILE_STATUS_PADDING + tile_idx];
+    const TileDescriptor tile_descriptor = reinterpret_cast<TileDescriptor&>(alias);
     return tile_descriptor.value;
   }
 };
@@ -877,7 +877,7 @@ struct ScanTileState<T, false>
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE void InitializeStatus(int num_tiles)
   {
-    int tile_idx = static_cast<int>((blockIdx.x * blockDim.x) + threadIdx.x);
+    const int tile_idx = static_cast<int>((blockIdx.x * blockDim.x) + threadIdx.x);
     if (tile_idx < num_tiles)
     {
       // Not-yet-set
@@ -1073,7 +1073,7 @@ struct ReduceByKeyScanTileState<ValueT, KeyT, true>
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE void InitializeStatus(int num_tiles)
   {
-    int tile_idx               = static_cast<int>((blockIdx.x * blockDim.x) + threadIdx.x);
+    const int tile_idx         = static_cast<int>((blockIdx.x * blockDim.x) + threadIdx.x);
     TxnWord val                = TxnWord();
     TileDescriptor* descriptor = reinterpret_cast<TileDescriptor*>(&val);
 
@@ -1248,7 +1248,7 @@ struct TilePrefixCallbackOp
     // Perform a segmented reduction to get the prefix for the current window.
     // Use the swizzled scan operator because we are now scanning *down* towards thread0.
 
-    int tail_flag = (predecessor_status == StatusWord(SCAN_TILE_INCLUSIVE));
+    const int tail_flag = (predecessor_status == StatusWord(SCAN_TILE_INCLUSIVE));
     window_aggregate =
       WarpReduceT(temp_storage.warp_reduce).TailSegmentedReduce(value, tail_flag, SwizzleScanOp<ScanOpT>(scan_op));
   }

--- a/cub/cub/block/block_exchange.cuh
+++ b/cub/cub/block/block_exchange.cuh
@@ -182,7 +182,7 @@ private:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; i++)
     {
-      int item_offset = linear_tid * ItemsPerThread + i;
+      int item_offset = linear_tid * ItemsPerThread + i; // NOLINT(misc-const-correctness)
       if constexpr (INSERT_PADDING)
       {
         item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -195,7 +195,7 @@ private:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; i++)
     {
-      int item_offset = i * BLOCK_THREADS + linear_tid;
+      int item_offset = i * BLOCK_THREADS + linear_tid; // NOLINT(misc-const-correctness)
       if constexpr (INSERT_PADDING)
       {
         item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -291,7 +291,7 @@ private:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; i++)
     {
-      int item_offset = warp_offset + i + (lane_id * ItemsPerThread);
+      int item_offset = warp_offset + i + (lane_id * ItemsPerThread); // NOLINT(misc-const-correctness)
       if constexpr (INSERT_PADDING)
       {
         item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -304,7 +304,7 @@ private:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; i++)
     {
-      int item_offset = warp_offset + (i * WARP_TIME_SLICED_THREADS) + lane_id;
+      int item_offset = warp_offset + (i * WARP_TIME_SLICED_THREADS) + lane_id; // NOLINT(misc-const-correctness)
       if constexpr (INSERT_PADDING)
       {
         item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -332,7 +332,7 @@ private:
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int i = 0; i < ItemsPerThread; i++)
       {
-        int item_offset = i + lane_id * ItemsPerThread;
+        int item_offset = i + lane_id * ItemsPerThread; // NOLINT(misc-const-correctness)
         if constexpr (INSERT_PADDING)
         {
           item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -345,7 +345,7 @@ private:
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int i = 0; i < ItemsPerThread; i++)
       {
-        int item_offset = i * WARP_TIME_SLICED_THREADS + lane_id;
+        int item_offset = i * WARP_TIME_SLICED_THREADS + lane_id; // NOLINT(misc-const-correctness)
         if constexpr (INSERT_PADDING)
         {
           item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -364,7 +364,7 @@ private:
         _CCCL_PRAGMA_UNROLL_FULL()
         for (int i = 0; i < ItemsPerThread; i++)
         {
-          int item_offset = i + lane_id * ItemsPerThread;
+          int item_offset = i + lane_id * ItemsPerThread; // NOLINT(misc-const-correctness)
           if constexpr (INSERT_PADDING)
           {
             item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -377,7 +377,7 @@ private:
         _CCCL_PRAGMA_UNROLL_FULL()
         for (int i = 0; i < ItemsPerThread; i++)
         {
-          int item_offset = i * WARP_TIME_SLICED_THREADS + lane_id;
+          int item_offset = i * WARP_TIME_SLICED_THREADS + lane_id; // NOLINT(misc-const-correctness)
           if constexpr (INSERT_PADDING)
           {
             item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -405,7 +405,7 @@ private:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; i++)
     {
-      int item_offset = i * BLOCK_THREADS + linear_tid;
+      int item_offset = i * BLOCK_THREADS + linear_tid; // NOLINT(misc-const-correctness)
       if constexpr (INSERT_PADDING)
       {
         item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -419,7 +419,7 @@ private:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; i++)
     {
-      int item_offset = linear_tid * ItemsPerThread + i;
+      int item_offset = linear_tid * ItemsPerThread + i; // NOLINT(misc-const-correctness)
       if constexpr (INSERT_PADDING)
       {
         item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -516,7 +516,7 @@ private:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; i++)
     {
-      int item_offset = warp_offset + (i * WARP_TIME_SLICED_THREADS) + lane_id;
+      int item_offset = warp_offset + (i * WARP_TIME_SLICED_THREADS) + lane_id; // NOLINT(misc-const-correctness)
       if constexpr (INSERT_PADDING)
       {
         item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -529,7 +529,7 @@ private:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; i++)
     {
-      int item_offset = warp_offset + i + (lane_id * ItemsPerThread);
+      int item_offset = warp_offset + i + (lane_id * ItemsPerThread); // NOLINT(misc-const-correctness)
       if constexpr (INSERT_PADDING)
       {
         item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -562,7 +562,7 @@ private:
         _CCCL_PRAGMA_UNROLL_FULL()
         for (int i = 0; i < ItemsPerThread; i++)
         {
-          int item_offset = i * WARP_TIME_SLICED_THREADS + lane_id;
+          int item_offset = i * WARP_TIME_SLICED_THREADS + lane_id; // NOLINT(misc-const-correctness)
           if constexpr (INSERT_PADDING)
           {
             item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -575,7 +575,7 @@ private:
         _CCCL_PRAGMA_UNROLL_FULL()
         for (int i = 0; i < ItemsPerThread; i++)
         {
-          int item_offset = i + lane_id * ItemsPerThread;
+          int item_offset = i + lane_id * ItemsPerThread; // NOLINT(misc-const-correctness)
           if constexpr (INSERT_PADDING)
           {
             item_offset += item_offset >> LOG_SMEM_BANKS;
@@ -606,7 +606,7 @@ private:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; i++)
     {
-      int item_offset = ranks[i];
+      int item_offset = ranks[i]; // NOLINT(misc-const-correctness)
       if constexpr (INSERT_PADDING)
       {
         item_offset = (item_offset >> LOG_SMEM_BANKS) + item_offset;
@@ -619,7 +619,7 @@ private:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; i++)
     {
-      int item_offset = linear_tid * ItemsPerThread + i;
+      int item_offset = linear_tid * ItemsPerThread + i; // NOLINT(misc-const-correctness)
       if constexpr (INSERT_PADDING)
       {
         item_offset = (item_offset >> LOG_SMEM_BANKS) + item_offset;
@@ -713,7 +713,7 @@ private:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; i++)
     {
-      int item_offset = ranks[i];
+      int item_offset = ranks[i]; // NOLINT(misc-const-correctness)
       if constexpr (INSERT_PADDING)
       {
         item_offset = (item_offset >> LOG_SMEM_BANKS) + item_offset;
@@ -726,7 +726,7 @@ private:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; i++)
     {
-      int item_offset = i * BLOCK_THREADS + linear_tid;
+      int item_offset = i * BLOCK_THREADS + linear_tid; // NOLINT(misc-const-correctness)
       if constexpr (INSERT_PADDING)
       {
         item_offset = (item_offset >> LOG_SMEM_BANKS) + item_offset;

--- a/cub/cub/block/block_radix_rank.cuh
+++ b/cub/cub/block/block_radix_rank.cuh
@@ -403,7 +403,7 @@ private:
   _CCCL_DEVICE _CCCL_FORCEINLINE void ScanCounters()
   {
     // Upsweep scan
-    PackedCounter raking_partial = Upsweep();
+    const PackedCounter raking_partial = Upsweep();
 
     // Compute exclusive sum
     PackedCounter exclusive_partial;
@@ -561,8 +561,8 @@ public:
 
         // Obtain ex/inclusive digit counts.  (Unfortunately these all reside in the
         // first counter column, resulting in unavoidable bank conflicts.)
-        unsigned int counter_lane = (bin_idx & (COUNTER_LANES - 1));
-        unsigned int sub_counter  = bin_idx >> (LOG_COUNTER_LANES);
+        const unsigned int counter_lane = (bin_idx & (COUNTER_LANES - 1));
+        const unsigned int sub_counter  = bin_idx >> (LOG_COUNTER_LANES);
 
         exclusive_digit_prefix[track] = temp_storage.aliasable.digit_counters[counter_lane][0][sub_counter];
       }
@@ -756,16 +756,16 @@ public:
       digit_counters[ITEM] = &temp_storage.aliasable.warp_digit_counters[digit][warp_id];
 
       // Number of occurrences in previous strips
-      DigitCounterT warp_digit_prefix = *digit_counters[ITEM];
+      const DigitCounterT warp_digit_prefix = *digit_counters[ITEM];
 
       // Warp-sync
       __syncwarp(0xFFFFFFFF);
 
       // Number of peers having same digit as me
-      int32_t digit_count = ::cuda::std::popcount(peer_mask);
+      const int32_t digit_count = ::cuda::std::popcount(peer_mask);
 
       // Number of lower-ranked peers having same digit seen so far
-      int32_t peer_digit_prefix = ::cuda::std::popcount(peer_mask & lane_mask_lt);
+      const int32_t peer_digit_prefix = ::cuda::std::popcount(peer_mask & lane_mask_lt);
 
       if (peer_digit_prefix == 0)
       {
@@ -969,7 +969,7 @@ struct BlockRadixRankMatchEarlyCounts
 
     _CCCL_DEVICE _CCCL_FORCEINLINE int ThreadBin(int u)
     {
-      int bin = threadIdx.x * BINS_PER_THREAD + u;
+      const int bin = threadIdx.x * BINS_PER_THREAD + u;
       return IsDescending ? RADIX_DIGITS - 1 - bin : bin;
     }
 
@@ -1001,7 +1001,7 @@ struct BlockRadixRankMatchEarlyCounts
       __syncwarp(WARP_MASK);
 
       // compute private per-part histograms
-      int part = lane % NUM_PARTS;
+      const int part = lane % NUM_PARTS;
 
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int u = 0; u < KEYS_PER_THREAD; ++u)
@@ -1021,8 +1021,8 @@ struct BlockRadixRankMatchEarlyCounts
         _CCCL_PRAGMA_UNROLL_FULL()
         for (int u = 0; u < WARP_BINS_PER_THREAD; ++u)
         {
-          int bin = lane + u * WARP_THREADS;
-          bins[u] = cub::ThreadReduce(warp_histograms[bin], ::cuda::std::plus<>{});
+          const int bin = lane + u * WARP_THREADS;
+          bins[u]       = cub::ThreadReduce(warp_histograms[bin], ::cuda::std::plus<>{});
         }
         __syncthreads();
 
@@ -1032,7 +1032,7 @@ struct BlockRadixRankMatchEarlyCounts
         _CCCL_PRAGMA_UNROLL_FULL()
         for (int u = 0; u < WARP_BINS_PER_THREAD; ++u)
         {
-          int bin           = lane + u * WARP_THREADS;
+          const int bin     = lane + u * WARP_THREADS;
           warp_offsets[bin] = bins[u];
         }
       }
@@ -1044,14 +1044,14 @@ struct BlockRadixRankMatchEarlyCounts
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int u = 0; u < BINS_PER_THREAD; ++u)
       {
-        bins[u] = 0;
-        int bin = ThreadBin(u);
+        bins[u]       = 0;
+        const int bin = ThreadBin(u);
         if (FULL_BINS || (bin >= 0 && bin < RADIX_DIGITS))
         {
           _CCCL_PRAGMA_UNROLL_FULL()
           for (int j_warp = 0; j_warp < BLOCK_WARPS; ++j_warp)
           {
-            int warp_offset             = s.warp_offsets[j_warp][bin];
+            const int warp_offset       = s.warp_offsets[j_warp][bin];
             s.warp_offsets[j_warp][bin] = bins[u];
             bins[u] += warp_offset;
           }
@@ -1064,10 +1064,10 @@ struct BlockRadixRankMatchEarlyCounts
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int u = 0; u < BINS_PER_THREAD; ++u)
       {
-        int bin = ThreadBin(u);
+        const int bin = ThreadBin(u);
         if (FULL_BINS || (bin >= 0 && bin < RADIX_DIGITS))
         {
-          int digit_offset = offsets[u];
+          const int digit_offset = offsets[u];
           _CCCL_PRAGMA_UNROLL_FULL()
           for (int j_warp = 0; j_warp < BLOCK_WARPS; ++j_warp)
           {
@@ -1095,9 +1095,9 @@ struct BlockRadixRankMatchEarlyCounts
         ::cuda::std::uint32_t bin_mask = *p_match_mask;
         // TODO(bgruber): __bit_log2 regresses cub.bench.radix_sort.keys.base up to 30% on H200, see cccl_private/#586
         // int leader      = ::cuda::std::__bit_log2(bin_mask);
-        int leader      = (WARP_THREADS - 1) - ::cuda::std::countl_zero(bin_mask);
-        int warp_offset = 0;
-        int popc        = ::cuda::std::popcount(bin_mask & ::cuda::ptx::get_sreg_lanemask_le());
+        const int leader = (WARP_THREADS - 1) - ::cuda::std::countl_zero(bin_mask);
+        int warp_offset  = 0;
+        const int popc   = ::cuda::std::popcount(bin_mask & ::cuda::ptx::get_sreg_lanemask_le());
         if (lane == leader)
         {
           // atomic is a bit faster
@@ -1127,9 +1127,9 @@ struct BlockRadixRankMatchEarlyCounts
           detail::warp_in_block_matcher_t<RadixBits, PARTIAL_WARP_THREADS, BLOCK_WARPS - 1>::match_any(bin, warp);
         // TODO(bgruber): __bit_log2 regresses cub.bench.radix_sort.keys.base up to 30% on H200, see cccl_private/#586
         // int leader      = ::cuda::std::__bit_log2(bin_mask);
-        int leader      = (WARP_THREADS - 1) - ::cuda::std::countl_zero(bin_mask);
-        int warp_offset = 0;
-        int popc        = ::cuda::std::popcount(bin_mask & ::cuda::ptx::get_sreg_lanemask_le());
+        const int leader = (WARP_THREADS - 1) - ::cuda::std::countl_zero(bin_mask);
+        int warp_offset  = 0;
+        const int popc   = ::cuda::std::popcount(bin_mask & ::cuda::ptx::get_sreg_lanemask_le());
         if (lane == leader)
         {
           // atomic is a bit faster

--- a/cub/cub/block/block_radix_sort.cuh
+++ b/cub/cub/block/block_radix_sort.cuh
@@ -374,7 +374,7 @@ private:
     // Radix sorting passes
     while (true)
     {
-      int pass_bits = ::cuda::std::min(RadixBits, end_bit - begin_bit);
+      const int pass_bits = ::cuda::std::min(RadixBits, end_bit - begin_bit);
       auto digit_extractor =
         traits::template digit_extractor<fundamental_digit_extractor_t>(begin_bit, pass_bits, decomposer);
 
@@ -453,7 +453,7 @@ public:
     // Radix sorting passes
     while (true)
     {
-      int pass_bits = ::cuda::std::min(RadixBits, end_bit - begin_bit);
+      const int pass_bits = ::cuda::std::min(RadixBits, end_bit - begin_bit);
       auto digit_extractor =
         traits::template digit_extractor<fundamental_digit_extractor_t>(begin_bit, pass_bits, decomposer);
 

--- a/cub/cub/block/block_scan.cuh
+++ b/cub/cub/block/block_scan.cuh
@@ -1500,7 +1500,7 @@ public:
     else
     {
       // Reduce consecutive thread items in registers
-      ::cuda::std::plus<> scan_op;
+      const ::cuda::std::plus<> scan_op;
       T thread_prefix = cub::ThreadReduce(input, scan_op);
 
       // Exclusive thread block-scan
@@ -1566,7 +1566,7 @@ public:
     else
     {
       // Reduce consecutive thread items in registers
-      ::cuda::std::plus<> scan_op;
+      const ::cuda::std::plus<> scan_op;
       T thread_prefix = cub::ThreadReduce(input, scan_op);
 
       // Exclusive thread block-scan
@@ -1650,7 +1650,7 @@ public:
     else
     {
       // Reduce consecutive thread items in registers
-      ::cuda::std::plus<> scan_op;
+      const ::cuda::std::plus<> scan_op;
       T thread_prefix = cub::ThreadReduce(input, scan_op);
 
       // Exclusive thread block-scan

--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -339,9 +339,9 @@ template <typename T, int ItemsPerThread, typename OutputIteratorT>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 StoreDirectWarpStriped(int linear_tid, OutputIteratorT block_itr, T (&items)[ItemsPerThread])
 {
-  int tid         = linear_tid & (detail::warp_threads - 1);
-  int wid         = linear_tid >> detail::log2_warp_threads;
-  int warp_offset = wid * detail::warp_threads * ItemsPerThread;
+  const int tid         = linear_tid & (detail::warp_threads - 1);
+  const int wid         = linear_tid >> detail::log2_warp_threads;
+  const int warp_offset = wid * detail::warp_threads * ItemsPerThread;
 
   OutputIteratorT thread_itr = block_itr + warp_offset + tid;
 
@@ -393,9 +393,9 @@ template <typename T, int ItemsPerThread, typename OutputIteratorT>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 StoreDirectWarpStriped(int linear_tid, OutputIteratorT block_itr, T (&items)[ItemsPerThread], int valid_items)
 {
-  int tid         = linear_tid & (detail::warp_threads - 1);
-  int wid         = linear_tid >> detail::log2_warp_threads;
-  int warp_offset = wid * detail::warp_threads * ItemsPerThread;
+  const int tid         = linear_tid & (detail::warp_threads - 1);
+  const int wid         = linear_tid >> detail::log2_warp_threads;
+  const int warp_offset = wid * detail::warp_threads * ItemsPerThread;
 
   OutputIteratorT thread_itr = block_itr + warp_offset + tid;
 

--- a/cub/cub/block/radix_rank_sort_operations.cuh
+++ b/cub/cub/block/radix_rank_sort_operations.cuh
@@ -74,9 +74,9 @@ struct BaseDigitExtractor<KeyT, true>
 
   static _CCCL_HOST_DEVICE _CCCL_FORCEINLINE UnsignedBits ProcessFloatMinusZero(UnsignedBits key)
   {
-    UnsignedBits TWIDDLED_MINUS_ZERO_BITS =
+    const UnsignedBits TWIDDLED_MINUS_ZERO_BITS =
       TraitsT::TwiddleIn(UnsignedBits(1) << UnsignedBits(8 * sizeof(UnsignedBits) - 1));
-    UnsignedBits TWIDDLED_ZERO_BITS = TraitsT::TwiddleIn(0);
+    const UnsignedBits TWIDDLED_ZERO_BITS = TraitsT::TwiddleIn(0);
     return key == TWIDDLED_MINUS_ZERO_BITS ? TWIDDLED_ZERO_BITS : key;
   }
 };
@@ -406,7 +406,7 @@ struct digit_f
 
       if (bits_to_copy)
       {
-        bit_ordered_type ordered_src =
+        const bit_ordered_type ordered_src =
           BaseDigitExtractor<T>::ProcessFloatMinusZero(reinterpret_cast<bit_ordered_type&>(src));
 
         const ::cuda::std::uint32_t mask = (1 << bits_to_copy) - 1;

--- a/cub/cub/block/specializations/block_histogram_sort.cuh
+++ b/cub/cub/block/specializations/block_histogram_sort.cuh
@@ -171,7 +171,7 @@ struct BlockHistogramSort
     int flags[ItemsPerThread]; // unused
 
     // Compute head flags to demarcate contiguous runs of the same bin in the sorted tile
-    DiscontinuityOp flag_op(temp_storage);
+    const DiscontinuityOp flag_op(temp_storage);
     BlockDiscontinuityT(temp_storage.discontinuities.flag).FlagHeads(flags, items, flag_op);
 
     // Update begin for first item
@@ -188,7 +188,7 @@ struct BlockHistogramSort
     _CCCL_PRAGMA_UNROLL_FULL()
     for (; histo_offset + BLOCK_THREADS <= Bins; histo_offset += BLOCK_THREADS)
     {
-      int thread_offset = histo_offset + linear_tid;
+      const int thread_offset = histo_offset + linear_tid;
       CounterT count =
         temp_storage.discontinuities.run_end[thread_offset] - temp_storage.discontinuities.run_begin[thread_offset];
       histogram[thread_offset] += count;
@@ -197,7 +197,7 @@ struct BlockHistogramSort
     // Finish up with guarded composition if necessary
     if ((Bins % BLOCK_THREADS != 0) && (histo_offset + linear_tid < Bins))
     {
-      int thread_offset = histo_offset + linear_tid;
+      const int thread_offset = histo_offset + linear_tid;
       CounterT count =
         temp_storage.discontinuities.run_end[thread_offset] - temp_storage.discontinuities.run_begin[thread_offset];
       histogram[thread_offset] += count;

--- a/cub/cub/block/specializations/block_reduce_raking.cuh
+++ b/cub/cub/block/specializations/block_reduce_raking.cuh
@@ -191,11 +191,12 @@ struct BlockReduceRaking
 
         partial = RakingReduction<IS_FULL_TILE>(reduction_op, raking_segment, partial, num_valid, constant_v<1>);
 
-        int valid_raking_threads = (IS_FULL_TILE) ? RAKING_THREADS : (num_valid + SEGMENT_LENGTH - 1) / SEGMENT_LENGTH;
+        const int valid_raking_threads =
+          (IS_FULL_TILE) ? RAKING_THREADS : (num_valid + SEGMENT_LENGTH - 1) / SEGMENT_LENGTH;
 
         // sync before re-using shmem (warp_storage/raking_grid are aliased)
         static_assert(RAKING_THREADS <= warp_threads, "RAKING_THREADS must be <= warp size.");
-        unsigned int mask = static_cast<unsigned int>((1ull << RAKING_THREADS) - 1);
+        const unsigned int mask = static_cast<unsigned int>((1ull << RAKING_THREADS) - 1);
         __syncwarp(mask);
 
         partial = WarpReduce(temp_storage.warp_storage)
@@ -220,7 +221,7 @@ struct BlockReduceRaking
   template <bool IS_FULL_TILE>
   _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T partial, int num_valid)
   {
-    ::cuda::std::plus<> reduction_op;
+    const ::cuda::std::plus<> reduction_op;
 
     return Reduce<IS_FULL_TILE>(partial, num_valid, reduction_op);
   }

--- a/cub/cub/block/specializations/block_reduce_warp_reductions.cuh
+++ b/cub/cub/block/specializations/block_reduce_warp_reductions.cuh
@@ -125,7 +125,7 @@ struct BlockReduceWarpReductions
       NV_IF_ELSE_TARGET(
         NV_PROVIDES_SM_60,
         ({
-          ::cuda::atomic_ref<T, ::cuda::thread_scope_block> atomic_target(temp_storage.warp_aggregates[0]);
+          const ::cuda::atomic_ref<T, ::cuda::thread_scope_block> atomic_target(temp_storage.warp_aggregates[0]);
           atomic_target.fetch_add(warp_aggregate, ::cuda::memory_order_relaxed);
         }),
         (atomicAdd(&temp_storage.warp_aggregates[0], warp_aggregate);));
@@ -189,7 +189,7 @@ struct BlockReduceWarpReductions
   template <bool FullTile>
   _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T input, int num_valid)
   {
-    ::cuda::std::plus<> reduction_op;
+    const ::cuda::std::plus<> reduction_op;
     const int warp_offset = (warp_id * logical_warp_size);
     const int warp_num_valid =
       ((FullTile && even_warp_multiple) || (warp_offset + logical_warp_size <= num_valid))

--- a/cub/cub/block/specializations/block_topk_air.cuh
+++ b/cub/cub/block/specializations/block_topk_air.cuh
@@ -417,14 +417,14 @@ private:
     }
 
     // TODO (elstehle): Add support for custom decomposers
-    identity_decomposer_t decomposer;
+    const identity_decomposer_t decomposer;
 
     // Get bit-twiddled sortkeys. For float keys, -0.0 is normalized to +0.0 for ranking. When
     // not scattering the original keys, track which keys were -0.0 so we can restore -0.0 in
     // the output via a bitvector.
     bit_ordered_type(&unsigned_keys)[ItemsPerThread] = reinterpret_cast<bit_ordered_type(&)[ItemsPerThread]>(keys);
     constexpr int flip_back_num_words                = ::cuda::ceil_div(items_per_thread, 32);
-    [[maybe_unused]] ::cuda::std::uint32_t flip_back_bits[flip_back_num_words] = {};
+    [[maybe_unused]] ::cuda::std::uint32_t flip_back_bits[flip_back_num_words] = {}; // NOLINT(misc-const-correctness)
     if constexpr (::cuda::is_floating_point_v<KeyT>)
     {
       const bit_ordered_type twiddled_minus_zero =

--- a/cub/cub/detail/fast_modulo_division.cuh
+++ b/cub/cub/detail/fast_modulo_division.cuh
@@ -156,7 +156,7 @@ public:
     }
     constexpr int BitSize   = sizeof(T) * CHAR_BIT; // 32
     constexpr int BitOffset = BitSize / 16; // 2
-    int num_bits            = ::cuda::std::bit_width(udivisor) + 1;
+    const int num_bits      = ::cuda::std::bit_width(udivisor) + 1;
     _CCCL_ASSERT(static_cast<size_t>(num_bits + BitSize - BitOffset) < sizeof(larger_t) * CHAR_BIT, "overflow error");
     // without explicit power-of-two check, num_bits needs to replace +1 with !::cuda::is_power_of_two(udivisor)
     _multiplier  = static_cast<unsigned_t>(::cuda::ceil_div(larger_t{1} << (num_bits + BitSize - BitOffset), //

--- a/cub/cub/detail/launcher/cuda_runtime.cuh
+++ b/cub/cub/detail/launcher/cuda_runtime.cuh
@@ -29,11 +29,11 @@ struct TripleChevronFactory
   {
     if (dependent_launch)
     {
-      [[maybe_unused]] int sm_version = 0;
+      [[maybe_unused]] int sm_version = 0; // NOLINT(misc-const-correctness)
       _CCCL_ASSERT(SmVersion(sm_version) == cudaSuccess, "Failed to query SM compute capability");
       if (sm_version >= 900)
       {
-        [[maybe_unused]] ::cuda::compute_capability cc;
+        [[maybe_unused]] ::cuda::compute_capability cc; // NOLINT(misc-const-correctness)
         _CCCL_ASSERT(PtxComputeCap(cc) == cudaSuccess, "Failed to query PTX compute capability");
         _CCCL_ASSERT((cc >= ::cuda::compute_capability{9, 0}),
                      "Enabling PDL for a kernel launch requires CC 9.0+ PTX/SASS when running on SM90+");
@@ -69,7 +69,7 @@ struct TripleChevronFactory
   _CCCL_HIDE_FROM_ABI CUB_RUNTIME_FUNCTION ::cudaError_t MultiProcessorCount(int& sm_count) const
   {
     int device_ordinal;
-    ::cudaError_t error = CubDebug(::cudaGetDevice(&device_ordinal));
+    const ::cudaError_t error = CubDebug(::cudaGetDevice(&device_ordinal));
     if (::cudaSuccess != error)
     {
       return error;
@@ -89,7 +89,7 @@ struct TripleChevronFactory
   _CCCL_HIDE_FROM_ABI CUB_RUNTIME_FUNCTION ::cudaError_t MaxGridDimX(int& max_grid_dim_x) const
   {
     int device_ordinal;
-    ::cudaError_t error = CubDebug(::cudaGetDevice(&device_ordinal));
+    const ::cudaError_t error = CubDebug(::cudaGetDevice(&device_ordinal));
     if (::cudaSuccess != error)
     {
       return error;

--- a/cub/cub/detail/rfa.cuh
+++ b/cub/cub/detail/rfa.cuh
@@ -104,7 +104,7 @@ private:
   /// Return a binned floating-point bin
   [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE static ftype binned_bins(int index)
   {
-    ftype* bins = get_shared_bin_array<ftype, max_index + max_fold>();
+    const ftype* bins = get_shared_bin_array<ftype, max_index + max_fold>();
     return bins[index];
   }
 
@@ -286,8 +286,8 @@ private:
   //! with absolute value less than @p max_abs_val
   _CCCL_DEVICE void binned_update(const ftype max_abs_val)
   {
-    int X_index = binned_dindex(max_abs_val);
-    int shift   = binned_index() - X_index;
+    const int X_index = binned_dindex(max_abs_val);
+    const int shift   = binned_index() - X_index;
     if (shift > 0)
     {
       _CCCL_PRAGMA_UNROLL_FULL()
@@ -468,9 +468,9 @@ private:
     const auto X_index = binned_index();
     if (X_index <= (3 * mant_dig) / bin_width)
     {
-      double scale_down = ::cuda::std::ldexpf(0.5f, 1 - (2 * mant_dig - bin_width));
-      double scale_up   = ::cuda::std::ldexpf(0.5f, 1 - (2 * mant_dig - bin_width));
-      int scaled        = ::cuda::std::max(::cuda::std::min(Fold, (3 * mant_dig) / bin_width - X_index), 0);
+      const double scale_down = ::cuda::std::ldexpf(0.5f, 1 - (2 * mant_dig - bin_width));
+      const double scale_up   = ::cuda::std::ldexpf(0.5f, 1 - (2 * mant_dig - bin_width));
+      const int scaled        = ::cuda::std::max(::cuda::std::min(Fold, (3 * mant_dig) / bin_width - X_index), 0);
       if (X_index == 0)
       {
         Y += carry(0) * ((binned_bins(0 + X_index) / 6.0) * scale_down * expansion);

--- a/cub/cub/detail/temporary_storage.cuh
+++ b/cub/cub/detail/temporary_storage.cuh
@@ -314,7 +314,7 @@ public:
 
     this->prepare_interface();
 
-    if (cudaError_t error = detail::alias_temporaries(d_temp_storage, temp_storage_bytes, m_pointers, m_sizes))
+    if (const cudaError_t error = detail::alias_temporaries(d_temp_storage, temp_storage_bytes, m_pointers, m_sizes))
     {
       return error;
     }

--- a/cub/cub/detail/warpspeed/allocators/smem_allocator.cuh
+++ b/cub/cub/detail/warpspeed/allocators/smem_allocator.cuh
@@ -66,7 +66,7 @@ struct SmemAllocator
         NV_IS_DEVICE,
         (
           // Convert allocated smem address to generic pointer
-          void* mPtrAllocation = __cvta_shared_to_generic(ptrAllocation32);
+          const void* mPtrAllocation = __cvta_shared_to_generic(ptrAllocation32);
           // Ensure alignment calculation does not move down into rest of kernel code.
           return optimizeSmemPtr(mPtrAllocation);))
     }

--- a/cub/cub/detail/warpspeed/resource/smem_resource.cuh
+++ b/cub/cub/detail/warpspeed/resource/smem_resource.cuh
@@ -47,9 +47,9 @@ private:
   [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr SmemResourceRaw
   makeSmemResourceRaw(SyncHandler& syncHandler, SmemAllocator& smemAllocator, Stages stages, Elems elems = Elems{1})
   {
-    int align       = alignof(_Tp);
-    int sizeBytes   = ::cuda::std::to_underlying(elems) * sizeof(_Tp);
-    int strideBytes = sizeBytes;
+    const int align       = alignof(_Tp);
+    const int sizeBytes   = ::cuda::std::to_underlying(elems) * sizeof(_Tp);
+    const int strideBytes = sizeBytes;
 
     void* ptrBase = smemAllocator.alloc(::cuda::std::to_underlying(stages) * strideBytes, align);
     return {syncHandler, ptrBase, sizeBytes, strideBytes, ::cuda::std::to_underlying(stages)};

--- a/cub/cub/detail/warpspeed/resource/smem_resource_raw.cuh
+++ b/cub/cub/detail/warpspeed/resource/smem_resource_raw.cuh
@@ -67,9 +67,9 @@ struct SmemResourceRaw
   _CCCL_HOST_DEVICE_API constexpr void
   addPhase(SyncHandler& syncHandler, ::cuda::std::uint64_t* ptrBarrier, const SquadDesc (&squads)[numSquads])
   {
-    int numOwningThreads = squadCountThreads(squads);
+    const int numOwningThreads = squadCountThreads(squads);
 
-    int curPhase = mNumPhases;
+    const int curPhase = mNumPhases;
     mNumPhases++;
 
     syncHandler.registerPhase(mResourceHandle, numOwningThreads, ptrBarrier);
@@ -169,7 +169,7 @@ struct SmemResourceRaw
 
     // The release of the previous phase occurs on the `phase - 1` barrier. So
     // that is what we wait on.
-    int phaseAcq                       = (mNumPhases + phase - 1) % mNumPhases;
+    const int phaseAcq                 = (mNumPhases + phase - 1) % mNumPhases;
     ::cuda::std::uint64_t* ptrBarPhase = mPtrBar[phaseAcq];
 
     while (!::cuda::ptx::mbarrier_try_wait_parity(&ptrBarPhase[mStageCurrent], mParity[phase]))

--- a/cub/cub/detail/warpspeed/sync_handler.cuh
+++ b/cub/cub/detail/warpspeed/sync_handler.cuh
@@ -70,7 +70,7 @@ struct SyncHandler
     _WS_CONSTANT_ASSERT(mNextResourceHandle < mMaxNumResources, "Cannot register more than 10 resources.");
 
     // Get a handle
-    int handle = mNextResourceHandle;
+    const int handle = mNextResourceHandle;
     mNextResourceHandle++;
     // Set the number of stages
     mNumStages[handle] = numStages;
@@ -84,7 +84,7 @@ struct SyncHandler
     _WS_CONSTANT_ASSERT(resourceHandle < mNextResourceHandle, "Invalid resource handle.");
 
     // Get phase index:
-    int curPhase = mNumPhases[resourceHandle];
+    const int curPhase = mNumPhases[resourceHandle];
     _WS_CONSTANT_ASSERT(curPhase < mMaxNumPhases, "Cannot register more phases than maximum.");
 
     mNumOwningThreads[resourceHandle][curPhase] = numOwningThreads;
@@ -118,8 +118,8 @@ struct SyncHandler
           break;
         }
 
-        uint64_t* ptrBar     = mPtrBar[ri][pi];
-        int numOwningThreads = mNumOwningThreads[ri][pi];
+        uint64_t* ptrBar           = mPtrBar[ri][pi];
+        const int numOwningThreads = mNumOwningThreads[ri][pi];
         // use block strided iteration to vectorize setup of barriers
         for (int si = static_cast<int>(sr.threadIdxX); si < numStages; si += NumThreads)
         {

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -1331,15 +1331,15 @@ public:
   __for_each_in_extents(const LayoutMapping& layout_mapping, OpType op, const EnvT& env = {})
   {
     using namespace cub::detail;
-    using extents_type                   = typename LayoutMapping::extents_type;
-    using extent_index_type              = typename extents_type::index_type;
-    using fast_mod_array_t               = ::cuda::std::array<fast_div_mod<extent_index_type>, extents_type::rank()>;
-    static constexpr auto seq            = ::cuda::std::make_index_sequence<extents_type::rank()>{};
-    constexpr bool is_layout_right       = ::cuda::std::__is_cuda_std_layout_right_mapping_v<LayoutMapping>;
-    auto extents                         = layout_mapping.extents();
-    fast_mod_array_t sub_sizes_div_array = cub::detail::sub_sizes_fast_div_mod<is_layout_right>(extents, seq);
-    fast_mod_array_t extents_div_array   = cub::detail::extents_fast_div_mod(extents, seq);
-    for_each::op_wrapper_extents_t<OpType, extents_type, is_layout_right, fast_mod_array_t> op_wrapper{
+    using extents_type             = typename LayoutMapping::extents_type;
+    using extent_index_type        = typename extents_type::index_type;
+    using fast_mod_array_t         = ::cuda::std::array<fast_div_mod<extent_index_type>, extents_type::rank()>;
+    static constexpr auto seq      = ::cuda::std::make_index_sequence<extents_type::rank()>{};
+    constexpr bool is_layout_right = ::cuda::std::__is_cuda_std_layout_right_mapping_v<LayoutMapping>;
+    auto extents                   = layout_mapping.extents();
+    const fast_mod_array_t sub_sizes_div_array = cub::detail::sub_sizes_fast_div_mod<is_layout_right>(extents, seq);
+    const fast_mod_array_t extents_div_array   = cub::detail::extents_fast_div_mod(extents, seq);
+    const for_each::op_wrapper_extents_t<OpType, extents_type, is_layout_right, fast_mod_array_t> op_wrapper{
       op, extents, sub_sizes_div_array, extents_div_array};
     using ShapeT = implicit_prom_t<extent_index_type>;
     auto shape   = static_cast<ShapeT>(cub::detail::size(extents));

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -1428,10 +1428,10 @@ public:
     // Wrapped input iterator to produce index-value <OffsetT, InputT> tuples
     using ArgIndexInputIteratorT = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
 
-    ArgIndexInputIteratorT d_indexed_in(d_in);
+    const ArgIndexInputIteratorT d_indexed_in(d_in);
 
     // Initial value
-    init_value_t initial_value{AccumT(1, ::cuda::std::numeric_limits<InputValueT>::max())};
+    const init_value_t initial_value{AccumT(1, ::cuda::std::numeric_limits<InputValueT>::max())};
 
     return detail::reduce::dispatch<AccumT>(
       d_temp_storage,
@@ -1891,10 +1891,10 @@ public:
     // Wrapped input iterator to produce index-value <OffsetT, InputT> tuples
     using ArgIndexInputIteratorT = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
 
-    ArgIndexInputIteratorT d_indexed_in(d_in);
+    const ArgIndexInputIteratorT d_indexed_in(d_in);
 
     // Initial value
-    init_value_t initial_value{AccumT(1, ::cuda::std::numeric_limits<InputValueT>::lowest())};
+    const init_value_t initial_value{AccumT(1, ::cuda::std::numeric_limits<InputValueT>::lowest())};
 
     return detail::reduce::dispatch<AccumT>(
       d_temp_storage,

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -388,7 +388,7 @@ struct DeviceScan
     using init_value_t = cub::detail::it_value_t<InputIteratorT>;
 
     // Initial value
-    init_value_t init_value{};
+    const init_value_t init_value{};
 
     return detail::scan::dispatch(
       d_temp_storage,
@@ -468,7 +468,7 @@ struct DeviceScan
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceScan::ExclusiveSum");
 
     using init_value_t = cub::detail::it_value_t<InputIteratorT>;
-    init_value_t init_value{};
+    const init_value_t init_value{};
 
     return scan_impl_env(
       d_in, d_out, ::cuda::std::plus<>{}, detail::InputValue<init_value_t>(init_value), num_items, env);
@@ -2672,7 +2672,7 @@ struct DeviceScan
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceScan::ExclusiveSumByKey");
     using init_value_t = cub::detail::it_value_t<ValuesInputIteratorT>;
-    init_value_t init_value{};
+    const init_value_t init_value{};
     return scan_by_key_impl<::cuda::std::execution::env<>>(
       d_temp_storage,
       temp_storage_bytes,

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -143,7 +143,7 @@ private:
     constexpr bool is_min = ::cuda::std::is_same_v<ReductionOpT, cub::detail::arg_min>;
     auto sentinel =
       is_min ? ::cuda::std::numeric_limits<input_value_t>::max() : ::cuda::std::numeric_limits<input_value_t>::lowest();
-    init_value_t initial_value{accum_t(1, sentinel)};
+    const init_value_t initial_value{accum_t(1, sentinel)};
 
     using default_policy_selector_t =
       detail::segmented_reduce::policy_selector_from_types<accum_t, offset_t, ReductionOpT>;
@@ -1650,9 +1650,9 @@ public:
 
     // Wrapped input iterator to produce index-value <OverrideOffsetT, InputT> tuples
     using ArgIndexInputIteratorT = ArgIndexInputIterator<InputIteratorT, OverrideOffsetT, OutputValueT>;
-    ArgIndexInputIteratorT d_indexed_in(d_in);
+    const ArgIndexInputIteratorT d_indexed_in(d_in);
 
-    init_value_t initial_value{OverrideAccumT(1, ::cuda::std::numeric_limits<InputValueT>::max())};
+    const init_value_t initial_value{OverrideAccumT(1, ::cuda::std::numeric_limits<InputValueT>::max())};
 
     static_assert(::cuda::std::is_integral_v<OverrideOffsetT>, "Offset iterator value type should be integral.");
     if constexpr (::cuda::std::is_integral_v<OverrideOffsetT>)
@@ -1788,9 +1788,9 @@ public:
 
     // Wrapped input iterator to produce index-value <OverrideOffsetT, InputT> tuples
     using ArgIndexInputIteratorT = ArgIndexInputIterator<InputIteratorT, OverrideOffsetT, OutputValueT>;
-    ArgIndexInputIteratorT d_indexed_in(d_in);
+    const ArgIndexInputIteratorT d_indexed_in(d_in);
 
-    init_value_t initial_value{OverrideAccumT(1, ::cuda::std::numeric_limits<InputValueT>::max())};
+    const init_value_t initial_value{OverrideAccumT(1, ::cuda::std::numeric_limits<InputValueT>::max())};
 
     return variable_size_env_impl<OverrideAccumT, OverrideOffsetT>(
       d_indexed_in, d_out, num_segments, d_begin_offsets, d_end_offsets, cub::ArgMin{}, initial_value, env);
@@ -2448,9 +2448,9 @@ public:
 
     // Wrapped input iterator to produce index-value <OverrideOffsetT, InputT> tuples
     using ArgIndexInputIteratorT = ArgIndexInputIterator<InputIteratorT, OverrideOffsetT, OutputValueT>;
-    ArgIndexInputIteratorT d_indexed_in(d_in);
+    const ArgIndexInputIteratorT d_indexed_in(d_in);
 
-    init_value_t initial_value{OverrideAccumT(1, ::cuda::std::numeric_limits<InputValueT>::lowest())};
+    const init_value_t initial_value{OverrideAccumT(1, ::cuda::std::numeric_limits<InputValueT>::lowest())};
 
     static_assert(::cuda::std::is_integral_v<OverrideOffsetT>, "Offset iterator value type should be integral.");
     if constexpr (::cuda::std::is_integral_v<OverrideOffsetT>)
@@ -2586,9 +2586,9 @@ public:
 
     // Wrapped input iterator to produce index-value <OverrideOffsetT, InputT> tuples
     using ArgIndexInputIteratorT = ArgIndexInputIterator<InputIteratorT, OverrideOffsetT, OutputValueT>;
-    ArgIndexInputIteratorT d_indexed_in(d_in);
+    const ArgIndexInputIteratorT d_indexed_in(d_in);
 
-    init_value_t initial_value{OverrideAccumT(1, ::cuda::std::numeric_limits<InputValueT>::lowest())};
+    const init_value_t initial_value{OverrideAccumT(1, ::cuda::std::numeric_limits<InputValueT>::lowest())};
 
     return variable_size_env_impl<OverrideAccumT, OverrideOffsetT>(
       d_indexed_in, d_out, num_segments, d_begin_offsets, d_end_offsets, cub::ArgMax{}, initial_value, env);

--- a/cub/cub/device/device_segmented_scan.cuh
+++ b/cub/cub/device/device_segmented_scan.cuh
@@ -216,10 +216,10 @@ public:
     check_common_iterator_value_is_integral<BeginOffsetIteratorInputT, EndOffsetIteratorInputT>();
 
     using scan_op_t = ::cuda::std::plus<>;
-    scan_op_t scan_op{};
+    const scan_op_t scan_op{};
 
     using init_value_t = detail::it_value_t<InputIteratorT>;
-    init_value_t init_value{};
+    const init_value_t init_value{};
 
     return detail::segmented_scan::dispatch(
       d_temp_storage,
@@ -471,10 +471,10 @@ public:
                                             BeginOffsetIteratorOutputT>();
 
     using scan_op_t = ::cuda::std::plus<>;
-    scan_op_t scan_op{};
+    const scan_op_t scan_op{};
 
     using init_value_t = cub::detail::it_value_t<InputIteratorT>;
-    init_value_t init_value{};
+    const init_value_t init_value{};
 
     return cub::detail::segmented_scan::dispatch(
       d_temp_storage,
@@ -1259,7 +1259,7 @@ public:
     check_common_iterator_value_is_integral<BeginOffsetIteratorInputT, EndOffsetIteratorInputT>();
 
     using scan_op_t = ::cuda::std::plus<>;
-    scan_op_t scan_op{};
+    const scan_op_t scan_op{};
 
     return cub::detail::segmented_scan::dispatch(
       d_temp_storage,
@@ -1502,7 +1502,7 @@ public:
                                             BeginOffsetIteratorOutputT>();
 
     using scan_op_t = ::cuda::std::plus<>;
-    scan_op_t scan_op{};
+    const scan_op_t scan_op{};
 
     return cub::detail::segmented_scan::dispatch(
       d_temp_storage,

--- a/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
+++ b/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
@@ -90,8 +90,8 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceAdjacentDifferenceDifferenceKernel(
 
   Agent agent(storage, input, first_tile_previous, result, difference_op, num_items);
 
-  int tile_idx      = static_cast<int>(blockIdx.x);
-  OffsetT tile_base = static_cast<OffsetT>(tile_idx) * AdjacentDifferencePolicyT::ITEMS_PER_TILE;
+  const int tile_idx = static_cast<int>(blockIdx.x);
+  OffsetT tile_base  = static_cast<OffsetT>(tile_idx) * AdjacentDifferencePolicyT::ITEMS_PER_TILE;
 
   agent.Process(tile_idx, tile_base);
 }
@@ -166,10 +166,10 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceAdjacentDifference"
       constexpr int tile_size = AdjacentDifferencePolicyT::ITEMS_PER_TILE;
       const int num_tiles     = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
 
-      size_t first_tile_previous_size = (AliasOpt == MayAlias::Yes) * num_tiles * sizeof(InputT);
+      const size_t first_tile_previous_size = (AliasOpt == MayAlias::Yes) * num_tiles * sizeof(InputT);
 
-      void* allocations[1]       = {nullptr};
-      size_t allocation_sizes[1] = {(AliasOpt == MayAlias::Yes) * first_tile_previous_size};
+      void* allocations[1]             = {nullptr};
+      const size_t allocation_sizes[1] = {(AliasOpt == MayAlias::Yes) * first_tile_previous_size};
 
       error = CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes));
 
@@ -384,10 +384,10 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   const int tile_size = active_policy.threads_per_block * active_policy.items_per_thread;
   const int num_tiles = static_cast<int>(::cuda::ceil_div(static_cast<offset_t>(num_items), tile_size));
 
-  size_t first_tile_previous_size = (AliasOpt == MayAlias::Yes) * num_tiles * sizeof(input_t);
+  const size_t first_tile_previous_size = (AliasOpt == MayAlias::Yes) * num_tiles * sizeof(input_t);
 
-  void* allocations[1]       = {nullptr};
-  size_t allocation_sizes[1] = {(AliasOpt == MayAlias::Yes) * first_tile_previous_size};
+  void* allocations[1]             = {nullptr};
+  const size_t allocation_sizes[1] = {(AliasOpt == MayAlias::Yes) * first_tile_previous_size};
 
   if (const auto error =
         CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -136,7 +136,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().lookback.large_buffer.thr
     const BufferOffsetT buffer_id = block_buffer_id;
 
     // The relative offset of this tile within the buffer it's assigned to
-    BufferSizeT tile_offset_within_buffer =
+    const BufferSizeT tile_offset_within_buffer =
       static_cast<BufferSizeT>(tile_id - buffer_tile_offsets[buffer_id]) * TILE_SIZE;
 
     // If the tile has already reached beyond the work of the end of the last buffer

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -754,7 +754,7 @@ _CCCL_HOST_API cudaError_t launch_baseline_arm(
     //                                                       [2] large-segment ids.
     //   !any_small_segments (large-only): [0] tile offsets, [1] segment-size transform-scan temp storage.
     static constexpr int allocations_array_size     = only_small_segments ? 1 : (any_small_segments ? 3 : 2);
-    size_t allocation_sizes[allocations_array_size] = {1};
+    size_t allocation_sizes[allocations_array_size] = {1}; // NOLINT(misc-const-correctness)
 
     using num_segments_val_t         = typename ::cuda::args::__traits<NumSegmentsParameterT>::element_type;
     using counters_t                 = batched_topk_counters<num_segments_val_t>;

--- a/cub/cub/device/dispatch/dispatch_find.cuh
+++ b/cub/cub/device/dispatch/dispatch_find.cuh
@@ -158,8 +158,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   const int findif_grid_size = ::cuda::std::min(num_tiles, max_blocks);
 
   // Temporary storage allocation requirements
-  void* allocations[1]       = {};
-  size_t allocation_sizes[1] = {sizeof(OffsetT)};
+  void* allocations[1]             = {};
+  const size_t allocation_sizes[1] = {sizeof(OffsetT)};
   if (const auto error =
         CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
   {
@@ -171,7 +171,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     return cudaSuccess;
   }
 
-  OffsetT* found_pos_ptr = [&] {
+  OffsetT* found_pos_ptr = [&] { // NOLINT(misc-const-correctness)
     if constexpr (can_write_to_output_directly)
     {
       return reinterpret_cast<OffsetT*>(THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_out));

--- a/cub/cub/device/dispatch/dispatch_for.cuh
+++ b/cub/cub/device/dispatch/dispatch_for.cuh
@@ -37,7 +37,7 @@ template <typename PolicySelector, typename OffsetT, typename OpT>
 CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t
 invoke_dynamic_block_size(OffsetT num_items, OpT op, cudaStream_t stream, ForPolicy active_policy)
 {
-  int threads_per_block = 256;
+  int threads_per_block = 256; // NOLINT(misc-const-correctness)
   auto kernel           = detail::for_each::dynamic_kernel<PolicySelector, OffsetT, OpT>;
   NV_IF_TARGET(NV_IS_HOST, ({
                  int _{};

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -252,7 +252,7 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
   }
 
   // Get device occupancy for sweep_kernel
-  int histogram_sweep_occupancy = histogram_sweep_sm_occupancy * sm_count;
+  const int histogram_sweep_occupancy = histogram_sweep_sm_occupancy * sm_count;
 
   if (num_row_pixels * NUM_CHANNELS == row_stride_samples)
   {
@@ -263,14 +263,14 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
   }
 
   // Get grid dimensions, trying to keep total blocks ~histogram_sweep_occupancy
-  int pixels_per_tile = threads_per_block * pixels_per_thread;
-  int tiles_per_row   = static_cast<int>(::cuda::ceil_div(num_row_pixels, pixels_per_tile));
-  int blocks_per_row  = ::cuda::std::min(histogram_sweep_occupancy, tiles_per_row);
-  int blocks_per_col =
+  const int pixels_per_tile = threads_per_block * pixels_per_thread;
+  const int tiles_per_row   = static_cast<int>(::cuda::ceil_div(num_row_pixels, pixels_per_tile));
+  const int blocks_per_row  = ::cuda::std::min(histogram_sweep_occupancy, tiles_per_row);
+  const int blocks_per_col =
     (blocks_per_row > 0)
       ? int(::cuda::std::min(static_cast<OffsetT>(histogram_sweep_occupancy / blocks_per_row), num_rows))
       : 0;
-  int num_thread_blocks = blocks_per_row * blocks_per_col;
+  const int num_thread_blocks = blocks_per_row * blocks_per_col;
 
   dim3 sweep_grid_dims;
   sweep_grid_dims.x = (unsigned int) blocks_per_row;
@@ -305,7 +305,7 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
   }
 
   // Construct the grid queue descriptor
-  GridQueue<int> tile_queue(allocations[NUM_ALLOCATIONS - 1]);
+  const GridQueue<int> tile_queue(allocations[NUM_ALLOCATIONS - 1]);
 
   // Wrap arrays so we can pass them by-value to the kernel
   ::cuda::std::array<CounterT*, NUM_ACTIVE_CHANNELS> d_privatized_histograms_wrapper;
@@ -323,7 +323,7 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
   ::cuda::std::transform(num_output_levels.begin(), num_output_levels.end(), num_output_bins_wrapper.begin(), minus_one);
 
   constexpr int histogram_init_threads_per_block = 256;
-  int histogram_init_grid_dims =
+  const int histogram_init_grid_dims =
     (max_num_output_bins + histogram_init_threads_per_block - 1) / histogram_init_threads_per_block;
 
   // Log DeviceHistogramInitKernel configuration
@@ -838,7 +838,7 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch_range(
     using OutputDecodeOpT = typename TransformsT::template SearchTransform<const LevelT*>;
 
     ::cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_privatized_levels;
-    ::cuda::std::array<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op{};
+    const ::cuda::std::array<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op{};
     ::cuda::std::array<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op{};
     int max_levels = num_output_levels[0];
 
@@ -852,7 +852,7 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch_range(
         max_levels = num_output_levels[channel];
       }
     }
-    int max_num_output_bins = max_levels - 1;
+    const int max_num_output_bins = max_levels - 1;
 
     constexpr int PRIVATIZED_SMEM_BINS = 256;
 
@@ -894,7 +894,7 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch_range(
     using OutputDecodeOpT = typename TransformsT::PassThruTransform;
 
     ::cuda::std::array<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op{};
-    ::cuda::std::array<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op{};
+    const ::cuda::std::array<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op{};
     int max_levels = num_output_levels[0];
 
     for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
@@ -905,7 +905,7 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch_range(
         max_levels = num_output_levels[channel];
       }
     }
-    int max_num_output_bins = max_levels - 1;
+    const int max_num_output_bins = max_levels - 1;
 
     // Dispatch
     if (max_num_output_bins > max_privatized_smem_bins)
@@ -1020,7 +1020,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_even(
     using CommonT = typename TransformsT::ScaleTransform::CommonT;
 
     ::cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_privatized_levels;
-    ::cuda::std::array<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op{};
+    const ::cuda::std::array<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op{};
     ::cuda::std::array<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op{};
     int max_levels = num_output_levels[0];
 
@@ -1028,7 +1028,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_even(
     {
       num_privatized_levels[channel] = 257;
 
-      int num_levels = num_output_levels[channel];
+      const int num_levels = num_output_levels[channel];
       if (kernel_source.MayOverflow(static_cast<CommonT>(num_levels - 1), upper_level, lower_level, channel))
       {
         if (!d_temp_storage)
@@ -1045,7 +1045,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_even(
         max_levels = num_levels;
       }
     }
-    int max_num_output_bins = max_levels - 1;
+    const int max_num_output_bins = max_levels - 1;
 
     constexpr int PRIVATIZED_SMEM_BINS = 256;
 
@@ -1089,12 +1089,12 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_even(
     using CommonT = typename TransformsT::ScaleTransform::CommonT;
 
     ::cuda::std::array<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op{};
-    ::cuda::std::array<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op{};
+    const ::cuda::std::array<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op{};
     int max_levels = num_output_levels[0];
 
     for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
     {
-      int num_levels = num_output_levels[channel];
+      const int num_levels = num_output_levels[channel];
       if (kernel_source.MayOverflow(static_cast<CommonT>(num_levels - 1), upper_level, lower_level, channel))
       {
         if (!d_temp_storage)
@@ -1111,7 +1111,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_even(
         max_levels = num_levels;
       }
     }
-    int max_num_output_bins = max_levels - 1;
+    const int max_num_output_bins = max_levels - 1;
 
     if (max_num_output_bins > max_privatized_smem_bins)
     {

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -249,8 +249,8 @@ public:
       num_tiles * detail::vsmem_helper_impl<typename merge_sort_vsmem_t::merge_agent_t>::vsmem_per_block;
     const ::cuda::std::size_t virtual_shared_memory_size = (::cuda::std::max) (block_sort_smem_size, merge_smem_size);
 
-    void* allocations[4]       = {nullptr, nullptr, nullptr, nullptr};
-    size_t allocation_sizes[4] = {
+    void* allocations[4]             = {nullptr, nullptr, nullptr, nullptr};
+    const size_t allocation_sizes[4] = {
       merge_partitions_size, temporary_keys_storage_size, temporary_values_storage_size, virtual_shared_memory_size};
 
     if (const auto error =
@@ -538,8 +538,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
 #endif // CUB_DEFINE_RUNTIME_POLICIES
     const ::cuda::std::size_t virtual_shared_memory_size = (::cuda::std::max) (block_sort_smem_size, merge_smem_size);
 
-    void* allocations[4]       = {nullptr, nullptr, nullptr, nullptr};
-    size_t allocation_sizes[4] = {
+    void* allocations[4]             = {nullptr, nullptr, nullptr, nullptr};
+    const size_t allocation_sizes[4] = {
       merge_partitions_size, temporary_keys_storage_size, temporary_values_storage_size, virtual_shared_memory_size};
 
     if (const auto error =

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -347,7 +347,7 @@ public:
     int& current_bit,
     PassConfigT& pass_config)
   {
-    int pass_bits = ::cuda::std::min(pass_config.radix_bits, end_bit - current_bit);
+    const int pass_bits = ::cuda::std::min(pass_config.radix_bits, end_bit - current_bit);
 
     // Log upsweep_kernel configuration
 #ifdef CUB_DEBUG_LOG
@@ -374,7 +374,7 @@ public:
 #endif // CUB_DEBUG_LOG
 
     // Spine length written by the upsweep kernel in the current pass.
-    int pass_spine_length = pass_config.even_share.grid_size * pass_config.radix_digits;
+    const int pass_spine_length = pass_config.even_share.grid_size * pass_config.radix_digits;
 
     // Invoke upsweep_kernel with same grid size as downsweep_kernel
     launcher_factory(pass_config.even_share.grid_size, pass_config.upsweep_config.threads_per_block, 0, stream)
@@ -972,12 +972,13 @@ private:
     }
 
     // Get maximum spine length
-    int max_grid_size = ::cuda::std::max(pass_config.max_downsweep_grid_size, alt_pass_config.max_downsweep_grid_size);
-    int spine_length  = (max_grid_size * pass_config.radix_digits) + pass_config.scan_config.tile_size;
+    const int max_grid_size =
+      ::cuda::std::max(pass_config.max_downsweep_grid_size, alt_pass_config.max_downsweep_grid_size);
+    const int spine_length = (max_grid_size * pass_config.radix_digits) + pass_config.scan_config.tile_size;
 
     // Temporary storage allocation requirements
-    void* allocations[3]       = {};
-    size_t allocation_sizes[3] = {
+    void* allocations[3]             = {};
+    const size_t allocation_sizes[3] = {
       // bytes needed for privatized block digit histograms
       spine_length * sizeof(OffsetT),
 
@@ -1003,11 +1004,11 @@ private:
 
     // Pass planning.  Run passes of the alternate digit-size configuration until we have an even multiple of our
     // preferred digit size
-    int num_bits           = end_bit - begin_bit;
-    int num_passes         = ::cuda::ceil_div(num_bits, pass_config.radix_bits);
-    bool is_num_passes_odd = num_passes & 1;
-    int max_alt_passes     = (num_passes * pass_config.radix_bits) - num_bits;
-    int alt_end_bit        = ::cuda::std::min(end_bit, begin_bit + (max_alt_passes * alt_pass_config.radix_bits));
+    const int num_bits           = end_bit - begin_bit;
+    int num_passes               = ::cuda::ceil_div(num_bits, pass_config.radix_bits);
+    const bool is_num_passes_odd = num_passes & 1;
+    const int max_alt_passes     = (num_passes * pass_config.radix_bits) - num_bits;
+    const int alt_end_bit        = ::cuda::std::min(end_bit, begin_bit + (max_alt_passes * alt_pass_config.radix_bits));
 
     // Alias the temporary storage allocations
     OffsetT* d_spine = static_cast<OffsetT*>(allocations[0]);
@@ -1508,7 +1509,7 @@ struct dispatch_impl
     int& current_bit,
     PassConfigT& pass_config)
   {
-    int pass_bits = ::cuda::std::min(pass_config.radix_bits, end_bit - current_bit);
+    const int pass_bits = ::cuda::std::min(pass_config.radix_bits, end_bit - current_bit);
 
     // Log upsweep_kernel configuration
 #ifdef CUB_DEBUG_LOG
@@ -1535,7 +1536,7 @@ struct dispatch_impl
 #endif // CUB_DEBUG_LOG
 
     // Spine length written by the upsweep kernel in the current pass.
-    int pass_spine_length = pass_config.even_share.grid_size * pass_config.radix_digits;
+    const int pass_spine_length = pass_config.even_share.grid_size * pass_config.radix_digits;
 
     // Invoke upsweep_kernel with same grid size as downsweep_kernel
     if (const auto error = CubDebug(
@@ -1707,12 +1708,12 @@ struct dispatch_impl
     }
 
     // Get maximum spine length
-    int max_grid_size = ::cuda::std::max(pc.max_downsweep_grid_size, alt_pc.max_downsweep_grid_size);
-    int spine_length  = (max_grid_size * pc.radix_digits) + pc.scan_config.tile_size;
+    const int max_grid_size = ::cuda::std::max(pc.max_downsweep_grid_size, alt_pc.max_downsweep_grid_size);
+    const int spine_length  = (max_grid_size * pc.radix_digits) + pc.scan_config.tile_size;
 
     // Temporary storage allocation requirements
-    void* allocations[3]       = {};
-    size_t allocation_sizes[3] = {
+    void* allocations[3]             = {};
+    const size_t allocation_sizes[3] = {
       // bytes needed for privatized block digit histograms
       spine_length * sizeof(OffsetT),
 
@@ -1738,11 +1739,11 @@ struct dispatch_impl
 
     // Pass planning.  Run passes of the alternate digit-size configuration until we have an even multiple of our
     // preferred digit size
-    int num_bits           = end_bit - begin_bit;
-    int num_passes         = ::cuda::ceil_div(num_bits, pc.radix_bits);
-    bool is_num_passes_odd = num_passes & 1;
-    int max_alt_passes     = (num_passes * pc.radix_bits) - num_bits;
-    int alt_end_bit        = ::cuda::std::min(end_bit, begin_bit + (max_alt_passes * alt_pc.radix_bits));
+    const int num_bits           = end_bit - begin_bit;
+    int num_passes               = ::cuda::ceil_div(num_bits, pc.radix_bits);
+    const bool is_num_passes_odd = num_passes & 1;
+    const int max_alt_passes     = (num_passes * pc.radix_bits) - num_bits;
+    const int alt_end_bit        = ::cuda::std::min(end_bit, begin_bit + (max_alt_passes * alt_pc.radix_bits));
 
     // Alias the temporary storage allocations
     OffsetT* d_spine = static_cast<OffsetT*>(allocations[0]);
@@ -1821,14 +1822,14 @@ struct dispatch_impl
     const int onesweep_tile_items       = onesweep_items_per_thread * onesweep_block_threads;
     // portions handle inputs with >=2**30 elements, due to the way lookback works
     // for testing purposes, one portion is <= 2**28 elements
-    const PortionOffsetT portion_size = ((1 << 28) - 1) / onesweep_tile_items * onesweep_tile_items;
-    int num_passes                    = ::cuda::ceil_div(end_bit - begin_bit, radix_bits);
-    OffsetT num_portions              = static_cast<OffsetT>(::cuda::ceil_div(num_items, portion_size));
-    PortionOffsetT max_num_blocks     = ::cuda::ceil_div(
+    const PortionOffsetT portion_size   = ((1 << 28) - 1) / onesweep_tile_items * onesweep_tile_items;
+    const int num_passes                = ::cuda::ceil_div(end_bit - begin_bit, radix_bits);
+    OffsetT num_portions                = static_cast<OffsetT>(::cuda::ceil_div(num_items, portion_size));
+    const PortionOffsetT max_num_blocks = ::cuda::ceil_div(
       static_cast<int>(::cuda::std::min(num_items, static_cast<OffsetT>(portion_size))), onesweep_tile_items);
 
-    size_t value_size         = keys_only ? 0 : kernel_source.ValueSize();
-    size_t allocation_sizes[] = {
+    const size_t value_size         = keys_only ? 0 : kernel_source.ValueSize();
+    const size_t allocation_sizes[] = {
       // bins
       num_portions * num_passes * radix_digits * sizeof(OffsetT),
       // lookback
@@ -1854,11 +1855,11 @@ struct dispatch_impl
       return cudaSuccess;
     }
 
-    OffsetT* d_bins           = (OffsetT*) allocations[0];
+    OffsetT* d_bins           = (OffsetT*) allocations[0]; // NOLINT(misc-const-correctness)
     AtomicOffsetT* d_lookback = (AtomicOffsetT*) allocations[1];
     KeyT* d_keys_tmp2         = (KeyT*) allocations[2];
     ValueT* d_values_tmp2     = (ValueT*) allocations[3];
-    AtomicOffsetT* d_ctrs     = (AtomicOffsetT*) allocations[4];
+    AtomicOffsetT* d_ctrs     = (AtomicOffsetT*) allocations[4]; // NOLINT(misc-const-correctness)
 
     ::cuda::compute_capability cc{};
     if (const auto error = CubDebug(launcher_factory.PtxComputeCap(cc)))
@@ -1991,13 +1992,13 @@ struct dispatch_impl
 
     for (int current_bit = begin_bit, pass = 0; current_bit < end_bit; current_bit += radix_bits, ++pass)
     {
-      int num_bits = ::cuda::std::min(end_bit - current_bit, radix_bits);
+      const int num_bits = ::cuda::std::min(end_bit - current_bit, radix_bits);
       for (OffsetT portion = 0; portion < num_portions; ++portion)
       {
-        PortionOffsetT portion_num_items = static_cast<PortionOffsetT>(
+        const PortionOffsetT portion_num_items = static_cast<PortionOffsetT>(
           ::cuda::std::min(num_items - portion * portion_size, static_cast<OffsetT>(portion_size)));
 
-        PortionOffsetT num_blocks       = ::cuda::ceil_div(portion_num_items, onesweep_tile_items);
+        const PortionOffsetT num_blocks = ::cuda::ceil_div(portion_num_items, onesweep_tile_items);
         const size_t num_lookback_items = static_cast<size_t>(num_blocks) * radix_digits;
 
         if (use_pdl)

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -372,16 +372,16 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce") DispatchRe
       return error;
     }
 
-    int reduce_device_occupancy = reduce_config.sm_occupancy * sm_count;
+    const int reduce_device_occupancy = reduce_config.sm_occupancy * sm_count;
 
     // Even-share work distribution
-    int max_blocks = reduce_device_occupancy * detail::subscription_factor;
+    const int max_blocks = reduce_device_occupancy * detail::subscription_factor;
     GridEvenShare<OffsetT> even_share;
     even_share.DispatchInit(num_items, max_blocks, reduce_config.tile_size);
 
     // Temporary storage allocation requirements
-    void* allocations[1]       = {};
-    size_t allocation_sizes[1] = {
+    void* allocations[1]             = {};
+    const size_t allocation_sizes[1] = {
       max_blocks * kernel_source.AccumSize() // bytes needed for privatized block
                                              // reductions
     };
@@ -402,10 +402,10 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce") DispatchRe
     }
 
     // Alias the allocation for the privatized per-block reductions
-    AccumT* d_block_reductions = static_cast<AccumT*>(allocations[0]);
+    AccumT* d_block_reductions = static_cast<AccumT*>(allocations[0]); // NOLINT(misc-const-correctness)
 
     // Get grid size for device_reduce_sweep_kernel
-    int reduce_grid_size = even_share.grid_size;
+    const int reduce_grid_size = even_share.grid_size;
 
     // Log device_reduce_sweep_kernel configuration
 #ifdef CUB_DEBUG_LOG
@@ -723,6 +723,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_regular_size_reduce(
   const int reduce_device_occupancy = sm_occupancy * sm_count;
   const int max_blocks              = reduce_device_occupancy * detail::subscription_factor;
 
+  // NOLINTNEXTLINE(misc-const-correctness)
   [[maybe_unused]] AccumT* d_block_reductions = nullptr; // buffer for per-block aggregates for the two-phase code path
   if constexpr (!StableReductionOrder)
   {
@@ -735,8 +736,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_regular_size_reduce(
   else
   {
     // Temporary storage allocation requirements
-    void* allocations[1]       = {};
-    size_t allocation_sizes[1] = {
+    void* allocations[1]             = {};
+    const size_t allocation_sizes[1] = {
       max_blocks * kernel_source.AccumSize() // bytes needed for privatized block reductions
     };
 
@@ -758,7 +759,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_regular_size_reduce(
     d_block_reductions = static_cast<AccumT*>(allocations[0]);
   }
 
-  GridEvenShare<offset_t> even_share;
+  GridEvenShare<offset_t> even_share; // NOLINT(misc-const-correctness)
   if constexpr (!::cuda::args::__traits<OffsetT>::is_deferred)
   {
     const auto tile_size = active_policy.multi_tile.threads_per_block * active_policy.multi_tile.items_per_thread;
@@ -981,7 +982,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   // Older nvcc versions eagerly instantiate discarded statements in generic lambdas, so perform this conversion here.
   // Both suppressions are needed for "never referenced" and "set but never used" diagnostics across supported nvcc
   // and MSVC combinations.
-  [[maybe_unused]] offset_t offset_num_items{};
+  [[maybe_unused]] offset_t offset_num_items{}; // NOLINT(misc-const-correctness)
   if constexpr (StableReductionOrder && !::cuda::args::__traits<OffsetT>::is_deferred)
   {
     offset_num_items = static_cast<offset_t>(num_items);

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -404,8 +404,8 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey
       }
 
       // Number of input tiles
-      int tile_size = threads_per_block * items_per_thread;
-      int num_tiles = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
+      const int tile_size = threads_per_block * items_per_thread;
+      const int num_tiles = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
 
       // The amount of virtual shared memory to allocate
       const auto vsmem_size = num_tiles * vsmem_helper_t::vsmem_per_block;
@@ -417,7 +417,7 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey
       {
         break; // bytes needed for tile status descriptors
       }
-      size_t allocation_sizes[2] = {tile_descriptor_memory, vsmem_size};
+      const size_t allocation_sizes[2] = {tile_descriptor_memory, vsmem_size};
 
       // Compute allocation pointers into the single storage blob (or compute
       // the necessary size of the blob)
@@ -445,7 +445,7 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey
       }
 
       // Log init_kernel configuration
-      int init_grid_size = ::cuda::std::max(1, ::cuda::ceil_div(num_tiles, INIT_KERNEL_THREADS));
+      const int init_grid_size = ::cuda::std::max(1, ::cuda::ceil_div(num_tiles, INIT_KERNEL_THREADS));
 
 #ifdef CUB_DEBUG_LOG
       _CubLog("Invoking init_kernel<<<%d, %d, 0, %lld>>>()\n", init_grid_size, INIT_KERNEL_THREADS, (long long) stream);
@@ -499,7 +499,7 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey
       }
 
       // Run grids in epochs (in case number of tiles exceeds max x-dimension
-      int scan_grid_size = ::cuda::std::min(num_tiles, max_dim_x);
+      const int scan_grid_size = ::cuda::std::min(num_tiles, max_dim_x);
       for (int start_tile = 0; start_tile < num_tiles; start_tile += scan_grid_size)
       {
         // Log reduce_by_key_kernel configuration
@@ -766,8 +766,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     {
       return error;
     }
-    size_t allocation_sizes[2] = {tile_descriptor_memory, vsmem_size};
-    void* allocations[2]       = {};
+    const size_t allocation_sizes[2] = {tile_descriptor_memory, vsmem_size};
+    void* allocations[2]             = {};
 
     if (const auto error =
           CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))

--- a/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
@@ -211,11 +211,11 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t invok
 
   // A deferred problem size cannot be read on the host, so these defaults stand: the kernel consumes the whole
   // problem in a single launch with the worst-case grid, whose surplus blocks exit early.
-  int num_chunks           = 1;
-  int chunk_grid_size      = max_blocks;
-  int partial_chunk_size   = 0;
-  bool has_partial_chunk   = false;
-  int last_chunk_grid_size = max_blocks;
+  int num_chunks           = 1; // NOLINT(misc-const-correctness)
+  int chunk_grid_size      = max_blocks; // NOLINT(misc-const-correctness)
+  int partial_chunk_size   = 0; // NOLINT(misc-const-correctness)
+  bool has_partial_chunk   = false; // NOLINT(misc-const-correctness)
+  int last_chunk_grid_size = max_blocks; // NOLINT(misc-const-correctness)
   if constexpr (!::cuda::args::__traits<OffsetT>::is_deferred)
   {
     num_chunks = static_cast<int>(::cuda::ceil_div(num_items, num_items_per_chunk));
@@ -233,8 +233,8 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t invok
   const int reduce_grid_size = chunk_grid_size * (num_chunks - 1) + last_chunk_grid_size;
 
   // Temporary storage allocation requirements
-  void* allocations[1]       = {};
-  size_t allocation_sizes[1] = {
+  void* allocations[1]             = {};
+  const size_t allocation_sizes[1] = {
     reduce_grid_size * sizeof(DeterministicAccumT) // bytes needed for privatized block reductions
   };
 
@@ -450,7 +450,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   using deterministic_add_t  = deterministic_sum_t<AccumT>;
   using input_unwrapped_it_t = THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator_t<InputIteratorT>;
 
-  input_unwrapped_it_t d_in_unwrapped = THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_in);
+  const input_unwrapped_it_t d_in_unwrapped = THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_in);
 
   // A deferred problem size cannot be compared against the single-tile capacity on the host, so a deferred
   // reduction always takes the two-pass path.

--- a/cub/cub/device/dispatch/dispatch_rle.cuh
+++ b/cub/cub/device/dispatch/dispatch_rle.cuh
@@ -393,7 +393,7 @@ struct CCCL_DEPRECATED_BECAUSE("Please use DeviceRunLengthEncode") DeviceRleDisp
         : ::cuda::ceil_div(num_items, capped_num_items_per_invocation);
 
     // Number of input tiles
-    int max_num_tiles = static_cast<int>(::cuda::ceil_div(max_num_items_per_invocation, tile_size));
+    const int max_num_tiles = static_cast<int>(::cuda::ceil_div(max_num_items_per_invocation, tile_size));
 
     // Specify temporary storage allocation requirements
     size_t allocation_sizes[3];
@@ -424,8 +424,8 @@ struct CCCL_DEPRECATED_BECAUSE("Please use DeviceRunLengthEncode") DeviceRleDisp
     // Iterate over the partitions until all input is processed
     for (global_offset_t partition_idx = 0; partition_idx < num_partitions; partition_idx++)
     {
-      global_offset_t current_partition_offset = partition_idx * capped_num_items_per_invocation;
-      global_offset_t current_num_items =
+      const global_offset_t current_partition_offset = partition_idx * capped_num_items_per_invocation;
+      const global_offset_t current_num_items =
         (partition_idx + 1 == num_partitions)
           ? (num_items - current_partition_offset)
           : capped_num_items_per_invocation;
@@ -442,7 +442,7 @@ struct CCCL_DEPRECATED_BECAUSE("Please use DeviceRunLengthEncode") DeviceRleDisp
       }
 
       // Log init_kernel configuration
-      int init_grid_size = ::cuda::std::max(1, ::cuda::ceil_div(num_current_tiles, init_kernel_threads));
+      const int init_grid_size = ::cuda::std::max(1, ::cuda::ceil_div(num_current_tiles, init_kernel_threads));
 
 #ifdef CUB_DEBUG_LOG
       _CubLog("Invoking device_scan_init_kernel<<<%d, %d, 0, %lld>>>()\n",
@@ -752,8 +752,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
 
   for (global_offset_t partition_idx = 0; partition_idx < num_partitions; partition_idx++)
   {
-    global_offset_t current_partition_offset = partition_idx * capped_num_items_per_invocation;
-    global_offset_t current_num_items =
+    const global_offset_t current_partition_offset = partition_idx * capped_num_items_per_invocation;
+    const global_offset_t current_num_items =
       (partition_idx + 1 == num_partitions) ? (num_items - current_partition_offset) : capped_num_items_per_invocation;
 
     const auto num_current_tiles = static_cast<int>(::cuda::ceil_div(current_num_items, tile_size));

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -414,7 +414,7 @@ struct dispatch_scan_by_key
       return cudaSuccess;
     }
 
-    KeyT* d_keys_prev_in = static_cast<KeyT*>(allocations[1]);
+    KeyT* d_keys_prev_in = static_cast<KeyT*>(allocations[1]); // NOLINT(misc-const-correctness)
 
     // Construct the tile status interface
     if (const auto error = CubDebug(tile_state.Init(num_tiles, allocations[0], allocation_sizes[0])))
@@ -780,7 +780,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     return cudaSuccess;
   }
 
-  KeyT* d_keys_prev_in = static_cast<KeyT*>(allocations[1]);
+  KeyT* d_keys_prev_in = static_cast<KeyT*>(allocations[1]); // NOLINT(misc-const-correctness)
 
   // Construct the tile status interface
   if (const auto error = CubDebug(tile_state.Init(num_tiles, allocations[0], allocation_sizes[0])))

--- a/cub/cub/device/dispatch/dispatch_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_radix_sort.cuh
@@ -289,7 +289,7 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceSegmentedRadixSort"
     cudaError error = cudaSuccess;
 
     // The number of bits to process in this pass
-    int pass_bits = ::cuda::std::min(pass_config.radix_bits, (end_bit - current_bit));
+    const int pass_bits = ::cuda::std::min(pass_config.radix_bits, (end_bit - current_bit));
 
     // The offset type (used to specialize the kernel template), large enough to index any segment within a single
     // invocation
@@ -447,8 +447,8 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceSegmentedRadixSort"
       }
 
       // Temporary storage allocation requirements
-      void* allocations[2]       = {};
-      size_t allocation_sizes[2] = {
+      void* allocations[2]             = {};
+      const size_t allocation_sizes[2] = {
         // bytes needed for 3rd keys buffer
         (is_overwrite_okay) ? 0 : num_items * kernel_source.KeySize(),
 
@@ -475,13 +475,13 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceSegmentedRadixSort"
 
       // Pass planning.  Run passes of the alternate digit-size configuration until we have an even multiple of our
       // preferred digit size
-      int radix_bits         = policy.RadixBits(policy.Segmented());
-      int alt_radix_bits     = policy.RadixBits(policy.AltSegmented());
-      int num_bits           = end_bit - begin_bit;
-      int num_passes         = ::cuda::std::max(::cuda::ceil_div(num_bits, radix_bits), 1); // num_bits may be zero
-      bool is_num_passes_odd = num_passes & 1;
-      int max_alt_passes     = (num_passes * radix_bits) - num_bits;
-      int alt_end_bit        = ::cuda::std::min(end_bit, begin_bit + (max_alt_passes * alt_radix_bits));
+      const int radix_bits     = policy.RadixBits(policy.Segmented());
+      const int alt_radix_bits = policy.RadixBits(policy.AltSegmented());
+      const int num_bits       = end_bit - begin_bit;
+      int num_passes           = ::cuda::std::max(::cuda::ceil_div(num_bits, radix_bits), 1); // num_bits may be zero
+      const bool is_num_passes_odd = num_passes & 1;
+      const int max_alt_passes     = (num_passes * radix_bits) - num_bits;
+      const int alt_end_bit        = ::cuda::std::min(end_bit, begin_bit + (max_alt_passes * alt_radix_bits));
 
       DoubleBuffer<KeyT> d_keys_remaining_passes(
         (is_overwrite_okay || is_num_passes_odd) ? d_keys.Alternate() : static_cast<KeyT*>(allocations[0]),
@@ -723,8 +723,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_passes(
     return error;
   }
 
-  void* allocations[2]       = {};
-  size_t allocation_sizes[2] = {
+  void* allocations[2]             = {};
+  const size_t allocation_sizes[2] = {
     (is_overwrite_okay) ? 0 : num_items * kernel_source.KeySize(),
     (is_overwrite_okay || keys_only) ? 0 : num_items * sizeof(ValueT),
   };

--- a/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
@@ -875,8 +875,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_fixed_size(
   const auto tiles_per_invocation        = num_segments_per_invocation * tiles_per_segment;
 
   // Temporary storage allocation requirements
-  void* allocations[1]       = {};
-  size_t allocation_sizes[1] = {static_cast<size_t>(tiles_per_invocation) * kernel_source.AccumSize()};
+  void* allocations[1]             = {};
+  const size_t allocation_sizes[1] = {static_cast<size_t>(tiles_per_invocation) * kernel_source.AccumSize()};
 
   if (const auto error =
         CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
@@ -889,7 +889,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_fixed_size(
     return cudaSuccess;
   }
 
-  AccumT* d_block_reductions = static_cast<AccumT*>(allocations[0]);
+  AccumT* d_block_reductions = static_cast<AccumT*>(allocations[0]); // NOLINT(misc-const-correctness)
 
   for (::cuda::std::int64_t invocation_index = 0; invocation_index < num_invocations; invocation_index++)
   {

--- a/cub/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/cub/device/dispatch/dispatch_select_if.cuh
@@ -692,7 +692,7 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceSelect/DevicePartit
         }
 
         // Log scan_init_kernel configuration
-        int init_grid_size = ::cuda::std::max(1, ::cuda::ceil_div(current_num_tiles, INIT_KERNEL_THREADS));
+        const int init_grid_size = ::cuda::std::max(1, ::cuda::ceil_div(current_num_tiles, INIT_KERNEL_THREADS));
 
 #ifdef CUB_DEBUG_LOG
         _CubLog("Invoking scan_init_kernel<<<%d, %d, 0, %lld>>>()\n",
@@ -874,7 +874,7 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceSelect/DevicePartit
     cudaStream_t stream)
   {
     int ptx_version = 0;
-    if (cudaError_t error = CubDebug(PtxVersion(ptx_version)))
+    if (const cudaError_t error = CubDebug(PtxVersion(ptx_version)))
     {
       return error;
     }

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh
@@ -144,8 +144,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming(
 
   for (global_offset_t partition_idx = 0; partition_idx < num_partitions; partition_idx++)
   {
-    global_offset_t current_partition_offset = partition_idx * capped_num_items_per_invocation;
-    global_offset_t current_num_items =
+    const global_offset_t current_partition_offset = partition_idx * capped_num_items_per_invocation;
+    const global_offset_t current_num_items =
       (partition_idx + 1 == num_partitions) ? (num_items - current_partition_offset) : capped_num_items_per_invocation;
 
     const auto num_current_tiles = static_cast<int>(::cuda::ceil_div(current_num_items, tile_size));
@@ -215,7 +215,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming(
       const bool is_first_partition = (partition_idx == 0);
       const bool is_last_partition  = (partition_idx + 1 == num_partitions);
       const int buffer_selector     = partition_idx % 2;
-      streaming_context_t streaming_context{
+      const streaming_context_t streaming_context{
         is_first_partition,
         is_last_partition,
         is_first_partition ? d_keys_in : d_keys_in + current_partition_offset - 1,

--- a/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
@@ -390,7 +390,7 @@ struct dispatch_three_way_partition_if
   {
     // Get PTX version
     int ptx_version = 0;
-    if (cudaError error = CubDebug(launcher_factory.PtxVersion(ptx_version)); cudaSuccess != error)
+    if (const cudaError error = CubDebug(launcher_factory.PtxVersion(ptx_version)); cudaSuccess != error)
     {
       return error;
     }

--- a/cub/cub/device/dispatch/dispatch_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_topk.cuh
@@ -43,7 +43,7 @@ namespace detail::topk
 template <typename T, int BitsPerPass>
 [[nodiscard]] _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr unsigned calc_mask(const int pass)
 {
-  int num_bits = calc_start_bit<T, BitsPerPass>(pass - 1) - calc_start_bit<T, BitsPerPass>(pass);
+  const int num_bits = calc_start_bit<T, BitsPerPass>(pass - 1) - calc_start_bit<T, BitsPerPass>(pass);
   return (1 << num_bits) - 1;
 }
 
@@ -79,7 +79,7 @@ struct extract_bin_op_t<T, SelectDirection, BitsPerPass, DecomposerT, true>
     {
       bits = ~bits;
     }
-    int bucket = (bits >> start_bit) & mask;
+    const int bucket = (bits >> start_bit) & mask;
     return bucket;
   }
 };
@@ -540,7 +540,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     const OffsetT candidate_buffer_length =
       (::cuda::std::max) (OffsetT{1}, num_items / coefficient_for_candidate_buffer);
 
-    constexpr int allocations_array_size            = keys_only ? 4 : 6;
+    constexpr int allocations_array_size = keys_only ? 4 : 6;
+    // NOLINTNEXTLINE(misc-const-correctness)
     size_t allocation_sizes[allocations_array_size] = {
       size_counter,
       size_histogram,
@@ -621,7 +622,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
 
     // Initialize address variables
     counter_t* counter = static_cast<counter_t*>(allocations[0]);
-    OffsetT* histogram = static_cast<decltype(histogram)>(allocations[1]);
+    OffsetT* histogram = static_cast<decltype(histogram)>(allocations[1]); // NOLINT(misc-const-correctness)
 
     // Pass 0: dedicated histogram-only kernel over the full input
     {
@@ -645,7 +646,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
       const auto histogram_kernel_max_occupancy = static_cast<unsigned int>(histogram_kernel_blocks_per_sm * num_sms);
       const auto histogram_grid_size            = (::cuda::std::min) (histogram_kernel_max_occupancy, num_tiles);
 
-      extract_bin_op extract_op(0, total_bits, decomposer);
+      const extract_bin_op extract_op(0, total_bits, decomposer);
       if (const auto error = CubDebug(
             launcher_factory(histogram_grid_size, threads_per_block, 0, stream)
               .doit(histogram_kernel,
@@ -678,8 +679,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     int pass = 1;
     for (; pass < num_passes; pass++)
     {
-      extract_bin_op extract_op(pass, total_bits, decomposer);
-      identify_candidates_op identify_op(&counter->kth_key_bits, pass, total_bits, decomposer);
+      const extract_bin_op extract_op(pass, total_bits, decomposer);
+      const identify_candidates_op identify_op(&counter->kth_key_bits, pass, total_bits, decomposer);
 
       if (const auto error = CubDebug(
             launcher_factory(topk_grid_size, threads_per_block, 0, stream)
@@ -723,7 +724,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
       key_in_t,
       identify_candidates_op>;
 
-    identify_candidates_op identify_op(&counter->kth_key_bits, pass, total_bits, decomposer);
+    const identify_candidates_op identify_op(&counter->kth_key_bits, pass, total_bits, decomposer);
     int last_filter_kernel_blocks_per_sm = 0;
     if (const auto error = CubDebug(launcher_factory.MaxSmOccupancy(
           last_filter_kernel_blocks_per_sm, topk_last_filter_kernel, threads_per_block)))

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -241,7 +241,7 @@ struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceSelect::UniqueByKey
     // Number of input tiles
     const auto threads_per_block = policy.threads_per_block;
     const auto items_per_thread  = policy.items_per_thread;
-    int tile_size                = threads_per_block * items_per_thread;
+    const int tile_size          = threads_per_block * items_per_thread;
     int num_tiles                = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
     const auto vsmem_size        = num_tiles * vsmem_per_block;
 
@@ -572,7 +572,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
 
     const auto threads_per_block = active_policy.threads_per_block;
     const auto items_per_thread  = active_policy.items_per_thread;
-    int tile_size                = threads_per_block * items_per_thread;
+    const int tile_size          = threads_per_block * items_per_thread;
     int num_tiles                = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
     const auto vsmem_size        = num_tiles * vsmem_per_block;
 

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -60,7 +60,7 @@ struct Transforms
                          CacheModifiedInputIterator<LOAD_MODIFIER, LevelT, OffsetT>,
                          LevelIteratorT>;
 
-      WrappedLevelIteratorT wrapped_levels(d_levels);
+      const WrappedLevelIteratorT wrapped_levels(d_levels);
 
       const int num_bins = num_output_levels - 1;
       if (valid)

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -421,7 +421,7 @@ __launch_bounds__(current_policy<PolicySelector>().single_tile.threads_per_block
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
   {
-    int item_offset = ITEM * BLOCK_THREADS + threadIdx.x;
+    const int item_offset = ITEM * BLOCK_THREADS + threadIdx.x;
     if (item_offset < num_items)
     {
       d_keys_out[item_offset] = keys[ITEM];
@@ -576,12 +576,12 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(OffsetT* const d_
 
   // load the bins
   OffsetT bins[BINS_PER_THREAD];
-  int bin_start = blockIdx.x * RADIX_DIGITS;
+  const int bin_start = blockIdx.x * RADIX_DIGITS;
 
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int u = 0; u < BINS_PER_THREAD; ++u)
   {
-    int bin = threadIdx.x * BINS_PER_THREAD + u;
+    const int bin = threadIdx.x * BINS_PER_THREAD + u;
     if (bin >= RADIX_DIGITS)
     {
       break;
@@ -596,7 +596,7 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(OffsetT* const d_
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int u = 0; u < BINS_PER_THREAD; ++u)
   {
-    int bin = threadIdx.x * BINS_PER_THREAD + u;
+    const int bin = threadIdx.x * BINS_PER_THREAD + u;
     if (bin >= RADIX_DIGITS)
     {
       break;

--- a/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
@@ -246,7 +246,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().multi_tile.threads_per_bl
       NV_IF_ELSE_TARGET(
         NV_PROVIDES_SM_60,
         ({
-          ::cuda::atomic_ref<AccumT, ::cuda::thread_scope_device> atomic_target(d_out[0]);
+          const ::cuda::atomic_ref<AccumT, ::cuda::thread_scope_device> atomic_target(d_out[0]);
           atomic_target.fetch_add(blockIdx.x == 0 ? reduction_op(init, block_aggregate) : block_aggregate,
                                   ::cuda::memory_order_relaxed);
         }),

--- a/cub/cub/device/dispatch/kernels/kernel_reduce_deterministic.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce_deterministic.cuh
@@ -170,7 +170,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().multi_tile.threads_per_bl
   AccumT thread_aggregate{};
   int count = 0;
 
-  int n_threads = active_grid_size * threads_per_block;
+  const int n_threads = active_grid_size * threads_per_block;
 
   if constexpr (sizeof(num_items_t) == 8)
   {

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
@@ -218,7 +218,7 @@ __launch_bounds__(segmented_radix_sort_kernel_launch_bounds<PolicySelector, AltD
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int track = 0; track < bins_tracked_per_thread; ++track)
     {
-      int bin_idx = (threadIdx.x * bins_tracked_per_thread) + track;
+      const int bin_idx = (threadIdx.x * bins_tracked_per_thread) + track;
 
       if ((threads_per_block == radix_digits) || (bin_idx < radix_digits))
       {
@@ -231,7 +231,7 @@ __launch_bounds__(segmented_radix_sort_kernel_launch_bounds<PolicySelector, AltD
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int track = 0; track < bins_tracked_per_thread; ++track)
     {
-      int bin_idx = (threadIdx.x * bins_tracked_per_thread) + track;
+      const int bin_idx = (threadIdx.x * bins_tracked_per_thread) + track;
 
       if ((threads_per_block == radix_digits) || (bin_idx < radix_digits))
       {
@@ -251,7 +251,7 @@ __launch_bounds__(segmented_radix_sort_kernel_launch_bounds<PolicySelector, AltD
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int track = 0; track < bins_tracked_per_thread; ++track)
     {
-      int bin_idx = (threadIdx.x * bins_tracked_per_thread) + track;
+      const int bin_idx = (threadIdx.x * bins_tracked_per_thread) + track;
 
       if ((threads_per_block == radix_digits) || (bin_idx < radix_digits))
       {
@@ -264,7 +264,7 @@ __launch_bounds__(segmented_radix_sort_kernel_launch_bounds<PolicySelector, AltD
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int track = 0; track < bins_tracked_per_thread; ++track)
     {
-      int bin_idx = (threadIdx.x * bins_tracked_per_thread) + track;
+      const int bin_idx = (threadIdx.x * bins_tracked_per_thread) + track;
 
       if ((threads_per_block == radix_digits) || (bin_idx < radix_digits))
       {

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_scan.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_scan.cuh
@@ -291,7 +291,7 @@ public:
       }
 
       n_segments               = ::cuda::std::min(n_segments, static_cast<int>(NumSegments));
-      unsigned n_chunks        = ::cuda::ceil_div(n_segments, threads_per_block);
+      const unsigned n_chunks  = ::cuda::ceil_div(n_segments, threads_per_block);
       OffsetT exclusive_prefix = 0;
       using plus_t             = ::cuda::std::plus<>;
       const plus_t offsets_scan_op{};
@@ -428,7 +428,7 @@ private:
         if constexpr (has_init)
         {
           const packer_iv<ScanOpT, AccumT> packer_op{scan_op, initial_value};
-          multi_segmented_input_iterator it_in{d_in, chunk_begin, searcher, input_begin_idx_it, packer_op};
+          const multi_segmented_input_iterator it_in{d_in, chunk_begin, searcher, input_begin_idx_it, packer_op};
 
           if (chunk_size == tile_items)
           {
@@ -442,7 +442,7 @@ private:
         else
         {
           constexpr packer<AccumT> packer_op{};
-          multi_segmented_input_iterator it_in{d_in, chunk_begin, searcher, input_begin_idx_it, packer_op};
+          const multi_segmented_input_iterator it_in{d_in, chunk_begin, searcher, input_begin_idx_it, packer_op};
 
           if (chunk_size == tile_items)
           {
@@ -488,7 +488,7 @@ private:
         if constexpr (is_inclusive)
         {
           constexpr projector<AccumT> projector_op{};
-          multi_segmented_output_iterator it_out{d_out, out_offset, searcher, output_begin_idx_it, projector_op};
+          const multi_segmented_output_iterator it_out{d_out, out_offset, searcher, output_begin_idx_it, projector_op};
 
           if (chunk_size == tile_items)
           {
@@ -502,7 +502,7 @@ private:
         else
         {
           const projector_iv<AccumT> projector_op{initial_value};
-          multi_segmented_output_iterator it_out{d_out, out_offset, searcher, output_begin_idx_it, projector_op};
+          const multi_segmented_output_iterator it_out{d_out, out_offset, searcher, output_begin_idx_it, projector_op};
           if (chunk_size == tile_items)
           {
             storer.Store(it_out, thread_flag_values);
@@ -654,7 +654,7 @@ __launch_bounds__(current_policy<PolicySelector>().block.threads_per_block)
 
     using IdT             = decltype(work_id);
     const auto end_offset = ::cuda::std::min<IdT>(suggested_end_offset, n_segments);
-    int size              = end_offset - start_offset;
+    const int size        = end_offset - start_offset;
 
     auto worker_input_begin_idx_it  = begin_offset_d_in + start_offset;
     auto worker_input_end_idx_it    = end_offset_d_in + start_offset;

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -1084,7 +1084,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       // implies an always_true predicate, so we store unconditionally.
       for (int idx = num_vecs * store_vec_size + threadIdx.x; idx < valid_items; idx += threads_per_block)
       {
-        char* smem         = smem_base;
+        const char* smem   = smem_base;
         auto fetch_operand = [&](auto aligned_ptr) {
           using T                = typename decltype(aligned_ptr)::value_type;
           const int head_padding = alignof(T) < bulk_copy_alignment ? aligned_ptr.head_padding : 0;
@@ -1110,7 +1110,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       const int idx = j * threads_per_block + threadIdx.x;
       if (full_tile || idx < valid_items)
       {
-        char* smem         = smem_base;
+        const char* smem   = smem_base;
         auto fetch_operand = [&](auto aligned_ptr) {
           using T                = typename decltype(aligned_ptr)::value_type;
           const int head_padding = alignof(T) < bulk_copy_alignment ? aligned_ptr.head_padding : 0;

--- a/cub/cub/grid/grid_even_share.cuh
+++ b/cub/cub/grid/grid_even_share.cuh
@@ -115,8 +115,8 @@ public:
     this->num_items    = num_items_;
     this->total_tiles  = static_cast<int>(
       ::cuda::std::min(OffsetT{::cuda::std::numeric_limits<int>::max()}, ::cuda::ceil_div(num_items_, tile_items)));
-    this->grid_size         = ::cuda::std::min(total_tiles, max_grid_size);
-    int avg_tiles_per_block = total_tiles / grid_size;
+    this->grid_size               = ::cuda::std::min(total_tiles, max_grid_size);
+    const int avg_tiles_per_block = total_tiles / grid_size;
     // leftover grains go to big blocks:
     this->big_shares         = total_tiles - (avg_tiles_per_block * grid_size);
     this->normal_share_items = static_cast<OffsetT>(avg_tiles_per_block) * tile_items;

--- a/cub/cub/iterator/arg_index_input_iterator.cuh
+++ b/cub/cub/iterator/arg_index_input_iterator.cuh
@@ -193,7 +193,7 @@ public:
   template <typename Distance>
   _CCCL_HOST_DEVICE _CCCL_FORCEINLINE reference operator[](Distance n) const
   {
-    self_type offset = (*this) + n;
+    const self_type offset = (*this) + n;
     return *offset;
   }
 

--- a/cub/cub/iterator/tex_obj_input_iterator.cuh
+++ b/cub/cub/iterator/tex_obj_input_iterator.cuh
@@ -150,7 +150,7 @@ public:
     this->ptr        = const_cast<::cuda::std::remove_cv_t<QualifiedT>*>(ptr);
     this->tex_offset = static_cast<difference_type>(tex_offset);
 
-    cudaChannelFormatDesc channel_desc = cudaCreateChannelDesc<TextureWord>();
+    const cudaChannelFormatDesc channel_desc = cudaCreateChannelDesc<TextureWord>();
     cudaResourceDesc res_desc;
     cudaTextureDesc tex_desc;
     memset(&res_desc, 0, sizeof(cudaResourceDesc));
@@ -239,7 +239,7 @@ public:
   template <typename Distance>
   _CCCL_HOST_DEVICE _CCCL_FORCEINLINE reference operator[](Distance n) const
   {
-    self_type offset = (*this) + n;
+    const self_type offset = (*this) + n;
     return *offset;
   }
 

--- a/cub/cub/thread/thread_reduce.cuh
+++ b/cub/cub/thread/thread_reduce.cuh
@@ -359,13 +359,13 @@ _CCCL_DEVICE _CCCL_FORCEINLINE auto ThreadReduceSimd(const Input& input, Reducti
   auto unpacked_values = unsafe_bitcast<UnpackedType>(simd_reduction);
   // Create a reversed copy of the SIMD reduction result and apply the SIMD operator.
   // This avoids redundant instructions for converting to and from 32-bit registers
-  T unpacked_values_rev[] = {unpacked_values[1], unpacked_values[0]};
-  auto simd_reduction_rev = unsafe_bitcast<SimdType>(unpacked_values_rev);
-  SimdType result         = SimdReduceOp{}(simd_reduction, simd_reduction_rev);
+  const T unpacked_values_rev[] = {unpacked_values[1], unpacked_values[0]};
+  auto simd_reduction_rev       = unsafe_bitcast<SimdType>(unpacked_values_rev);
+  SimdType result               = SimdReduceOp{}(simd_reduction, simd_reduction_rev); // NOLINT(misc-const-correctness)
   // repeat the same optimization for the last element
   if constexpr (length % simd_ratio == 1)
   {
-    T tail[]       = {input[length - 1], T{}};
+    const T tail[] = {input[length - 1], T{}};
     auto tail_simd = unsafe_bitcast<SimdType>(tail);
     result         = SimdReduceOp{}(result, tail_simd);
   }

--- a/cub/cub/util_allocator.cuh
+++ b/cub/cub/util_allocator.cuh
@@ -536,7 +536,7 @@ struct CCCL_DEPRECATED_BECAUSE("cub::CachingDeviceAllocator is deprecated; use c
         mutex.lock();
 
         // Iterate the range of free blocks on the same device
-        BlockDescriptor free_key(device);
+        const BlockDescriptor free_key(device);
         CachedBlocks::iterator block_itr = cached_blocks.lower_bound(free_key);
 
         while ((block_itr != cached_blocks.end()) && (block_itr->device == device))
@@ -695,7 +695,7 @@ struct CCCL_DEPRECATED_BECAUSE("cub::CachingDeviceAllocator is deprecated; use c
     // Find corresponding block descriptor
     bool recached = false;
     BlockDescriptor search_key(d_ptr, device);
-    BusyBlocks::iterator block_itr = live_blocks.find(search_key);
+    const BusyBlocks::iterator block_itr = live_blocks.find(search_key);
     if (block_itr != live_blocks.end())
     {
       // Remove from live blocks
@@ -823,7 +823,7 @@ struct CCCL_DEPRECATED_BECAUSE("cub::CachingDeviceAllocator is deprecated; use c
     while (!cached_blocks.empty())
     {
       // Get first block
-      CachedBlocks::iterator begin = cached_blocks.begin();
+      const CachedBlocks::iterator begin = cached_blocks.begin();
 
       // Get entry-point device ordinal if necessary
       if (entrypoint_device == INVALID_DEVICE_ORDINAL)

--- a/cub/cub/util_debug.cuh
+++ b/cub/cub/util_debug.cuh
@@ -121,7 +121,7 @@ Debug(cudaError_t error, [[maybe_unused]] const char* filename, [[maybe_unused]]
   #define CUB_TEMP_DEVICE_CODE last_error = cudaGetLastError()
   #endif
 
-  cudaError_t last_error = cudaSuccess;
+  cudaError_t last_error = cudaSuccess; // NOLINT(misc-const-correctness)
 
   NV_IF_ELSE_TARGET(
     NV_IS_HOST,

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -124,7 +124,7 @@ CUB_RUNTIME_FUNCTION inline int device_count_uncached()
 // TODO(bgruber): remove in CCCL 4.0
 _CCCL_HOST inline int device_count_cached_value()
 {
-  static int count = device_count_uncached();
+  static const int count = device_count_uncached();
   return count;
 }
 
@@ -302,7 +302,7 @@ CUB_RUNTIME_FUNCTION cudaError_t PtxVersionUncached(int& ptx_version)
   // it can be called.
   [[maybe_unused]] const auto empty_kernel = detail::EmptyKernel<T>;
 
-  cudaError_t result = cudaSuccess;
+  cudaError_t result = cudaSuccess; // NOLINT(misc-const-correctness)
   NV_IF_ELSE_TARGET(NV_IS_HOST,
                     ({
                       cudaFuncAttributes empty_kernel_attrs;
@@ -319,7 +319,7 @@ CUB_RUNTIME_FUNCTION cudaError_t PtxVersionUncached(int& ptx_version)
 template <class T = void>
 _CCCL_HOST cudaError_t PtxVersionUncached(int& ptx_version, int device)
 {
-  SwitchDevice sd(device);
+  const SwitchDevice sd(device);
   return PtxVersionUncached<T>(ptx_version);
 }
 

--- a/cub/cub/util_ptx.cuh
+++ b/cub/cub/util_ptx.cuh
@@ -148,6 +148,7 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE unsigned int WarpMask([[maybe_unused]] unsig
   constexpr bool is_pow_of_two = ::cuda::is_power_of_two(LOGICAL_WARP_THREADS);
   constexpr bool is_arch_warp  = LOGICAL_WARP_THREADS == detail::warp_threads;
 
+  // NOLINTNEXTLINE(misc-const-correctness)
   unsigned int member_mask = 0xFFFFFFFFu >> (detail::warp_threads - LOGICAL_WARP_THREADS);
 
   if constexpr (is_pow_of_two && !is_arch_warp)
@@ -218,8 +219,8 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleUp(T input, int src_offset, int first_th
   constexpr int WORDS = (sizeof(T) + sizeof(ShuffleWord) - 1) / sizeof(ShuffleWord);
 
   T output;
-  ShuffleWord* output_alias = reinterpret_cast<ShuffleWord*>(&output);
-  ShuffleWord* input_alias  = reinterpret_cast<ShuffleWord*>(&input);
+  ShuffleWord* output_alias      = reinterpret_cast<ShuffleWord*>(&output);
+  const ShuffleWord* input_alias = reinterpret_cast<ShuffleWord*>(&input);
 
   unsigned int shuffle_word;
   shuffle_word    = SHFL_UP_SYNC((unsigned int) input_alias[0], src_offset, first_thread | SHFL_C, member_mask);
@@ -296,8 +297,8 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleDown(T input, int src_offset, int last_t
   constexpr int WORDS = (sizeof(T) + sizeof(ShuffleWord) - 1) / sizeof(ShuffleWord);
 
   T output;
-  ShuffleWord* output_alias = reinterpret_cast<ShuffleWord*>(&output);
-  ShuffleWord* input_alias  = reinterpret_cast<ShuffleWord*>(&input);
+  ShuffleWord* output_alias      = reinterpret_cast<ShuffleWord*>(&output);
+  const ShuffleWord* input_alias = reinterpret_cast<ShuffleWord*>(&input);
 
   unsigned int shuffle_word;
   shuffle_word    = SHFL_DOWN_SYNC((unsigned int) input_alias[0], src_offset, last_thread | SHFL_C, member_mask);
@@ -370,8 +371,8 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleIndex(T input, int src_lane, unsigned in
   constexpr int WORDS = (sizeof(T) + sizeof(ShuffleWord) - 1) / sizeof(ShuffleWord);
 
   T output;
-  ShuffleWord* output_alias = reinterpret_cast<ShuffleWord*>(&output);
-  ShuffleWord* input_alias  = reinterpret_cast<ShuffleWord*>(&input);
+  ShuffleWord* output_alias      = reinterpret_cast<ShuffleWord*>(&output);
+  const ShuffleWord* input_alias = reinterpret_cast<ShuffleWord*>(&input);
 
   unsigned int shuffle_word;
   shuffle_word    = __shfl_sync(member_mask, (unsigned int) input_alias[0], src_lane, LOGICAL_WARP_THREADS);
@@ -427,7 +428,7 @@ struct warp_matcher_t<LABEL_BITS, warp_threads>
     for (int BIT = 0; BIT < LABEL_BITS; ++BIT)
     {
       unsigned int mask;
-      unsigned int current_bit = 1 << BIT;
+      const unsigned int current_bit = 1 << BIT;
       asm("{\n"
           "    .reg .pred p;\n"
           "    and.b32 %0, %1, %2;"
@@ -452,7 +453,7 @@ struct warp_matcher_t<LABEL_BITS, warp_threads>
  */
 _CCCL_DEVICE _CCCL_FORCEINLINE uint32_t LogicShiftLeft(uint32_t val, uint32_t num_bits)
 {
-  uint32_t ret{};
+  uint32_t ret{}; // NOLINT(misc-const-correctness)
   asm("shl.b32 %0, %1, %2;" : "=r"(ret) : "r"(val), "r"(num_bits));
   return ret;
 }
@@ -463,7 +464,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE uint32_t LogicShiftLeft(uint32_t val, uint32_t nu
  */
 _CCCL_DEVICE _CCCL_FORCEINLINE uint32_t LogicShiftRight(uint32_t val, uint32_t num_bits)
 {
-  uint32_t ret{};
+  uint32_t ret{}; // NOLINT(misc-const-correctness)
   asm("shr.b32 %0, %1, %2;" : "=r"(ret) : "r"(val), "r"(num_bits));
   return ret;
 }

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -952,13 +952,13 @@ struct BaseTraits<FLOATING_POINT, true, _UnsignedBits, T>
 
   static _CCCL_HOST_DEVICE _CCCL_FORCEINLINE UnsignedBits TwiddleIn(UnsignedBits key)
   {
-    UnsignedBits mask = (key & HIGH_BIT) ? UnsignedBits(-1) : HIGH_BIT;
+    const UnsignedBits mask = (key & HIGH_BIT) ? UnsignedBits(-1) : HIGH_BIT;
     return key ^ mask;
   };
 
   static _CCCL_HOST_DEVICE _CCCL_FORCEINLINE UnsignedBits TwiddleOut(UnsignedBits key)
   {
-    UnsignedBits mask = (key & HIGH_BIT) ? HIGH_BIT : UnsignedBits(-1);
+    const UnsignedBits mask = (key & HIGH_BIT) ? HIGH_BIT : UnsignedBits(-1);
     return key ^ mask;
   };
 

--- a/cub/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -124,7 +124,7 @@ struct WarpReduceShfl
   ReduceStep(unsigned int input, ::cuda::std::plus<> /*reduction_op*/, int last_lane, int offset)
   {
     unsigned int output;
-    int shfl_c = last_lane | SHFL_C; // Shuffle control (mask and last_lane)
+    const int shfl_c = last_lane | SHFL_C; // Shuffle control (mask and last_lane)
 
     // Use predicate set from SHFL to guard against invalid peers
     asm volatile(
@@ -160,7 +160,7 @@ struct WarpReduceShfl
   ReduceStep(float input, ::cuda::std::plus<> /*reduction_op*/, int last_lane, int offset)
   {
     float output;
-    int shfl_c = last_lane | SHFL_C; // Shuffle control (mask and last_lane)
+    const int shfl_c = last_lane | SHFL_C; // Shuffle control (mask and last_lane)
 
     // Use predicate set from SHFL to guard against invalid peers
     asm volatile(
@@ -273,7 +273,7 @@ struct WarpReduceShfl
   ReduceStep(double input, ::cuda::std::plus<> /*reduction_op*/, int last_lane, int offset)
   {
     double output;
-    int shfl_c = last_lane | SHFL_C; // Shuffle control (mask and last_lane)
+    const int shfl_c = last_lane | SHFL_C; // Shuffle control (mask and last_lane)
 
     // Use predicate set from SHFL to guard against invalid peers
     asm volatile(
@@ -520,7 +520,7 @@ struct WarpReduceShfl
     warp_flags |= 1u << (LOGICAL_WARP_THREADS - 1);
 
     // Find the next set flag
-    int last_lane = ::cuda::std::countr_zero(warp_flags);
+    const int last_lane = ::cuda::std::countr_zero(warp_flags);
 
     T output = input;
     // Template-iterate reduction steps

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -127,7 +127,7 @@ struct WarpScanShfl
   InclusiveScanStep(int input, ::cuda::std::plus<> /*scan_op*/, int first_lane, int offset)
   {
     int output;
-    int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
+    const int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
 
     // Use predicate set from SHFL to guard against invalid peers
     asm volatile(
@@ -163,7 +163,7 @@ struct WarpScanShfl
   InclusiveScanStep(unsigned int input, ::cuda::std::plus<> /*scan_op*/, int first_lane, int offset)
   {
     unsigned int output;
-    int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
+    const int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
 
     // Use predicate set from SHFL to guard against invalid peers
     asm volatile(
@@ -199,7 +199,7 @@ struct WarpScanShfl
   InclusiveScanStep(float input, ::cuda::std::plus<> /*scan_op*/, int first_lane, int offset)
   {
     float output;
-    int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
+    const int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
 
     // Use predicate set from SHFL to guard against invalid peers
     asm volatile(
@@ -235,7 +235,7 @@ struct WarpScanShfl
   InclusiveScanStep(unsigned long long input, ::cuda::std::plus<> /*scan_op*/, int first_lane, int offset)
   {
     unsigned long long output;
-    int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
+    const int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
 
     // Use predicate set from SHFL to guard against invalid peers
     asm volatile(
@@ -276,7 +276,7 @@ struct WarpScanShfl
   InclusiveScanStep(long long input, ::cuda::std::plus<> /*scan_op*/, int first_lane, int offset)
   {
     long long output;
-    int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
+    const int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
 
     // Use predicate set from SHFL to guard against invalid peers
     asm volatile(
@@ -317,7 +317,7 @@ struct WarpScanShfl
   InclusiveScanStep(double input, ::cuda::std::plus<> /*scan_op*/, int first_lane, int offset)
   {
     double output;
-    int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
+    const int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
 
     // Use predicate set from SHFL to guard against invalid peers
     asm volatile(
@@ -525,7 +525,7 @@ struct WarpScanShfl
     inclusive_output = input;
 
     // Iterate scan steps
-    int segment_first_lane = 0;
+    const int segment_first_lane = 0;
 
     // Iterate scan steps
     _CCCL_PRAGMA_UNROLL_FULL()

--- a/cub/cub/warp/warp_bitonic_sort.cuh
+++ b/cub/cub/warp/warp_bitonic_sort.cuh
@@ -570,7 +570,7 @@ private:
   {
     // Each stage divides the inputs into groups and sorts within each group.
     // Sort direction of each group should be adjusted to maintain the bitonic property.
-    unsigned int group_reverse = Reverse;
+    unsigned int group_reverse = Reverse; // NOLINT(misc-const-correctness)
     if constexpr (Stage == num_stages - 1)
     {
       // The last stage contains only one group, and the sort direction is just Reverse


### PR DESCRIPTION
Part of the `misc-const-correctness` split of the umbrella branch `jacobf/2026-09-02/misc-const-correctness`.

This PR adds `const` to local variables under:
  - `cub/cub/`

It does **not** enable the check. `misc-const-correctness` stays disabled in `.clang-tidy` until the final PR of the series.